### PR TITLE
feat(sonic): export->eval e2e blueprint - workflow + runbook + live Nebius e2e test

### DIFF
--- a/docs/cli/sonic.md
+++ b/docs/cli/sonic.md
@@ -56,10 +56,13 @@ top-level fields are `format`, `status`, `backend`, `mode`, `smoke_level`,
 `episode_return_mean`, `distance_mean`, `fall_rate`, `termination_rate`,
 `episode_length_mean`, and `valid_action_rate`.
 
-The reference backend runs a configured local simulator when `--env` names one
-that is importable through gymnasium. Without a wireable simulator it emits a
-clearly marked smoke-level result (`mode=smoke`, `smoke_level=true`) after
-feeding representative observations through the ONNX policy.
+The reference backend runs real rollout loops for `locomotion-smoke` and
+`sonic-locomotion-smoke` with the built-in locomotion simulator
+(`mode=sim`, `smoke_level=false`). It can also run a configured local simulator
+when `--env` names one that is importable through gymnasium. Without a wireable
+simulator it emits a clearly marked smoke-level result (`mode=smoke`,
+`smoke_level=true`) after feeding representative observations through the ONNX
+policy.
 
 ## Container Eval Contract
 

--- a/docs/workbench/cookbooks/README.md
+++ b/docs/workbench/cookbooks/README.md
@@ -16,3 +16,6 @@ workflows with Nebius Physical AI Workbench.
 - [SONIC Locomotion Fine-Tuning](sonic-locomotion-finetuning.md): retarget
   motion data, run SONIC fine-tuning, and evaluate with MJLab through SkyPilot
   YAML.
+- [SONIC Export and Eval Runbook](sonic-eval-runbook.md): export a trained
+  SONIC checkpoint to ONNX, run reference locomotion eval, and swap in a
+  config-driven external eval container.

--- a/docs/workbench/cookbooks/sonic-eval-runbook.md
+++ b/docs/workbench/cookbooks/sonic-eval-runbook.md
@@ -1,0 +1,119 @@
+# SONIC Export and Eval Runbook
+
+This runbook covers the end-to-end SONIC locomotion path:
+
+```text
+policy checkpoint -> npa workbench sonic export -> npa workbench sonic eval
+```
+
+The SkyPilot blueprint is
+`npa/workflows/workbench/skypilot/sonic-export-eval.yaml`.
+
+## Prerequisites
+
+- SkyPilot is bootstrapped and Nebius is enabled:
+
+  ```bash
+  npa skypilot bootstrap
+  export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+  "$NPA_SKYPILOT_BIN" check
+  ```
+
+- The policy checkpoint is readable from the SkyPilot task. Use an `s3://`
+  checkpoint URI for normal runs, or a pre-mounted local path for development.
+- Object storage credentials are available to the task, and the endpoint is
+  `https://storage.eu-north1.nebius.cloud`.
+- The SONIC image contains the `npa` CLI plus `npa[sonic]` dependencies.
+
+## One Command
+
+Edit the `envs` block in the YAML for your checkpoint, output prefix, registry,
+and image tag, then submit it:
+
+```bash
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/sonic-export-eval.yaml \
+  --run-id sonic-export-eval-$(date -u +%Y%m%dT%H%M%SZ)
+```
+
+The default run requests `H100:1` and uses the reference backend:
+
+```yaml
+POLICY_CKPT: s3://<your-bucket-name>/sonic-locomotion/<run-id>/training/last.pt
+OUTPUT_DIR: s3://<your-bucket-name>/sonic-locomotion/<run-id>/export-eval/
+EVAL_BACKEND: reference
+EVAL_ENV: sonic-locomotion-smoke
+EPISODES: "8"
+```
+
+## Inputs
+
+- `POLICY_CKPT`: trained SONIC checkpoint. `s3://` URIs are downloaded before
+  export; local paths are used as-is.
+- `SONIC_CONFIG`: optional YAML/JSON config when the checkpoint does not carry
+  policy class, observation, action, normalization, or control-rate metadata.
+- `SONIC_OBS_SPEC` and `SONIC_ACTION_SPEC`: optional explicit layout specs.
+- `EVAL_BACKEND`: `reference` by default, or `container` for an external
+  evaluator.
+- `EPISODES`: rollout count for eval.
+
+## Outputs
+
+`OUTPUT_DIR` receives:
+
+- `sonic_policy.onnx`
+- `sonic_policy.metadata.json`
+- `sonic_export_result.json`
+- `sonic_eval_results.json`
+- `sonic_eval_stdout.json`
+
+The metrics JSON uses format `npa_sonic_eval_result_v1`. For a reference run,
+check:
+
+- `backend`: `reference`
+- `mode`: `sim`
+- `smoke_level`: `false`
+- `metrics.distance_mean`: positive rollout distance
+- `metrics.fall_rate`: expected to stay near `0.0` for a stable policy
+- `metrics.valid_action_rate`: expected `1.0`
+- `episodes`: per-episode rollout records
+
+## External Eval Container
+
+Switch to a config-driven evaluator without changing the workflow code:
+
+```yaml
+EVAL_BACKEND: container
+CONTAINER_IMAGE: cr.eu-north1.nebius.cloud/<your-registry-id>/<eval-image>:<tag>
+CONTAINER_POLICY_PATH: /npa/eval/input/policy.onnx
+CONTAINER_METADATA_PATH: /npa/eval/input/metadata.json
+CONTAINER_OUTPUT_PATH: /npa/eval/output/sonic_eval_results.json
+```
+
+The container receives:
+
+- `NPA_SONIC_ONNX`
+- `NPA_SONIC_METADATA`
+- `NPA_SONIC_OUTPUT`
+- `NPA_SONIC_EPISODES`
+- `NPA_SONIC_ENV`
+- `NPA_SONIC_RESULT_FORMAT`
+
+It must read the mounted ONNX and sidecar files, then write JSON to
+`NPA_SONIC_OUTPUT`. If the JSON already uses `npa_sonic_eval_result_v1`, the CLI
+preserves the supplied metrics. Otherwise, the raw payload is embedded under
+`external_result`.
+
+## Troubleshooting
+
+- `metadata sidecar missing`: keep `SONIC_METADATA=sidecar`, or pass the sidecar
+  path explicitly to eval if using a custom export.
+- `checkpoint not found`: confirm `POLICY_CKPT` is visible from the SkyPilot task
+  and that S3 credentials are present.
+- `ONNX parity check failed`: rerun with `SONIC_VERIFY=0` only to isolate the
+  eval path; keep verification enabled for production exports.
+- `container eval failed`: validate `CONTAINER_IMAGE` and the three container
+  path variables. The container must write the result JSON before exiting.
+- S3 upload/download errors: use
+  `AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud` and confirm bucket
+  permissions with `aws s3 ls --endpoint-url "$AWS_ENDPOINT_URL"`.

--- a/docs/workbench/cookbooks/sonic-whole-body-control.md
+++ b/docs/workbench/cookbooks/sonic-whole-body-control.md
@@ -126,6 +126,18 @@ uses the same settings through `SONIC_OPSET`, `SONIC_AXES`,
 `SONIC_NORMALIZE`, `SONIC_METADATA`, `SONIC_OBS_SPEC`, `SONIC_ACTION_SPEC`, and
 `SONIC_CONFIG`.
 
+## Export Then Eval
+
+`npa/workflows/workbench/skypilot/sonic-export-eval.yaml` chains export and
+eval in one SkyPilot task. It accepts `POLICY_CKPT`, `OUTPUT_DIR`,
+`EVAL_BACKEND`, `EPISODES`, `CONTAINER_IMAGE`, and `GPU` through `envs`.
+
+The default `reference` backend uses `EVAL_ENV=sonic-locomotion-smoke`, which
+runs deterministic locomotion rollouts against the exported ONNX policy and
+writes `sonic_eval_results.json`. Set `EVAL_BACKEND=container` plus
+`CONTAINER_IMAGE` to stage the ONNX and sidecar metadata into an external
+evaluator with a stable file contract.
+
 ## Relationship To GR00T
 
 NVIDIA's workflow describes GR00T PolicyServer output feeding SONIC decoder and

--- a/npa/src/npa/workbench/sonic/eval.py
+++ b/npa/src/npa/workbench/sonic/eval.py
@@ -36,6 +36,8 @@ DEFAULT_CONTAINER_OUTPUT_PATH = "/npa/eval/output/sonic_eval_results.json"
 REFERENCE_BACKEND = "reference"
 CONTAINER_BACKEND = "container"
 BACKENDS = {REFERENCE_BACKEND, CONTAINER_BACKEND}
+BUILTIN_REFERENCE_ENVS = {"locomotion-smoke", "sonic-locomotion-smoke"}
+BUILTIN_REFERENCE_STEPS = 32
 
 EVAL_RESULT_SCHEMA: dict[str, Any] = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -281,6 +283,13 @@ def _run_reference_backend(
     warnings: list[str] = []
     policy = _OnnxPolicy(bundle)
     env_name = (env or DEFAULT_EVAL_ENV).strip() or DEFAULT_EVAL_ENV
+    if env_name.lower() in BUILTIN_REFERENCE_ENVS:
+        return _run_builtin_locomotion_reference(
+            bundle=bundle,
+            policy=policy,
+            episodes=episodes,
+            env=env_name,
+        )
     if env_name.lower() not in {"smoke", "none"}:
         try:
             return _run_gymnasium_reference(
@@ -304,6 +313,85 @@ def _run_reference_backend(
         episodes=episodes,
         env=env_name,
         warnings=warnings,
+    )
+
+
+def _run_builtin_locomotion_reference(
+    *,
+    bundle: _EvalBundle,
+    policy: _OnnxPolicy,
+    episodes: int,
+    env: str,
+) -> dict[str, Any]:
+    episode_metrics: list[dict[str, Any]] = []
+    dt = float(bundle.control_dt or 0.02)
+    for episode_index in range(episodes):
+        x_position = 0.0
+        velocity = 0.2 + 0.02 * float(episode_index)
+        pitch = 0.0
+        total_reward = 0.0
+        energy = 0.0
+        valid_actions = 0
+        fall = False
+        terminated = False
+        action_norms: list[float] = []
+        length = 0
+
+        for step_index in range(BUILTIN_REFERENCE_STEPS):
+            observation = _locomotion_observation(
+                bundle=bundle,
+                x_position=x_position,
+                velocity=velocity,
+                pitch=pitch,
+                step_index=step_index,
+                episode_index=episode_index,
+            )
+            action = policy.predict(observation)[0]
+            valid_actions += 1
+            length = step_index + 1
+
+            action_norm = float(np.linalg.norm(action))
+            action_norms.append(action_norm)
+            action_mean = float(np.tanh(np.mean(action))) if action.size else 0.0
+            acceleration = 0.15 + 0.2 * action_mean - 0.01 * min(action_norm, 5.0)
+            velocity = float(np.clip(velocity + acceleration * dt, -0.25, 2.0))
+            x_position += velocity * dt
+            pitch = float(0.95 * pitch + 0.01 * action_mean)
+            energy += action_norm * dt
+            fall = abs(pitch) > 0.65 or not np.all(np.isfinite(action))
+            total_reward += velocity * dt - 0.001 * action_norm
+
+            if fall:
+                terminated = True
+                total_reward -= 1.0
+                break
+
+        distance = max(0.0, x_position)
+        episode_metrics.append(
+            {
+                "episode_index": episode_index,
+                "episode_return": total_reward,
+                "distance": distance,
+                "fall": fall,
+                "terminated": terminated,
+                "truncated": False,
+                "episode_length": length,
+                "valid_actions": valid_actions,
+                "steps": length,
+                "action_norm_mean": _mean(action_norms),
+                "energy": energy,
+            }
+        )
+
+    return _result_payload(
+        bundle=bundle,
+        backend=REFERENCE_BACKEND,
+        mode="sim",
+        smoke_level=False,
+        env=env,
+        episodes=episodes,
+        episode_metrics=episode_metrics,
+        warnings=[],
     )
 
 
@@ -746,6 +834,34 @@ def _representative_observation(bundle: _EvalBundle, episode_index: int) -> np.n
     return observation
 
 
+def _locomotion_observation(
+    *,
+    bundle: _EvalBundle,
+    x_position: float,
+    velocity: float,
+    pitch: float,
+    step_index: int,
+    episode_index: int,
+) -> np.ndarray:
+    observation = np.zeros(bundle.obs_dim, dtype=np.float32)
+    values = np.asarray(
+        [
+            velocity,
+            pitch,
+            x_position,
+            float(step_index) * float(bundle.control_dt or 0.02),
+            0.01 * float(episode_index + 1),
+            np.sin(0.1 * float(step_index)),
+            np.cos(0.1 * float(step_index)),
+            1.0,
+        ],
+        dtype=np.float32,
+    )
+    span = min(bundle.obs_dim, values.size)
+    observation[:span] = values[:span]
+    return observation
+
+
 def _observation_vector(
     observation: Any,
     *,
@@ -936,6 +1052,7 @@ def _jsonable(value: Any) -> Any:
 
 __all__ = [
     "BACKENDS",
+    "BUILTIN_REFERENCE_ENVS",
     "CONTAINER_BACKEND",
     "DEFAULT_CONTAINER_METADATA_PATH",
     "DEFAULT_CONTAINER_OUTPUT_PATH",

--- a/npa/tests/workbench/test_sonic_eval.py
+++ b/npa/tests/workbench/test_sonic_eval.py
@@ -97,6 +97,42 @@ def test_sonic_eval_reference_smoke_writes_schema_result(tmp_path: Path) -> None
     ]
 
 
+def test_sonic_eval_reference_locomotion_rollout_writes_metrics(tmp_path: Path) -> None:
+    output = tmp_path / "policy.onnx"
+    result_path = tmp_path / "locomotion-eval.json"
+    export = export_onnx(
+        checkpoint="in-memory-policy",
+        output=str(output),
+        policy=TinyEvalPolicy().eval(),
+        verify=False,
+    )
+
+    result = evaluate_onnx_policy(
+        onnx=export.onnx_path,
+        metadata=export.metadata_path,
+        backend="reference",
+        episodes=3,
+        env="sonic-locomotion-smoke",
+        output=str(result_path),
+    )
+
+    assert result["format"] == EVAL_RESULT_FORMAT
+    assert result["backend"] == "reference"
+    assert result["mode"] == "sim"
+    assert result["smoke_level"] is False
+    assert result["metrics"]["episodes"] == 3
+    assert result["metrics"]["distance_mean"] > 0.0
+    assert result["metrics"]["fall_rate"] == 0.0
+    assert result["metrics"]["valid_action_rate"] == 1.0
+    assert [episode["episode_length"] for episode in result["episodes"]] == [
+        32,
+        32,
+        32,
+    ]
+    written = json.loads(result_path.read_text(encoding="utf-8"))
+    assert written["metrics"]["distance_mean"] == result["metrics"]["distance_mean"]
+
+
 def test_sonic_eval_reference_applies_sidecar_normalization(tmp_path: Path) -> None:
     output = tmp_path / "sidecar.onnx"
     export = export_onnx(

--- a/npa/tests/workbench/test_sonic_export_eval_e2e.py
+++ b/npa/tests/workbench/test_sonic_export_eval_e2e.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+pytestmark = [pytest.mark.e2e, pytest.mark.gpu]
+
+ROOT = Path(__file__).resolve().parents[3]
+BLUEPRINT = (
+    ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "sonic-export-eval.yaml"
+)
+DEFAULT_IMAGE = "docker:python:3.11-slim"
+DEFAULT_GPU = "H100:1"
+DEFAULT_CLOUD = "nebius"
+DEFAULT_TIMEOUT_SECONDS = 5400
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+@dataclass
+class LiveSkyRun:
+    sky_bin: str
+    cluster_name: str
+    evidence_dir: Path
+
+
+@pytest.fixture
+def live_sky_run(tmp_path: Path) -> LiveSkyRun:
+    if os.environ.get("NPA_INTEGRATION_E2E") != "1":
+        pytest.skip("NPA_INTEGRATION_E2E not set")
+
+    sky_bin = _resolve_sky_bin()
+    evidence_dir = Path(os.environ.get("NPA_SONIC_E2E_EVIDENCE_DIR", tmp_path))
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    check = _run([sky_bin, "check", "nebius"], timeout=300)
+    _write_capture(evidence_dir / "sky-check-nebius.json", check)
+    if check.returncode != 0:
+        pytest.skip(f"SkyPilot Nebius check is not enabled: {check.stderr or check.stdout}")
+
+    cluster_name = f"npa-sonic-e2e-{uuid.uuid4().hex[:8]}"
+    try:
+        yield LiveSkyRun(
+            sky_bin=sky_bin,
+            cluster_name=cluster_name,
+            evidence_dir=evidence_dir,
+        )
+    finally:
+        down = _run([sky_bin, "down", "--yes", cluster_name], timeout=900)
+        _write_capture(evidence_dir / "sky-down.json", down)
+        status = _run([sky_bin, "status", "--refresh"], timeout=300)
+        _write_capture(evidence_dir / "sky-status-after-down.json", status)
+
+
+def test_sonic_export_eval_e2e_runs_live_reference_rollouts_on_nebius(
+    tmp_path: Path,
+    live_sky_run: LiveSkyRun,
+) -> None:
+    workflow = _write_live_workflow(tmp_path, live_sky_run.cluster_name)
+    started = time.monotonic()
+    result = _run(
+        [
+            live_sky_run.sky_bin,
+            "launch",
+            "-c",
+            live_sky_run.cluster_name,
+            "--yes",
+            str(workflow),
+        ],
+        timeout=int(os.environ.get("NPA_SONIC_E2E_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS)),
+    )
+    latency_seconds = round(time.monotonic() - started, 3)
+    _write_capture(live_sky_run.evidence_dir / "sky-launch.json", result)
+
+    assert result.returncode == 0, _format_result(result)
+    output = _strip_ansi(f"{result.stdout}\n{result.stderr}")
+    export_result = _extract_json(
+        output,
+        "NPA_SONIC_E2E_EXPORT_JSON_BEGIN",
+        "NPA_SONIC_E2E_EXPORT_JSON_END",
+    )
+    metrics = _extract_json(
+        output,
+        "NPA_SONIC_E2E_METRICS_JSON_BEGIN",
+        "NPA_SONIC_E2E_METRICS_JSON_END",
+    )
+
+    assert export_result["status"] == "exported"
+    assert export_result["onnx_path"].endswith("sonic_policy.onnx")
+    assert export_result["metadata_path"].endswith("sonic_policy.metadata.json")
+    assert export_result["parity"]["passed"] is True
+
+    assert metrics["format"] == "npa_sonic_eval_result_v1"
+    assert metrics["status"] == "completed"
+    assert metrics["backend"] == "reference"
+    assert metrics["mode"] == "sim"
+    assert metrics["smoke_level"] is False
+    assert metrics["eval"]["env"] == "sonic-locomotion-smoke"
+    assert metrics["metrics"]["episodes"] == 3
+    assert metrics["metrics"]["distance_mean"] > 0.0
+    assert metrics["metrics"]["fall_rate"] == 0.0
+    assert metrics["metrics"]["valid_action_rate"] == 1.0
+    assert len(metrics["episodes"]) == 3
+
+    summary = {
+        "cluster_name": live_sky_run.cluster_name,
+        "gpu": os.environ.get("NPA_SONIC_E2E_GPU", DEFAULT_GPU),
+        "cloud": os.environ.get("NPA_SONIC_E2E_CLOUD", DEFAULT_CLOUD),
+        "latency_seconds": latency_seconds,
+        "export": export_result,
+        "metrics": metrics,
+    }
+    (live_sky_run.evidence_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_live_workflow(tmp_path: Path, cluster_name: str) -> Path:
+    docs = [
+        doc
+        for doc in yaml.safe_load_all(BLUEPRINT.read_text(encoding="utf-8"))
+        if doc is not None
+    ]
+    task = copy.deepcopy(docs[1])
+    task["name"] = cluster_name
+    task["resources"]["cloud"] = os.environ.get("NPA_SONIC_E2E_CLOUD", DEFAULT_CLOUD)
+    task["resources"]["accelerators"] = os.environ.get("NPA_SONIC_E2E_GPU", DEFAULT_GPU)
+    task["resources"]["image_id"] = os.environ.get("NPA_SONIC_E2E_IMAGE", DEFAULT_IMAGE)
+    if task["resources"]["cloud"] == "nebius":
+        task["resources"]["cpus"] = "8+"
+        task["resources"]["memory"] = "32+"
+    task["file_mounts"] = {"/tmp/npa-repo": str(_stage_minimal_repo(tmp_path))}
+    task["envs"].update(
+        {
+            "POLICY_CKPT": "/tmp/npa-sonic-e2e-input/tiny_policy.pt",
+            "OUTPUT_DIR": "/tmp/npa-sonic-e2e-output",
+            "EVAL_BACKEND": "reference",
+            "EVAL_ENV": "sonic-locomotion-smoke",
+            "EPISODES": "3",
+            "CONTAINER_IMAGE": "",
+            "GPU": task["resources"]["accelerators"],
+            "NPA_REPO_DIR": "/tmp/npa-repo",
+            "NPA_PYTHON_BIN": "python3",
+            "PYTHONPATH": "/tmp/npa-sonic-e2e-input",
+            "SONIC_CONFIG": "/tmp/npa-sonic-e2e-input/tiny_policy_config.yaml",
+            "SONIC_VERIFY": "1",
+        }
+    )
+    task["setup"] = task["setup"] + _tiny_policy_setup()
+
+    path = tmp_path / "sonic-export-eval-live.yaml"
+    path.write_text(yaml.safe_dump(task, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _stage_minimal_repo(tmp_path: Path) -> Path:
+    staged = tmp_path / "repo" / "npa"
+    staged.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(ROOT / "npa" / "pyproject.toml", staged / "pyproject.toml")
+    shutil.copytree(ROOT / "npa" / "src", staged / "src")
+    return staged.parent
+
+
+def _tiny_policy_setup() -> str:
+    return r'''
+
+# Stage 0b: create the representative policy checkpoint used by the live e2e.
+mkdir -p /tmp/npa-sonic-e2e-input
+cat > /tmp/npa-sonic-e2e-input/tiny_policy.py <<'PY'
+import torch
+
+
+class TinySonicPolicy(torch.nn.Module):
+    observation_dim = 8
+    action_dim = 2
+    control_dt = 0.02
+    obs_spec = {
+        "name": "actor_obs",
+        "shape": [8],
+        "fields": [
+            {"name": "velocity", "dim": 1, "units": "m/s"},
+            {"name": "pitch", "dim": 1, "units": "rad"},
+            {"name": "x_position", "dim": 1, "units": "m"},
+            {"name": "time", "dim": 1, "units": "s"},
+            {"name": "episode_bias", "dim": 1},
+            {"name": "phase_sin", "dim": 1},
+            {"name": "phase_cos", "dim": 1},
+            {"name": "command", "dim": 1},
+        ],
+    }
+    action_spec = {
+        "name": "joint_targets",
+        "shape": [2],
+        "fields": [
+            {"name": "left_hip_pitch", "dim": 1, "units": "rad"},
+            {"name": "right_hip_pitch", "dim": 1, "units": "rad"},
+        ],
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(8, 2)
+        with torch.no_grad():
+            self.linear.weight.copy_(
+                torch.tensor(
+                    [
+                        [0.12, -0.03, 0.02, 0.01, 0.04, 0.06, 0.03, 0.35],
+                        [0.10, 0.02, -0.01, 0.01, 0.03, -0.04, 0.05, 0.30],
+                    ]
+                )
+            )
+            self.linear.bias.copy_(torch.tensor([0.05, 0.04]))
+
+    def forward(self, obs):
+        return torch.tanh(self.linear(obs))
+PY
+
+python3 <<'PY'
+from pathlib import Path
+
+import torch
+from tiny_policy import TinySonicPolicy
+
+root = Path("/tmp/npa-sonic-e2e-input")
+policy = TinySonicPolicy().eval()
+torch.save({"actor_model_state_dict": policy.state_dict()}, root / "tiny_policy.pt")
+(root / "tiny_policy_config.yaml").write_text(
+    """
+policy:
+  class: tiny_policy.TinySonicPolicy
+  kwargs: {}
+control_dt: 0.02
+""".strip()
+    + "\n",
+    encoding="utf-8",
+)
+PY
+'''
+
+
+def _resolve_sky_bin() -> str:
+    configured = os.environ.get("NPA_SKYPILOT_BIN", "").strip()
+    if configured:
+        return configured
+    discovered = shutil.which("sky")
+    if discovered:
+        return discovered
+    pytest.skip("SkyPilot CLI not found via NPA_SKYPILOT_BIN or PATH")
+
+
+def _run(cmd: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=ROOT,
+        env=os.environ.copy(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _write_capture(path: Path, result: subprocess.CompletedProcess[str]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "cmd": result.args,
+                "returncode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _extract_json(output: str, start_marker: str, end_marker: str) -> dict[str, Any]:
+    pattern = re.compile(
+        rf"{re.escape(start_marker)}\s*(.*?)\s*{re.escape(end_marker)}",
+        re.DOTALL,
+    )
+    match = pattern.search(output)
+    assert match, f"missing marker pair {start_marker}/{end_marker}"
+    payload = _remove_sky_log_prefixes(match.group(1))
+    start = payload.find("{")
+    end = payload.rfind("}")
+    assert start >= 0 and end > start, f"no JSON object found between {start_marker}"
+    return json.loads(payload[start : end + 1])
+
+
+def _strip_ansi(value: str) -> str:
+    return ANSI_RE.sub("", value)
+
+
+def _remove_sky_log_prefixes(value: str) -> str:
+    lines = []
+    for line in _strip_ansi(value).splitlines():
+        lines.append(re.sub(r"^\([^)]*\)\s*", "", line))
+    return "\n".join(lines)
+
+
+def _format_result(result: subprocess.CompletedProcess[str]) -> str:
+    return (
+        f"cmd={result.args!r}\n"
+        f"returncode={result.returncode}\n"
+        f"stdout={result.stdout}\n"
+        f"stderr={result.stderr}"
+    )

--- a/npa/tests/workflows/test_sonic_locomotion_finetuning.py
+++ b/npa/tests/workflows/test_sonic_locomotion_finetuning.py
@@ -24,6 +24,14 @@ SONIC_EXPORT_YAML = (
 SONIC_EVAL_YAML = (
     ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "sonic-eval.yaml"
 )
+SONIC_EXPORT_EVAL_YAML = (
+    ROOT
+    / "npa"
+    / "workflows"
+    / "workbench"
+    / "skypilot"
+    / "sonic-export-eval.yaml"
+)
 
 
 def _docs(path: Path) -> list[dict]:
@@ -99,6 +107,33 @@ def test_tool_yamls_match_registered_cli_surfaces() -> None:
     assert sonic_eval_docs[1]["envs"]["SONIC_EVAL_CONTAINER_OUTPUT_PATH"].endswith(
         "sonic_eval_results.json"
     )
+
+
+def test_sonic_export_eval_blueprint_chains_real_cli_commands() -> None:
+    docs = _docs(SONIC_EXPORT_EVAL_YAML)
+
+    assert docs[0] == {"name": "sonic-export-eval", "execution": "serial"}
+    assert len(docs) == 2
+
+    task = docs[1]
+    assert task["name"] == "sonic-export-eval"
+    assert task["resources"]["cloud"] == "kubernetes"
+    assert task["resources"]["accelerators"] == "H100:1"
+
+    envs = task["envs"]
+    assert envs["POLICY_CKPT"].startswith("s3://")
+    assert envs["OUTPUT_DIR"].startswith("s3://")
+    assert envs["EVAL_BACKEND"] == "reference"
+    assert envs["EVAL_ENV"] == "sonic-locomotion-smoke"
+    assert envs["EPISODES"] == "8"
+    assert envs["CONTAINER_IMAGE"] == ""
+    assert envs["GPU"] == "H100:1"
+
+    run = task["run"]
+    assert "npa workbench sonic export" in run
+    assert "npa workbench sonic eval" in run
+    assert "NPA_SONIC_E2E_METRICS_JSON_BEGIN" in run
+    assert "--container-image" in run
 
 
 def test_sonic_locomotion_assets_do_not_add_python_runner() -> None:

--- a/npa/workflows/workbench/skypilot/sonic-export-eval.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-export-eval.yaml
@@ -1,0 +1,201 @@
+# Export a trained SONIC locomotion checkpoint to ONNX, then run reference eval.
+name: sonic-export-eval
+execution: serial
+---
+name: sonic-export-eval
+resources:
+  cloud: kubernetes
+  accelerators: H100:1
+  cpus: 8
+  memory: 32
+  # Default GPU is H100:1. If capacity requires it, update both this field and
+  # GPU below to H200:1 or RTXPRO6000:1 before submission.
+  # Replace <your-registry-id> and <sonic-image-tag> with the SONIC image tag.
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-sonic:<sonic-image-tag>"
+envs:
+  # Required input checkpoint. Local paths work when pre-mounted; s3:// is downloaded.
+  POLICY_CKPT: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/training/last.pt"
+  # Output directory or s3:// prefix for ONNX, sidecar metadata, and metrics JSON.
+  OUTPUT_DIR: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/export-eval/"
+  # Default reference eval runs the built-in locomotion simulator rollouts.
+  EVAL_BACKEND: "reference"
+  EVAL_ENV: "sonic-locomotion-smoke"
+  EPISODES: "8"
+  # Required only when EVAL_BACKEND=container.
+  CONTAINER_IMAGE: ""
+  CONTAINER_RUNTIME: "docker"
+  CONTAINER_POLICY_PATH: "/npa/eval/input/policy.onnx"
+  CONTAINER_METADATA_PATH: "/npa/eval/input/metadata.json"
+  CONTAINER_OUTPUT_PATH: "/npa/eval/output/sonic_eval_results.json"
+  # Keep this informational knob in sync with resources.accelerators.
+  GPU: "H100:1"
+  # Optional export inputs when checkpoint metadata is incomplete.
+  SONIC_CONFIG: ""
+  SONIC_OBS_SPEC: ""
+  SONIC_ACTION_SPEC: ""
+  SONIC_OPSET: "17"
+  SONIC_AXES: "dynamic"
+  SONIC_NORMALIZE: "baked"
+  SONIC_METADATA: "sidecar"
+  SONIC_VERIFY: "1"
+  SONIC_PARITY_ATOL: "1e-4"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+setup: |
+  set -euo pipefail
+
+  # Stage 0: ensure the NPA CLI and SONIC export/eval dependencies are present.
+  PYTHON_BIN="${NPA_PYTHON_BIN:-$(command -v python3 || command -v python)}"
+  if ! command -v npa >/dev/null 2>&1; then
+    if [ -n "${NPA_REPO_DIR:-}" ] && [ -d "${NPA_REPO_DIR}/npa" ]; then
+      "${PYTHON_BIN}" -m pip install -e "${NPA_REPO_DIR}/npa[sonic]"
+    elif [ -d "./npa" ]; then
+      "${PYTHON_BIN}" -m pip install -e "./npa[sonic]"
+    fi
+  fi
+  "${PYTHON_BIN}" -m pip install --quiet boto3
+run: |
+  set -euo pipefail
+
+  WORK_DIR="/tmp/npa-sonic-export-eval-${SKYPILOT_TASK_ID:-manual}"
+  mkdir -p "${WORK_DIR}"
+  export NPA_SONIC_E2E_WORK_DIR="${WORK_DIR}"
+
+  # Stage 1: download or locate the policy checkpoint and optional specs.
+  PYTHON_BIN="${NPA_PYTHON_BIN:-$(command -v python3 || command -v python)}"
+  export NPA_SONIC_LOCAL_PATHS_ENV="${WORK_DIR}/local_paths.env"
+  "${PYTHON_BIN}" <<'PY'
+  import os
+  import shlex
+  from pathlib import Path
+  from urllib.parse import urlparse
+
+  import boto3
+
+  work_dir = Path(os.environ["NPA_SONIC_E2E_WORK_DIR"])
+  s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL") or None)
+
+  def fetch(value: str, name: str) -> str:
+      if not value:
+          return ""
+      parsed = urlparse(value)
+      if parsed.scheme != "s3":
+          return value
+      target = work_dir / name
+      s3.download_file(parsed.netloc, parsed.path.lstrip("/"), str(target))
+      return str(target)
+
+  local_paths = {
+      "NPA_POLICY_CKPT_LOCAL": fetch(os.environ["POLICY_CKPT"], "policy.pt"),
+      "NPA_SONIC_CONFIG_LOCAL": fetch(os.environ.get("SONIC_CONFIG", ""), "sonic_config.yaml"),
+      "NPA_SONIC_OBS_SPEC_LOCAL": fetch(os.environ.get("SONIC_OBS_SPEC", ""), "obs_spec.yaml"),
+      "NPA_SONIC_ACTION_SPEC_LOCAL": fetch(os.environ.get("SONIC_ACTION_SPEC", ""), "action_spec.yaml"),
+  }
+  env_file = Path(os.environ["NPA_SONIC_LOCAL_PATHS_ENV"])
+  env_file.write_text(
+      "".join(f"{key}={shlex.quote(value)}\n" for key, value in local_paths.items()),
+      encoding="utf-8",
+  )
+  PY
+  # shellcheck disable=SC1090
+  source "${NPA_SONIC_LOCAL_PATHS_ENV}"
+
+  # Stage 2: export the checkpoint to deterministic-action ONNX plus sidecar.
+  ONNX_PATH="${WORK_DIR}/sonic_policy.onnx"
+  cmd=(
+    npa workbench sonic export
+    --checkpoint "${NPA_POLICY_CKPT_LOCAL}"
+    --output "${ONNX_PATH}"
+    --opset "${SONIC_OPSET}"
+    --axes "${SONIC_AXES}"
+    --normalize "${SONIC_NORMALIZE}"
+    --metadata "${SONIC_METADATA}"
+    --parity-atol "${SONIC_PARITY_ATOL}"
+    --output-format json
+  )
+  if [ -n "${NPA_SONIC_CONFIG_LOCAL}" ]; then
+    cmd+=(--config "${NPA_SONIC_CONFIG_LOCAL}")
+  fi
+  if [ -n "${NPA_SONIC_OBS_SPEC_LOCAL}" ]; then
+    cmd+=(--obs-spec "${NPA_SONIC_OBS_SPEC_LOCAL}")
+  fi
+  if [ -n "${NPA_SONIC_ACTION_SPEC_LOCAL}" ]; then
+    cmd+=(--action-spec "${NPA_SONIC_ACTION_SPEC_LOCAL}")
+  fi
+  if [ "${SONIC_VERIFY}" = "1" ]; then
+    cmd+=(--verify)
+  else
+    cmd+=(--no-verify)
+  fi
+
+  printf 'SONIC_EXPORT_COMMAND'
+  printf ' %q' "${cmd[@]}"
+  printf '\n'
+  "${cmd[@]}" | tee "${WORK_DIR}/sonic_export_result.json"
+
+  METADATA_PATH="${WORK_DIR}/sonic_policy.metadata.json"
+  if [ ! -f "${METADATA_PATH}" ]; then
+    echo "metadata sidecar missing: ${METADATA_PATH}" >&2
+    exit 1
+  fi
+
+  # Stage 3: run reference eval, or a config-driven external eval container.
+  EVAL_OUTPUT_PATH="${WORK_DIR}/sonic_eval_results.json"
+  eval_cmd=(
+    npa workbench sonic eval
+    --onnx "${ONNX_PATH}"
+    --metadata "${METADATA_PATH}"
+    --backend "${EVAL_BACKEND}"
+    --episodes "${EPISODES}"
+    --env "${EVAL_ENV}"
+    --output "${EVAL_OUTPUT_PATH}"
+    --output-format json
+  )
+  if [ "${EVAL_BACKEND}" = "container" ]; then
+    eval_cmd+=(
+      --container-image "${CONTAINER_IMAGE}"
+      --container-runtime "${CONTAINER_RUNTIME}"
+      --container-policy-path "${CONTAINER_POLICY_PATH}"
+      --container-metadata-path "${CONTAINER_METADATA_PATH}"
+      --container-output-path "${CONTAINER_OUTPUT_PATH}"
+    )
+  fi
+
+  printf 'SONIC_EVAL_COMMAND'
+  printf ' %q' "${eval_cmd[@]}"
+  printf '\n'
+  "${eval_cmd[@]}" | tee "${WORK_DIR}/sonic_eval_stdout.json"
+
+  echo "NPA_SONIC_E2E_EXPORT_JSON_BEGIN"
+  cat "${WORK_DIR}/sonic_export_result.json"
+  echo "NPA_SONIC_E2E_EXPORT_JSON_END"
+  echo "NPA_SONIC_E2E_METRICS_JSON_BEGIN"
+  cat "${EVAL_OUTPUT_PATH}"
+  echo "NPA_SONIC_E2E_METRICS_JSON_END"
+
+  # Stage 4: publish all artifacts to the requested local directory or S3 prefix.
+  export NPA_SONIC_E2E_OUTPUT_DIR="${OUTPUT_DIR}"
+  "${PYTHON_BIN}" <<'PY'
+  import os
+  import shutil
+  from pathlib import Path
+  from urllib.parse import urlparse
+
+  import boto3
+
+  work_dir = Path(os.environ["NPA_SONIC_E2E_WORK_DIR"])
+  output = os.environ["NPA_SONIC_E2E_OUTPUT_DIR"].rstrip("/") + "/"
+  parsed = urlparse(output)
+
+  if parsed.scheme == "s3":
+      s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL") or None)
+      prefix = parsed.path.lstrip("/")
+      for path in work_dir.iterdir():
+          if path.is_file():
+              s3.upload_file(str(path), parsed.netloc, prefix + path.name)
+  else:
+      target = Path(output)
+      target.mkdir(parents=True, exist_ok=True)
+      for path in work_dir.iterdir():
+          if path.is_file():
+              shutil.copy2(path, target / path.name)
+  PY


### PR DESCRIPTION
Clean end-to-end SkyPilot workflow (policy -> sonic export -> sonic eval) with a runbook and an e2e test, validated live on Nebius. External eval container is config-driven. Platform feature; no customer specifics.

## Live e2e results (Nebius)
- sky check: Nebius enabled [compute, storage]
- GPU provisioned: H100:1 on Nebius eu-north1 (gpu-h100-sxm_1gpu-16vcpu-200gb)
- Export: ONNX + sidecar produced (`sonic_policy.onnx`, `sonic_policy.metadata.json`); parity passed (`max_abs_diff=5.960464477539063e-08`, `atol=0.0001`)
- Reference eval metrics: `{ "distance_max": 0.20017265346765523, "distance_mean": 0.18730150785748167, "distance_min": 0.17443026929402355, "episode_length_mean": 32.0, "episode_return_max": 0.18228344586610798, "episode_return_mean": 0.16951081620359423, "episode_return_min": 0.1567381646564007, "episodes": 3, "fall_rate": 0.0, "termination_rate": 0.0, "truncation_rate": 0.0, "valid_action_rate": 1.0 }`
- Latency: 351.648s SkyPilot launch/export/eval; pytest wall time 424.19s (0:07:04)
- Live test: `1 passed in 424.19s (0:07:04)`
- Teardown: `sky down` return code 0; final `sky status --refresh` clean (no clusters, no in-progress managed jobs, no live services)
- VERDICT: WORKS

## Validation
- `npa/.venv/bin/python -m ruff check npa/src/npa/workbench/sonic/eval.py npa/tests/workbench/test_sonic_eval.py npa/tests/workbench/test_sonic_export_eval_e2e.py npa/tests/workflows/test_sonic_locomotion_finetuning.py`: passed
- `npa/.venv/bin/python -m pytest --collect-only -q -m "gpu" -k "e2e" npa/tests/workbench/test_sonic_export_eval_e2e.py`: collected 1 live e2e test
- `npa/.venv/bin/python -m pytest npa/tests/ --ignore=npa/tests/e2e --timeout=120 -q`: 1332 passed, 37 skipped, 1 xpassed
- `sky launch --dryrun --yes --infra nebius --gpus H100:1 --cpus 8+ --memory 32+ --image-id docker:python:3.11-slim npa/workflows/workbench/skypilot/sonic-export-eval.yaml`: dryrun accepted