### PR TITLE
Add on-demand live GPU e2e CI

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -144,10 +144,9 @@ jobs:
           cluster_pattern='^(sim-to-real-live-|npa-vlm-live-|npa-sonic-e2e-)'
 
           list_live_e2e_clusters() {
-            "${NPA_SKYPILOT_BIN}" status --refresh 2>&1 \
+            "${NPA_SKYPILOT_BIN}" status --refresh 2>/tmp/sky-status-stderr.log \
               | sed -E 's/\x1b\[[0-9;]*[mK]//g' \
-              | awk '{print $1}' \
-              | grep -E "${cluster_pattern}" \
+              | awk -v pattern="${cluster_pattern}" '$1 ~ pattern && $1 !~ /:$/ {print $1}' \
               | sort -u || true
           }
 
@@ -163,6 +162,16 @@ jobs:
               echo "No live e2e SkyPilot clusters remain."
               exit 0
             fi
+            for cluster in "${remaining[@]}"; do
+              echo "Retrying teardown ${cluster}"
+              if ! down_output="$("${NPA_SKYPILOT_BIN}" down --yes "${cluster}" 2>&1)"; then
+                printf '%s\n' "${down_output}"
+                if grep -Eq 'Cluster\(s\) not found|No project found for region' <<< "${down_output}"; then
+                  echo "Purging stale SkyPilot metadata for ${cluster}"
+                  "${NPA_SKYPILOT_BIN}" down --yes --purge "${cluster}" || true
+                fi
+              fi
+            done
             printf 'Waiting for live e2e clusters to disappear: %s\n' "${remaining[*]}"
             sleep 10
           done

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -37,6 +37,7 @@ jobs:
       NEBIUS_S3_ACCESS_KEY_ID: ${{ secrets.NEBIUS_S3_ACCESS_KEY_ID }}
       NEBIUS_S3_SECRET_ACCESS_KEY: ${{ secrets.NEBIUS_S3_SECRET_ACCESS_KEY }}
       NEBIUS_S3_ENDPOINT: ${{ secrets.NEBIUS_S3_ENDPOINT }}
+      NEBIUS_TENANT_ID: ${{ secrets.NEBIUS_TENANT_ID }}
       NPA_S3_BUCKET: ${{ secrets.NPA_S3_BUCKET }}
       NPA_REGISTRY_ID: ${{ secrets.NPA_REGISTRY_ID }}
       AWS_ACCESS_KEY_ID: ${{ secrets.NEBIUS_S3_ACCESS_KEY_ID }}
@@ -78,12 +79,15 @@ jobs:
 
       - name: Write Nebius credentials and verify SkyPilot
         run: |
+          set -euo pipefail
+
           missing=()
           for name in \
             NEBIUS_SA_KEY \
             NEBIUS_S3_ACCESS_KEY_ID \
             NEBIUS_S3_SECRET_ACCESS_KEY \
             NEBIUS_S3_ENDPOINT \
+            NEBIUS_TENANT_ID \
             NPA_S3_BUCKET \
             NPA_REGISTRY_ID
           do
@@ -99,6 +103,7 @@ jobs:
           install -m 700 -d "${HOME}/.nebius" "${HOME}/.aws"
           umask 077
           printf '%s' "${NEBIUS_SA_KEY}" > "${HOME}/.nebius/credentials.json"
+          printf '%s' "${NEBIUS_TENANT_ID}" > "${HOME}/.nebius/NEBIUS_TENANT_ID.txt"
           npa/.venv/bin/python -m json.tool "${HOME}/.nebius/credentials.json" > /dev/null
 
           {
@@ -112,7 +117,11 @@ jobs:
             printf 'endpoint_url=%s\n' "${NEBIUS_S3_ENDPOINT}"
           } > "${HOME}/.aws/config"
 
-          "${NPA_SKYPILOT_BIN}" check nebius
+          "${NPA_SKYPILOT_BIN}" check nebius 2>&1 | tee /tmp/sky-check-nebius.log
+          if ! grep -Eq 'Nebius: enabled.*compute' /tmp/sky-check-nebius.log; then
+            echo "SkyPilot Nebius compute access is not enabled." >&2
+            exit 1
+          fi
           "${NPA_SKYPILOT_BIN}" check
 
       # GitHub-hosted runners only orchestrate SkyPilot. If hosted networking or

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -1,0 +1,162 @@
+name: Live GPU e2e
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+  schedule:
+    - cron: "17 2 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  live-e2e:
+    name: Live GPU e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'live-e2e') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    env:
+      NPA_INTEGRATION_E2E: "1"
+      NPA_DRY_RUN: "0"
+      DRY_RUN: "0"
+      NPA_LIVE_GPU_FAILOVER: "H100:1,H200:1,A100:1,L40S:1,RTX6000:1"
+      NPA_SONIC_E2E_GPU: "H100:1"
+      NPA_VLM_EVAL_LIVE_LAUNCH_TIMEOUT_SECONDS: "2400"
+      NPA_VLM_EVAL_LIVE_HEALTH_TIMEOUT_SECONDS: "900"
+      NPA_VLM_EVAL_LIVE_REQUEST_TIMEOUT_SECONDS: "240"
+      NPA_SONIC_E2E_TIMEOUT_SECONDS: "2700"
+      NEBIUS_SA_KEY: ${{ secrets.NEBIUS_SA_KEY }}
+      NEBIUS_S3_ACCESS_KEY_ID: ${{ secrets.NEBIUS_S3_ACCESS_KEY_ID }}
+      NEBIUS_S3_SECRET_ACCESS_KEY: ${{ secrets.NEBIUS_S3_SECRET_ACCESS_KEY }}
+      NEBIUS_S3_ENDPOINT: ${{ secrets.NEBIUS_S3_ENDPOINT }}
+      NPA_S3_BUCKET: ${{ secrets.NPA_S3_BUCKET }}
+      NPA_REGISTRY_ID: ${{ secrets.NPA_REGISTRY_ID }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.NEBIUS_S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.NEBIUS_S3_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.NEBIUS_S3_ENDPOINT }}
+      NPA_STORAGE_ENDPOINT: ${{ secrets.NEBIUS_S3_ENDPOINT }}
+      NPA_E2E_S3_BUCKET: ${{ secrets.NPA_S3_BUCKET }}
+      NPA_E2E_S3_ENDPOINT: ${{ secrets.NEBIUS_S3_ENDPOINT }}
+      NPA_E2E_S3_ACCESS_KEY_ID: ${{ secrets.NEBIUS_S3_ACCESS_KEY_ID }}
+      NPA_E2E_S3_SECRET_ACCESS_KEY: ${{ secrets.NEBIUS_S3_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install system test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+
+      - name: Install npa in repo venv
+        run: |
+          python -m venv npa/.venv
+          npa/.venv/bin/python -m pip install --upgrade pip setuptools wheel
+          npa/.venv/bin/python -m pip install -e "npa[server,adapter]" pytest pytest-cov pytest-mock pytest-timeout
+
+      - name: Install SkyPilot 0.12.2
+        run: |
+          npa/.venv/bin/npa skypilot bootstrap
+          sky_bin="$(npa/.venv/bin/npa skypilot status --bin-path)"
+          echo "NPA_SKYPILOT_BIN=${sky_bin}" >> "${GITHUB_ENV}"
+          dirname "${sky_bin}" >> "${GITHUB_PATH}"
+          "${sky_bin}" --version
+
+      - name: Write Nebius credentials and verify SkyPilot
+        run: |
+          missing=()
+          for name in \
+            NEBIUS_SA_KEY \
+            NEBIUS_S3_ACCESS_KEY_ID \
+            NEBIUS_S3_SECRET_ACCESS_KEY \
+            NEBIUS_S3_ENDPOINT \
+            NPA_S3_BUCKET \
+            NPA_REGISTRY_ID
+          do
+            if [ -z "${!name:-}" ]; then
+              missing+=("${name}")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing required GitHub secrets: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+          install -m 700 -d "${HOME}/.nebius" "${HOME}/.aws"
+          umask 077
+          printf '%s' "${NEBIUS_SA_KEY}" > "${HOME}/.nebius/credentials.json"
+          npa/.venv/bin/python -m json.tool "${HOME}/.nebius/credentials.json" > /dev/null
+
+          {
+            printf '[nebius]\n'
+            printf 'aws_access_key_id=%s\n' "${NEBIUS_S3_ACCESS_KEY_ID}"
+            printf 'aws_secret_access_key=%s\n' "${NEBIUS_S3_SECRET_ACCESS_KEY}"
+          } > "${HOME}/.aws/credentials"
+          {
+            printf '[profile nebius]\n'
+            printf 'region=eu-north1\n'
+            printf 'endpoint_url=%s\n' "${NEBIUS_S3_ENDPOINT}"
+          } > "${HOME}/.aws/config"
+
+          "${NPA_SKYPILOT_BIN}" check nebius
+          "${NPA_SKYPILOT_BIN}" check
+
+      # GitHub-hosted runners only orchestrate SkyPilot. If hosted networking or
+      # auth proves flaky, move this job to a self-hosted runner with SkyPilot
+      # preconfigured and keep the same teardown contract below.
+      - name: Run live GPU e2e tests
+        timeout-minutes: 55
+        run: |
+          npa/.venv/bin/python -m pytest npa/tests/ -m "gpu and e2e" -vv --tb=short
+
+      - name: Tear down live GPU clusters
+        if: always()
+        timeout-minutes: 10
+        run: |
+          if [ -z "${NPA_SKYPILOT_BIN:-}" ] || [ ! -x "${NPA_SKYPILOT_BIN}" ]; then
+            echo "SkyPilot binary is unavailable; no live e2e clusters can be queried."
+            exit 0
+          fi
+
+          cluster_pattern='^(sim-to-real-live-|npa-vlm-live-|npa-sonic-e2e-)'
+
+          list_live_e2e_clusters() {
+            "${NPA_SKYPILOT_BIN}" status --refresh 2>&1 \
+              | sed -E 's/\x1b\[[0-9;]*[mK]//g' \
+              | awk '{print $1}' \
+              | grep -E "${cluster_pattern}" \
+              | sort -u || true
+          }
+
+          mapfile -t clusters < <(list_live_e2e_clusters)
+          for cluster in "${clusters[@]}"; do
+            echo "Tearing down ${cluster}"
+            "${NPA_SKYPILOT_BIN}" down --yes "${cluster}" || true
+          done
+
+          for _attempt in $(seq 1 30); do
+            mapfile -t remaining < <(list_live_e2e_clusters)
+            if [ "${#remaining[@]}" -eq 0 ]; then
+              echo "No live e2e SkyPilot clusters remain."
+              exit 0
+            fi
+            printf 'Waiting for live e2e clusters to disappear: %s\n' "${remaining[*]}"
+            sleep 10
+          done
+
+          printf 'Timed out waiting for live e2e clusters to disappear: %s\n' "${remaining[*]}" >&2
+          exit 1


### PR DESCRIPTION
## Summary
- add a separate `Live GPU e2e` workflow for manual dispatch, nightly scheduled runs, and PR runs gated by the `live-e2e` label
- bootstrap the repo venv plus pinned SkyPilot 0.12.2, write Nebius/S3 credentials from Actions secrets, and run `npa/.venv/bin/python -m pytest npa/tests/ -m "gpu and e2e"`
- always tear down matching SkyPilot clusters with explicit `sky down --yes`; cleanup is hardened for stale SkyPilot status records after failed Nebius failover attempts

## Secrets
Configured in this repo via `gh secret set` without logging values:
- `NEBIUS_SA_KEY`
- `NEBIUS_S3_ACCESS_KEY_ID`
- `NEBIUS_S3_SECRET_ACCESS_KEY`
- `NEBIUS_S3_ENDPOINT`
- `NEBIUS_TENANT_ID`
- `NPA_S3_BUCKET`
- `NPA_REGISTRY_ID`

## Validation
- `actionlint .github/workflows/*.yml`
- `npa/.venv/bin/python -m pytest npa/tests/ -m "gpu and e2e" --collect-only -q` selected the two current `gpu and e2e` tests
- existing fast CI workflow files were not modified; latest fast PR checks pass
- latest label-gated live PR run reached SkyPilot, failed during hosted-runner SSH setup to Nebius VMs, and then completed the `if: always()` teardown step successfully with `No live e2e SkyPilot clusters remain.`

## Notes
- Current marker selection collects `npa/tests/workbench/test_sonic_export_eval_e2e.py::test_sonic_export_eval_e2e_runs_live_reference_rollouts_on_nebius` and `npa/tests/workbench/test_vlm_eval_loop_e2e.py::test_vlm_eval_loop_e2e_scores_rollouts_and_reports`. The separate sim-to-real composition pipeline remains marked `e2e_pipeline`, not `gpu and e2e`.
- No `--down` or autodown launch flag is used for Nebius; launch is plain pytest/SkyPilot and cleanup is explicit `sky down --yes` under `if: always()`.
- Hosted runner live execution is not green yet: Nebius instances allocate, but SkyPilot cannot SSH before its 600s timeout. The workflow includes the requested self-hosted-with-SkyPilot fallback note.
