### PR TITLE
guardrails: support local customer denylist source

### DIFF
--- a/.github/workflows/confidentiality-scan.yml
+++ b/.github/workflows/confidentiality-scan.yml
@@ -49,10 +49,11 @@ jobs:
           run_scan() {
             local pattern_env="$1"
             local label="$2"
-            shift 2
+            local required="$3"
+            shift 3
 
-            if [ -z "${!pattern_env:-}" ]; then
-              echo "::warning::${label} confidentiality scan is not configured; populate the ${pattern_env} secret to enable denylist enforcement"
+            if [ "${required}" != "true" ] && [ -z "${!pattern_env:-}" ]; then
+              echo "::warning::${label} confidentiality scan is not configured; populate the ${pattern_env} secret to enable supplemental denylist enforcement"
               return 0
             fi
 
@@ -60,5 +61,5 @@ jobs:
             npa/.venv/bin/python -m npa.guardrails.confidentiality "${args[@]}" --pattern-env "${pattern_env}" "$@"
           }
 
-          run_scan CUSTOMER_DENYLIST customer
-          run_scan INFRA_DENYLIST operator-private --ignore-case
+          run_scan CUSTOMER_DENYLIST customer true
+          run_scan INFRA_DENYLIST operator-private false --ignore-case

--- a/docs/testing/guardrails.md
+++ b/docs/testing/guardrails.md
@@ -2,10 +2,14 @@
 
 This repository has additive no-GPU guardrails for PRs:
 
-- `confidentiality scan`: scans the PR diff and tracked tree with regexes sourced from the `CUSTOMER_DENYLIST` and `INFRA_DENYLIST` GitHub Actions secrets. The workflow prints only redacted file locations.
+- `confidentiality scan`: scans the PR diff and tracked tree with regexes sourced from the required `CUSTOMER_DENYLIST` GitHub Actions secret and, when configured, the supplemental `INFRA_DENYLIST` secret. Local operator runs may provide the same regexes through `${PATTERN_ENV}_FILE` or `~/.config/npa/<lowercase-pattern-env>.regex`. The workflow prints only redacted file locations and fails closed when the required customer source is absent.
 - `harness guardrails`: runs static three-tier workbench contracts, pytest collection protection, GPU-skip lint, and SkyPilot teardown lint.
 
 Recommended branch-protection policy is an admin decision. The confidentiality scan and harness guardrails are designed to be merge-blocking checks; the local registry check is informational until it can run from an environment with registry reachability.
+
+Operator-private denylist files must stay outside the repository. For example,
+`CUSTOMER_DENYLIST` falls back to `~/.config/npa/customer-denylist.regex` for
+local scans when the environment variable is not set.
 
 ## Local Registry Image Check
 

--- a/npa/src/npa/guardrails/confidentiality.py
+++ b/npa/src/npa/guardrails/confidentiality.py
@@ -6,6 +6,7 @@ The scanner intentionally reports only locations, never matched text.
 from __future__ import annotations
 
 import argparse
+from collections.abc import Mapping
 from dataclasses import dataclass
 import os
 from pathlib import Path
@@ -20,6 +21,57 @@ class ScanHit:
 
     source: str
     line_number: int
+
+
+@dataclass(frozen=True)
+class DenylistPattern:
+    """Operator-provided denylist regex plus its redacted source name."""
+
+    pattern: str
+    source: str
+
+
+def default_pattern_file(pattern_env: str) -> Path:
+    """Return the local operator-private fallback path for a denylist env name."""
+
+    file_name = pattern_env.lower().replace("_", "-")
+    return Path("~/.config/npa").expanduser() / f"{file_name}.regex"
+
+
+def load_denylist_pattern(
+    pattern_env: str,
+    *,
+    pattern_file: Path | None = None,
+    environ: Mapping[str, str] = os.environ,
+) -> DenylistPattern:
+    """Load a denylist regex from an env var or an operator-private file."""
+
+    env_pattern = environ.get(pattern_env)
+    if env_pattern and env_pattern.strip():
+        return DenylistPattern(pattern=env_pattern, source=pattern_env)
+
+    pattern_file_env = f"{pattern_env}_FILE"
+    configured_file = environ.get(pattern_file_env)
+    if configured_file:
+        source_path = Path(configured_file).expanduser()
+        source_name = f"{pattern_file_env}:{source_path}"
+    elif pattern_file:
+        source_path = pattern_file.expanduser()
+        source_name = f"--pattern-file:{source_path}"
+    else:
+        source_path = default_pattern_file(pattern_env)
+        source_name = f"default-file:{source_path}"
+
+    if source_path.is_file():
+        return DenylistPattern(
+            pattern=source_path.read_text(encoding="utf-8"),
+            source=source_name,
+        )
+
+    raise ValueError(
+        f"{pattern_env} is empty and no denylist file was found at {source_path} "
+        f"(or via {pattern_file_env})"
+    )
 
 
 def compile_denylist(
@@ -98,6 +150,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Environment variable containing the denylist regex.",
     )
     parser.add_argument(
+        "--pattern-file",
+        type=Path,
+        help=(
+            "Operator-private file containing the denylist regex. If omitted, "
+            "the scanner checks ${PATTERN_ENV}_FILE, then "
+            "~/.config/npa/<lowercase-pattern-env>.regex."
+        ),
+    )
+    parser.add_argument(
         "--ignore-case",
         action="store_true",
         help="Match denylist regexes case-insensitively.",
@@ -105,13 +166,20 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        source_pattern = load_denylist_pattern(
+            args.pattern_env,
+            pattern_file=args.pattern_file,
+        )
         denylist = compile_denylist(
-            os.environ.get(args.pattern_env, ""),
-            source=args.pattern_env,
+            source_pattern.pattern,
+            source=source_pattern.source,
             ignore_case=args.ignore_case,
         )
     except ValueError as exc:
         print(f"confidentiality scan not configured: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"confidentiality scan source cannot be read: {exc}", file=sys.stderr)
         return 2
     except re.error as exc:
         print(f"confidentiality scan regex is invalid: {exc}", file=sys.stderr)

--- a/npa/tests/guardrails/test_confidentiality_scan.py
+++ b/npa/tests/guardrails/test_confidentiality_scan.py
@@ -7,6 +7,8 @@ import pytest
 
 from npa.guardrails.confidentiality import (
     compile_denylist,
+    load_denylist_pattern,
+    main,
     scan_paths,
     scan_text,
     tracked_text_files,
@@ -64,3 +66,53 @@ def test_confidentiality_matcher_names_empty_pattern_source() -> None:
 def test_confidentiality_matcher_surfaces_invalid_regex() -> None:
     with pytest.raises(re.error):
         compile_denylist("[")
+
+
+def test_denylist_loader_prefers_env_pattern_over_file(tmp_path) -> None:
+    pattern_file = tmp_path / "customer.regex"
+    pattern_file.write_text("file-only-pattern\n", encoding="utf-8")
+
+    loaded = load_denylist_pattern(
+        "CUSTOMER_DENYLIST",
+        pattern_file=pattern_file,
+        environ={"CUSTOMER_DENYLIST": "env-only-pattern"},
+    )
+
+    assert loaded.pattern == "env-only-pattern"
+    assert loaded.source == "CUSTOMER_DENYLIST"
+
+
+def test_denylist_loader_reads_configured_file_env(tmp_path) -> None:
+    pattern_file = tmp_path / "customer.regex"
+    pattern_file.write_text("configured-file-pattern\n", encoding="utf-8")
+
+    loaded = load_denylist_pattern(
+        "CUSTOMER_DENYLIST",
+        environ={"CUSTOMER_DENYLIST_FILE": str(pattern_file)},
+    )
+
+    assert loaded.pattern == "configured-file-pattern\n"
+    assert loaded.source == f"CUSTOMER_DENYLIST_FILE:{pattern_file}"
+
+
+def test_denylist_loader_reads_explicit_pattern_file(tmp_path) -> None:
+    pattern_file = tmp_path / "customer.regex"
+    pattern_file.write_text("explicit-file-pattern\n", encoding="utf-8")
+
+    loaded = load_denylist_pattern("CUSTOMER_DENYLIST", pattern_file=pattern_file, environ={})
+
+    assert loaded.pattern == "explicit-file-pattern\n"
+    assert loaded.source == f"--pattern-file:{pattern_file}"
+
+
+def test_denylist_loader_fails_closed_when_source_missing(tmp_path) -> None:
+    missing_file = tmp_path / "missing.regex"
+
+    with pytest.raises(ValueError, match="CUSTOMER_DENYLIST is empty"):
+        load_denylist_pattern("CUSTOMER_DENYLIST", pattern_file=missing_file, environ={})
+
+
+def test_confidentiality_scan_cli_fails_closed_when_source_missing(tmp_path) -> None:
+    missing_file = tmp_path / "missing.regex"
+
+    assert main(["--repo-root", str(tmp_path), "--pattern-file", str(missing_file)]) == 2


### PR DESCRIPTION
## Summary
- load confidentiality denylist regexes from the configured env var first, then `${PATTERN_ENV}_FILE`, then `~/.config/npa/<lowercase-pattern-env>.regex`
- keep `CUSTOMER_DENYLIST` mandatory/fail-closed in CI while preserving the existing optional warning behavior for an unconfigured supplemental `INFRA_DENYLIST`
- document that local denylist files are operator-private and must stay outside the repo

## Verification
- `npa/.venv/bin/ruff check npa/src/npa/guardrails/confidentiality.py npa/tests/guardrails/test_confidentiality_scan.py`
- `npa/.venv/bin/python -m pytest npa/tests/guardrails -q` (`25 passed`, one existing warning)
- synthetic local tree scan: `confidentiality scan passed; hits=0`
- workflow wrapper simulation: configured customer source passes; absent supplemental infra source warns
- missing customer source check exits `2`
- Dev VM isolated worktree scan found the operator-private local source and passed with `hits=0`
- Dev VM missing-source check exits `2`
- verified no denylist regex file is tracked in the repo
