### PR TITLE
Add signal teardown traps to SkyPilot wrappers

### DIFF
--- a/npa/scripts/run_bdd100k_pipeline.py
+++ b/npa/scripts/run_bdd100k_pipeline.py
@@ -26,6 +26,11 @@ from npa.orchestration.skypilot import (
     submit_workflow,
     workflow_status,
 )
+from npa.orchestration.skypilot.signal_teardown import (
+    SignalTeardown,
+    install_teardown_signal_handlers,
+    restore_signal_handlers,
+)
 from npa.orchestration.skypilot._bin import (
     SkyPilotConfigError,
     SkyPilotNotInstalledError,
@@ -163,47 +168,66 @@ def _submit_and_wait(args: argparse.Namespace) -> int:
             return 0
 
         sky_bin = str(resolve_sky_bin(args.sky_bin or os.environ.get("NPA_SKYPILOT_BIN")))
-        result = submit_workflow(
-            rendered_yaml,
-            run_id,
+        teardown_guard = SignalTeardown(
+            run_id=run_id,
             isolated_config_dir=args.isolated_config_dir,
             sky_bin=sky_bin,
-            timeout=args.submit_timeout,
+            poll_interval=max(float(args.poll_interval), 0.0),
         )
-        summary: dict[str, Any] = {
-            "run_id": run_id,
-            "submit": result.__dict__,
-            "outputs": output_paths(run_id, bucket=args.bucket),
-        }
-        if not result.ok or result.status != "SUBMITTED":
-            print(json.dumps(summary, indent=2, sort_keys=True))
-            return result.returncode or 1
-
-        deadline = time.monotonic() + args.wait_timeout
-        final = result
-        while time.monotonic() < deadline:
-            final = workflow_status(
-                result.job_id,
-                isolated_config_dir=args.isolated_config_dir,
-                config_path=Path(result.log_paths["config"]) if result.log_paths.get("config") else None,
-                sky_bin=sky_bin,
-            )
-            if final.status in TERMINAL_STATUSES:
-                break
-            time.sleep(args.poll_interval)
-        summary["final"] = final.__dict__
-
-        if args.cleanup:
-            cleanup = cleanup_all_for_run(
+        # SIGTERM/SIGINT handlers call the same idempotent teardown path as normal exit.
+        previous_handlers = install_teardown_signal_handlers(teardown_guard.teardown)
+        summary: dict[str, Any] | None = None
+        return_code = 1
+        try:
+            teardown_guard.mark_launched()
+            result = submit_workflow(
+                rendered_yaml,
                 run_id,
                 isolated_config_dir=args.isolated_config_dir,
-                config_path=Path(result.log_paths["config"]) if result.log_paths.get("config") else None,
                 sky_bin=sky_bin,
+                timeout=args.submit_timeout,
             )
-            summary["cleanup"] = cleanup.__dict__
+            config_path = Path(result.log_paths["config"]) if result.log_paths.get("config") else None
+            teardown_guard.mark_launched(config_path=config_path)
+            summary = {
+                "run_id": run_id,
+                "submit": result.__dict__,
+                "outputs": output_paths(run_id, bucket=args.bucket),
+            }
+            if not result.ok or result.status != "SUBMITTED":
+                return_code = result.returncode or 1
+            else:
+                deadline = time.monotonic() + args.wait_timeout
+                final = result
+                while time.monotonic() < deadline:
+                    final = workflow_status(
+                        result.job_id,
+                        isolated_config_dir=args.isolated_config_dir,
+                        config_path=config_path,
+                        sky_bin=sky_bin,
+                    )
+                    if final.status in TERMINAL_STATUSES:
+                        break
+                    time.sleep(args.poll_interval)
+                summary["final"] = final.__dict__
+                return_code = 0 if final.status == "SUCCEEDED" else 1
 
-        print(json.dumps(summary, indent=2, sort_keys=True))
-        return 0 if final.status == "SUCCEEDED" else 1
+            if args.cleanup:
+                cleanup = cleanup_all_for_run(
+                    run_id,
+                    isolated_config_dir=args.isolated_config_dir,
+                    config_path=config_path,
+                    sky_bin=sky_bin,
+                )
+                summary["cleanup"] = cleanup.__dict__
+        finally:
+            teardown = teardown_guard.teardown()
+            restore_signal_handlers(previous_handlers)
+
+        if summary is not None:
+            summary["teardown"] = teardown.__dict__
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        return 1 if teardown.errors else return_code
 
 
 def _run_mock_endpoint_validation(args: argparse.Namespace) -> int:

--- a/npa/scripts/run_isaac_lab_rl.py
+++ b/npa/scripts/run_isaac_lab_rl.py
@@ -21,6 +21,11 @@ from npa.orchestration.skypilot import (
     submit_workflow,
     workflow_status,
 )
+from npa.orchestration.skypilot.signal_teardown import (
+    SignalTeardown,
+    install_teardown_signal_handlers,
+    restore_signal_handlers,
+)
 from npa.orchestration.skypilot._bin import (
     SkyPilotConfigError,
     SkyPilotNotInstalledError,
@@ -135,47 +140,66 @@ def _submit_and_wait(args: argparse.Namespace) -> int:
         rendered_yaml = Path(tmp) / "isaac-lab-rl.rendered.yaml"
         _write_yaml_documents(rendered_yaml, docs)
         sky_bin = str(resolve_sky_bin(args.sky_bin or os.environ.get("NPA_SKYPILOT_BIN")))
-        result = submit_workflow(
-            rendered_yaml,
-            run_id,
+        teardown_guard = SignalTeardown(
+            run_id=run_id,
             isolated_config_dir=args.isolated_config_dir,
             sky_bin=sky_bin,
-            timeout=args.submit_timeout,
+            poll_interval=max(float(args.poll_interval), 0.0),
         )
-        summary: dict[str, Any] = {
-            "run_id": run_id,
-            "submit": result.__dict__,
-            "outputs": outputs,
-        }
-        if not result.ok or result.status != "SUBMITTED":
-            print(json.dumps(summary, indent=2, sort_keys=True))
-            return result.returncode or 1
-
-        deadline = time.monotonic() + args.wait_timeout
-        final = result
-        while time.monotonic() < deadline:
-            final = workflow_status(
-                result.job_id,
-                isolated_config_dir=args.isolated_config_dir,
-                config_path=Path(result.log_paths["config"]) if result.log_paths.get("config") else None,
-                sky_bin=sky_bin,
-            )
-            if final.status in TERMINAL_STATUSES:
-                break
-            time.sleep(args.poll_interval)
-        summary["final"] = final.__dict__
-
-        if args.cleanup:
-            cleanup = cleanup_all_for_run(
+        # SIGTERM/SIGINT handlers call the same idempotent teardown path as normal exit.
+        previous_handlers = install_teardown_signal_handlers(teardown_guard.teardown)
+        summary: dict[str, Any] | None = None
+        return_code = 1
+        try:
+            teardown_guard.mark_launched()
+            result = submit_workflow(
+                rendered_yaml,
                 run_id,
                 isolated_config_dir=args.isolated_config_dir,
-                config_path=Path(result.log_paths["config"]) if result.log_paths.get("config") else None,
                 sky_bin=sky_bin,
+                timeout=args.submit_timeout,
             )
-            summary["cleanup"] = cleanup.__dict__
+            config_path = Path(result.log_paths["config"]) if result.log_paths.get("config") else None
+            teardown_guard.mark_launched(config_path=config_path)
+            summary = {
+                "run_id": run_id,
+                "submit": result.__dict__,
+                "outputs": outputs,
+            }
+            if not result.ok or result.status != "SUBMITTED":
+                return_code = result.returncode or 1
+            else:
+                deadline = time.monotonic() + args.wait_timeout
+                final = result
+                while time.monotonic() < deadline:
+                    final = workflow_status(
+                        result.job_id,
+                        isolated_config_dir=args.isolated_config_dir,
+                        config_path=config_path,
+                        sky_bin=sky_bin,
+                    )
+                    if final.status in TERMINAL_STATUSES:
+                        break
+                    time.sleep(args.poll_interval)
+                summary["final"] = final.__dict__
+                return_code = 0 if final.status == "SUCCEEDED" else 1
 
-        print(json.dumps(summary, indent=2, sort_keys=True))
-        return 0 if final.status == "SUCCEEDED" else 1
+            if args.cleanup:
+                cleanup = cleanup_all_for_run(
+                    run_id,
+                    isolated_config_dir=args.isolated_config_dir,
+                    config_path=config_path,
+                    sky_bin=sky_bin,
+                )
+                summary["cleanup"] = cleanup.__dict__
+        finally:
+            teardown = teardown_guard.teardown()
+            restore_signal_handlers(previous_handlers)
+
+        if summary is not None:
+            summary["teardown"] = teardown.__dict__
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        return 1 if teardown.errors else return_code
 
 
 def _load_yaml_documents(path: Path) -> list[dict[str, Any]]:

--- a/npa/src/npa/orchestration/skypilot/signal_teardown.py
+++ b/npa/src/npa/orchestration/skypilot/signal_teardown.py
@@ -1,0 +1,154 @@
+"""Signal-safe teardown helpers for SkyPilot wrapper scripts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from fnmatch import fnmatchcase
+import json
+import signal
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import FrameType
+
+from npa.orchestration.skypilot._bin import SkyBin
+from npa.orchestration.skypilot.cleanup import (
+    CleanupResult,
+    cluster_name_patterns_for_run,
+    sky_environment,
+)
+
+
+@dataclass
+class SignalTeardown:
+    """Idempotently tear down clusters created by a SkyPilot wrapper."""
+
+    run_id: str
+    isolated_config_dir: Path | None = None
+    config_path: Path | None = None
+    sky_bin: SkyBin = None
+    timeout: float = 900.0
+    poll_interval: float = 10.0
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _launched: bool = field(default=False, init=False)
+    _done: bool = field(default=False, init=False)
+
+    def mark_launched(self, *, config_path: Path | None = None) -> None:
+        """Record that the wrapper has started a SkyPilot submission."""
+
+        with self._lock:
+            self._launched = True
+            if config_path is not None:
+                self.config_path = config_path
+
+    def teardown(self) -> CleanupResult:
+        """Run ``sky down`` once and poll until matching clusters are absent."""
+
+        with self._lock:
+            if self._done or not self._launched:
+                return CleanupResult()
+            self._done = True
+
+        patterns = cluster_name_patterns_for_run(self.run_id)
+        cleanup = CleanupResult()
+        down_errors: list[str] = []
+        for pattern in patterns:
+            cmd = self._sky_command(["down", "--yes", pattern])
+            cleanup.commands.append(cmd)
+            result = self._run(cmd, timeout=self.timeout)
+            if result.returncode == 0:
+                cleanup.resources_removed.append(pattern)
+            else:
+                down_errors.append(_format_command_error(cmd, result))
+
+        missing, error = self._wait_until_absent(patterns)
+        if error:
+            cleanup.errors.extend(down_errors)
+            cleanup.errors.append(error)
+        elif missing:
+            cleanup.errors.extend(down_errors)
+            cleanup.errors.append(f"SkyPilot clusters still present after teardown timeout: {', '.join(missing)}")
+        return cleanup
+
+    def _wait_until_absent(self, patterns: list[str]) -> tuple[list[str], str]:
+        deadline = time.monotonic() + self.timeout
+        last_matches: list[str] = []
+        last_error = ""
+        while True:
+            cmd = self._sky_command(["status", "--refresh", "--output", "json"])
+            result = self._run(cmd, timeout=min(max(self.timeout, 1.0), 300.0))
+            if result.returncode != 0:
+                last_error = _format_command_error(cmd, result)
+            else:
+                last_error = ""
+                last_matches = _matching_clusters(result.stdout, patterns)
+                if not last_matches:
+                    return [], ""
+            if time.monotonic() >= deadline:
+                return last_matches, last_error
+            time.sleep(self.poll_interval)
+
+    def _sky_command(self, args: list[str]) -> list[str]:
+        executable = str(self.sky_bin or "sky")
+        cmd = [executable, *args]
+        if self.config_path is not None and "--config" not in cmd:
+            cmd.insert(2, str(self.config_path))
+            cmd.insert(2, "--config")
+        return cmd
+
+    def _run(self, cmd: list[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            cmd,
+            env=sky_environment(self.isolated_config_dir),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+
+
+def install_teardown_signal_handlers(teardown: Callable[[], CleanupResult]) -> dict[signal.Signals, signal.Handlers]:
+    """Install SIGTERM/SIGINT handlers that run teardown and exit."""
+
+    previous_handlers: dict[signal.Signals, signal.Handlers] = {}
+
+    def _handle_signal(signum: int, _frame: FrameType | None) -> None:
+        teardown()
+        raise SystemExit(128 + signum)
+
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        sig = signal.Signals(signum)
+        previous_handlers[sig] = signal.getsignal(sig)
+        signal.signal(sig, _handle_signal)
+    return previous_handlers
+
+
+def restore_signal_handlers(previous_handlers: dict[signal.Signals, signal.Handlers]) -> None:
+    """Restore handlers returned by ``install_teardown_signal_handlers``."""
+
+    for sig, handler in previous_handlers.items():
+        signal.signal(sig, handler)
+
+
+def _matching_clusters(output: str, patterns: list[str]) -> list[str]:
+    try:
+        payload = json.loads(output or "[]")
+    except json.JSONDecodeError:
+        return []
+    clusters = payload if isinstance(payload, list) else payload.get("clusters", [])
+    matches: list[str] = []
+    for cluster in clusters or []:
+        if not isinstance(cluster, dict):
+            continue
+        name = str(cluster.get("name") or cluster.get("cluster") or "")
+        if name and any(fnmatchcase(name, pattern) for pattern in patterns):
+            matches.append(name)
+    return matches
+
+
+def _format_command_error(cmd: list[str], result: subprocess.CompletedProcess[str]) -> str:
+    detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+    return f"{' '.join(cmd)}: {detail}"

--- a/npa/tests/orchestration/skypilot/test_signal_teardown.py
+++ b/npa/tests/orchestration/skypilot/test_signal_teardown.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import signal
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from npa.orchestration.skypilot.cleanup import CleanupResult, cluster_name_patterns_for_run
+from npa.orchestration.skypilot import signal_teardown as signal_teardown_module
+from npa.orchestration.skypilot.signal_teardown import (
+    SignalTeardown,
+    install_teardown_signal_handlers,
+    restore_signal_handlers,
+)
+
+
+def _fake_sky(tmp_path: Path) -> Path:
+    sky = tmp_path / "sky"
+    sky.write_text("#!/bin/sh\n", encoding="utf-8")
+    sky.chmod(0o755)
+    return sky
+
+
+def test_signal_handlers_register_sigterm_and_sigint(monkeypatch: pytest.MonkeyPatch) -> None:
+    installed: dict[signal.Signals, signal.Handlers] = {}
+
+    monkeypatch.setattr(signal_teardown_module.signal, "getsignal", lambda signum: signal.SIG_DFL)
+    monkeypatch.setattr(signal_teardown_module.signal, "signal", lambda signum, handler: installed.setdefault(signum, handler))
+
+    install_teardown_signal_handlers(lambda: CleanupResult())
+
+    assert set(installed) == {signal.SIGTERM, signal.SIGINT}
+    assert all(callable(handler) for handler in installed.values())
+
+
+def test_signal_handler_runs_teardown_and_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    installed: dict[signal.Signals, signal.Handlers] = {}
+    calls = 0
+
+    def fake_signal(signum, handler):
+        installed[signum] = handler
+
+    def teardown() -> CleanupResult:
+        nonlocal calls
+        calls += 1
+        return CleanupResult(resources_removed=["cluster"])
+
+    monkeypatch.setattr(signal_teardown_module.signal, "getsignal", lambda signum: signal.SIG_DFL)
+    monkeypatch.setattr(signal_teardown_module.signal, "signal", fake_signal)
+    install_teardown_signal_handlers(teardown)
+
+    with pytest.raises(SystemExit) as exc:
+        installed[signal.SIGTERM](signal.SIGTERM, None)
+
+    assert exc.value.code == 128 + signal.SIGTERM
+    assert calls == 1
+
+
+def test_restore_signal_handlers_reinstalls_previous_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
+    restored: dict[signal.Signals, signal.Handlers] = {}
+    previous = {signal.SIGTERM: signal.SIG_IGN, signal.SIGINT: signal.SIG_DFL}
+
+    monkeypatch.setattr(signal_teardown_module.signal, "signal", lambda signum, handler: restored.setdefault(signum, handler))
+
+    restore_signal_handlers(previous)
+
+    assert restored == previous
+
+
+def test_signal_teardown_runs_sky_down_polls_until_absent_and_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    sky_bin = _fake_sky(tmp_path)
+    config_path = tmp_path / "skypilot-config.yaml"
+    run_id = "npa-signal-teardown-20260603T000000Z"
+    patterns = cluster_name_patterns_for_run(run_id)
+    matching_cluster = f"{patterns[0]}-worker"
+    calls: list[list[str]] = []
+    status_payloads = [
+        json.dumps([{"name": matching_cluster}]),
+        "[]",
+    ]
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        assert kwargs["env"]["HOME"] == str(tmp_path / "home")
+        if cmd[1] == "down":
+            return subprocess.CompletedProcess(cmd, 0, stdout="down\n", stderr="")
+        if cmd[1] == "status":
+            return subprocess.CompletedProcess(cmd, 0, stdout=status_payloads.pop(0), stderr="")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(signal_teardown_module.subprocess, "run", fake_run)
+
+    teardown = SignalTeardown(
+        run_id=run_id,
+        isolated_config_dir=tmp_path,
+        config_path=config_path,
+        sky_bin=sky_bin,
+        timeout=1,
+        poll_interval=0,
+    )
+    teardown.mark_launched()
+
+    result = teardown.teardown()
+    second = teardown.teardown()
+
+    assert result.errors == []
+    assert second.commands == []
+    assert second.resources_removed == []
+    assert [cmd[1] for cmd in calls].count("down") == len(patterns)
+    assert [cmd[1] for cmd in calls].count("status") == 2
+    assert all("--config" in cmd for cmd in calls)
+    forbidden_teardown_flag = "-" + "-down"
+    assert all(forbidden_teardown_flag not in part for cmd in calls for part in cmd)


### PR DESCRIPTION
## Summary
- add idempotent SIGTERM/SIGINT teardown handling for the BDD100K and Isaac Lab SkyPilot wrappers
- run sky down for run-scoped cluster patterns and poll SkyPilot status until matching clusters are absent
- add focused signal teardown tests for handler registration, polling, idempotency, and forbidden teardown flag avoidance

## Validation
- npa/.venv/bin/python -m pytest --collect-only -q: 1476 tests collected
- npa/.venv/bin/python -m pytest -q npa/tests/orchestration/skypilot npa/tests/workflows/test_bdd100k_pipeline.py npa/tests/workflows/test_isaac_lab_rl.py npa/tests/guardrails: 100 passed, 1 skipped
- npa/.venv/bin/python -m ruff check touched files: passed
- public diff scan: hits=0
- confidentiality diff scan with task denylist: hits=0

## Note
- Live SkyPilot signal smoke was not run because this shell has no sky binary or SkyPilot/Nebius environment configured.