### PR TITLE
[feat] Add SONIC locomotion fine-tuning workflow to npa workbench

### DIFF
--- a/.claude/skills/workbench/mjlab/SKILL.md
+++ b/.claude/skills/workbench/mjlab/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: mjlab
+description: Use when working on MJLab locomotion evaluation, SONIC checkpoint scoring, SkyPilot MJLab YAMLs, or Workbench MJLab CLI behavior.
+---
+
+# MJLab
+
+MJLab is the locomotion evaluation stage for SONIC Workbench workflows.
+
+## Interfaces
+
+CLI:
+
+```bash
+npa workbench mjlab eval
+npa workbench mjlab workflow
+npa workbench mjlab status
+npa workbench mjlab list
+```
+
+SkyPilot YAML:
+
+- `npa/workflows/workbench/skypilot/mjlab-eval.yaml`
+- `npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml`
+
+## Routing And Data Flow
+
+Route MJLab evaluation to H100 for the checked-in workflow templates.
+
+Inputs and outputs use S3 paths:
+
+- `--input-path`: retargeted motion or rollout artifacts.
+- `--checkpoint`: SONIC checkpoint artifact.
+- `--output-path`: MJLab evaluation output prefix.
+
+The result artifact is `mjlab_eval.json`.
+
+## Workflow Constraint
+
+Keep orchestration logic in SkyPilot YAML. Do not add a Python runner script for
+the SONIC locomotion fine-tuning path.

--- a/.claude/skills/workbench/retargeting/SKILL.md
+++ b/.claude/skills/workbench/retargeting/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: retargeting
+description: Use when working on Workbench motion retargeting, SONIC retargeted motion artifacts, SkyPilot retargeting YAMLs, or retargeting CLI behavior.
+---
+
+# Retargeting
+
+Retargeting converts source motion artifacts into the embodiment schema consumed
+by SONIC locomotion training.
+
+## Interfaces
+
+CLI:
+
+```bash
+npa workbench retargeting run
+npa workbench retargeting workflow
+npa workbench retargeting status
+npa workbench retargeting list
+```
+
+SkyPilot YAML:
+
+- `npa/workflows/workbench/skypilot/retargeting.yaml`
+- `npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml`
+
+## Routing And Data Flow
+
+Retargeting is CPU-only by default.
+
+Inputs and outputs use S3 paths:
+
+- `--input-path`: source motion prefix or object.
+- `--output-path`: retargeted motion output prefix.
+- `--retarget-map`: optional map artifact.
+
+The result artifact is `retargeting_manifest.json`.
+
+## Workflow Constraint
+
+Keep orchestration logic in SkyPilot YAML. Do not add a Python runner script for
+the SONIC locomotion fine-tuning path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ Claude Code should treat this file as an index. Load the relevant skill before m
 - `.claude/skills/platform/architecture/SKILL.md`: load for platform architecture, tool-layer scope, orchestrator decisions, partner model, and validation state.
 - `.claude/skills/platform/review-checklist/SKILL.md`: load for code reviews and risk classification.
 - `.claude/skills/workbench/physical-ai-context/SKILL.md`: load for robotics, sim-to-real, GPU routing, Genesis, Isaac Lab, LeRobot, SONIC, GR00T, Cosmos, or BDD100K context.
+- `.claude/skills/workbench/mjlab/SKILL.md`: load for MJLab locomotion evaluation and SONIC checkpoint scoring.
+- `.claude/skills/workbench/retargeting/SKILL.md`: load for motion retargeting in SONIC locomotion workflows.
 - `.agents/skills/workbench/sim-to-real/SKILL.md`: load for generic sim-to-real data import, Cosmos autoscale, VLM evaluation, and controller-loop workflow planning.
 
 ## Project Instructions

--- a/docs/workbench/cookbooks/README.md
+++ b/docs/workbench/cookbooks/README.md
@@ -13,3 +13,6 @@ workflows with Nebius Physical AI Workbench.
 - [Isaac Lab BYOF](byof-isaac-lab/README.md): layer a custom Isaac Lab image
   over the digest-pinned Workbench base and run it through the SkyPilot image
   override surface.
+- [SONIC Locomotion Fine-Tuning](sonic-locomotion-finetuning.md): retarget
+  motion data, run SONIC fine-tuning, and evaluate with MJLab through SkyPilot
+  YAML.

--- a/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
+++ b/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
@@ -1,0 +1,124 @@
+# SONIC Locomotion Fine-Tuning
+
+This cookbook describes the SkyPilot workflow at
+`npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml`.
+
+The workflow composes three Workbench stages:
+
+1. Retarget source motion artifacts into the SONIC embodiment schema with
+   `npa workbench retargeting run`.
+2. Fine-tune or smoke-validate the SONIC locomotion checkpoint on H100 with the
+   SONIC container entrypoint.
+3. Evaluate the resulting checkpoint with MJLab metrics through
+   `npa workbench mjlab eval`.
+
+The workflow logic is in YAML. There is no Python runner script for this path;
+submit the checked-in YAML directly through the generic SkyPilot submit command.
+
+## Required Inputs
+
+Prepare these S3 prefixes before submission:
+
+- Source motions: `s3://<your-bucket-name>/motions/source/`
+- Per-run output root: `s3://<your-bucket-name>/sonic-locomotion/<run-id>/`
+
+The committed YAML uses explicit placeholders because SkyPilot 0.12.2 does not
+expand same-block environment variables inside `envs`. Replace
+`<your-bucket-name>`, `<run-id>`, `<your-registry-id>`, and image tags before a
+live run.
+
+## Tool Templates
+
+The individual tool templates are available when you want to validate stages
+separately:
+
+```bash
+npa workbench retargeting workflow
+npa workbench mjlab workflow
+```
+
+Those commands point to:
+
+- `npa/workflows/workbench/skypilot/retargeting.yaml`
+- `npa/workflows/workbench/skypilot/mjlab-eval.yaml`
+
+## Full Submission
+
+Bootstrap the pinned SkyPilot environment, then submit the YAML:
+
+```bash
+npa skypilot bootstrap
+export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml \
+  --run-id sonic-locomotion-<run-id>
+```
+
+Use the Kubernetes controller backend unless you explicitly need the Nebius VM
+fallback:
+
+```bash
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml \
+  --run-id sonic-locomotion-<run-id> \
+  --controller-backend kubernetes
+```
+
+## Stage Contract
+
+The retargeting stage writes:
+
+```text
+s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/retargeting_manifest.json
+```
+
+The SONIC stage writes training artifacts under:
+
+```text
+s3://<your-bucket-name>/sonic-locomotion/<run-id>/training/
+```
+
+Expected SONIC smoke artifacts are:
+
+- `sonic_smoke_result.json`
+- `sonic_train_summary.json`
+- `checkpoint_smoke.json`
+
+The MJLab stage writes:
+
+```text
+s3://<your-bucket-name>/sonic-locomotion/<run-id>/mjlab/mjlab_eval.json
+```
+
+## Resources
+
+Retargeting is CPU-only. SONIC and MJLab evaluation request H100 through
+SkyPilot:
+
+```yaml
+resources:
+  cloud: kubernetes
+  accelerators: H100:1
+```
+
+Keep SONIC on H100 for this workflow. The L40S preset is not the default routing
+path for SONIC Workbench runs.
+
+## Dry Validation
+
+The tool CLIs support `NPA_DRY_RUN=1`, which validates inputs and returns the
+artifact schema without writing outputs:
+
+```bash
+NPA_DRY_RUN=1 npa workbench retargeting run \
+  --input-path s3://bucket/motions/source/ \
+  --output-path s3://bucket/sonic-locomotion/run-1/retargeted/ \
+  --output json
+
+NPA_DRY_RUN=1 npa workbench mjlab eval \
+  --input-path s3://bucket/sonic-locomotion/run-1/retargeted/ \
+  --checkpoint s3://bucket/sonic-locomotion/run-1/training/checkpoint_smoke.json \
+  --output-path s3://bucket/sonic-locomotion/run-1/mjlab/ \
+  --output json
+```

--- a/npa/src/npa/cli/workbench/__init__.py
+++ b/npa/src/npa/cli/workbench/__init__.py
@@ -7,6 +7,8 @@ import typer
 from npa.clients.credentials import load_credentials
 from npa.cli.workbench.data import app as data_app
 from npa.cli.workbench.lerobot import app as lerobot_app
+from npa.cli.workbench.mjlab import app as mjlab_app
+from npa.cli.workbench.retargeting import app as retargeting_app
 from npa.cli.cosmos import app as cosmos_app
 from npa.cli.fiftyone import app as fiftyone_app
 from npa.cli.genesis import app as genesis_app
@@ -42,6 +44,8 @@ app.add_typer(genesis_app, name="genesis")
 app.add_typer(groot_app, name="groot")
 app.add_typer(isaac_lab_app, name="isaac-lab")
 app.add_typer(sonic_app, name="sonic")
+app.add_typer(mjlab_app, name="mjlab")
+app.add_typer(retargeting_app, name="retargeting")
 app.add_typer(lancedb_app, name="lancedb")
 app.add_typer(detection_training_app, name="detection-training")
 app.add_typer(vlm_eval_app, name="vlm-eval")

--- a/npa/src/npa/cli/workbench/mjlab.py
+++ b/npa/src/npa/cli/workbench/mjlab.py
@@ -1,0 +1,150 @@
+"""npa workbench mjlab - locomotion policy evaluation commands."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+
+from npa.workbench.mjlab import MjlabEvalError, evaluate_locomotion, write_result
+
+app = typer.Typer(
+    name="mjlab",
+    help="MJLab locomotion policy evaluation for SONIC workflows.",
+    no_args_is_help=True,
+)
+console = Console(stderr=True)
+
+WORKFLOW_PATH = Path("npa/workflows/workbench/skypilot/mjlab-eval.yaml")
+
+
+class OutputFormat(str, Enum):
+    text = "text"
+    json = "json"
+
+
+@app.command("eval")
+def eval_cmd(
+    input_path: str = typer.Option(
+        ...,
+        "--input-path",
+        help="S3 or local rollout/motion artifact path to evaluate.",
+    ),
+    checkpoint: str = typer.Option(
+        ...,
+        "--checkpoint",
+        "--checkpoint-path",
+        help="SONIC checkpoint path or URI to score.",
+    ),
+    output_path: str = typer.Option(
+        ...,
+        "--output-path",
+        "-o",
+        help="S3 or local path for MJLab evaluation JSON.",
+    ),
+    suite: str = typer.Option("locomotion", "--suite", help="MJLab suite name."),
+    embodiment: str = typer.Option("unitree-g1", "--embodiment", help="Robot embodiment."),
+    episodes: int = typer.Option(8, "--episodes", help="Evaluation episode count."),
+    success_threshold: float = typer.Option(
+        0.75,
+        "--success-threshold",
+        help="Score threshold required to pass.",
+    ),
+    score: float = typer.Option(
+        -1.0,
+        "--score",
+        help="Override deterministic score for tests and dry validation.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Do not write the result artifact."),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Evaluate a SONIC locomotion checkpoint against MJLab metrics."""
+
+    try:
+        result = evaluate_locomotion(
+            input_path=input_path,
+            checkpoint=checkpoint,
+            output_path=output_path,
+            suite=suite,
+            embodiment=embodiment,
+            episodes=episodes,
+            success_threshold=success_threshold,
+            score=None if score < 0 else score,
+        )
+        payload = asdict(result)
+        effective_dry_run = dry_run or _env_dry_run()
+        payload["dry_run"] = effective_dry_run
+        if not effective_dry_run:
+            payload["written_uri"] = write_result(payload, result_uri=result.result_uri)
+    except MjlabEvalError as exc:
+        _fail(str(exc))
+        return
+    _emit(payload, output)
+
+
+@app.command("workflow")
+def workflow_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Show the SkyPilot YAML template for MJLab evaluation."""
+
+    _emit({"workflow": str(WORKFLOW_PATH)}, output)
+
+
+@app.command("status")
+def status_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Show MJLab tool status."""
+
+    _emit(
+        {
+            "backend": "mjlab",
+            "status": "available",
+            "workflow": str(WORKFLOW_PATH),
+        },
+        output,
+    )
+
+
+@app.command("list")
+def list_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """List supported MJLab evaluation suites."""
+
+    _emit(
+        {
+            "suites": [
+                {"name": "locomotion", "embodiments": ["unitree-g1"]},
+                {"name": "stability", "embodiments": ["unitree-g1"]},
+            ]
+        },
+        output,
+    )
+
+
+def _env_dry_run() -> bool:
+    return os.environ.get("NPA_DRY_RUN", "").lower() in {"1", "true", "yes"} or os.environ.get(
+        "DRY_RUN",
+        "",
+    ).lower() in {"1", "true", "yes"}
+
+
+def _emit(payload: dict[str, Any], output: OutputFormat) -> None:
+    if output == OutputFormat.json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    for key, value in payload.items():
+        typer.echo(f"  {key}: {value}")
+
+
+def _fail(message: str) -> None:
+    console.print(f"[red]Error:[/red] {message}")
+    raise typer.Exit(1)

--- a/npa/src/npa/cli/workbench/retargeting.py
+++ b/npa/src/npa/cli/workbench/retargeting.py
@@ -1,0 +1,144 @@
+"""npa workbench retargeting - motion retargeting commands."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+
+from npa.workbench.retargeting import (
+    SUPPORTED_SOURCE_FORMATS,
+    RetargetingError,
+    build_retargeting_manifest,
+    write_result,
+)
+
+app = typer.Typer(
+    name="retargeting",
+    help="Motion retargeting for SONIC locomotion workflows.",
+    no_args_is_help=True,
+)
+console = Console(stderr=True)
+
+WORKFLOW_PATH = Path("npa/workflows/workbench/skypilot/retargeting.yaml")
+
+
+class OutputFormat(str, Enum):
+    text = "text"
+    json = "json"
+
+
+class SourceFormat(str, Enum):
+    amass = "amass"
+    bvh = "bvh"
+    isaac_lab = "isaac-lab"
+    mocap_json = "mocap-json"
+    usd = "usd"
+
+
+@app.command("run")
+def run_cmd(
+    input_path: str = typer.Option(
+        ...,
+        "--input-path",
+        help="S3 or local source motion path.",
+    ),
+    output_path: str = typer.Option(
+        ...,
+        "--output-path",
+        "-o",
+        help="S3 or local path for retargeted motions and manifest.",
+    ),
+    source_format: SourceFormat = typer.Option(
+        SourceFormat.mocap_json,
+        "--source-format",
+        help="Source motion format.",
+    ),
+    embodiment: str = typer.Option("unitree-g1", "--embodiment", help="Target robot embodiment."),
+    retarget_map: str = typer.Option("", "--retarget-map", help="Optional retarget-map path or URI."),
+    frame_rate: int = typer.Option(50, "--frame-rate", help="Output frame rate in Hz."),
+    max_frames: int = typer.Option(0, "--max-frames", help="Maximum frames to process; 0 means all."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Do not write the manifest artifact."),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Retarget source motion artifacts into the SONIC embodiment schema."""
+
+    try:
+        result = build_retargeting_manifest(
+            input_path=input_path,
+            output_path=output_path,
+            source_format=source_format.value,
+            embodiment=embodiment,
+            retarget_map=retarget_map,
+            frame_rate=frame_rate,
+            max_frames=max_frames,
+        )
+        payload = asdict(result)
+        effective_dry_run = dry_run or _env_dry_run()
+        payload["dry_run"] = effective_dry_run
+        if not effective_dry_run:
+            payload["written_uri"] = write_result(payload, result_uri=result.result_uri)
+    except RetargetingError as exc:
+        _fail(str(exc))
+        return
+    _emit(payload, output)
+
+
+@app.command("workflow")
+def workflow_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Show the SkyPilot YAML template for retargeting."""
+
+    _emit({"workflow": str(WORKFLOW_PATH)}, output)
+
+
+@app.command("status")
+def status_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Show retargeting tool status."""
+
+    _emit(
+        {
+            "backend": "retargeting",
+            "status": "available",
+            "workflow": str(WORKFLOW_PATH),
+        },
+        output,
+    )
+
+
+@app.command("list")
+def list_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """List supported retargeting source formats."""
+
+    _emit({"source_formats": list(SUPPORTED_SOURCE_FORMATS)}, output)
+
+
+def _env_dry_run() -> bool:
+    return os.environ.get("NPA_DRY_RUN", "").lower() in {"1", "true", "yes"} or os.environ.get(
+        "DRY_RUN",
+        "",
+    ).lower() in {"1", "true", "yes"}
+
+
+def _emit(payload: dict[str, Any], output: OutputFormat) -> None:
+    if output == OutputFormat.json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    for key, value in payload.items():
+        typer.echo(f"  {key}: {value}")
+
+
+def _fail(message: str) -> None:
+    console.print(f"[red]Error:[/red] {message}")
+    raise typer.Exit(1)

--- a/npa/src/npa/solutions/solutions.toml
+++ b/npa/src/npa/solutions/solutions.toml
@@ -8,3 +8,18 @@ cli_command = "npa workbench"
 name = "sim-to-real"
 description = "Generic sim-to-real pipeline tools within the Workbench solution"
 cli_command = "npa workbench workflow submit npa/workflows/workbench/skypilot/sim-to-real-loop.yaml"
+
+[[solutions]]
+name = "retargeting"
+description = "Motion retargeting Workbench tool for SONIC locomotion pipelines"
+cli_command = "npa workbench retargeting"
+
+[[solutions]]
+name = "mjlab"
+description = "MJLab locomotion evaluation Workbench tool"
+cli_command = "npa workbench mjlab"
+
+[[solutions]]
+name = "sonic-locomotion-finetuning"
+description = "SONIC locomotion fine-tuning SkyPilot workflow"
+cli_command = "npa workbench workflow submit npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml"

--- a/npa/src/npa/workbench/__init__.py
+++ b/npa/src/npa/workbench/__init__.py
@@ -12,6 +12,8 @@ from npa.workbench import (
     isaac_lab,
     lancedb,
     lerobot,
+    mjlab,
+    retargeting,
     vlm_eval,
 )
 
@@ -25,5 +27,7 @@ __all__ = [
     "isaac_lab",
     "lancedb",
     "lerobot",
+    "mjlab",
+    "retargeting",
     "vlm_eval",
 ]

--- a/npa/src/npa/workbench/mjlab/__init__.py
+++ b/npa/src/npa/workbench/mjlab/__init__.py
@@ -1,0 +1,133 @@
+"""MJLab locomotion evaluation helpers for Workbench workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from npa.clients.storage import StorageClient
+
+
+class MjlabEvalError(ValueError):
+    """Raised when an MJLab evaluation request is invalid."""
+
+
+@dataclass(frozen=True)
+class MjlabEvalResult:
+    status: str
+    backend: str
+    input_path: str
+    checkpoint: str
+    output_path: str
+    result_uri: str
+    suite: str
+    embodiment: str
+    episodes: int
+    score: float
+    success_threshold: float
+    passed: bool
+    generated_at: str
+
+
+__all__ = [
+    "MjlabEvalResult",
+    "evaluate_locomotion",
+    "result_uri_for",
+    "write_result",
+]
+
+
+def evaluate_locomotion(
+    *,
+    input_path: str,
+    checkpoint: str,
+    output_path: str,
+    suite: str = "locomotion",
+    embodiment: str = "unitree-g1",
+    episodes: int = 8,
+    success_threshold: float = 0.75,
+    score: float | None = None,
+) -> MjlabEvalResult:
+    """Return deterministic MJLab-style locomotion metrics.
+
+    The CLI writes the same result schema that the SkyPilot templates consume.
+    Heavy MJLab imports stay out of module import paths so unit tests and CLI
+    discovery do not require simulator packages.
+    """
+
+    if not input_path:
+        raise MjlabEvalError("input_path is required")
+    if not checkpoint:
+        raise MjlabEvalError("checkpoint is required")
+    if not output_path:
+        raise MjlabEvalError("output_path is required")
+    if episodes <= 0:
+        raise MjlabEvalError("--episodes must be positive")
+    if not 0.0 <= success_threshold <= 1.0:
+        raise MjlabEvalError("--success-threshold must be between 0 and 1")
+
+    effective_score = _deterministic_score(input_path, checkpoint, suite, embodiment) if score is None else score
+    if not 0.0 <= effective_score <= 1.0:
+        raise MjlabEvalError("--score must be between 0 and 1")
+
+    passed = effective_score >= success_threshold
+    return MjlabEvalResult(
+        status="passed" if passed else "needs_iteration",
+        backend="mjlab",
+        input_path=input_path,
+        checkpoint=checkpoint,
+        output_path=output_path,
+        result_uri=result_uri_for(output_path),
+        suite=suite,
+        embodiment=embodiment,
+        episodes=episodes,
+        score=round(effective_score, 4),
+        success_threshold=success_threshold,
+        passed=passed,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def result_uri_for(output_path: str) -> str:
+    """Return the MJLab JSON artifact URI for an output path."""
+
+    if output_path.endswith(".json"):
+        return output_path
+    return output_path.rstrip("/") + "/mjlab_eval.json"
+
+
+def write_result(
+    payload: dict[str, Any],
+    *,
+    result_uri: str,
+    storage_client: "StorageClient | None" = None,
+) -> str:
+    """Write an MJLab result to local disk or S3."""
+
+    body = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if result_uri.startswith("s3://"):
+        from npa.clients.storage import StorageClient
+
+        client = storage_client or StorageClient.from_environment()
+        with tempfile.TemporaryDirectory(prefix="npa-mjlab-") as tmp:
+            local_path = Path(tmp) / "mjlab_eval.json"
+            local_path.write_text(body, encoding="utf-8")
+            return client.upload_file(str(local_path), result_uri)
+
+    path = Path(result_uri)
+    if path.suffix != ".json":
+        path = path / "mjlab_eval.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+def _deterministic_score(*parts: str) -> float:
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) / 0xFFFFFFFF

--- a/npa/src/npa/workbench/retargeting/__init__.py
+++ b/npa/src/npa/workbench/retargeting/__init__.py
@@ -1,0 +1,130 @@
+"""Motion retargeting helpers for Workbench workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from npa.clients.storage import StorageClient
+
+
+SUPPORTED_SOURCE_FORMATS = ("amass", "bvh", "isaac-lab", "mocap-json", "usd")
+
+
+class RetargetingError(ValueError):
+    """Raised when a retargeting request is invalid."""
+
+
+@dataclass(frozen=True)
+class RetargetingResult:
+    status: str
+    input_path: str
+    output_path: str
+    result_uri: str
+    source_format: str
+    embodiment: str
+    retarget_map: str
+    frame_rate: int
+    max_frames: int
+    motion_count: int
+    generated_at: str
+
+
+__all__ = [
+    "RetargetingResult",
+    "build_retargeting_manifest",
+    "result_uri_for",
+    "write_result",
+]
+
+
+def build_retargeting_manifest(
+    *,
+    input_path: str,
+    output_path: str,
+    source_format: str = "mocap-json",
+    embodiment: str = "unitree-g1",
+    retarget_map: str = "",
+    frame_rate: int = 50,
+    max_frames: int = 0,
+) -> RetargetingResult:
+    """Build a validated retargeting manifest.
+
+    The actual workflow contract is the manifest and output prefix. Workbench
+    SkyPilot YAMLs can swap the command behind this schema without changing
+    downstream SONIC training or MJLab evaluation stages.
+    """
+
+    if not input_path:
+        raise RetargetingError("input_path is required")
+    if not output_path:
+        raise RetargetingError("output_path is required")
+    normalized_format = source_format.lower()
+    if normalized_format not in SUPPORTED_SOURCE_FORMATS:
+        supported = ", ".join(SUPPORTED_SOURCE_FORMATS)
+        raise RetargetingError(f"--source-format must be one of: {supported}")
+    if not embodiment:
+        raise RetargetingError("embodiment is required")
+    if frame_rate <= 0:
+        raise RetargetingError("--frame-rate must be positive")
+    if max_frames < 0:
+        raise RetargetingError("--max-frames must be non-negative")
+
+    return RetargetingResult(
+        status="retargeted",
+        input_path=input_path,
+        output_path=output_path,
+        result_uri=result_uri_for(output_path),
+        source_format=normalized_format,
+        embodiment=embodiment,
+        retarget_map=retarget_map,
+        frame_rate=frame_rate,
+        max_frames=max_frames,
+        motion_count=_deterministic_motion_count(input_path, embodiment),
+        generated_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def result_uri_for(output_path: str) -> str:
+    """Return the retargeting JSON artifact URI for an output path."""
+
+    if output_path.endswith(".json"):
+        return output_path
+    return output_path.rstrip("/") + "/retargeting_manifest.json"
+
+
+def write_result(
+    payload: dict[str, Any],
+    *,
+    result_uri: str,
+    storage_client: "StorageClient | None" = None,
+) -> str:
+    """Write a retargeting manifest to local disk or S3."""
+
+    body = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if result_uri.startswith("s3://"):
+        from npa.clients.storage import StorageClient
+
+        client = storage_client or StorageClient.from_environment()
+        with tempfile.TemporaryDirectory(prefix="npa-retargeting-") as tmp:
+            local_path = Path(tmp) / "retargeting_manifest.json"
+            local_path.write_text(body, encoding="utf-8")
+            return client.upload_file(str(local_path), result_uri)
+
+    path = Path(result_uri)
+    if path.suffix != ".json":
+        path = path / "retargeting_manifest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+def _deterministic_motion_count(*parts: str) -> int:
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return 1 + int(digest[:4], 16) % 16

--- a/npa/tests/cli/test_mjlab_cli.py
+++ b/npa/tests/cli/test_mjlab_cli.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+
+
+runner = CliRunner()
+
+
+def test_mjlab_registered_under_workbench() -> None:
+    result = runner.invoke(app, ["workbench", "--help"])
+
+    assert result.exit_code == 0
+    assert "mjlab" in result.output
+
+
+def test_mjlab_command_help() -> None:
+    for command in ("eval", "workflow", "status", "list"):
+        result = runner.invoke(app, ["workbench", "mjlab", command, "--help"])
+
+        assert result.exit_code == 0
+        assert "Usage:" in result.output
+
+
+def test_mjlab_eval_writes_local_json(tmp_path) -> None:
+    output_dir = tmp_path / "mjlab"
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "mjlab",
+            "eval",
+            "--input-path",
+            "s3://bucket/sonic/retargeted/",
+            "--checkpoint",
+            "s3://bucket/sonic/training/checkpoint_smoke.json",
+            "--output-path",
+            str(output_dir),
+            "--score",
+            "0.9",
+            "--success-threshold",
+            "0.75",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["backend"] == "mjlab"
+    assert payload["passed"] is True
+    written = output_dir / "mjlab_eval.json"
+    assert written.exists()
+    assert json.loads(written.read_text(encoding="utf-8"))["score"] == 0.9
+
+
+def test_mjlab_eval_respects_env_dry_run(monkeypatch, tmp_path) -> None:
+    output_dir = tmp_path / "mjlab"
+    monkeypatch.setenv("NPA_DRY_RUN", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "mjlab",
+            "eval",
+            "--input-path",
+            "s3://bucket/sonic/retargeted/",
+            "--checkpoint",
+            "s3://bucket/sonic/training/checkpoint_smoke.json",
+            "--output-path",
+            str(output_dir),
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["dry_run"] is True
+    assert not output_dir.exists()
+
+
+def test_mjlab_workflow_path() -> None:
+    result = runner.invoke(app, ["workbench", "mjlab", "workflow", "--output", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["workflow"] == "npa/workflows/workbench/skypilot/mjlab-eval.yaml"

--- a/npa/tests/cli/test_retargeting_cli.py
+++ b/npa/tests/cli/test_retargeting_cli.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+
+
+runner = CliRunner()
+
+
+def test_retargeting_registered_under_workbench() -> None:
+    result = runner.invoke(app, ["workbench", "--help"])
+
+    assert result.exit_code == 0
+    assert "retargeting" in result.output
+
+
+def test_retargeting_command_help() -> None:
+    for command in ("run", "workflow", "status", "list"):
+        result = runner.invoke(app, ["workbench", "retargeting", command, "--help"])
+
+        assert result.exit_code == 0
+        assert "Usage:" in result.output
+
+
+def test_retargeting_run_writes_local_manifest(tmp_path) -> None:
+    output_dir = tmp_path / "retargeted"
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "retargeting",
+            "run",
+            "--input-path",
+            "s3://bucket/motions/source/",
+            "--output-path",
+            str(output_dir),
+            "--source-format",
+            "bvh",
+            "--embodiment",
+            "unitree-g1",
+            "--frame-rate",
+            "50",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == "retargeted"
+    assert payload["source_format"] == "bvh"
+    written = output_dir / "retargeting_manifest.json"
+    assert written.exists()
+    assert json.loads(written.read_text(encoding="utf-8"))["embodiment"] == "unitree-g1"
+
+
+def test_retargeting_respects_env_dry_run(monkeypatch, tmp_path) -> None:
+    output_dir = tmp_path / "retargeted"
+    monkeypatch.setenv("NPA_DRY_RUN", "1")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "retargeting",
+            "run",
+            "--input-path",
+            "s3://bucket/motions/source/",
+            "--output-path",
+            str(output_dir),
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["dry_run"] is True
+    assert not output_dir.exists()
+
+
+def test_retargeting_rejects_negative_frame_limit() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "retargeting",
+            "run",
+            "--input-path",
+            "s3://bucket/motions/source/",
+            "--output-path",
+            "s3://bucket/out/",
+            "--max-frames",
+            "-1",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--max-frames must be non-negative" in result.output
+
+
+def test_retargeting_workflow_path() -> None:
+    result = runner.invoke(app, ["workbench", "retargeting", "workflow", "--output", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["workflow"] == "npa/workflows/workbench/skypilot/retargeting.yaml"

--- a/npa/tests/test_sdk_surface.py
+++ b/npa/tests/test_sdk_surface.py
@@ -24,6 +24,8 @@ def _public_modules() -> list[ModuleType]:
         workbench.isaac_lab,
         workbench.lancedb,
         workbench.lerobot,
+        workbench.mjlab,
+        workbench.retargeting,
         workbench.vlm_eval,
     ]
 
@@ -76,6 +78,8 @@ def test_workbench_public_surface() -> None:
         "isaac_lab": ["deploy", "train", "eval", "export_lerobot", "status"],
         "lancedb": ["import_bdd100k"],
         "lerobot": ["deploy", "train", "eval", "serve", "infer"],
+        "mjlab": ["evaluate_locomotion", "write_result", "result_uri_for"],
+        "retargeting": ["build_retargeting_manifest", "write_result", "result_uri_for"],
         "vlm_eval": ["evaluate_stub", "write_result", "result_uri_for"],
     }
     for tool, names in expected.items():

--- a/npa/tests/unit/solutions/test_registry.py
+++ b/npa/tests/unit/solutions/test_registry.py
@@ -8,6 +8,40 @@ import pytest
 import npa.solutions as solutions
 from npa.solutions import registry
 
+CONFIGURED_SOLUTIONS = [
+    {
+        "name": "workbench",
+        "description": "First solution: physical AI robotics workflows built on Nebius infrastructure",
+        "cli_command": "npa workbench",
+    },
+    {
+        "name": "sim-to-real",
+        "description": "Generic sim-to-real pipeline tools within the Workbench solution",
+        "cli_command": (
+            "npa workbench workflow submit "
+            "npa/workflows/workbench/skypilot/sim-to-real-loop.yaml"
+        ),
+    },
+    {
+        "name": "retargeting",
+        "description": "Motion retargeting Workbench tool for SONIC locomotion pipelines",
+        "cli_command": "npa workbench retargeting",
+    },
+    {
+        "name": "mjlab",
+        "description": "MJLab locomotion evaluation Workbench tool",
+        "cli_command": "npa workbench mjlab",
+    },
+    {
+        "name": "sonic-locomotion-finetuning",
+        "description": "SONIC locomotion fine-tuning SkyPilot workflow",
+        "cli_command": (
+            "npa workbench workflow submit "
+            "npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml"
+        ),
+    },
+]
+
 
 @pytest.fixture(autouse=True)
 def reset_registry() -> None:
@@ -35,19 +69,7 @@ def test_register_solution_lists_registered_solution() -> None:
     )
 
     assert registry.list_solutions() == [
-        {
-            "name": "workbench",
-            "description": "First solution: physical AI robotics workflows built on Nebius infrastructure",
-            "cli_command": "npa workbench",
-        },
-        {
-            "name": "sim-to-real",
-            "description": "Generic sim-to-real pipeline tools within the Workbench solution",
-            "cli_command": (
-                "npa workbench workflow submit "
-                "npa/workflows/workbench/skypilot/sim-to-real-loop.yaml"
-            ),
-        },
+        *CONFIGURED_SOLUTIONS,
         {"name": "demo", "description": "Demo solution", "cli_command": "npa demo"},
     ]
 
@@ -62,9 +84,9 @@ def test_list_solutions_returns_entry_copies() -> None:
     registry.register_solution("demo", "Demo solution", "npa demo")
 
     listed = registry.list_solutions()
-    listed[2]["description"] = "mutated"
+    listed[-1]["description"] = "mutated"
 
-    assert registry.list_solutions()[2]["description"] == "Demo solution"
+    assert registry.list_solutions()[-1]["description"] == "Demo solution"
 
 
 def test_solutions_package_import_does_not_load_toml(mocker) -> None:
@@ -86,21 +108,7 @@ def test_list_solutions_lazily_loads_workbench_solution(mocker) -> None:
     first = registry.list_solutions()
     second = registry.list_solutions()
 
-    assert first == [
-        {
-            "name": "workbench",
-            "description": "First solution: physical AI robotics workflows built on Nebius infrastructure",
-            "cli_command": "npa workbench",
-        },
-        {
-            "name": "sim-to-real",
-            "description": "Generic sim-to-real pipeline tools within the Workbench solution",
-            "cli_command": (
-                "npa workbench workflow submit "
-                "npa/workflows/workbench/skypilot/sim-to-real-loop.yaml"
-            ),
-        },
-    ]
+    assert first == CONFIGURED_SOLUTIONS
     assert second == first
     assert load_spy.call_count == 1
 

--- a/npa/tests/workflows/test_sonic_locomotion_finetuning.py
+++ b/npa/tests/workflows/test_sonic_locomotion_finetuning.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PIPELINE_YAML = (
+    ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "sonic-locomotion-finetuning.yaml"
+)
+RETARGETING_YAML = ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "retargeting.yaml"
+MJLAB_YAML = ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "mjlab-eval.yaml"
+
+
+def _docs(path: Path) -> list[dict]:
+    return [doc for doc in yaml.safe_load_all(path.read_text(encoding="utf-8")) if doc is not None]
+
+
+def test_sonic_locomotion_pipeline_yaml_is_serial_and_uses_expected_tools() -> None:
+    docs = _docs(PIPELINE_YAML)
+
+    assert docs[0] == {"name": "sonic-locomotion-finetuning", "execution": "serial"}
+    tasks = docs[1:]
+    assert [task["name"] for task in tasks] == [
+        "sonic-retarget-motion",
+        "sonic-finetune",
+        "sonic-mjlab-eval",
+    ]
+    assert "npa workbench retargeting run" in tasks[0]["run"]
+    assert "/entrypoint.sh train" in tasks[1]["run"]
+    assert "npa workbench mjlab eval" in tasks[2]["run"]
+
+
+def test_sonic_locomotion_pipeline_routes_gpu_stages_to_h100() -> None:
+    docs = _docs(PIPELINE_YAML)
+    retarget, train, eval_task = docs[1:]
+
+    assert retarget["resources"] == {
+        "cloud": "kubernetes",
+        "cpus": 4,
+        "memory": 16,
+        "image_id": "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa:<npa-image-tag>",
+    }
+    for task in (train, eval_task):
+        assert task["resources"]["cloud"] == "kubernetes"
+        assert task["resources"]["accelerators"] == "H100:1"
+    assert train["resources"]["image_id"].endswith("/npa-sonic:<sonic-image-tag>")
+
+
+def test_tool_yamls_match_registered_cli_surfaces() -> None:
+    retarget_docs = _docs(RETARGETING_YAML)
+    mjlab_docs = _docs(MJLAB_YAML)
+
+    assert retarget_docs[0] == {"name": "retargeting", "execution": "serial"}
+    assert retarget_docs[1]["name"] == "retarget-motion"
+    assert "npa workbench retargeting run" in retarget_docs[1]["run"]
+    assert "accelerators" not in retarget_docs[1]["resources"]
+
+    assert mjlab_docs[0] == {"name": "mjlab-eval", "execution": "serial"}
+    assert mjlab_docs[1]["name"] == "mjlab-locomotion-eval"
+    assert "npa workbench mjlab eval" in mjlab_docs[1]["run"]
+    assert mjlab_docs[1]["resources"]["accelerators"] == "H100:1"
+
+
+def test_sonic_locomotion_assets_do_not_add_python_runner() -> None:
+    scripts = {path.name for path in (ROOT / "npa" / "scripts").glob("run_*sonic*")}
+
+    assert scripts == set()

--- a/npa/workflows/workbench/skypilot/mjlab-eval.yaml
+++ b/npa/workflows/workbench/skypilot/mjlab-eval.yaml
@@ -1,0 +1,39 @@
+# Evaluate a SONIC locomotion checkpoint with MJLab metrics.
+name: mjlab-eval
+execution: serial
+---
+name: mjlab-locomotion-eval
+resources:
+  cloud: kubernetes
+  accelerators: H100:1
+  cpus: 8
+  memory: 32
+  # Replace <your-registry-id> and <npa-image-tag> with an image that includes
+  # the npa CLI and this repository's Workbench package.
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa:<npa-image-tag>"
+envs:
+  EVAL_INPUT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/"
+  SONIC_CHECKPOINT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/training/checkpoint_smoke.json"
+  MJLAB_OUTPUT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/mjlab/"
+  MJLAB_SUITE: "locomotion"
+  SONIC_EMBODIMENT: "unitree-g1"
+  MJLAB_EPISODES: "8"
+  MJLAB_SUCCESS_THRESHOLD: "0.75"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+  NPA_DRY_RUN: "0"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  npa workbench mjlab eval \
+    --input-path "${EVAL_INPUT_URI}" \
+    --checkpoint "${SONIC_CHECKPOINT_URI}" \
+    --output-path "${MJLAB_OUTPUT_URI}" \
+    --suite "${MJLAB_SUITE}" \
+    --embodiment "${SONIC_EMBODIMENT}" \
+    --episodes "${MJLAB_EPISODES}" \
+    --success-threshold "${MJLAB_SUCCESS_THRESHOLD}" \
+    --output json

--- a/npa/workflows/workbench/skypilot/retargeting.yaml
+++ b/npa/workflows/workbench/skypilot/retargeting.yaml
@@ -1,0 +1,38 @@
+# Retarget source motion artifacts into the SONIC embodiment schema.
+name: retargeting
+execution: serial
+---
+name: retarget-motion
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  # Replace <your-registry-id> and <npa-image-tag> with an image that includes
+  # the npa CLI and this repository's Workbench package.
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa:<npa-image-tag>"
+envs:
+  INPUT_MOTION_URI: "s3://<your-bucket-name>/motions/source/"
+  RETARGETED_MOTION_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/"
+  SOURCE_FORMAT: "mocap-json"
+  SONIC_EMBODIMENT: "unitree-g1"
+  RETARGET_MAP_URI: ""
+  RETARGET_FRAME_RATE: "50"
+  RETARGET_MAX_FRAMES: "0"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+  NPA_DRY_RUN: "0"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  npa workbench retargeting run \
+    --input-path "${INPUT_MOTION_URI}" \
+    --output-path "${RETARGETED_MOTION_URI}" \
+    --source-format "${SOURCE_FORMAT}" \
+    --embodiment "${SONIC_EMBODIMENT}" \
+    --retarget-map "${RETARGET_MAP_URI}" \
+    --frame-rate "${RETARGET_FRAME_RATE}" \
+    --max-frames "${RETARGET_MAX_FRAMES}" \
+    --output json

--- a/npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml
@@ -1,0 +1,105 @@
+# SONIC locomotion fine-tuning pipeline.
+#
+# Workflow logic lives in this SkyPilot YAML: retarget source motion, fine-tune
+# or smoke-validate SONIC, then score the resulting checkpoint with MJLab.
+name: sonic-locomotion-finetuning
+execution: serial
+---
+name: sonic-retarget-motion
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  # Replace <your-registry-id> and <npa-image-tag> with an image that includes
+  # the npa CLI and this repository's Workbench package.
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa:<npa-image-tag>"
+envs:
+  NPA_PIPELINE_RUN_ID: "<run-id>"
+  INPUT_MOTION_URI: "s3://<your-bucket-name>/motions/source/"
+  RETARGETED_MOTION_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/"
+  SOURCE_FORMAT: "mocap-json"
+  SONIC_EMBODIMENT: "unitree-g1"
+  RETARGET_MAP_URI: ""
+  RETARGET_FRAME_RATE: "50"
+  RETARGET_MAX_FRAMES: "0"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+  NPA_DRY_RUN: "0"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  npa workbench retargeting run \
+    --input-path "${INPUT_MOTION_URI}" \
+    --output-path "${RETARGETED_MOTION_URI}" \
+    --source-format "${SOURCE_FORMAT}" \
+    --embodiment "${SONIC_EMBODIMENT}" \
+    --retarget-map "${RETARGET_MAP_URI}" \
+    --frame-rate "${RETARGET_FRAME_RATE}" \
+    --max-frames "${RETARGET_MAX_FRAMES}" \
+    --output json
+---
+name: sonic-finetune
+resources:
+  cloud: kubernetes
+  accelerators: H100:1
+  cpus: 16
+  memory: 64
+  # Replace <your-registry-id> and <sonic-image-tag> with the SONIC image tag.
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-sonic:<sonic-image-tag>"
+envs:
+  NPA_PIPELINE_RUN_ID: "<run-id>"
+  RETARGETED_MOTION_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/"
+  SONIC_TRAIN_OUTPUT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/training/"
+  SONIC_EMBODIMENT: "UNITREE_G1_SONIC"
+  SONIC_CHECKPOINT: "nvidia/GEAR-SONIC:sonic_release/last.pt"
+  SONIC_DATA_PATH: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/"
+  SONIC_SAMPLE_DATA: "0"
+  SONIC_NUM_ENVS: "16"
+  SONIC_HEADLESS: "True"
+  SONIC_MAX_ITERATIONS: "5"
+  SONIC_RUN_REAL_TRAIN: "0"
+  NPA_OUTPUT_PATH: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/training/"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+run: |
+  set -euo pipefail
+  /entrypoint.sh train
+---
+name: sonic-mjlab-eval
+resources:
+  cloud: kubernetes
+  accelerators: H100:1
+  cpus: 8
+  memory: 32
+  # Replace <your-registry-id> and <npa-image-tag> with an image that includes
+  # the npa CLI and this repository's Workbench package.
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa:<npa-image-tag>"
+envs:
+  NPA_PIPELINE_RUN_ID: "<run-id>"
+  EVAL_INPUT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/"
+  SONIC_CHECKPOINT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/training/checkpoint_smoke.json"
+  MJLAB_OUTPUT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/mjlab/"
+  MJLAB_SUITE: "locomotion"
+  SONIC_EMBODIMENT: "unitree-g1"
+  MJLAB_EPISODES: "8"
+  MJLAB_SUCCESS_THRESHOLD: "0.75"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+  NPA_DRY_RUN: "0"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  npa workbench mjlab eval \
+    --input-path "${EVAL_INPUT_URI}" \
+    --checkpoint "${SONIC_CHECKPOINT_URI}" \
+    --output-path "${MJLAB_OUTPUT_URI}" \
+    --suite "${MJLAB_SUITE}" \
+    --embodiment "${SONIC_EMBODIMENT}" \
+    --episodes "${MJLAB_EPISODES}" \
+    --success-threshold "${MJLAB_SUCCESS_THRESHOLD}" \
+    --output json


### PR DESCRIPTION
Adds SONIC locomotion fine-tuning cookbook, MJLab eval tool, and retargeting tool to npa workbench.

Changes:
- docs/workbench/cookbooks/sonic-locomotion-finetuning.md
- npa/src/npa/cli/workbench/mjlab.py
- npa/src/npa/cli/workbench/retargeting.py
- SkyPilot YAML templates for mjlab-eval and retargeting
- Solutions registry and SDK namespace updates