### PR TITLE
[feat] Add Sereact sim-to-real pipeline tools to npa workbench

### DIFF
--- a/.claude/skills/workbench/sereact-sim-to-real/SKILL.md
+++ b/.claude/skills/workbench/sereact-sim-to-real/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: sereact-sim-to-real
+description: Use when working on Sereact sim-to-real pipeline data import, Cosmos autoscaling, VLM eval stubs, or the sim-to-real controller-loop SkyPilot workflow.
+---
+
+# Sereact Sim-To-Real
+
+Sereact sim-to-real is a Workbench pipeline pattern that stages raw S3 data,
+runs parallel Cosmos candidate generation, and gates each iteration with the
+stub VLM eval backend.
+
+## Interfaces
+
+CLI:
+
+```bash
+npa workbench data sync
+npa workbench data status
+npa workbench data list
+npa workbench cosmos autoscale
+npa workbench vlm-eval run
+npa workbench vlm-eval status
+npa workbench vlm-eval list
+```
+
+Workflow:
+
+```bash
+npa/scripts/run_sim_to_real_loop.py --render-only
+npa workbench workflow submit npa/workflows/workbench/skypilot/sim-to-real-loop.yaml
+```
+
+## Data Flow
+
+Use S3 URIs for every handoff. The controller loop writes iteration-scoped
+outputs under:
+
+```text
+s3://${NPA_S3_BUCKET}/sereact-sim-to-real/<run-id>/iter-XX/
+```
+
+The data bridge supports scoped project credentials and only falls back to host
+credentials when the operator passes `--allow-host-creds`.
+
+## Cosmos Autoscale
+
+`npa workbench cosmos autoscale` is for saved serverless Cosmos endpoint
+aliases. Use it to set replica bounds before running a parallel candidate
+generation loop.
+
+## Validation Scope
+
+The VLM eval backend is intentionally a deterministic stub. Do not add a real
+VLM backend, Lightwheel integration, native SkyPilot loop syntax, or ONNX export
+as part of this pipeline surface unless a later task explicitly asks for it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Claude Code should treat this file as an index. Load the relevant skill before m
 - `.claude/skills/platform/architecture/SKILL.md`: load for platform architecture, tool-layer scope, orchestrator decisions, partner model, and validation state.
 - `.claude/skills/platform/review-checklist/SKILL.md`: load for code reviews and risk classification.
 - `.claude/skills/workbench/physical-ai-context/SKILL.md`: load for robotics, sim-to-real, GPU routing, Genesis, Isaac Lab, LeRobot, SONIC, GR00T, Cosmos, or BDD100K context.
+- `.claude/skills/workbench/sereact-sim-to-real/SKILL.md`: load for Sereact data import, Cosmos autoscale, VLM stub evaluation, and the controller-loop workflow.
 
 ## Project Instructions
 

--- a/npa/scripts/run_sim_to_real_controller.py
+++ b/npa/scripts/run_sim_to_real_controller.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Run the Sereact sim-to-real controller loop."""
+
+from __future__ import annotations
+
+import sys
+
+from npa.workflows.sereact_sim_to_real import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/npa/scripts/run_sim_to_real_loop.py
+++ b/npa/scripts/run_sim_to_real_loop.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Submit or render the Sereact sim-to-real SkyPilot controller workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from npa.orchestration.skypilot import WorkflowResult, submit_workflow
+from npa.orchestration.skypilot._bin import (
+    SkyPilotConfigError,
+    SkyPilotNotInstalledError,
+    SkyPilotVersionError,
+    resolve_sky_bin,
+)
+
+DEFAULT_YAML = (
+    Path(__file__).resolve().parents[1]
+    / "workflows"
+    / "workbench"
+    / "skypilot"
+    / "sim-to-real-loop.yaml"
+)
+DEFAULT_BUCKET = os.environ.get("NPA_S3_BUCKET", "your-bucket-name")
+DEFAULT_SOURCE = f"s3://{DEFAULT_BUCKET}/sereact/raw/"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    run_id = args.run_id or _default_run_id()
+    docs = render_workflow(
+        args.yaml_path,
+        run_id=run_id,
+        bucket=args.bucket,
+        source_uri=args.source_uri,
+        max_iterations=args.max_iterations,
+        success_threshold=args.success_threshold,
+        dry_run=args.controller_dry_run,
+    )
+    rendered = _write_rendered_yaml(docs, run_id=run_id)
+    summary = {
+        "run_id": run_id,
+        "rendered_yaml": str(rendered),
+        "outputs": output_paths(run_id, bucket=args.bucket),
+    }
+    if args.render_only:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+
+    try:
+        sky_bin = str(resolve_sky_bin(args.sky_bin or os.environ.get("NPA_SKYPILOT_BIN")))
+        result = submit_workflow(
+            rendered,
+            run_id,
+            isolated_config_dir=args.isolated_config_dir,
+            sky_bin=sky_bin,
+            timeout=args.submit_timeout,
+        )
+    except (SkyPilotNotInstalledError, SkyPilotConfigError, SkyPilotVersionError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    summary["submit"] = result.__dict__ if isinstance(result, WorkflowResult) else result
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if getattr(result, "ok", False) else 1
+
+
+def render_workflow(
+    yaml_path: Path,
+    *,
+    run_id: str,
+    bucket: str = DEFAULT_BUCKET,
+    source_uri: str = DEFAULT_SOURCE,
+    max_iterations: int = 3,
+    success_threshold: float = 0.8,
+    dry_run: bool = False,
+) -> list[dict[str, Any]]:
+    """Return SkyPilot YAML documents with run-scoped S3 paths injected."""
+    docs = _load_yaml_documents(yaml_path)
+    root_uri = f"s3://{bucket}/sereact-sim-to-real/{run_id}"
+    for doc in docs:
+        envs = doc.get("envs") if isinstance(doc, dict) else None
+        if not isinstance(envs, dict):
+            continue
+        envs.update(
+            {
+                "NPA_PIPELINE_RUN_ID": run_id,
+                "S3_BUCKET": bucket,
+                "PIPELINE_ROOT_URI": root_uri,
+                "SEREACT_SOURCE_URI": source_uri,
+                "SEREACT_OUTPUT_URI": f"{root_uri}/",
+                "SEREACT_MAX_ITERATIONS": str(max_iterations),
+                "SEREACT_SUCCESS_THRESHOLD": str(success_threshold),
+                "NPA_DRY_RUN": "1" if dry_run else "0",
+            }
+        )
+    return docs
+
+
+def output_paths(run_id: str, *, bucket: str = DEFAULT_BUCKET) -> dict[str, str]:
+    root = f"s3://{bucket}/sereact-sim-to-real/{run_id}"
+    return {
+        "root": f"{root}/",
+        "imported_data": f"{root}/iter-*/imported-data/",
+        "cosmos_candidates": f"{root}/iter-*/cosmos-candidates/",
+        "vlm_eval": f"{root}/iter-*/vlm-eval/",
+    }
+
+
+def _write_rendered_yaml(docs: list[dict[str, Any]], *, run_id: str) -> Path:
+    tmp = Path(tempfile.mkdtemp(prefix=f"npa-sereact-sim2real-{run_id}-"))
+    path = tmp / "sim-to-real-loop.rendered.yaml"
+    path.write_text(yaml.safe_dump_all(docs, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _load_yaml_documents(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        docs = [doc for doc in yaml.safe_load_all(handle) if doc is not None]
+    if not all(isinstance(doc, dict) for doc in docs):
+        raise ValueError(f"SkyPilot YAML documents must be mappings: {path}")
+    return docs
+
+
+def _default_run_id() -> str:
+    return "sereact-sim2real-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--yaml-path", "--yaml", dest="yaml_path", type=Path, default=DEFAULT_YAML)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--source-uri", default=DEFAULT_SOURCE)
+    parser.add_argument("--max-iterations", type=int, default=3)
+    parser.add_argument("--success-threshold", type=float, default=0.8)
+    parser.add_argument("--controller-dry-run", action="store_true")
+    parser.add_argument("--render-only", action="store_true")
+    parser.add_argument("--sky-bin", default="")
+    parser.add_argument("--isolated-config-dir", type=Path, default=None)
+    parser.add_argument("--submit-timeout", type=int, default=1800)
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/npa/src/npa/cli/cosmos/__init__.py
+++ b/npa/src/npa/cli/cosmos/__init__.py
@@ -1447,6 +1447,107 @@ def _deploy_serverless_endpoint(
     _output(result, output)
 
 
+@app.command("autoscale")
+def autoscale_cmd(
+    min_replicas: int = typer.Option(
+        1,
+        "--min-replicas",
+        help="Minimum serverless endpoint replicas.",
+    ),
+    max_replicas: int = typer.Option(
+        4,
+        "--max-replicas",
+        help="Maximum serverless endpoint replicas for parallel Cosmos inference.",
+    ),
+    target_concurrency: int = typer.Option(
+        0,
+        "--target-concurrency",
+        help="Optional target concurrent requests per replica.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show the autoscale plan only."),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Configure Cosmos serverless endpoint autoscaling."""
+    if min_replicas < 0:
+        _fail(f"--min-replicas must be non-negative, got {min_replicas}")
+    if max_replicas < 1:
+        _fail(f"--max-replicas must be positive, got {max_replicas}")
+    if max_replicas < min_replicas:
+        _fail("--max-replicas must be greater than or equal to --min-replicas")
+    if target_concurrency < 0:
+        _fail(f"--target-concurrency must be non-negative, got {target_concurrency}")
+
+    cfg = _get_config()
+    if not is_serverless_runtime(getattr(cfg, "runtime", "")):
+        _fail("Cosmos autoscale requires a --runtime serverless endpoint alias.")
+    project_id = _serverless_project_id(cfg)
+    endpoint_ref = _serverless_endpoint_ref(cfg)
+    if not project_id or not endpoint_ref:
+        _fail("Cosmos autoscale requires saved serverless project and endpoint metadata.")
+
+    plan = {
+        "project": getattr(cfg, "project", ""),
+        "name": getattr(cfg, "name", ""),
+        "runtime": "serverless",
+        "serverless_project_id": project_id,
+        "endpoint": endpoint_ref,
+        "min_replicas": min_replicas,
+        "max_replicas": max_replicas,
+        "target_concurrency": target_concurrency,
+    }
+    if dry_run or _env_dry_run():
+        _output({"status": "dry_run", **plan}, output)
+        return
+
+    try:
+        info = ServerlessClient().set_endpoint_autoscale(
+            project_id,
+            endpoint_ref,
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+            target_concurrency=target_concurrency,
+        )
+    except ServerlessClientError as exc:
+        _fail_serverless(exc, output)
+        return
+
+    write_config(
+        {
+            "projects": {
+                getattr(cfg, "project", ""): {
+                    "workbenches": {
+                        getattr(cfg, "name", ""): {
+                            "serverless": {
+                                "autoscale": {
+                                    "min_replicas": min_replicas,
+                                    "max_replicas": max_replicas,
+                                    "target_concurrency": target_concurrency,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    )
+    _output(
+        {
+            "status": "configured",
+            **plan,
+            "endpoint_id": info.id,
+            "endpoint_name": info.name,
+            "serverless_status": info.status.value,
+        },
+        output,
+    )
+
+
+def _env_dry_run() -> bool:
+    return os.environ.get("NPA_DRY_RUN", "").lower() in {"1", "true", "yes"} or os.environ.get(
+        "DRY_RUN", ""
+    ).lower() in {"1", "true", "yes"}
+
+
 def _read_existing_outputs(
     proj_alias: str,
     wb_name: str,

--- a/npa/src/npa/cli/workbench/__init__.py
+++ b/npa/src/npa/cli/workbench/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import typer
 
 from npa.clients.credentials import load_credentials
+from npa.cli.workbench.data import app as data_app
 from npa.cli.workbench.lerobot import app as lerobot_app
 from npa.cli.cosmos import app as cosmos_app
 from npa.cli.fiftyone import app as fiftyone_app
@@ -14,6 +15,7 @@ from npa.cli.isaac_lab import app as isaac_lab_app
 from npa.cli.workbench.sonic import app as sonic_app
 from npa.cli.workbench.lancedb import app as lancedb_app
 from npa.cli.workbench.detection_training import app as detection_training_app
+from npa.cli.workbench.vlm_eval import app as vlm_eval_app
 from npa.cli.workbench.workflow import app as workflow_app
 
 app = typer.Typer(
@@ -33,6 +35,7 @@ def main() -> None:
 
 
 app.add_typer(lerobot_app, name="lerobot")
+app.add_typer(data_app, name="data")
 app.add_typer(cosmos_app, name="cosmos")
 app.add_typer(fiftyone_app, name="fiftyone")
 app.add_typer(genesis_app, name="genesis")
@@ -41,4 +44,5 @@ app.add_typer(isaac_lab_app, name="isaac-lab")
 app.add_typer(sonic_app, name="sonic")
 app.add_typer(lancedb_app, name="lancedb")
 app.add_typer(detection_training_app, name="detection-training")
+app.add_typer(vlm_eval_app, name="vlm-eval")
 app.add_typer(workflow_app, name="workflow")

--- a/npa/src/npa/cli/workbench/data.py
+++ b/npa/src/npa/cli/workbench/data.py
@@ -1,0 +1,192 @@
+"""npa workbench data - S3 data bridge commands."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from enum import Enum
+from typing import Any
+
+import typer
+from rich.console import Console
+
+from npa.clients.project_credentials import s3_client_for_project
+from npa.errors import ScopedCredentialError
+from npa.workbench.data import (
+    DataBridgeError,
+    list_s3_objects,
+    status_s3_prefix,
+    sync_s3_prefix,
+)
+
+app = typer.Typer(
+    name="data",
+    help="S3 data import bridge for Workbench pipelines.",
+    no_args_is_help=True,
+)
+console = Console(stderr=True)
+
+_project_alias = ""
+
+
+class OutputFormat(str, Enum):
+    text = "text"
+    json = "json"
+
+
+@app.callback()
+def main(
+    project: str = typer.Option(
+        "",
+        "--project",
+        "-p",
+        help="Default project alias for S3 credentials.",
+    ),
+) -> None:
+    """S3 data import bridge for Workbench pipelines."""
+    global _project_alias
+    _project_alias = project
+
+
+@app.command("sync")
+def sync_cmd(
+    input_path: str = typer.Option(
+        ...,
+        "--input-path",
+        "--source-uri",
+        "--source",
+        help="Source S3 URI or prefix.",
+    ),
+    output_path: str = typer.Option(
+        ...,
+        "--output-path",
+        "--destination-uri",
+        "--destination",
+        help="Destination S3 URI or prefix.",
+    ),
+    source_project: str = typer.Option(
+        "",
+        "--source-project",
+        help="Project alias for source S3 credentials. Defaults to --project.",
+    ),
+    target_project: str = typer.Option(
+        "",
+        "--target-project",
+        help="Project alias for target S3 credentials. Defaults to --project.",
+    ),
+    allow_host_creds: bool = typer.Option(
+        False,
+        "--allow-host-creds",
+        help="Allow host S3 credentials when scoped project credentials are absent.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Plan the sync without writing destination objects.",
+    ),
+    limit: int = typer.Option(0, "--limit", help="Maximum objects to process; 0 means all."),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Copy S3 objects between pipeline prefixes."""
+    effective_dry_run = dry_run or _env_dry_run()
+    src_project = source_project or _project_alias or None
+    dst_project = target_project or _project_alias or None
+    try:
+        source_s3 = s3_client_for_project(src_project, allow_host_creds=allow_host_creds)
+        target_s3 = s3_client_for_project(dst_project, allow_host_creds=allow_host_creds)
+        result = sync_s3_prefix(
+            input_path,
+            output_path,
+            source_s3_client=source_s3,
+            target_s3_client=target_s3,
+            dry_run=effective_dry_run,
+            limit=limit,
+        )
+    except (DataBridgeError, ScopedCredentialError) as exc:
+        _fail(str(exc))
+        return
+    _emit(asdict(result), output)
+
+
+@app.command("status")
+def status_cmd(
+    input_path: str = typer.Option(
+        ...,
+        "--input-path",
+        "--uri",
+        help="S3 URI or prefix to inspect.",
+    ),
+    project: str = typer.Option(
+        "",
+        "--source-project",
+        help="Project alias for S3 credentials. Defaults to --project.",
+    ),
+    allow_host_creds: bool = typer.Option(
+        False,
+        "--allow-host-creds",
+        help="Allow host S3 credentials when scoped project credentials are absent.",
+    ),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Show object count and bytes for an S3 prefix."""
+    try:
+        s3 = s3_client_for_project(project or _project_alias or None, allow_host_creds=allow_host_creds)
+        payload = status_s3_prefix(input_path, s3_client=s3)
+    except (DataBridgeError, ScopedCredentialError) as exc:
+        _fail(str(exc))
+        return
+    _emit(payload, output)
+
+
+@app.command("list")
+def list_cmd(
+    input_path: str = typer.Option(
+        ...,
+        "--input-path",
+        "--uri",
+        help="S3 URI or prefix to list.",
+    ),
+    project: str = typer.Option(
+        "",
+        "--source-project",
+        help="Project alias for S3 credentials. Defaults to --project.",
+    ),
+    allow_host_creds: bool = typer.Option(
+        False,
+        "--allow-host-creds",
+        help="Allow host S3 credentials when scoped project credentials are absent.",
+    ),
+    limit: int = typer.Option(100, "--limit", help="Maximum objects to print; 0 means all."),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """List S3 objects under a Workbench data prefix."""
+    try:
+        s3 = s3_client_for_project(project or _project_alias or None, allow_host_creds=allow_host_creds)
+        objects = list_s3_objects(input_path, s3_client=s3, limit=limit)
+    except (DataBridgeError, ScopedCredentialError) as exc:
+        _fail(str(exc))
+        return
+    _emit({"uri": input_path, "objects": [asdict(item) for item in objects]}, output)
+
+
+def _env_dry_run() -> bool:
+    return os.environ.get("NPA_DRY_RUN", "").lower() in {"1", "true", "yes"} or os.environ.get(
+        "DRY_RUN", ""
+    ).lower() in {"1", "true", "yes"}
+
+
+def _emit(payload: dict[str, Any], output: OutputFormat) -> None:
+    if output == OutputFormat.json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    for key, value in payload.items():
+        if key in {"copied", "objects", "sample"}:
+            typer.echo(f"  {key}: {len(value)}")
+        else:
+            typer.echo(f"  {key}: {value}")
+
+
+def _fail(message: str) -> None:
+    console.print(f"[red]Error:[/red] {message}")
+    raise typer.Exit(1)

--- a/npa/src/npa/cli/workbench/vlm_eval.py
+++ b/npa/src/npa/cli/workbench/vlm_eval.py
@@ -1,0 +1,109 @@
+"""npa workbench vlm-eval - stub VLM evaluation commands."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from enum import Enum
+from typing import Any
+
+import typer
+from rich.console import Console
+
+from npa.workbench.vlm_eval import VlmEvalError, evaluate_stub, write_result
+
+app = typer.Typer(
+    name="vlm-eval",
+    help="Stub VLM evaluation for sim-to-real pipeline gating.",
+    no_args_is_help=True,
+)
+console = Console(stderr=True)
+
+
+class OutputFormat(str, Enum):
+    text = "text"
+    json = "json"
+
+
+@app.command("run")
+def run_cmd(
+    input_path: str = typer.Option(..., "--input-path", help="S3 or local artifact path to score."),
+    output_path: str = typer.Option(..., "--output-path", help="S3 or local path for eval JSON."),
+    task: str = typer.Option("sereact-sim-to-real", "--task", help="Evaluation task label."),
+    model: str = typer.Option("vlm-eval-stub", "--model", help="Stub model label."),
+    success_threshold: float = typer.Option(
+        0.8,
+        "--success-threshold",
+        help="Score threshold required to pass.",
+    ),
+    score: float = typer.Option(
+        -1.0,
+        "--score",
+        help="Override stub score for tests and controller loops.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Do not write the result artifact."),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Produce deterministic stub VLM metrics for a pipeline artifact."""
+    try:
+        result = evaluate_stub(
+            input_path=input_path,
+            output_path=output_path,
+            task=task,
+            model=model,
+            success_threshold=success_threshold,
+            score=None if score < 0 else score,
+        )
+        payload = asdict(result)
+        effective_dry_run = dry_run or _env_dry_run()
+        payload["dry_run"] = effective_dry_run
+        if not effective_dry_run:
+            payload["written_uri"] = write_result(payload, result_uri=result.result_uri)
+    except VlmEvalError as exc:
+        _fail(str(exc))
+        return
+    _emit(payload, output)
+
+
+@app.command("status")
+def status_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Show stub backend status."""
+    _emit(
+        {
+            "backend": "stub",
+            "status": "available",
+            "real_vlm_backend": False,
+            "message": "VLM eval is a schema-compatible stub.",
+        },
+        output,
+    )
+
+
+@app.command("list")
+def list_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """List available VLM eval backends."""
+    _emit({"backends": [{"name": "stub", "real_backend": False}]}, output)
+
+
+def _emit(payload: dict[str, Any], output: OutputFormat) -> None:
+    if output == OutputFormat.json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    for key, value in payload.items():
+        typer.echo(f"  {key}: {value}")
+
+
+def _env_dry_run() -> bool:
+    return os.environ.get("NPA_DRY_RUN", "").lower() in {"1", "true", "yes"} or os.environ.get(
+        "DRY_RUN", ""
+    ).lower() in {"1", "true", "yes"}
+
+
+def _fail(message: str) -> None:
+    console.print(f"[red]Error:[/red] {message}")
+    raise typer.Exit(1)

--- a/npa/src/npa/clients/serverless.py
+++ b/npa/src/npa/clients/serverless.py
@@ -8,7 +8,6 @@ from datetime import datetime, timezone
 from enum import Enum
 import json
 import logging
-import os
 import re
 import shutil
 import shlex
@@ -675,6 +674,40 @@ class ServerlessClient:
         if result.returncode != 0:
             self._raise_for_error(result, f"start_endpoint failed for {endpoint}")
         return self._parse_endpoint_info(result.stdout, project_id=project_id)
+
+    def set_endpoint_autoscale(
+        self,
+        project_id: str,
+        endpoint: str,
+        *,
+        min_replicas: int,
+        max_replicas: int,
+        target_concurrency: int = 0,
+    ) -> EndpointInfo:
+        """Update endpoint replica bounds for serverless autoscaling."""
+        info = self.get_endpoint(project_id, endpoint)
+        args = [
+            "ai",
+            "endpoint",
+            "update",
+            "--id",
+            info.id,
+            "--min-replicas",
+            str(min_replicas),
+            "--max-replicas",
+            str(max_replicas),
+        ]
+        if target_concurrency:
+            args.extend(["--target-concurrency", str(target_concurrency)])
+        args.extend(["--format", "json"])
+        result = self._run(args)
+        if result.returncode != 0:
+            self._raise_for_error(result, f"set_endpoint_autoscale failed for {endpoint}")
+        try:
+            parsed = self._parse_endpoint_info(result.stdout, project_id=project_id)
+        except json.JSONDecodeError:
+            parsed = EndpointInfo(id="", name="", project_id=project_id)
+        return parsed if parsed.id or parsed.name else self.get_endpoint(project_id, info.id)
 
     def get_endpoint_logs(
         self,

--- a/npa/src/npa/sdk/workbench/__init__.py
+++ b/npa/src/npa/sdk/workbench/__init__.py
@@ -4,6 +4,6 @@ from __future__ import annotations
 
 from npa.workbench import lancedb
 
-from . import detection_training
+from . import data, detection_training, vlm_eval
 
-__all__ = ["detection_training", "lancedb"]
+__all__ = ["data", "detection_training", "lancedb", "vlm_eval"]

--- a/npa/src/npa/sdk/workbench/data.py
+++ b/npa/src/npa/sdk/workbench/data.py
@@ -1,0 +1,11 @@
+"""SDK wrappers for the Workbench data bridge CLI."""
+
+from __future__ import annotations
+
+from npa._sdk import make_cli_wrapper
+
+sync = make_cli_wrapper("npa.cli.workbench.data", "sync_cmd", "Sync S3 data prefixes.")
+status = make_cli_wrapper("npa.cli.workbench.data", "status_cmd", "Show data prefix status.")
+list = make_cli_wrapper("npa.cli.workbench.data", "list_cmd", "List data prefix objects.")
+
+__all__ = ["list", "status", "sync"]

--- a/npa/src/npa/sdk/workbench/vlm_eval.py
+++ b/npa/src/npa/sdk/workbench/vlm_eval.py
@@ -1,0 +1,11 @@
+"""SDK wrappers for the Workbench VLM eval stub CLI."""
+
+from __future__ import annotations
+
+from npa._sdk import make_cli_wrapper
+
+run = make_cli_wrapper("npa.cli.workbench.vlm_eval", "run_cmd", "Run stub VLM evaluation.")
+status = make_cli_wrapper("npa.cli.workbench.vlm_eval", "status_cmd", "Show VLM eval status.")
+list = make_cli_wrapper("npa.cli.workbench.vlm_eval", "list_cmd", "List VLM eval backends.")
+
+__all__ = ["list", "run", "status"]

--- a/npa/src/npa/solutions/solutions.toml
+++ b/npa/src/npa/solutions/solutions.toml
@@ -3,3 +3,8 @@
 name = "workbench"
 description = "First solution: physical AI robotics workflows built on Nebius infrastructure"
 cli_command = "npa workbench"
+
+[[solutions]]
+name = "sereact-sim-to-real"
+description = "Sereact sim-to-real pipeline tools within the Workbench solution"
+cli_command = "npa workbench workflow submit npa/workflows/workbench/skypilot/sim-to-real-loop.yaml"

--- a/npa/src/npa/workbench/__init__.py
+++ b/npa/src/npa/workbench/__init__.py
@@ -2,6 +2,28 @@
 
 from __future__ import annotations
 
-from npa.workbench import cosmos, detection_training, fiftyone, genesis, groot, isaac_lab, lancedb, lerobot
+from npa.workbench import (
+    cosmos,
+    data,
+    detection_training,
+    fiftyone,
+    genesis,
+    groot,
+    isaac_lab,
+    lancedb,
+    lerobot,
+    vlm_eval,
+)
 
-__all__ = ["cosmos", "detection_training", "fiftyone", "genesis", "groot", "isaac_lab", "lancedb", "lerobot"]
+__all__ = [
+    "cosmos",
+    "data",
+    "detection_training",
+    "fiftyone",
+    "genesis",
+    "groot",
+    "isaac_lab",
+    "lancedb",
+    "lerobot",
+    "vlm_eval",
+]

--- a/npa/src/npa/workbench/cosmos/__init__.py
+++ b/npa/src/npa/workbench/cosmos/__init__.py
@@ -12,6 +12,9 @@ register_byovm = make_cli_wrapper(
 )
 list = make_cli_wrapper("npa.cli.cosmos", "list_cmd", "List Cosmos workbenches.")
 deploy = make_cli_wrapper("npa.cli.cosmos", "deploy_cmd", "Deploy a Cosmos workbench.")
+autoscale = make_cli_wrapper(
+    "npa.cli.cosmos", "autoscale_cmd", "Configure Cosmos serverless autoscaling."
+)
 serve = make_cli_wrapper("npa.cli.cosmos", "serve_cmd", "Serve a Cosmos model.")
 finetune = make_cli_wrapper("npa.cli.cosmos", "finetune_cmd", "Run Cosmos finetuning.")
 optimize = make_cli_wrapper("npa.cli.cosmos", "optimize_cmd", "Run Cosmos optimization.")
@@ -26,6 +29,7 @@ __all__ = [
     "register_byovm",
     "list",
     "deploy",
+    "autoscale",
     "serve",
     "finetune",
     "optimize",

--- a/npa/src/npa/workbench/data/__init__.py
+++ b/npa/src/npa/workbench/data/__init__.py
@@ -1,0 +1,224 @@
+"""S3 data bridge helpers for Workbench pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+
+class DataBridgeError(ValueError):
+    """Raised when a Workbench data bridge operation is invalid."""
+
+
+@dataclass(frozen=True)
+class DataObject:
+    uri: str
+    bucket: str
+    key: str
+    size_bytes: int = 0
+    last_modified: str = ""
+
+
+@dataclass(frozen=True)
+class DataSyncResult:
+    status: str
+    source_uri: str
+    output_path: str
+    dry_run: bool
+    object_count: int
+    bytes_total: int
+    copied: list[dict[str, Any]]
+    generated_at: str
+
+
+__all__ = [
+    "DataObject",
+    "DataSyncResult",
+    "list_s3_objects",
+    "parse_s3_uri",
+    "status_s3_prefix",
+    "sync_s3_prefix",
+]
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Parse an S3 URI into bucket and key/prefix."""
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise DataBridgeError(f"Expected an s3:// URI, got: {uri}")
+    return parsed.netloc, parsed.path.lstrip("/")
+
+
+def list_s3_objects(
+    uri: str,
+    *,
+    s3_client: Any,
+    limit: int = 0,
+) -> list[DataObject]:
+    """List S3 objects under a URI prefix."""
+    if limit < 0:
+        raise DataBridgeError(f"limit must be non-negative, got {limit}")
+    bucket, prefix = parse_s3_uri(uri)
+    objects: list[DataObject] = []
+    for item in _iter_s3_objects(s3_client, bucket=bucket, prefix=prefix):
+        objects.append(_object_from_item(bucket, item))
+        if limit and len(objects) >= limit:
+            break
+    return objects
+
+
+def status_s3_prefix(uri: str, *, s3_client: Any, sample_limit: int = 10) -> dict[str, Any]:
+    """Return a compact status payload for an S3 prefix."""
+    objects = list_s3_objects(uri, s3_client=s3_client)
+    sample = [asdict(item) for item in objects[:sample_limit]]
+    return {
+        "uri": uri,
+        "status": "available" if objects else "empty",
+        "object_count": len(objects),
+        "bytes_total": sum(item.size_bytes for item in objects),
+        "sample": sample,
+        "generated_at": _now_iso(),
+    }
+
+
+def sync_s3_prefix(
+    source_uri: str,
+    output_path: str,
+    *,
+    source_s3_client: Any,
+    target_s3_client: Any | None = None,
+    dry_run: bool = False,
+    limit: int = 0,
+) -> DataSyncResult:
+    """Copy objects from one S3 prefix to another, preserving relative keys."""
+    source_bucket, source_prefix = parse_s3_uri(source_uri)
+    target_bucket, target_prefix = parse_s3_uri(output_path)
+    target_client = target_s3_client or source_s3_client
+    objects = list_s3_objects(source_uri, s3_client=source_s3_client, limit=limit)
+    copied: list[dict[str, Any]] = []
+
+    for obj in objects:
+        relative_key = _relative_key(obj.key, source_prefix)
+        target_key = _join_s3_key(target_prefix, relative_key)
+        target_uri = f"s3://{target_bucket}/{target_key}"
+        if not dry_run:
+            _copy_object(
+                source_s3_client=source_s3_client,
+                target_s3_client=target_client,
+                source_bucket=source_bucket,
+                source_key=obj.key,
+                target_bucket=target_bucket,
+                target_key=target_key,
+            )
+        copied.append(
+            {
+                "source_uri": obj.uri,
+                "target_uri": target_uri,
+                "size_bytes": obj.size_bytes,
+            }
+        )
+
+    return DataSyncResult(
+        status="dry_run" if dry_run else "synced",
+        source_uri=source_uri,
+        output_path=output_path,
+        dry_run=dry_run,
+        object_count=len(objects),
+        bytes_total=sum(item.size_bytes for item in objects),
+        copied=copied,
+        generated_at=_now_iso(),
+    )
+
+
+def _iter_s3_objects(s3_client: Any, *, bucket: str, prefix: str):
+    if hasattr(s3_client, "get_paginator"):
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            yield from page.get("Contents", [])
+        return
+
+    token = None
+    while True:
+        kwargs = {"Bucket": bucket, "Prefix": prefix}
+        if token:
+            kwargs["ContinuationToken"] = token
+        page = s3_client.list_objects_v2(**kwargs)
+        yield from page.get("Contents", [])
+        if not page.get("IsTruncated"):
+            return
+        token = page.get("NextContinuationToken")
+        if not token:
+            return
+
+
+def _object_from_item(bucket: str, item: dict[str, Any]) -> DataObject:
+    key = str(item.get("Key", ""))
+    last_modified = item.get("LastModified", "")
+    if isinstance(last_modified, datetime):
+        last_modified_text = last_modified.astimezone(timezone.utc).isoformat()
+    else:
+        last_modified_text = str(last_modified or "")
+    return DataObject(
+        uri=f"s3://{bucket}/{key}",
+        bucket=bucket,
+        key=key,
+        size_bytes=int(item.get("Size") or 0),
+        last_modified=last_modified_text,
+    )
+
+
+def _relative_key(key: str, source_prefix: str) -> str:
+    if not source_prefix:
+        return key
+    if source_prefix.endswith("/") and key.startswith(source_prefix):
+        return key[len(source_prefix):]
+    source_dir = source_prefix.rstrip("/") + "/"
+    if key.startswith(source_dir):
+        return key[len(source_dir):]
+    if key == source_prefix:
+        return key.rsplit("/", 1)[-1]
+    return key
+
+
+def _join_s3_key(prefix: str, relative_key: str) -> str:
+    clean_relative = relative_key.lstrip("/")
+    if not clean_relative:
+        raise DataBridgeError("Cannot sync an object with an empty relative key")
+    clean_prefix = prefix.strip("/")
+    if not clean_prefix:
+        return clean_relative
+    return f"{clean_prefix}/{clean_relative}"
+
+
+def _copy_object(
+    *,
+    source_s3_client: Any,
+    target_s3_client: Any,
+    source_bucket: str,
+    source_key: str,
+    target_bucket: str,
+    target_key: str,
+) -> None:
+    if source_s3_client is target_s3_client and hasattr(target_s3_client, "copy_object"):
+        target_s3_client.copy_object(
+            Bucket=target_bucket,
+            Key=target_key,
+            CopySource={"Bucket": source_bucket, "Key": source_key},
+        )
+        return
+
+    response = source_s3_client.get_object(Bucket=source_bucket, Key=source_key)
+    body = response["Body"].read()
+    metadata = dict(response.get("Metadata") or {})
+    target_s3_client.put_object(
+        Bucket=target_bucket,
+        Key=target_key,
+        Body=body,
+        Metadata=metadata,
+    )
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/npa/src/npa/workbench/vlm_eval/__init__.py
+++ b/npa/src/npa/workbench/vlm_eval/__init__.py
@@ -1,0 +1,113 @@
+"""Stub VLM evaluation helpers for sim-to-real pipeline validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from npa.clients.storage import StorageClient
+
+
+class VlmEvalError(ValueError):
+    """Raised when a VLM evaluation request is invalid."""
+
+
+@dataclass(frozen=True)
+class VlmEvalResult:
+    status: str
+    backend: str
+    input_path: str
+    output_path: str
+    result_uri: str
+    task: str
+    model: str
+    score: float
+    success_threshold: float
+    passed: bool
+    generated_at: str
+
+
+__all__ = [
+    "VlmEvalResult",
+    "evaluate_stub",
+    "result_uri_for",
+    "write_result",
+]
+
+
+def evaluate_stub(
+    *,
+    input_path: str,
+    output_path: str,
+    task: str = "sereact-sim-to-real",
+    model: str = "vlm-eval-stub",
+    success_threshold: float = 0.8,
+    score: float | None = None,
+) -> VlmEvalResult:
+    """Return deterministic stub metrics without calling a VLM backend."""
+    if not input_path:
+        raise VlmEvalError("input_path is required")
+    if not output_path:
+        raise VlmEvalError("output_path is required")
+    if not 0.0 <= success_threshold <= 1.0:
+        raise VlmEvalError("--success-threshold must be between 0 and 1")
+    effective_score = _deterministic_score(input_path, task, model) if score is None else score
+    if not 0.0 <= effective_score <= 1.0:
+        raise VlmEvalError("--score must be between 0 and 1")
+    passed = effective_score >= success_threshold
+    return VlmEvalResult(
+        status="passed" if passed else "needs_iteration",
+        backend="stub",
+        input_path=input_path,
+        output_path=output_path,
+        result_uri=result_uri_for(output_path),
+        task=task,
+        model=model,
+        score=round(effective_score, 4),
+        success_threshold=success_threshold,
+        passed=passed,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def result_uri_for(output_path: str) -> str:
+    """Return the JSON artifact URI for an output path."""
+    if output_path.endswith(".json"):
+        return output_path
+    return output_path.rstrip("/") + "/vlm_eval_stub.json"
+
+
+def write_result(
+    payload: dict[str, Any],
+    *,
+    result_uri: str,
+    storage_client: "StorageClient | None" = None,
+) -> str:
+    """Write a VLM stub result to local disk or S3."""
+    body = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if result_uri.startswith("s3://"):
+        from npa.clients.storage import StorageClient
+
+        client = storage_client or StorageClient.from_environment()
+        with tempfile.TemporaryDirectory(prefix="npa-vlm-eval-") as tmp:
+            local_path = Path(tmp) / "vlm_eval_stub.json"
+            local_path.write_text(body, encoding="utf-8")
+            return client.upload_file(str(local_path), result_uri)
+
+    path = Path(result_uri)
+    if path.suffix != ".json":
+        path = path / "vlm_eval_stub.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+def _deterministic_score(*parts: str) -> float:
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) / 0xFFFFFFFF

--- a/npa/src/npa/workflows/sereact_sim_to_real.py
+++ b/npa/src/npa/workflows/sereact_sim_to_real.py
@@ -1,0 +1,259 @@
+"""Controller-loop helpers for the Sereact sim-to-real SkyPilot workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class ControllerSettings:
+    run_id: str
+    input_path: str
+    output_path: str
+    max_iterations: int = 3
+    success_threshold: float = 0.8
+    dry_run: bool = True
+    cosmos_prompt: str = "Generate sim augmentation candidates for Sereact grasp policy gaps."
+
+
+@dataclass(frozen=True)
+class ControllerStep:
+    iteration: int
+    stage: str
+    command: list[str]
+    output_path: str
+
+
+@dataclass(frozen=True)
+class ControllerResult:
+    status: str
+    run_id: str
+    dry_run: bool
+    iterations_planned: int
+    steps: list[dict[str, Any]]
+    generated_at: str
+
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def build_iteration_steps(settings: ControllerSettings, iteration: int) -> list[ControllerStep]:
+    """Build the command plan for one controller-loop iteration."""
+    if iteration < 1:
+        raise ValueError("iteration must be positive")
+    root = settings.output_path.rstrip("/")
+    imported = f"{root}/iter-{iteration:02d}/imported-data/"
+    cosmos_out = f"{root}/iter-{iteration:02d}/cosmos-candidates/"
+    eval_out = f"{root}/iter-{iteration:02d}/vlm-eval/"
+    return [
+        ControllerStep(
+            iteration=iteration,
+            stage="data_import",
+            command=[
+                "npa",
+                "workbench",
+                "data",
+                "sync",
+                "--input-path",
+                settings.input_path,
+                "--output-path",
+                imported,
+                "--output",
+                "json",
+            ],
+            output_path=imported,
+        ),
+        ControllerStep(
+            iteration=iteration,
+            stage="cosmos_generate",
+            command=[
+                "npa",
+                "workbench",
+                "cosmos",
+                "infer",
+                "--prompt",
+                settings.cosmos_prompt,
+                "--input-path",
+                imported,
+                "--output-path",
+                cosmos_out,
+                "--output",
+                "json",
+            ],
+            output_path=cosmos_out,
+        ),
+        ControllerStep(
+            iteration=iteration,
+            stage="vlm_eval",
+            command=[
+                "npa",
+                "workbench",
+                "vlm-eval",
+                "run",
+                "--input-path",
+                cosmos_out,
+                "--output-path",
+                eval_out,
+                "--success-threshold",
+                str(settings.success_threshold),
+                "--output",
+                "json",
+            ],
+            output_path=eval_out,
+        ),
+    ]
+
+
+def build_controller_plan(settings: ControllerSettings) -> ControllerResult:
+    """Return the full controller plan without executing commands."""
+    _validate_settings(settings)
+    steps = [
+        asdict(step)
+        for iteration in range(1, settings.max_iterations + 1)
+        for step in build_iteration_steps(settings, iteration)
+    ]
+    return ControllerResult(
+        status="planned",
+        run_id=settings.run_id,
+        dry_run=True,
+        iterations_planned=settings.max_iterations,
+        steps=steps,
+        generated_at=_now_iso(),
+    )
+
+
+def run_controller(
+    settings: ControllerSettings,
+    *,
+    runner: CommandRunner = subprocess.run,
+) -> ControllerResult:
+    """Run the controller loop or return the dry-run plan."""
+    _validate_settings(settings)
+    if settings.dry_run:
+        return build_controller_plan(settings)
+
+    executed: list[dict[str, Any]] = []
+    for iteration in range(1, settings.max_iterations + 1):
+        for step in build_iteration_steps(settings, iteration):
+            result = runner(
+                step.command,
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            record = asdict(step)
+            record.update(
+                {
+                    "returncode": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                }
+            )
+            executed.append(record)
+            if result.returncode != 0:
+                return ControllerResult(
+                    status="failed",
+                    run_id=settings.run_id,
+                    dry_run=False,
+                    iterations_planned=iteration,
+                    steps=executed,
+                    generated_at=_now_iso(),
+                )
+        if _last_vlm_step_passed(executed):
+            return ControllerResult(
+                status="succeeded",
+                run_id=settings.run_id,
+                dry_run=False,
+                iterations_planned=iteration,
+                steps=executed,
+                generated_at=_now_iso(),
+            )
+    return ControllerResult(
+        status="needs_iteration",
+        run_id=settings.run_id,
+        dry_run=False,
+        iterations_planned=settings.max_iterations,
+        steps=executed,
+        generated_at=_now_iso(),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    settings = ControllerSettings(
+        run_id=args.run_id,
+        input_path=args.input_path,
+        output_path=args.output_path,
+        max_iterations=args.max_iterations,
+        success_threshold=args.success_threshold,
+        dry_run=args.dry_run or _env_dry_run(),
+        cosmos_prompt=args.cosmos_prompt,
+    )
+    try:
+        result = run_controller(settings)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+    if result.status in {"failed", "needs_iteration"}:
+        return 1
+    return 0
+
+
+def _validate_settings(settings: ControllerSettings) -> None:
+    if not settings.run_id:
+        raise ValueError("run_id is required")
+    if not settings.input_path.startswith("s3://"):
+        raise ValueError("input_path must be an s3:// URI")
+    if not settings.output_path.startswith("s3://"):
+        raise ValueError("output_path must be an s3:// URI")
+    if settings.max_iterations < 1:
+        raise ValueError("max_iterations must be positive")
+    if not 0.0 <= settings.success_threshold <= 1.0:
+        raise ValueError("success_threshold must be between 0 and 1")
+
+
+def _last_vlm_step_passed(executed: list[dict[str, Any]]) -> bool:
+    for step in reversed(executed):
+        if step.get("stage") != "vlm_eval":
+            continue
+        try:
+            payload = json.loads(str(step.get("stdout") or "{}"))
+        except json.JSONDecodeError:
+            return False
+        return bool(payload.get("passed"))
+    return False
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--input-path", required=True)
+    parser.add_argument("--output-path", required=True)
+    parser.add_argument("--max-iterations", type=int, default=3)
+    parser.add_argument("--success-threshold", type=float, default=0.8)
+    parser.add_argument("--cosmos-prompt", default=ControllerSettings.cosmos_prompt)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _env_dry_run() -> bool:
+    return os.environ.get("NPA_DRY_RUN", "").lower() in {"1", "true", "yes"} or os.environ.get(
+        "DRY_RUN", ""
+    ).lower() in {"1", "true", "yes"}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/npa/tests/cli/test_cosmos_cli.py
+++ b/npa/tests/cli/test_cosmos_cli.py
@@ -128,6 +128,7 @@ def _access_denied(message: str = "AccessDenied") -> ClientError:
         "status",
         "system-info",
         "list",
+        "autoscale",
         "cleanup-partial",
     ],
 )
@@ -143,6 +144,130 @@ def test_cosmos_registered_under_workbench() -> None:
 
     assert result.exit_code == 0
     assert "cosmos" in result.output
+
+
+def test_cosmos_autoscale_dry_run_uses_saved_serverless_alias(mocker) -> None:
+    mocker.patch("npa.cli.cosmos.resolve_config", return_value=_serverless_cfg())
+    client_cls = mocker.patch("npa.cli.cosmos.ServerlessClient")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "cosmos",
+            "autoscale",
+            "--min-replicas",
+            "1",
+            "--max-replicas",
+            "3",
+            "--target-concurrency",
+            "8",
+            "--dry-run",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == "dry_run"
+    assert payload["runtime"] == "serverless"
+    assert payload["endpoint"] == "endpoint-1"
+    assert payload["max_replicas"] == 3
+    client_cls.assert_not_called()
+
+
+def test_cosmos_autoscale_respects_env_dry_run(mocker, monkeypatch) -> None:
+    mocker.patch("npa.cli.cosmos.resolve_config", return_value=_serverless_cfg())
+    client_cls = mocker.patch("npa.cli.cosmos.ServerlessClient")
+    monkeypatch.setenv("DRY_RUN", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "cosmos",
+            "autoscale",
+            "--min-replicas",
+            "1",
+            "--max-replicas",
+            "3",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["status"] == "dry_run"
+    client_cls.assert_not_called()
+
+
+def test_cosmos_autoscale_updates_endpoint_and_persists_policy(mocker) -> None:
+    mocker.patch("npa.cli.cosmos.resolve_config", return_value=_serverless_cfg())
+    write_config = mocker.patch("npa.cli.cosmos.write_config")
+    client = mocker.Mock()
+    client.set_endpoint_autoscale.return_value = EndpointInfo(
+        id="endpoint-1",
+        name="npa-cosmos-proj-cosmos",
+        project_id="project-1",
+        status=EndpointStatus.RUNNING,
+        url="https://cosmos.example",
+    )
+    mocker.patch("npa.cli.cosmos.ServerlessClient", return_value=client)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "cosmos",
+            "autoscale",
+            "--min-replicas",
+            "2",
+            "--max-replicas",
+            "5",
+            "--target-concurrency",
+            "16",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == "configured"
+    client.set_endpoint_autoscale.assert_called_once_with(
+        "project-1",
+        "endpoint-1",
+        min_replicas=2,
+        max_replicas=5,
+        target_concurrency=16,
+    )
+    autoscale = write_config.call_args.args[0]["projects"]["proj"]["workbenches"]["cosmos"][
+        "serverless"
+    ]["autoscale"]
+    assert autoscale == {
+        "min_replicas": 2,
+        "max_replicas": 5,
+        "target_concurrency": 16,
+    }
+
+
+def test_cosmos_autoscale_requires_valid_bounds() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "cosmos",
+            "autoscale",
+            "--min-replicas",
+            "4",
+            "--max-replicas",
+            "2",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--max-replicas must be greater than or equal" in result.output
 
 
 def _mock_train_env(mocker):

--- a/npa/tests/cli/test_workbench_data_cli.py
+++ b/npa/tests/cli/test_workbench_data_cli.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from io import BytesIO
+
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+
+
+runner = CliRunner()
+
+
+class FakeS3:
+    def __init__(self, name: str = "fake") -> None:
+        self.name = name
+        self.objects: dict[tuple[str, str], dict] = {}
+
+    def add(self, bucket: str, key: str, body: bytes, metadata: dict | None = None) -> None:
+        self.objects[(bucket, key)] = {"Body": body, "Metadata": metadata or {}}
+
+    def get_object(self, *, Bucket: str, Key: str):
+        item = self.objects[(Bucket, Key)]
+        return {"Body": BytesIO(item["Body"]), "Metadata": dict(item["Metadata"])}
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, Metadata: dict) -> None:
+        self.add(Bucket, Key, Body, Metadata)
+
+    def list_objects_v2(
+        self,
+        *,
+        Bucket: str,
+        Prefix: str,
+        ContinuationToken: str | None = None,
+    ):
+        del ContinuationToken
+        contents = [
+            {"Key": key, "Size": len(item["Body"])}
+            for (bucket, key), item in sorted(self.objects.items())
+            if bucket == Bucket and key.startswith(Prefix)
+        ]
+        return {"IsTruncated": False, "KeyCount": len(contents), "Contents": contents}
+
+
+def test_workbench_data_command_help() -> None:
+    result = runner.invoke(app, ["workbench", "data", "--help"])
+
+    assert result.exit_code == 0
+    assert "S3 data import bridge" in result.output
+
+
+def test_workbench_data_sync_copies_between_s3_prefixes(monkeypatch) -> None:
+    source = FakeS3("source")
+    target = FakeS3("target")
+    source.add("raw", "sereact/a.json", b"{}")
+    source.add("raw", "sereact/nested/b.json", b'{"b": true}')
+
+    def fake_client(project, allow_host_creds=False):
+        assert allow_host_creds is False
+        return source if project == "src" else target
+
+    monkeypatch.setattr("npa.cli.workbench.data.s3_client_for_project", fake_client)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "data",
+            "sync",
+            "--source-project",
+            "src",
+            "--target-project",
+            "dst",
+            "--input-path",
+            "s3://raw/sereact/",
+            "--output-path",
+            "s3://stage/imported/",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == "synced"
+    assert payload["object_count"] == 2
+    assert sorted(target.objects) == [
+        ("stage", "imported/a.json"),
+        ("stage", "imported/nested/b.json"),
+    ]
+
+
+def test_workbench_data_sync_respects_dry_run(monkeypatch) -> None:
+    source = FakeS3("source")
+    target = FakeS3("target")
+    source.add("raw", "sereact/a.json", b"{}")
+
+    def fake_client(project, allow_host_creds=False):
+        return source if project == "src" else target
+
+    monkeypatch.setattr("npa.cli.workbench.data.s3_client_for_project", fake_client)
+    monkeypatch.setenv("NPA_DRY_RUN", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "data",
+            "sync",
+            "--source-project",
+            "src",
+            "--target-project",
+            "dst",
+            "--input-path",
+            "s3://raw/sereact/",
+            "--output-path",
+            "s3://stage/imported/",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == "dry_run"
+    assert payload["dry_run"] is True
+    assert target.objects == {}
+
+
+def test_workbench_data_status_and_list(monkeypatch) -> None:
+    source = FakeS3("source")
+    source.add("raw", "sereact/a.json", b"1234")
+    source.add("raw", "sereact/b.json", b"12")
+    monkeypatch.setattr(
+        "npa.cli.workbench.data.s3_client_for_project",
+        lambda project, allow_host_creds=False: source,
+    )
+
+    status = runner.invoke(
+        app,
+        [
+            "workbench",
+            "data",
+            "status",
+            "--input-path",
+            "s3://raw/sereact/",
+            "--output",
+            "json",
+        ],
+    )
+    listing = runner.invoke(
+        app,
+        [
+            "workbench",
+            "data",
+            "list",
+            "--input-path",
+            "s3://raw/sereact/",
+            "--limit",
+            "1",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert status.exit_code == 0
+    assert json.loads(status.output)["bytes_total"] == 6
+    assert listing.exit_code == 0
+    assert len(json.loads(listing.output)["objects"]) == 1

--- a/npa/tests/cli/test_workbench_vlm_eval_cli.py
+++ b/npa/tests/cli/test_workbench_vlm_eval_cli.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+
+
+runner = CliRunner()
+
+
+def test_workbench_vlm_eval_command_help() -> None:
+    result = runner.invoke(app, ["workbench", "vlm-eval", "--help"])
+
+    assert result.exit_code == 0
+    assert "Stub VLM evaluation" in result.output
+
+
+def test_workbench_vlm_eval_run_writes_local_json(tmp_path) -> None:
+    output_dir = tmp_path / "eval"
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "vlm-eval",
+            "run",
+            "--input-path",
+            "s3://bucket/cosmos/out/",
+            "--output-path",
+            str(output_dir),
+            "--score",
+            "0.9",
+            "--success-threshold",
+            "0.8",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["backend"] == "stub"
+    assert payload["passed"] is True
+    written = output_dir / "vlm_eval_stub.json"
+    assert written.exists()
+    assert json.loads(written.read_text(encoding="utf-8"))["score"] == 0.9
+
+
+def test_workbench_vlm_eval_dry_run_does_not_write(tmp_path) -> None:
+    output_dir = tmp_path / "eval"
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "vlm-eval",
+            "run",
+            "--input-path",
+            "s3://bucket/cosmos/out/",
+            "--output-path",
+            str(output_dir),
+            "--dry-run",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["dry_run"] is True
+    assert not output_dir.exists()
+
+
+def test_workbench_vlm_eval_respects_env_dry_run(monkeypatch, tmp_path) -> None:
+    output_dir = tmp_path / "eval"
+    monkeypatch.setenv("NPA_DRY_RUN", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "vlm-eval",
+            "run",
+            "--input-path",
+            "s3://bucket/cosmos/out/",
+            "--output-path",
+            str(output_dir),
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["dry_run"] is True
+    assert not output_dir.exists()

--- a/npa/tests/clients/test_serverless.py
+++ b/npa/tests/clients/test_serverless.py
@@ -597,6 +597,43 @@ def test_start_stop_endpoint(method: str, command: str) -> None:
     assert info.id == "endpoint-1"
 
 
+def test_set_endpoint_autoscale_updates_resolved_endpoint() -> None:
+    calls: list[list[str]] = []
+
+    def fake_runner(args, **kwargs):
+        calls.append(args)
+        if args[3] == "list":
+            return _result(args, 0, '{"items": [' + _endpoint_json() + "]}")
+        return _result(args, 0, _endpoint_json())
+
+    client = ServerlessClient(nebius_bin="nebius", subprocess_runner=fake_runner)
+
+    info = client.set_endpoint_autoscale(
+        "project-1",
+        "cosmos",
+        min_replicas=2,
+        max_replicas=6,
+        target_concurrency=16,
+    )
+
+    assert info.status is EndpointStatus.RUNNING
+    assert calls[-1][1:] == [
+        "ai",
+        "endpoint",
+        "update",
+        "--id",
+        "endpoint-1",
+        "--min-replicas",
+        "2",
+        "--max-replicas",
+        "6",
+        "--target-concurrency",
+        "16",
+        "--format",
+        "json",
+    ]
+
+
 def test_get_endpoint_logs_uses_resolved_id() -> None:
     calls: list[list[str]] = []
 

--- a/npa/tests/test_sdk_surface.py
+++ b/npa/tests/test_sdk_surface.py
@@ -17,12 +17,14 @@ def _public_modules() -> list[ModuleType]:
         network,
         workflow,
         workbench.cosmos,
+        workbench.data,
         workbench.fiftyone,
         workbench.genesis,
         workbench.groot,
         workbench.isaac_lab,
         workbench.lancedb,
         workbench.lerobot,
+        workbench.vlm_eval,
     ]
 
 
@@ -66,13 +68,15 @@ def test_workbench_public_surface() -> None:
     from npa import workbench
 
     expected = {
-        "cosmos": ["deploy", "serve", "infer", "status", "system_info"],
+        "cosmos": ["deploy", "autoscale", "serve", "infer", "status", "system_info"],
+        "data": ["sync_s3_prefix", "status_s3_prefix", "list_s3_objects"],
         "fiftyone": ["deploy", "launch", "load_dataset", "status", "system_info"],
         "genesis": ["train_teacher", "generate_demos", "simulate", "deploy"],
         "groot": ["deploy", "serve", "infer", "convert", "status"],
         "isaac_lab": ["deploy", "train", "eval", "export_lerobot", "status"],
         "lancedb": ["import_bdd100k"],
         "lerobot": ["deploy", "train", "eval", "serve", "infer"],
+        "vlm_eval": ["evaluate_stub", "write_result", "result_uri_for"],
     }
     for tool, names in expected.items():
         tool_module = getattr(workbench, tool)

--- a/npa/tests/unit/solutions/test_registry.py
+++ b/npa/tests/unit/solutions/test_registry.py
@@ -40,6 +40,14 @@ def test_register_solution_lists_registered_solution() -> None:
             "description": "First solution: physical AI robotics workflows built on Nebius infrastructure",
             "cli_command": "npa workbench",
         },
+        {
+            "name": "sereact-sim-to-real",
+            "description": "Sereact sim-to-real pipeline tools within the Workbench solution",
+            "cli_command": (
+                "npa workbench workflow submit "
+                "npa/workflows/workbench/skypilot/sim-to-real-loop.yaml"
+            ),
+        },
         {"name": "demo", "description": "Demo solution", "cli_command": "npa demo"},
     ]
 
@@ -54,9 +62,9 @@ def test_list_solutions_returns_entry_copies() -> None:
     registry.register_solution("demo", "Demo solution", "npa demo")
 
     listed = registry.list_solutions()
-    listed[1]["description"] = "mutated"
+    listed[2]["description"] = "mutated"
 
-    assert registry.list_solutions()[1]["description"] == "Demo solution"
+    assert registry.list_solutions()[2]["description"] == "Demo solution"
 
 
 def test_solutions_package_import_does_not_load_toml(mocker) -> None:
@@ -83,7 +91,15 @@ def test_list_solutions_lazily_loads_workbench_solution(mocker) -> None:
             "name": "workbench",
             "description": "First solution: physical AI robotics workflows built on Nebius infrastructure",
             "cli_command": "npa workbench",
-        }
+        },
+        {
+            "name": "sereact-sim-to-real",
+            "description": "Sereact sim-to-real pipeline tools within the Workbench solution",
+            "cli_command": (
+                "npa workbench workflow submit "
+                "npa/workflows/workbench/skypilot/sim-to-real-loop.yaml"
+            ),
+        },
     ]
     assert second == first
     assert load_spy.call_count == 1

--- a/npa/tests/workflows/test_sim_to_real_loop.py
+++ b/npa/tests/workflows/test_sim_to_real_loop.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from npa.workflows.sereact_sim_to_real import (
+    ControllerSettings,
+    build_controller_plan,
+    run_controller,
+)
+
+
+ROOT = Path(__file__).resolve().parents[3]
+YAML_PATH = ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "sim-to-real-loop.yaml"
+WRAPPER_PATH = ROOT / "npa" / "scripts" / "run_sim_to_real_loop.py"
+
+
+def _docs() -> list[dict]:
+    return [doc for doc in yaml.safe_load_all(YAML_PATH.read_text(encoding="utf-8")) if doc]
+
+
+def _load_wrapper_module():
+    spec = importlib.util.spec_from_file_location("run_sim_to_real_loop", WRAPPER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sim_to_real_loop_yaml_uses_controller_job_pattern() -> None:
+    docs = _docs()
+
+    assert docs[0] == {"name": "sereact-sim-to-real-loop", "execution": "serial"}
+    assert len(docs[1:]) == 1
+    task = docs[1]
+    assert task["name"] == "sereact-controller-loop"
+    assert task["resources"] == {"cloud": "kubernetes", "cpus": 8, "memory": 32}
+    assert "npa.workflows.sereact_sim_to_real" in task["run"]
+    assert "NPA_DRY_RUN" in task["envs"]
+
+
+def test_sim_to_real_wrapper_renders_run_scoped_paths(capsys) -> None:
+    wrapper = _load_wrapper_module()
+
+    rc = wrapper.main(
+        [
+            "--yaml",
+            str(YAML_PATH),
+            "--render-only",
+            "--controller-dry-run",
+            "--run-id",
+            "sereact-test",
+            "--bucket",
+            "bucket",
+            "--source-uri",
+            "s3://bucket/raw/",
+            "--max-iterations",
+            "2",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    rendered = Path(payload["rendered_yaml"])
+    docs = [doc for doc in yaml.safe_load_all(rendered.read_text(encoding="utf-8")) if doc]
+    envs = docs[1]["envs"]
+    assert envs["NPA_PIPELINE_RUN_ID"] == "sereact-test"
+    assert envs["SEREACT_SOURCE_URI"] == "s3://bucket/raw/"
+    assert envs["SEREACT_OUTPUT_URI"] == "s3://bucket/sereact-sim-to-real/sereact-test/"
+    assert envs["SEREACT_MAX_ITERATIONS"] == "2"
+    assert envs["NPA_DRY_RUN"] == "1"
+
+
+def test_sereact_controller_plan_contains_data_cosmos_and_vlm_steps() -> None:
+    result = build_controller_plan(
+        ControllerSettings(
+            run_id="run-1",
+            input_path="s3://bucket/raw/",
+            output_path="s3://bucket/out/",
+            max_iterations=2,
+            dry_run=True,
+        )
+    )
+
+    stages = [step["stage"] for step in result.steps]
+    assert stages == [
+        "data_import",
+        "cosmos_generate",
+        "vlm_eval",
+        "data_import",
+        "cosmos_generate",
+        "vlm_eval",
+    ]
+    commands = json.dumps([step["command"] for step in result.steps]).lower()
+    assert "lightwheel" not in commands
+    assert "onnx" not in commands
+
+
+def test_sereact_controller_stops_when_vlm_stub_passes() -> None:
+    calls: list[list[str]] = []
+
+    def fake_runner(command, **kwargs):
+        calls.append(command)
+        stdout = '{"passed": true}' if "vlm-eval" in command else "{}"
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    result = run_controller(
+        ControllerSettings(
+            run_id="run-1",
+            input_path="s3://bucket/raw/",
+            output_path="s3://bucket/out/",
+            max_iterations=3,
+            dry_run=False,
+        ),
+        runner=fake_runner,
+    )
+
+    assert result.status == "succeeded"
+    assert result.iterations_planned == 1
+    assert len(calls) == 3

--- a/npa/workflows/workbench/skypilot/sim-to-real-loop.yaml
+++ b/npa/workflows/workbench/skypilot/sim-to-real-loop.yaml
@@ -1,0 +1,27 @@
+name: sereact-sim-to-real-loop
+execution: serial
+---
+name: sereact-controller-loop
+resources:
+  cloud: kubernetes
+  cpus: 8
+  memory: 32
+envs:
+  NPA_PIPELINE_RUN_ID: sereact-sim2real-dev
+  S3_BUCKET: your-bucket-name
+  PIPELINE_ROOT_URI: s3://your-bucket-name/sereact-sim-to-real/dev
+  SEREACT_SOURCE_URI: s3://your-bucket-name/sereact/raw/
+  SEREACT_OUTPUT_URI: s3://your-bucket-name/sereact-sim-to-real/dev/
+  SEREACT_MAX_ITERATIONS: '3'
+  SEREACT_SUCCESS_THRESHOLD: '0.8'
+  NPA_DRY_RUN: '0'
+setup: |
+  python3 -m pip install -e /opt/nebius-physical-ai/npa
+run: |
+  set -euo pipefail
+  python3 -m npa.workflows.sereact_sim_to_real \
+    --run-id "${NPA_PIPELINE_RUN_ID}" \
+    --input-path "${SEREACT_SOURCE_URI}" \
+    --output-path "${SEREACT_OUTPUT_URI}" \
+    --max-iterations "${SEREACT_MAX_ITERATIONS}" \
+    --success-threshold "${SEREACT_SUCCESS_THRESHOLD}"


### PR DESCRIPTION
## Pipeline Summary
- Agents invoked: triage, dev, reviewer
- Blast score: n/a
- Retry count: 0

### Product Critic Warnings
- None

### Security Findings
- None

### Pipeline Warnings
- None

### Agent Reasoning
- Request is actionable, in-scope for nebius/nebius-physical-ai, and highly detailed. All three stages have concrete CLI contracts, output schemas, acceptance criteria, and explicit anti-scope. No ambiguity requiring clarification. Classified as feat (new product behavior). Priority P2: meaningful new capability, no production breakage or security exposure.
- Dev Manager completed all worker stages.
- All acceptance criteria are met. Stage A (data sync/status/list), Stage B (cosmos autoscale), and Stage C (VLM eval stub + SkyPilot workflow + controller scripts) are all present in the diff. Post-merge test run shows zero new failures vs. the baseline; only the same 5 pre-existing credential-profile failures remain. Anti-scope is respected — no Lightwheel, no real VLM backend, no ONNX export, no native SkyPilot loop syntax. No hardcoded secrets or private IDs detected. Blast radius matches the task scope precisely.

DRY_RUN=false: branch was pushed and a PR was opened.