### PR TITLE
Isolate Hugging Face access checks in tests

### DIFF
--- a/npa/tests/cli/test_groot_cli.py
+++ b/npa/tests/cli/test_groot_cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import shlex
 from contextlib import contextmanager
 from pathlib import Path
@@ -12,6 +11,7 @@ from typer.testing import CliRunner
 
 from npa.cli.groot import (
     COSMOS_REASON_REVISION,
+    COSMOS_REASON_MODEL,
     DEFAULT_MODEL,
     GROOT_CONTAINER_ENV_FILE,
     GROOT_CONTAINER_NAME,
@@ -137,12 +137,16 @@ def test_groot_list_filters_to_groot_workbenches(mocker) -> None:
     assert "train" not in result.output
 
 
-@pytest.mark.skipif(
-    not os.environ.get("HF_TOKEN"),
-    reason="requires HF_TOKEN",
-)
 def test_groot_deploy_dry_run_defaults_to_l40s(mocker) -> None:
     mocker.patch("npa.cli.groot.resolve_environment", return_value=None)
+    mocker.patch(
+        "npa.cli.groot.resolve_credentials",
+        return_value=CredentialsConfig(tokens={"HF_TOKEN": "hf-test"}),
+    )
+    validate_hf_access = mocker.patch(
+        "npa.cli.groot.validate_hf_access",
+        return_value=SimpleNamespace(ok=True, error=""),
+    )
     mocker.patch("npa.cli.groot.list_projects", return_value={})
     init = mocker.patch("npa.cli.groot.provisioner.init")
     apply = mocker.patch("npa.cli.groot.provisioner.apply")
@@ -171,6 +175,10 @@ def test_groot_deploy_dry_run_defaults_to_l40s(mocker) -> None:
     assert "Deploy complete" in result.output
     assert "gpu-l40s-a" in result.output
     assert "http://<pending>:8080" in result.output
+    assert [call.args for call in validate_hf_access.call_args_list] == [
+        ("hf-test", DEFAULT_MODEL),
+        ("hf-test", COSMOS_REASON_MODEL),
+    ]
     init.assert_not_called()
     apply.assert_not_called()
 

--- a/npa/tests/cli/test_workbench_app_status.py
+++ b/npa/tests/cli/test_workbench_app_status.py
@@ -100,6 +100,10 @@ def test_cosmos_registers_after_terraform_before_app_install_and_marks_failure(
         "npa.cli.cosmos.resolve_credentials",
         return_value=CredentialsConfig(tokens={"HF_TOKEN": "hf-test"}),
     )
+    validate_hf_access = mocker.patch(
+        "npa.cli.cosmos.validate_hf_access",
+        return_value=mocker.MagicMock(ok=True, error=""),
+    )
     mocker.patch("npa.cli.cosmos.list_projects", return_value={})
     mocker.patch(
         "npa.cli.cosmos.write_config",
@@ -139,6 +143,7 @@ def test_cosmos_registers_after_terraform_before_app_install_and_marks_failure(
 
     assert result.exit_code == 1
     assert "Cosmos installation failed: install boom" in result.output
+    validate_hf_access.assert_called_once()
     assert events == [
         ("write", "provisioned"),
         ("status", "installing"),

--- a/npa/tests/conftest.py
+++ b/npa/tests/conftest.py
@@ -1,4 +1,7 @@
 import os
+from urllib.parse import urlparse
+
+import httpx
 import pytest
 
 from npa.clients.project_credentials import CredentialPair
@@ -11,6 +14,72 @@ os.environ.setdefault("NPA_S3_BUCKET", "test-bucket-00000000")
 
 def pytest_collection_finish(session: pytest.Session) -> None:
     assert_nonzero_collection(len(session.items))
+
+
+def _is_huggingface_url(url: object) -> bool:
+    host = urlparse(str(url)).hostname or ""
+    return host == "huggingface.co" or host.endswith(".huggingface.co")
+
+
+@pytest.fixture(autouse=True)
+def block_live_huggingface_http(monkeypatch, request):
+    """Keep unit tests from depending on live Hugging Face availability."""
+    live_markers = {
+        "byovm_live",
+        "e2e",
+        "e2e_pipeline",
+        "e2e_serverless",
+        "gpu",
+        "multi_gpu",
+        "ngc_e2e",
+    }
+    if any(request.node.get_closest_marker(marker) for marker in live_markers):
+        return
+
+    def blocked(method: str, url: object) -> None:
+        if _is_huggingface_url(url):
+            raise AssertionError(
+                f"Live Hugging Face HTTP is blocked in unit tests: {method} {url}. "
+                "Mock the access check instead."
+            )
+
+    original_head = httpx.head
+    original_get = httpx.get
+    original_post = httpx.post
+    original_request = httpx.request
+    original_client_request = httpx.Client.request
+    original_async_client_request = httpx.AsyncClient.request
+
+    def guarded_head(url, *args, **kwargs):
+        blocked("HEAD", url)
+        return original_head(url, *args, **kwargs)
+
+    def guarded_get(url, *args, **kwargs):
+        blocked("GET", url)
+        return original_get(url, *args, **kwargs)
+
+    def guarded_post(url, *args, **kwargs):
+        blocked("POST", url)
+        return original_post(url, *args, **kwargs)
+
+    def guarded_request(method, url, *args, **kwargs):
+        blocked(str(method).upper(), url)
+        return original_request(method, url, *args, **kwargs)
+
+    def guarded_client_request(self, method, url, *args, **kwargs):
+        blocked(str(method).upper(), url)
+        return original_client_request(self, method, url, *args, **kwargs)
+
+    async def guarded_async_client_request(self, method, url, *args, **kwargs):
+        blocked(str(method).upper(), url)
+        return await original_async_client_request(self, method, url, *args, **kwargs)
+
+    monkeypatch.setattr(httpx, "head", guarded_head)
+    monkeypatch.setattr(httpx, "get", guarded_get)
+    monkeypatch.setattr(httpx, "post", guarded_post)
+    monkeypatch.setattr(httpx, "request", guarded_request)
+    monkeypatch.setattr(httpx.Client, "request", guarded_client_request)
+    monkeypatch.setattr(httpx.AsyncClient, "request", guarded_async_client_request)
 
 
 @pytest.fixture

--- a/npa/tests/test_huggingface.py
+++ b/npa/tests/test_huggingface.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import httpx
+import pytest
 
 from npa.clients.huggingface import validate_hf_access
 
@@ -33,13 +34,26 @@ def test_validate_hf_access_rejects_403() -> None:
     assert result.status_code == 403
 
 
-def validate_hf_access_with_status(status_code: int):
-    import pytest
+def test_live_hf_access_is_blocked_by_unit_guard() -> None:
+    with pytest.raises(AssertionError, match="Live Hugging Face HTTP is blocked"):
+        validate_hf_access("hf-token", "nvidia/model")
 
+
+def test_validate_hf_access_reports_rate_limit_without_network() -> None:
+    result = validate_hf_access_with_status(429)
+
+    assert result.ok is False
+    assert result.status_code == 429
+    assert (
+        result.error
+        == "Unable to validate Hugging Face access to nvidia/model: HTTP 429"
+    )
+
+
+def validate_hf_access_with_status(status_code: int):
     mocker = pytest.MonkeyPatch()
     try:
         mocker.setattr("httpx.head", lambda *args, **kwargs: httpx.Response(status_code))
         return validate_hf_access("hf-token", "nvidia/model")
     finally:
         mocker.undo()
-


### PR DESCRIPTION
## Summary
- Mock Cosmos and GR00T gated-model access checks in unit tests that previously depended on live Hugging Face state.
- Add an autouse unit-test guard that blocks unmocked httpx calls to huggingface.co while leaving marked live/e2e tests alone.
- Preserve offline HF failure coverage with a mocked HTTP 429 case and a guard regression test.

## Verification
- npa/.venv/bin/python -m pytest npa/tests/cli/test_workbench_app_status.py npa/tests/test_huggingface.py npa/tests/workbench/test_cosmos3_access.py npa/tests/cli/test_groot_cli.py::test_groot_deploy_dry_run_defaults_to_l40s npa/tests/test_credentials.py -q
- npa/.venv/bin/python -m pytest npa/tests/cli/test_cosmos_cli.py npa/tests/cli/test_groot_cli.py -q
- npa/.venv/bin/python -m pytest --collect-only -q npa/tests (1474 collected, 2 skipped)
- npa/.venv/bin/python -m ruff check npa/tests/conftest.py npa/tests/cli/test_workbench_app_status.py npa/tests/test_huggingface.py npa/tests/cli/test_groot_cli.py
- Public diff scan: hits=0

Production Hugging Face validation behavior is unchanged; this PR changes tests only.