### PR TITLE
ci: run manual live GPU e2e from an operator host

### DIFF
--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -23,6 +23,9 @@ NPA_E2E_PROJECT=eu-north1 NPA_INTEGRATION_E2E=1 pytest npa/tests/e2e/ -v
 The harness also auto-selects `eu-north1` when that project has storage
 credentials configured, matching the current operator demo environment.
 
+Live GPU tests marked `gpu and e2e` run manually from the Nebius Dev VM, not
+from GitHub Actions. See [Live GPU E2E On The Dev VM](live-e2e.md).
+
 ## What E2E Tests Cover
 
 Current Python e2e tests cover:

--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -23,8 +23,9 @@ NPA_E2E_PROJECT=eu-north1 NPA_INTEGRATION_E2E=1 pytest npa/tests/e2e/ -v
 The harness also auto-selects `eu-north1` when that project has storage
 credentials configured, matching the current operator demo environment.
 
-Live GPU tests marked `gpu and e2e` run manually from the Nebius Dev VM, not
-from GitHub Actions. See [Live GPU E2E On The Dev VM](live-e2e.md).
+Live GPU tests marked `gpu and e2e` run manually from a SkyPilot-capable
+operator host, not from GitHub Actions. See
+[Live GPU E2E On An Operator Host](live-e2e.md).
 
 ## What E2E Tests Cover
 

--- a/docs/testing/live-e2e.md
+++ b/docs/testing/live-e2e.md
@@ -1,65 +1,63 @@
-# Live GPU E2E On The Dev VM
+# Live GPU E2E On An Operator Host
 
-Live GPU e2e runs execute from the Nebius Dev VM, on demand, by a human
-operator. They do not run in GitHub Actions and there is no cron, systemd timer,
-nightly workflow, or other scheduled execution.
+Live GPU e2e runs execute from a SkyPilot-capable operator host, on demand.
+They do not run in GitHub Actions and there is no cron, systemd timer, nightly
+workflow, or other scheduled execution.
 
 Use this path for the `gpu and e2e` pytest subset, including the VLM live GPU
 tests, SONIC live SkyPilot test, and the spine e2e once its marker lands.
 
 ## Why Not GitHub Actions
 
-GitHub-hosted runners are outside Nebius. The VMs launched during these tests
-are reachable from the Nebius-connected Dev VM, but they are not reliably
-reachable over SSH from GitHub-hosted runners. A hosted workflow can therefore
-start infrastructure and still fail to validate or tear it down correctly.
+GitHub-hosted runners are outside the operator's configured Nebius environment.
+The VMs launched during these tests may be reachable from the operator host, but
+they are not reliably reachable over SSH from GitHub-hosted runners. A hosted
+workflow can therefore start infrastructure and still fail to validate or tear it
+down correctly.
 
-Do not reintroduce a hosted `live-e2e.yml` workflow for this path. The Dev VM is
-the runner location for live GPU validation.
+Do not reintroduce a hosted `live-e2e.yml` workflow for this path. Use an
+operator-controlled host for live GPU validation.
 
 ## Why There Is No Nightly Job
 
 Live GPU e2e tests provision real GPU resources. A scheduled unattended run can
 spend money overnight and can leave a leaked cluster when nobody is watching.
 
-Runs stay manual and on demand. Do not install a cron entry, systemd timer, PM2
-job, GitHub Actions schedule, or any other automatic trigger for
+Runs stay manual and on demand. Do not install a cron entry, systemd timer,
+background process job, GitHub Actions schedule, or any other automatic trigger for
 `scripts/live-e2e.sh`.
 
 ## Prerequisites
 
-Run from the Nebius-connected Dev VM checkout after installing the normal NPA
-development environment:
+Run from a SkyPilot-capable checkout after installing the normal NPA development
+environment:
 
 ```bash
-cd /opt/nebius-physical-ai
+cd ~/repos/nebius-physical-ai
 npa/.venv/bin/python -m pip install -e npa
 ```
 
-The runner uses credentials from the VM process environment and local VM config
+The runner uses credentials from the host process environment and local config
 files only. It does not read GitHub Actions secrets.
 
 By default the script looks for local env files at:
 
-- `/home/ubuntu/codex-runner/env`
-- `/home/ubuntu/codex-runner/.env`
-- `~/.codex-runner/env`
-- `~/.codex-runner/.env`
 - `~/.npa/live-e2e.env`
+- `~/.config/npa/live-e2e.env`
 
 To use a specific file:
 
 ```bash
-export NPA_LIVE_E2E_ENV_FILE=/path/to/dev-vm-live-e2e.env
+export NPA_LIVE_E2E_ENV_FILE=/path/to/live-e2e.env
 ```
 
 The SkyPilot executable defaults to:
 
 ```bash
-export NPA_SKYPILOT_BIN=/home/ubuntu/.npa/skypilot-venv/bin/sky
+export NPA_SKYPILOT_BIN="$HOME/.npa/skypilot-venv/bin/sky"
 ```
 
-Override it only when the Dev VM has a different SkyPilot venv:
+Override it when the operator host uses a different SkyPilot install:
 
 ```bash
 export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
@@ -102,18 +100,15 @@ Each run writes a timestamped log under:
 
 Override the log directory with `NPA_LIVE_E2E_LOG_DIR`.
 
-ntfy is optional but expected on the Dev VM. Configure either a full URL or a
-topic name:
+An optional notification webhook can receive run status messages:
 
 ```bash
-export NPA_NTFY_TOPIC_URL=https://ntfy.sh/<topic>
-# or
-export NPA_NTFY_TOPIC=<topic>
+export NPA_LIVE_E2E_NOTIFY_URL=https://example.invalid/live-e2e-hook
 ```
 
-When `GITHUB_TOKEN` or `GH_TOKEN` is available in the Dev VM environment, the
+When `GITHUB_TOKEN` or `GH_TOKEN` is available in the host environment, the
 script posts a GitHub commit status to the current commit with context
-`live-e2e/dev-vm`. Disable that for a local dry run:
+`live-e2e`. Disable that for a local dry run:
 
 ```bash
 export NPA_LIVE_E2E_POST_GITHUB_STATUS=0
@@ -135,10 +130,11 @@ script trap and the tests' own `finally` fixtures.
 
 If the process is interrupted, the trap still runs teardown. If teardown cannot
 verify an empty status before the timeout, the script exits non-zero and reports
-the failure in ntfy and the commit status when those are configured.
+the failure through the configured notification endpoint and commit status.
 
 ## Post-Merge Validation
 
 After this runner lands and the spine e2e marker fix merges, run
-`bash scripts/live-e2e.sh` once on the Dev VM to validate the full selected live
-set. Do not add a timer after that validation; keep future runs manual.
+`bash scripts/live-e2e.sh` once on a SkyPilot-capable operator host to validate
+the full selected live set. Do not add a timer after that validation; keep future
+runs manual.

--- a/docs/testing/live-e2e.md
+++ b/docs/testing/live-e2e.md
@@ -1,0 +1,144 @@
+# Live GPU E2E On The Dev VM
+
+Live GPU e2e runs execute from the Nebius Dev VM, on demand, by a human
+operator. They do not run in GitHub Actions and there is no cron, systemd timer,
+nightly workflow, or other scheduled execution.
+
+Use this path for the `gpu and e2e` pytest subset, including the VLM live GPU
+tests, SONIC live SkyPilot test, and the spine e2e once its marker lands.
+
+## Why Not GitHub Actions
+
+GitHub-hosted runners are outside Nebius. The VMs launched during these tests
+are reachable from the Nebius-connected Dev VM, but they are not reliably
+reachable over SSH from GitHub-hosted runners. A hosted workflow can therefore
+start infrastructure and still fail to validate or tear it down correctly.
+
+Do not reintroduce a hosted `live-e2e.yml` workflow for this path. The Dev VM is
+the runner location for live GPU validation.
+
+## Why There Is No Nightly Job
+
+Live GPU e2e tests provision real GPU resources. A scheduled unattended run can
+spend money overnight and can leave a leaked cluster when nobody is watching.
+
+Runs stay manual and on demand. Do not install a cron entry, systemd timer, PM2
+job, GitHub Actions schedule, or any other automatic trigger for
+`scripts/live-e2e.sh`.
+
+## Prerequisites
+
+Run from the Nebius-connected Dev VM checkout after installing the normal NPA
+development environment:
+
+```bash
+cd /opt/nebius-physical-ai
+npa/.venv/bin/python -m pip install -e npa
+```
+
+The runner uses credentials from the VM process environment and local VM config
+files only. It does not read GitHub Actions secrets.
+
+By default the script looks for local env files at:
+
+- `/home/ubuntu/codex-runner/env`
+- `/home/ubuntu/codex-runner/.env`
+- `~/.codex-runner/env`
+- `~/.codex-runner/.env`
+- `~/.npa/live-e2e.env`
+
+To use a specific file:
+
+```bash
+export NPA_LIVE_E2E_ENV_FILE=/path/to/dev-vm-live-e2e.env
+```
+
+The SkyPilot executable defaults to:
+
+```bash
+export NPA_SKYPILOT_BIN=/home/ubuntu/.npa/skypilot-venv/bin/sky
+```
+
+Override it only when the Dev VM has a different SkyPilot venv:
+
+```bash
+export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+```
+
+## Run
+
+Run manually:
+
+```bash
+bash scripts/live-e2e.sh
+```
+
+The script runs:
+
+```bash
+npa/.venv/bin/python -m pytest -m "gpu and e2e" npa/tests/ -q
+```
+
+The default GPU candidate order is H100 first:
+
+```text
+H100:1,H200:1,A100:1,L40S:1,RTX6000:1
+```
+
+Override the order for a manual run:
+
+```bash
+export NPA_LIVE_E2E_GPU_CANDIDATES=H100:1,H200:1,L40S:1
+bash scripts/live-e2e.sh
+```
+
+## Logs And Notifications
+
+Each run writes a timestamped log under:
+
+```text
+~/npa-live-e2e-logs/
+```
+
+Override the log directory with `NPA_LIVE_E2E_LOG_DIR`.
+
+ntfy is optional but expected on the Dev VM. Configure either a full URL or a
+topic name:
+
+```bash
+export NPA_NTFY_TOPIC_URL=https://ntfy.sh/<topic>
+# or
+export NPA_NTFY_TOPIC=<topic>
+```
+
+When `GITHUB_TOKEN` or `GH_TOKEN` is available in the Dev VM environment, the
+script posts a GitHub commit status to the current commit with context
+`live-e2e/dev-vm`. Disable that for a local dry run:
+
+```bash
+export NPA_LIVE_E2E_POST_GITHUB_STATUS=0
+```
+
+## Verified Teardown
+
+Before pytest starts, and again after it exits, the runner clears matching
+SkyPilot clusters and polls until none remain. The default prefixes are:
+
+```text
+npa-vlm-live npa-sonic-e2e npa-spine-e2e npa-live-e2e
+```
+
+The teardown path calls `sky down --yes <cluster>` for matching clusters and
+then checks `sky status --refresh` until the prefix list is empty. The pytest
+command itself does not pass a teardown flag to SkyPilot; teardown remains in the
+script trap and the tests' own `finally` fixtures.
+
+If the process is interrupted, the trap still runs teardown. If teardown cannot
+verify an empty status before the timeout, the script exits non-zero and reports
+the failure in ntfy and the commit status when those are configured.
+
+## Post-Merge Validation
+
+After this runner lands and the spine e2e marker fix merges, run
+`bash scripts/live-e2e.sh` once on the Dev VM to validate the full selected live
+set. Do not add a timer after that validation; keep future runs manual.

--- a/npa/pyproject.toml
+++ b/npa/pyproject.toml
@@ -76,7 +76,6 @@ packages = ["src/npa"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/npa/solutions/solutions.toml" = "npa/solutions/solutions.toml"
-"src/npa/workbench/vlm_eval/fixtures/sample_benchmark" = "npa/workbench/vlm_eval/fixtures/sample_benchmark"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/live-e2e.sh
+++ b/scripts/live-e2e.sh
@@ -26,11 +26,8 @@ if [[ -n "${NPA_LIVE_E2E_ENV_FILE:-}" ]]; then
   fi
 else
   for env_file in \
-    "/home/ubuntu/codex-runner/env" \
-    "/home/ubuntu/codex-runner/.env" \
-    "${HOME}/.codex-runner/env" \
-    "${HOME}/.codex-runner/.env" \
-    "${HOME}/.npa/live-e2e.env"; do
+    "${NPA_CONFIG_HOME:-${HOME}/.npa}/live-e2e.env" \
+    "${XDG_CONFIG_HOME:-${HOME}/.config}/npa/live-e2e.env"; do
     source_env_file "$env_file" || true
   done
 fi
@@ -42,7 +39,7 @@ mkdir -p "$LOG_DIR"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
 PYTHON_BIN="${NPA_LIVE_E2E_PYTHON_BIN:-${REPO_ROOT}/npa/.venv/bin/python}"
-export NPA_SKYPILOT_BIN="${NPA_SKYPILOT_BIN:-/home/ubuntu/.npa/skypilot-venv/bin/sky}"
+export NPA_SKYPILOT_BIN="${NPA_SKYPILOT_BIN:-${HOME}/.npa/skypilot-venv/bin/sky}"
 export NPA_INTEGRATION_E2E="${NPA_INTEGRATION_E2E:-1}"
 export PYTHONUNBUFFERED="${PYTHONUNBUFFERED:-1}"
 
@@ -53,7 +50,7 @@ KILL_AFTER_SECONDS="${NPA_LIVE_E2E_KILL_AFTER_SECONDS:-900}"
 TEARDOWN_TIMEOUT_SECONDS="${NPA_LIVE_E2E_TEARDOWN_TIMEOUT_SECONDS:-1200}"
 TEARDOWN_POLL_SECONDS="${NPA_LIVE_E2E_TEARDOWN_POLL_SECONDS:-30}"
 CLUSTER_PREFIXES="${NPA_LIVE_E2E_CLUSTER_PREFIXES:-npa-vlm-live npa-sonic-e2e npa-spine-e2e npa-live-e2e}"
-GITHUB_STATUS_CONTEXT="${NPA_LIVE_E2E_GITHUB_CONTEXT:-live-e2e/dev-vm}"
+GITHUB_STATUS_CONTEXT="${NPA_LIVE_E2E_GITHUB_CONTEXT:-live-e2e}"
 
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
@@ -64,47 +61,31 @@ die() {
   exit 2
 }
 
-ntfy_url() {
-  if [[ -n "${NPA_NTFY_URL:-}" ]]; then
-    printf '%s\n' "$NPA_NTFY_URL"
+notification_url() {
+  if [[ -n "${NPA_LIVE_E2E_NOTIFY_URL:-}" ]]; then
+    printf '%s\n' "$NPA_LIVE_E2E_NOTIFY_URL"
     return
   fi
-  if [[ -n "${NPA_NTFY_TOPIC_URL:-}" ]]; then
-    printf '%s\n' "$NPA_NTFY_TOPIC_URL"
+  if [[ -n "${NPA_NOTIFY_URL:-}" ]]; then
+    printf '%s\n' "$NPA_NOTIFY_URL"
     return
   fi
-  if [[ -n "${NTFY_TOPIC_URL:-}" ]]; then
-    printf '%s\n' "$NTFY_TOPIC_URL"
-    return
-  fi
-  if [[ -n "${NPA_NTFY_TOPIC:-}" ]]; then
-    if [[ "$NPA_NTFY_TOPIC" == http://* || "$NPA_NTFY_TOPIC" == https://* ]]; then
-      printf '%s\n' "$NPA_NTFY_TOPIC"
-    else
-      printf 'https://ntfy.sh/%s\n' "$NPA_NTFY_TOPIC"
-    fi
-    return
-  fi
-  if [[ -n "${NTFY_TOPIC:-}" ]]; then
-    if [[ "$NTFY_TOPIC" == http://* || "$NTFY_TOPIC" == https://* ]]; then
-      printf '%s\n' "$NTFY_TOPIC"
-    else
-      printf 'https://ntfy.sh/%s\n' "$NTFY_TOPIC"
-    fi
+  if [[ -n "${NOTIFY_URL:-}" ]]; then
+    printf '%s\n' "$NOTIFY_URL"
   fi
 }
 
-notify_ntfy() {
+notify_webhook() {
   local state="$1"
   local body="$2"
   local url
-  url="$(ntfy_url || true)"
+  url="$(notification_url || true)"
   if [[ -z "$url" ]]; then
-    log "ntfy not configured; skipping notification"
+    log "notification endpoint not configured; skipping notification"
     return 0
   fi
   if ! command -v curl >/dev/null 2>&1; then
-    log "curl not found; skipping ntfy notification"
+    log "curl not found; skipping notification"
     return 0
   fi
 
@@ -113,7 +94,7 @@ notify_ntfy() {
     -H "Priority: default" \
     --data-binary "$body" \
     "$url" >/dev/null; then
-    log "ntfy notification failed"
+    log "notification post failed"
   fi
 }
 
@@ -339,14 +320,14 @@ finish() {
 
   if [[ "$rc" -eq 0 ]]; then
     state="success"
-    description="Dev-VM live GPU e2e passed"
+    description="Live GPU e2e passed"
   else
     state="failure"
-    description="Dev-VM live GPU e2e failed"
+    description="Live GPU e2e failed"
   fi
 
   post_github_status "$state" "$description"
-  notify_ntfy "$state" "${description}. Log: ${LOG_FILE}"
+  notify_webhook "$state" "${description}. Log: ${LOG_FILE}"
   log "${description}. Log: ${LOG_FILE}"
   exit "$rc"
 }
@@ -357,7 +338,7 @@ trap 'exit 143' TERM
 
 cd "$REPO_ROOT"
 
-log "Starting on-demand Dev-VM live GPU e2e"
+log "Starting on-demand live GPU e2e"
 log "Repository: ${REPO_ROOT}"
 log "Log file: ${LOG_FILE}"
 if [[ "${#SOURCED_ENV_FILES[@]}" -gt 0 ]]; then
@@ -369,8 +350,8 @@ fi
 [[ -x "$PYTHON_BIN" ]] || die "Python executable is missing or not executable: ${PYTHON_BIN}"
 [[ -x "$NPA_SKYPILOT_BIN" ]] || die "SkyPilot executable is missing or not executable: ${NPA_SKYPILOT_BIN}"
 
-post_github_status "pending" "Dev-VM live GPU e2e running"
-notify_ntfy "running" "Dev-VM live GPU e2e started. Log: ${LOG_FILE}"
+post_github_status "pending" "Live GPU e2e running"
+notify_webhook "running" "Live GPU e2e started. Log: ${LOG_FILE}"
 
 log "Clearing pre-existing live-e2e SkyPilot clusters before pytest"
 down_matching_clusters || true

--- a/scripts/live-e2e.sh
+++ b/scripts/live-e2e.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${NPA_LIVE_E2E_REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/.." && pwd)}"
+
+SOURCED_ENV_FILES=()
+
+source_env_file() {
+  local path="$1"
+  if [[ ! -r "$path" ]]; then
+    return 1
+  fi
+
+  set -a
+  # shellcheck source=/dev/null
+  . "$path"
+  set +a
+  SOURCED_ENV_FILES+=("$path")
+}
+
+if [[ -n "${NPA_LIVE_E2E_ENV_FILE:-}" ]]; then
+  if ! source_env_file "$NPA_LIVE_E2E_ENV_FILE"; then
+    printf 'Configured NPA_LIVE_E2E_ENV_FILE is not readable: %s\n' "$NPA_LIVE_E2E_ENV_FILE" >&2
+    exit 2
+  fi
+else
+  for env_file in \
+    "/home/ubuntu/codex-runner/env" \
+    "/home/ubuntu/codex-runner/.env" \
+    "${HOME}/.codex-runner/env" \
+    "${HOME}/.codex-runner/.env" \
+    "${HOME}/.npa/live-e2e.env"; do
+    source_env_file "$env_file" || true
+  done
+fi
+
+RUN_STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG_DIR="${NPA_LIVE_E2E_LOG_DIR:-${HOME}/npa-live-e2e-logs}"
+LOG_FILE="${LOG_DIR}/live-e2e-${RUN_STAMP}.log"
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+PYTHON_BIN="${NPA_LIVE_E2E_PYTHON_BIN:-${REPO_ROOT}/npa/.venv/bin/python}"
+export NPA_SKYPILOT_BIN="${NPA_SKYPILOT_BIN:-/home/ubuntu/.npa/skypilot-venv/bin/sky}"
+export NPA_INTEGRATION_E2E="${NPA_INTEGRATION_E2E:-1}"
+export PYTHONUNBUFFERED="${PYTHONUNBUFFERED:-1}"
+
+MARK_EXPR="${NPA_LIVE_E2E_MARK_EXPR:-gpu and e2e}"
+PYTEST_TARGET="${NPA_LIVE_E2E_PYTEST_TARGET:-npa/tests/}"
+TIMEOUT_SECONDS="${NPA_LIVE_E2E_TIMEOUT_SECONDS:-14400}"
+KILL_AFTER_SECONDS="${NPA_LIVE_E2E_KILL_AFTER_SECONDS:-900}"
+TEARDOWN_TIMEOUT_SECONDS="${NPA_LIVE_E2E_TEARDOWN_TIMEOUT_SECONDS:-1200}"
+TEARDOWN_POLL_SECONDS="${NPA_LIVE_E2E_TEARDOWN_POLL_SECONDS:-30}"
+CLUSTER_PREFIXES="${NPA_LIVE_E2E_CLUSTER_PREFIXES:-npa-vlm-live npa-sonic-e2e npa-spine-e2e npa-live-e2e}"
+GITHUB_STATUS_CONTEXT="${NPA_LIVE_E2E_GITHUB_CONTEXT:-live-e2e/dev-vm}"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+die() {
+  log "ERROR: $*"
+  exit 2
+}
+
+ntfy_url() {
+  if [[ -n "${NPA_NTFY_URL:-}" ]]; then
+    printf '%s\n' "$NPA_NTFY_URL"
+    return
+  fi
+  if [[ -n "${NPA_NTFY_TOPIC_URL:-}" ]]; then
+    printf '%s\n' "$NPA_NTFY_TOPIC_URL"
+    return
+  fi
+  if [[ -n "${NTFY_TOPIC_URL:-}" ]]; then
+    printf '%s\n' "$NTFY_TOPIC_URL"
+    return
+  fi
+  if [[ -n "${NPA_NTFY_TOPIC:-}" ]]; then
+    if [[ "$NPA_NTFY_TOPIC" == http://* || "$NPA_NTFY_TOPIC" == https://* ]]; then
+      printf '%s\n' "$NPA_NTFY_TOPIC"
+    else
+      printf 'https://ntfy.sh/%s\n' "$NPA_NTFY_TOPIC"
+    fi
+    return
+  fi
+  if [[ -n "${NTFY_TOPIC:-}" ]]; then
+    if [[ "$NTFY_TOPIC" == http://* || "$NTFY_TOPIC" == https://* ]]; then
+      printf '%s\n' "$NTFY_TOPIC"
+    else
+      printf 'https://ntfy.sh/%s\n' "$NTFY_TOPIC"
+    fi
+  fi
+}
+
+notify_ntfy() {
+  local state="$1"
+  local body="$2"
+  local url
+  url="$(ntfy_url || true)"
+  if [[ -z "$url" ]]; then
+    log "ntfy not configured; skipping notification"
+    return 0
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    log "curl not found; skipping ntfy notification"
+    return 0
+  fi
+
+  if ! curl -fsS \
+    -H "Title: NPA live e2e ${state}" \
+    -H "Priority: default" \
+    --data-binary "$body" \
+    "$url" >/dev/null; then
+    log "ntfy notification failed"
+  fi
+}
+
+github_status_payload() {
+  local state="$1"
+  local description="$2"
+  local target_url="${3:-}"
+  python3 - "$state" "$description" "$target_url" "$GITHUB_STATUS_CONTEXT" <<'PY'
+import json
+import sys
+
+state, description, target_url, context = sys.argv[1:5]
+payload = {
+    "state": state,
+    "description": description[:140],
+    "context": context,
+}
+if target_url:
+    payload["target_url"] = target_url
+print(json.dumps(payload, separators=(",", ":")))
+PY
+}
+
+post_github_status() {
+  local state="$1"
+  local description="$2"
+  local target_url="${3:-${NPA_LIVE_E2E_TARGET_URL:-}}"
+  if [[ "${NPA_LIVE_E2E_POST_GITHUB_STATUS:-1}" == "0" ]]; then
+    log "GitHub commit status disabled"
+    return 0
+  fi
+
+  local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+  if [[ -z "$token" ]]; then
+    log "GitHub token not configured; skipping commit status"
+    return 0
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    log "curl not found; skipping GitHub commit status"
+    return 0
+  fi
+
+  local repo="${GITHUB_REPOSITORY:-${NPA_LIVE_E2E_GITHUB_REPO:-nebius/nebius-physical-ai}}"
+  local sha="${NPA_LIVE_E2E_COMMIT_SHA:-}"
+  if [[ -z "$sha" ]]; then
+    sha="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+  fi
+
+  local payload
+  payload="$(github_status_payload "$state" "$description" "$target_url")"
+  if ! curl -fsS \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${token}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    --data "$payload" \
+    "https://api.github.com/repos/${repo}/statuses/${sha}" >/dev/null; then
+    log "GitHub commit status post failed for ${repo}@${sha}"
+  fi
+}
+
+sky_status_output() {
+  "$NPA_SKYPILOT_BIN" status --refresh 2>&1 || true
+}
+
+list_matching_clusters() {
+  sky_status_output | awk -v prefixes="$CLUSTER_PREFIXES" '
+    BEGIN {
+      count = split(prefixes, parts, /[ ,]+/)
+    }
+    /^[[:space:]]*$/ { next }
+    /^Fetching/ { next }
+    /^Clusters/ { next }
+    /^NAME[[:space:]]/ { next }
+    {
+      name = $1
+      for (i = 1; i <= count; i++) {
+        if (parts[i] != "" && index(name, parts[i]) == 1) {
+          print name
+        }
+      }
+    }
+  ' | sort -u
+}
+
+down_matching_clusters() {
+  local clusters cluster rc
+  clusters="$(list_matching_clusters || true)"
+  if [[ -z "$clusters" ]]; then
+    log "No matching SkyPilot clusters found"
+    return 0
+  fi
+
+  rc=0
+  while IFS= read -r cluster; do
+    [[ -z "$cluster" ]] && continue
+    log "Tearing down SkyPilot cluster: ${cluster}"
+    if ! "$NPA_SKYPILOT_BIN" down --yes "$cluster"; then
+      log "SkyPilot teardown command failed for ${cluster}"
+      rc=1
+    fi
+  done <<< "$clusters"
+  return "$rc"
+}
+
+verify_no_matching_clusters() {
+  local deadline clusters
+  deadline=$((SECONDS + TEARDOWN_TIMEOUT_SECONDS))
+
+  while (( SECONDS < deadline )); do
+    clusters="$(list_matching_clusters || true)"
+    if [[ -z "$clusters" ]]; then
+      log "Verified no matching SkyPilot clusters remain"
+      return 0
+    fi
+    log "Waiting for SkyPilot clusters to disappear: $(tr '\n' ' ' <<< "$clusters")"
+    down_matching_clusters || true
+    sleep "$TEARDOWN_POLL_SECONDS"
+  done
+
+  clusters="$(list_matching_clusters || true)"
+  if [[ -n "$clusters" ]]; then
+    log "SkyPilot clusters still present after teardown timeout:"
+    printf '%s\n' "$clusters"
+  fi
+  return 1
+}
+
+run_with_timeout() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --kill-after="${KILL_AFTER_SECONDS}s" "${TIMEOUT_SECONDS}s" "$@"
+  else
+    log "GNU timeout not found; running without an outer wall-clock cap"
+    "$@"
+  fi
+}
+
+run_pytest_attempts() {
+  local candidates_csv rc attempt total gpu
+  if [[ -n "${NPA_SONIC_E2E_GPU:-}" ]]; then
+    candidates_csv="$NPA_SONIC_E2E_GPU"
+  else
+    candidates_csv="${NPA_LIVE_E2E_GPU_CANDIDATES:-H100:1,H200:1,A100:1,L40S:1,RTX6000:1}"
+  fi
+
+  IFS=',' read -r -a candidates <<< "$candidates_csv"
+  total="${#candidates[@]}"
+  rc=1
+  attempt=1
+
+  for gpu in "${candidates[@]}"; do
+    gpu="$(xargs <<< "$gpu")"
+    [[ -z "$gpu" ]] && continue
+    export NPA_SONIC_E2E_GPU="$gpu"
+    export NPA_LIVE_E2E_GPU_ATTEMPT="$gpu"
+
+    log "Running live GPU e2e attempt ${attempt}/${total} with GPU candidate ${gpu}"
+    log "Pytest command: ${PYTHON_BIN} -m pytest -m '${MARK_EXPR}' ${PYTEST_TARGET}"
+
+    set +e
+    run_with_timeout "$PYTHON_BIN" -m pytest -m "$MARK_EXPR" "$PYTEST_TARGET" -q
+    rc=$?
+    set -e
+
+    if [[ "$rc" -eq 0 ]]; then
+      log "Live GPU e2e passed with GPU candidate ${gpu}"
+      return 0
+    fi
+
+    log "Live GPU e2e attempt ${attempt}/${total} failed with exit code ${rc}"
+    down_matching_clusters || true
+    verify_no_matching_clusters || return 1
+    attempt=$((attempt + 1))
+  done
+
+  return "$rc"
+}
+
+finish() {
+  local rc="$?"
+  local cleanup_rc=0
+  local state description
+  trap - EXIT INT TERM
+
+  log "Final SkyPilot cleanup starting"
+  set +e
+  down_matching_clusters
+  cleanup_rc=$?
+  if ! verify_no_matching_clusters; then
+    cleanup_rc=1
+  fi
+  set -e
+
+  if [[ "$rc" -eq 0 && "$cleanup_rc" -ne 0 ]]; then
+    rc=1
+  fi
+
+  if [[ "$rc" -eq 0 ]]; then
+    state="success"
+    description="Dev-VM live GPU e2e passed"
+  else
+    state="failure"
+    description="Dev-VM live GPU e2e failed"
+  fi
+
+  post_github_status "$state" "$description"
+  notify_ntfy "$state" "${description}. Log: ${LOG_FILE}"
+  log "${description}. Log: ${LOG_FILE}"
+  exit "$rc"
+}
+
+trap finish EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+cd "$REPO_ROOT"
+
+log "Starting on-demand Dev-VM live GPU e2e"
+log "Repository: ${REPO_ROOT}"
+log "Log file: ${LOG_FILE}"
+if [[ "${#SOURCED_ENV_FILES[@]}" -gt 0 ]]; then
+  log "Loaded local env files: ${SOURCED_ENV_FILES[*]}"
+else
+  log "No local env file loaded; using current process environment"
+fi
+
+[[ -x "$PYTHON_BIN" ]] || die "Python executable is missing or not executable: ${PYTHON_BIN}"
+[[ -x "$NPA_SKYPILOT_BIN" ]] || die "SkyPilot executable is missing or not executable: ${NPA_SKYPILOT_BIN}"
+
+post_github_status "pending" "Dev-VM live GPU e2e running"
+notify_ntfy "running" "Dev-VM live GPU e2e started. Log: ${LOG_FILE}"
+
+log "Clearing pre-existing live-e2e SkyPilot clusters before pytest"
+down_matching_clusters || true
+verify_no_matching_clusters
+
+run_pytest_attempts

--- a/scripts/live-e2e.sh
+++ b/scripts/live-e2e.sh
@@ -164,15 +164,29 @@ post_github_status() {
 
   local payload
   payload="$(github_status_payload "$state" "$description" "$target_url")"
-  if ! curl -fsS \
+  if curl -fsS \
     -X POST \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer ${token}" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     --data "$payload" \
     "https://api.github.com/repos/${repo}/statuses/${sha}" >/dev/null; then
-    log "GitHub commit status post failed for ${repo}@${sha}"
+    return 0
   fi
+
+  if command -v gh >/dev/null 2>&1; then
+    log "GitHub commit status curl post failed for ${repo}@${sha}; retrying with gh api"
+    if printf '%s' "$payload" | GH_TOKEN="$token" gh api \
+      --method POST \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "/repos/${repo}/statuses/${sha}" \
+      --input - >/dev/null; then
+      return 0
+    fi
+  fi
+
+  log "GitHub commit status post failed for ${repo}@${sha}"
 }
 
 sky_status_output() {

--- a/scripts/live-e2e.sh
+++ b/scripts/live-e2e.sh
@@ -147,14 +147,6 @@ post_github_status() {
   fi
 
   local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
-  if [[ -z "$token" ]]; then
-    log "GitHub token not configured; skipping commit status"
-    return 0
-  fi
-  if ! command -v curl >/dev/null 2>&1; then
-    log "curl not found; skipping GitHub commit status"
-    return 0
-  fi
 
   local repo="${GITHUB_REPOSITORY:-${NPA_LIVE_E2E_GITHUB_REPO:-nebius/nebius-physical-ai}}"
   local sha="${NPA_LIVE_E2E_COMMIT_SHA:-}"
@@ -164,7 +156,7 @@ post_github_status() {
 
   local payload
   payload="$(github_status_payload "$state" "$description" "$target_url")"
-  if curl -fsS \
+  if [[ -n "$token" ]] && command -v curl >/dev/null 2>&1 && curl -fsS \
     -X POST \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer ${token}" \
@@ -175,18 +167,38 @@ post_github_status() {
   fi
 
   if command -v gh >/dev/null 2>&1; then
-    log "GitHub commit status curl post failed for ${repo}@${sha}; retrying with gh api"
-    if printf '%s' "$payload" | GH_TOKEN="$token" gh api \
-      --method POST \
-      -H "Accept: application/vnd.github+json" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      "/repos/${repo}/statuses/${sha}" \
-      --input - >/dev/null; then
+    if [[ -n "$token" ]]; then
+      log "GitHub commit status curl post failed for ${repo}@${sha}; retrying with gh api"
+    else
+      log "GitHub token env not configured; trying authenticated gh api for ${repo}@${sha}"
+    fi
+    if post_github_status_with_gh "$payload" "$repo" "$sha" "$token"; then
       return 0
     fi
   fi
 
   log "GitHub commit status post failed for ${repo}@${sha}"
+}
+
+post_github_status_with_gh() {
+  local payload="$1"
+  local repo="$2"
+  local sha="$3"
+  local token="${4:-}"
+  local cmd=(
+    gh api
+    --method POST
+    -H "Accept: application/vnd.github+json"
+    -H "X-GitHub-Api-Version: 2022-11-28"
+    "/repos/${repo}/statuses/${sha}"
+    --input -
+  )
+
+  if [[ -n "$token" ]]; then
+    printf '%s' "$payload" | GH_TOKEN="$token" "${cmd[@]}" >/dev/null
+  else
+    printf '%s' "$payload" | "${cmd[@]}" >/dev/null
+  fi
 }
 
 sky_status_output() {


### PR DESCRIPTION
## Summary
- Supersedes #29 hosted-runner approach; PR #29 is closed because GitHub-hosted runners cannot reliably reach operator-managed Nebius live test infrastructure.
- Adds scripts/live-e2e.sh, an on-demand runner for `pytest -m "gpu and e2e" npa/tests/` with H100-first GPU candidates, timestamped logs, optional webhook notifications, optional GitHub commit statuses, pre-run orphan cleanup, and final verified SkyPilot teardown.
- Documents that live GPU e2e runs are manual only from a SkyPilot-capable operator host, with no GitHub Actions workflow, cron, systemd timer, nightly job, or other schedule.

## Validation
- `bash -n scripts/live-e2e.sh`
- `git diff --check`
- Customer-name scan: clean.
- Infra-leak scan: clean.
- Confirmed no diff under `.github/workflows` in the scrub commit.

## Follow-up
- After this PR and #28 merge, run `bash scripts/live-e2e.sh` once manually from a configured operator host to validate the live set end to end. Do not install a timer or schedule.