### PR TITLE
Add general training config interface

### DIFF
--- a/npa/docker/workbench/sonic/entrypoint.sh
+++ b/npa/docker/workbench/sonic/entrypoint.sh
@@ -195,6 +195,71 @@ sys.exit(0 if ok else 1)
 PY
 }
 
+write_train_summary() {
+  local command="$1"
+  local rc="$2"
+  "$PYTHON_BIN" <<PY
+import json
+import os
+import pathlib
+import shutil
+import time
+
+out = pathlib.Path(${OUTPUT_DIR@Q})
+out.mkdir(parents=True, exist_ok=True)
+roots = [
+    pathlib.Path("/opt/sonic/runs"),
+    pathlib.Path("/opt/sonic/outputs"),
+    pathlib.Path("/opt/sonic/logs"),
+    out,
+]
+checkpoint_suffixes = (".pt", ".pth", ".safetensors", ".ckpt")
+checkpoints = []
+for root in roots:
+    if not root.exists():
+        continue
+    checkpoints.extend(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix in checkpoint_suffixes
+    )
+checkpoints = sorted(checkpoints, key=lambda path: (path.stat().st_mtime, str(path)))
+latest = checkpoints[-1] if checkpoints else None
+stable = out / f"sonic_checkpoint{latest.suffix if latest else '.pt'}"
+if latest is not None and latest != stable:
+    shutil.copy2(latest, stable)
+summary = {
+    "status": "success" if int(${rc@Q}) == 0 and latest is not None else "failed",
+    "exit_code": int(${rc@Q}),
+    "tool": "sonic",
+    "command": ${command@Q},
+    "embodiment": os.environ.get("SONIC_EMBODIMENT", "UNITREE_G1_SONIC"),
+    "checkpoint": os.environ.get("SONIC_CHECKPOINT", "nvidia/GEAR-SONIC:sonic_release/last.pt"),
+    "data_path": os.environ.get("NPA_TRAINING_DATA_PATH") or os.environ.get("SONIC_DATA_PATH", ""),
+    "overrides": json.loads(os.environ.get("NPA_TRAINING_OVERRIDES_JSON", "[]")),
+    "sample_data": os.environ.get("SONIC_SAMPLE_DATA", "1") == "1",
+    "num_envs": int(os.environ.get("SONIC_NUM_ENVS", "16")),
+    "steps": int(os.environ.get("SONIC_STEPS", os.environ.get("SONIC_MAX_ITERATIONS", "5"))),
+    "wandb": {
+        "enabled": os.environ.get("NPA_TRAINING_WANDB_ENABLED", "0") == "1",
+        "project": os.environ.get("NPA_TRAINING_WANDB_PROJECT", ""),
+        "run_name": os.environ.get("NPA_TRAINING_WANDB_RUN_NAME", ""),
+        "mode": os.environ.get("WANDB_MODE", ""),
+    },
+    "checkpoint_path": str(latest) if latest is not None else "",
+    "stable_checkpoint_path": str(stable) if latest is not None else "",
+    "checkpoint_s3_uri": os.environ.get("NPA_CHECKPOINT_S3_URI", os.environ.get("NPA_OUTPUT_PATH", "")),
+    "timestamp": int(time.time()),
+}
+manifest = {"format": "npa_sonic_training_checkpoint_v1", **summary}
+(out / "sonic_train_summary.json").write_text(json.dumps(summary, indent=2))
+(out / "npa_sonic_checkpoint_manifest.json").write_text(json.dumps(manifest, indent=2))
+print("NPA_SONIC_CONTAINER_TRAIN_DONE", out / "sonic_train_summary.json", flush=True)
+if summary["status"] != "success":
+    raise SystemExit(summary["exit_code"] or 3)
+PY
+}
+
 write_eval_result() {
   "$PYTHON_BIN" <<'PY'
 import json
@@ -400,6 +465,24 @@ run_real_train() {
   fi
   if [ -n "$smpl_motion_file" ]; then
     hydra_args+=("++manager_env.commands.motion.motion_lib_cfg.smpl_motion_file=${smpl_motion_file}")
+  fi
+  if [ -n "${SONIC_DATA_PATH:-}" ]; then
+    hydra_args+=("+data_path=${SONIC_DATA_PATH}")
+  fi
+  if [ -n "${NPA_TRAINING_OVERRIDES_JSON:-}" ]; then
+    while IFS= read -r override; do
+      [ -n "$override" ] && hydra_args+=("$override")
+    done < <("$PYTHON_BIN" - <<'PY'
+import json
+import os
+
+for item in json.loads(os.environ.get("NPA_TRAINING_OVERRIDES_JSON", "[]")):
+    print(item)
+PY
+)
+  elif [ -n "${NPA_TRAINING_OVERRIDES:-}" ]; then
+    read -r -a extra_hydra_args <<< "${NPA_TRAINING_OVERRIDES}"
+    hydra_args+=("${extra_hydra_args[@]}")
   fi
   printf 'NPA_SONIC_REAL_TRAIN mode=%s checkpoint=%s iterations=%s num_envs=%s\n' \
     "$train_mode" "$checkpoint_path" "${SONIC_MAX_ITERATIONS:-5}" "${SONIC_NUM_ENVS:-16}"

--- a/npa/scripts/run_isaac_lab_rl.py
+++ b/npa/scripts/run_isaac_lab_rl.py
@@ -71,6 +71,14 @@ def render_workflow(
     iterations: int,
     output_root: str = DEFAULT_OUTPUT_ROOT,
     image: str = "",
+    data_path: str = "",
+    overrides: list[str] | None = None,
+    wandb_enabled: bool = False,
+    wandb_project: str = "",
+    wandb_run_name: str = "",
+    wandb_mode: str = "offline",
+    checkpoint_s3_uri: str = "",
+    checkpoint_s3_endpoint_url: str = "",
 ) -> list[dict[str, Any]]:
     docs = _load_yaml_documents(yaml_path)
     train_docs = [doc for doc in docs[1:] if isinstance(doc.get("envs"), dict)]
@@ -80,6 +88,20 @@ def render_workflow(
         envs["NPA_ISAAC_LAB_RUN_ID"] = run_id
         envs["ISAAC_LAB_TASK"] = task
         envs["ISAAC_LAB_ITERATIONS"] = str(iterations)
+        rendered_overrides = list(overrides or [])
+        envs["NPA_TRAINING_DATA_PATH"] = data_path
+        envs["NPA_TRAINING_OVERRIDES_JSON"] = json.dumps(rendered_overrides)
+        envs["NPA_TRAINING_OVERRIDES"] = " ".join(rendered_overrides)
+        envs["NPA_TRAINING_WANDB_ENABLED"] = "1" if wandb_enabled else "0"
+        envs["NPA_TRAINING_WANDB_PROJECT"] = wandb_project
+        envs["NPA_TRAINING_WANDB_RUN_NAME"] = wandb_run_name
+        envs["WANDB_MODE"] = wandb_mode if wandb_enabled else "disabled"
+        envs["NPA_CHECKPOINT_S3_URI"] = checkpoint_s3_uri
+        envs["NPA_CHECKPOINT_S3_ENDPOINT_URL"] = checkpoint_s3_endpoint_url
+        if checkpoint_s3_endpoint_url:
+            envs["AWS_ENDPOINT_URL"] = checkpoint_s3_endpoint_url
+            envs["NEBIUS_S3_ENDPOINT"] = checkpoint_s3_endpoint_url
+        envs["ISAAC_LAB_HYDRA_OVERRIDES"] = " ".join(["agent.save_interval=1", *rendered_overrides]).strip()
         variant = str(envs.get("RUN_VARIANT") or doc.get("name") or "").strip()
         prefix = output_root.rstrip("/") + f"/{run_id}/"
         if multiple and variant:
@@ -121,6 +143,14 @@ def _submit_and_wait(args: argparse.Namespace) -> int:
         iterations=args.iterations,
         output_root=args.output_root,
         image=args.image,
+        data_path=args.data_path,
+        overrides=args.override,
+        wandb_enabled=args.wandb,
+        wandb_project=args.wandb_project,
+        wandb_run_name=args.wandb_run_name,
+        wandb_mode=args.wandb_mode,
+        checkpoint_s3_uri=args.checkpoint_s3_uri,
+        checkpoint_s3_endpoint_url=args.checkpoint_s3_endpoint_url,
     )
     variants = [
         str(doc.get("envs", {}).get("RUN_VARIANT"))
@@ -226,6 +256,14 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--run-id", default="")
     parser.add_argument("--output-root", default=DEFAULT_OUTPUT_ROOT)
     parser.add_argument("--image", default="", help="Container image override, e.g. cr.../npa-isaac-lab:tag.")
+    parser.add_argument("--data-path", default="", help="Canonical custom training data path.")
+    parser.add_argument("--override", action="append", default=[], help="Canonical training override KEY=VALUE.")
+    parser.add_argument("--wandb", action="store_true", help="Enable W&B logging.")
+    parser.add_argument("--wandb-project", default="")
+    parser.add_argument("--wandb-run-name", default="")
+    parser.add_argument("--wandb-mode", default="offline")
+    parser.add_argument("--checkpoint-s3-uri", default="")
+    parser.add_argument("--checkpoint-s3-endpoint-url", default="")
     parser.add_argument("--sky-bin", default="")
     parser.add_argument("--isolated-config-dir", type=Path, default=None)
     parser.add_argument("--submit-timeout", type=int, default=1800)

--- a/npa/src/npa/cli/genesis/__init__.py
+++ b/npa/src/npa/cli/genesis/__init__.py
@@ -57,6 +57,15 @@ from npa.serverless_common import (
     split_serverless_env,
     validate_output_path,
 )
+from npa.workbench.training_config import (
+    TrainingConfig,
+    TrainingConfigError,
+    build_training_config,
+    checkpoint_s3_uri as resolve_checkpoint_s3_uri,
+    overrides_to_mapping,
+    shell_env_exports,
+    upload_checkpoint_path,
+)
 
 app = typer.Typer(
     name="genesis",
@@ -168,38 +177,63 @@ def _genesis_serverless_train_teacher_command(
     max_iterations: int,
     action_space: str,
     seed: int,
+    training_config: TrainingConfig | None = None,
+    env_overrides: dict[str, Any] | None = None,
+    ppo_overrides: dict[str, Any] | None = None,
 ) -> str:
+    config = training_config or TrainingConfig()
     local_dir = "/tmp/npa-genesis-train-teacher"
+    training_env = shell_env_exports(config.env())
     script = f"""
 import json, os, pathlib, time
 
 out = pathlib.Path("{local_dir}")
 out.mkdir(parents=True, exist_ok=True)
+log_dir = out / "logs"
 started = time.time()
-try:
-    import genesis as gs  # noqa: F401
-    import_status = "available"
-except Exception as exc:
-    import_status = f"unavailable: {{type(exc).__name__}}: {{exc}}"
+from npa.genesis.train_teacher import PPOConfig, train_teacher
+
+ppo_cfg = PPOConfig()
+for key, value in {json.dumps(ppo_overrides or {}, sort_keys=True)}.items():
+    setattr(ppo_cfg, key, value)
+result = train_teacher(
+    n_envs={n_envs},
+    max_iterations={max_iterations},
+    output_dir=out,
+    device=os.environ.get("NPA_TRAINING_DEVICE", "cuda"),
+    log_dir=log_dir,
+    seed={seed},
+    ppo_cfg=ppo_cfg,
+    action_space={action_space!r},
+    env_overrides={json.dumps(env_overrides or {}, sort_keys=True)} or None,
+)
 summary = {{
-    "status": "success",
+    **result,
     "tool": "genesis",
-    "n_envs": {n_envs},
-    "max_iterations": {max_iterations},
-    "action_space": {action_space!r},
-    "seed": {seed},
-    "genesis_import": import_status,
     "job": os.environ.get("NPA_JOB_NAME", ""),
     "duration_seconds": round(time.time() - started, 3),
+    "data_path": os.environ.get("NPA_TRAINING_DATA_PATH", ""),
+    "overrides": json.loads(os.environ.get("NPA_TRAINING_OVERRIDES_JSON", "[]") or "[]"),
+    "wandb": {{
+        "enabled": os.environ.get("NPA_TRAINING_WANDB_ENABLED", "0") == "1",
+        "project": os.environ.get("NPA_TRAINING_WANDB_PROJECT", ""),
+        "run_name": os.environ.get("NPA_TRAINING_WANDB_RUN_NAME", ""),
+        "mode": os.environ.get("WANDB_MODE", ""),
+    }},
+    "checkpoint_s3_uri": os.environ.get("NPA_CHECKPOINT_S3_URI", ""),
 }}
 (out / "train_teacher_summary.json").write_text(json.dumps(summary, indent=2))
-(out / "model.pt").write_text(json.dumps({{"format": "npa_genesis_serverless_smoke_v1", **summary}}, indent=2))
+(out / "npa_genesis_checkpoint_manifest.json").write_text(json.dumps({{
+    "format": "npa_genesis_ppo_checkpoint_v1",
+    **summary,
+}}, indent=2))
 print("NPA_GENESIS_SERVERLESS_TRAIN_TEACHER_DONE", os.environ.get("NPA_OUTPUT_PATH", ""), flush=True)
 """.strip()
     upload = build_serverless_output_upload_cmd(local_dir, "")
     body = (
         'NPA_PYTHON_BIN="${NPA_PYTHON_BIN:-python3}"\n'
         'if ! command -v "$NPA_PYTHON_BIN" >/dev/null 2>&1; then NPA_PYTHON_BIN=python; fi\n'
+        f'{training_env}\n'
         f'"$NPA_PYTHON_BIN" <<\'PY\'\n{script}\nPY\n{upload}'
     )
     return _remote_bash(body)
@@ -210,6 +244,9 @@ def _genesis_serverless_train_teacher(
     n_envs: int,
     max_iterations: int,
     output_path: str,
+    training_config: TrainingConfig,
+    env_overrides: dict[str, Any],
+    ppo_overrides: dict[str, Any],
     project_id: str,
     image: str,
     gpu_type: str,
@@ -254,9 +291,13 @@ def _genesis_serverless_train_teacher(
         out,
         {
             "NPA_JOB_NAME": name,
-            "GENESIS_SERVERLESS_SMOKE": "1",
+            "GENESIS_SERVERLESS_REAL_TRAIN": "1",
+            **training_config.env(),
         },
     )
+    merged_env = dict(env)
+    merged_env.update(extra_env)
+    env, extra_env = split_serverless_env(merged_env)
     client = ServerlessClient()
     try:
         existing = client.get_job(name, resolved_project_id)
@@ -271,7 +312,15 @@ def _genesis_serverless_train_teacher(
             project_id=resolved_project_id,
             name=name,
             image=image or container_image_for_tool("genesis", registry=resolve_container_registry(proj_alias)),
-            command=_genesis_serverless_train_teacher_command(n_envs=n_envs, max_iterations=max_iterations, action_space=action_space, seed=seed),
+            command=_genesis_serverless_train_teacher_command(
+                n_envs=n_envs,
+                max_iterations=max_iterations,
+                action_space=action_space,
+                seed=seed,
+                training_config=training_config,
+                env_overrides=env_overrides,
+                ppo_overrides=ppo_overrides,
+            ),
             gpu_type=platform,
             gpu_count=resolved_gpu_count,
             preset=preset,
@@ -288,7 +337,16 @@ def _genesis_serverless_train_teacher(
         _fail(f"Serverless Job failed: {exc}")
     except TimeoutError as exc:
         _fail(str(exc))
-    _output({"status": "submitted" if submit_only else info.status, "job_id": info.id, "job_name": info.name, "output_path": out}, output_format)
+    _output(
+        {
+            "status": "submitted" if submit_only else info.status,
+            "job_id": info.id,
+            "job_name": info.name,
+            "output_path": out,
+            "training_config": training_config.public_dict(),
+        },
+        output_format,
+    )
 
 
 def _parse_positive_int(value: str | None) -> int:
@@ -720,6 +778,11 @@ _RANGE_SHORTHANDS: dict[str, tuple[str, int]] = {
 _RANGE_DEFAULTS: dict[str, tuple] = {
     "friction_range": (0.3, 1.2),
 }
+_GENESIS_THRESHOLD_KEYS = {
+    "approach_threshold",
+    "lift_threshold",
+    "place_threshold",
+}
 
 
 def _expand_env_overrides(overrides: dict[str, object]) -> dict[str, object]:
@@ -729,8 +792,6 @@ def _expand_env_overrides(overrides: dict[str, object]) -> dict[str, object]:
     so callers that feed overrides directly to EnvConfig don't blow up.
     Returns a new dict.
     """
-    from npa.genesis.diagnose import _THRESHOLD_KEYS
-
     out: dict[str, object] = {}
     range_updates: dict[str, list] = {}  # field_name → [min, max]
 
@@ -741,7 +802,7 @@ def _expand_env_overrides(overrides: dict[str, object]) -> dict[str, object]:
                 default = _RANGE_DEFAULTS.get(field, (0.0, 1.0))
                 range_updates[field] = list(default)
             range_updates[field][idx] = float(value)
-        elif key in _THRESHOLD_KEYS:
+        elif key in _GENESIS_THRESHOLD_KEYS:
             # Keep as-is — callers that care (diagnose, tune) handle these.
             out[key] = value
         else:
@@ -751,6 +812,67 @@ def _expand_env_overrides(overrides: dict[str, object]) -> dict[str, object]:
         out[field] = tuple(vals)
 
     return out
+
+
+_GENESIS_RUNNER_OVERRIDE_KEYS = {"n_envs", "max_iterations", "seed", "action_space"}
+_GENESIS_PPO_OVERRIDE_KEYS = {
+    "actor_hidden_dims",
+    "critic_hidden_dims",
+    "activation",
+    "init_noise_std",
+    "learning_rate",
+    "num_learning_epochs",
+    "num_mini_batches",
+    "gamma",
+    "lam",
+    "clip_param",
+    "value_loss_coef",
+    "entropy_coef",
+    "max_grad_norm",
+    "use_clipped_value_loss",
+    "schedule",
+    "desired_kl",
+    "num_steps_per_env",
+    "save_interval",
+    "empirical_normalization",
+}
+
+
+def _split_genesis_training_overrides(
+    overrides: tuple[str, ...],
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Route canonical overrides to runner, PPO, or EnvConfig settings."""
+
+    if not overrides:
+        return {}, {}, {}
+    runner: dict[str, Any] = {}
+    ppo: dict[str, Any] = {}
+    env: dict[str, Any] = {}
+    for raw_key, value in overrides_to_mapping(overrides).items():
+        key = raw_key.removeprefix("genesis.")
+        leaf = key.rsplit(".", 1)[-1]
+        if key in _GENESIS_RUNNER_OVERRIDE_KEYS:
+            runner[key] = value
+        elif leaf in _GENESIS_PPO_OVERRIDE_KEYS:
+            ppo[leaf] = value
+        elif key.startswith(("env.", "environment.")):
+            env[key.split(".", 1)[1]] = value
+        else:
+            env[key] = value
+    return runner, ppo, _expand_env_overrides(env)
+
+
+def _ppo_config_from_overrides(overrides: dict[str, Any]):
+    if not overrides:
+        return None
+    from npa.genesis.train_teacher import PPOConfig
+
+    config = PPOConfig()
+    for key, value in overrides.items():
+        if key not in _GENESIS_PPO_OVERRIDE_KEYS:
+            _fail(f"Unsupported Genesis PPO override: {key}")
+        setattr(config, key, value)
+    return config
 
 
 # ── train-teacher ───────────────────────────────────────────────────────
@@ -764,6 +886,20 @@ def train_teacher_cmd(
         "./checkpoints/teacher/", "--output", "-o", help="Checkpoint output directory."
     ),
     output_path: str = typer.Option("", "--output-path", help="S3 URI where serverless training artifacts are written."),
+    data_path: str = typer.Option("", "--data-path", help="Optional custom training data path recorded with the run."),
+    override: list[str] = typer.Option(
+        [],
+        "--override",
+        help="Generic training override as KEY=VALUE. Repeat for PPO, EnvConfig, or runner keys.",
+    ),
+    wandb_enabled: bool = typer.Option(False, "--wandb/--no-wandb", help="Enable W&B logging metadata for the training run."),
+    wandb_project: str = typer.Option("", "--wandb-project", help="W&B project name."),
+    wandb_run_name: str = typer.Option("", "--wandb-run-name", help="W&B run name."),
+    wandb_mode: str = typer.Option("offline", "--wandb-mode", help="W&B mode such as online, offline, or disabled."),
+    checkpoint_s3_uri: str = typer.Option("", "--checkpoint-s3-uri", help="S3 URI for checkpoint upload."),
+    checkpoint_s3_endpoint_url: str = typer.Option("", "--checkpoint-s3-endpoint-url", help="S3-compatible endpoint URL."),
+    checkpoint_s3_access_key_id: str = typer.Option("", "--checkpoint-s3-access-key-id", help="S3 access key ID."),
+    checkpoint_s3_secret_access_key: str = typer.Option("", "--checkpoint-s3-secret-access-key", help="S3 secret access key."),
     runtime: WorkbenchRuntime = typer.Option(WorkbenchRuntime.vm, "--runtime", help="Runtime. serverless creates a Nebius AI Job."),
     project_id: str = typer.Option("", "--project-id", help="Nebius project ID for serverless Jobs."),
     image: str = typer.Option("", "--image", help="Container image for the serverless Job."),
@@ -793,15 +929,47 @@ def train_teacher_cmd(
     ),
 ) -> None:
     """Train an RL teacher policy with PPO using privileged state in Genesis."""
+    try:
+        training_config = build_training_config(
+            data_path=data_path,
+            overrides=override,
+            wandb_enabled=wandb_enabled,
+            wandb_project=wandb_project,
+            wandb_run_name=wandb_run_name,
+            wandb_mode=wandb_mode,
+            checkpoint_s3_uri=checkpoint_s3_uri,
+            checkpoint_s3_endpoint_url=checkpoint_s3_endpoint_url,
+            checkpoint_s3_access_key_id=checkpoint_s3_access_key_id,
+            checkpoint_s3_secret_access_key=checkpoint_s3_secret_access_key,
+        )
+        runner_overrides, ppo_overrides, shared_env_overrides = _split_genesis_training_overrides(
+            training_config.overrides
+        )
+    except TrainingConfigError as exc:
+        _fail(str(exc))
+        return
+    if runner_overrides:
+        n_envs = int(runner_overrides.get("n_envs", n_envs))
+        max_iterations = int(runner_overrides.get("max_iterations", max_iterations))
+        seed = int(runner_overrides.get("seed", seed))
+        if runner_overrides.get("action_space"):
+            action_space = ActionSpace(str(runner_overrides["action_space"]))
     if n_envs <= 0:
         _fail(f"--n-envs must be positive, got {n_envs}")
     if max_iterations <= 0:
         _fail(f"--max-iterations must be positive, got {max_iterations}")
+    env_overrides = _expand_env_overrides(_parse_env_overrides(env_override))
+    env_overrides.update(shared_env_overrides)
+    checkpoint_output_path = resolve_checkpoint_s3_uri(training_config, output_path)
+    train_overrides = {k: v for k, v in env_overrides.items() if k not in _GENESIS_THRESHOLD_KEYS}
     if _is_serverless_runtime(runtime):
         _genesis_serverless_train_teacher(
             n_envs=n_envs,
             max_iterations=max_iterations,
-            output_path=output_path,
+            output_path=checkpoint_output_path,
+            training_config=training_config,
+            env_overrides=train_overrides,
+            ppo_overrides=ppo_overrides,
             project_id=project_id,
             image=image,
             gpu_type=gpu_type,
@@ -818,11 +986,8 @@ def train_teacher_cmd(
         )
         return
 
-    env_overrides = _expand_env_overrides(_parse_env_overrides(env_override))
-
     # Threshold keys are for diagnose, not training — strip them.
-    from npa.genesis.diagnose import _THRESHOLD_KEYS
-    train_overrides = {k: v for k, v in env_overrides.items() if k not in _THRESHOLD_KEYS}
+    ppo_cfg = _ppo_config_from_overrides(ppo_overrides)
 
     console.print("[bold]Training teacher (PPO)[/bold]")
     console.print(f"  n_envs={n_envs}  max_iterations={max_iterations}")
@@ -842,12 +1007,17 @@ def train_teacher_cmd(
             device=device,
             log_dir=Path(log_dir),
             seed=seed,
+            ppo_cfg=ppo_cfg,
             action_space=action_space.value,
             env_overrides=train_overrides if train_overrides else None,
         )
     except TrainingError as exc:
         _fail(str(exc))
         return
+    uploaded_checkpoint = upload_checkpoint_path(Path(output), training_config)
+    if uploaded_checkpoint:
+        result["checkpoint_s3_uri"] = uploaded_checkpoint
+    result["training_config"] = training_config.public_dict()
 
     if output_format == OutputFormat.json:
         typer.echo(json.dumps(result, indent=2))
@@ -1266,6 +1436,20 @@ def tune_cmd(
         "./checkpoints/tune/", "--output", "-o",
         help="Output directory for per-round checkpoints.",
     ),
+    data_path: str = typer.Option("", "--data-path", help="Optional custom training data path recorded with the run."),
+    override: list[str] = typer.Option(
+        [],
+        "--override",
+        help="Generic training override as KEY=VALUE. Repeat for PPO, EnvConfig, or tune runner keys.",
+    ),
+    wandb_enabled: bool = typer.Option(False, "--wandb/--no-wandb", help="Enable W&B logging metadata for the training run."),
+    wandb_project: str = typer.Option("", "--wandb-project", help="W&B project name."),
+    wandb_run_name: str = typer.Option("", "--wandb-run-name", help="W&B run name."),
+    wandb_mode: str = typer.Option("offline", "--wandb-mode", help="W&B mode such as online, offline, or disabled."),
+    checkpoint_s3_uri: str = typer.Option("", "--checkpoint-s3-uri", help="S3 URI for checkpoint upload."),
+    checkpoint_s3_endpoint_url: str = typer.Option("", "--checkpoint-s3-endpoint-url", help="S3-compatible endpoint URL."),
+    checkpoint_s3_access_key_id: str = typer.Option("", "--checkpoint-s3-access-key-id", help="S3 access key ID."),
+    checkpoint_s3_secret_access_key: str = typer.Option("", "--checkpoint-s3-secret-access-key", help="S3 secret access key."),
     log_dir: str = typer.Option(
         "./logs/tune/", "--log-dir", help="Tensorboard log directory.",
     ),
@@ -1309,7 +1493,38 @@ def tune_cmd(
     if not 0.0 <= min_success_rate <= 1.0:
         _fail(f"--min-success-rate must be in [0.0, 1.0], got {min_success_rate}")
 
+    try:
+        training_config = build_training_config(
+            data_path=data_path,
+            overrides=override,
+            wandb_enabled=wandb_enabled,
+            wandb_project=wandb_project,
+            wandb_run_name=wandb_run_name,
+            wandb_mode=wandb_mode,
+            checkpoint_s3_uri=checkpoint_s3_uri,
+            checkpoint_s3_endpoint_url=checkpoint_s3_endpoint_url,
+            checkpoint_s3_access_key_id=checkpoint_s3_access_key_id,
+            checkpoint_s3_secret_access_key=checkpoint_s3_secret_access_key,
+        )
+        runner_overrides, ppo_overrides, shared_env_overrides = _split_genesis_training_overrides(
+            training_config.overrides
+        )
+    except TrainingConfigError as exc:
+        _fail(str(exc))
+        return
+    if runner_overrides:
+        n_envs = int(runner_overrides.get("n_envs", n_envs))
+        seed = int(runner_overrides.get("seed", seed))
+        if runner_overrides.get("action_space"):
+            action_space = ActionSpace(str(runner_overrides["action_space"]))
+        if "max_iterations" in runner_overrides:
+            retrain_iterations = int(runner_overrides["max_iterations"])
+    if retrain_iterations <= 0:
+        _fail(f"--retrain-iterations must be positive, got {retrain_iterations}")
+    if n_envs <= 0:
+        _fail(f"--n-envs must be positive, got {n_envs}")
     env_overrides = _expand_env_overrides(_parse_env_overrides(env_override))
+    env_overrides.update(shared_env_overrides)
 
     console.print("[bold]Auto-tuning teacher policy[/bold]")
     console.print(f"  checkpoint: {ckpt}")
@@ -1335,11 +1550,16 @@ def tune_cmd(
             device=device,
             action_space=action_space.value,
             env_overrides=env_overrides if env_overrides else None,
+            ppo_overrides=ppo_overrides,
             min_success_rate=min_success_rate,
         )
     except TuneError as exc:
         _fail(str(exc))
         return
+    uploaded_checkpoint = upload_checkpoint_path(Path(output), training_config)
+    if uploaded_checkpoint:
+        result["checkpoint_s3_uri"] = uploaded_checkpoint
+    result["training_config"] = training_config.public_dict()
 
     if output_format == OutputFormat.json:
         typer.echo(json.dumps(result, indent=2))

--- a/npa/src/npa/cli/groot/__init__.py
+++ b/npa/src/npa/cli/groot/__init__.py
@@ -112,6 +112,14 @@ from npa.serverless_common import (
     split_serverless_env,
     validate_output_path,
 )
+from npa.workbench.training_config import (
+    TrainingConfig,
+    TrainingConfigError,
+    build_training_config,
+    checkpoint_s3_uri as resolve_checkpoint_s3_uri,
+    render_overrides,
+    shell_env_exports,
+)
 
 app = typer.Typer(
     name="groot",
@@ -1648,16 +1656,19 @@ def _build_finetune_command(
     num_gpus: int,
     config: str,
     endpoint_url: str,
+    checkpoint_endpoint_url: str = "",
     max_steps: int | None = None,
     global_batch_size: int | None = None,
     dataloader_num_workers: int | None = None,
     save_steps: int | None = None,
     save_total_limit: int | None = None,
     save_only_model: bool = False,
+    training_config: TrainingConfig | None = None,
 ) -> str:
+    training = training_config or TrainingConfig()
     dataset_dir, dataset_setup = _resolve_remote_path_setup(
-        input_path,
-        _cache_dir("data", input_path),
+        training.data_path or input_path,
+        _cache_dir("data", training.data_path or input_path),
         endpoint_url,
     )
     if _is_hf_groot_model_ref(base_model):
@@ -1686,7 +1697,7 @@ def _build_finetune_command(
         else output_path
     )
     upload_cmd = (
-        _remote_upload_dir_cmd(output_dir, output_path, endpoint_url)
+        _remote_upload_dir_cmd(output_dir, output_path, checkpoint_endpoint_url or endpoint_url)
         if output_is_s3
         else "true"
     )
@@ -1708,9 +1719,14 @@ def _build_finetune_command(
         train_args += f" \\\n  --save-total-limit {save_total_limit}"
     if save_only_model:
         train_args += " \\\n  --save-only-model"
+    override_args = render_overrides(training.overrides, style="cli")
+    if override_args:
+        train_args += f" \\\n  {override_args}"
+    training_env = shell_env_exports(training.env())
     script = f"""\
 set -euo pipefail
 cd {GROOT_REPO}
+{training_env}
 mkdir -p {GROOT_DATA_CACHE} {GROOT_CHECKPOINT_CACHE} {GROOT_DATA_MOUNT}/checkpoints {GROOT_CONFIG_CACHE}
 {dataset_setup}{base_setup}{config_setup}modality_config_path={shlex.quote(resolved_config)}
 if [ -z "$modality_config_path" ] && [ -f {shlex.quote(dataset_dir)}/meta/npa_groot_modality_config.py ]; then
@@ -3326,11 +3342,25 @@ def reload_env_cmd(
 @app.command("finetune")
 def finetune_cmd(
     input_path: str = typer.Option(
-        ..., "--input-path", help="S3 URI for a GR00T LeRobot training dataset."
+        "", "--input-path", help="Compatibility alias for --data-path."
     ),
+    data_path: str = typer.Option("", "--data-path", help="Custom GR00T LeRobot training dataset path."),
     output_path: str = typer.Option(
-        ..., "--output-path", help="S3 URI for a fine-tuned checkpoint directory."
+        "", "--output-path", help="Compatibility checkpoint output path; prefer --checkpoint-s3-uri for S3."
     ),
+    override: list[str] = typer.Option(
+        [],
+        "--override",
+        help="Generic trainer override as KEY=VALUE. Repeat for any underlying GR00T training arg.",
+    ),
+    wandb_enabled: bool = typer.Option(False, "--wandb/--no-wandb", help="Enable W&B environment for the training run."),
+    wandb_project: str = typer.Option("", "--wandb-project", help="W&B project name."),
+    wandb_run_name: str = typer.Option("", "--wandb-run-name", help="W&B run name."),
+    wandb_mode: str = typer.Option("offline", "--wandb-mode", help="W&B mode such as online, offline, or disabled."),
+    checkpoint_s3_uri: str = typer.Option("", "--checkpoint-s3-uri", help="S3 URI for checkpoint upload."),
+    checkpoint_s3_endpoint_url: str = typer.Option("", "--checkpoint-s3-endpoint-url", help="S3-compatible endpoint URL."),
+    checkpoint_s3_access_key_id: str = typer.Option("", "--checkpoint-s3-access-key-id", help="S3 access key ID."),
+    checkpoint_s3_secret_access_key: str = typer.Option("", "--checkpoint-s3-secret-access-key", help="S3 secret access key."),
     base_model: str = typer.Option(
         DEFAULT_MODEL, "--base-model", help="Base GR00T checkpoint ID or S3 URI."
     ),
@@ -3371,41 +3401,68 @@ def finetune_cmd(
     if num_gpus <= 0:
         _fail(f"--num-gpus must be positive, got {num_gpus}")
     try:
-        input_path = validate_read_path(
-            input_path,
+        training_config = build_training_config(
+            data_path=data_path,
+            overrides=override,
+            wandb_enabled=wandb_enabled,
+            wandb_project=wandb_project,
+            wandb_run_name=wandb_run_name,
+            wandb_mode=wandb_mode,
+            checkpoint_s3_uri=checkpoint_s3_uri,
+            checkpoint_s3_endpoint_url=checkpoint_s3_endpoint_url,
+            checkpoint_s3_access_key_id=checkpoint_s3_access_key_id,
+            checkpoint_s3_secret_access_key=checkpoint_s3_secret_access_key,
+        )
+        effective_input_path = validate_read_path(
+            training_config.data_path or input_path,
             tool="GR00T finetune",
-            option="--input-path",
+            option="--data-path",
             allow_hf=False,
         )
-        output_path = validate_write_path(
-            output_path,
+        checkpoint_output_path = validate_write_path(
+            resolve_checkpoint_s3_uri(training_config, output_path),
             tool="GR00T finetune",
-            option="--output-path",
+            option="--checkpoint-s3-uri",
             required=True,
         )
-    except PathContractError as exc:
+        if not training_config.data_path:
+            training_config = build_training_config(
+                data_path=effective_input_path,
+                overrides=override,
+                wandb_enabled=wandb_enabled,
+                wandb_project=wandb_project,
+                wandb_run_name=wandb_run_name,
+                wandb_mode=wandb_mode,
+                checkpoint_s3_uri=checkpoint_s3_uri,
+                checkpoint_s3_endpoint_url=checkpoint_s3_endpoint_url,
+                checkpoint_s3_access_key_id=checkpoint_s3_access_key_id,
+                checkpoint_s3_secret_access_key=checkpoint_s3_secret_access_key,
+            )
+    except (PathContractError, TrainingConfigError) as exc:
         _fail(str(exc))
     cfg = _get_ssh_config()
-    ssh = _ssh_client(cfg)
+    ssh = _ssh_client(cfg, extra_tokens=training_config.env())
     tag = _normalize_embodiment_tag(robot_embodiment)
     cmd = _runtime_command(
         cfg,
         _build_finetune_command(
-            input_path=input_path,
-            output_path=output_path,
+            input_path=effective_input_path,
+            output_path=checkpoint_output_path,
             base_model=base_model,
             robot_embodiment=tag,
             num_gpus=num_gpus,
             config=config,
             endpoint_url=cfg.storage.endpoint_url,
+            checkpoint_endpoint_url=training_config.checkpoint_s3.endpoint_url,
             max_steps=max_steps,
             global_batch_size=global_batch_size,
             dataloader_num_workers=dataloader_num_workers,
             save_steps=save_steps,
             save_total_limit=save_total_limit,
             save_only_model=save_only_model,
+            training_config=training_config,
         ),
-        pass_env=GROOT_REMOTE_ENV_NAMES,
+        pass_env=(*GROOT_REMOTE_ENV_NAMES, *tuple(training_config.env().keys())),
     )
 
     start = time.time()
@@ -3418,11 +3475,13 @@ def finetune_cmd(
     result = {
         "status": "success" if exit_code == 0 else "failed",
         "exit_code": exit_code,
-        "input_path": input_path,
-        "output_path": output_path,
+        "input_path": effective_input_path,
+        "data_path": training_config.data_path,
+        "output_path": checkpoint_output_path,
         "base_model": base_model,
         "robot_embodiment": tag,
         "num_gpus": num_gpus,
+        "training_config": training_config.public_dict(),
         "duration_seconds": round(time.time() - start, 1),
     }
     if exit_code != 0:

--- a/npa/src/npa/cli/isaac_lab/__init__.py
+++ b/npa/src/npa/cli/isaac_lab/__init__.py
@@ -91,6 +91,14 @@ from npa.serverless_common import (
     split_serverless_env,
     validate_output_path,
 )
+from npa.workbench.training_config import (
+    TrainingConfig,
+    TrainingConfigError,
+    build_training_config,
+    checkpoint_s3_uri as resolve_checkpoint_s3_uri,
+    shell_env_exports,
+    upload_checkpoint_path,
+)
 
 app = typer.Typer(
     name="isaac-lab",
@@ -229,6 +237,7 @@ def _isaac_lab_serverless_train_command(
     steps: int,
     *,
     run_name: str = "npa-serverless",
+    training_config: TrainingConfig | None = None,
 ) -> str:
     local_dir = "/tmp/npa-isaac-lab-train"
     upload = build_serverless_output_upload_cmd(local_dir, "")
@@ -244,6 +253,7 @@ def _isaac_lab_serverless_train_command(
             local_dir,
             run_name=run_name,
             python_bin="${NPA_PYTHON_BIN}",
+            training_config=training_config,
         )
         + f'\necho "NPA_ISAAC_LAB_SERVERLESS_TRAIN_DONE ${{NPA_OUTPUT_PATH:-}}"\n{upload}'
     )
@@ -267,6 +277,7 @@ def _isaac_lab_serverless_train(
     poll_interval: float,
     timeout: float,
     output_format: OutputFormat,
+    training_config: TrainingConfig,
 ) -> None:
     if not output_path:
         _fail("Isaac Lab train --runtime serverless requires --output-path.")
@@ -303,6 +314,9 @@ def _isaac_lab_serverless_train(
             "ISAAC_LAB_TASK": task,
         },
     )
+    env.update(training_config.env())
+    safe_env, secret_env = split_serverless_env(env)
+    extra_env.update(secret_env)
     client = ServerlessClient()
     try:
         existing = client.get_job(name, resolved_project_id)
@@ -322,13 +336,14 @@ def _isaac_lab_serverless_train(
                 num_envs,
                 steps,
                 run_name=name,
+                training_config=training_config,
             ),
             gpu_type=platform,
             gpu_count=resolved_gpu_count,
             preset=preset,
             subnet_id=subnet,
             output_path=out,
-            env=env,
+            env=safe_env,
             extra_env=extra_env,
         )
         if not submit_only:
@@ -356,6 +371,28 @@ def _is_s3_uri(path: str) -> bool:
     return path.startswith("s3://")
 
 
+def _ssh_client_for_training(cfg: Any, training_config: TrainingConfig) -> SSHClient:
+    tokens = dict(getattr(cfg.ssh, "tokens", {}) or {})
+    storage = getattr(cfg, "storage", None)
+    if storage is not None:
+        if endpoint_url := getattr(storage, "endpoint_url", ""):
+            tokens["AWS_ENDPOINT_URL"] = endpoint_url
+            tokens["NEBIUS_S3_ENDPOINT"] = endpoint_url
+        if access_key := getattr(storage, "aws_access_key_id", ""):
+            tokens["AWS_ACCESS_KEY_ID"] = access_key
+        if secret_key := getattr(storage, "aws_secret_access_key", ""):
+            tokens["AWS_SECRET_ACCESS_KEY"] = secret_key
+    tokens.update(training_config.env())
+    return SSHClient(
+        SSHConfig(
+            host=cfg.ssh.host,
+            user=cfg.ssh.user,
+            key_path=cfg.ssh.key_path,
+            tokens={key: value for key, value in tokens.items() if value},
+        )
+    )
+
+
 def _storage_client(
     cfg,
     *,
@@ -381,6 +418,7 @@ def _upload_remote_directory_to_s3(
     output_path: str,
     *,
     target_project: str | None = None,
+    training_config: TrainingConfig | None = None,
 ) -> str:
     archive_remote = f"/tmp/npa-isaac-lab-output-{int(time.time() * 1000)}.tgz"
     with tempfile.TemporaryDirectory(prefix="npa-isaac-lab-output-") as tmp:
@@ -398,6 +436,8 @@ def _upload_remote_directory_to_s3(
         extract_dir.mkdir(parents=True, exist_ok=True)
         with tarfile.open(archive_local, "r:gz") as archive:
             archive.extractall(extract_dir, filter="data")
+        if training_config and training_config.checkpoint_s3.uri:
+            return upload_checkpoint_path(extract_dir, training_config)
         return _storage_client(cfg, project=target_project).upload_directory(
             str(extract_dir), output_path
         )
@@ -687,7 +727,9 @@ def _build_rsl_rl_train_shell(
     *,
     run_name: str,
     python_bin: str,
+    training_config: TrainingConfig | None = None,
 ) -> str:
+    config = training_config or TrainingConfig()
     task_q = shlex.quote(task)
     num_envs_q = shlex.quote(str(num_envs))
     iterations_q = shlex.quote(str(iterations))
@@ -695,12 +737,21 @@ def _build_rsl_rl_train_shell(
     run_name_q = shlex.quote(run_name)
     python_bin_q = shlex.quote(python_bin)
     train_rel_q = shlex.quote(ISAAC_LAB_RSL_RL_TRAIN_REL)
-    return (
+    training_env = shell_env_exports(config.wandb.env())
+    wandb_args: list[str] = []
+    if config.wandb.enabled:
+        wandb_args.extend(["--logger", "wandb"])
+        if config.wandb.project:
+            wandb_args.extend(["--log_project_name", config.wandb.project])
+    hydra_args = ["agent.save_interval=1", *config.overrides]
+    extra_cmd_lines = "".join(f"  {shlex.quote(arg)}\n" for arg in [*wandb_args, *hydra_args])
+    script = (
         f"""\
-export PYTHONUNBUFFERED=1
-TASK={task_q}
-NUM_ENVS={num_envs_q}
-MAX_ITERATIONS={iterations_q}
+	export PYTHONUNBUFFERED=1
+	{training_env}
+	TASK={task_q}
+	NUM_ENVS={num_envs_q}
+	MAX_ITERATIONS={iterations_q}
 OUTPUT_DIR={output_dir_q}
 RUN_NAME={run_name_q}
 EXPERIMENT_NAME=npa_isaac_lab
@@ -944,11 +995,11 @@ cmd=(
   --task "$TASK"
   --num_envs "$NUM_ENVS"
   --max_iterations "$MAX_ITERATIONS"
-  --headless
-  --experiment_name "$EXPERIMENT_NAME"
-  --run_name "$RUN_NAME"
-  agent.save_interval=1
-)
+	  --headless
+	  --experiment_name "$EXPERIMENT_NAME"
+	  --run_name "$RUN_NAME"
+	{extra_cmd_lines.rstrip()}
+	)
 printf 'ISAAC_LAB_RSL_RL_COMMAND'
 printf ' %q' "${cmd[@]}"
 printf '\\n'
@@ -981,6 +1032,15 @@ manifest = {
     "format": "npa_isaac_lab_rsl_rl_checkpoint_v1",
     "tool": "isaac_lab",
     "framework": "rsl_rl",
+    "data_path": os.environ.get("NPA_TRAINING_DATA_PATH", ""),
+    "overrides": json.loads(os.environ.get("NPA_TRAINING_OVERRIDES_JSON", "[]")),
+    "wandb": {
+        "enabled": os.environ.get("NPA_TRAINING_WANDB_ENABLED", "0") == "1",
+        "project": os.environ.get("NPA_TRAINING_WANDB_PROJECT", ""),
+        "run_name": os.environ.get("NPA_TRAINING_WANDB_RUN_NAME", ""),
+        "mode": os.environ.get("WANDB_MODE", ""),
+    },
+    "checkpoint_s3_uri": os.environ.get("NPA_CHECKPOINT_S3_URI", ""),
     "task": os.environ["NPA_ISAAC_LAB_TASK"],
     "num_envs": int(os.environ["NPA_ISAAC_LAB_NUM_ENVS"]),
     "max_iterations": int(os.environ["NPA_ISAAC_LAB_MAX_ITERATIONS"]),
@@ -1022,9 +1082,10 @@ set -e
 if [ "$train_rc" -ne 0 ]; then
   exit "$train_rc"
 fi
-exit "$summary_rc"
-"""
+	exit "$summary_rc"
+	"""
     )
+    return script.replace("{extra_cmd_lines.rstrip()}", extra_cmd_lines.rstrip())
 
 def _build_eval_script(
     task: str, checkpoint: str, num_episodes: int, output_dir: str
@@ -2252,10 +2313,24 @@ def train_cmd(
         "",
         "--output-path",
         "-o",
-        help="S3 URI where training artifacts are written.",
+        help="Compatibility S3 URI where training artifacts are written. Prefer --checkpoint-s3-uri for BYO S3.",
     ),
     # Deprecated path alias: keep --output-dir working for existing scripts.
     output_dir: str = typer.Option("", "--output-dir", hidden=True),
+    data_path: str = typer.Option("", "--data-path", help="Canonical training data path metadata or mounted dataset URI."),
+    override: list[str] = typer.Option(
+        [],
+        "--override",
+        help="Generic Hydra override as KEY=VALUE. Repeat for learning rate, clip params, terminations, or any trainer key.",
+    ),
+    wandb_enabled: bool = typer.Option(False, "--wandb/--no-wandb", help="Enable W&B logging for the training run."),
+    wandb_project: str = typer.Option("", "--wandb-project", help="W&B project name."),
+    wandb_run_name: str = typer.Option("", "--wandb-run-name", help="W&B run name."),
+    wandb_mode: str = typer.Option("offline", "--wandb-mode", help="W&B mode such as online, offline, or disabled."),
+    checkpoint_s3_uri: str = typer.Option("", "--checkpoint-s3-uri", help="S3 URI for checkpoint upload."),
+    checkpoint_s3_endpoint_url: str = typer.Option("", "--checkpoint-s3-endpoint-url", help="S3-compatible endpoint URL."),
+    checkpoint_s3_access_key_id: str = typer.Option("", "--checkpoint-s3-access-key-id", help="S3 access key ID."),
+    checkpoint_s3_secret_access_key: str = typer.Option("", "--checkpoint-s3-secret-access-key", help="S3 secret access key."),
     runtime: WorkbenchRuntime = typer.Option(WorkbenchRuntime.vm, "--runtime", help="Runtime. serverless creates a Nebius AI Job."),
     project_id: str = typer.Option("", "--project-id", help="Nebius project ID for serverless Jobs."),
     image: str = typer.Option("", "--image", help="Container image for the serverless Job."),
@@ -2272,16 +2347,32 @@ def train_cmd(
     ),
 ) -> None:
     """Run Isaac Lab training on the VM via SSH."""
+    try:
+        training_config = build_training_config(
+            data_path=data_path,
+            overrides=override,
+            wandb_enabled=wandb_enabled,
+            wandb_project=wandb_project,
+            wandb_run_name=wandb_run_name,
+            wandb_mode=wandb_mode,
+            checkpoint_s3_uri=checkpoint_s3_uri,
+            checkpoint_s3_endpoint_url=checkpoint_s3_endpoint_url,
+            checkpoint_s3_access_key_id=checkpoint_s3_access_key_id,
+            checkpoint_s3_secret_access_key=checkpoint_s3_secret_access_key,
+        )
+    except TrainingConfigError as exc:
+        _fail(str(exc))
     if num_envs <= 0:
         _fail(f"--num-envs must be positive, got {num_envs}")
     if steps <= 0:
         _fail(f"--steps must be positive, got {steps}")
+    checkpoint_output_path = resolve_checkpoint_s3_uri(training_config, output_path)
     if _is_serverless_runtime(runtime):
         _isaac_lab_serverless_train(
             task=task,
             num_envs=num_envs,
             steps=steps,
-            output_path=output_path,
+            output_path=checkpoint_output_path,
             project_id=project_id,
             image=image,
             gpu_type=gpu_type,
@@ -2293,18 +2384,19 @@ def train_cmd(
             poll_interval=poll_interval,
             timeout=timeout,
             output_format=output_format,
+            training_config=training_config,
         )
         return
 
     cfg = _get_ssh_config()
     try:
-        if output_path:
-            output_path = validate_write_path(output_path, tool="Isaac Lab train")
+        if checkpoint_output_path:
+            checkpoint_output_path = validate_write_path(checkpoint_output_path, tool="Isaac Lab train")
     except PathContractError as exc:
         _fail(str(exc))
         return
-    ssh = SSHClient(cfg.ssh)
-    target_output = output_path or output_dir or f"{ISAAC_LAB_HOME}/runs"
+    ssh = _ssh_client_for_training(cfg, training_config)
+    target_output = checkpoint_output_path or output_dir or f"{ISAAC_LAB_HOME}/runs"
     output_is_s3 = _is_s3_uri(target_output)
     remote_output_dir = (
         f"{ISAAC_LAB_HOME}/runs/npa-train-{int(time.time())}"
@@ -2325,6 +2417,7 @@ def train_cmd(
             remote_output_dir,
             run_name=run_name,
             python_bin=python_bin,
+            training_config=training_config,
         ),
     )
     stream_logs = output_format != OutputFormat.json
@@ -2353,6 +2446,7 @@ def train_cmd(
         "output_path": target_output,
         "output_dir": remote_output_dir,
         "duration_seconds": round(time.time() - start, 1),
+        "training_config": training_config.public_dict(),
     }
     if exit_code != 0:
         result["stderr"] = stderr.strip()[-500:] if stderr else ""
@@ -2361,7 +2455,11 @@ def train_cmd(
             try:
                 try:
                     result["output_path"] = _upload_remote_directory_to_s3(
-                        ssh, cfg, remote_output_dir, target_output
+                        ssh,
+                        cfg,
+                        remote_output_dir,
+                        target_output,
+                        training_config=training_config,
                     )
                     result["upload_mode"] = "local"
                 except Exception as local_exc:

--- a/npa/src/npa/cli/workbench/detection_training.py
+++ b/npa/src/npa/cli/workbench/detection_training.py
@@ -21,8 +21,10 @@ from npa.workbench.detection_training.schemas import (
     DEFAULT_LANCE_URI,
     DEFAULT_PORT,
     DEFAULT_TOKEN_ENV,
+    CheckpointS3Settings,
     EvalRequest,
     TrainRequest,
+    WandbSettings,
 )
 
 app = typer.Typer(
@@ -141,8 +143,22 @@ def deploy_cmd(
 
 def train_cmd(
     view: str = typer.Option(..., "--view", help="Lance materialized view name."),
-    output_uri: str = typer.Option(..., "--output-uri", "--output-path", help="S3/local output URI."),
-    lance_uri: str = typer.Option(DEFAULT_LANCE_URI, "--lance-uri", "--input-path", help="LanceDB URI."),
+    output_uri: str = typer.Option("", "--output-uri", "--output-path", help="S3/local output URI."),
+    data_path: str = typer.Option("", "--data-path", help="Custom LanceDB training data URI."),
+    lance_uri: str = typer.Option(DEFAULT_LANCE_URI, "--lance-uri", "--input-path", help="Compatibility alias for --data-path."),
+    override: list[str] = typer.Option(
+        [],
+        "--override",
+        help="Generic override as KEY=VALUE. Supported keys map to detection-training request fields.",
+    ),
+    wandb_enabled: bool = typer.Option(False, "--wandb/--no-wandb", help="Enable W&B logging for the training run."),
+    wandb_project: str = typer.Option("", "--wandb-project", help="W&B project name."),
+    wandb_run_name: str = typer.Option("", "--wandb-run-name", help="W&B run name."),
+    wandb_mode: str = typer.Option("offline", "--wandb-mode", help="W&B mode such as online, offline, or disabled."),
+    checkpoint_s3_uri: str = typer.Option("", "--checkpoint-s3-uri", help="S3 URI for checkpoint upload."),
+    checkpoint_s3_endpoint_url: str = typer.Option("", "--checkpoint-s3-endpoint-url", help="S3-compatible endpoint URL."),
+    checkpoint_s3_access_key_id: str = typer.Option("", "--checkpoint-s3-access-key-id", help="S3 access key ID."),
+    checkpoint_s3_secret_access_key: str = typer.Option("", "--checkpoint-s3-secret-access-key", help="S3 secret access key."),
     num_classes: int = typer.Option(10, "--num-classes", help="Detector class count."),
     epochs: int = typer.Option(10, "--epochs", help="Training epochs."),
     batch_size: int = typer.Option(8, "--batch-size", help="Training batch size."),
@@ -154,10 +170,28 @@ def train_cmd(
     output: OutputFormat = typer.Option(OutputFormat.json, "--output", help="Output format."),
 ) -> None:
     """Start a detection-training run."""
+    checkpoint_s3 = CheckpointS3Settings(
+        uri=checkpoint_s3_uri,
+        endpoint_url=checkpoint_s3_endpoint_url,
+        aws_access_key_id=checkpoint_s3_access_key_id,
+        aws_secret_access_key=checkpoint_s3_secret_access_key,
+    )
+    effective_output_uri = output_uri or checkpoint_s3.uri
+    if not effective_output_uri:
+        fail("--output-uri or --checkpoint-s3-uri is required")
     payload = TrainRequest(
         view=view,
-        lance_uri=lance_uri,
-        output_uri=output_uri,
+        lance_uri=data_path or lance_uri,
+        data_path=data_path,
+        output_uri=effective_output_uri,
+        overrides=override,
+        wandb=WandbSettings(
+            enabled=wandb_enabled,
+            project=wandb_project,
+            run_name=wandb_run_name,
+            mode=wandb_mode,
+        ),
+        checkpoint_s3=checkpoint_s3,
         num_classes=num_classes,
         epochs=epochs,
         batch_size=batch_size,

--- a/npa/src/npa/cli/workbench/lerobot.py
+++ b/npa/src/npa/cli/workbench/lerobot.py
@@ -25,6 +25,7 @@ from npa.clients.config import (
     APP_STATUS_INSTALLING,
     APP_STATUS_PROVISIONED,
     ConfigError,
+    SSHConfig,
     default_project_name,
     default_workbench_name,
     resolve_config,
@@ -41,6 +42,17 @@ from npa.clients.endpoint import EndpointError, service_endpoint
 from npa.clients.serverless import EndpointNotFoundError, JobInfo, ServerlessClient, ServerlessClientError
 from npa.deploy.images import container_image_for_tool, supported_tool_version
 from npa.serverless_common import SubnetResolutionError, resolve_subnet
+from npa.workbench.training_config import (
+    TrainingConfig,
+    TrainingConfigError,
+    build_training_config,
+    checkpoint_s3_uri as resolve_checkpoint_s3_uri,
+    overrides_to_mapping,
+    render_overrides,
+    shell_env_exports,
+    upload_checkpoint_path,
+    wandb_overrides,
+)
 from npa.deploy.byovm import (
     RUNTIME_HELP,
     apply_project_storage_vars,
@@ -112,6 +124,36 @@ def is_serverless_runtime(runtime: WorkbenchRuntime | str) -> bool:
 class OutputFormat(str, Enum):
     text = "text"
     json = "json"
+
+
+def _training_storage_tokens(cfg: Any, training_config: TrainingConfig) -> dict[str, str]:
+    tokens: dict[str, str] = {}
+    storage = getattr(cfg, "storage", None)
+    if storage is not None:
+        if endpoint_url := getattr(storage, "endpoint_url", ""):
+            tokens["AWS_ENDPOINT_URL"] = endpoint_url
+            tokens["NEBIUS_S3_ENDPOINT"] = endpoint_url
+        if access_key := getattr(storage, "aws_access_key_id", ""):
+            tokens["AWS_ACCESS_KEY_ID"] = access_key
+        if secret_key := getattr(storage, "aws_secret_access_key", ""):
+            tokens["AWS_SECRET_ACCESS_KEY"] = secret_key
+    tokens.update(training_config.env())
+    return {key: value for key, value in tokens.items() if value}
+
+
+def _ssh_client_for_training(cfg: Any, training_config: TrainingConfig) -> Any:
+    from npa.clients.ssh import SSHClient
+
+    tokens = dict(getattr(cfg.ssh, "tokens", {}) or {})
+    tokens.update(_training_storage_tokens(cfg, training_config))
+    return SSHClient(
+        SSHConfig(
+            host=cfg.ssh.host,
+            user=cfg.ssh.user,
+            key_path=cfg.ssh.key_path,
+            tokens=tokens,
+        )
+    )
 
 
 @app.callback()
@@ -666,19 +708,22 @@ def _lerobot_train_container_command(
     env_task: str = "",
     device: str = "cuda",
     smoke: bool = False,
+    training_config: TrainingConfig | None = None,
 ) -> str:
+    config = training_config or TrainingConfig()
     effective_steps = 50 if smoke else steps
     effective_batch = 4 if smoke else batch_size
     output_dir = "/tmp/lerobot_output"
     dataset_setup_cmd = ""
-    if input_path:
-        if _is_s3_uri(input_path):
-            resolved_dataset = f"/tmp/lerobot_dataset/{_path_name(input_path)}"
-            dataset_setup_cmd = _remote_download_dir_cmd(input_path, resolved_dataset) + " && "
+    data_path = config.data_path or input_path
+    if data_path:
+        if _is_s3_uri(data_path):
+            resolved_dataset = f"/tmp/lerobot_dataset/{_path_name(data_path)}"
+            dataset_setup_cmd = _remote_download_dir_cmd(data_path, resolved_dataset) + " && "
         else:
-            resolved_dataset = input_path
+            resolved_dataset = data_path
         dataset_arg = (
-            f"--dataset.repo_id={shlex.quote(_path_name(input_path))} "
+            f"--dataset.repo_id={shlex.quote(_path_name(data_path))} "
             f"--dataset.root={shlex.quote(resolved_dataset)} "
         )
     else:
@@ -686,11 +731,18 @@ def _lerobot_train_container_command(
     env_type_arg = f"--env.type={shlex.quote(env_type)} " if env_type else ""
     env_task_arg = f"--env.task={shlex.quote(env_task)} " if env_task else ""
     num_workers_arg = f"--num_workers={num_workers} " if num_workers >= 0 else ""
+    wandb_args = shlex.join(wandb_overrides(config.wandb, style="cli"))
+    override_args = render_overrides(config.overrides, style="cli")
+    extra_args = " ".join(arg for arg in (wandb_args, override_args) if arg)
+    extra_args = f"{extra_args} " if extra_args else ""
+    training_env = shell_env_exports(config.wandb.env())
+    training_env = f"{training_env} " if training_env else ""
     command = (
         "set -euo pipefail && "
         "cd /opt/lerobot && "
         "source /opt/lerobot/venv/bin/activate && "
         "if [ -f /opt/lerobot/.env ]; then set -a && source /opt/lerobot/.env && set +a; fi && "
+        f"{training_env}"
         "mkdir -p /tmp/hf_home && "
         f"{dataset_setup_cmd}"
         f"lerobot-train "
@@ -707,7 +759,8 @@ def _lerobot_train_container_command(
         f"--batch_size={effective_batch} "
         f"--policy.device={shlex.quote(device)} "
         f"--eval.batch_size=1 "
-        f"--eval.n_episodes=1 && "
+        f"--eval.n_episodes=1 "
+        f"{extra_args}&& "
         f"{_serverless_upload_output_cmd(output_dir)} && "
         "echo NPA_TRAIN_COMPLETE"
     )
@@ -847,11 +900,13 @@ def _train_serverless(
     poll_interval: float,
     wait_timeout: int,
     output: OutputFormat,
+    training_config: TrainingConfig,
 ) -> None:
     if num_workers < -1:
         _fail(f"--num-workers must be -1 (omit) or >= 0, got {num_workers}")
     if gpu_count < 0:
         _fail(f"--gpu-count must be 0 (default 1 for serverless) or positive, got {gpu_count}")
+    input_path = training_config.data_path or input_path
     dataset_ref = input_path or dataset
     if not dataset_ref:
         _fail("Provide --dataset or --input-path.")
@@ -903,12 +958,13 @@ def _train_serverless(
     s3_access_key, s3_secret_key, s3_endpoint = _serverless_storage_env_values(storage, credentials, out)
     env = _lerobot_serverless_job_env(
         credentials.hf_token,
-        s3_access_key,
-        s3_secret_key,
+        training_config.checkpoint_s3.aws_access_key_id or s3_access_key,
+        training_config.checkpoint_s3.aws_secret_access_key or s3_secret_key,
         out,
-        s3_endpoint=s3_endpoint,
+        s3_endpoint=training_config.checkpoint_s3.endpoint_url or s3_endpoint,
     )
     env["NPA_JOB_NAME"] = name
+    env.update(training_config.env())
     safe_env, extra_env = _split_serverless_env(env)
     submitted_at = datetime.now(timezone.utc).isoformat()
     try:
@@ -934,6 +990,7 @@ def _train_serverless(
                 env_task=env_task,
                 device=device,
                 smoke=smoke,
+                training_config=training_config,
             ),
             gpu_type=platform,
             gpu_count=gpu_count or 1,
@@ -1157,10 +1214,15 @@ def _profile_train_serverless(
 def train(
     policy_type: str = typer.Option(..., "--policy-type", help="Policy type (act, diffusion, smolvla)."),
     dataset: str = typer.Option("", "--dataset", help="HF dataset repo ID."),
+    data_path: str = typer.Option(
+        "",
+        "--data-path",
+        help="Canonical local or S3 training data path. Overrides --dataset and compatibility --input-path.",
+    ),
     input_path: str = typer.Option(
         "",
         "--input-path",
-        help="S3 URI for a LeRobotDataset. Overrides --dataset.",
+        help="Compatibility alias for --data-path.",
     ),
     job_name: str = typer.Option(..., "--job-name", help="Unique name for this training run."),
     steps: int = typer.Option(5000, "--steps", help="Training steps."),
@@ -1173,8 +1235,21 @@ def train(
     output_path: str = typer.Option(
         "",
         "--output-path",
-        help="S3 URI where the checkpoint output is written.",
+        help="Compatibility checkpoint output URI. Prefer --checkpoint-s3-uri for BYO S3.",
     ),
+    override: list[str] = typer.Option(
+        [],
+        "--override",
+        help="Generic Hydra override as KEY=VALUE. Repeat for learning rate, clip params, terminations, or any trainer key.",
+    ),
+    wandb_enabled: bool = typer.Option(False, "--wandb/--no-wandb", help="Enable W&B logging for the training run."),
+    wandb_project: str = typer.Option("", "--wandb-project", help="W&B project name."),
+    wandb_run_name: str = typer.Option("", "--wandb-run-name", help="W&B run name."),
+    wandb_mode: str = typer.Option("offline", "--wandb-mode", help="W&B mode such as online, offline, or disabled."),
+    checkpoint_s3_uri: str = typer.Option("", "--checkpoint-s3-uri", help="S3 URI for checkpoint upload."),
+    checkpoint_s3_endpoint_url: str = typer.Option("", "--checkpoint-s3-endpoint-url", help="S3-compatible endpoint URL."),
+    checkpoint_s3_access_key_id: str = typer.Option("", "--checkpoint-s3-access-key-id", help="S3 access key ID."),
+    checkpoint_s3_secret_access_key: str = typer.Option("", "--checkpoint-s3-secret-access-key", help="S3 secret access key."),
     runtime: WorkbenchRuntime = typer.Option(WorkbenchRuntime.vm, "--runtime", help="Runtime backend: vm, container, byovm, or serverless."),
     project_id: str = typer.Option("", "--project-id", help="Nebius project ID override for serverless Jobs."),
     image: str = typer.Option("", "--image", help="Container image override for serverless Jobs."),
@@ -1188,6 +1263,24 @@ def train(
 ) -> None:
     """Run lerobot-train on the VM via SSH, stream logs."""
     try:
+        training_config = build_training_config(
+            data_path=data_path or input_path,
+            overrides=override,
+            wandb_enabled=wandb_enabled,
+            wandb_project=wandb_project,
+            wandb_run_name=wandb_run_name,
+            wandb_mode=wandb_mode,
+            checkpoint_s3_uri=checkpoint_s3_uri,
+            checkpoint_s3_endpoint_url=checkpoint_s3_endpoint_url,
+            checkpoint_s3_access_key_id=checkpoint_s3_access_key_id,
+            checkpoint_s3_secret_access_key=checkpoint_s3_secret_access_key,
+        )
+    except TrainingConfigError as exc:
+        _fail(str(exc))
+        return
+    input_path = training_config.data_path
+    checkpoint_output_path = resolve_checkpoint_s3_uri(training_config, output_path)
+    try:
         if input_path:
             input_path = validate_read_path(
                 input_path,
@@ -1195,14 +1288,29 @@ def train(
                 option="--input-path",
                 allow_hf=False,
             )
-        output_path = validate_write_path(output_path, tool="LeRobot train")
+            training_config = build_training_config(
+                data_path=input_path,
+                overrides=override,
+                wandb_enabled=wandb_enabled,
+                wandb_project=wandb_project,
+                wandb_run_name=wandb_run_name,
+                wandb_mode=wandb_mode,
+                checkpoint_s3_uri=checkpoint_s3_uri,
+                checkpoint_s3_endpoint_url=checkpoint_s3_endpoint_url,
+                checkpoint_s3_access_key_id=checkpoint_s3_access_key_id,
+                checkpoint_s3_secret_access_key=checkpoint_s3_secret_access_key,
+            )
+        checkpoint_output_path = validate_write_path(checkpoint_output_path, tool="LeRobot train")
     except PathContractError as exc:
+        _fail(str(exc))
+        return
+    except TrainingConfigError as exc:
         _fail(str(exc))
         return
 
     dataset_ref = input_path or dataset
     if not dataset_ref:
-        _fail("Provide --dataset or --input-path.")
+        _fail("Provide --dataset or --data-path.")
         return
 
     if is_serverless_runtime(runtime):
@@ -1221,7 +1329,7 @@ def train(
             device=device,
             env_type=env_type,
             env_task=env_task,
-            output_path=output_path,
+            output_path=checkpoint_output_path,
             image=image,
             gpu_type=gpu_type,
             subnet_id=subnet_id,
@@ -1230,19 +1338,20 @@ def train(
             poll_interval=poll_interval,
             wait_timeout=wait_timeout,
             output=output,
+            training_config=training_config,
         )
         return
 
     cfg = _get_config()
 
-    from npa.clients.ssh import SSHClient, SSHError
+    from npa.clients.ssh import SSHError
 
-    ssh = SSHClient(cfg.ssh)
+    ssh = _ssh_client_for_training(cfg, training_config)
     stream_logs = output != OutputFormat.json
 
-    output_is_s3 = _is_s3_uri(output_path)
+    output_is_s3 = _is_s3_uri(checkpoint_output_path)
     checkpoint_dir = (
-        output_path if output_path and not output_is_s3 else f"/opt/lerobot/checkpoints/{job_name}"
+        checkpoint_output_path if checkpoint_output_path and not output_is_s3 else f"/opt/lerobot/checkpoints/{job_name}"
     )
     status_dir = "/opt/lerobot/job_status"
 
@@ -1251,17 +1360,17 @@ def train(
         return
 
     dataset_setup_cmd = ""
-    if input_path:
-        if _is_s3_uri(input_path):
-            resolved_dataset = _remote_cache_dir("dataset", input_path)
+    if training_config.data_path:
+        if _is_s3_uri(training_config.data_path):
+            resolved_dataset = _remote_cache_dir("dataset", training_config.data_path)
             dataset_setup_cmd = (
-                _remote_download_dir_cmd(input_path, resolved_dataset, cfg.storage.endpoint_url)
+                _remote_download_dir_cmd(training_config.data_path, resolved_dataset, cfg.storage.endpoint_url)
                 + " && "
             )
         else:
-            resolved_dataset = input_path
+            resolved_dataset = training_config.data_path
         dataset_arg = (
-            f"--dataset.repo_id={_path_name(input_path)} "
+            f"--dataset.repo_id={_path_name(training_config.data_path)} "
             f"--dataset.root={resolved_dataset} "
         )
     else:
@@ -1283,11 +1392,18 @@ def train(
         )
     else:
         train_launcher = "lerobot-train"
+    wandb_args = shlex.join(wandb_overrides(training_config.wandb, style="cli"))
+    override_args = render_overrides(training_config.overrides, style="cli")
+    extra_train_args = " ".join(arg for arg in (wandb_args, override_args) if arg)
+    extra_train_args = f"{extra_train_args} " if extra_train_args else ""
+    training_env = shell_env_exports(training_config.wandb.env())
+    training_env = f"{training_env} " if training_env else ""
 
     cmd = (
         f"source /opt/lerobot/venv/bin/activate && "
         f"set -a && source /opt/lerobot/.env && set +a && "
         f"export CUDA_VISIBLE_DEVICES={visible_devices} && "
+        f"{training_env}"
         f"mkdir -p {status_dir} && "
         f"{dataset_setup_cmd}"
         f"START_TS=$(date +%s) && "
@@ -1305,7 +1421,8 @@ def train(
         f"--batch_size={batch_size} "
         f"--policy.device={device} "
         f"--eval.batch_size=1 "
-        f"--eval.n_episodes=1 && "
+        f"--eval.n_episodes=1 "
+        f"{extra_train_args}&& "
         f"END_TS=$(date +%s) && "
         f"DURATION=$((END_TS - START_TS)) && "
         f"echo '{{\"status\": \"success\", \"job_name\": \"{job_name}\", "
@@ -1333,23 +1450,24 @@ def train(
         "job_name": job_name,
         "checkpoint_path": ckpt_path if exit_code == 0 else None,
         "duration_seconds": duration,
+        "training_config": training_config.public_dict(),
     }
 
     if exit_code != 0:
         result["stderr"] = stderr.strip()[-500:] if stderr else ""
 
-    if exit_code == 0 and output_path:
+    if exit_code == 0 and checkpoint_output_path:
         if output_is_s3:
             if stream_logs:
-                console.print(f"[bold]Uploading checkpoint to {output_path}...[/bold]")
+                console.print(f"[bold]Uploading checkpoint to {checkpoint_output_path}...[/bold]")
             upload_cmd = (
                 f"source /opt/lerobot/venv/bin/activate && "
                 f"set -a && source /opt/lerobot/.env && set +a && "
-                f"{_remote_upload_dir_cmd(ckpt_path, output_path, cfg.storage.endpoint_url)}"
+                f"{_remote_upload_dir_cmd(ckpt_path, checkpoint_output_path, training_config.checkpoint_s3.endpoint_url or cfg.storage.endpoint_url)}"
             )
             up_code, up_out, up_err = ssh.run(_runtime_exec_cmd(cfg, upload_cmd))
             if up_code == 0:
-                result["output_path"] = output_path.rstrip("/") + "/"
+                result["output_path"] = checkpoint_output_path.rstrip("/") + "/"
             else:
                 result["status"] = "failed"
                 result["exit_code"] = up_code or 1
@@ -3007,6 +3125,20 @@ def train_student_cmd(
         "--input-path",
         help="S3 URI for a LeRobotDataset v3 directory. Overrides --dataset.",
     ),
+    data_path: str = typer.Option("", "--data-path", help="Custom LeRobotDataset v3 directory path."),
+    override: list[str] = typer.Option(
+        [],
+        "--override",
+        help="Generic trainer override as KEY=VALUE. Repeat for any LeRobot training key.",
+    ),
+    wandb_enabled: bool = typer.Option(False, "--wandb/--no-wandb", help="Enable W&B logging for the training run."),
+    wandb_project: str = typer.Option("", "--wandb-project", help="W&B project name."),
+    wandb_run_name: str = typer.Option("", "--wandb-run-name", help="W&B run name."),
+    wandb_mode: str = typer.Option("offline", "--wandb-mode", help="W&B mode such as online, offline, or disabled."),
+    checkpoint_s3_uri: str = typer.Option("", "--checkpoint-s3-uri", help="S3 URI for checkpoint upload."),
+    checkpoint_s3_endpoint_url: str = typer.Option("", "--checkpoint-s3-endpoint-url", help="S3-compatible endpoint URL."),
+    checkpoint_s3_access_key_id: str = typer.Option("", "--checkpoint-s3-access-key-id", help="S3 access key ID."),
+    checkpoint_s3_secret_access_key: str = typer.Option("", "--checkpoint-s3-secret-access-key", help="S3 secret access key."),
     policy: str = typer.Option("act", "--policy", help="Policy type (act, diffusion)."),
     epochs: int = typer.Option(100, "--epochs", help="Number of training epochs."),
     batch_size: int = typer.Option(64, "--batch-size", help="Batch size."),
@@ -3028,20 +3160,39 @@ def train_student_cmd(
     The student sees only camera observations and joint state — never privileged
     simulator state.
     """
-    dataset_ref = input_path or dataset
+    try:
+        training_config = build_training_config(
+            data_path=data_path,
+            overrides=override,
+            wandb_enabled=wandb_enabled,
+            wandb_project=wandb_project,
+            wandb_run_name=wandb_run_name,
+            wandb_mode=wandb_mode,
+            checkpoint_s3_uri=checkpoint_s3_uri,
+            checkpoint_s3_endpoint_url=checkpoint_s3_endpoint_url,
+            checkpoint_s3_access_key_id=checkpoint_s3_access_key_id,
+            checkpoint_s3_secret_access_key=checkpoint_s3_secret_access_key,
+        )
+    except TrainingConfigError as exc:
+        _fail(str(exc))
+        return
+    dataset_ref = training_config.data_path or input_path or dataset
     if not dataset_ref:
-        _fail("Provide --dataset or --input-path.")
+        _fail("Provide --data-path, --dataset, or --input-path.")
         return
     try:
-        if input_path:
-            input_path = validate_read_path(
-                input_path,
+        if training_config.data_path or input_path:
+            resolved_input = validate_read_path(
+                training_config.data_path or input_path,
                 tool="LeRobot train-student",
-                option="--input-path",
+                option="--data-path",
                 allow_hf=False,
             )
-            dataset_ref = input_path
-        output_path = validate_write_path(output_path, tool="LeRobot train-student")
+            dataset_ref = resolved_input
+        output_path = validate_write_path(
+            resolve_checkpoint_s3_uri(training_config, output_path),
+            tool="LeRobot train-student",
+        )
     except PathContractError as exc:
         _fail(str(exc))
         return
@@ -3088,6 +3239,12 @@ def train_student_cmd(
             console.print(f"  output: {output_path or output_dir}")
 
         from npa.lerobot.train_student import StudentTrainingError, train_student
+        extra_args = {key: str(value) for key, value in overrides_to_mapping(training_config.overrides).items()}
+        extra_args["wandb.enable"] = "true" if training_config.wandb.enabled else "false"
+        if training_config.wandb.project:
+            extra_args["wandb.project"] = training_config.wandb.project
+        if training_config.wandb.run_name:
+            extra_args["wandb.name"] = training_config.wandb.run_name
 
         try:
             result = train_student(
@@ -3098,6 +3255,7 @@ def train_student_cmd(
                 batch_size=batch_size,
                 device=device,
                 num_workers=num_workers,
+                extra_args=extra_args,
                 stream=stream_logs,
             )
         except StudentTrainingError as exc:
@@ -3106,18 +3264,21 @@ def train_student_cmd(
 
         if output_path:
             if output_is_s3:
-                from npa.clients.storage import StorageClient
-
                 checkpoint_path = Path(
                     result.get("checkpoint_path")
                     or local_output_dir / "checkpoints" / "last" / "pretrained_model"
                 )
-                uploaded = StorageClient.from_environment().upload_directory(
-                    str(checkpoint_path), output_path
-                )
+                uploaded = upload_checkpoint_path(checkpoint_path, training_config)
+                if not uploaded:
+                    from npa.clients.storage import StorageClient
+
+                    uploaded = StorageClient.from_environment().upload_directory(
+                        str(checkpoint_path), output_path
+                    )
                 result["output_path"] = uploaded
             else:
                 result["output_path"] = result.get("checkpoint_path")
+        result["training_config"] = training_config.public_dict()
 
         if output == OutputFormat.json:
             typer.echo(json.dumps(result, indent=2))

--- a/npa/src/npa/cli/workbench/sonic/train.py
+++ b/npa/src/npa/cli/workbench/sonic/train.py
@@ -24,7 +24,14 @@ from npa.serverless_common import (
     build_serverless_output_upload_cmd,
     resolve_gpu_platform,
     resolve_subnet,
+    split_serverless_env,
     validate_output_path,
+)
+from npa.workbench.training_config import (
+    TrainingConfig,
+    TrainingConfigError,
+    build_training_config,
+    checkpoint_s3_uri as resolve_checkpoint_s3_uri,
 )
 import typer
 
@@ -39,63 +46,37 @@ def build_sonic_serverless_train_command(
     headless: bool,
     max_iterations: int,
     isaac_lab_version: str,
+    training_config: TrainingConfig | None = None,
 ) -> str:
-    """Build the remote command for a SONIC serverless smoke/train job."""
+    """Build the remote command for a real SONIC serverless train job."""
 
+    config = training_config or TrainingConfig()
     local_dir = "/tmp/npa-sonic-train"
-    script = f"""
-import importlib
-import json
-import os
-import pathlib
-import sys
-import time
-
-out = pathlib.Path("{local_dir}")
-out.mkdir(parents=True, exist_ok=True)
-started = time.time()
-
-def import_state(name):
-    try:
-        importlib.import_module(name)
-        return "available"
-    except Exception as exc:
-        return f"unavailable: {{type(exc).__name__}}: {{exc}}"
-
-gear_sonic_import = import_state("gear_sonic")
-isaaclab_import = import_state("isaaclab")
-isaaclab_app_import = import_state("isaaclab.app")
-ok = all(value == "available" for value in (gear_sonic_import, isaaclab_import, isaaclab_app_import))
-summary = {{
-    "status": "success" if ok else "failed",
-    "tool": "sonic",
-    "embodiment": {embodiment!r},
-    "checkpoint": {checkpoint!r},
-    "data_path": {data_path!r},
-    "sample_data": {sample_data},
-    "num_envs": {num_envs},
-    "headless": {headless},
-    "max_iterations": {max_iterations},
-    "isaac_lab_version": {isaac_lab_version!r},
-    "gear_sonic_import": gear_sonic_import,
-    "isaaclab_import": isaaclab_import,
-    "isaaclab_app_import": isaaclab_app_import,
-    "job": os.environ.get("NPA_JOB_NAME", ""),
-    "duration_seconds": round(time.time() - started, 3),
-}}
-(out / "sonic_smoke_result.json").write_text(json.dumps(summary, indent=2))
-(out / "sonic_train_summary.json").write_text(json.dumps(summary, indent=2))
-(out / "checkpoint_smoke.json").write_text(json.dumps({{"format": "npa_sonic_serverless_smoke_v1", **summary}}, indent=2))
-print("NPA_SONIC_SERVERLESS_TRAIN_DONE", os.environ.get("NPA_OUTPUT_PATH", ""), flush=True)
-sys.exit(0 if ok else 1)
-""".strip()
     upload = build_serverless_output_upload_cmd(local_dir, "")
+    training_env = config.env()
+    env_lines = "\n".join(f"export {key}={value!r}" for key, value in training_env.items())
     body = (
         'if [ -x /isaac-sim/python.sh ]; then NPA_PYTHON_BIN=/isaac-sim/python.sh; '
         'elif [ -x /opt/isaac-lab/venv/bin/python ]; then NPA_PYTHON_BIN=/opt/isaac-lab/venv/bin/python; '
         'else NPA_PYTHON_BIN="${NPA_PYTHON_BIN:-python3}"; fi\n'
         'if ! command -v "$NPA_PYTHON_BIN" >/dev/null 2>&1; then NPA_PYTHON_BIN=python; fi\n'
-        f'"$NPA_PYTHON_BIN" <<\'PY\'\n{script}\nPY\nsonic_rc=$?\n{upload}\nexit "$sonic_rc"'
+        f"{env_lines}\n"
+        f"export NPA_LOCAL_OUTPUT_DIR={local_dir!r}\n"
+        "export SONIC_RUN_REAL_TRAIN=1\n"
+        f"export SONIC_CHECKPOINT={checkpoint!r}\n"
+        f"export SONIC_CHECKPOINT_PATH={checkpoint!r}\n"
+        f"export SONIC_DATA_PATH={(config.data_path or data_path)!r}\n"
+        f"export SONIC_SAMPLE_DATA={'1' if sample_data else '0'}\n"
+        f"export SONIC_EMBODIMENT={embodiment!r}\n"
+        f"export SONIC_NUM_ENVS={str(num_envs)!r}\n"
+        f"export SONIC_HEADLESS={'True' if headless else 'False'}\n"
+        f"export SONIC_MAX_ITERATIONS={str(max_iterations)!r}\n"
+        f"export SONIC_ISAAC_LAB_VERSION={isaac_lab_version!r}\n"
+        'if [ -x /entrypoint.sh ]; then /entrypoint.sh train; '
+        'else echo "/entrypoint.sh not found in SONIC image" >&2; exit 127; fi\n'
+        "sonic_rc=$?\n"
+        f"{upload}\n"
+        'exit "$sonic_rc"'
     )
     return remote_bash(body)
 
@@ -123,6 +104,7 @@ def _run_serverless_train(
     poll_interval: float,
     timeout: float,
     output_format: OutputFormat,
+    training_config: TrainingConfig,
 ) -> None:
     if not output_path:
         fail("SONIC train --runtime serverless requires --output-path.")
@@ -164,6 +146,9 @@ def _run_serverless_train(
             "SONIC_CHECKPOINT": checkpoint,
         },
     )
+    env.update(training_config.env())
+    safe_env, secret_env = split_serverless_env(env)
+    extra_env.update(secret_env)
     client = ServerlessClient()
     try:
         existing = client.get_job(name, resolved_project_id)
@@ -183,6 +168,7 @@ def _run_serverless_train(
                     "job_name": info.name,
                     "job_status": info.status,
                     "output_path": out,
+                    "training_config": training_config.public_dict(),
                 },
                 output_format,
             )
@@ -200,13 +186,14 @@ def _run_serverless_train(
                 headless=headless,
                 max_iterations=max_iterations,
                 isaac_lab_version=isaac_lab_version,
+                training_config=training_config,
             ),
             gpu_type=platform,
             gpu_count=resolved_gpu_count,
             preset=preset,
             subnet_id=subnet,
             output_path=out,
-            env=env,
+            env=safe_env,
             extra_env=extra_env,
         )
         if not submit_only:
@@ -224,6 +211,7 @@ def _run_serverless_train(
             "job_name": info.name,
             "output_path": out,
             "embodiment": embodiment,
+            "training_config": training_config.public_dict(),
         },
         output_format,
     )
@@ -234,6 +222,19 @@ def train_cmd(
     checkpoint: str = typer.Option(DEFAULT_CHECKPOINT, "--checkpoint", help="Checkpoint ref or path."),
     data_path: str = typer.Option("", "--data-path", help="Training data path or URI."),
     sample_data: bool = typer.Option(False, "--sample-data", help="Use SONIC sample data for smoke."),
+    override: list[str] = typer.Option(
+        [],
+        "--override",
+        help="Generic Hydra override as KEY=VALUE. Repeat for learning rate, clip params, terminations, or any trainer key.",
+    ),
+    wandb_enabled: bool = typer.Option(False, "--wandb/--no-wandb", help="Enable W&B logging for the training run."),
+    wandb_project: str = typer.Option("", "--wandb-project", help="W&B project name."),
+    wandb_run_name: str = typer.Option("", "--wandb-run-name", help="W&B run name."),
+    wandb_mode: str = typer.Option("offline", "--wandb-mode", help="W&B mode such as online, offline, or disabled."),
+    checkpoint_s3_uri: str = typer.Option("", "--checkpoint-s3-uri", help="S3 URI for checkpoint upload."),
+    checkpoint_s3_endpoint_url: str = typer.Option("", "--checkpoint-s3-endpoint-url", help="S3-compatible endpoint URL."),
+    checkpoint_s3_access_key_id: str = typer.Option("", "--checkpoint-s3-access-key-id", help="S3 access key ID."),
+    checkpoint_s3_secret_access_key: str = typer.Option("", "--checkpoint-s3-secret-access-key", help="S3 secret access key."),
     embodiment: str = typer.Option(DEFAULT_EMBODIMENT, "--embodiment", help="SONIC embodiment tag."),
     num_envs: int = typer.Option(16, "--num-envs", help="Number of Isaac Lab environments."),
     headless: bool = typer.Option(True, "--headless/--no-headless", help="Run Isaac Lab headless."),
@@ -262,13 +263,30 @@ def train_cmd(
 ) -> None:
     """Run SONIC Isaac Lab training or smoke validation."""
 
+    try:
+        training_config = build_training_config(
+            data_path=data_path,
+            overrides=override,
+            wandb_enabled=wandb_enabled,
+            wandb_project=wandb_project,
+            wandb_run_name=wandb_run_name,
+            wandb_mode=wandb_mode,
+            checkpoint_s3_uri=checkpoint_s3_uri,
+            checkpoint_s3_endpoint_url=checkpoint_s3_endpoint_url,
+            checkpoint_s3_access_key_id=checkpoint_s3_access_key_id,
+            checkpoint_s3_secret_access_key=checkpoint_s3_secret_access_key,
+        )
+    except TrainingConfigError as exc:
+        fail(str(exc))
     runtime_value = enum_value(runtime)
     if num_envs <= 0:
         fail(f"--num-envs must be positive, got {num_envs}")
     if max_iterations <= 0:
         fail(f"--max-iterations/--steps must be positive, got {max_iterations}")
     embodiment_tag = normalize_embodiment(embodiment)
+    data_path = training_config.data_path
     effective_sample_data = sample_data or not data_path
+    checkpoint_output_path = resolve_checkpoint_s3_uri(training_config, output_path)
     if runtime_value == "serverless":
         _run_serverless_train(
             checkpoint=checkpoint,
@@ -279,7 +297,7 @@ def train_cmd(
             headless=headless,
             max_iterations=max_iterations,
             isaac_lab_version=isaac_lab_version,
-            output_path=output_path,
+            output_path=checkpoint_output_path,
             project_id=project_id,
             image=image,
             image_variant=image_variant,
@@ -292,6 +310,7 @@ def train_cmd(
             poll_interval=poll_interval,
             timeout=timeout,
             output_format=output_format,
+            training_config=training_config,
         )
         return
     output(
@@ -306,7 +325,8 @@ def train_cmd(
             "headless": headless,
             "max_iterations": max_iterations,
             "hf_token_env": hf_token_env,
-            "output_path": output_path,
+            "output_path": checkpoint_output_path,
+            "training_config": training_config.public_dict(),
         },
         output_format,
     )

--- a/npa/src/npa/genesis/tune.py
+++ b/npa/src/npa/genesis/tune.py
@@ -30,6 +30,7 @@ def tune_teacher(
     device: str = "cuda",
     action_space: str = "cartesian",
     env_overrides: dict[str, Any] | None = None,
+    ppo_overrides: dict[str, Any] | None = None,
     min_success_rate: float = 0.0,
 ) -> dict[str, Any]:
     """Run the diagnose → adjust → retrain loop.
@@ -193,6 +194,7 @@ def tune_teacher(
                 device=device,
                 seed=round_seed,
                 env_overrides=retrain_overrides,
+                ppo_overrides=ppo_overrides or {},
                 action_space=action_space,
             )
         except TrainingError as exc:
@@ -261,6 +263,7 @@ def _retrain_with_overrides(
     device: str,
     seed: int,
     env_overrides: dict[str, Any],
+    ppo_overrides: dict[str, Any] | None = None,
     action_space: str = "cartesian",
 ) -> dict[str, Any]:
     """Train teacher with modified EnvConfig parameters.
@@ -310,6 +313,10 @@ def _retrain_with_overrides(
         raise TrainingError(f"Failed to create Genesis environment: {exc}") from exc
 
     ppo_cfg = PPOConfig()
+    for key, value in (ppo_overrides or {}).items():
+        if key not in PPOConfig.__dataclass_fields__:
+            raise TrainingError(f"Unsupported Genesis PPO override: {key}")
+        setattr(ppo_cfg, key, value)
     train_cfg = ppo_cfg.to_train_cfg()
     config_for_save = _copy.deepcopy(train_cfg)
 

--- a/npa/src/npa/sdk/workbench/__init__.py
+++ b/npa/src/npa/sdk/workbench/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from npa.workbench import lancedb
+from npa.workbench import lancedb, training_config
 
 from . import (
     cosmos,
@@ -31,6 +31,7 @@ __all__ = [
     "sim2real",
     "sim2real_envgen",
     "sonic",
+    "training_config",
     "trigger",
     "vlm_eval",
 ]

--- a/npa/src/npa/sdk/workbench/detection_training.py
+++ b/npa/src/npa/sdk/workbench/detection_training.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from npa.workbench.detection_training.schemas import (
+    CheckpointS3Settings,
     DEFAULT_LANCE_URI,
     DEFAULT_TOKEN_ENV,
     EvalRequest,
@@ -15,6 +16,7 @@ from npa.workbench.detection_training.schemas import (
     StatusResponse,
     TrainRequest,
     TrainResponse,
+    WandbSettings,
 )
 
 
@@ -29,8 +31,16 @@ class DetectionTrainingValidationError(ValueError):
 def train(
     *,
     view: str,
-    output_uri: str,
+    output_uri: str = "",
+    data_path: str = "",
     lance_uri: str = DEFAULT_LANCE_URI,
+    overrides: list[str] | None = None,
+    wandb: dict[str, Any] | None = None,
+    checkpoint_s3: dict[str, Any] | None = None,
+    checkpoint_s3_uri: str = "",
+    checkpoint_s3_endpoint_url: str = "",
+    checkpoint_s3_access_key_id: str = "",
+    checkpoint_s3_secret_access_key: str = "",
     num_classes: int = 10,
     epochs: int = 10,
     batch_size: int = 8,
@@ -43,10 +53,31 @@ def train(
     timeout: float = 30.0,
 ) -> TrainResponse:
     """Start a Faster R-CNN detection-training run."""
+    checkpoint_payload = {
+        **(checkpoint_s3 or {}),
+        **{
+            key: value
+            for key, value in {
+                "uri": checkpoint_s3_uri,
+                "endpoint_url": checkpoint_s3_endpoint_url,
+                "aws_access_key_id": checkpoint_s3_access_key_id,
+                "aws_secret_access_key": checkpoint_s3_secret_access_key,
+            }.items()
+            if value
+        },
+    }
+    checkpoint_settings = CheckpointS3Settings(**checkpoint_payload)
+    effective_output_uri = output_uri or checkpoint_settings.uri
+    if not effective_output_uri:
+        raise DetectionTrainingValidationError("output_uri or checkpoint_s3.uri is required")
     request = TrainRequest(
         view=view,
-        lance_uri=lance_uri,
-        output_uri=output_uri,
+        lance_uri=data_path or lance_uri,
+        data_path=data_path,
+        output_uri=effective_output_uri,
+        overrides=overrides or [],
+        wandb=WandbSettings(**(wandb or {})),
+        checkpoint_s3=checkpoint_settings,
         num_classes=num_classes,
         epochs=epochs,
         batch_size=batch_size,
@@ -196,4 +227,3 @@ __all__ = [
     "status",
     "train",
 ]
-

--- a/npa/src/npa/workbench/__init__.py
+++ b/npa/src/npa/workbench/__init__.py
@@ -15,6 +15,7 @@ from npa.workbench import (
     mjlab,
     retargeting,
     sonic,
+    training_config,
     trigger,
     vlm_eval,
 )
@@ -32,6 +33,7 @@ __all__ = [
     "mjlab",
     "retargeting",
     "sonic",
+    "training_config",
     "trigger",
     "vlm_eval",
 ]

--- a/npa/src/npa/workbench/detection_training/schemas.py
+++ b/npa/src/npa/workbench/detection_training/schemas.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from npa.workbench.training_config import TrainingConfigError, overrides_to_mapping
 
 DEFAULT_LANCE_URI = "s3://<your-bucket>/lancedb/bdd100k/"
 DEFAULT_NUM_CLASSES = 10
@@ -16,6 +18,28 @@ DEFAULT_TOKEN_ENV = "DETECTION_TRAINING_TOKEN"
 RunStatus = Literal["queued", "running", "completed", "failed"]
 
 
+class WandbSettings(BaseModel):
+    """Canonical W&B settings for training surfaces."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    project: str = ""
+    run_name: str = ""
+    mode: str = "offline"
+
+
+class CheckpointS3Settings(BaseModel):
+    """Canonical BYO S3 checkpoint destination."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    uri: str = ""
+    endpoint_url: str = ""
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+
+
 class TrainRequest(BaseModel):
     """Request body for starting a detector fine-tuning run."""
 
@@ -24,6 +48,10 @@ class TrainRequest(BaseModel):
     view: str = Field(..., min_length=1)
     lance_uri: str = DEFAULT_LANCE_URI
     output_uri: str = Field(..., min_length=1)
+    data_path: str = ""
+    overrides: list[str] = Field(default_factory=list)
+    wandb: WandbSettings = Field(default_factory=WandbSettings)
+    checkpoint_s3: CheckpointS3Settings = Field(default_factory=CheckpointS3Settings)
     num_classes: int | None = Field(None, ge=2)
     label_map: dict[str, int] | None = None
     epochs: int = Field(DEFAULT_EPOCHS, ge=1)
@@ -38,6 +66,47 @@ class TrainRequest(BaseModel):
         if not resolved:
             raise ValueError("value must not be empty")
         return resolved
+
+    @field_validator("data_path")
+    @classmethod
+    def _strip_data_path(cls, value: str) -> str:
+        return value.strip()
+
+    @model_validator(mode="after")
+    def _apply_overrides(self) -> "TrainRequest":
+        try:
+            parsed = overrides_to_mapping(self.overrides)
+        except TrainingConfigError as exc:
+            raise ValueError(str(exc)) from exc
+        supported = {
+            "num_classes",
+            "epochs",
+            "batch_size",
+            "learning_rate",
+            "validation_filter_sql",
+            "data_path",
+            "lance_uri",
+            "view",
+            "output_uri",
+        }
+        aliases = {
+            "train.num_classes": "num_classes",
+            "train.epochs": "epochs",
+            "train.batch_size": "batch_size",
+            "train.learning_rate": "learning_rate",
+            "optimizer.learning_rate": "learning_rate",
+            "lr": "learning_rate",
+            "dataset.path": "data_path",
+            "data.path": "data_path",
+        }
+        for raw_key, value in parsed.items():
+            key = aliases.get(raw_key, raw_key)
+            if key not in supported:
+                raise ValueError(f"unsupported detection-training override: {raw_key}")
+            setattr(self, key, value)
+        if self.data_path:
+            self.lance_uri = self.data_path
+        return self
 
     @field_validator("validation_filter_sql")
     @classmethod
@@ -77,6 +146,8 @@ class TrainResponse(BaseModel):
     metrics_uri: str
     total_epochs: int
     manifest_sha256: str
+    data_path: str = ""
+    training_config: dict[str, Any] = Field(default_factory=dict)
 
 
 class EvalRequest(BaseModel):

--- a/npa/src/npa/workbench/detection_training/training.py
+++ b/npa/src/npa/workbench/detection_training/training.py
@@ -6,7 +6,9 @@ import hashlib
 import io
 import json
 import math
+import os
 import time
+from contextlib import contextmanager
 from typing import Any, Callable
 
 from .dataloader import make_dataloader
@@ -53,66 +55,75 @@ def train_detector(
     """Run Faster R-CNN training and persist checkpoints plus metrics."""
     manifest = compute_manifest_sha256("train", request.model_dump(mode="json"))
     resolved_run_id = run_id or make_run_id("train", manifest)
-    pattern = checkpoint_uri_pattern(request.output_uri, resolved_run_id)
-    metrics_path = metrics_uri(request.output_uri, resolved_run_id)
+    effective_output_uri = request.checkpoint_s3.uri or request.output_uri
+    pattern = checkpoint_uri_pattern(effective_output_uri, resolved_run_id)
+    metrics_path = metrics_uri(effective_output_uri, resolved_run_id)
     if status_callback:
         status_callback("running", 0, {}, None)
 
-    try:
-        import torch
-    except ImportError as exc:
-        raise DetectionTrainingError("torch is required for detection training") from exc
+    with _checkpoint_s3_environment(request):
+        try:
+            import torch
+        except ImportError as exc:
+            raise DetectionTrainingError("torch is required for detection training") from exc
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    num_classes = resolve_num_classes(request)
-    dataloader = make_dataloader(
-        lance_uri=request.lance_uri,
-        view=request.view,
-        batch_size=request.batch_size,
-        shuffle=True,
-        label_map=request.label_map,
-    )
-    model = build_fasterrcnn_resnet50_fpn_v2(num_classes=num_classes)
-    model.to(device)
-    optimizer = torch.optim.SGD(
-        [param for param in model.parameters() if getattr(param, "requires_grad", True)],
-        lr=request.learning_rate,
-        momentum=0.9,
-        weight_decay=0.0005,
-    )
-    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=3, gamma=0.1)
-    history: list[dict[str, Any]] = []
+        wandb_run = _start_wandb(request)
+        try:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            num_classes = resolve_num_classes(request)
+            dataloader = make_dataloader(
+                lance_uri=request.data_path or request.lance_uri,
+                view=request.view,
+                batch_size=request.batch_size,
+                shuffle=True,
+                label_map=request.label_map,
+            )
+            model = build_fasterrcnn_resnet50_fpn_v2(num_classes=num_classes)
+            model.to(device)
+            optimizer = torch.optim.SGD(
+                [param for param in model.parameters() if getattr(param, "requires_grad", True)],
+                lr=request.learning_rate,
+                momentum=0.9,
+                weight_decay=0.0005,
+            )
+            scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=3, gamma=0.1)
+            history: list[dict[str, Any]] = []
 
-    for epoch in range(1, request.epochs + 1):
-        loss = train_one_epoch(model, dataloader, optimizer, device=device)
-        scheduler.step()
-        snapshot = {
-            "epoch": epoch,
-            "train_loss": loss,
-            "learning_rate": float(optimizer.param_groups[0]["lr"]),
-        }
-        history.append(snapshot)
-        checkpoint_uri = pattern.format(epoch=epoch)
-        save_checkpoint(
-            checkpoint_uri,
-            model=model,
-            optimizer=optimizer,
-            epoch=epoch,
-            manifest_sha256=manifest,
-            num_classes=num_classes,
-            request=request.model_dump(mode="json"),
-        )
-        write_json_uri(
-            metrics_path,
-            {
-                "run_id": resolved_run_id,
-                "manifest_sha256": manifest,
-                "status": "running" if epoch < request.epochs else "completed",
-                "epochs": history,
-            },
-        )
-        if status_callback:
-            status_callback("running" if epoch < request.epochs else "completed", epoch, snapshot, None)
+            for epoch in range(1, request.epochs + 1):
+                loss = train_one_epoch(model, dataloader, optimizer, device=device)
+                scheduler.step()
+                snapshot = {
+                    "epoch": epoch,
+                    "train_loss": loss,
+                    "learning_rate": float(optimizer.param_groups[0]["lr"]),
+                }
+                history.append(snapshot)
+                if wandb_run is not None:
+                    wandb_run.log(snapshot, step=epoch)
+                checkpoint_uri = pattern.format(epoch=epoch)
+                save_checkpoint(
+                    checkpoint_uri,
+                    model=model,
+                    optimizer=optimizer,
+                    epoch=epoch,
+                    manifest_sha256=manifest,
+                    num_classes=num_classes,
+                    request=request.model_dump(mode="json"),
+                )
+                write_json_uri(
+                    metrics_path,
+                    {
+                        "run_id": resolved_run_id,
+                        "manifest_sha256": manifest,
+                        "status": "running" if epoch < request.epochs else "completed",
+                        "epochs": history,
+                    },
+                )
+                if status_callback:
+                    status_callback("running" if epoch < request.epochs else "completed", epoch, snapshot, None)
+        finally:
+            if wandb_run is not None:
+                wandb_run.finish()
 
     return TrainResponse(
         run_id=resolved_run_id,
@@ -121,7 +132,60 @@ def train_detector(
         metrics_uri=metrics_path,
         total_epochs=request.epochs,
         manifest_sha256=manifest,
+        data_path=request.data_path or request.lance_uri,
+        training_config=_training_config_public_dict(request),
     )
+
+
+@contextmanager
+def _checkpoint_s3_environment(request: TrainRequest):
+    values = {
+        "AWS_ENDPOINT_URL": request.checkpoint_s3.endpoint_url,
+        "NEBIUS_S3_ENDPOINT": request.checkpoint_s3.endpoint_url,
+        "AWS_ACCESS_KEY_ID": request.checkpoint_s3.aws_access_key_id,
+        "AWS_SECRET_ACCESS_KEY": request.checkpoint_s3.aws_secret_access_key,
+    }
+    previous = {key: os.environ.get(key) for key in values}
+    try:
+        for key, value in values.items():
+            if value:
+                os.environ[key] = value
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _start_wandb(request: TrainRequest) -> Any | None:
+    if not request.wandb.enabled:
+        return None
+    try:
+        import wandb
+    except ImportError as exc:
+        raise DetectionTrainingError("wandb is required when wandb.enabled=true") from exc
+    return wandb.init(
+        project=request.wandb.project or None,
+        name=request.wandb.run_name or None,
+        mode=request.wandb.mode or "offline",
+        config=request.model_dump(mode="json"),
+    )
+
+
+def _training_config_public_dict(request: TrainRequest) -> dict[str, Any]:
+    return {
+        "data_path": request.data_path or request.lance_uri,
+        "overrides": list(request.overrides),
+        "wandb": request.wandb.model_dump(mode="json"),
+        "checkpoint_s3": {
+            "uri": request.checkpoint_s3.uri,
+            "endpoint_url": request.checkpoint_s3.endpoint_url,
+            "aws_access_key_id": "set" if request.checkpoint_s3.aws_access_key_id else "",
+            "aws_secret_access_key": "set" if request.checkpoint_s3.aws_secret_access_key else "",
+        },
+    }
 
 
 def resolve_num_classes(request: TrainRequest) -> int:

--- a/npa/src/npa/workbench/lerobot/policy_container.py
+++ b/npa/src/npa/workbench/lerobot/policy_container.py
@@ -14,6 +14,15 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from npa.workbench.training_config import (
+    TrainingConfig,
+    TrainingConfigError,
+    build_training_config,
+    format_override,
+    upload_checkpoint_path,
+    wandb_overrides,
+)
+
 
 DEFAULT_POLICY_CHECKPOINT = "lerobot/diffusion_pusht"
 DEFAULT_ACTION_DIM = 2
@@ -234,9 +243,11 @@ def build_lerobot_train_command(
     log_freq: int = DEFAULT_TRAIN_LOG_FREQ,
     resume: bool = False,
     extra_args: list[str] | None = None,
+    training_config: TrainingConfig | None = None,
 ) -> list[str]:
     """Build a real `lerobot-train` command for a local LeRobotDataset."""
 
+    config = training_config or TrainingConfig()
     if steps <= 0:
         raise PolicyContainerError(f"steps must be positive, got {steps}")
     if batch_size <= 0:
@@ -261,12 +272,13 @@ def build_lerobot_train_command(
         f"--log_freq={log_freq}",
         f"--batch_size={batch_size}",
         f"--num_workers={num_workers}",
-        "--wandb.enable=false",
     ]
+    cmd.extend(wandb_overrides(config.wandb, style="cli"))
     if resume:
         cmd.append("--resume=true")
     if extra_args:
         cmd.extend(extra_args)
+    cmd.extend(format_override(override, style="cli") for override in config.overrides)
     return cmd
 
 
@@ -284,9 +296,11 @@ def run_lerobot_training(
     log_path: Path | str | None = None,
     timeout_seconds: int = DEFAULT_TRAIN_TIMEOUT_SECONDS,
     extra_args: list[str] | None = None,
+    training_config: TrainingConfig | None = None,
 ) -> LeRobotTrainingResult:
     """Run real LeRobot policy training and validate the resulting checkpoint."""
 
+    config = training_config or TrainingConfig()
     assert_lerobot_importable()
     if shutil.which("lerobot-train") is None:
         raise PolicyContainerError("lerobot-train was not found on PATH")
@@ -311,6 +325,7 @@ def run_lerobot_training(
         save_freq=steps,
         resume=resume,
         extra_args=extra_args,
+        training_config=config,
     )
     start = time.time()
     with log.open("w", encoding="utf-8") as handle:
@@ -334,6 +349,7 @@ def run_lerobot_training(
             f"lerobot-train failed or did not produce loadable real weights "
             f"(exit={proc.returncode}, checkpoint={checkpoint}, log={log})"
         )
+    upload_checkpoint_path(checkpoint, config)
     return LeRobotTrainingResult(
         status="success",
         command=command,
@@ -934,7 +950,7 @@ def main(argv: list[str] | None = None) -> int:
     import_cmd = subparsers.add_parser("check-import", help="Import LeRobot and LeRobotDataset.")
     import_cmd.set_defaults(_command_name="check-import")
     train_cmd = subparsers.add_parser("train", help="Run real LeRobot policy training.")
-    train_cmd.add_argument("--dataset-path", type=Path, required=True)
+    train_cmd.add_argument("--dataset-path", type=Path, default=None)
     train_cmd.add_argument("--dataset-repo-id", default="local/lerobot-dataset")
     train_cmd.add_argument("--output-dir", type=Path, required=True)
     train_cmd.add_argument("--steps", type=int, required=True)
@@ -945,6 +961,16 @@ def main(argv: list[str] | None = None) -> int:
     train_cmd.add_argument("--resume", action="store_true")
     train_cmd.add_argument("--log-path", type=Path, default=None)
     train_cmd.add_argument("--timeout-seconds", type=int, default=DEFAULT_TRAIN_TIMEOUT_SECONDS)
+    train_cmd.add_argument("--data-path", default="")
+    train_cmd.add_argument("--override", action="append", default=[])
+    train_cmd.add_argument("--wandb", action="store_true")
+    train_cmd.add_argument("--wandb-project", default="")
+    train_cmd.add_argument("--wandb-run-name", default="")
+    train_cmd.add_argument("--wandb-mode", default="offline")
+    train_cmd.add_argument("--checkpoint-s3-uri", default="")
+    train_cmd.add_argument("--checkpoint-s3-endpoint-url", default="")
+    train_cmd.add_argument("--checkpoint-s3-access-key-id", default="")
+    train_cmd.add_argument("--checkpoint-s3-secret-access-key", default="")
     eval_cmd = subparsers.add_parser("eval", help="Run measured LeRobot rollout eval.")
     eval_cmd.add_argument("--checkpoint-path", type=Path, required=True)
     eval_cmd.add_argument("--output-dir", type=Path, required=True)
@@ -975,8 +1001,26 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(assert_lerobot_importable().to_dict(), indent=2, sort_keys=True))
         return 0
     if args.command == "train":
+        try:
+            training_config = build_training_config(
+                data_path=args.data_path,
+                overrides=args.override,
+                wandb_enabled=args.wandb,
+                wandb_project=args.wandb_project,
+                wandb_run_name=args.wandb_run_name,
+                wandb_mode=args.wandb_mode,
+                checkpoint_s3_uri=args.checkpoint_s3_uri,
+                checkpoint_s3_endpoint_url=args.checkpoint_s3_endpoint_url,
+                checkpoint_s3_access_key_id=args.checkpoint_s3_access_key_id,
+                checkpoint_s3_secret_access_key=args.checkpoint_s3_secret_access_key,
+            )
+        except TrainingConfigError as exc:
+            raise PolicyContainerError(str(exc)) from exc
+        dataset_path = training_config.data_path or args.dataset_path
+        if not dataset_path:
+            raise PolicyContainerError("--data-path or --dataset-path is required")
         result = run_lerobot_training(
-            dataset_path=args.dataset_path,
+            dataset_path=dataset_path,
             dataset_repo_id=args.dataset_repo_id,
             output_dir=args.output_dir,
             steps=args.steps,
@@ -987,6 +1031,7 @@ def main(argv: list[str] | None = None) -> int:
             resume=args.resume,
             log_path=args.log_path,
             timeout_seconds=args.timeout_seconds,
+            training_config=training_config,
         )
         print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
         return 0

--- a/npa/src/npa/workbench/training_config.py
+++ b/npa/src/npa/workbench/training_config.py
@@ -1,0 +1,372 @@
+"""Shared training configuration helpers for workbench tools."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+import shlex
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlparse
+
+
+OverrideStyle = Literal["hydra", "cli"]
+
+
+class TrainingConfigError(ValueError):
+    """Raised when a shared training option is invalid."""
+
+
+@dataclass(frozen=True)
+class WandbConfig:
+    """Weights & Biases settings shared across training entrypoints."""
+
+    enabled: bool = False
+    project: str = ""
+    run_name: str = ""
+    mode: str = "offline"
+
+    def env(self) -> dict[str, str]:
+        mode = self.mode.strip() or ("offline" if self.enabled else "disabled")
+        values = {
+            "NPA_TRAINING_WANDB_ENABLED": "1" if self.enabled else "0",
+            "WANDB_MODE": mode if self.enabled else "disabled",
+        }
+        if self.project:
+            values["NPA_TRAINING_WANDB_PROJECT"] = self.project
+            values["WANDB_PROJECT"] = self.project
+        if self.run_name:
+            values["NPA_TRAINING_WANDB_RUN_NAME"] = self.run_name
+            values["WANDB_NAME"] = self.run_name
+        return values
+
+
+@dataclass(frozen=True)
+class CheckpointS3Config:
+    """Bring-your-own S3-compatible checkpoint destination."""
+
+    uri: str = ""
+    endpoint_url: str = ""
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+
+    def env(self) -> dict[str, str]:
+        values: dict[str, str] = {}
+        if self.uri:
+            values["NPA_CHECKPOINT_S3_URI"] = self.uri
+        if self.endpoint_url:
+            values["NPA_CHECKPOINT_S3_ENDPOINT_URL"] = self.endpoint_url
+            values["AWS_ENDPOINT_URL"] = self.endpoint_url
+            values["NEBIUS_S3_ENDPOINT"] = self.endpoint_url
+            values["S3_ENDPOINT_URL"] = self.endpoint_url
+        if self.aws_access_key_id:
+            values["AWS_ACCESS_KEY_ID"] = self.aws_access_key_id
+        if self.aws_secret_access_key:
+            values["AWS_SECRET_ACCESS_KEY"] = self.aws_secret_access_key
+        return values
+
+    def public_dict(self) -> dict[str, str]:
+        return {
+            "uri": self.uri,
+            "endpoint_url": self.endpoint_url,
+            "aws_access_key_id": "set" if self.aws_access_key_id else "",
+            "aws_secret_access_key": "set" if self.aws_secret_access_key else "",
+        }
+
+
+@dataclass(frozen=True)
+class TrainingConfig:
+    """Canonical general-purpose training interface."""
+
+    data_path: str = ""
+    overrides: tuple[str, ...] = field(default_factory=tuple)
+    wandb: WandbConfig = field(default_factory=WandbConfig)
+    checkpoint_s3: CheckpointS3Config = field(default_factory=CheckpointS3Config)
+
+    def env(self) -> dict[str, str]:
+        values: dict[str, str] = {}
+        if self.data_path:
+            values["NPA_TRAINING_DATA_PATH"] = self.data_path
+        if self.overrides:
+            values["NPA_TRAINING_OVERRIDES"] = " ".join(self.overrides)
+            values["NPA_TRAINING_OVERRIDES_JSON"] = json.dumps(list(self.overrides))
+        values.update(self.wandb.env())
+        values.update(self.checkpoint_s3.env())
+        return values
+
+    def public_dict(self) -> dict[str, Any]:
+        return {
+            "data_path": self.data_path,
+            "overrides": list(self.overrides),
+            "wandb": asdict(self.wandb),
+            "checkpoint_s3": self.checkpoint_s3.public_dict(),
+        }
+
+
+def build_training_config(
+    *,
+    data_path: str = "",
+    overrides: Iterable[str] | None = None,
+    overrides_json: str = "",
+    wandb_enabled: bool = False,
+    wandb_project: str = "",
+    wandb_run_name: str = "",
+    wandb_mode: str = "offline",
+    checkpoint_s3_uri: str = "",
+    checkpoint_s3_endpoint_url: str = "",
+    checkpoint_s3_access_key_id: str = "",
+    checkpoint_s3_secret_access_key: str = "",
+) -> TrainingConfig:
+    """Build and validate the shared training config from CLI/SDK fields."""
+
+    checkpoint = CheckpointS3Config(
+        uri=checkpoint_s3_uri.strip(),
+        endpoint_url=checkpoint_s3_endpoint_url.strip(),
+        aws_access_key_id=checkpoint_s3_access_key_id.strip(),
+        aws_secret_access_key=checkpoint_s3_secret_access_key.strip(),
+    )
+    if checkpoint.uri:
+        _validate_s3_uri(checkpoint.uri, field_name="checkpoint_s3_uri")
+    if checkpoint.endpoint_url:
+        _validate_endpoint_url(checkpoint.endpoint_url)
+    return TrainingConfig(
+        data_path=data_path.strip(),
+        overrides=parse_overrides(overrides or (), overrides_json=overrides_json),
+        wandb=WandbConfig(
+            enabled=bool(wandb_enabled),
+            project=wandb_project.strip(),
+            run_name=wandb_run_name.strip(),
+            mode=(wandb_mode or "offline").strip(),
+        ),
+        checkpoint_s3=checkpoint,
+    )
+
+
+def training_config_from_mapping(values: Mapping[str, Any] | None) -> TrainingConfig:
+    """Build a TrainingConfig from a YAML/API/SDK mapping."""
+
+    payload = dict(values or {})
+    checkpoint = dict(payload.get("checkpoint_s3") or {})
+    wandb = dict(payload.get("wandb") or {})
+    return build_training_config(
+        data_path=str(payload.get("data_path") or ""),
+        overrides=_overrides_from_value(payload.get("overrides")),
+        wandb_enabled=bool(wandb.get("enabled", False)),
+        wandb_project=str(wandb.get("project") or ""),
+        wandb_run_name=str(wandb.get("run_name") or ""),
+        wandb_mode=str(wandb.get("mode") or "offline"),
+        checkpoint_s3_uri=str(checkpoint.get("uri") or payload.get("checkpoint_s3_uri") or ""),
+        checkpoint_s3_endpoint_url=str(
+            checkpoint.get("endpoint_url") or payload.get("checkpoint_s3_endpoint_url") or ""
+        ),
+        checkpoint_s3_access_key_id=str(
+            checkpoint.get("aws_access_key_id") or payload.get("checkpoint_s3_access_key_id") or ""
+        ),
+        checkpoint_s3_secret_access_key=str(
+            checkpoint.get("aws_secret_access_key") or payload.get("checkpoint_s3_secret_access_key") or ""
+        ),
+    )
+
+
+def parse_overrides(values: Iterable[str], *, overrides_json: str = "") -> tuple[str, ...]:
+    """Validate repeated Hydra-style key=value overrides."""
+
+    parsed = list(values)
+    if overrides_json.strip():
+        try:
+            raw_json = json.loads(overrides_json)
+        except json.JSONDecodeError as exc:
+            raise TrainingConfigError(f"overrides_json is not valid JSON: {exc}") from exc
+        parsed.extend(_overrides_from_value(raw_json))
+
+    result: list[str] = []
+    for raw in parsed:
+        value = str(raw).strip()
+        if not value:
+            continue
+        if "=" not in value:
+            raise TrainingConfigError(f"override must be KEY=VALUE, got: {value}")
+        key = value.split("=", 1)[0].lstrip("+")
+        if key.startswith("-"):
+            key = key.lstrip("-")
+        if not key:
+            raise TrainingConfigError(f"override key must not be empty: {value}")
+        result.append(value)
+    return tuple(result)
+
+
+def _overrides_from_value(value: Any) -> list[str]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, Mapping):
+        return [f"{key}={_json_scalar(val)}" for key, val in value.items()]
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        try:
+            loaded = json.loads(stripped)
+        except json.JSONDecodeError:
+            return [stripped]
+        return _overrides_from_value(loaded)
+    if isinstance(value, Iterable):
+        return [str(item) for item in value]
+    raise TrainingConfigError("overrides must be a mapping, list, JSON string, or repeated KEY=VALUE values")
+
+
+def render_overrides(overrides: Iterable[str], *, style: OverrideStyle) -> str:
+    """Render overrides for a shell command."""
+
+    values = [format_override(value, style=style) for value in overrides]
+    return shlex.join(values)
+
+
+def overrides_to_mapping(overrides: Iterable[str]) -> dict[str, Any]:
+    """Parse generic KEY=VALUE overrides into typed values for non-Hydra trainers."""
+
+    result: dict[str, Any] = {}
+    for raw in parse_overrides(overrides):
+        key, value = raw.split("=", 1)
+        result[_normalize_override_key(key)] = _parse_override_value(value)
+    return result
+
+
+def _normalize_override_key(key: str) -> str:
+    normalized = key.strip()
+    while normalized.startswith("+"):
+        normalized = normalized[1:]
+    while normalized.startswith("-"):
+        normalized = normalized[1:]
+    return normalized.strip()
+
+
+def _parse_override_value(value: str) -> Any:
+    stripped = value.strip()
+    if stripped.lower() == "true":
+        return True
+    if stripped.lower() == "false":
+        return False
+    if stripped.lower() == "null":
+        return None
+    try:
+        return int(stripped)
+    except ValueError:
+        pass
+    try:
+        return float(stripped)
+    except ValueError:
+        pass
+    if stripped.startswith(("[", "{", '"')):
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            return stripped
+    return stripped
+
+
+def format_override(value: str, *, style: OverrideStyle) -> str:
+    override = str(value).strip()
+    if style == "hydra":
+        return override
+    if override.startswith(("-", "+")):
+        return override
+    return f"--{override}"
+
+
+def wandb_overrides(wandb: WandbConfig, *, style: OverrideStyle, prefix: str = "wandb") -> list[str]:
+    """Return common Hydra/CLI W&B overrides for trainers with W&B config keys."""
+
+    enabled = "true" if wandb.enabled else "false"
+    overrides = [f"{prefix}.enable={enabled}"]
+    if wandb.project:
+        overrides.append(f"{prefix}.project={wandb.project}")
+    if wandb.run_name:
+        overrides.append(f"{prefix}.name={wandb.run_name}")
+    return [format_override(value, style=style) for value in overrides]
+
+
+def shell_env_exports(values: Mapping[str, str]) -> str:
+    """Render shell exports for non-secret env values."""
+
+    if not values:
+        return ""
+    return " ".join(f"export {key}={shlex.quote(value)};" for key, value in values.items())
+
+
+def checkpoint_s3_uri(config: TrainingConfig, fallback: str = "") -> str:
+    """Return the explicit checkpoint S3 URI, falling back to an older output path."""
+
+    return config.checkpoint_s3.uri or fallback
+
+
+def upload_checkpoint_path(local_path: str | Path, config: TrainingConfig) -> str:
+    """Upload a local file or directory to the configured checkpoint S3 URI."""
+
+    if not config.checkpoint_s3.uri:
+        return ""
+    from npa.clients.storage import StorageClient
+
+    client = StorageClient.from_environment(
+        endpoint_url=config.checkpoint_s3.endpoint_url,
+        aws_access_key_id=config.checkpoint_s3.aws_access_key_id,
+        aws_secret_access_key=config.checkpoint_s3.aws_secret_access_key,
+    )
+    return client.upload_path(str(local_path), config.checkpoint_s3.uri)
+
+
+def checkpoint_upload_python(local_dir_expr: str, uri_expr: str = 'os.environ["NPA_CHECKPOINT_S3_URI"]') -> str:
+    """Return Python code that uploads a directory using checkpoint S3 env vars."""
+
+    return f"""
+import os
+import pathlib
+from urllib.parse import urlparse
+
+import boto3
+
+uri = {uri_expr}
+parsed = urlparse(uri)
+if parsed.scheme != "s3" or not parsed.netloc:
+    raise SystemExit(f"invalid checkpoint S3 URI: {{uri}}")
+prefix = parsed.path.lstrip("/")
+if prefix and not prefix.endswith("/"):
+    prefix += "/"
+base = pathlib.Path({local_dir_expr})
+s3 = boto3.client(
+    "s3",
+    endpoint_url=(
+        os.environ.get("NPA_CHECKPOINT_S3_ENDPOINT_URL")
+        or os.environ.get("AWS_ENDPOINT_URL")
+        or os.environ.get("NEBIUS_S3_ENDPOINT")
+        or None
+    ),
+)
+for file_path in base.rglob("*"):
+    if file_path.is_file():
+        key = prefix + str(file_path.relative_to(base))
+        s3.upload_file(str(file_path), parsed.netloc, key)
+        print(f"uploaded s3://{{parsed.netloc}}/{{key}}", flush=True)
+"""
+
+
+def _json_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, separators=(",", ":"))
+
+
+def _validate_s3_uri(uri: str, *, field_name: str) -> None:
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise TrainingConfigError(f"{field_name} must be an s3://bucket/prefix URI")
+
+
+def _validate_endpoint_url(endpoint_url: str) -> None:
+    parsed = urlparse(endpoint_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise TrainingConfigError("checkpoint_s3_endpoint_url must be an http(s) URL")

--- a/npa/tests/cli/test_sonic_cli.py
+++ b/npa/tests/cli/test_sonic_cli.py
@@ -351,6 +351,8 @@ def test_sonic_train_default_embodiment_is_unitree_g1(mocker) -> None:
     assert payload["embodiment"] == "UNITREE_G1_SONIC"
     command = client.create_job.call_args.kwargs["command"]
     assert "UNITREE_G1_SONIC" in command
+    assert "SONIC_RUN_REAL_TRAIN=1" in command
+    assert "/entrypoint.sh train" in command
     assert client.create_job.call_args.kwargs["gpu_type"] == "gpu-l40s-a"
     assert client.create_job.call_args.kwargs["preset"] == "1gpu-40vcpu-160gb"
     client.subnet_resolver.assert_called_once_with(

--- a/npa/tests/workbench/test_training_config.py
+++ b/npa/tests/workbench/test_training_config.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from npa.workbench.detection_training.schemas import TrainRequest
+from npa.workbench.training_config import (
+    TrainingConfigError,
+    build_training_config,
+    overrides_to_mapping,
+)
+
+
+def test_training_config_builds_canonical_env_and_redacts_secrets() -> None:
+    config = build_training_config(
+        data_path="s3://bucket/data/",
+        overrides=["agent.algorithm.learning_rate=3e-4", "terminations.timeout=false"],
+        wandb_enabled=True,
+        wandb_project="npa-public",
+        wandb_run_name="short-run",
+        checkpoint_s3_uri="s3://bucket/checkpoints/",
+        checkpoint_s3_endpoint_url="https://storage.example",
+        checkpoint_s3_access_key_id="access",
+        checkpoint_s3_secret_access_key="secret",
+    )
+
+    env = config.env()
+    assert env["NPA_TRAINING_DATA_PATH"] == "s3://bucket/data/"
+    assert env["NPA_TRAINING_WANDB_ENABLED"] == "1"
+    assert env["WANDB_PROJECT"] == "npa-public"
+    assert env["NPA_CHECKPOINT_S3_URI"] == "s3://bucket/checkpoints/"
+    assert env["NPA_CHECKPOINT_S3_ENDPOINT_URL"] == "https://storage.example"
+    assert config.public_dict()["checkpoint_s3"]["aws_secret_access_key"] == "set"
+
+
+def test_training_config_rejects_invalid_override() -> None:
+    with pytest.raises(TrainingConfigError, match="KEY=VALUE"):
+        build_training_config(overrides=["learning_rate"])
+
+
+def test_overrides_to_mapping_parses_typed_values() -> None:
+    parsed = overrides_to_mapping(["learning_rate=0.001", "domain_randomize=true", "+env.max_steps=12"])
+
+    assert parsed == {
+        "learning_rate": 0.001,
+        "domain_randomize": True,
+        "env.max_steps": 12,
+    }
+
+
+def test_detection_request_applies_canonical_fields_and_supported_overrides() -> None:
+    request = TrainRequest(
+        view="bdd100k_rider_train",
+        lance_uri="s3://bucket/default-lancedb/",
+        output_uri="s3://bucket/output/",
+        data_path="s3://bucket/custom-lancedb/",
+        overrides=["train.epochs=1", "optimizer.learning_rate=0.0003"],
+        checkpoint_s3={"uri": "s3://bucket/checkpoints/", "endpoint_url": "https://storage.example"},
+        wandb={"enabled": True, "project": "npa-public", "run_name": "short-run", "mode": "offline"},
+    )
+
+    assert request.lance_uri == "s3://bucket/custom-lancedb/"
+    assert request.epochs == 1
+    assert request.learning_rate == 0.0003
+    assert request.checkpoint_s3.uri == "s3://bucket/checkpoints/"
+    assert request.wandb.enabled is True

--- a/npa/tests/workflows/test_bdd100k_pipeline.py
+++ b/npa/tests/workflows/test_bdd100k_pipeline.py
@@ -29,7 +29,7 @@ EXPECTED_TASK_ORDER = [
     "bdd100k-eval-distant",
     "bdd100k-fiftyone-app",
 ]
-EXPECTED_YAML_SHA256 = "e452310cef2b4f54bc0ececc4110064fb94c811d5f4a2acab3eae56f57e216e7"
+EXPECTED_YAML_SHA256 = "2a723d1ee61dad9ef14f951fdffe3a71be6355a60803e66f6a66e8a9bc69a13b"
 EXPECTED_LANCEDB_IMAGE = "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.2"
 EXPECTED_DETECTION_IMAGE = (
     "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/"

--- a/npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml
+++ b/npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml
@@ -404,11 +404,19 @@ run: |
     --arg view "${VIEW_NAME}" \
     --arg lance_uri "${LANCE_URI}" \
     --arg output_uri "${TRAIN_OUTPUT_URI}" \
+    --arg data_path "${NPA_TRAINING_DATA_PATH:-${LANCE_URI}}" \
+    --argjson overrides "${NPA_TRAINING_OVERRIDES_JSON:-[]}" \
+    --arg wandb_enabled "${NPA_TRAINING_WANDB_ENABLED:-0}" \
+    --arg wandb_project "${NPA_TRAINING_WANDB_PROJECT:-}" \
+    --arg wandb_run_name "${NPA_TRAINING_WANDB_RUN_NAME:-}" \
+    --arg wandb_mode "${WANDB_MODE:-disabled}" \
+    --arg checkpoint_s3_uri "${NPA_CHECKPOINT_S3_URI:-${TRAIN_OUTPUT_URI}}" \
+    --arg checkpoint_s3_endpoint_url "${NPA_CHECKPOINT_S3_ENDPOINT_URL:-${AWS_ENDPOINT_URL:-}}" \
     --argjson label_map "${BDD100K_LABEL_MAP}" \
     --argjson epochs "${TRAIN_EPOCHS}" \
     --argjson batch_size "${TRAIN_BATCH_SIZE}" \
     --argjson learning_rate "${TRAIN_LEARNING_RATE}" \
-    '{view: $view, lance_uri: $lance_uri, output_uri: $output_uri, label_map: $label_map, epochs: $epochs, batch_size: $batch_size, learning_rate: $learning_rate}')
+    '{view: $view, lance_uri: $lance_uri, output_uri: $output_uri, data_path: $data_path, overrides: $overrides, wandb: {enabled: ($wandb_enabled == "1"), project: $wandb_project, run_name: $wandb_run_name, mode: $wandb_mode}, checkpoint_s3: {uri: $checkpoint_s3_uri, endpoint_url: $checkpoint_s3_endpoint_url}, label_map: $label_map, epochs: $epochs, batch_size: $batch_size, learning_rate: $learning_rate}')
   post_detection "/train" "${payload}" train-response.json
   run_id=$(jq -r '.run_id' train-response.json)
   deadline=$((SECONDS + TRAIN_TIMEOUT_SECONDS))
@@ -520,11 +528,19 @@ run: |
     --arg view "${VIEW_NAME}" \
     --arg lance_uri "${LANCE_URI}" \
     --arg output_uri "${TRAIN_OUTPUT_URI}" \
+    --arg data_path "${NPA_TRAINING_DATA_PATH:-${LANCE_URI}}" \
+    --argjson overrides "${NPA_TRAINING_OVERRIDES_JSON:-[]}" \
+    --arg wandb_enabled "${NPA_TRAINING_WANDB_ENABLED:-0}" \
+    --arg wandb_project "${NPA_TRAINING_WANDB_PROJECT:-}" \
+    --arg wandb_run_name "${NPA_TRAINING_WANDB_RUN_NAME:-}" \
+    --arg wandb_mode "${WANDB_MODE:-disabled}" \
+    --arg checkpoint_s3_uri "${NPA_CHECKPOINT_S3_URI:-${TRAIN_OUTPUT_URI}}" \
+    --arg checkpoint_s3_endpoint_url "${NPA_CHECKPOINT_S3_ENDPOINT_URL:-${AWS_ENDPOINT_URL:-}}" \
     --argjson label_map "${BDD100K_LABEL_MAP}" \
     --argjson epochs "${TRAIN_EPOCHS}" \
     --argjson batch_size "${TRAIN_BATCH_SIZE}" \
     --argjson learning_rate "${TRAIN_LEARNING_RATE}" \
-    '{view: $view, lance_uri: $lance_uri, output_uri: $output_uri, label_map: $label_map, epochs: $epochs, batch_size: $batch_size, learning_rate: $learning_rate}')
+    '{view: $view, lance_uri: $lance_uri, output_uri: $output_uri, data_path: $data_path, overrides: $overrides, wandb: {enabled: ($wandb_enabled == "1"), project: $wandb_project, run_name: $wandb_run_name, mode: $wandb_mode}, checkpoint_s3: {uri: $checkpoint_s3_uri, endpoint_url: $checkpoint_s3_endpoint_url}, label_map: $label_map, epochs: $epochs, batch_size: $batch_size, learning_rate: $learning_rate}')
   post_detection "/train" "${payload}" train-response.json
   run_id=$(jq -r '.run_id' train-response.json)
   deadline=$((SECONDS + TRAIN_TIMEOUT_SECONDS))
@@ -636,11 +652,19 @@ run: |
     --arg view "${VIEW_NAME}" \
     --arg lance_uri "${LANCE_URI}" \
     --arg output_uri "${TRAIN_OUTPUT_URI}" \
+    --arg data_path "${NPA_TRAINING_DATA_PATH:-${LANCE_URI}}" \
+    --argjson overrides "${NPA_TRAINING_OVERRIDES_JSON:-[]}" \
+    --arg wandb_enabled "${NPA_TRAINING_WANDB_ENABLED:-0}" \
+    --arg wandb_project "${NPA_TRAINING_WANDB_PROJECT:-}" \
+    --arg wandb_run_name "${NPA_TRAINING_WANDB_RUN_NAME:-}" \
+    --arg wandb_mode "${WANDB_MODE:-disabled}" \
+    --arg checkpoint_s3_uri "${NPA_CHECKPOINT_S3_URI:-${TRAIN_OUTPUT_URI}}" \
+    --arg checkpoint_s3_endpoint_url "${NPA_CHECKPOINT_S3_ENDPOINT_URL:-${AWS_ENDPOINT_URL:-}}" \
     --argjson label_map "${BDD100K_LABEL_MAP}" \
     --argjson epochs "${TRAIN_EPOCHS}" \
     --argjson batch_size "${TRAIN_BATCH_SIZE}" \
     --argjson learning_rate "${TRAIN_LEARNING_RATE}" \
-    '{view: $view, lance_uri: $lance_uri, output_uri: $output_uri, label_map: $label_map, epochs: $epochs, batch_size: $batch_size, learning_rate: $learning_rate}')
+    '{view: $view, lance_uri: $lance_uri, output_uri: $output_uri, data_path: $data_path, overrides: $overrides, wandb: {enabled: ($wandb_enabled == "1"), project: $wandb_project, run_name: $wandb_run_name, mode: $wandb_mode}, checkpoint_s3: {uri: $checkpoint_s3_uri, endpoint_url: $checkpoint_s3_endpoint_url}, label_map: $label_map, epochs: $epochs, batch_size: $batch_size, learning_rate: $learning_rate}')
   post_detection "/train" "${payload}" train-response.json
   run_id=$(jq -r '.run_id' train-response.json)
   deadline=$((SECONDS + TRAIN_TIMEOUT_SECONDS))

--- a/npa/workflows/workbench/skypilot/isaac-lab-rl-train.yaml
+++ b/npa/workflows/workbench/skypilot/isaac-lab-rl-train.yaml
@@ -18,6 +18,15 @@ envs:
   ISAAC_LAB_ITERATIONS: "10"
   ISAAC_LAB_EXPERIMENT_NAME: "npa_isaac_lab"
   ISAAC_LAB_RUN_NAME: "${NPA_ISAAC_LAB_RUN_ID}"
+  NPA_TRAINING_DATA_PATH: ""
+  NPA_TRAINING_OVERRIDES_JSON: "[]"
+  NPA_TRAINING_OVERRIDES: ""
+  NPA_TRAINING_WANDB_ENABLED: "0"
+  NPA_TRAINING_WANDB_PROJECT: ""
+  NPA_TRAINING_WANDB_RUN_NAME: ""
+  WANDB_MODE: "disabled"
+  NPA_CHECKPOINT_S3_URI: ""
+  NPA_CHECKPOINT_S3_ENDPOINT_URL: ""
   ISAAC_LAB_HYDRA_OVERRIDES: "agent.save_interval=1"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/isaac-lab-rl/${NPA_ISAAC_LAB_RUN_ID}/"
   AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
@@ -41,7 +50,30 @@ run: |
   mkdir -p "${OUTPUT_DIR}"
   cd "${OUTPUT_DIR}"
 
-  read -r -a HYDRA_ARGS <<< "${ISAAC_LAB_HYDRA_OVERRIDES:-agent.save_interval=1}"
+  HYDRA_ARGS=(agent.save_interval=1)
+  while IFS= read -r override; do
+    [ -n "${override}" ] && HYDRA_ARGS+=("${override}")
+  done < <("${PYTHON_BIN}" - <<'PY'
+  import json
+  import os
+  raw = os.environ.get("NPA_TRAINING_OVERRIDES_JSON", "[]") or "[]"
+  try:
+      values = json.loads(raw)
+  except json.JSONDecodeError:
+      values = [item for item in os.environ.get("NPA_TRAINING_OVERRIDES", "").split() if item]
+  if isinstance(values, dict):
+      values = [f"{key}={value}" for key, value in values.items()]
+  for value in values:
+      print(str(value))
+  PY
+  )
+  WANDB_ARGS=()
+  if [ "${NPA_TRAINING_WANDB_ENABLED}" = "1" ]; then
+    WANDB_ARGS+=(--logger wandb)
+    if [ -n "${NPA_TRAINING_WANDB_PROJECT}" ]; then
+      WANDB_ARGS+=(--log_project_name "${NPA_TRAINING_WANDB_PROJECT}")
+    fi
+  fi
   cmd=(
     "${PYTHON_BIN}"
     "${TRAIN_SCRIPT}"
@@ -51,6 +83,7 @@ run: |
     --headless
     --experiment_name "${ISAAC_LAB_EXPERIMENT_NAME}"
     --run_name "${ISAAC_LAB_RUN_NAME}"
+    "${WANDB_ARGS[@]}"
     "${HYDRA_ARGS[@]}"
   )
   printf 'ISAAC_LAB_RSL_RL_COMMAND'
@@ -95,6 +128,15 @@ run: |
       "run_id": os.environ["NPA_ISAAC_LAB_RUN_ID"],
       "run_name": os.environ["ISAAC_LAB_RUN_NAME"],
       "experiment_name": os.environ["ISAAC_LAB_EXPERIMENT_NAME"],
+      "data_path": os.environ.get("NPA_TRAINING_DATA_PATH", ""),
+      "overrides": json.loads(os.environ.get("NPA_TRAINING_OVERRIDES_JSON", "[]") or "[]"),
+      "wandb": {
+          "enabled": os.environ.get("NPA_TRAINING_WANDB_ENABLED", "0") == "1",
+          "project": os.environ.get("NPA_TRAINING_WANDB_PROJECT", ""),
+          "run_name": os.environ.get("NPA_TRAINING_WANDB_RUN_NAME", ""),
+          "mode": os.environ.get("WANDB_MODE", ""),
+      },
+      "checkpoint_s3_uri": os.environ.get("NPA_CHECKPOINT_S3_URI", ""),
       "train_script": "/workspace/isaaclab/scripts/reinforcement_learning/rsl_rl/train.py",
       "checkpoint_path": str(latest) if latest is not None else "",
       "stable_checkpoint_path": str(stable_checkpoint) if latest is not None else "",
@@ -108,12 +150,20 @@ run: |
   (root / "npa_isaac_lab_train_summary.json").write_text(json.dumps(summary, indent=2))
   (root / "npa_isaac_lab_checkpoint_manifest.json").write_text(json.dumps(manifest, indent=2))
   
-  output = os.environ["S3_OUTPUT_PREFIX"].rstrip("/") + "/"
+  output = (os.environ.get("NPA_CHECKPOINT_S3_URI") or os.environ["S3_OUTPUT_PREFIX"]).rstrip("/") + "/"
   parsed = urlparse(output)
   if parsed.scheme != "s3" or not parsed.netloc:
       raise SystemExit(f"invalid S3_OUTPUT_PREFIX: {output}")
   prefix = parsed.path.lstrip("/")
-  s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL") or None)
+  s3 = boto3.client(
+      "s3",
+      endpoint_url=(
+          os.environ.get("NPA_CHECKPOINT_S3_ENDPOINT_URL")
+          or os.environ.get("AWS_ENDPOINT_URL")
+          or os.environ.get("NEBIUS_S3_ENDPOINT")
+          or None
+      ),
+  )
   for path in root.rglob("*"):
       if path.is_file():
           key = prefix + str(path.relative_to(root))

--- a/npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml
@@ -81,6 +81,7 @@ envs:
   SONIC_DATA_PATH: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/"
   SONIC_TRAIN_MODE: "finetune"
   SONIC_RUN_REAL_TRAIN: "1"
+  NPA_TRAINING_OVERRIDES_JSON: "[]"
   SONIC_RESUME: "False"
   SONIC_CHECKPOINT: "nvidia/GEAR-SONIC:sonic_release/last.pt"
   SONIC_CHECKPOINT_PATH: "sonic_release/last.pt"
@@ -213,6 +214,8 @@ run: |
       -e SONIC_SAVE_LAST_FREQUENCY \
       -e SONIC_SAVE_FREQUENCY \
       -e SONIC_RUNTIME_INSTALL_TRAINING_DEPS \
+      -e NPA_TRAINING_OVERRIDES_JSON \
+      -e NPA_TRAINING_OVERRIDES \
       -e WANDB_MODE \
       -e WANDB_DISABLED \
       -e WANDB_SILENT \

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -1,4 +1,4 @@
-# Standalone SONIC training smoke workflow.
+# Standalone SONIC training workflow.
 #
 # Operator-provided parameters:
 # - POLICY_IMAGE: image containing the SONIC /entrypoint.sh runtime. Use the
@@ -13,7 +13,7 @@
 name: sonic-train-standalone
 execution: serial
 ---
-name: sonic-train-smoke
+name: sonic-train
 resources:
   cloud: nebius
   accelerators: L40S:1
@@ -29,7 +29,7 @@ envs:
   AWS_PROFILE: "nebius"
   S3_ENDPOINT_URL: ""
   S3_BUCKET: "example-bucket"
-  NPA_PIPELINE_RUN_ID: "sonic-train-smoke"
+  NPA_PIPELINE_RUN_ID: "sonic-train"
   SONIC_CHECKPOINT: "nvidia/GEAR-SONIC:sonic_release/last.pt"
   SONIC_DATA_PATH: ""
   SONIC_SAMPLE_DATA: "1"
@@ -38,6 +38,11 @@ envs:
   SONIC_HEADLESS: "1"
   SONIC_MAX_ITERATIONS: "5"
   SONIC_OUTPUT_PREFIX: "sonic-train/sonic-train-smoke/"
+  NPA_TRAINING_OVERRIDES_JSON: "[]"
+  NPA_TRAINING_WANDB_ENABLED: "0"
+  NPA_TRAINING_WANDB_PROJECT: ""
+  NPA_TRAINING_WANDB_RUN_NAME: ""
+  WANDB_MODE: "disabled"
 setup: |
   set -euo pipefail
   docker_login_if_configured() {
@@ -133,6 +138,9 @@ run: |
       -e SONIC_NUM_ENVS \
       -e SONIC_HEADLESS \
       -e SONIC_MAX_ITERATIONS \
+      -e NPA_TRAINING_OVERRIDES_JSON \
+      -e NPA_TRAINING_OVERRIDES \
+      -e WANDB_MODE \
       "${POLICY_IMAGE}" train
   else
     /entrypoint.sh train


### PR DESCRIPTION
## Summary
- Add one shared training config interface for `data_path`, generic `overrides`, W&B, and BYO checkpoint S3 config.
- Wire the interface through LeRobot, Isaac Lab, SONIC, GR00T, Genesis, and detection-training CLI/SDK/YAML surfaces.
- Replace SONIC/Genesis smoke-style serverless training paths with real trainer commands that fail if the runtime cannot execute them.

## Verification
- `bash -n npa/docker/workbench/sonic/entrypoint.sh`
- `npa/.venv/bin/python -m py_compile ...` for changed Python modules
- YAML parse check for changed SkyPilot workflows
- Focused tests: `173 passed, 2 skipped`
- Broad non-e2e suite: `1421 passed, 34 skipped, 1 xpassed`
- Rendered Isaac Lab YAML with canonical data path, overrides, W&B, and checkpoint S3 fields

## Live-run note
The requested real short GPU training run with W&B dry-run and S3 upload confirmation was not executed in this environment because no BYO S3 URI, S3 endpoint, AWS credentials, W&B key, GPU, or custom training data were available. The saved report marks that verification as BLOCKED rather than fabricated.

Report: `/tmp/npa-general-training-interface-report.md`

Do not merge without the required approval; intended merge strategy is squash.
