### PR TITLE
Restore FiftyOne public endpoint wiring

### DIFF
--- a/docs/cli/fiftyone.md
+++ b/docs/cli/fiftyone.md
@@ -60,6 +60,9 @@ datasets  Inspect datasets through the FiftyOne GraphQL API.
 ```bash
 npa workbench fiftyone --help
 npa workbench fiftyone ensure-ingress --help
+npa workbench fiftyone launch --address 0.0.0.0 --port 5151
 ```
+
+`--address 0.0.0.0` binds the FiftyOne App for public endpoint use; the app is unauthenticated, so only expose trusted datasets.
 
 Regenerate this page with `bash scripts/build_docs.sh` after changing `fiftyone`.

--- a/docs/workbench/cookbooks/bdd100k-pipeline.md
+++ b/docs/workbench/cookbooks/bdd100k-pipeline.md
@@ -11,13 +11,14 @@ The workflow composes the six BDD100K reproduction stages:
 4. Create the three failure-mode materialized views with `POST /create-mv`.
 5. Train one detector per failure-mode view with `POST /train`.
 6. Evaluate each trained detector with `POST /eval`.
+7. Launch a FiftyOne App on `--address 0.0.0.0 --port 5151` with the SkyPilot port exposed for public review.
 
 SkyPilot 0.12.2 supports serial pipelines and all-parallel job groups, but not
 mixed dependency graphs in one YAML. This pipeline therefore serializes the
 three training tasks and three evaluation tasks. The logical DAG is still:
 
 ```text
-ingest -> CPU backfill -> CLIP backfill -> materialized views -> training x3 -> eval x3
+ingest -> CPU backfill -> CLIP backfill -> materialized views -> training x3 -> eval x3 -> FiftyOne app
 ```
 
 ## Dry Validation
@@ -71,6 +72,9 @@ submission:
 
 - `cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:<lancedb-image-tag>`
 - `cr.eu-north1.nebius.cloud/<your-registry-id>/npa-detection-training:<detection-training-image-tag>`
+- `cr.eu-north1.nebius.cloud/<your-registry-id>/npa-fiftyone:<fiftyone-image-tag>`
+
+The final FiftyOne task exposes port `5151` through SkyPilot. The app does not add authentication; restrict the run inputs to datasets that are safe to show publicly and use `sky status --endpoint 5151 <cluster>` to resolve the public URL.
 
 ## Output Layout
 

--- a/npa/src/npa/cli/fiftyone/__init__.py
+++ b/npa/src/npa/cli/fiftyone/__init__.py
@@ -140,6 +140,7 @@ FIFTYONE_K8S_PUBLIC_URL_ANNOTATION = "npa.nebius.com/public-url"
 FIFTYONE_K8S_SERVICE_TYPE_ANNOTATION = "npa.nebius.com/service-type"
 FIFTYONE_K8S_EXTERNAL_IP_TIMEOUT_SEC = 300
 DEFAULT_APP_PORT = 5151
+DEFAULT_APP_ADDRESS = "0.0.0.0"
 DEFAULT_CPU_PLATFORM = "cpu-d3"
 DEFAULT_CPU_PRESET = "4vcpu-16gb"
 DEFAULT_CPU_IMAGE_FAMILY = "ubuntu24.04-driverless"
@@ -223,6 +224,15 @@ app.add_typer(datasets_app, name="datasets")
 def _fail(msg: str, code: int = 1) -> None:
     console.print(f"[red]Error:[/red] {msg}", soft_wrap=True)
     raise typer.Exit(code)
+
+
+def _normalize_app_address(address: str) -> str:
+    normalized = (address or DEFAULT_APP_ADDRESS).strip()
+    if not normalized:
+        _fail("--address must not be empty")
+    if not re.fullmatch(r"[A-Za-z0-9_.:-]+", normalized):
+        _fail("--address must be a single host or IP address")
+    return normalized
 
 
 def _confirm_or_exit(prompt: str) -> None:
@@ -1300,7 +1310,13 @@ fi
 """
 
 
-def _service_setup_script(port: int, dataset_name: str | None = None) -> str:
+def _service_setup_script(
+    port: int,
+    dataset_name: str | None = None,
+    *,
+    address: str = DEFAULT_APP_ADDRESS,
+) -> str:
+    address = _normalize_app_address(address)
     if dataset_name is None:
         dataset_update = (
             'if [ -n "$current_dataset" ]; then\n'
@@ -1318,6 +1334,7 @@ def _service_setup_script(port: int, dataset_name: str | None = None) -> str:
 service_user="$(id -un)"
 was_active="false"
 current_port=""
+current_address=""
 current_dataset=""
 read_env_var() {{
   key="$1"
@@ -1333,6 +1350,7 @@ if systemctl is-active --quiet {FIFTYONE_SERVICE}; then
 fi
 if [ -f /etc/npa-fiftyone/env ]; then
   current_port="$(grep -E '^FIFTYONE_DEFAULT_APP_PORT=' /etc/npa-fiftyone/env | tail -n 1 | cut -d= -f2- || true)"
+  current_address="$(grep -E '^FIFTYONE_DEFAULT_APP_ADDRESS=' /etc/npa-fiftyone/env | tail -n 1 | cut -d= -f2- || true)"
   current_dataset="$(grep -E '^FIFTYONE_DATASET_NAME=' /etc/npa-fiftyone/env | tail -n 1 | cut -d= -f2- || true)"
 fi
 aws_access_key_id="$(read_env_var AWS_ACCESS_KEY_ID)"
@@ -1349,7 +1367,7 @@ if [ -z "$nebius_s3_endpoint" ]; then
 fi
 sudo mkdir -p /etc/npa-fiftyone
 sudo tee /etc/npa-fiftyone/env >/dev/null <<'ENV'
-FIFTYONE_DEFAULT_APP_ADDRESS=0.0.0.0
+FIFTYONE_DEFAULT_APP_ADDRESS={address}
 FIFTYONE_DEFAULT_APP_PORT={port}
 FIFTYONE_DATABASE_DIR={FIFTYONE_HOME}/db
 FIFTYONE_DEFAULT_DATASET_DIR={FIFTYONE_HOME}/datasets
@@ -1389,8 +1407,8 @@ WantedBy=multi-user.target
 UNIT
 sudo systemctl daemon-reload
 sudo systemctl enable {FIFTYONE_SERVICE}
-if [ "$was_active" = "true" ] && [ "$current_port" = "{port}" ]; then
-  echo "FiftyOne already running on port {port}"
+if [ "$was_active" = "true" ] && [ "$current_port" = "{port}" ] && [ "$current_address" = "{address}" ]; then
+  echo "FiftyOne already running on {address}:{port}"
 else
   sudo systemctl reset-failed {FIFTYONE_SERVICE} || true
   sudo systemctl restart {FIFTYONE_SERVICE}
@@ -1408,7 +1426,12 @@ exit 0
 """
 
 
-def _build_install_command(port: int = DEFAULT_APP_PORT) -> str:
+def _build_install_command(
+    port: int = DEFAULT_APP_PORT,
+    *,
+    address: str = DEFAULT_APP_ADDRESS,
+) -> str:
+    address = _normalize_app_address(address)
     app_py = _build_app_py()
     script = f"""\
 set -euo pipefail
@@ -1434,7 +1457,7 @@ PY
 mkdir -p "$HOME/.fiftyone"
 cat > "$HOME/.fiftyone/config.json" <<'JSON'
 {{
-  "default_app_address": "0.0.0.0",
+  "default_app_address": "{address}",
   "default_app_port": {port}
 }}
 JSON
@@ -1446,17 +1469,18 @@ if version != "{FIFTYONE_VERSION}":
     raise RuntimeError(f"expected fiftyone {FIFTYONE_VERSION}, found {{version}}")
 print("FIFTYONE_ENV_SMOKE_OK")
 PY
-{_service_setup_script(port)}
+{_service_setup_script(port, address=address)}
 """
     return _remote_bash(script)
 
 
-def _build_launch_command(port: int) -> str:
+def _build_launch_command(port: int, *, address: str = DEFAULT_APP_ADDRESS) -> str:
+    address = _normalize_app_address(address)
     script = f"""\
 set -euo pipefail
 test -x {FIFTYONE_VENV}/bin/python
 test -f {FIFTYONE_HOME}/app.py
-{_service_setup_script(port)}
+{_service_setup_script(port, address=address)}
 """
     return _remote_bash(script)
 
@@ -2240,7 +2264,8 @@ def _k8s_get_json(kind: str, name: str, *, namespace: str, kubeconfig: str) -> d
     return payload if isinstance(payload, dict) else None
 
 
-def _k8s_app_command(port: int) -> str:
+def _k8s_app_command(port: int, *, address: str = DEFAULT_APP_ADDRESS) -> str:
+    address = _normalize_app_address(address)
     return f"""\
 source {FIFTYONE_VENV}/bin/activate
 export FIFTYONE_DATABASE_DIR="${{FIFTYONE_DATABASE_DIR:-{FIFTYONE_HOME}/db}}"
@@ -2266,7 +2291,7 @@ def handle_stop(signum, frame):
 signal.signal(signal.SIGINT, handle_stop)
 signal.signal(signal.SIGTERM, handle_stop)
 
-address = os.environ.get("FIFTYONE_DEFAULT_APP_ADDRESS", "0.0.0.0")
+address = os.environ.get("FIFTYONE_DEFAULT_APP_ADDRESS", "{address}")
 port = int(os.environ.get("FIFTYONE_DEFAULT_APP_PORT", "{port}"))
 dataset_name = os.environ.get("FIFTYONE_DATASET_NAME", "").strip()
 dataset = fo.load_dataset(dataset_name) if dataset_name and dataset_name in fo.list_datasets() else None
@@ -2287,9 +2312,11 @@ def _kubernetes_manifest(
     name: str,
     namespace: str,
     port: int,
+    address: str,
     service_type: str,
     image_pull_secret: str,
 ) -> dict[str, Any]:
+    address = _normalize_app_address(address)
     labels = {
         "app": name,
         "app.kubernetes.io/name": name,
@@ -2316,10 +2343,10 @@ def _kubernetes_manifest(
                                     "name": "app",
                                     "image": image,
                                     "imagePullPolicy": "IfNotPresent",
-                                    "command": ["/bin/bash", "-lc", _k8s_app_command(port)],
+                                    "command": ["/bin/bash", "-lc", _k8s_app_command(port, address=address)],
                                     "ports": [{"name": "http", "containerPort": port}],
                                     "env": [
-                                        {"name": "FIFTYONE_DEFAULT_APP_ADDRESS", "value": "0.0.0.0"},
+                                        {"name": "FIFTYONE_DEFAULT_APP_ADDRESS", "value": address},
                                         {"name": "FIFTYONE_DEFAULT_APP_PORT", "value": str(port)},
                                         {"name": "FIFTYONE_DATABASE_DIR", "value": f"{FIFTYONE_HOME}/db"},
                                         {"name": "FIFTYONE_DEFAULT_DATASET_DIR", "value": f"{FIFTYONE_HOME}/datasets"},
@@ -2433,9 +2460,11 @@ def _save_k8s_workbench_state(
     name: str,
     namespace: str,
     port: int,
+    address: str,
     service_type: str,
     public_url: str,
 ) -> None:
+    address = _normalize_app_address(address)
     project = _project_alias or cluster_name
     workbench = _workbench_name or "fiftyone"
     endpoint = public_url or f"http://{name}.{namespace}.svc.cluster.local:{port}"
@@ -2453,6 +2482,7 @@ def _save_k8s_workbench_state(
                             "endpoint_strategy": "public" if public_url else "cluster",
                             "service_port": port,
                             "app_port": port,
+                            "app_address": address,
                             "app_status": APP_STATUS_HEALTHY,
                             "kubernetes": {
                                 "cluster_name": cluster_name,
@@ -2461,6 +2491,7 @@ def _save_k8s_workbench_state(
                                 "service_name": name,
                                 "service_type": service_type,
                                 "public_url": public_url,
+                                "app_address": address,
                             },
                         }
                     }
@@ -2478,12 +2509,14 @@ def _deploy_kubernetes_fiftyone(
     name: str,
     namespace: str,
     port: int,
+    address: str,
     image_pull_secret: str,
     public_ip: bool,
     destroy: bool,
     dry_run: bool,
     output: OutputFormat,
 ) -> None:
+    address = _normalize_app_address(address)
     service_type = "LoadBalancer" if public_ip else "ClusterIP"
     resolved_kubeconfig = _resolve_required_kubeconfig(cluster_name=cluster_name, kubeconfig=kubeconfig)
     if destroy:
@@ -2497,6 +2530,7 @@ def _deploy_kubernetes_fiftyone(
         name=name,
         namespace=namespace,
         port=port,
+        address=address,
         service_type=service_type,
         image_pull_secret=image_pull_secret,
     )
@@ -2539,6 +2573,7 @@ def _deploy_kubernetes_fiftyone(
         name=name,
         namespace=namespace,
         port=port,
+        address=address,
         service_type=service_type,
         public_url=public_url,
     )
@@ -2550,6 +2585,7 @@ def _deploy_kubernetes_fiftyone(
         "service_type": service_type,
         "cluster_url": f"http://{name}.{namespace}.svc.cluster.local:{port}",
         "public_url": public_url,
+        "app_address": address,
     }
     _output(payload, output)
 
@@ -2680,6 +2716,11 @@ def deploy_cmd(
     ),
     verify_env: bool = typer.Option(bool(os.environ.get("CI")), "--verify-env/--no-verify-env", help="Audit deployed shared credentials after app deploy."),
     port: int = typer.Option(DEFAULT_APP_PORT, "--port", help="FiftyOne app port on the VM."),
+    address: str = typer.Option(
+        DEFAULT_APP_ADDRESS,
+        "--address",
+        help="FiftyOne app bind address. Use 0.0.0.0 for a public endpoint.",
+    ),
     preemptible: bool = typer.Option(True, "--preemptible/--no-preemptible", help="Preemptible GPU instance."),
     runtime: WorkbenchRuntime = typer.Option(
         WorkbenchRuntime.vm,
@@ -2710,6 +2751,7 @@ def deploy_cmd(
     output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
 ) -> None:
     """Deploy or destroy a FiftyOne dataset curation VM."""
+    address = _normalize_app_address(address)
     byovm = is_byovm_runtime(runtime)
     if _is_serverless_runtime(runtime):
         _fail("FiftyOne deploy does not use --runtime serverless; use `npa workbench fiftyone load-dataset --runtime serverless`.")
@@ -2725,6 +2767,7 @@ def deploy_cmd(
             name=service_name,
             namespace=namespace,
             port=port,
+            address=address,
             image_pull_secret=image_pull_secret,
             public_ip=public_ip,
             destroy=destroy,
@@ -3152,6 +3195,7 @@ def deploy_cmd(
         "endpoint_strategy": initial_endpoint_strategy,
         "service_port": port,
         "app_port": port,
+        "app_address": address,
         **byovm_fields,
         "ssh": {"host": vm_ip, "user": ssh_user, "key_path": ssh_key},
         "storage": {"checkpoint_bucket": bucket_display, "endpoint_url": storage_ep},
@@ -3230,7 +3274,7 @@ def deploy_cmd(
 
                 try:
                     service_env = {
-                        "FIFTYONE_DEFAULT_APP_ADDRESS": "0.0.0.0",
+                        "FIFTYONE_DEFAULT_APP_ADDRESS": address,
                         "FIFTYONE_DEFAULT_APP_PORT": str(port),
                         "FIFTYONE_DATABASE_DIR": FIFTYONE_CONTAINER_DB_DIR,
                         "FIFTYONE_DEFAULT_DATASET_DIR": f"{FIFTYONE_HOME}/datasets",
@@ -3318,7 +3362,7 @@ def deploy_cmd(
                 console.print(f"    [dry-run] Would create {FIFTYONE_VENV}, install FiftyOne, and start port {port}")
             else:
                 try:
-                    _run_fiftyone_command(ssh, _build_install_command(port), stream=True)
+                    _run_fiftyone_command(ssh, _build_install_command(port, address=address), stream=True)
                 except SSHError as exc:
                     fail_app(f"FiftyOne installation failed: {exc}")
                     return
@@ -3438,6 +3482,7 @@ def deploy_cmd(
             "uses_gpu": uses_gpu,
             "runtime": runtime.value,
             "app_port": port,
+            "app_address": address,
             "tf_outputs": tf_outputs,
         }, indent=2))
 
@@ -3445,9 +3490,15 @@ def deploy_cmd(
 @app.command("launch")
 def launch_cmd(
     port: int = typer.Option(DEFAULT_APP_PORT, "--port", help="FiftyOne app port."),
+    address: str = typer.Option(
+        DEFAULT_APP_ADDRESS,
+        "--address",
+        help="FiftyOne app bind address. Use 0.0.0.0 for a public endpoint.",
+    ),
     output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
 ) -> None:
     """Start the FiftyOne app over SSH and print the browser URL."""
+    address = _normalize_app_address(address)
     cfg = _get_ssh_config()
     ssh = SSHClient(cfg.ssh)
     url = _endpoint_for_port(cfg.endpoint, cfg.ssh.host, port)
@@ -3455,7 +3506,7 @@ def launch_cmd(
     command = (
         _build_container_launch_command(port)
         if _is_container_runtime(cfg)
-        else _build_launch_command(port)
+        else _build_launch_command(port, address=address)
     )
 
     try:
@@ -3469,6 +3520,7 @@ def launch_cmd(
         "url": url,
         "browser_url": browser_url,
         "port": port,
+        "address": address,
     }
     if output == OutputFormat.json and out.strip():
         result["stdout_tail"] = out.strip()[-1000:]

--- a/npa/src/npa/workbench/fiftyone/__init__.py
+++ b/npa/src/npa/workbench/fiftyone/__init__.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from npa._sdk import make_cli_wrapper
+from typing import Any
+
+from npa._sdk import call_cli_callback, make_cli_wrapper
+
+DEFAULT_APP_ADDRESS = "0.0.0.0"
+DEFAULT_APP_PORT = 5151
 
 ensure_ingress = make_cli_wrapper(
     "npa.cli.fiftyone", "ensure_ingress_cmd", "Ensure ingress for a FiftyOne workbench."
@@ -14,7 +19,25 @@ list = make_cli_wrapper("npa.cli.fiftyone", "list_cmd", "List FiftyOne workbench
 deploy = make_cli_wrapper(
     "npa.cli.fiftyone", "deploy_cmd", "Deploy a FiftyOne workbench."
 )
-launch = make_cli_wrapper("npa.cli.fiftyone", "launch_cmd", "Launch FiftyOne.")
+
+
+def launch(
+    *,
+    port: int = DEFAULT_APP_PORT,
+    address: str = DEFAULT_APP_ADDRESS,
+    output: str = "text",
+) -> Any:
+    """Launch FiftyOne with a configurable bind address and port."""
+    from npa.cli.fiftyone import launch_cmd
+
+    return call_cli_callback(
+        launch_cmd,
+        port=port,
+        address=address,
+        output=output,
+    )
+
+
 curate = make_cli_wrapper(
     "npa.cli.fiftyone", "curate_cmd", "Curate and export a LeRobotDataset with FiftyOne."
 )

--- a/npa/tests/cli/test_fiftyone_cli.py
+++ b/npa/tests/cli/test_fiftyone_cli.py
@@ -124,6 +124,8 @@ def test_fiftyone_deploy_defaults_to_cpu_without_gpu_flags(tmp_path: Path, mocke
             "-n",
             "curate",
             "deploy",
+            "--address",
+            "0.0.0.0",
             "--project-id",
             "project",
             "--tenant-id",
@@ -876,13 +878,14 @@ def test_fiftyone_launch_builds_remote_command_and_url(mocker) -> None:
 
     result = runner.invoke(
         app,
-        ["workbench", "fiftyone", "launch", "--port", "6161"],
+        ["workbench", "fiftyone", "launch", "--port", "6161", "--address", "0.0.0.0"],
     )
 
     assert result.exit_code == 0
     assert "http://fiftyone.example:6161" in result.output
     cmd = ssh.run.call_args.args[0]
     assert "test -x /opt/fiftyone/venv/bin/python" in cmd
+    assert "FIFTYONE_DEFAULT_APP_ADDRESS=0.0.0.0" in cmd
     assert "FIFTYONE_DEFAULT_APP_PORT=6161" in cmd
     assert "sudo systemctl enable npa-fiftyone-app" in cmd
     assert "http://127.0.0.1:6161/" in cmd

--- a/npa/tests/workflows/test_bdd100k_pipeline.py
+++ b/npa/tests/workflows/test_bdd100k_pipeline.py
@@ -27,8 +27,9 @@ EXPECTED_TASK_ORDER = [
     "bdd100k-eval-rider",
     "bdd100k-eval-nighttime",
     "bdd100k-eval-distant",
+    "bdd100k-fiftyone-app",
 ]
-EXPECTED_YAML_SHA256 = "d3019a472c96105e6e11eb76cd27dcd58065ac5c6da906ad0288775a81d204b4"
+EXPECTED_YAML_SHA256 = "54909c28411d6ba27dbcc72c8c471c6e47385dc5da2ac8f09a78ee3be1a49cfa"
 SYNTHETIC_BDD100K_LABEL_MAP = {
     "person": 0,
     "rider": 1,
@@ -81,6 +82,7 @@ def test_bdd100k_pipeline_yaml_has_expected_logical_stages_and_resources() -> No
         "materialized_views": 1,
         "training": 3,
         "evaluation": 3,
+        "fiftyone_app": 1,
     }
     assert len(tasks) == sum(logical_stage_counts.values())
 
@@ -112,6 +114,17 @@ def test_bdd100k_pipeline_yaml_has_expected_logical_stages_and_resources() -> No
         assert resources["accelerators"] == "H100:1"
         assert resources["cpus"] == 8
         assert resources["memory"] == 32
+
+    fiftyone = by_name["bdd100k-fiftyone-app"]
+    assert fiftyone["resources"] == {
+        "cloud": "kubernetes",
+        "cpus": 4,
+        "memory": 16,
+        "ports": 5151,
+        "image_id": "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-fiftyone:<fiftyone-image-tag>",
+    }
+    assert fiftyone["envs"]["FIFTYONE_DEFAULT_APP_ADDRESS"] == "0.0.0.0"
+    assert fiftyone["envs"]["FIFTYONE_DEFAULT_APP_PORT"] == "5151"
 
 
 def test_bdd100k_pipeline_wrapper_renders_run_id_and_submits_in_order(monkeypatch, tmp_path, capsys) -> None:

--- a/npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml
+++ b/npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml
@@ -963,3 +963,78 @@ run: |
   if [[ "${WRITE_CANONICAL_EVAL_METRICS}" == "1" ]] && command -v aws >/dev/null 2>&1; then
     aws s3 cp eval-response.json "${EVAL_OUTPUT_URI%/}/metrics.json" --endpoint-url "${NEBIUS_S3_ENDPOINT}"
   fi
+---
+# Stage 7: launch a public FiftyOne App for review.
+name: bdd100k-fiftyone-app
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  ports: 5151
+  # Replace <your-registry-id> with your Nebius container registry ID
+  # Replace <fiftyone-image-tag> with the output of: npa workbench fiftyone system-info
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-fiftyone:<fiftyone-image-tag>"
+envs:
+  NPA_PIPELINE_RUN_ID: "<your-run-id>"
+  S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
+  S3_PREFIX: "bdd100k-pipeline/${NPA_PIPELINE_RUN_ID}"
+  PIPELINE_ROOT_URI: "s3://${NPA_S3_BUCKET}/bdd100k-pipeline/${NPA_PIPELINE_RUN_ID}"
+  LANCE_URI: "s3://${NPA_S3_BUCKET}/bdd100k-pipeline/${NPA_PIPELINE_RUN_ID}/lancedb/"
+  FIFTYONE_DEFAULT_APP_ADDRESS: "0.0.0.0"
+  FIFTYONE_DEFAULT_APP_PORT: "5151"
+  FIFTYONE_PUBLIC_URL: ""
+run: |
+  set -euo pipefail
+  python - <<'PY'
+  from __future__ import annotations
+
+  import os
+  import signal
+  import time
+
+  try:
+      import fiftyone as fo
+  except ModuleNotFoundError:
+      lancedb_endpoint = os.environ.get("LANCEDB_ENDPOINT", "")
+      detection_endpoint = os.environ.get("DETECTION_TRAINING_ENDPOINT", "")
+      if (
+          lancedb_endpoint.startswith("http://127.0.0.1:")
+          and detection_endpoint.startswith("http://127.0.0.1:")
+      ):
+          print("NPA_FIFTYONE_APP_SKIPPED mock endpoint validation", flush=True)
+          raise SystemExit(0)
+      raise
+
+  stop = False
+
+
+  def handle_stop(signum, frame):
+      global stop
+      stop = True
+
+
+  signal.signal(signal.SIGINT, handle_stop)
+  signal.signal(signal.SIGTERM, handle_stop)
+
+  address = os.environ.get("FIFTYONE_DEFAULT_APP_ADDRESS", "0.0.0.0")
+  port = int(os.environ.get("FIFTYONE_DEFAULT_APP_PORT", "5151"))
+  dataset_name = os.environ.get("FIFTYONE_DATASET_NAME", "").strip()
+  dataset = None
+  if dataset_name and dataset_name in fo.list_datasets():
+      dataset = fo.load_dataset(dataset_name)
+  session = fo.launch_app(dataset, remote=True, address=address, port=port, auto=False)
+  endpoint = os.environ.get("FIFTYONE_PUBLIC_URL", "").strip()
+  if not endpoint:
+      endpoint = f"http://{address}:{port}"
+      print(
+          f"NPA_FIFTYONE_ENDPOINT_HINT run `sky status --endpoint {port} <cluster>` "
+          "to resolve the public URL",
+          flush=True,
+      )
+  print(f"NPA_FIFTYONE_APP_READY {endpoint}", flush=True)
+  try:
+      while not stop:
+          time.sleep(1)
+  finally:
+      session.close()
+  PY


### PR DESCRIPTION
## Summary

- Add configurable FiftyOne app bind address support across SDK and CLI launch/deploy paths.
- Thread the address into VM systemd env, Kubernetes manifest env, saved workbench state, and JSON output.
- Add a final BDD100K SkyPilot FiftyOne review task exposing port 5151 and launching the app on 0.0.0.0.
- Document the public endpoint flag and unauthenticated exposure caveat.

## Validation

- PYTHONPATH=/opt/nebius-physical-ai-fiftyone-public/npa/src /opt/nebius-physical-ai/npa/.venv/bin/python -m pytest npa/tests/cli/test_fiftyone_cli.py::test_fiftyone_deploy_defaults_to_cpu_without_gpu_flags npa/tests/cli/test_fiftyone_cli.py::test_fiftyone_launch_builds_remote_command_and_url npa/tests/cli/test_fiftyone_cli.py::test_fiftyone_kubernetes_deploy_public_ip_manifest_is_loadbalancer npa/tests/workflows/test_bdd100k_pipeline.py -q
- /opt/nebius-physical-ai/npa/.venv/bin/ruff check npa/src/npa/cli/fiftyone/__init__.py npa/src/npa/workbench/fiftyone/__init__.py npa/tests/cli/test_fiftyone_cli.py npa/tests/workflows/test_bdd100k_pipeline.py
- git diff --check
- npa workbench fiftyone launch --help
- npa workbench fiftyone deploy --help

## Notes

- Did not launch SkyPilot jobs, FiftyOne, or MongoDB.
- The public FiftyOne app remains unauthenticated; only expose trusted datasets.
- Editing the workflow YAML leaves the frozen /tmp/nebius-demo package out of sync until a separate confirmation run updates it.