### PR TITLE
Add H100 sim-to-real quickstart

### DIFF
--- a/docs/workbench/README.md
+++ b/docs/workbench/README.md
@@ -7,12 +7,14 @@ workflows, and operational runbooks.
 
 | Path | Purpose |
 | --- | --- |
-| [getting-started.md](getting-started.md) | Fresh-clone onboarding path for install, credentials, first deploy, and BDD100K pipeline validation |
+| [getting-started.md](getting-started.md) | Fresh-clone onboarding path for install, credentials, and first Workbench runs |
+| [sim-to-real-quickstart.md](sim-to-real-quickstart.md) | One-command H100 sim-to-real proof run with checkpoint, metric, S3 artifacts, and teardown |
 | [../quickstart.md](../quickstart.md) | Full `npa` CLI quickstart |
 | [../cli/README.md](../cli/README.md) | CLI command reference index |
 | [../cli-errors.md](../cli-errors.md) | End-user CLI error formatting, exit codes, and JSON error output |
 | [../sdk/errors.md](../sdk/errors.md) | Typed exceptions for programmatic SDK consumers and agents |
 | [cookbooks/README.md](cookbooks/README.md) | Reproducibility cookbooks for specific workloads |
+| [cookbooks/sim-to-real-pipeline.md](cookbooks/sim-to-real-pipeline.md) | Raw YAML, CLI wrapper, SDK, and BYO contract details for the sim-to-real pipeline |
 | [cookbooks/vlm-eval-loop-runbook.md](cookbooks/vlm-eval-loop-runbook.md) | Sim-to-real VLM-eval loop: self-hosted VLM serving, rollout scoring, and task-success reporting |
 | [cookbooks/lerobot-gpu-benchmarks.md](cookbooks/lerobot-gpu-benchmarks.md) | Reproducing the May 2026 LeRobot GPU benchmark research |
 | [troubleshooting/known-footguns.md](troubleshooting/known-footguns.md) | Known Workbench operational footguns and mitigations |
@@ -24,6 +26,7 @@ workflows, and operational runbooks.
 | Reader | Start with |
 | --- | --- |
 | Customer running their first Workbench workload | [getting-started.md](getting-started.md) |
+| Customer running the first H100 sim-to-real proof | [sim-to-real-quickstart.md](sim-to-real-quickstart.md) |
 | Operator reproducing a workload | [cookbooks/README.md](cookbooks/README.md) |
 | SDK integrator or agent author | [../sdk/errors.md](../sdk/errors.md) |
 | Internal engineer triaging a failure | [../cli-errors.md](../cli-errors.md) |

--- a/docs/workbench/cookbooks/README.md
+++ b/docs/workbench/cookbooks/README.md
@@ -5,6 +5,9 @@ workflows with Nebius Physical AI Workbench.
 
 ## Available Cookbooks
 
+- [Sim-To-Real Pipeline](sim-to-real-pipeline.md): CLI, SDK, raw SkyPilot, BYO
+  policy image, BYO S3 endpoint, eval, feedback, artifact, and teardown details
+  behind the one-command H100 quickstart.
 - [VLM-Eval Loop Runbook](vlm-eval-loop-runbook.md): serve a VLM with vLLM,
   score rollout directories with `vlm-eval`, and write a task-success report.
 - [LeRobot GPU Benchmarks](lerobot-gpu-benchmarks.md): reproduce the May 2026

--- a/docs/workbench/cookbooks/sim-to-real-pipeline.md
+++ b/docs/workbench/cookbooks/sim-to-real-pipeline.md
@@ -12,6 +12,30 @@ copy is:
 s3://$NPA_S3_BUCKET/datasets/lerobot-pusht/
 ```
 
+## One-Command H100 Quickstart
+
+For the shortest live proof run, use the quickstart wrapper from the repository
+root:
+
+```bash
+npa/.venv/bin/python npa/scripts/run_sim_to_real_quickstart.py
+```
+
+That command is a thin wrapper over this cookbook's CLI/YAML path. It renders
+`npa/workflows/workbench/skypilot/sim-to-real-pipeline.yaml`, submits it through
+SkyPilot on `H100:1`, runs `npa.workflows.sim_to_real real-loop`, prints the
+task-success score plus checkpoint/report/Rerun S3 URIs, and tears down the
+run-scoped cluster with `sky down` plus a status poll.
+
+Expected timing is split by cache state. Warm runs target about 5-6 minutes for
+the small proof configuration. Cold runs can take longer because they include
+H100 provisioning, source checkout, Python/runtime bootstrap, dependency
+installation, and dataset staging. The command prints the measured wall-clock
+for each invocation.
+
+See [../sim-to-real-quickstart.md](../sim-to-real-quickstart.md) for the exact
+output format and zero-flag credential resolution.
+
 ## Prerequisites
 
 ```bash
@@ -97,8 +121,9 @@ managed-Kubernetes path, currently in `us-central1`, scheduled by node labels an
 
 ## CLI Wrapper Path
 
-The CLI wrapper renders the same YAML, fills the same envs, submits it through
-the NPA SkyPilot helper, and then polls the managed job:
+The full CLI wrapper renders the same YAML, fills the same envs, submits it
+through the NPA SkyPilot helper, and then polls the managed job. Use it when you
+want explicit control over every pipeline knob:
 
 ```bash
 npa/.venv/bin/python npa/scripts/run_sim_to_real_pipeline.py \
@@ -119,6 +144,12 @@ npa/.venv/bin/python npa/scripts/run_sim_to_real_pipeline.py \
   --controller-backend nebius \
   --cleanup
 ```
+
+The quickstart wrapper above uses the same path with smaller defaults:
+`--train-steps 20`, `--train-step-budget 20`, `--max-training-iterations 1`,
+`--eval-episodes 1`, `--task-cloud nebius`, and `--gpu H100:1`. It launches
+the rendered YAML directly with a run-scoped SkyPilot cluster name so teardown
+can poll that exact cluster.
 
 ## SDK Path
 

--- a/docs/workbench/getting-started.md
+++ b/docs/workbench/getting-started.md
@@ -6,11 +6,13 @@
 This guide assumes `npa` is already installed, the Nebius CLI is authenticated,
 and user-level credentials are already configured in
 `~/.npa/credentials.yaml`. It takes a first-time partner from platform setup to a
-workbench-capable machine that can run the Isaac Lab BYOF cookbook and write the
-first checkpoint to Nebius S3.
+workbench-capable machine that can run either the H100 sim-to-real quickstart or
+the Isaac Lab BYOF cookbook and write the first checkpoint to S3.
 
 For the canonical credential setup, see [quickstart.md](../quickstart.md). For
-the BYOF training path, see
+the H100 sim-to-real proof path, see
+[sim-to-real-quickstart.md](sim-to-real-quickstart.md). For the BYOF training
+path, see
 [cookbooks/byof-isaac-lab/README.md](cookbooks/byof-isaac-lab/README.md).
 For the SkyPilot runtime details, see
 [orchestration/skypilot-setup.md](../orchestration/skypilot-setup.md).
@@ -24,6 +26,7 @@ Operator-required prerequisites:
 - A Nebius account with access to the target project and tenant.
 - A managed Kubernetes context for the target workbench cluster, normally
   `npa-workbench-eu-north1`.
+- H100 capacity for the headless sim-to-real quickstart.
 - Provisioned RT-core GPU capacity for Isaac Lab, normally L40S in
   `eu-north1`. H100 and H200 do not satisfy Isaac Lab rendering requirements.
 - A current registry pull secret in the Kubernetes namespace that SkyPilot will
@@ -217,9 +220,28 @@ npa workbench fiftyone list
 Gate: command help renders, and a fresh machine may report that no workbench
 projects are configured.
 
+## First Sim-To-Real Run
+
+After the gates above pass, run the H100 quickstart:
+
+```bash
+npa/.venv/bin/python npa/scripts/run_sim_to_real_quickstart.py
+```
+
+The command prints the run ID, wall-clock time, task-success metric, checkpoint
+URI, report URI, Rerun URI, and `cluster_absent=True` after teardown. The first
+proof checkpoint path has this structure:
+
+```bash
+s3://${NPA_S3_BUCKET}/sim-to-real/<run-id>/checkpoints/policy/
+```
+
+Continue with [sim-to-real-quickstart.md](sim-to-real-quickstart.md) for the
+exact output format and override options.
+
 ## First BYOF Run
 
-After the gates above pass, continue with
+For Isaac Lab, continue with
 [cookbooks/byof-isaac-lab/README.md](cookbooks/byof-isaac-lab/README.md) and
 follow its sections in order.
 
@@ -247,6 +269,8 @@ manifest from S3.
 
 - [cookbooks/byof-isaac-lab/README.md](cookbooks/byof-isaac-lab/README.md):
   first Isaac Lab BYOF checkpoint.
+- [sim-to-real-quickstart.md](sim-to-real-quickstart.md): first H100
+  sim-to-real checkpoint and eval metric.
 - [orchestration/skypilot-setup.md](../orchestration/skypilot-setup.md):
   isolated SkyPilot runtime details.
 - [quickstart.md](../quickstart.md): platform install and canonical credential

--- a/docs/workbench/sim-to-real-quickstart.md
+++ b/docs/workbench/sim-to-real-quickstart.md
@@ -1,0 +1,130 @@
+# Sim-To-Real H100 Quickstart
+
+Run one small, real sim-to-real loop on an H100 and get a tangible result in S3:
+a trained LeRobot policy checkpoint, a task-success metric, a JSON report, and a
+Rerun artifact.
+
+This guide uses the maintained sim-to-real stack:
+
+- SkyPilot YAML: `npa/workflows/workbench/skypilot/sim-to-real-pipeline.yaml`
+- CLI wrapper: `npa/scripts/run_sim_to_real_pipeline.py`
+- Quickstart wrapper: `npa/scripts/run_sim_to_real_quickstart.py`
+- Runtime module: `npa.workflows.sim_to_real real-loop`
+
+The quickstart wrapper only fills defaults, submits the existing YAML, prints
+the result, and tears the run down with `sky down` plus a status poll.
+
+## Prerequisites
+
+Complete the platform [quickstart](../quickstart.md) and keep storage credentials
+in `~/.npa/credentials.yaml`:
+
+```yaml
+storage:
+  aws_access_key_id: <your-s3-access-key-id>
+  aws_secret_access_key: <your-s3-secret-access-key>
+  endpoint_url: https://storage.eu-north1.nebius.cloud
+  bucket: s3://<your-bucket>/
+```
+
+The command also accepts the equivalent environment variables:
+
+```bash
+export S3_BUCKET=<your-bucket>
+export AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud
+export AWS_ACCESS_KEY_ID=<your-s3-access-key-id>
+export AWS_SECRET_ACCESS_KEY=<your-s3-secret-access-key>
+```
+
+SkyPilot is installed outside the NPA virtualenv. The quickstart tries to reuse
+`NPA_SKYPILOT_BIN` or the `skypilot.sky_bin` entry in `~/.npa/config.yaml`; if
+neither exists, it bootstraps the pinned SkyPilot runtime before launch.
+
+## One Command
+
+From the repository root:
+
+```bash
+npa/.venv/bin/python npa/scripts/run_sim_to_real_quickstart.py
+```
+
+The default run:
+
+- provisions one `H100:1` worker through SkyPilot;
+- downloads the pinned public LeRobot PushT dataset if the staged S3 copy is not
+  already present;
+- runs a tiny real LeRobot train/eval feedback loop;
+- writes checkpoint weights, eval output, training signal, report, and Rerun
+  artifact to `s3://<bucket>/sim-to-real/<run-id>/`;
+- prints the task-success score and artifact URIs;
+- runs `sky down` for the run-scoped cluster and polls until it is absent.
+
+The final lines look like:
+
+```text
+sim-to-real quickstart result
+run_id: s2r-quickstart-...
+workflow_status: SUCCEEDED
+wall_clock_seconds: ...
+metric: task_success_score=...
+checkpoint_uri: s3://<bucket>/sim-to-real/<run-id>/checkpoints/policy/
+report_uri: s3://<bucket>/sim-to-real/<run-id>/reports/sim-to-real-report.json
+rrd_uri: s3://<bucket>/sim-to-real/<run-id>/viz/<run-id>.rrd
+teardown: cluster_absent=True
+```
+
+## Runtime
+
+The quickstart is sized for a small proof run, not a converged policy. Warm runs
+are expected to be in the 5-6 minute range when SkyPilot and package/image
+caches are already warm. Cold runs can take longer because they
+include H100 provisioning, source checkout, Python/runtime bootstrap, package
+installation, and dataset staging. Treat the printed wall-clock as the source
+of truth for each run.
+
+## Override Points
+
+Use flags or environment variables when you want to bring your own storage,
+policy image, or dataset:
+
+```bash
+npa/.venv/bin/python npa/scripts/run_sim_to_real_quickstart.py \
+  --bucket <your-bucket> \
+  --s3-endpoint https://<your-s3-compatible-endpoint> \
+  --source-ref <branch-or-tag> \
+  --policy-image <registry>/<image>:<tag> \
+  --input-data-uri s3://<your-bucket>/datasets/<your-lerobot-dataset>/
+```
+
+Common overrides:
+
+| Setting | Default | Override |
+| --- | --- | --- |
+| Storage bucket | `storage.bucket` in `~/.npa/credentials.yaml` | `--bucket` or `S3_BUCKET` |
+| S3 endpoint | `storage.endpoint_url` or `https://storage.eu-north1.nebius.cloud` | `--s3-endpoint`, `AWS_ENDPOINT_URL`, or `NEBIUS_S3_ENDPOINT` |
+| Run prefix | `sim-to-real/<run-id>` | `--s3-prefix` |
+| Source checkout | public repo `main` | `--source-repo` and `--source-ref` |
+| Policy image | `npa-lerobot-policy:0.1.0` | `--policy-image` or `POLICY_IMAGE` |
+| Dataset | pinned public LeRobot PushT staged under the run bucket | `--input-data-uri` |
+| GPU | `H100:1` | `--gpu` |
+| Step budget | 20 steps, one train/eval iteration | `--train-steps`, `--train-step-budget`, `--max-training-iterations` |
+
+Keep `--gpu H100:1` for the quickstart proof path. Use other accelerators only
+for explicit experiments.
+
+## Cleanup Guarantees
+
+The wrapper installs `SIGINT` and `SIGTERM` handlers. On success, failure, or
+Ctrl-C it runs run-scoped teardown through `sky down --yes <pattern>` and polls
+`sky status --refresh --output json` until no matching cluster remains. It does
+not rely on unsupported teardown flags.
+
+If teardown cannot prove absence, the command exits non-zero and reports
+`cluster_absent=False`.
+
+## Deeper Paths
+
+Use the [sim-to-real pipeline cookbook](cookbooks/sim-to-real-pipeline.md) for
+the equivalent raw SkyPilot, CLI wrapper, and SDK entry points. Those paths share
+the same YAML, artifact layout, S3 handoff, eval backends, and BYO policy image
+contract as this quickstart.

--- a/npa/scripts/run_sim_to_real_quickstart.py
+++ b/npa/scripts/run_sim_to_real_quickstart.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""One-command H100 sim-to-real quickstart.
+
+This script is intentionally orchestration glue. It renders and submits the
+checked-in sim-to-real SkyPilot YAML, runs the existing real LeRobot loop on a
+small H100 job, fetches the uploaded report from S3, and always tears down the
+run-scoped SkyPilot cluster with ``sky down``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from run_sim_to_real_pipeline import (  # noqa: E402
+    DEFAULT_YAML,
+    _s3_secret_envs,
+    _write_yaml_documents,
+    output_paths,
+    render_workflow,
+)
+
+from npa.clients.credentials import load_credentials, storage_endpoint_url  # noqa: E402
+from npa.clients.storage import StorageClient  # noqa: E402
+from npa.cli.skypilot import SkyPilotBootstrapError, bootstrap_skypilot  # noqa: E402
+from npa.orchestration.skypilot import WorkflowResult  # noqa: E402
+from npa.orchestration.skypilot._bin import (  # noqa: E402
+    SkyPilotConfigError,
+    SkyPilotNotInstalledError,
+    SkyPilotVersionError,
+    resolve_config,
+    resolve_sky_bin,
+)
+from npa.orchestration.skypilot.cleanup import CleanupResult, run_tag, sky_environment  # noqa: E402
+from npa.orchestration.skypilot.signal_teardown import (  # noqa: E402
+    SignalTeardown,
+    install_teardown_signal_handlers,
+    restore_signal_handlers,
+)
+from npa.workflows.sim_to_real import (  # noqa: E402
+    DEFAULT_EVAL_BACKEND,
+    DEFAULT_FEEDBACK_SOURCE,
+    DEFAULT_FEEDBACK_TYPE,
+    DEFAULT_S3_ENDPOINT,
+    DEFAULT_SIM_BACKEND,
+    default_policy_image,
+    default_s3_prefix,
+)
+
+DEFAULT_RUN_PREFIX = "s2r-quickstart"
+DEFAULT_TRAIN_STEPS = 20
+DEFAULT_TRAIN_STEP_BUDGET = 20
+DEFAULT_MAX_TRAINING_ITERATIONS = 1
+DEFAULT_EVAL_EPISODES = 1
+DEFAULT_TRAIN_BATCH_SIZE = 4
+DEFAULT_TRAIN_NUM_WORKERS = 2
+DEFAULT_GPU = "H100:1"
+DEFAULT_SOURCE_REPO = "https://github.com/nebius/nebius-physical-ai.git"
+DEFAULT_SOURCE_REF = "main"
+STORAGE_ENV_KEYS = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "S3_BUCKET",
+    "NPA_S3_BUCKET",
+    "S3_ENDPOINT_URL",
+    "AWS_ENDPOINT_URL",
+    "NEBIUS_S3_ENDPOINT",
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    run_id = args.run_id or _default_run_id()
+    started = time.perf_counter()
+    try:
+        storage = _resolve_storage(args, run_id)
+        sky_bin = _resolve_or_bootstrap_sky_bin(args)
+        sky_config = resolve_config(sky_bin=sky_bin, isolated_config_dir=args.isolated_config_dir)
+    except (
+        QuickstartConfigError,
+        SkyPilotConfigError,
+        SkyPilotNotInstalledError,
+        SkyPilotVersionError,
+        SkyPilotBootstrapError,
+    ) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    previous_env = _apply_storage_environment(storage)
+    try:
+        teardown = SignalTeardown(
+            run_id=run_id,
+            isolated_config_dir=sky_config.isolated_config_dir,
+            config_path=sky_config.global_config_path,
+            sky_bin=sky_bin,
+            timeout=float(args.teardown_timeout),
+            poll_interval=float(args.teardown_poll_interval),
+        )
+        previous_handlers = install_teardown_signal_handlers(teardown.teardown)
+        cleanup_payload: dict[str, Any] = {}
+        try:
+            try:
+                result = _submit_and_wait(args, run_id=run_id, storage=storage, sky_bin=str(sky_bin), teardown=teardown)
+            except Exception as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                result = WorkflowResult(status="FAILED", returncode=1, error=str(exc))
+            finally:
+                cleanup = teardown.teardown()
+                cleanup_payload = _cleanup_payload(cleanup)
+        finally:
+            restore_signal_handlers(previous_handlers)
+
+        wall_clock = round(time.perf_counter() - started, 2)
+        report = (
+            {}
+            if args.render_only or result.status != "SUCCEEDED"
+            else _download_report(storage, run_id=run_id, output_dir=args.local_output_dir)
+        )
+        summary = _result_summary(
+            run_id=run_id,
+            wall_clock_seconds=wall_clock,
+            workflow=result,
+            storage=storage,
+            report=report,
+            cleanup=cleanup_payload,
+        )
+        _print_summary(summary, as_json=args.output_json)
+        if args.render_only:
+            return 0
+        return 0 if result.status == "SUCCEEDED" and not cleanup_payload.get("errors") and report else 1
+    finally:
+        _restore_environment(previous_env)
+
+
+def _submit_and_wait(
+    args: argparse.Namespace,
+    *,
+    run_id: str,
+    storage: "StorageSettings",
+    sky_bin: str,
+    teardown: SignalTeardown,
+) -> WorkflowResult:
+    docs = render_workflow(
+        args.yaml_path,
+        run_id=run_id,
+        bucket=storage.bucket,
+        s3_prefix=storage.prefix,
+        s3_endpoint=storage.endpoint,
+        input_data_uri=args.input_data_uri,
+        dataset_repo_id=args.dataset_repo_id,
+        dataset_revision=args.dataset_revision,
+        policy_image=args.policy_image or default_policy_image(),
+        sim_backend=args.sim_backend,
+        eval_backend=args.eval_backend,
+        feedback_source=args.feedback_source,
+        feedback_type=args.feedback_type,
+        split_fraction=args.split_fraction,
+        env_count=args.env_count,
+        episodes=args.episodes,
+        train_steps=args.train_steps,
+        eval_episodes=args.eval_episodes,
+        threshold=args.threshold,
+        seed=args.seed,
+        gpu=args.gpu,
+        gpu_failover=args.gpu_failover,
+        max_training_iterations=args.max_training_iterations,
+        train_step_budget=args.train_step_budget,
+        min_eval_improvement=args.min_eval_improvement,
+        policy_type=args.policy_type,
+        train_batch_size=args.train_batch_size,
+        train_num_workers=args.train_num_workers,
+        policy_device=args.policy_device,
+        sky_bin=sky_bin,
+        task_cloud=args.task_cloud,
+        vlm_eval_backend=args.vlm_eval_backend,
+        vlm_eval_model=args.vlm_eval_model,
+        vlm_eval_endpoint_url=args.vlm_eval_endpoint_url,
+        vlm_eval_frame_selection=args.vlm_eval_frame_selection,
+        vlm_eval_max_frames=args.vlm_eval_max_frames,
+        vlm_eval_score=args.vlm_eval_score,
+        trainer_command=args.trainer_command,
+        byo_feedback_endpoint_url=args.byo_feedback_endpoint_url,
+        byo_feedback_command=args.byo_feedback_command,
+        byo_feedback_mode=args.byo_feedback_mode,
+        rerun_max_frames_per_episode=args.rerun_max_frames_per_episode,
+    )
+    _prepare_quickstart_docs(
+        docs,
+        run_id=run_id,
+        source_repo=args.source_repo,
+        source_ref=args.source_ref,
+    )
+
+    if args.render_only:
+        render_dir = Path(tempfile.mkdtemp(prefix=f"npa-{run_id}-"))
+        rendered_yaml = render_dir / "sim-to-real-quickstart.rendered.yaml"
+        _write_yaml_documents(rendered_yaml, docs)
+        print(json.dumps({"run_id": run_id, "rendered_yaml": str(rendered_yaml)}, indent=2, sort_keys=True))
+        return WorkflowResult(status="SUCCEEDED", job_id="render-only")
+
+    with tempfile.TemporaryDirectory(prefix=f"npa-{run_id}-") as tmp:
+        rendered_yaml = Path(tmp) / "sim-to-real-quickstart.rendered.yaml"
+        _write_yaml_documents(rendered_yaml, docs)
+        cluster_name = run_tag(run_id)
+        cmd = [sky_bin, "launch", "--cluster", cluster_name, "--name", cluster_name, "--yes"]
+        for secret_name in _s3_secret_envs():
+            if os.environ.get(secret_name):
+                cmd.extend(["--secret", secret_name])
+        cmd.append(str(rendered_yaml))
+        teardown.mark_launched()
+        try:
+            result = subprocess.run(
+                cmd,
+                env=sky_environment(args.isolated_config_dir),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=args.wait_timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return WorkflowResult(
+                status="TIMEOUT",
+                job_id=cluster_name,
+                returncode=124,
+                error=f"Timed out after {args.wait_timeout}s waiting for SkyPilot launch.",
+                submitted_yaml_path=str(rendered_yaml),
+                stdout=exc.stdout if isinstance(exc.stdout, str) else "",
+                stderr=exc.stderr if isinstance(exc.stderr, str) else "",
+            )
+        status = "SUCCEEDED" if result.returncode == 0 else "FAILED"
+        return WorkflowResult(
+            status=status,
+            job_id=cluster_name,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            submitted_yaml_path=str(rendered_yaml),
+        )
+
+
+def _prepare_quickstart_docs(
+    docs: list[dict[str, Any]],
+    *,
+    run_id: str,
+    source_repo: str,
+    source_ref: str,
+) -> None:
+    task_name = run_tag(run_id)
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        doc["name"] = task_name
+        envs = doc.get("envs")
+        if isinstance(envs, dict):
+            envs["NPA_SOURCE_REPO"] = source_repo
+            envs["NPA_SOURCE_REF"] = source_ref
+
+
+class QuickstartConfigError(ValueError):
+    """Raised when quickstart prerequisites are missing."""
+
+
+class StorageSettings:
+    """Resolved S3-compatible storage settings for the quickstart."""
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        prefix: str,
+        endpoint: str,
+        access_key_id: str,
+        secret_access_key: str,
+    ) -> None:
+        self.bucket = bucket
+        self.prefix = prefix
+        self.endpoint = endpoint
+        self.access_key_id = access_key_id
+        self.secret_access_key = secret_access_key
+
+
+def _resolve_storage(args: argparse.Namespace, run_id: str) -> StorageSettings:
+    credentials = load_credentials(path=args.credential_path)
+    bucket_value = args.bucket or os.environ.get("S3_BUCKET") or os.environ.get("NPA_S3_BUCKET") or credentials.s3_bucket
+    bucket, credential_prefix = _split_bucket_and_prefix(bucket_value)
+    if not bucket:
+        raise QuickstartConfigError(
+            "S3 bucket is not configured. Set S3_BUCKET/NPA_S3_BUCKET, pass --bucket, "
+            "or set storage.bucket in ~/.npa/credentials.yaml."
+        )
+    endpoint = storage_endpoint_url(
+        args.s3_endpoint
+        or os.environ.get("S3_ENDPOINT_URL", "")
+        or os.environ.get("AWS_ENDPOINT_URL", "")
+        or os.environ.get("NEBIUS_S3_ENDPOINT", "")
+        or credentials.s3_endpoint
+        or DEFAULT_S3_ENDPOINT
+    )
+    prefix = args.s3_prefix or _join_s3_prefix(credential_prefix, default_s3_prefix(run_id))
+    access_key_id = os.environ.get("AWS_ACCESS_KEY_ID") or credentials.s3_access_key_id
+    secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY") or credentials.s3_secret_access_key
+    if not access_key_id or not secret_access_key:
+        raise QuickstartConfigError(
+            "S3 credentials are not configured. Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY "
+            "or storage access keys in ~/.npa/credentials.yaml."
+        )
+    return StorageSettings(
+        bucket=bucket,
+        prefix=prefix,
+        endpoint=endpoint,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+    )
+
+
+def _resolve_or_bootstrap_sky_bin(args: argparse.Namespace) -> Path:
+    requested = args.sky_bin or os.environ.get("NPA_SKYPILOT_BIN", "")
+    try:
+        return resolve_sky_bin(requested or None)
+    except SkyPilotNotInstalledError:
+        if requested or args.no_bootstrap_skypilot:
+            raise
+        result = bootstrap_skypilot()
+        os.environ.setdefault("NPA_SKYPILOT_BIN", str(result.sky_bin))
+        return result.sky_bin
+
+
+def _apply_storage_environment(storage: StorageSettings) -> dict[str, str | None]:
+    previous = {key: os.environ.get(key) for key in STORAGE_ENV_KEYS}
+    os.environ["AWS_ACCESS_KEY_ID"] = storage.access_key_id
+    os.environ["AWS_SECRET_ACCESS_KEY"] = storage.secret_access_key
+    os.environ["S3_BUCKET"] = storage.bucket
+    os.environ["NPA_S3_BUCKET"] = storage.bucket
+    os.environ["S3_ENDPOINT_URL"] = storage.endpoint
+    os.environ["AWS_ENDPOINT_URL"] = storage.endpoint
+    os.environ["NEBIUS_S3_ENDPOINT"] = storage.endpoint
+    return previous
+
+
+def _restore_environment(previous: dict[str, str | None]) -> None:
+    for key, value in previous.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _download_report(storage: StorageSettings, *, run_id: str, output_dir: Path | None) -> dict[str, Any]:
+    paths = output_paths(run_id, bucket=storage.bucket, s3_prefix=storage.prefix, s3_endpoint=storage.endpoint)
+    report_uri = paths.get("report", "")
+    if not report_uri:
+        return {}
+    target_dir = output_dir or Path(tempfile.mkdtemp(prefix=f"npa-{run_id}-report-"))
+    target_dir.mkdir(parents=True, exist_ok=True)
+    report_path = target_dir / "sim-to-real-report.json"
+    client = StorageClient.from_environment(
+        endpoint_url=storage.endpoint,
+        aws_access_key_id=storage.access_key_id,
+        aws_secret_access_key=storage.secret_access_key,
+    )
+    deadline = time.monotonic() + 120
+    while True:
+        try:
+            client.download_path(report_uri, str(report_path))
+            if report_path.exists() and report_path.stat().st_size > 0:
+                return json.loads(report_path.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+        if time.monotonic() >= deadline:
+            return {}
+        time.sleep(5)
+
+
+def _result_summary(
+    *,
+    run_id: str,
+    wall_clock_seconds: float,
+    workflow: WorkflowResult,
+    storage: StorageSettings,
+    report: dict[str, Any],
+    cleanup: dict[str, Any],
+) -> dict[str, Any]:
+    paths = output_paths(run_id, bucket=storage.bucket, s3_prefix=storage.prefix, s3_endpoint=storage.endpoint)
+    outer_loop = report.get("outer_loop", {}) if isinstance(report, dict) else {}
+    feedback = report.get("feedback", {}) if isinstance(report, dict) else {}
+    metric_value = outer_loop.get("score", feedback.get("score"))
+    summary = {
+        "run_id": run_id,
+        "workflow_status": workflow.status,
+        "wall_clock_seconds": wall_clock_seconds,
+        "metric": {
+            "name": "task_success_score",
+            "value": metric_value,
+            "decision": outer_loop.get("decision", ""),
+            "trend": outer_loop.get("trend", []),
+        },
+        "artifacts": {
+            "checkpoint": paths.get("checkpoint", ""),
+            "report": paths.get("report", ""),
+            "rrd": paths.get("rrd", ""),
+        },
+        "teardown": {
+            "cluster_absent": not cleanup.get("errors"),
+            **cleanup,
+        },
+    }
+    if workflow.status != "SUCCEEDED":
+        summary["error"] = workflow.error or _tail_text(workflow.stderr, workflow.stdout)
+    return summary
+
+
+def _print_summary(summary: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return
+    print("sim-to-real quickstart result")
+    print(f"run_id: {summary['run_id']}")
+    print(f"workflow_status: {summary['workflow_status']}")
+    print(f"wall_clock_seconds: {summary['wall_clock_seconds']}")
+    metric = summary["metric"]
+    print(f"metric: {metric['name']}={metric['value']}")
+    if metric.get("trend"):
+        print(f"metric_trend: {metric['trend']}")
+    print(f"checkpoint_uri: {summary['artifacts']['checkpoint']}")
+    print(f"report_uri: {summary['artifacts']['report']}")
+    print(f"rrd_uri: {summary['artifacts']['rrd']}")
+    print(f"teardown: cluster_absent={summary['teardown']['cluster_absent']}")
+    if summary.get("error"):
+        print(f"error: {summary['error']}")
+
+
+def _cleanup_payload(cleanup: CleanupResult | Any) -> dict[str, Any]:
+    try:
+        return asdict(cleanup)
+    except TypeError:
+        return {"resources_removed": [], "errors": [], "commands": []}
+
+
+def _tail_text(*values: str, max_lines: int = 24, max_chars: int = 4000) -> str:
+    text = "\n".join(value.strip() for value in values if value and value.strip())
+    if not text:
+        return ""
+    lines = text.splitlines()[-max_lines:]
+    return "\n".join(lines)[-max_chars:]
+
+
+def _split_bucket_and_prefix(value: str) -> tuple[str, str]:
+    raw = str(value or "").strip().rstrip("/")
+    if not raw:
+        return "", ""
+    if raw.startswith("s3://"):
+        parsed = urlparse(raw)
+        return parsed.netloc, parsed.path.strip("/")
+    bucket, _, prefix = raw.partition("/")
+    return bucket, prefix.strip("/")
+
+
+def _join_s3_prefix(*parts: str) -> str:
+    return "/".join(part.strip("/") for part in parts if part and part.strip("/"))
+
+
+def _default_run_id() -> str:
+    return DEFAULT_RUN_PREFIX + "-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--yaml", "--yaml-path", dest="yaml_path", type=Path, default=DEFAULT_YAML)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--bucket", default="")
+    parser.add_argument("--s3-prefix", default="")
+    parser.add_argument("--s3-endpoint", default="")
+    parser.add_argument("--credential-path", type=Path, default=None)
+    parser.add_argument("--local-output-dir", type=Path, default=None)
+    parser.add_argument("--source-repo", default=os.environ.get("NPA_SOURCE_REPO", DEFAULT_SOURCE_REPO))
+    parser.add_argument("--source-ref", default=os.environ.get("NPA_SOURCE_REF", DEFAULT_SOURCE_REF))
+    parser.add_argument("--input-data-uri", default="")
+    parser.add_argument("--dataset-repo-id", default="lerobot/pusht")
+    parser.add_argument("--dataset-revision", default="7628202a2180972f291ba1bc6723834921e72c19")
+    parser.add_argument("--policy-image", default=os.environ.get("POLICY_IMAGE", ""))
+    parser.add_argument("--sim-backend", default=DEFAULT_SIM_BACKEND)
+    parser.add_argument("--eval-backend", default=DEFAULT_EVAL_BACKEND)
+    parser.add_argument("--feedback-source", default=DEFAULT_FEEDBACK_SOURCE)
+    parser.add_argument("--feedback-type", default=DEFAULT_FEEDBACK_TYPE)
+    parser.add_argument("--split-fraction", type=float, default=0.8)
+    parser.add_argument("--env-count", type=int, default=10)
+    parser.add_argument("--episodes", type=int, default=2)
+    parser.add_argument("--train-steps", type=int, default=DEFAULT_TRAIN_STEPS)
+    parser.add_argument("--eval-episodes", type=int, default=DEFAULT_EVAL_EPISODES)
+    parser.add_argument("--threshold", type=float, default=0.75)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--gpu", default=os.environ.get("NPA_GPU_TYPE", DEFAULT_GPU))
+    parser.add_argument("--gpu-failover", default=os.environ.get("NPA_GPU_FAILOVER", ""))
+    parser.add_argument("--max-training-iterations", type=int, default=DEFAULT_MAX_TRAINING_ITERATIONS)
+    parser.add_argument("--train-step-budget", type=int, default=DEFAULT_TRAIN_STEP_BUDGET)
+    parser.add_argument("--min-eval-improvement", type=float, default=0.0)
+    parser.add_argument("--policy-type", default="act")
+    parser.add_argument("--train-batch-size", type=int, default=DEFAULT_TRAIN_BATCH_SIZE)
+    parser.add_argument("--train-num-workers", type=int, default=DEFAULT_TRAIN_NUM_WORKERS)
+    parser.add_argument("--policy-device", default="cuda")
+    parser.add_argument("--task-cloud", choices=("kubernetes", "nebius"), default="nebius")
+    parser.add_argument("--controller-backend", choices=("kubernetes", "nebius"), default="nebius")
+    parser.add_argument("--vlm-eval-backend", default="stub")
+    parser.add_argument("--vlm-eval-model", default="vlm-eval-stub")
+    parser.add_argument("--vlm-eval-endpoint-url", default="")
+    parser.add_argument("--vlm-eval-frame-selection", default="keyframes")
+    parser.add_argument("--vlm-eval-max-frames", type=int, default=4)
+    parser.add_argument("--vlm-eval-score", type=float, default=None)
+    parser.add_argument("--trainer-command", default="")
+    parser.add_argument("--byo-feedback-endpoint-url", default="")
+    parser.add_argument("--byo-feedback-command", default="")
+    parser.add_argument("--byo-feedback-mode", choices=("provided-rollout", "self-rollout"), default="provided-rollout")
+    parser.add_argument("--rerun-max-frames-per-episode", type=int, default=8)
+    parser.add_argument("--sky-bin", default="")
+    parser.add_argument("--isolated-config-dir", type=Path, default=None)
+    parser.add_argument("--submit-timeout", type=int, default=1800)
+    parser.add_argument("--wait-timeout", type=int, default=14400)
+    parser.add_argument("--poll-interval", type=int, default=30)
+    parser.add_argument("--teardown-timeout", type=int, default=900)
+    parser.add_argument("--teardown-poll-interval", type=int, default=10)
+    parser.add_argument("--no-bootstrap-skypilot", action="store_true")
+    parser.add_argument("--render-only", action="store_true")
+    parser.add_argument("--output-json", action="store_true")
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npa/tests/workflows/test_sim_to_real_pipeline.py
+++ b/npa/tests/workflows/test_sim_to_real_pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import stat
+import subprocess
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -44,6 +45,7 @@ from npa.workflows.lerobot_dataset import seeded_episode_split, summarize_lerobo
 ROOT = Path(__file__).resolve().parents[3]
 YAML_PATH = ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "sim-to-real-pipeline.yaml"
 WRAPPER_PATH = ROOT / "npa" / "scripts" / "run_sim_to_real_pipeline.py"
+QUICKSTART_PATH = ROOT / "npa" / "scripts" / "run_sim_to_real_quickstart.py"
 
 
 def _nebius_catalog() -> NebiusGpuCatalog:
@@ -59,6 +61,15 @@ def _nebius_catalog() -> NebiusGpuCatalog:
 
 def _load_wrapper_module():
     spec = importlib.util.spec_from_file_location("run_sim_to_real_pipeline", WRAPPER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_quickstart_module():
+    spec = importlib.util.spec_from_file_location("run_sim_to_real_quickstart", QUICKSTART_PATH)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -445,6 +456,162 @@ def test_runner_passes_controller_backend_to_submit(monkeypatch, tmp_path: Path,
     assert captured["docs"][0]["envs"]["NPA_SIM_TO_REAL_RUN_ID"] == "s2r-submit"
     assert captured["docs"][0]["resources"]["cloud"] == "nebius"
     assert "image_id" not in captured["docs"][0]["resources"]
+
+
+def test_quickstart_uses_credentials_h100_defaults_and_tears_down(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    quickstart = _load_quickstart_module()
+    run_id = "s2r-quickstart-test-20260604T000000Z"
+    sky_bin = tmp_path / "sky"
+    sky_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    sky_bin.chmod(sky_bin.stat().st_mode | stat.S_IXUSR)
+    credentials = tmp_path / "credentials.yaml"
+    credentials.write_text(
+        "\n".join(
+            [
+                "storage:",
+                "  aws_access_key_id: quickstart-access-key",
+                "  aws_secret_access_key: quickstart-secret-key",
+                "  endpoint_url: https://storage.eu-north1.nebius.cloud",
+                "  bucket: s3://quickstart-bucket/experiments/",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    captured: dict[str, object] = {}
+
+    class FakeTeardown:
+        instances: list["FakeTeardown"] = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.marked: list[Path | None] = []
+            self.teardown_calls = 0
+            self.instances.append(self)
+
+        def mark_launched(self, *, config_path=None):
+            self.marked.append(config_path)
+
+        def teardown(self):
+            self.teardown_calls += 1
+            return quickstart.CleanupResult(resources_removed=["cluster"])
+
+    class FakeStorageClient:
+        @classmethod
+        def from_environment(cls, **kwargs):
+            captured["storage_client"] = kwargs
+            return cls()
+
+        def download_path(self, uri, local_path):
+            captured["download_uri"] = uri
+            Path(local_path).write_text(
+                json.dumps(
+                    {
+                        "outer_loop": {
+                            "score": 0.5,
+                            "decision": "retrain",
+                            "trend": [0.5],
+                        },
+                        "feedback": {"score": 0.5},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+    def fake_render_workflow(yaml_path, **kwargs):
+        captured["render"] = kwargs
+        return [
+            {
+                "name": "sim-to-real-pipeline",
+                "resources": {"cloud": kwargs["task_cloud"], "accelerators": kwargs["gpu"]},
+                "envs": {"NPA_SIM_TO_REAL_RUN_ID": kwargs["run_id"]},
+                "run": "true",
+            }
+        ]
+
+    def fake_run(cmd, **kwargs):
+        captured["launch_cmd"] = cmd
+        captured["launch_env"] = kwargs["env"]
+        yaml_path = Path(cmd[-1])
+        captured["submitted_yaml"] = [
+            doc for doc in yaml.safe_load_all(Path(yaml_path).read_text(encoding="utf-8")) if doc is not None
+        ]
+        return subprocess.CompletedProcess(cmd, 0, stdout="done\n", stderr="")
+
+    monkeypatch.setattr(quickstart, "SignalTeardown", FakeTeardown)
+    monkeypatch.setattr(quickstart, "install_teardown_signal_handlers", lambda teardown: {})
+    monkeypatch.setattr(quickstart, "restore_signal_handlers", lambda handlers: None)
+    monkeypatch.setattr(quickstart, "StorageClient", FakeStorageClient)
+    monkeypatch.setattr(quickstart, "render_workflow", fake_render_workflow)
+    monkeypatch.setattr(quickstart.subprocess, "run", fake_run)
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("S3_BUCKET", raising=False)
+    monkeypatch.delenv("NPA_S3_BUCKET", raising=False)
+
+    rc = quickstart.main(
+        [
+            "--run-id",
+            run_id,
+            "--credential-path",
+            str(credentials),
+            "--sky-bin",
+            str(sky_bin),
+            "--poll-interval",
+            "0",
+            "--source-ref",
+            "quickstart-test-branch",
+            "--teardown-poll-interval",
+            "0",
+            "--output-json",
+        ]
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    render = captured["render"]
+    assert render["bucket"] == "quickstart-bucket"
+    assert render["s3_prefix"] == f"experiments/sim-to-real/{run_id}"
+    assert render["gpu"] == "H100:1"
+    assert render["gpu_failover"] == ""
+    assert render["train_steps"] == 20
+    assert render["train_step_budget"] == 20
+    assert render["max_training_iterations"] == 1
+    assert render["eval_episodes"] == 1
+    assert render["task_cloud"] == "nebius"
+    assert captured["launch_cmd"][:6] == [
+        str(sky_bin),
+        "launch",
+        "--cluster",
+        quickstart.run_tag(run_id),
+        "--name",
+        quickstart.run_tag(run_id),
+    ]
+    assert "--secret" in captured["launch_cmd"]
+    assert "AWS_ACCESS_KEY_ID" in captured["launch_cmd"]
+    assert "AWS_SECRET_ACCESS_KEY" in captured["launch_cmd"]
+    assert captured["submitted_yaml"][0]["name"] == quickstart.run_tag(run_id)
+    assert "workdir" not in captured["submitted_yaml"][0]
+    assert captured["submitted_yaml"][0]["envs"]["NPA_SIM_TO_REAL_RUN_ID"] == run_id
+    assert captured["submitted_yaml"][0]["envs"]["NPA_SOURCE_REPO"] == quickstart.DEFAULT_SOURCE_REPO
+    assert captured["submitted_yaml"][0]["envs"]["NPA_SOURCE_REF"] == "quickstart-test-branch"
+    assert FakeTeardown.instances[0].marked == [None]
+    assert FakeTeardown.instances[0].teardown_calls == 1
+    assert output["metric"]["value"] == 0.5
+    assert output["artifacts"]["checkpoint"] == f"s3://quickstart-bucket/experiments/sim-to-real/{run_id}/checkpoints/policy/"
+    assert output["teardown"]["cluster_absent"] is True
+
+
+def test_quickstart_splits_bucket_uri_prefix() -> None:
+    quickstart = _load_quickstart_module()
+
+    assert quickstart._split_bucket_and_prefix("s3://bucket/path/to/runs/") == ("bucket", "path/to/runs")
+    assert quickstart._split_bucket_and_prefix("bucket/path") == ("bucket", "path")
+    assert quickstart._join_s3_prefix("path/to/runs", "sim-to-real/run") == "path/to/runs/sim-to-real/run"
 
 
 def test_sdk_module_exposes_local_smoke(tmp_path: Path) -> None:

--- a/npa/workflows/workbench/README.md
+++ b/npa/workflows/workbench/README.md
@@ -1,43 +1,54 @@
-# NPA Workflow Templates
+# NPA SkyPilot Workflow Templates
 
-This directory contains Argo WorkflowTemplate definitions for Workbench reference architectures. The current templates use the pod-as-worker execution model: each workflow step is a Kubernetes pod that performs the step work directly.
+This directory contains Workbench reference workflows for robotics,
+simulation, perception, eval, and synthetic-data workloads. SkyPilot is the
+workflow orchestrator for these templates.
 
 ## Layout
 
-- `templates/`: reference architecture WorkflowTemplates.
-- `steps/`: reusable step WorkflowTemplates referenced with `templateRef`.
-- `schemas/`: conventions for parameters, artifacts, naming, and runtime constraints.
+- `skypilot/`: runnable SkyPilot YAMLs for reference pipelines.
+- `schemas/`: conventions for parameters, artifacts, naming, and runtime
+  constraints.
+- `steps/` and `templates/`: legacy placeholders kept for compatibility with
+  older examples; new workflow work should use `skypilot/`.
 
-## Install Templates
+## Sim-To-Real
 
-Use the target cluster kubeconfig for every command:
-
-```bash
-export KUBECONFIG=/tmp/<run-id>/kubeconfig
-argo template create -n argo npa/workflows/workbench/steps/placeholder-step.yaml
-argo template create -n argo npa/workflows/workbench/templates/curate-augment-train.yaml
-```
-
-For an existing template, use `argo template update -n argo <file>`.
-
-## Submit
-
-Submit a Workflow from a WorkflowTemplate:
+The H100 quickstart submits:
 
 ```bash
-argo submit -n argo \
-  --from workflowtemplate/curate-augment-train \
-  -p dataset-uri=s3://${NPA_S3_BUCKET}/argo-artifacts/fixtures/curate-augment-train-v1/fixture-dataset.txt \
-  --watch
+npa/.venv/bin/python npa/scripts/run_sim_to_real_quickstart.py
 ```
 
-## Inspect
+It renders and runs:
+
+```text
+npa/workflows/workbench/skypilot/sim-to-real-pipeline.yaml
+```
+
+The deeper reference path is documented in
+`docs/workbench/cookbooks/sim-to-real-pipeline.md`.
+
+## Submission Pattern
+
+Use the thin Python wrappers under `npa/scripts/` when a workflow needs runtime
+substitution, S3 paths, secret-env injection, GPU validation, or cleanup:
 
 ```bash
-argo list -n argo
-argo watch -n argo <workflow-name>
-argo get -n argo <workflow-name>
-argo logs -n argo <workflow-name>
+npa/.venv/bin/python npa/scripts/run_sim_to_real_pipeline.py --help
+npa/.venv/bin/python npa/scripts/run_isaac_lab_rl.py --help
+npa/.venv/bin/python npa/scripts/run_bdd100k_pipeline.py --help
 ```
 
-The conventions document is the source of truth for parameter names, artifact flow, S3 layout, image rules, and GPU exclusions.
+Invoke SkyPilot through `NPA_SKYPILOT_BIN`, normally resolved by:
+
+```bash
+npa skypilot bootstrap
+export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+```
+
+## Cleanup
+
+Wrappers that create live GPU resources must use explicit SkyPilot cleanup and
+must poll for absence when they own the user-facing lifecycle. Do not rely on a
+detached terminal or manual cleanup as the only teardown path.

--- a/npa/workflows/workbench/skypilot/sim-to-real-pipeline.yaml
+++ b/npa/workflows/workbench/skypilot/sim-to-real-pipeline.yaml
@@ -62,20 +62,28 @@ envs:
   SEED: "42"
   CUSTOM_LEROBOT_TRAINER_COMMAND: ""
   RERUN_MAX_FRAMES_PER_EPISODE: "32"
+  NPA_SOURCE_REPO: "https://github.com/nebius/nebius-physical-ai.git"
+  NPA_SOURCE_REF: "main"
 setup: |
   set -e
-  if [ -d ./npa ]; then
-    python3 -m venv ./npa/.venv
-    ./npa/.venv/bin/python -m pip install --upgrade pip setuptools wheel
-    ./npa/.venv/bin/python -m pip install -e ./npa
-  else
-    echo "Expected SkyPilot workdir to contain ./npa" >&2
-    exit 2
+  if [ ! -f ./npa/pyproject.toml ]; then
+    rm -rf ./npa ./npa-source
+    git clone --depth 1 --branch "${NPA_SOURCE_REF}" "${NPA_SOURCE_REPO}" ./npa-source
+    ln -s ./npa-source/npa ./npa
   fi
+  sudo apt-get update
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ffmpeg
+  python3 -m pip install --user "uv>=0.9,<1"
+  export PATH="${HOME}/.local/bin:${PATH}"
+  uv python install 3.12
+  uv venv --python 3.12 --seed ./npa/.venv
+  ./npa/.venv/bin/python -m pip install --upgrade pip setuptools wheel
+  ./npa/.venv/bin/python -m pip install -e ./npa
   ./npa/.venv/bin/python -m pip install "lerobot[pusht]==0.5.1" safetensors huggingface_hub datasets
   ./npa/.venv/bin/python -m npa.workbench.lerobot.policy_container check-import
 run: |
   set -euo pipefail
+  export PATH="$(pwd)/npa/.venv/bin:${PATH}"
 
   report_dir="/tmp/npa-sim-to-real-${NPA_SIM_TO_REAL_RUN_ID}"
   mkdir -p "${report_dir}"


### PR DESCRIPTION
## Summary

- Add a one-command H100 sim-to-real quickstart wrapper at `npa/scripts/run_sim_to_real_quickstart.py`.
- Add a new getting-started guide and wire it into the Workbench docs/cookbooks.
- Keep the quickstart on the existing sim-to-real YAML/runtime surface, with source repo/ref overrides, BYO S3-compatible storage, BYO policy image, and direct `sky launch` teardown through `sky down` plus absence polling.
- Harden the SkyPilot setup path for the live H100 image: public source checkout, Python 3.12 venv via `uv`, FFmpeg runtime libs for `torchcodec`, and venv `PATH` for LeRobot console scripts.

## Live H100 Evidence

Cold proof run:

- Run ID: `s2r-quickstart-cold10-20260604T230200Z`
- Status: `SUCCEEDED`
- Wall-clock: `472.09s`
- Metric: `task_success_score=0.0`, decision `retrain`
- Artifacts: `s3://<redacted>/checkpoints/sim-to-real/s2r-quickstart-cold10-20260604T230200Z/{checkpoints,reports,viz}/`
- Teardown: wrapper reported `cluster_absent=true`

Warm comparison run:

- Run ID: `s2r-quickstart-warm1-20260604T231011Z`
- Status: `SUCCEEDED`
- Wall-clock: `470.89s`
- Metric: `task_success_score=0.0`, decision `retrain`
- Artifacts: `s3://<redacted>/checkpoints/sim-to-real/s2r-quickstart-warm1-20260604T231011Z/{checkpoints,reports,viz}/`
- Teardown: wrapper reported `cluster_absent=true`

Post-run `sky status --refresh --output json` showed no H100 quickstart cluster remaining. An unrelated L40S cluster was left untouched.

## Validation

- `npa/.venv/bin/python -m ruff check npa/scripts/run_sim_to_real_quickstart.py npa/tests/workflows/test_sim_to_real_pipeline.py`: passed
- `npa/.venv/bin/python -m pytest npa/tests/workflows/test_sim_to_real_pipeline.py npa/tests/orchestration/skypilot/test_signal_teardown.py -q`: `21 passed`
- `npa/.venv/bin/python -m pytest npa/tests/ --ignore=npa/tests/e2e --collect-only -q`: `1450 tests collected / 2 skipped`
- Final branch diff scan against `origin/main...HEAD`: `CUSTOMER_DENYLIST` hits `0`, public infra hits `0`, public-repo forbidden hits `0`, customer/secret-like hits `0`
- Extra redaction sanity scan for live validation strings and concrete S3 bucket names: hits `0`

Full non-e2e execution was not repeated after a previous full-suite attempt in a discarded `/tmp` clone ended with the test process removing the checkout working directory. Focused changed-surface tests, ruff, and non-zero collection are green.
