### PR TITLE
feat(sonic): wire workflow submit materialization

### DIFF
--- a/docs/cli/workflow.md
+++ b/docs/cli/workflow.md
@@ -42,4 +42,46 @@ npa workbench workflow --help
 npa workbench workflow submit --help
 ```
 
+## `submit` Materialization
+
+`submit` can replace `${VAR}` placeholders with repeated `--var KEY=VALUE`
+arguments before calling SkyPilot. For SONIC YAMLs, `--var` also overrides
+matching `envs` keys, and the command materializes the first-party image, S3
+endpoint, bucket, and prefix into the submitted YAML so SkyPilot does not need
+to interpolate values inside `envs`.
+
+```bash
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/sonic-train-standalone.yaml \
+  --run-id sonic-smoke-$(date -u +%Y%m%dT%H%M%SZ) \
+  --registry cr.eu-north1.nebius.cloud/<registry-id> \
+  --gpu-target l40s \
+  --s3-endpoint https://storage.eu-north1.nebius.cloud \
+  --s3-bucket <bucket> \
+  --s3-prefix sonic-workflow-proof/<run-id> \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY
+```
+
+For RTX PRO 6000 Kubernetes targets, use the same command with
+`--gpu-target gpu-rtx6000` and an accelerator string accepted by your SkyPilot
+Kubernetes GPU catalog, for example
+`--accelerators RTXPRO-6000-BLACKWELL-SERVER-EDITION:1`. The SONIC
+materializer resolves `gpu-rtx6000` to `npa-sonic:0.1.2-k8s`; L40S resolves to
+`npa-sonic:0.1.2`.
+
+When a Kubernetes target pulls from a private registry, provide a SkyPilot config
+through `--config-path` that adds the registry pull secret to worker pods:
+
+```yaml
+kubernetes:
+  pod_config:
+    spec:
+      imagePullSecrets:
+        - name: <registry-pull-secret>
+```
+
+Only set `serviceAccountName` in that pod config if the account also has the
+cluster-level permissions SkyPilot needs for node and pod discovery.
+
 Regenerate this page with `bash scripts/build_docs.sh` after changing `workflow`.

--- a/docs/workbench/cookbooks/sonic-eval-runbook.md
+++ b/docs/workbench/cookbooks/sonic-eval-runbook.md
@@ -39,13 +39,20 @@ The SkyPilot blueprint is
 
 ## One Command
 
-Edit the `envs` block in the YAML for your checkpoint, output prefix, registry,
-and image tag, then submit it:
+Submit through the generic workflow command. The SONIC materializer fills the
+first-party image and S3 endpoint as literal YAML values before SkyPilot sees
+the workflow:
 
 ```bash
 npa workbench workflow submit \
   npa/workflows/workbench/skypilot/sonic-export-eval.yaml \
-  --run-id sonic-export-eval-$(date -u +%Y%m%dT%H%M%SZ)
+  --run-id sonic-export-eval-$(date -u +%Y%m%dT%H%M%SZ) \
+  --registry "${NPA_REGISTRY}" \
+  --gpu-target l40s \
+  --s3-endpoint https://storage.eu-north1.nebius.cloud \
+  --s3-bucket <bucket> \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY
 ```
 
 The default run requests `L40S:1` and uses the reference backend:
@@ -57,6 +64,9 @@ EVAL_BACKEND: reference
 EVAL_ENV: sonic-locomotion-smoke
 EPISODES: "8"
 ```
+
+Use `--var POLICY_CKPT=s3://...` and `--var OUTPUT_DIR=s3://...` when you want
+to override the checkpoint or output prefix without editing a copy of the YAML.
 
 ## Inputs
 

--- a/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
+++ b/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
@@ -12,8 +12,12 @@ The workflow composes three Workbench stages:
 3. Evaluate the resulting checkpoint with MJLab metrics through
    `npa workbench mjlab eval`.
 
-The workflow logic is in YAML. There is no Python runner script for this path;
-submit the checked-in YAML directly through the generic SkyPilot submit command.
+The workflow logic is in YAML. There is no Python runner script for this path.
+The same YAML can be used three ways:
+
+- raw SkyPilot, after editing the YAML literals yourself;
+- SDK submission through `npa.sdk.workbench.sonic.submit_workflow`;
+- CLI submission through `npa workbench workflow submit`.
 
 ## Required Inputs
 
@@ -22,10 +26,11 @@ Prepare these S3 prefixes before submission:
 - Source motions: `s3://<your-bucket-name>/motions/source/`
 - Per-run output root: `s3://<your-bucket-name>/sonic-locomotion/<run-id>/`
 
-The committed YAML uses explicit placeholders because SkyPilot 0.12.2 does not
-expand same-block environment variables inside `envs`. Replace
-`<your-bucket-name>`, `<run-id>`, `<your-registry-id>`, and image tags before a
-live run.
+SkyPilot 0.12.2 does not expand same-block environment variables inside `envs`.
+For raw `sky` runs, replace `<your-bucket-name>`, `<run-id>`,
+`<your-registry-id>`, and image tags with literal values before launch. For CLI
+or SDK submission, pass the values to the SONIC materializer and it writes the
+literal YAML before calling SkyPilot.
 
 ## Tool Templates
 
@@ -42,9 +47,31 @@ Those commands point to:
 - `npa/workflows/workbench/skypilot/retargeting.yaml`
 - `npa/workflows/workbench/skypilot/mjlab-eval.yaml`
 
-## Full Submission
+## Raw SkyPilot
 
-Bootstrap the pinned SkyPilot environment, then submit the YAML:
+Copy the YAML, edit literals, then run it directly with SkyPilot:
+
+```bash
+cp npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml /tmp/sonic.yaml
+# Edit /tmp/sonic.yaml so image_id, AWS_ENDPOINT_URL, and all s3:// prefixes
+# contain concrete values. Do not leave ${VAR} in envs or image_id fields.
+sky jobs launch \
+  --name sonic-locomotion-<run-id> \
+  --secret AWS_ACCESS_KEY_ID \
+  --secret AWS_SECRET_ACCESS_KEY \
+  --yes \
+  /tmp/sonic.yaml
+```
+
+The `sonic-finetune` stage uses the first-party SONIC image. The retargeting and
+MJLab stages require a generic helper image that contains the `npa` CLI and this
+repository's Workbench package.
+
+## CLI Submission
+
+Bootstrap the pinned SkyPilot environment, then submit the YAML. The SONIC
+materializer resolves the first-party SONIC image from the manifest and fills
+literal S3 values before SkyPilot sees the YAML:
 
 ```bash
 npa skypilot bootstrap
@@ -52,7 +79,15 @@ export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
 
 npa workbench workflow submit \
   npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml \
-  --run-id sonic-locomotion-<run-id>
+  --run-id sonic-locomotion-<run-id> \
+  --registry cr.eu-north1.nebius.cloud/<registry-id> \
+  --npa-image cr.eu-north1.nebius.cloud/<registry-id>/npa:<tag> \
+  --gpu-target l40s \
+  --s3-endpoint https://storage.eu-north1.nebius.cloud \
+  --s3-bucket <bucket> \
+  --s3-prefix sonic-locomotion/<run-id> \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY
 ```
 
 Use the Kubernetes controller backend unless you explicitly need the Nebius VM
@@ -63,6 +98,50 @@ npa workbench workflow submit \
   npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml \
   --run-id sonic-locomotion-<run-id> \
   --controller-backend kubernetes
+```
+
+For RTX PRO 6000 Kubernetes targets, use:
+
+```bash
+--gpu-target gpu-rtx6000 \
+--accelerators RTXPRO-6000-BLACKWELL-SERVER-EDITION:1
+```
+
+This resolves the SONIC stage to `npa-sonic:0.1.2-k8s`. L40S resolves to
+`npa-sonic:0.1.2`.
+
+For Kubernetes targets that pull private images, pass a SkyPilot config with the
+namespace's registry pull secret:
+
+```yaml
+kubernetes:
+  pod_config:
+    spec:
+      imagePullSecrets:
+        - name: <registry-pull-secret>
+```
+
+Use that file with `--config-path`. Only add `serviceAccountName` when the
+service account has the Kubernetes node and pod discovery permissions required
+by SkyPilot.
+
+## SDK Submission
+
+```python
+from pathlib import Path
+from npa.sdk.workbench import sonic
+
+sonic.submit_workflow(
+    Path("npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml"),
+    run_id="sonic-locomotion-run",
+    registry="cr.eu-north1.nebius.cloud/<registry-id>",
+    npa_image="cr.eu-north1.nebius.cloud/<registry-id>/npa:<tag>",
+    gpu_target="l40s",
+    s3_endpoint="https://storage.eu-north1.nebius.cloud",
+    s3_bucket="<bucket>",
+    s3_prefix="sonic-locomotion/sonic-locomotion-run",
+    secret_envs=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+)
 ```
 
 ## Stage Contract

--- a/docs/workbench/cookbooks/sonic-train-runbook.md
+++ b/docs/workbench/cookbooks/sonic-train-runbook.md
@@ -43,6 +43,84 @@ When validating an unpromoted build, pass the pushed image explicitly:
 --image "${NPA_REGISTRY}/npa-sonic:0.1.2"
 ```
 
+## Standalone SkyPilot YAML
+
+The raw SkyPilot training smoke is
+`npa/workflows/workbench/skypilot/sonic-train-standalone.yaml`. It has literal
+editable defaults because SkyPilot 0.12.2 does not interpolate `${VAR}` inside
+`envs` or `resources.image_id`.
+
+For a zero-NPA raw SkyPilot run, copy the YAML, replace these literals, and
+launch it directly:
+
+| YAML field | L40S value | RTX PRO 6000 Kubernetes value |
+| --- | --- | --- |
+| `resources.image_id` and `POLICY_IMAGE` | `cr.eu-north1.nebius.cloud/<registry-id>/npa-sonic:0.1.2` | `cr.eu-north1.nebius.cloud/<registry-id>/npa-sonic:0.1.2-k8s` |
+| `SONIC_GPU_TYPE` | `l40s` | `gpu-rtx6000` |
+| `SONIC_IMAGE_VARIANT` | `sonic-l40s-baked` | `sonic-k8s-host-mounted` |
+| `S3_ENDPOINT_URL` | your S3-compatible endpoint | your S3-compatible endpoint |
+| `S3_BUCKET` / `SONIC_OUTPUT_PREFIX` | your artifact destination | your artifact destination |
+
+```bash
+cp npa/workflows/workbench/skypilot/sonic-train-standalone.yaml /tmp/sonic-train.yaml
+# Edit /tmp/sonic-train.yaml with concrete image and S3 values.
+sky jobs launch \
+  --name sonic-train-smoke \
+  --secret AWS_ACCESS_KEY_ID \
+  --secret AWS_SECRET_ACCESS_KEY \
+  --yes \
+  /tmp/sonic-train.yaml
+```
+
+The same YAML can be submitted through the CLI, which materializes the image and
+S3 values before SkyPilot submission:
+
+```bash
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/sonic-train-standalone.yaml \
+  --run-id sonic-train-smoke \
+  --registry "${NPA_REGISTRY}" \
+  --gpu-target l40s \
+  --s3-endpoint https://storage.eu-north1.nebius.cloud \
+  --s3-bucket <bucket> \
+  --s3-prefix sonic-train/sonic-train-smoke \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY
+```
+
+For Kubernetes targets that pull from a private registry, pass a SkyPilot config
+with the namespace's registry pull secret:
+
+```yaml
+kubernetes:
+  pod_config:
+    spec:
+      imagePullSecrets:
+        - name: <registry-pull-secret>
+```
+
+Then add `--config-path /path/to/skypilot-kubernetes.yaml` to the submit command.
+Do not set `serviceAccountName` unless that account can also list Kubernetes
+nodes and pods for SkyPilot prechecks.
+
+SDK equivalent:
+
+```python
+from pathlib import Path
+from npa.sdk.workbench import sonic
+
+sonic.submit_workflow(
+    Path("npa/workflows/workbench/skypilot/sonic-train-standalone.yaml"),
+    run_id="sonic-train-smoke",
+    registry="cr.eu-north1.nebius.cloud/<registry-id>",
+    gpu_target="l40s",
+    s3_endpoint="https://storage.eu-north1.nebius.cloud",
+    s3_bucket="<bucket>",
+    s3_prefix="sonic-train/sonic-train-smoke",
+    secret_envs=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+)
+```
+
 Build and push the required first-party image from the repo root. Use the L40S
 baked variant for compute-only VM hosts:
 

--- a/docs/workbench/sonic-image-catalog.md
+++ b/docs/workbench/sonic-image-catalog.md
@@ -50,6 +50,38 @@ SkyPilot YAMLs expose the same selectors through env vars such as
 `SONIC_EVAL_CONTAINER_GPU_TARGET`, and
 `SONIC_EVAL_CONTAINER_IMAGE_VARIANT`.
 
+For standard workflow submission, the same selector is available on the generic
+workflow command. The submitted YAML is materialized with literal env values
+before SkyPilot sees it:
+
+```bash
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/sonic-train-standalone.yaml \
+  --registry "${NPA_REGISTRY}" \
+  --gpu-target l40s \
+  --s3-endpoint https://storage.eu-north1.nebius.cloud \
+  --s3-bucket <bucket> \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY
+```
+
+SDK users call the same materializer:
+
+```python
+from pathlib import Path
+from npa.sdk.workbench import sonic
+
+sonic.submit_workflow(
+    Path("npa/workflows/workbench/skypilot/sonic-train-standalone.yaml"),
+    run_id="sonic-smoke",
+    registry="cr.eu-north1.nebius.cloud/<registry-id>",
+    gpu_target="gpu-rtx6000",
+    s3_endpoint="https://storage.eu-north1.nebius.cloud",
+    s3_bucket="<bucket>",
+    secret_envs=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+)
+```
+
 ## Build Commands
 
 Baked L40S variant:

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -79,6 +79,67 @@ def submit_cmd(
         "--var",
         help="Variable substitution as KEY=VALUE.",
     ),
+    tool: str = typer.Option(
+        "",
+        "--tool",
+        help="Workflow-specific materializer. Currently supported: sonic.",
+    ),
+    registry: str = typer.Option(
+        "",
+        "--registry",
+        help="Container registry used by workflow materializers.",
+    ),
+    image: str = typer.Option(
+        "",
+        "--image",
+        help="First-party tool image override used by workflow materializers.",
+    ),
+    npa_image: str = typer.Option(
+        "",
+        "--npa-image",
+        help="Generic NPA helper image override for multi-tool workflows.",
+    ),
+    gpu_target: str = typer.Option(
+        "",
+        "--gpu-target",
+        "--gpu-type",
+        help="GPU target used by workflow materializers.",
+    ),
+    image_variant: str = typer.Option(
+        "",
+        "--image-variant",
+        help="Manifest image variant used by workflow materializers.",
+    ),
+    accelerators: str = typer.Option(
+        "",
+        "--accelerators",
+        help="SkyPilot accelerator string for materialized GPU tasks.",
+    ),
+    cloud: str = typer.Option(
+        "",
+        "--cloud",
+        help="Cloud value for materialized GPU tasks.",
+    ),
+    s3_endpoint: str = typer.Option(
+        "",
+        "--s3-endpoint",
+        help="S3-compatible endpoint materialized into workflow envs.",
+    ),
+    s3_bucket: str = typer.Option(
+        "",
+        "--s3-bucket",
+        help="S3 bucket name materialized into workflow envs.",
+    ),
+    s3_prefix: str = typer.Option(
+        "",
+        "--s3-prefix",
+        help="S3 object prefix materialized into workflow envs.",
+    ),
+    secret_env: list[str] = typer.Option(
+        [],
+        "--secret-env",
+        help="Environment variable name to pass to SkyPilot as a secret.",
+    ),
     output_format: OutputFormat = typer.Option(
         OutputFormat.text,
         "--output-format",
@@ -94,13 +155,54 @@ def submit_cmd(
     substitutions = _parse_submit_vars(var)
     submitted_yaml_path = yaml_path
     submitted_yaml_context: tempfile.TemporaryDirectory[str] | None = None
-    if substitutions:
+    materializer = _resolve_materializer(tool, yaml_path)
+    if substitutions or materializer:
         submitted_yaml_context = tempfile.TemporaryDirectory(prefix="npa-workflow-")
         submitted_yaml_path = Path(submitted_yaml_context.name) / yaml_path.name
 
     try:
+        source_yaml_path = yaml_path
         if substitutions:
             substituted = _substitute_workflow_vars(yaml_path, substitutions)
+            source_yaml_path = Path(submitted_yaml_context.name) / f"substituted-{yaml_path.name}"
+            source_yaml_path.write_text(substituted, encoding="utf-8")
+
+        if materializer == "sonic":
+            from npa.workbench.sonic.workflow import (
+                materialize_sonic_workflow,
+                unresolved_submit_placeholders,
+            )
+
+            try:
+                plan = materialize_sonic_workflow(
+                    source_yaml_path,
+                    run_id=run_id or _default_submit_run_id(yaml_path),
+                    registry=registry,
+                    image=image,
+                    npa_image=npa_image,
+                    gpu_target=gpu_target,
+                    image_variant=image_variant,
+                    s3_endpoint=s3_endpoint,
+                    s3_bucket=s3_bucket,
+                    s3_prefix=s3_prefix,
+                    accelerators=accelerators,
+                    cloud=cloud,
+                    env_overrides=substitutions,
+                )
+            except ValueError as exc:
+                _fail(str(exc))
+                return
+            unresolved = unresolved_submit_placeholders(plan.yaml_text)
+            if unresolved:
+                _fail(
+                    "SONIC workflow still has unresolved submit placeholders: "
+                    + ", ".join(unresolved)
+                )
+                return
+            submitted_yaml_path.write_text(plan.yaml_text, encoding="utf-8")
+            _warn_unresolved_placeholders(plan.yaml_text)
+        elif substitutions:
+            substituted = source_yaml_path.read_text(encoding="utf-8")
             _warn_unresolved_placeholders(substituted)
             submitted_yaml_path.write_text(substituted, encoding="utf-8")
         else:
@@ -113,6 +215,7 @@ def submit_cmd(
             config_path=config_path,
             sky_bin=sky_bin or None,
             controller_backend=controller_backend.value,
+            secret_envs=secret_env,
             timeout=submit_timeout,
         )
     except OSError as exc:
@@ -149,6 +252,15 @@ def _parse_submit_vars(var: list[str]) -> dict[str, str]:
             _fail("Invalid --var format. Use KEY=VALUE.")
         substitutions[key] = value
     return substitutions
+
+
+def _resolve_materializer(tool: str, yaml_path: Path) -> str:
+    requested = tool.strip().lower()
+    if requested in {"", "auto"}:
+        return "sonic" if "sonic" in yaml_path.name.lower() else ""
+    if requested != "sonic":
+        _fail(f"Unsupported workflow materializer: {tool}")
+    return requested
 
 
 def _substitute_workflow_vars(yaml_path: Path, substitutions: dict[str, str]) -> str:

--- a/npa/src/npa/sdk/workbench/sonic.py
+++ b/npa/src/npa/sdk/workbench/sonic.py
@@ -11,6 +11,11 @@ from npa.workbench.sonic import (
     load_export_metadata,
     validate_onnx_parity,
 )
+from npa.workbench.sonic.workflow import (
+    SonicWorkflowPlan,
+    materialize_sonic_workflow,
+    submit_sonic_workflow,
+)
 
 train = make_cli_wrapper("npa.cli.workbench.sonic.train", "train_cmd", "Run SONIC training.")
 eval = make_cli_wrapper(
@@ -18,14 +23,21 @@ eval = make_cli_wrapper(
     "eval_cmd",
     "Evaluate a SONIC ONNX policy.",
 )
+materialize_workflow = materialize_sonic_workflow
+submit_workflow = submit_sonic_workflow
 
 __all__ = [
     "SonicExportError",
     "SonicExportResult",
     "SonicParityResult",
+    "SonicWorkflowPlan",
     "export_onnx",
     "eval",
     "load_export_metadata",
+    "materialize_workflow",
+    "materialize_sonic_workflow",
+    "submit_workflow",
+    "submit_sonic_workflow",
     "train",
     "validate_onnx_parity",
 ]

--- a/npa/src/npa/workbench/sonic/workflow.py
+++ b/npa/src/npa/workbench/sonic/workflow.py
@@ -1,0 +1,317 @@
+"""SONIC SkyPilot workflow materialization and submission helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Sequence
+
+import yaml
+
+from npa.deploy.images import container_image_for_tool, sonic_image_entry
+from npa.orchestration.skypilot.controller import DEFAULT_CONTROLLER_BACKEND, ControllerBackend
+from npa.orchestration.skypilot.workflow import WorkflowResult
+from npa.orchestration.skypilot.workflow import submit_workflow as _submit_skypilot_workflow
+
+
+DEFAULT_S3_ENDPOINT = "https://storage.eu-north1.nebius.cloud"
+DEFAULT_GPU_TARGET = "l40s"
+DEFAULT_SONIC_WORKFLOW_PREFIX = "sonic-locomotion"
+UNRESOLVED_SUBMIT_TOKENS = ("<your-", "<sonic-image-tag>", "<npa-image-tag>", "example.invalid")
+
+
+@dataclass(frozen=True)
+class SonicWorkflowPlan:
+    """Resolved values used to submit a SONIC workflow YAML."""
+
+    yaml_text: str
+    run_id: str
+    policy_image: str
+    npa_image: str
+    gpu_target: str
+    image_variant: str
+    s3_endpoint: str
+    s3_bucket: str
+    s3_prefix: str
+    accelerators: str
+    cloud: str
+
+
+def materialize_sonic_workflow(
+    yaml_path: Path,
+    *,
+    run_id: str,
+    registry: str = "",
+    image: str = "",
+    npa_image: str = "",
+    gpu_target: str = DEFAULT_GPU_TARGET,
+    image_variant: str = "",
+    s3_endpoint: str = "",
+    s3_bucket: str = "",
+    s3_prefix: str = "",
+    accelerators: str = "",
+    cloud: str = "",
+    env_overrides: dict[str, str] | None = None,
+) -> SonicWorkflowPlan:
+    """Return a concrete SONIC workflow YAML with no submit-time env indirection."""
+
+    docs = _load_yaml_documents(yaml_path)
+    resolved_run_id = run_id or _default_run_id(yaml_path)
+    resolved_gpu_target = (gpu_target or DEFAULT_GPU_TARGET).strip()
+    entry = sonic_image_entry(
+        gpu_target=resolved_gpu_target or None,
+        image_variant=image_variant or None,
+    )
+    resolved_variant = str(entry["id"])
+    resolved_policy_image = image or container_image_for_tool(
+        "sonic",
+        registry=registry or None,
+        gpu_target=resolved_gpu_target or None,
+        image_variant=resolved_variant,
+    )
+    resolved_npa_image = npa_image
+    resolved_endpoint = _resolve_s3_endpoint(s3_endpoint)
+    resolved_bucket = s3_bucket or os.environ.get("NPA_S3_BUCKET", "")
+    resolved_prefix = _resolve_s3_prefix(s3_prefix, resolved_run_id)
+    resolved_accelerators = accelerators or _default_accelerators(resolved_gpu_target)
+    resolved_cloud = cloud or _default_cloud(resolved_gpu_target)
+
+    replacements = {
+        "sonic-locomotion/<run-id>/": resolved_prefix,
+        f"sonic-locomotion/{resolved_run_id}/": resolved_prefix,
+        "<run-id>": resolved_run_id,
+        "${NPA_PIPELINE_RUN_ID}": resolved_run_id,
+        "${POLICY_IMAGE}": resolved_policy_image,
+        "${S3_ENDPOINT_URL}": resolved_endpoint,
+    }
+    if resolved_bucket:
+        replacements["<your-bucket-name>"] = resolved_bucket
+
+    materialized = [_replace_strings(doc, replacements) for doc in docs]
+    for doc in materialized:
+        if isinstance(doc, dict):
+            _materialize_task_doc(
+                doc,
+                run_id=resolved_run_id,
+                policy_image=resolved_policy_image,
+                npa_image=resolved_npa_image,
+                gpu_target=resolved_gpu_target,
+                image_variant=resolved_variant,
+                s3_endpoint=resolved_endpoint,
+                s3_bucket=resolved_bucket,
+                s3_prefix=resolved_prefix,
+                accelerators=resolved_accelerators,
+                cloud=resolved_cloud,
+                env_overrides=env_overrides or {},
+            )
+
+    yaml_text = yaml.safe_dump_all(materialized, sort_keys=False)
+    return SonicWorkflowPlan(
+        yaml_text=yaml_text,
+        run_id=resolved_run_id,
+        policy_image=resolved_policy_image,
+        npa_image=resolved_npa_image,
+        gpu_target=resolved_gpu_target,
+        image_variant=resolved_variant,
+        s3_endpoint=resolved_endpoint,
+        s3_bucket=resolved_bucket,
+        s3_prefix=resolved_prefix,
+        accelerators=resolved_accelerators,
+        cloud=resolved_cloud,
+    )
+
+
+def submit_sonic_workflow(
+    yaml_path: Path,
+    *,
+    run_id: str = "",
+    registry: str = "",
+    image: str = "",
+    npa_image: str = "",
+    gpu_target: str = DEFAULT_GPU_TARGET,
+    image_variant: str = "",
+    s3_endpoint: str = "",
+    s3_bucket: str = "",
+    s3_prefix: str = "",
+    accelerators: str = "",
+    cloud: str = "",
+    env_overrides: dict[str, str] | None = None,
+    isolated_config_dir: Path | None = None,
+    config_path: Path | None = None,
+    sky_bin: str | None = None,
+    controller_backend: ControllerBackend = DEFAULT_CONTROLLER_BACKEND,
+    secret_envs: Sequence[str] | None = None,
+    timeout: int = 1800,
+) -> WorkflowResult:
+    """Materialize and submit a SONIC SkyPilot workflow."""
+
+    plan = materialize_sonic_workflow(
+        yaml_path,
+        run_id=run_id,
+        registry=registry,
+        image=image,
+        npa_image=npa_image,
+        gpu_target=gpu_target,
+        image_variant=image_variant,
+        s3_endpoint=s3_endpoint,
+        s3_bucket=s3_bucket,
+        s3_prefix=s3_prefix,
+        accelerators=accelerators,
+        cloud=cloud,
+        env_overrides=env_overrides,
+    )
+    unresolved = unresolved_submit_placeholders(plan.yaml_text)
+    if unresolved:
+        raise ValueError(
+            "SONIC workflow still has unresolved submit placeholders: "
+            + ", ".join(unresolved)
+        )
+    with tempfile.TemporaryDirectory(prefix="npa-sonic-workflow-") as tmp:
+        prepared = Path(tmp) / Path(yaml_path).name
+        prepared.write_text(plan.yaml_text, encoding="utf-8")
+        return _submit_skypilot_workflow(
+            prepared,
+            plan.run_id,
+            isolated_config_dir=isolated_config_dir,
+            config_path=config_path,
+            sky_bin=sky_bin,
+            controller_backend=controller_backend,
+            secret_envs=secret_envs,
+            timeout=timeout,
+        )
+
+
+def _load_yaml_documents(path: Path) -> list[Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return [doc for doc in yaml.safe_load_all(handle) if doc is not None]
+
+
+def unresolved_submit_placeholders(yaml_text: str) -> list[str]:
+    """Return placeholder tokens that should never reach SkyPilot submit."""
+
+    return [token for token in UNRESOLVED_SUBMIT_TOKENS if token in yaml_text]
+
+
+def _default_run_id(yaml_path: Path) -> str:
+    stem = re.sub(r"[^A-Za-z0-9_.-]+", "-", Path(yaml_path).stem).strip("-")
+    return stem or "sonic-workflow"
+
+
+def _resolve_s3_endpoint(explicit: str) -> str:
+    return (
+        explicit
+        or os.environ.get("S3_ENDPOINT_URL")
+        or os.environ.get("AWS_ENDPOINT_URL")
+        or os.environ.get("NEBIUS_S3_ENDPOINT")
+        or DEFAULT_S3_ENDPOINT
+    )
+
+
+def _resolve_s3_prefix(explicit: str, run_id: str) -> str:
+    prefix = explicit.strip("/") if explicit else f"{DEFAULT_SONIC_WORKFLOW_PREFIX}/{run_id}"
+    return prefix.rstrip("/") + "/"
+
+
+def _default_accelerators(gpu_target: str) -> str:
+    normalized = gpu_target.strip().lower().replace("_", "-")
+    if "rtx" in normalized or "blackwell" in normalized or "sm-120" in normalized:
+        return "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
+    return "L40S:1"
+
+
+def _default_cloud(gpu_target: str) -> str:
+    normalized = gpu_target.strip().lower().replace("_", "-")
+    if "rtx" in normalized or "blackwell" in normalized or "sm-120" in normalized:
+        return "kubernetes"
+    return "nebius"
+
+
+def _replace_strings(value: Any, replacements: dict[str, str]) -> Any:
+    if isinstance(value, str):
+        for old, new in replacements.items():
+            value = value.replace(old, new)
+        return value
+    if isinstance(value, list):
+        return [_replace_strings(item, replacements) for item in value]
+    if isinstance(value, dict):
+        return {key: _replace_strings(item, replacements) for key, item in value.items()}
+    return value
+
+
+def _materialize_task_doc(
+    doc: dict[str, Any],
+    *,
+    run_id: str,
+    policy_image: str,
+    npa_image: str,
+    gpu_target: str,
+    image_variant: str,
+    s3_endpoint: str,
+    s3_bucket: str,
+    s3_prefix: str,
+    accelerators: str,
+    cloud: str,
+    env_overrides: dict[str, str],
+) -> None:
+    envs = doc.get("envs")
+    resources = doc.get("resources")
+    if not isinstance(envs, dict) or not isinstance(resources, dict):
+        return
+
+    has_sonic_env = _has_sonic_env(doc)
+    uses_sonic_runtime_image = _uses_sonic_runtime_image(doc)
+    image_id = str(resources.get("image_id", ""))
+    if uses_sonic_runtime_image:
+        resources["cloud"] = cloud
+        resources["image_id"] = f"docker:{policy_image}"
+        if resources.get("accelerators"):
+            resources["accelerators"] = accelerators
+    elif npa_image and _looks_like_npa_helper_image(image_id):
+        resources["image_id"] = f"docker:{npa_image}"
+
+    for key in ("POLICY_IMAGE", "CONTAINER_IMAGE", "SONIC_EVAL_CONTAINER_IMAGE"):
+        if key in envs and has_sonic_env:
+            envs[key] = policy_image
+    for key in ("SONIC_GPU_TYPE", "SONIC_GPU_TARGET", "CONTAINER_GPU_TARGET", "SONIC_EVAL_CONTAINER_GPU_TARGET"):
+        if key in envs and has_sonic_env:
+            envs[key] = gpu_target
+    for key in ("SONIC_IMAGE_VARIANT", "CONTAINER_IMAGE_VARIANT", "SONIC_EVAL_CONTAINER_IMAGE_VARIANT"):
+        if key in envs and has_sonic_env:
+            envs[key] = image_variant
+    for key in ("S3_ENDPOINT_URL", "AWS_ENDPOINT_URL", "NEBIUS_S3_ENDPOINT"):
+        if key in envs:
+            envs[key] = s3_endpoint
+    if "S3_BUCKET" in envs and s3_bucket:
+        envs["S3_BUCKET"] = s3_bucket
+    if "NPA_PIPELINE_RUN_ID" in envs:
+        envs["NPA_PIPELINE_RUN_ID"] = run_id
+    if "SONIC_OUTPUT_PREFIX" in envs:
+        envs["SONIC_OUTPUT_PREFIX"] = s3_prefix
+    for key, value in env_overrides.items():
+        if key in envs:
+            envs[key] = value
+
+
+def _has_sonic_env(doc: dict[str, Any]) -> bool:
+    envs = doc.get("envs")
+    return isinstance(envs, dict) and (
+        "SONIC_GPU_TYPE" in envs
+        or "SONIC_GPU_TARGET" in envs
+        or "POLICY_IMAGE" in envs
+        or "CONTAINER_IMAGE" in envs
+        or "SONIC_EVAL_CONTAINER_IMAGE" in envs
+    )
+
+
+def _uses_sonic_runtime_image(doc: dict[str, Any]) -> bool:
+    envs = doc.get("envs")
+    resources = doc.get("resources")
+    image_id = str(resources.get("image_id", "")) if isinstance(resources, dict) else ""
+    return isinstance(envs, dict) and ("npa-sonic" in image_id or "POLICY_IMAGE" in envs)
+
+
+def _looks_like_npa_helper_image(image_id: str) -> bool:
+    return "/npa:" in image_id or image_id.endswith("/npa:<npa-image-tag>")

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from typer.testing import CliRunner
+import yaml
 
 from npa.cli.main import app
 from npa.clients.config import SSHConfig, StorageConfig, WorkbenchConfig
@@ -11,6 +14,7 @@ from npa.workflows.distill_two_vm import TwoVMDistillError
 
 
 runner = CliRunner()
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.mark.parametrize(
@@ -70,6 +74,8 @@ def test_workbench_workflow_submit_dispatches_skypilot(mocker, tmp_path) -> None
             "run-1",
             "--submit-timeout",
             "30",
+            "--secret-env",
+            "AWS_ACCESS_KEY_ID",
         ],
     )
 
@@ -79,6 +85,7 @@ def test_workbench_workflow_submit_dispatches_skypilot(mocker, tmp_path) -> None
     submit_mock.assert_called_once()
     assert submit_mock.call_args.args == (yaml_path, "run-1")
     assert submit_mock.call_args.kwargs["timeout"] == 30
+    assert submit_mock.call_args.kwargs["secret_envs"] == ["AWS_ACCESS_KEY_ID"]
 
 
 def test_workbench_workflow_submit_substitutes_vars(mocker, tmp_path) -> None:
@@ -155,6 +162,96 @@ def test_workbench_workflow_submit_warns_on_unresolved_placeholders(mocker, tmp_
 
     assert result.exit_code == 0
     assert "Warning: unresolved placeholders remain: ${MISSING}" in result.output + result.stderr
+
+
+def test_workbench_workflow_submit_materializes_sonic_yaml(mocker) -> None:
+    yaml_path = REPO_ROOT / "workflows/workbench/skypilot/sonic-train-standalone.yaml"
+    captured: dict[str, object] = {}
+
+    def fake_submit_workflow(path, run_id, **kwargs):
+        captured["path"] = path
+        captured["run_id"] = run_id
+        captured["content"] = path.read_text(encoding="utf-8")
+        captured["kwargs"] = kwargs
+        return WorkflowResult(status="SUBMITTED", job_id="42", returncode=0)
+
+    mocker.patch(
+        "npa.orchestration.skypilot.workflow.submit_workflow",
+        side_effect=fake_submit_workflow,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(yaml_path),
+            "--run-id",
+            "sonic-run",
+            "--registry",
+            "registry.example/workbench",
+            "--gpu-target",
+            "gpu-rtx6000",
+            "--s3-endpoint",
+            "https://storage.example",
+            "--s3-bucket",
+            "proof-bucket",
+            "--s3-prefix",
+            "sonic-proof/sonic-run",
+            "--accelerators",
+            "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1",
+            "--var",
+            "SONIC_MAX_ITERATIONS=2",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["run_id"] == "sonic-run"
+    docs = [doc for doc in yaml.safe_load_all(str(captured["content"])) if doc]
+    task = docs[1]
+    envs = task["envs"]
+    assert task["resources"]["image_id"] == "docker:registry.example/workbench/npa-sonic:0.1.2-k8s"
+    assert task["resources"]["cloud"] == "kubernetes"
+    assert task["resources"]["accelerators"] == "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
+    assert envs["POLICY_IMAGE"] == "registry.example/workbench/npa-sonic:0.1.2-k8s"
+    assert envs["SONIC_GPU_TYPE"] == "gpu-rtx6000"
+    assert envs["SONIC_IMAGE_VARIANT"] == "sonic-k8s-host-mounted"
+    assert envs["S3_ENDPOINT_URL"] == "https://storage.example"
+    assert envs["S3_BUCKET"] == "proof-bucket"
+    assert envs["SONIC_OUTPUT_PREFIX"] == "sonic-proof/sonic-run/"
+    assert envs["SONIC_MAX_ITERATIONS"] == "2"
+    assert "${" not in task["resources"]["image_id"]
+    assert "${" not in "\n".join(str(value) for value in envs.values())
+
+
+def test_workbench_workflow_submit_blocks_unresolved_sonic_placeholders(mocker) -> None:
+    yaml_path = REPO_ROOT / "workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml"
+    submit_mock = mocker.patch("npa.orchestration.skypilot.workflow.submit_workflow")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(yaml_path),
+            "--run-id",
+            "sonic-run",
+            "--registry",
+            "registry.example/workbench",
+            "--gpu-target",
+            "l40s",
+            "--s3-endpoint",
+            "https://storage.example",
+            "--s3-bucket",
+            "proof-bucket",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "unresolved submit placeholders" in result.output
+    submit_mock.assert_not_called()
 
 
 def test_workflow_run_unknown_workflow_errors() -> None:

--- a/npa/tests/guardrails/test_three_tier_contract.py
+++ b/npa/tests/guardrails/test_three_tier_contract.py
@@ -220,7 +220,7 @@ def test_standalone_policy_yaml_is_parameterized_and_endpoint_safe() -> None:
     task = docs[1]
     envs = task["envs"]
 
-    assert task["resources"]["image_id"] == "docker:${POLICY_IMAGE}"
+    assert task["resources"]["image_id"] == "docker:example.invalid/npa-sonic:0.1.2"
     assert {
         "POLICY_IMAGE",
         "SONIC_GPU_TYPE",
@@ -233,4 +233,6 @@ def test_standalone_policy_yaml_is_parameterized_and_endpoint_safe() -> None:
     assert envs["SONIC_IMAGE_VARIANT"] == "sonic-l40s-baked"
     assert envs["S3_ENDPOINT_URL"] == ""
     assert envs["S3_BUCKET"] == "example-bucket"
+    assert "${" not in task["resources"]["image_id"]
+    assert "${" not in "\n".join(str(value) for value in envs.values())
     assert "nebius.cloud" not in text

--- a/npa/tests/workflows/test_sonic_locomotion_finetuning.py
+++ b/npa/tests/workflows/test_sonic_locomotion_finetuning.py
@@ -32,6 +32,14 @@ SONIC_EXPORT_EVAL_YAML = (
     / "skypilot"
     / "sonic-export-eval.yaml"
 )
+SONIC_TRAIN_STANDALONE_YAML = (
+    ROOT
+    / "npa"
+    / "workflows"
+    / "workbench"
+    / "skypilot"
+    / "sonic-train-standalone.yaml"
+)
 
 
 def _docs(path: Path) -> list[dict]:
@@ -74,6 +82,73 @@ def test_sonic_locomotion_pipeline_routes_first_party_sonic_to_l40s_manifest_ima
     assert train["resources"]["image_id"].endswith("/npa-sonic:<sonic-image-tag>")
     assert train["envs"]["SONIC_GPU_TYPE"] == "l40s"
     assert train["envs"]["SONIC_IMAGE_VARIANT"] == "sonic-l40s-baked"
+
+
+def test_sonic_workflow_materializer_resolves_images_and_s3_literals() -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        PIPELINE_YAML,
+        run_id="sonic-run",
+        registry="registry.example/workbench",
+        npa_image="registry.example/workbench/npa:tools",
+        gpu_target="gpu-rtx6000",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+        s3_prefix="sonic-proof/sonic-run",
+        accelerators="RTXPRO-6000-BLACKWELL-SERVER-EDITION:1",
+    )
+    docs = [doc for doc in yaml.safe_load_all(plan.yaml_text) if doc is not None]
+    retarget, train, eval_task = docs[1:]
+
+    assert retarget["resources"]["image_id"] == "docker:registry.example/workbench/npa:tools"
+    assert train["resources"]["image_id"] == "docker:registry.example/workbench/npa-sonic:0.1.2-k8s"
+    assert train["resources"]["cloud"] == "kubernetes"
+    assert train["resources"]["accelerators"] == "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
+    assert eval_task["resources"]["image_id"] == "docker:registry.example/workbench/npa:tools"
+    assert train["envs"]["SONIC_GPU_TYPE"] == "gpu-rtx6000"
+    assert train["envs"]["SONIC_IMAGE_VARIANT"] == "sonic-k8s-host-mounted"
+    assert train["envs"]["SONIC_TRAIN_OUTPUT_URI"] == "s3://proof-bucket/sonic-proof/sonic-run/training/"
+    assert retarget["envs"]["AWS_ENDPOINT_URL"] == "https://storage.example"
+    for task in (retarget, train, eval_task):
+        assert "${" not in task["resources"]["image_id"]
+        assert "${" not in "\n".join(str(value) for value in task["envs"].values())
+    assert "<your-" not in plan.yaml_text
+
+
+def test_sonic_sdk_submit_passes_secret_envs(mocker) -> None:
+    from npa.orchestration.skypilot.workflow import WorkflowResult
+    from npa.workbench.sonic import workflow as sonic_workflow
+
+    captured: dict[str, object] = {}
+
+    def fake_submit_workflow(path, run_id, **kwargs):
+        captured["content"] = path.read_text(encoding="utf-8")
+        captured["run_id"] = run_id
+        captured["kwargs"] = kwargs
+        return WorkflowResult(status="SUBMITTED", job_id="42", returncode=0)
+
+    mocker.patch.object(
+        sonic_workflow,
+        "_submit_skypilot_workflow",
+        side_effect=fake_submit_workflow,
+    )
+
+    result = sonic_workflow.submit_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-run",
+        registry="registry.example/workbench",
+        gpu_target="l40s",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+        s3_prefix="sonic-proof/sonic-run",
+        secret_envs=["AWS_ACCESS_KEY_ID"],
+    )
+
+    assert result.job_id == "42"
+    assert captured["run_id"] == "sonic-run"
+    assert captured["kwargs"]["secret_envs"] == ["AWS_ACCESS_KEY_ID"]
+    assert "registry.example/workbench/npa-sonic:0.1.2" in str(captured["content"])
 
 
 def test_tool_yamls_match_registered_cli_surfaces() -> None:

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -1,7 +1,7 @@
 # Standalone SONIC training smoke workflow.
 #
 # Operator-provided parameters:
-# - POLICY_IMAGE: image containing the npa CLI and SONIC runtime. Use the
+# - POLICY_IMAGE: image containing the SONIC /entrypoint.sh runtime. Use the
 #   manifest variant selected by SONIC_GPU_TYPE and SONIC_IMAGE_VARIANT.
 # - S3_ENDPOINT_URL: S3-compatible endpoint for artifact writes.
 # - S3_BUCKET: destination bucket name, without s3://.
@@ -10,11 +10,11 @@ execution: serial
 ---
 name: sonic-train-smoke
 resources:
-  cloud: kubernetes
+  cloud: nebius
   accelerators: L40S:1
   cpus: 16
   memory: 64
-  image_id: "docker:${POLICY_IMAGE}"
+  image_id: "docker:example.invalid/npa-sonic:0.1.2"
 envs:
   POLICY_IMAGE: "example.invalid/npa-sonic:0.1.2"
   SONIC_GPU_TYPE: "l40s"
@@ -29,16 +29,12 @@ envs:
   SONIC_NUM_ENVS: "16"
   SONIC_HEADLESS: "1"
   SONIC_MAX_ITERATIONS: "5"
-  SONIC_OUTPUT_PREFIX: "sonic-train/${NPA_PIPELINE_RUN_ID}/"
+  SONIC_OUTPUT_PREFIX: "sonic-train/sonic-train-smoke/"
 setup: |
   set -euo pipefail
-  PYTHON_BIN="${NPA_PYTHON_BIN:-$(command -v python3 || command -v python)}"
-  if ! command -v npa >/dev/null 2>&1; then
-    if [ -n "${NPA_REPO_DIR:-}" ] && [ -d "${NPA_REPO_DIR}/npa" ]; then
-      "${PYTHON_BIN}" -m pip install -e "${NPA_REPO_DIR}/npa"
-    elif [ -d "./npa" ]; then
-      "${PYTHON_BIN}" -m pip install -e ./npa
-    fi
+  if [ ! -x /entrypoint.sh ]; then
+    echo "The selected POLICY_IMAGE must provide the SONIC /entrypoint.sh runtime" >&2
+    exit 2
   fi
 run: |
   set -euo pipefail
@@ -54,28 +50,17 @@ run: |
   export AWS_ENDPOINT_URL="${S3_ENDPOINT_URL}"
   export NEBIUS_S3_ENDPOINT="${S3_ENDPOINT_URL}"
   output_path="s3://${S3_BUCKET}/${SONIC_OUTPUT_PREFIX}"
+  export NPA_OUTPUT_PATH="${output_path}"
+  export NPA_LOCAL_OUTPUT_DIR="${NPA_LOCAL_OUTPUT_DIR:-/tmp/npa-sonic-output}"
+  export SONIC_CHECKPOINT="${SONIC_CHECKPOINT}"
+  export SONIC_DATA_PATH="${SONIC_DATA_PATH}"
+  export SONIC_SAMPLE_DATA="${SONIC_SAMPLE_DATA}"
+  export SONIC_EMBODIMENT="${SONIC_EMBODIMENT}"
+  export SONIC_NUM_ENVS="${SONIC_NUM_ENVS}"
+  export SONIC_HEADLESS="${SONIC_HEADLESS}"
+  export SONIC_MAX_ITERATIONS="${SONIC_MAX_ITERATIONS}"
 
-  sample_args=()
-  if [ "${SONIC_SAMPLE_DATA}" = "1" ]; then
-    sample_args+=(--sample-data)
-  fi
+  printf 'SONIC_WORKFLOW_IMAGE policy_image=%s gpu_type=%s image_variant=%s\n' \
+    "${POLICY_IMAGE}" "${SONIC_GPU_TYPE}" "${SONIC_IMAGE_VARIANT}"
 
-  headless_arg="--headless"
-  if [ "${SONIC_HEADLESS}" = "0" ]; then
-    headless_arg="--no-headless"
-  fi
-
-  npa workbench sonic train \
-    --runtime serverless \
-    --checkpoint "${SONIC_CHECKPOINT}" \
-    --data-path "${SONIC_DATA_PATH}" \
-    "${sample_args[@]}" \
-    --embodiment "${SONIC_EMBODIMENT}" \
-    --num-envs "${SONIC_NUM_ENVS}" \
-    "${headless_arg}" \
-    --max-iterations "${SONIC_MAX_ITERATIONS}" \
-    --output-path "${output_path}" \
-    --gpu-type "${SONIC_GPU_TYPE}" \
-    --image-variant "${SONIC_IMAGE_VARIANT}" \
-    --image "${POLICY_IMAGE}" \
-    --output-format json
+  /entrypoint.sh train


### PR DESCRIPTION
## Summary

Wires SONIC into the standard `npa workbench workflow submit` path with a shared materializer for CLI and SDK use, while keeping the raw SkyPilot YAML independently runnable after literal parameter edits.

- Adds `npa.workbench.sonic.workflow` materialization/submission helpers.
- Extends `npa workbench workflow submit` with SONIC image/GPU/S3/materialization flags, including `--secret-env` pass-through.
- Exposes the same SDK path through `npa.sdk.workbench.sonic.submit_workflow`.
- Updates the standalone SONIC train YAML to run the SONIC `/entrypoint.sh` directly for the zero-NPA raw SkyPilot tier.
- Documents raw SkyPilot, CLI, and SDK tiers, BYO image/BYO S3 endpoint, GPU-to-image selection, and Kubernetes private-registry pull-secret config.

## Phase 0 Status

- Current `main`: `c24de77fa4d5fe622bc383b8adf092df045b69c1` (`guardrails: support local denylist source (#46)`).
- PR #42, `WORKS: fix(sonic): real Isaac Lab rendering on L40S + RTX PRO 6000 (two-image manifest)`, is merged at `7731da6377156f3e8c966aaa0cafa838fe6d3d0f` with green test, scan, gitleaks, guardrails, two-tag, and base-image scan checks. It landed the SONIC image manifest, `npa-sonic:0.1.2`, `npa-sonic:0.1.2-k8s`, resolver/doc updates, and render-proof evidence.
- SEAM remediation PR #47, `Fix Workbench image seams and registry defaults`, is open, non-draft, mergeable but unstable. Current checks include failing `test` and `gitleaks`; guardrails/scan/two-tag/base-image scans pass and Trivy is neutral.
- PR #47 claims to land cross-solution image seam fixes, including an additive LanceDB build/push for `npa-lancedb:0.30.2`, plus detection-training, GR00T, VLM, Retargeting/MJLab, and registry fallback cleanup. It is not merged yet.
- Direct overlap with this branch: `docs/workbench/cookbooks/sonic-locomotion-finetuning.md`, `docs/workbench/sonic-image-catalog.md`, and `npa/tests/workflows/test_sonic_locomotion_finetuning.py`. Other open PRs also touch SONIC workflow docs/tests/YAML, so this branch may need rebase coordination before merge.

## Discovery Result

The repo had useful SONIC YAML assets and a proven render path, but not a complete three-tier workflow submit surface:

- Raw YAML existed, but `sonic-train-standalone.yaml` used submit-time placeholders in `resources.image_id`/`envs` and invoked NPA from inside the task.
- Generic `workflow submit` only performed literal `${VAR}` replacement and did not apply SONIC manifest GPU-to-image selection.
- No SONIC SDK workflow submit helper existed.
- The full locomotion YAML still requires a generic helper image for retarget/MJLab stages; this PR adds the `--npa-image` path but does not guess or publish that image.

## What Changed

- L40S defaults resolve to `npa-sonic:0.1.2`; RTX PRO 6000/Blackwell defaults resolve to `npa-sonic:0.1.2-k8s`.
- CLI flags map to the same materialized YAML envs/resources used by the SDK:
  `--registry`, `--image`, `--npa-image`, `--gpu-target/--gpu-type`, `--image-variant`, `--accelerators`, `--cloud`, `--s3-endpoint`, `--s3-bucket`, `--s3-prefix`, and `--secret-env`.
- SONIC materialization fails before SkyPilot submission if operator placeholders such as `<your-registry-id>`, `<npa-image-tag>`, or `example.invalid` remain.
- Docs now show raw SkyPilot, CLI, and SDK usage, including S3 secret names and Kubernetes `imagePullSecrets` configuration for private registries.

## Verification

- Focused tests: `68 passed, 1 skipped, 12 warnings`
  - `tests/cli/test_workflow_cli.py`
  - `tests/cli/test_workflow_shim.py`
  - `tests/workflows/test_sonic_locomotion_finetuning.py`
  - `tests/guardrails/test_three_tier_contract.py`
  - `tests/cli/test_sonic_cli.py`
  - `tests/workbench/test_sonic_eval.py`
- Ruff: `ruff check ...` passed.
- `git diff --check` passed.
- `gitleaks detect --redact --no-git` found no leaks.
- No `.github/workflows` files touched.
- Registry presence verified:
  - `npa-sonic:0.1.2` linux/amd64 digest: `sha256:47196e98951bd9fb840967718fb7be4f8730fc599195d329930cb1bbadb7de74`
  - `npa-sonic:0.1.2-k8s` linux/amd64 digest: `sha256:0a4f95a0a4420ea13aa1e8106ac88429c940fc06a63f4adafaa3f123f8def8cf`

## Live Proof Attempts

All live attempts used isolated SkyPilot state. RTX PRO Kubernetes attempts used the pinned kubeconfig and context only. Cleanup used targeted `sky jobs cancel`/`sky down`; no global SkyPilot teardown was run and no LeRobot resources were touched.

- L40S via `npa workbench workflow submit`: submitted managed job successfully, then failed before task execution because SkyPilot tried to pre-pull the private `resources.image_id` image on the VM and registry auth was not available at image-pull time.
- RTX PRO 6000 via `npa workbench workflow submit`, pinned Kubernetes: submitted managed job successfully, then failed with Kubernetes image pull `403 Forbidden` before task execution.
- RTX PRO 6000 retry with `serviceAccountName` plus image pull secret: failed prechecks because that service account could not list cluster nodes.
- RTX PRO 6000 retry with only `imagePullSecrets`: avoided the explicit registry `403`, but SkyPilot failed runtime setup twice with `container not found ("ray-node")` while trying to exec into the worker pod. This indicates a second submit-path seam: the SONIC runtime image is not yet a SkyPilot-compatible Kubernetes `image_id` runtime image.
- Final cleanup check: isolated SkyPilot runtime reported no clusters, no in-progress managed jobs, and no services; the pinned Kubernetes namespace had no SONIC/controller pods left.

## Remaining Tiers And Plan

This PR lands the bounded three-tier wiring and docs, but does not claim full real-GPU workflow success because the submit path is blocked before SONIC code runs.

1. Make the submit runtime image compatible with SkyPilot bootstrapping.
   - Kubernetes: either build a SkyPilot-compatible `npa-sonic:0.1.2-k8s` runner image that satisfies the `ray-node`/exec/SSH setup expectations while preserving host-mounted Blackwell drivers, or route through a SkyPilot-compatible helper image that launches the SONIC runtime in a supported way.
   - Nebius VM/L40S: configure pre-pull private registry auth for SkyPilot `resources.image_id`, or avoid private `image_id` pre-pull by using a SkyPilot-compatible base image plus an authenticated runtime launch pattern.
2. Publish or select a generic Workbench helper image for retargeting and MJLab stages, then pass it through `--npa-image`.
3. Re-run:
   - raw SkyPilot standalone SONIC train on L40S,
   - CLI submit standalone train on L40S and RTX PRO 6000,
   - full retarget -> SONIC train -> MJLab locomotion workflow on both image variants.

No credentials are embedded in this branch; docs use placeholders and secret environment variable names only.
