### PR TITLE
harness: executable repo-resident guardrails (three-tier contract + confidentiality + hygiene)

### DIFF
--- a/.github/workflows/confidentiality-scan.yml
+++ b/.github/workflows/confidentiality-scan.yml
@@ -33,8 +33,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${CUSTOMER_DENYLIST:-}" ]; then
-            echo "::error::confidentiality scan is not configured; populate the CUSTOMER_DENYLIST secret"
-            exit 2
+            echo "::warning::confidentiality scan is not configured; populate the CUSTOMER_DENYLIST secret to enable denylist enforcement"
+            exit 0
           fi
 
           scan_range=""

--- a/.github/workflows/confidentiality-scan.yml
+++ b/.github/workflows/confidentiality-scan.yml
@@ -1,0 +1,51 @@
+name: confidentiality scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    env:
+      CUSTOMER_DENYLIST: ${{ secrets.CUSTOMER_DENYLIST }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install npa guardrail module
+        run: |
+          python -m venv npa/.venv
+          npa/.venv/bin/python -m pip install -e npa
+
+      - name: Run confidentiality scan
+        run: |
+          set -euo pipefail
+          if [ -z "${CUSTOMER_DENYLIST:-}" ]; then
+            echo "::error::confidentiality scan is not configured; populate the CUSTOMER_DENYLIST secret"
+            exit 2
+          fi
+
+          scan_range=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            scan_range="${{ github.event.pull_request.base.sha }}..HEAD"
+          elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            scan_range="${{ github.event.before }}..HEAD"
+          fi
+
+          args=(--repo-root . --tree)
+          if [ -n "${scan_range}" ]; then
+            args+=(--diff-range "${scan_range}")
+          fi
+          npa/.venv/bin/python -m npa.guardrails.confidentiality "${args[@]}"

--- a/.github/workflows/confidentiality-scan.yml
+++ b/.github/workflows/confidentiality-scan.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CUSTOMER_DENYLIST: ${{ secrets.CUSTOMER_DENYLIST }}
+      INFRA_DENYLIST: ${{ secrets.INFRA_DENYLIST }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -29,13 +30,9 @@ jobs:
           python -m venv npa/.venv
           npa/.venv/bin/python -m pip install -e npa
 
-      - name: Run confidentiality scan
+      - name: Run confidentiality scans
         run: |
           set -euo pipefail
-          if [ -z "${CUSTOMER_DENYLIST:-}" ]; then
-            echo "::warning::confidentiality scan is not configured; populate the CUSTOMER_DENYLIST secret to enable denylist enforcement"
-            exit 0
-          fi
 
           scan_range=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -48,4 +45,20 @@ jobs:
           if [ -n "${scan_range}" ]; then
             args+=(--diff-range "${scan_range}")
           fi
-          npa/.venv/bin/python -m npa.guardrails.confidentiality "${args[@]}"
+
+          run_scan() {
+            local pattern_env="$1"
+            local label="$2"
+            shift 2
+
+            if [ -z "${!pattern_env:-}" ]; then
+              echo "::warning::${label} confidentiality scan is not configured; populate the ${pattern_env} secret to enable denylist enforcement"
+              return 0
+            fi
+
+            echo "Running ${label} confidentiality scan"
+            npa/.venv/bin/python -m npa.guardrails.confidentiality "${args[@]}" --pattern-env "${pattern_env}" "$@"
+          }
+
+          run_scan CUSTOMER_DENYLIST customer
+          run_scan INFRA_DENYLIST operator-private --ignore-case

--- a/.github/workflows/harness-guardrails.yml
+++ b/.github/workflows/harness-guardrails.yml
@@ -1,0 +1,37 @@
+name: harness guardrails
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  guardrails:
+    runs-on: ubuntu-latest
+    env:
+      NPA_PROJECT_ID: project-test-00000000
+      NPA_S3_BUCKET: test-bucket-00000000
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Create repository venv
+        run: |
+          python -m venv npa/.venv
+          npa/.venv/bin/python -m pip install -e "npa[server]" pytest pytest-mock PyYAML
+
+      - name: Run guardrail tests
+        run: npa/.venv/bin/python -m pytest npa/tests/guardrails -q
+
+      - name: Assert standard test collection is non-zero
+        run: |
+          cd npa
+          .venv/bin/python -m pytest tests --ignore=tests/e2e --collect-only -q

--- a/docs/testing/guardrails.md
+++ b/docs/testing/guardrails.md
@@ -9,7 +9,7 @@ Recommended branch-protection policy is an admin decision. The confidentiality s
 
 ## Local Registry Image Check
 
-GitHub-hosted runners cannot reach Nebius resources. Image existence checks therefore stay out of GitHub CI and can be run from a host with access to the container registry:
+Registry image reachability is environment-dependent, so image existence checks stay out of GitHub CI and can be run from a host with access to the container registry:
 
 ```bash
 npa/.venv/bin/python npa/scripts/check_workflow_images.py --registry-id "$NPA_REGISTRY_ID"

--- a/docs/testing/guardrails.md
+++ b/docs/testing/guardrails.md
@@ -1,0 +1,22 @@
+# Repo-Resident Guardrails
+
+This repository has additive no-GPU guardrails for PRs:
+
+- `confidentiality scan`: scans the PR diff and tracked tree with a regex sourced from the `CUSTOMER_DENYLIST` GitHub Actions secret. The workflow prints only redacted file locations.
+- `harness guardrails`: runs static three-tier workbench contracts, pytest collection protection, GPU-skip lint, and SkyPilot teardown lint.
+
+Recommended branch-protection policy is an admin decision. The confidentiality scan and harness guardrails are designed to be merge-blocking checks; the local registry check is informational until it can run from an environment with registry reachability.
+
+## Local Registry Image Check
+
+GitHub-hosted runners cannot reach Nebius resources. Image existence checks therefore stay out of GitHub CI and can be run from a configured Dev VM:
+
+```bash
+npa/.venv/bin/python npa/scripts/check_workflow_images.py --registry-id "$NPA_REGISTRY_ID"
+```
+
+Current workflow image tags still include operator placeholders, so the script reports `SEAM` until those placeholders are rendered for a specific run or registry.
+
+## Proven-Run Drift
+
+The optional YAML-to-proven-run drift guard needs a committed canonical proven-run manifest before it can compare drift. Until that manifest exists, this remains a documented `SEAM` rather than a GitHub CI gate.

--- a/docs/testing/guardrails.md
+++ b/docs/testing/guardrails.md
@@ -2,14 +2,14 @@
 
 This repository has additive no-GPU guardrails for PRs:
 
-- `confidentiality scan`: scans the PR diff and tracked tree with a regex sourced from the `CUSTOMER_DENYLIST` GitHub Actions secret. The workflow prints only redacted file locations.
+- `confidentiality scan`: scans the PR diff and tracked tree with regexes sourced from the `CUSTOMER_DENYLIST` and `INFRA_DENYLIST` GitHub Actions secrets. The workflow prints only redacted file locations.
 - `harness guardrails`: runs static three-tier workbench contracts, pytest collection protection, GPU-skip lint, and SkyPilot teardown lint.
 
 Recommended branch-protection policy is an admin decision. The confidentiality scan and harness guardrails are designed to be merge-blocking checks; the local registry check is informational until it can run from an environment with registry reachability.
 
 ## Local Registry Image Check
 
-GitHub-hosted runners cannot reach Nebius resources. Image existence checks therefore stay out of GitHub CI and can be run from a configured Dev VM:
+GitHub-hosted runners cannot reach Nebius resources. Image existence checks therefore stay out of GitHub CI and can be run from a host with access to the container registry:
 
 ```bash
 npa/.venv/bin/python npa/scripts/check_workflow_images.py --registry-id "$NPA_REGISTRY_ID"

--- a/npa/pyproject.toml
+++ b/npa/pyproject.toml
@@ -76,7 +76,6 @@ packages = ["src/npa"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/npa/solutions/solutions.toml" = "npa/solutions/solutions.toml"
-"src/npa/workbench/vlm_eval/fixtures/sample_benchmark" = "npa/workbench/vlm_eval/fixtures/sample_benchmark"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/npa/scripts/check_workflow_images.py
+++ b/npa/scripts/check_workflow_images.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Dev-VM-runnable registry existence check for SkyPilot workflow images."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+from npa.guardrails.skypilot import (
+    image_refs_for_workflows,
+    inspect_image_exists,
+    resolve_workflow_image,
+    unresolved_image_placeholders,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument("--registry-id", default=os.environ.get("NPA_REGISTRY_ID", ""))
+    parser.add_argument("--strict-placeholders", action="store_true")
+    args = parser.parse_args(argv)
+
+    workflow_dir = args.repo_root / "npa" / "workflows" / "workbench" / "skypilot"
+    images = image_refs_for_workflows(sorted(workflow_dir.glob("*.yaml")))
+    unresolved = sorted({image for image in images if unresolved_image_placeholders(image)})
+    if unresolved and not args.strict_placeholders:
+        print(
+            json.dumps(
+                {
+                    "status": "SEAM",
+                    "reason": "workflow images still contain operator placeholders",
+                    "unresolved_count": len(unresolved),
+                    "checked_count": 0,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    if not args.registry_id:
+        print(
+            json.dumps(
+                {
+                    "status": "SEAM",
+                    "reason": "NPA_REGISTRY_ID is required for live registry inspection",
+                    "checked_count": 0,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    missing: list[str] = []
+    checked: list[str] = []
+    for image in images:
+        resolved = resolve_workflow_image(image, registry_id=args.registry_id)
+        if unresolved_image_placeholders(resolved):
+            missing.append(resolved)
+            continue
+        try:
+            ok = inspect_image_exists(resolved)
+        except RuntimeError as exc:
+            print(
+                json.dumps(
+                    {"status": "SEAM", "reason": str(exc), "checked_count": len(checked)},
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 0
+        checked.append(resolved)
+        if not ok:
+            missing.append(resolved)
+
+    status = "WORKS" if not missing else "BLOCKED"
+    print(
+        json.dumps(
+            {
+                "status": status,
+                "checked_count": len(checked),
+                "missing": missing,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if not missing else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/npa/scripts/check_workflow_images.py
+++ b/npa/scripts/check_workflow_images.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Dev-VM-runnable registry existence check for SkyPilot workflow images."""
+"""Registry existence check for SkyPilot workflow images."""
 
 from __future__ import annotations
 

--- a/npa/src/npa/_sdk.py
+++ b/npa/src/npa/_sdk.py
@@ -44,6 +44,8 @@ def make_cli_wrapper(module_name: str, callback_name: str, doc: str):
 
     wrapper.__doc__ = doc
     wrapper.__name__ = callback_name.removesuffix("_cmd")
+    wrapper.__npa_cli_module__ = module_name
+    wrapper.__npa_cli_callback__ = callback_name
     return wrapper
 
 

--- a/npa/src/npa/guardrails/__init__.py
+++ b/npa/src/npa/guardrails/__init__.py
@@ -1,0 +1,5 @@
+"""Repo-resident guardrails for CI and local operator checks."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/npa/src/npa/guardrails/confidentiality.py
+++ b/npa/src/npa/guardrails/confidentiality.py
@@ -22,12 +22,18 @@ class ScanHit:
     line_number: int
 
 
-def compile_denylist(pattern: str, *, source: str = "denylist") -> re.Pattern[str]:
+def compile_denylist(
+    pattern: str,
+    *,
+    source: str = "denylist",
+    ignore_case: bool = False,
+) -> re.Pattern[str]:
     """Compile the operator-provided denylist regex."""
 
     if not pattern.strip():
         raise ValueError(f"{source} is empty")
-    return re.compile(pattern)
+    flags = re.IGNORECASE if ignore_case else 0
+    return re.compile(pattern, flags=flags)
 
 
 def scan_text(text: str, denylist: re.Pattern[str], *, source: str) -> list[ScanHit]:
@@ -91,10 +97,19 @@ def main(argv: list[str] | None = None) -> int:
         default="CUSTOMER_DENYLIST",
         help="Environment variable containing the denylist regex.",
     )
+    parser.add_argument(
+        "--ignore-case",
+        action="store_true",
+        help="Match denylist regexes case-insensitively.",
+    )
     args = parser.parse_args(argv)
 
     try:
-        denylist = compile_denylist(os.environ.get(args.pattern_env, ""), source=args.pattern_env)
+        denylist = compile_denylist(
+            os.environ.get(args.pattern_env, ""),
+            source=args.pattern_env,
+            ignore_case=args.ignore_case,
+        )
     except ValueError as exc:
         print(f"confidentiality scan not configured: {exc}", file=sys.stderr)
         return 2

--- a/npa/src/npa/guardrails/confidentiality.py
+++ b/npa/src/npa/guardrails/confidentiality.py
@@ -22,11 +22,11 @@ class ScanHit:
     line_number: int
 
 
-def compile_denylist(pattern: str) -> re.Pattern[str]:
+def compile_denylist(pattern: str, *, source: str = "denylist") -> re.Pattern[str]:
     """Compile the operator-provided denylist regex."""
 
     if not pattern.strip():
-        raise ValueError("CUSTOMER_DENYLIST is empty")
+        raise ValueError(f"{source} is empty")
     return re.compile(pattern)
 
 
@@ -94,7 +94,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        denylist = compile_denylist(os.environ.get(args.pattern_env, ""))
+        denylist = compile_denylist(os.environ.get(args.pattern_env, ""), source=args.pattern_env)
     except ValueError as exc:
         print(f"confidentiality scan not configured: {exc}", file=sys.stderr)
         return 2

--- a/npa/src/npa/guardrails/confidentiality.py
+++ b/npa/src/npa/guardrails/confidentiality.py
@@ -40,15 +40,17 @@ def scan_text(text: str, denylist: re.Pattern[str], *, source: str) -> list[Scan
     return hits
 
 
-def tracked_files(repo_root: Path) -> list[Path]:
-    """Return Git-tracked files under the repository root."""
+def tracked_text_files(repo_root: Path) -> list[Path]:
+    """Return Git-tracked files that Git classifies as text."""
 
     result = subprocess.run(
-        ["git", "ls-files", "-z"],
+        ["git", "grep", "-Ilz", "-e", "", "--", "."],
         cwd=repo_root,
-        check=True,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
+    if result.returncode not in (0, 1):
+        result.check_returncode()
     names = [name for name in result.stdout.decode("utf-8").split("\0") if name]
     return [repo_root / name for name in names]
 
@@ -61,10 +63,7 @@ def scan_paths(paths: list[Path], denylist: re.Pattern[str], *, repo_root: Path)
         if not path.is_file():
             continue
         rel = str(path.relative_to(repo_root))
-        try:
-            text = path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
-            text = path.read_bytes().decode("utf-8", errors="ignore")
+        text = path.read_bytes().decode("utf-8", errors="ignore")
         hits.extend(scan_text(text, denylist, source=rel))
     return hits
 
@@ -106,7 +105,7 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = args.repo_root.resolve()
     hits: list[ScanHit] = []
     if args.tree:
-        hits.extend(scan_paths(tracked_files(repo_root), denylist, repo_root=repo_root))
+        hits.extend(scan_paths(tracked_text_files(repo_root), denylist, repo_root=repo_root))
     if args.diff_range:
         hits.extend(scan_git_diff(repo_root, args.diff_range, denylist))
 

--- a/npa/src/npa/guardrails/confidentiality.py
+++ b/npa/src/npa/guardrails/confidentiality.py
@@ -1,0 +1,123 @@
+"""Secret-sourced confidentiality denylist scanner.
+
+The scanner intentionally reports only locations, never matched text.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+@dataclass(frozen=True)
+class ScanHit:
+    """A redacted denylist match location."""
+
+    source: str
+    line_number: int
+
+
+def compile_denylist(pattern: str) -> re.Pattern[str]:
+    """Compile the operator-provided denylist regex."""
+
+    if not pattern.strip():
+        raise ValueError("CUSTOMER_DENYLIST is empty")
+    return re.compile(pattern)
+
+
+def scan_text(text: str, denylist: re.Pattern[str], *, source: str) -> list[ScanHit]:
+    """Return redacted hit locations for text."""
+
+    hits: list[ScanHit] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if denylist.search(line):
+            hits.append(ScanHit(source=source, line_number=line_number))
+    return hits
+
+
+def tracked_files(repo_root: Path) -> list[Path]:
+    """Return Git-tracked files under the repository root."""
+
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=repo_root,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    names = [name for name in result.stdout.decode("utf-8").split("\0") if name]
+    return [repo_root / name for name in names]
+
+
+def scan_paths(paths: list[Path], denylist: re.Pattern[str], *, repo_root: Path) -> list[ScanHit]:
+    """Scan paths and report redacted locations."""
+
+    hits: list[ScanHit] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        rel = str(path.relative_to(repo_root))
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            text = path.read_bytes().decode("utf-8", errors="ignore")
+        hits.extend(scan_text(text, denylist, source=rel))
+    return hits
+
+
+def scan_git_diff(repo_root: Path, diff_range: str, denylist: re.Pattern[str]) -> list[ScanHit]:
+    """Scan a Git diff range and report redacted locations."""
+
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", "--no-ext-diff", diff_range],
+        cwd=repo_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return scan_text(result.stdout, denylist, source=f"diff:{diff_range}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--diff-range", default="")
+    parser.add_argument("--tree", action="store_true")
+    parser.add_argument(
+        "--pattern-env",
+        default="CUSTOMER_DENYLIST",
+        help="Environment variable containing the denylist regex.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        denylist = compile_denylist(os.environ.get(args.pattern_env, ""))
+    except ValueError as exc:
+        print(f"confidentiality scan not configured: {exc}", file=sys.stderr)
+        return 2
+    except re.error as exc:
+        print(f"confidentiality scan regex is invalid: {exc}", file=sys.stderr)
+        return 2
+
+    repo_root = args.repo_root.resolve()
+    hits: list[ScanHit] = []
+    if args.tree:
+        hits.extend(scan_paths(tracked_files(repo_root), denylist, repo_root=repo_root))
+    if args.diff_range:
+        hits.extend(scan_git_diff(repo_root, args.diff_range, denylist))
+
+    if hits:
+        print("confidentiality scan failed; redacted hit locations:", file=sys.stderr)
+        for hit in hits:
+            print(f"{hit.source}:{hit.line_number}", file=sys.stderr)
+        return 1
+    print("confidentiality scan passed; hits=0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npa/src/npa/guardrails/pytest_collection.py
+++ b/npa/src/npa/guardrails/pytest_collection.py
@@ -1,0 +1,14 @@
+"""Pytest collection guardrails."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def assert_nonzero_collection(count: int) -> None:
+    """Reject test invocations that collected no tests."""
+
+    if count <= 0:
+        raise pytest.UsageError(
+            "pytest collected 0 tests; refusing a false green guardrail run"
+        )

--- a/npa/src/npa/guardrails/skypilot.py
+++ b/npa/src/npa/guardrails/skypilot.py
@@ -1,4 +1,4 @@
-"""Static guardrails for SkyPilot workflows and runner scripts."""
+"""Static guardrails for SkyPilot workflows and helper scripts."""
 
 from __future__ import annotations
 

--- a/npa/src/npa/guardrails/skypilot.py
+++ b/npa/src/npa/guardrails/skypilot.py
@@ -1,0 +1,143 @@
+"""Static guardrails for SkyPilot workflows and runner scripts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import shutil
+import subprocess
+from typing import Any
+
+import yaml
+
+
+FORBIDDEN_TEARDOWN_RE = re.compile(r"(^|\s)(--down)(\s|$)|\bautodown\b")
+SKYPILOT_LAUNCH_RE = re.compile(r"\bsubmit_workflow\b|\bsky\s+(jobs\s+launch|launch)\b")
+ENV_REF_RE = re.compile(r"\$\{([A-Z0-9_]+)(?::-[^}]*)?\}")
+PY_ENV_REF_RE = re.compile(
+    r"os\.environ(?:\.get)?\(\s*[\"']([A-Z0-9_]+)[\"']|"
+    r"os\.environ\[\s*[\"']([A-Z0-9_]+)[\"']"
+)
+
+
+@dataclass(frozen=True)
+class TextHit:
+    """A source-location hit for a static guard."""
+
+    path: Path
+    line_number: int
+    line: str
+
+
+def load_yaml_documents(path: Path) -> list[dict[str, Any]]:
+    """Load SkyPilot YAML documents as mappings."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        docs = [doc for doc in yaml.safe_load_all(handle) if doc is not None]
+    if not all(isinstance(doc, dict) for doc in docs):
+        raise ValueError(f"SkyPilot YAML documents must be mappings: {path}")
+    return docs
+
+
+def env_names_for_yaml(path: Path) -> set[str]:
+    """Return all env keys declared by a SkyPilot YAML file."""
+
+    names: set[str] = set()
+    for doc in load_yaml_documents(path):
+        envs = doc.get("envs")
+        if isinstance(envs, dict):
+            names.update(str(key) for key in envs)
+    return names
+
+
+def env_refs_for_yaml(path: Path) -> set[str]:
+    """Return all shell-style env references in setup/run blocks."""
+
+    refs: set[str] = set()
+    for doc in load_yaml_documents(path):
+        for key in ("setup", "run"):
+            value = doc.get(key)
+            if isinstance(value, str):
+                refs.update(ENV_REF_RE.findall(value))
+                for match in PY_ENV_REF_RE.findall(value):
+                    refs.update(name for name in match if name)
+    return refs
+
+
+def scan_for_forbidden_teardown(paths: list[Path]) -> list[TextHit]:
+    """Find unsupported SkyPilot teardown flags in workflow files and scripts."""
+
+    hits: list[TextHit] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if FORBIDDEN_TEARDOWN_RE.search(line):
+                hits.append(TextHit(path=path, line_number=line_number, line=line.strip()))
+    return hits
+
+
+def skypilot_launching_scripts_missing_sigterm(paths: list[Path]) -> list[Path]:
+    """Return SkyPilot-launching scripts without an explicit SIGTERM hook."""
+
+    missing: list[Path] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        if not SKYPILOT_LAUNCH_RE.search(text):
+            continue
+        if "SIGTERM" not in text and "trap " not in text:
+            missing.append(path)
+    return missing
+
+
+def image_refs_for_workflows(paths: list[Path]) -> list[str]:
+    """Extract workflow image references."""
+
+    refs: list[str] = []
+    for path in paths:
+        for doc in load_yaml_documents(path):
+            resources = doc.get("resources")
+            if not isinstance(resources, dict):
+                continue
+            image_id = resources.get("image_id")
+            if isinstance(image_id, str) and image_id.strip():
+                image = image_id.removeprefix("docker:").strip()
+                refs.append(image)
+    return refs
+
+
+def unresolved_image_placeholders(image: str) -> bool:
+    """Return true when a workflow image still needs operator substitution."""
+
+    return "<" in image or ">" in image or "${" in image
+
+
+def resolve_workflow_image(image: str, *, registry_id: str) -> str:
+    """Resolve the standard registry-id placeholder for local registry checks."""
+
+    return image.replace("<your-registry-id>", registry_id)
+
+
+def inspect_image_exists(image: str, *, timeout_s: int = 30) -> bool:
+    """Check a remote image with a locally installed registry inspection tool."""
+
+    commands = [
+        ["crane", "digest", image],
+        ["skopeo", "inspect", f"docker://{image}"],
+        ["docker", "manifest", "inspect", image],
+    ]
+    for command in commands:
+        if shutil.which(command[0]) is None:
+            continue
+        result = subprocess.run(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout_s,
+            check=False,
+        )
+        return result.returncode == 0
+    raise RuntimeError("install crane, skopeo, or docker to inspect registry images")

--- a/npa/src/npa/guardrails/three_tier.py
+++ b/npa/src/npa/guardrails/three_tier.py
@@ -1,0 +1,94 @@
+"""Three-tier CLI, SDK, and SkyPilot YAML coherence helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+import inspect
+from pathlib import Path
+
+from npa.guardrails.skypilot import env_names_for_yaml, env_refs_for_yaml
+
+
+@dataclass(frozen=True)
+class ParameterContract:
+    """A single parameter expected to exist across CLI, SDK, and YAML."""
+
+    cli_param: str
+    sdk_param: str
+    yaml_env: str
+    cli_flag: str
+
+
+@dataclass(frozen=True)
+class CapabilityContract:
+    """A workbench capability contract across all three access tiers."""
+
+    name: str
+    cli_module: str
+    cli_callback: str
+    sdk_module: str
+    sdk_attr: str
+    yaml_path: Path
+    params: tuple[ParameterContract, ...]
+
+
+def callback_parameters(module_name: str, callback_name: str) -> dict[str, inspect.Parameter]:
+    module = import_module(module_name)
+    callback = getattr(module, callback_name)
+    return dict(inspect.signature(callback).parameters)
+
+
+def option_flags(param: inspect.Parameter) -> set[str]:
+    default = param.default
+    flags: set[str] = set()
+    for decl in getattr(default, "param_decls", ()):
+        for part in str(decl).split("/"):
+            if part.startswith("--"):
+                flags.add(part)
+    return flags
+
+
+def sdk_parameters(module_name: str, attr_name: str) -> set[str]:
+    module = import_module(module_name)
+    attr = getattr(module, attr_name)
+    wrapped_module = getattr(attr, "__npa_cli_module__", "")
+    wrapped_callback = getattr(attr, "__npa_cli_callback__", "")
+    if wrapped_module and wrapped_callback:
+        return set(callback_parameters(wrapped_module, wrapped_callback))
+    return set(inspect.signature(attr).parameters)
+
+
+def validate_contract(contract: CapabilityContract, *, repo_root: Path) -> list[str]:
+    """Return validation failures for a capability contract."""
+
+    failures: list[str] = []
+    cli_params = callback_parameters(contract.cli_module, contract.cli_callback)
+    sdk_params = sdk_parameters(contract.sdk_module, contract.sdk_attr)
+    yaml_path = repo_root / contract.yaml_path
+    yaml_envs = env_names_for_yaml(yaml_path)
+    yaml_refs = env_refs_for_yaml(yaml_path)
+
+    for param in contract.params:
+        cli = cli_params.get(param.cli_param)
+        if cli is None:
+            failures.append(f"{contract.name}: CLI param missing: {param.cli_param}")
+        elif param.cli_flag not in option_flags(cli):
+            failures.append(
+                f"{contract.name}: CLI flag {param.cli_flag} missing for {param.cli_param}"
+            )
+        if param.sdk_param not in sdk_params:
+            failures.append(f"{contract.name}: SDK param missing: {param.sdk_param}")
+        if param.yaml_env not in yaml_envs:
+            failures.append(f"{contract.name}: YAML env missing: {param.yaml_env}")
+        elif param.yaml_env not in yaml_refs:
+            failures.append(f"{contract.name}: YAML env not referenced: {param.yaml_env}")
+    return failures
+
+
+def registered_workbench_tools() -> set[str]:
+    """Return registered `npa workbench` tool names."""
+
+    from npa.cli.workbench import app
+
+    return {str(group.name) for group in app.registered_groups if group.name}

--- a/npa/src/npa/sdk/workbench/sonic.py
+++ b/npa/src/npa/sdk/workbench/sonic.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from npa._sdk import make_cli_wrapper
 from npa.workbench.sonic import (
     SonicExportError,
     SonicExportResult,
@@ -11,11 +12,14 @@ from npa.workbench.sonic import (
     validate_onnx_parity,
 )
 
+train = make_cli_wrapper("npa.cli.workbench.sonic.train", "train_cmd", "Run SONIC training.")
+
 __all__ = [
     "SonicExportError",
     "SonicExportResult",
     "SonicParityResult",
     "export_onnx",
     "load_export_metadata",
+    "train",
     "validate_onnx_parity",
 ]

--- a/npa/tests/conftest.py
+++ b/npa/tests/conftest.py
@@ -3,9 +3,14 @@ import pytest
 
 from npa.clients.project_credentials import CredentialPair
 from npa.errors import ScopedCredentialError
+from npa.guardrails.pytest_collection import assert_nonzero_collection
 
 os.environ.setdefault("NPA_PROJECT_ID", "project-test-00000000")
 os.environ.setdefault("NPA_S3_BUCKET", "test-bucket-00000000")
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    assert_nonzero_collection(len(session.items))
 
 
 @pytest.fixture

--- a/npa/tests/guardrails/test_collection_guard.py
+++ b/npa/tests/guardrails/test_collection_guard.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from npa.guardrails.pytest_collection import assert_nonzero_collection
+
+
+def test_collection_guard_accepts_nonzero_collection() -> None:
+    assert_nonzero_collection(1)
+
+
+def test_collection_guard_rejects_zero_collection() -> None:
+    with pytest.raises(pytest.UsageError, match="collected 0 tests"):
+        assert_nonzero_collection(0)

--- a/npa/tests/guardrails/test_confidentiality_scan.py
+++ b/npa/tests/guardrails/test_confidentiality_scan.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 import re
+import subprocess
 
 import pytest
 
-from npa.guardrails.confidentiality import compile_denylist, scan_text
+from npa.guardrails.confidentiality import (
+    compile_denylist,
+    scan_paths,
+    scan_text,
+    tracked_text_files,
+)
 
 
 def test_confidentiality_matcher_reports_redacted_locations_only() -> None:
@@ -21,6 +27,20 @@ def test_confidentiality_matcher_reports_redacted_locations_only() -> None:
         ("fixture.txt", 3),
     ]
     assert not hasattr(hits[0], "line")
+
+
+def test_tree_scan_skips_binary_files_but_keeps_text_hits(tmp_path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, stdout=subprocess.PIPE)
+    (tmp_path / "public.txt").write_text("contains synthetic-secret\n", encoding="utf-8")
+    (tmp_path / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00synthetic-secret\n")
+    subprocess.run(["git", "add", "public.txt", "image.png"], cwd=tmp_path, check=True)
+
+    denylist = compile_denylist(r"synthetic-secret")
+    paths = tracked_text_files(tmp_path)
+    hits = scan_paths(paths, denylist, repo_root=tmp_path)
+
+    assert {path.name for path in paths} == {"public.txt"}
+    assert [(hit.source, hit.line_number) for hit in hits] == [("public.txt", 1)]
 
 
 def test_confidentiality_matcher_rejects_empty_pattern() -> None:

--- a/npa/tests/guardrails/test_confidentiality_scan.py
+++ b/npa/tests/guardrails/test_confidentiality_scan.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from npa.guardrails.confidentiality import compile_denylist, scan_text
+
+
+def test_confidentiality_matcher_reports_redacted_locations_only() -> None:
+    denylist = compile_denylist(r"synthetic-secret|project-codename")
+
+    hits = scan_text(
+        "public line\ncontains synthetic-secret here\ncontains project-codename here\n",
+        denylist,
+        source="fixture.txt",
+    )
+
+    assert [(hit.source, hit.line_number) for hit in hits] == [
+        ("fixture.txt", 2),
+        ("fixture.txt", 3),
+    ]
+    assert not hasattr(hits[0], "line")
+
+
+def test_confidentiality_matcher_rejects_empty_pattern() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        compile_denylist("")
+
+
+def test_confidentiality_matcher_surfaces_invalid_regex() -> None:
+    with pytest.raises(re.error):
+        compile_denylist("[")

--- a/npa/tests/guardrails/test_confidentiality_scan.py
+++ b/npa/tests/guardrails/test_confidentiality_scan.py
@@ -48,6 +48,11 @@ def test_confidentiality_matcher_rejects_empty_pattern() -> None:
         compile_denylist("")
 
 
+def test_confidentiality_matcher_names_empty_pattern_source() -> None:
+    with pytest.raises(ValueError, match="INFRA_DENYLIST is empty"):
+        compile_denylist("", source="INFRA_DENYLIST")
+
+
 def test_confidentiality_matcher_surfaces_invalid_regex() -> None:
     with pytest.raises(re.error):
         compile_denylist("[")

--- a/npa/tests/guardrails/test_confidentiality_scan.py
+++ b/npa/tests/guardrails/test_confidentiality_scan.py
@@ -29,6 +29,14 @@ def test_confidentiality_matcher_reports_redacted_locations_only() -> None:
     assert not hasattr(hits[0], "line")
 
 
+def test_confidentiality_matcher_can_ignore_case() -> None:
+    denylist = compile_denylist(r"synthetic-secret", ignore_case=True)
+
+    hits = scan_text("contains SYNTHETIC-SECRET here\n", denylist, source="fixture.txt")
+
+    assert [(hit.source, hit.line_number) for hit in hits] == [("fixture.txt", 1)]
+
+
 def test_tree_scan_skips_binary_files_but_keeps_text_hits(tmp_path) -> None:
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, stdout=subprocess.PIPE)
     (tmp_path / "public.txt").write_text("contains synthetic-secret\n", encoding="utf-8")

--- a/npa/tests/guardrails/test_hygiene_guards.py
+++ b/npa/tests/guardrails/test_hygiene_guards.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import warnings
+
+from npa.guardrails.skypilot import (
+    scan_for_forbidden_teardown,
+    skypilot_launching_scripts_missing_sigterm,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _workflow_and_runner_paths() -> list[Path]:
+    workflow_dir = REPO_ROOT / "npa" / "workflows" / "workbench" / "skypilot"
+    script_dir = REPO_ROOT / "npa" / "scripts"
+    return sorted(workflow_dir.glob("*.yaml")) + sorted(script_dir.glob("*.py"))
+
+
+def _test_paths() -> list[Path]:
+    root = REPO_ROOT / "npa" / "tests"
+    return sorted(root.rglob("test_*.py")) + sorted(root.rglob("conftest.py"))
+
+
+def test_no_unsupported_skypilot_down_or_autodown() -> None:
+    hits = scan_for_forbidden_teardown(_workflow_and_runner_paths())
+    assert not hits, "\n".join(f"{hit.path}:{hit.line_number}: {hit.line}" for hit in hits)
+
+
+def test_teardown_guard_catches_broken_fixture(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.sh"
+    bad.write_text("sky launch --down task.yaml\n", encoding="utf-8")
+
+    hits = scan_for_forbidden_teardown([bad])
+
+    assert len(hits) == 1
+    assert hits[0].line_number == 1
+
+
+def test_skypilot_launching_scripts_without_sigterm_are_warned() -> None:
+    missing = skypilot_launching_scripts_missing_sigterm(sorted((REPO_ROOT / "npa" / "scripts").glob("*.py")))
+    for path in missing:
+        warnings.warn(
+            f"SkyPilot-launching script lacks an explicit SIGTERM hook: {path.relative_to(REPO_ROOT)}",
+            UserWarning,
+            stacklevel=1,
+        )
+
+
+def test_gpu_tests_skip_only_on_explicit_env_flags() -> None:
+    violations: list[str] = []
+    for path in _test_paths():
+        violations.extend(_cuda_skip_violations(path))
+    assert not violations, "\n".join(violations)
+
+
+def test_gpu_skip_guard_catches_broken_fixture(tmp_path: Path) -> None:
+    bad = tmp_path / "test_bad_gpu_skip.py"
+    bad.write_text(
+        "import pytest\n"
+        "import torch\n\n"
+        "@pytest.mark.skipif(not torch.cuda.is_available(), reason='no local GPU')\n"
+        "def test_gpu():\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    violations = _cuda_skip_violations(bad)
+
+    assert violations
+    assert "local CUDA" in violations[0]
+
+
+def _cuda_skip_violations(path: Path) -> list[str]:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _is_pytest_mark_skipif(node) and _mentions_local_cuda(node, source):
+            violations.append(f"{path}:{node.lineno}: GPU skip depends on local CUDA")
+        if _is_pytest_skip(node):
+            parent = parents.get(node)
+            while parent is not None:
+                if isinstance(parent, ast.If) and _mentions_local_cuda(parent.test, source):
+                    violations.append(f"{path}:{node.lineno}: GPU skip depends on local CUDA")
+                    break
+                parent = parents.get(parent)
+    return violations
+
+
+def _is_pytest_mark_skipif(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "skipif"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "mark"
+        and isinstance(func.value.value, ast.Name)
+        and func.value.value.id == "pytest"
+    )
+
+
+def _is_pytest_skip(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "skip"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "pytest"
+    )
+
+
+def _mentions_local_cuda(node: ast.AST, source: str) -> bool:
+    segment = ast.get_source_segment(source, node) or ""
+    return "cuda.is_available" in segment or "torch.cuda" in segment

--- a/npa/tests/guardrails/test_hygiene_guards.py
+++ b/npa/tests/guardrails/test_hygiene_guards.py
@@ -13,7 +13,7 @@ from npa.guardrails.skypilot import (
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-def _workflow_and_runner_paths() -> list[Path]:
+def _workflow_and_script_paths() -> list[Path]:
     workflow_dir = REPO_ROOT / "npa" / "workflows" / "workbench" / "skypilot"
     script_dir = REPO_ROOT / "npa" / "scripts"
     return sorted(workflow_dir.glob("*.yaml")) + sorted(script_dir.glob("*.py"))
@@ -25,7 +25,7 @@ def _test_paths() -> list[Path]:
 
 
 def test_no_unsupported_skypilot_down_or_autodown() -> None:
-    hits = scan_for_forbidden_teardown(_workflow_and_runner_paths())
+    hits = scan_for_forbidden_teardown(_workflow_and_script_paths())
     assert not hits, "\n".join(f"{hit.path}:{hit.line_number}: {hit.line}" for hit in hits)
 
 

--- a/npa/tests/guardrails/test_three_tier_contract.py
+++ b/npa/tests/guardrails/test_three_tier_contract.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from npa.guardrails.skypilot import load_yaml_documents
+from npa.guardrails.three_tier import (
+    CapabilityContract,
+    ParameterContract,
+    registered_workbench_tools,
+    validate_contract,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+CONTRACTS: tuple[CapabilityContract, ...] = (
+    CapabilityContract(
+        name="sonic/train",
+        cli_module="npa.cli.workbench.sonic.train",
+        cli_callback="train_cmd",
+        sdk_module="npa.sdk.workbench.sonic",
+        sdk_attr="train",
+        yaml_path=Path("npa/workflows/workbench/skypilot/sonic-train-standalone.yaml"),
+        params=(
+            ParameterContract("checkpoint", "checkpoint", "SONIC_CHECKPOINT", "--checkpoint"),
+            ParameterContract("data_path", "data_path", "SONIC_DATA_PATH", "--data-path"),
+            ParameterContract("sample_data", "sample_data", "SONIC_SAMPLE_DATA", "--sample-data"),
+            ParameterContract("embodiment", "embodiment", "SONIC_EMBODIMENT", "--embodiment"),
+            ParameterContract("num_envs", "num_envs", "SONIC_NUM_ENVS", "--num-envs"),
+            ParameterContract("headless", "headless", "SONIC_HEADLESS", "--headless"),
+            ParameterContract("max_iterations", "max_iterations", "SONIC_MAX_ITERATIONS", "--max-iterations"),
+            ParameterContract("output_path", "output_path", "SONIC_OUTPUT_PREFIX", "--output-path"),
+            ParameterContract("image", "image", "POLICY_IMAGE", "--image"),
+        ),
+    ),
+    CapabilityContract(
+        name="sonic/export",
+        cli_module="npa.cli.workbench.sonic.export",
+        cli_callback="export_cmd",
+        sdk_module="npa.sdk.workbench.sonic",
+        sdk_attr="export_onnx",
+        yaml_path=Path("npa/workflows/workbench/skypilot/sonic-export.yaml"),
+        params=(
+            ParameterContract("checkpoint", "checkpoint", "SONIC_CHECKPOINT", "--checkpoint"),
+            ParameterContract("output_path", "output", "SONIC_OUTPUT", "--output"),
+            ParameterContract("opset", "opset", "SONIC_OPSET", "--opset"),
+            ParameterContract("axes", "axes", "SONIC_AXES", "--axes"),
+            ParameterContract("normalize", "normalize", "SONIC_NORMALIZE", "--normalize"),
+            ParameterContract("metadata", "metadata", "SONIC_METADATA", "--metadata"),
+            ParameterContract("obs_spec", "obs_spec", "SONIC_OBS_SPEC", "--obs-spec"),
+            ParameterContract("action_spec", "action_spec", "SONIC_ACTION_SPEC", "--action-spec"),
+            ParameterContract("config", "config", "SONIC_CONFIG", "--config"),
+            ParameterContract("verify", "verify", "SONIC_VERIFY", "--verify"),
+            ParameterContract("parity_atol", "parity_atol", "SONIC_PARITY_ATOL", "--parity-atol"),
+        ),
+    ),
+    CapabilityContract(
+        name="vlm-eval/run",
+        cli_module="npa.cli.workbench.vlm_eval",
+        cli_callback="run_cmd",
+        sdk_module="npa.sdk.workbench.vlm_eval",
+        sdk_attr="run",
+        yaml_path=Path("npa/workflows/workbench/skypilot/vlm-eval.yaml"),
+        params=(
+            ParameterContract("input_path", "input_path", "EVAL_INPUT_URI", "--input-path"),
+            ParameterContract("output_path", "output_path", "VLM_EVAL_OUTPUT_URI", "--output-path"),
+            ParameterContract("task", "task", "VLM_EVAL_TASK", "--task"),
+            ParameterContract("backend", "backend", "VLM_BACKEND", "--backend"),
+            ParameterContract("model", "model", "VLM_MODEL", "--model"),
+            ParameterContract("endpoint_url", "endpoint_url", "VLM_ENDPOINT_URL", "--endpoint-url"),
+            ParameterContract("frame_selection", "frame_selection", "VLM_FRAME_SELECTION", "--frame-selection"),
+            ParameterContract("max_frames", "max_frames", "VLM_MAX_FRAMES", "--max-frames"),
+            ParameterContract("success_threshold", "success_threshold", "VLM_SUCCESS_THRESHOLD", "--success-threshold"),
+        ),
+    ),
+    CapabilityContract(
+        name="detection-training/train",
+        cli_module="npa.cli.workbench.detection_training",
+        cli_callback="train_cmd",
+        sdk_module="npa.sdk.workbench.detection_training",
+        sdk_attr="train",
+        yaml_path=Path("npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml"),
+        params=(
+            ParameterContract("view", "view", "VIEW_NAME", "--view"),
+            ParameterContract("output_uri", "output_uri", "TRAIN_OUTPUT_URI", "--output-uri"),
+            ParameterContract("lance_uri", "lance_uri", "LANCE_URI", "--lance-uri"),
+            ParameterContract("epochs", "epochs", "TRAIN_EPOCHS", "--epochs"),
+            ParameterContract("batch_size", "batch_size", "TRAIN_BATCH_SIZE", "--batch-size"),
+            ParameterContract("learning_rate", "learning_rate", "TRAIN_LEARNING_RATE", "--learning-rate"),
+        ),
+    ),
+    CapabilityContract(
+        name="detection-training/eval",
+        cli_module="npa.cli.workbench.detection_training",
+        cli_callback="eval_cmd",
+        sdk_module="npa.sdk.workbench.detection_training",
+        sdk_attr="eval",
+        yaml_path=Path("npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml"),
+        params=(
+            ParameterContract("eval_view", "eval_view", "VIEW_NAME", "--eval-view"),
+            ParameterContract("output_uri", "output_uri", "EVAL_OUTPUT_URI", "--output-uri"),
+            ParameterContract("lance_uri", "lance_uri", "LANCE_URI", "--lance-uri"),
+        ),
+    ),
+)
+
+
+def test_current_three_tier_contracts_are_coherent() -> None:
+    failures: list[str] = []
+    for contract in CONTRACTS:
+        failures.extend(validate_contract(contract, repo_root=REPO_ROOT))
+    assert not failures, "\n".join(failures)
+
+
+def test_new_workbench_tools_require_contract_or_explicit_seam() -> None:
+    contracted = {contract.name.split("/", 1)[0] for contract in CONTRACTS}
+    seam = {
+        "cosmos",
+        "data",
+        "fiftyone",
+        "genesis",
+        "groot",
+        "isaac-lab",
+        "lancedb",
+        "lerobot",
+        "mjlab",
+        "retargeting",
+        "workflow",
+    }
+    discovered = registered_workbench_tools()
+    assert discovered == contracted | seam
+
+
+def test_contract_catches_deliberately_broken_yaml_fixture(tmp_path: Path) -> None:
+    source = REPO_ROOT / CONTRACTS[0].yaml_path
+    docs = load_yaml_documents(source)
+    task_doc = docs[1]
+    envs = dict(task_doc["envs"])
+    envs.pop("SONIC_CHECKPOINT")
+    task_doc["envs"] = envs
+    broken = tmp_path / "broken.yaml"
+    import yaml
+
+    broken.write_text(yaml.safe_dump_all(docs, sort_keys=False), encoding="utf-8")
+    broken_contract = replace(CONTRACTS[0], yaml_path=broken)
+
+    failures = validate_contract(broken_contract, repo_root=REPO_ROOT)
+
+    assert any("YAML env missing: SONIC_CHECKPOINT" in failure for failure in failures)
+
+
+def test_standalone_policy_yaml_is_parameterized_and_endpoint_safe() -> None:
+    path = REPO_ROOT / "npa/workflows/workbench/skypilot/sonic-train-standalone.yaml"
+    text = path.read_text(encoding="utf-8")
+    docs = load_yaml_documents(path)
+    task = docs[1]
+    envs = task["envs"]
+
+    assert task["resources"]["image_id"] == "docker:${POLICY_IMAGE}"
+    assert {"POLICY_IMAGE", "S3_ENDPOINT_URL", "S3_BUCKET"} <= set(envs)
+    assert envs["POLICY_IMAGE"].startswith("example.invalid/")
+    assert envs["S3_ENDPOINT_URL"] == ""
+    assert envs["S3_BUCKET"] == "example-bucket"
+    assert "nebius.cloud" not in text

--- a/npa/tests/guardrails/test_workflow_image_check.py
+++ b/npa/tests/guardrails/test_workflow_image_check.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from npa.guardrails.skypilot import (
+    image_refs_for_workflows,
+    resolve_workflow_image,
+    unresolved_image_placeholders,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_workflow_image_extraction_finds_skypilot_images() -> None:
+    workflow_dir = REPO_ROOT / "npa" / "workflows" / "workbench" / "skypilot"
+    images = image_refs_for_workflows(sorted(workflow_dir.glob("*.yaml")))
+
+    assert images
+    assert any("npa-sonic" in image for image in images)
+
+
+def test_registry_placeholder_resolution_is_local_check_ready() -> None:
+    image = "cr.eu-north1.nebius.cloud/<your-registry-id>/npa:tag"
+
+    resolved = resolve_workflow_image(image, registry_id="registry-test")
+
+    assert resolved == "cr.eu-north1.nebius.cloud/registry-test/npa:tag"
+    assert not unresolved_image_placeholders(resolved)
+
+
+def test_image_check_classifies_operator_placeholders_as_seam() -> None:
+    assert unresolved_image_placeholders("cr.eu-north1.nebius.cloud/<your-registry-id>/npa:<tag>")
+    assert unresolved_image_placeholders("${POLICY_IMAGE}")

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -1,0 +1,76 @@
+# Standalone SONIC training smoke workflow.
+#
+# Operator-provided parameters:
+# - POLICY_IMAGE: image containing the npa CLI and SONIC runtime.
+# - S3_ENDPOINT_URL: S3-compatible endpoint for artifact writes.
+# - S3_BUCKET: destination bucket name, without s3://.
+name: sonic-train-standalone
+execution: serial
+---
+name: sonic-train-smoke
+resources:
+  cloud: kubernetes
+  accelerators: H100:1
+  cpus: 16
+  memory: 64
+  image_id: "docker:${POLICY_IMAGE}"
+envs:
+  POLICY_IMAGE: "example.invalid/npa-sonic:latest"
+  S3_ENDPOINT_URL: ""
+  S3_BUCKET: "example-bucket"
+  NPA_PIPELINE_RUN_ID: "sonic-train-smoke"
+  SONIC_CHECKPOINT: "nvidia/GEAR-SONIC:sonic_release/last.pt"
+  SONIC_DATA_PATH: ""
+  SONIC_SAMPLE_DATA: "1"
+  SONIC_EMBODIMENT: "unitree-g1"
+  SONIC_NUM_ENVS: "16"
+  SONIC_HEADLESS: "1"
+  SONIC_MAX_ITERATIONS: "5"
+  SONIC_OUTPUT_PREFIX: "sonic-train/${NPA_PIPELINE_RUN_ID}/"
+setup: |
+  set -euo pipefail
+  PYTHON_BIN="${NPA_PYTHON_BIN:-$(command -v python3 || command -v python)}"
+  if ! command -v npa >/dev/null 2>&1; then
+    if [ -n "${NPA_REPO_DIR:-}" ] && [ -d "${NPA_REPO_DIR}/npa" ]; then
+      "${PYTHON_BIN}" -m pip install -e "${NPA_REPO_DIR}/npa"
+    elif [ -d "./npa" ]; then
+      "${PYTHON_BIN}" -m pip install -e ./npa
+    fi
+  fi
+run: |
+  set -euo pipefail
+  if [ -z "${S3_ENDPOINT_URL}" ]; then
+    echo "S3_ENDPOINT_URL must be provided by the operator" >&2
+    exit 2
+  fi
+  if [ "${S3_BUCKET}" = "example-bucket" ]; then
+    echo "S3_BUCKET must be provided by the operator" >&2
+    exit 2
+  fi
+
+  export AWS_ENDPOINT_URL="${S3_ENDPOINT_URL}"
+  export NEBIUS_S3_ENDPOINT="${S3_ENDPOINT_URL}"
+  output_path="s3://${S3_BUCKET}/${SONIC_OUTPUT_PREFIX}"
+
+  sample_args=()
+  if [ "${SONIC_SAMPLE_DATA}" = "1" ]; then
+    sample_args+=(--sample-data)
+  fi
+
+  headless_arg="--headless"
+  if [ "${SONIC_HEADLESS}" = "0" ]; then
+    headless_arg="--no-headless"
+  fi
+
+  npa workbench sonic train \
+    --runtime serverless \
+    --checkpoint "${SONIC_CHECKPOINT}" \
+    --data-path "${SONIC_DATA_PATH}" \
+    "${sample_args[@]}" \
+    --embodiment "${SONIC_EMBODIMENT}" \
+    --num-envs "${SONIC_NUM_ENVS}" \
+    "${headless_arg}" \
+    --max-iterations "${SONIC_MAX_ITERATIONS}" \
+    --output-path "${output_path}" \
+    --image "${POLICY_IMAGE}" \
+    --output-format json


### PR DESCRIPTION
## Summary
- Adds secret-sourced confidentiality scans for PR diffs and tracked tree content. Denylist values are supplied via GitHub Actions secrets and scan output reports only redacted locations.
- Runs separate customer and operator-private denylist checks from the same workflow and scanner module.
- Adds no-GPU harness guardrails for three-tier CLI/SDK/YAML coherence, pytest non-zero collection, GPU-skip discipline, and SkyPilot teardown lint.
- Adds a standalone parameterized SONIC training SkyPilot YAML with BYO policy image, endpoint, and bucket inputs.
- Adds a workflow image registry check that can be run from a registry-reachable host and reports SEAM while current images still contain operator placeholders.

## Branch protection recommendation
- Recommended required: confidentiality scan, harness guardrails.
- Recommended informational: registry image check until it can run from an environment with registry reachability.

## Seams
- Registry image existence is environment-dependent; run `npa/.venv/bin/python npa/scripts/check_workflow_images.py --registry-id "$NPA_REGISTRY_ID"` from a registry-reachable host.
- Proven-run YAML drift remains a documented seam until a canonical proven-run manifest is committed.
- Workbench tools without all three access tiers are explicitly classified in the three-tier guard test so new tools must be contracted or marked as a seam.

## Validation
- `INFRA_DENYLIST=... npa/.venv/bin/python -m npa.guardrails.confidentiality --repo-root . --tree --diff-range origin/main...HEAD --pattern-env INFRA_DENYLIST --ignore-case`: hits=0.
- `npa/.venv/bin/python -m pytest npa/tests/guardrails -q`: 20 passed, 2 expected SIGTERM-hook warnings.
- `npa/.venv/bin/python -m pytest npa/tests --ignore=npa/tests/e2e --collect-only -q`: 1384 collected, 2 skipped.
- `npa/.venv/bin/python -m ruff check` on changed Python files: passed.
- Workflow YAML parse check: passed.

## Setup note
Populate `CUSTOMER_DENYLIST` and `INFRA_DENYLIST` GitHub Actions secrets for the confidentiality scan to enforce both denylist sets. Denylist values are secret-sourced and are not committed.
