### PR TITLE
Fix SONIC VM registry auth for workflow submit

### DIFF
--- a/docs/cli/workflow.md
+++ b/docs/cli/workflow.md
@@ -55,7 +55,8 @@ npa workbench workflow submit \
   npa/workflows/workbench/skypilot/sonic-train-standalone.yaml \
   --run-id sonic-smoke-$(date -u +%Y%m%dT%H%M%SZ) \
   --registry cr.eu-north1.nebius.cloud/<registry-id> \
-  --gpu-target l40s \
+  --gpu-target h100 \
+  --use-spot \
   --s3-endpoint https://storage.eu-north1.nebius.cloud \
   --s3-bucket <bucket> \
   --s3-prefix sonic-workflow-proof/<run-id> \
@@ -63,12 +64,43 @@ npa workbench workflow submit \
   --secret-env AWS_SECRET_ACCESS_KEY
 ```
 
+For Nebius Container Registry VM pulls, the SONIC materializer adds SkyPilot's
+Docker login envs to the submitted YAML:
+
+```yaml
+envs:
+  SKYPILOT_DOCKER_USERNAME: iam
+  SKYPILOT_DOCKER_PASSWORD: <fresh-nebius-iam-token>
+  SKYPILOT_DOCKER_SERVER: cr.eu-north1.nebius.cloud
+```
+
+By default the password is minted at submit time with
+`nebius iam get-access-token`, matching Nebius Container Registry's
+short-lived-token login flow. BYO private registries can override the three
+values with:
+
+```bash
+npa workbench workflow submit ... \
+  --registry registry.example/workbench \
+  --registry-server registry.example \
+  --registry-username <username> \
+  --registry-password <token>
+```
+
+Prefer `NPA_REGISTRY_USERNAME`, `NPA_REGISTRY_PASSWORD`, and
+`NPA_REGISTRY_SERVER` when you do not want the token in shell history. Use
+`--no-registry-auth` only for public images or environments that preconfigure
+Docker auth outside SkyPilot.
+
 For RTX PRO 6000 Kubernetes targets, use the same command with
 `--gpu-target gpu-rtx6000` and an accelerator string accepted by your SkyPilot
 Kubernetes GPU catalog, for example
 `--accelerators RTXPRO-6000-BLACKWELL-SERVER-EDITION:1`. The SONIC
-materializer resolves `gpu-rtx6000` to `npa-sonic:0.1.2-k8s`; L40S resolves to
-`npa-sonic:0.1.2`.
+materializer resolves `gpu-rtx6000` to `npa-sonic:0.1.2-k8s`; H100, H200, L40S,
+and B200 VM targets resolve to `npa-sonic:0.1.2` with matching
+`accelerators: <GPU>:1` and the smallest known Nebius VM CPU/RAM preset for that
+GPU. Pass `--use-spot` when the capacity check only reports preemptible
+availability.
 
 When a Kubernetes target pulls from a private registry, provide a SkyPilot config
 through `--config-path` that adds the registry pull secret to worker pods:

--- a/docs/workbench-yaml-guide.md
+++ b/docs/workbench-yaml-guide.md
@@ -59,6 +59,45 @@ image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/<image>:<image-ta
 Use `npa workbench lancedb system-info` or the corresponding workbench tool's
 `system-info` command to find the current image tag for live submissions.
 
+For raw SkyPilot VM YAMLs that pull private images from Nebius Container
+Registry, add SkyPilot Docker login envs next to the task's other `envs`.
+Nebius Container Registry accepts username `iam` and a short-lived token from
+`nebius iam get-access-token`.
+
+```yaml
+resources:
+  cloud: nebius
+  accelerators: H100:1
+  cpus: 16
+  memory: 200
+  use_spot: true
+  image_id: "docker:cr.eu-north1.nebius.cloud/<registry-id>/<image>:<tag>"
+envs:
+  SKYPILOT_DOCKER_USERNAME: iam
+  SKYPILOT_DOCKER_PASSWORD: ""
+  SKYPILOT_DOCKER_SERVER: cr.eu-north1.nebius.cloud
+```
+
+Supply the token at launch time instead of committing it:
+
+```bash
+sky jobs launch raw-sonic.yaml \
+  --env SKYPILOT_DOCKER_PASSWORD="$(nebius iam get-access-token)"
+```
+
+For NPA's generic submit path, keep the same key in `envs` and pass:
+
+```bash
+npa workbench workflow submit raw-sonic.yaml \
+  --var SKYPILOT_DOCKER_PASSWORD="$(nebius iam get-access-token)"
+```
+
+Do not commit rendered tokens. When submitting through
+`npa workbench workflow submit --tool sonic`, the materializer fills these values
+for Nebius VM targets automatically and lets operators override them with
+`--registry-server`, `--registry-username`, and `--registry-password` for BYO
+registries.
+
 The BDD100K pipeline currently runs serially because the checked-in comment notes
 that SkyPilot `0.12.2` supports serial pipelines and all-parallel job groups, but
 not the mixed dependency graph needed to train and evaluate the three views in

--- a/docs/workbench/proofs/sonic-registry-auth-submit-proof-20260605.md
+++ b/docs/workbench/proofs/sonic-registry-auth-submit-proof-20260605.md
@@ -1,0 +1,107 @@
+# SONIC registry-auth submit proof, 2026-06-05
+
+This note records the live VM-GPU proof attempt for the SONIC `npa workbench
+workflow submit` path after adding SkyPilot Docker registry auth materialization.
+The proof used an isolated `/tmp` checkout on branch
+`dev-fix-sonic-registry-auth-proof`; it did not modify `.github/workflows`, did
+not touch the LeRobot cluster, and avoided the #47 overlap files.
+
+## Registry auth
+
+The SONIC materializer now emits SkyPilot Docker login environment variables for
+VM image pulls:
+
+- `SKYPILOT_DOCKER_USERNAME`
+- `SKYPILOT_DOCKER_PASSWORD`
+- `SKYPILOT_DOCKER_SERVER`
+
+For first-party Nebius Container Registry images, the default username is `iam`
+and the password is a fresh `nebius iam get-access-token` value minted at submit
+time. This follows the Nebius Container Registry short-lived token flow:
+`nebius iam get-access-token | docker login cr.<region>.nebius.cloud --username
+iam --password-stdin`. Customer BYO registry credentials can override the
+defaults through CLI flags, SDK parameters, or environment variables.
+
+Local auth sanity check:
+
+- `nebius iam get-access-token` succeeded.
+- `docker login cr.eu-north1.nebius.cloud` with username `iam` succeeded.
+- `docker manifest inspect cr.eu-north1.nebius.cloud/<registry-id>/npa-sonic:0.1.2`
+  succeeded after login.
+- S3 profile access to `s3://npa-sim2real-d87cf691/` succeeded with
+  `AWS_PROFILE=nebius`.
+
+Secrets were not written to this file or to PR text.
+
+## Capacity oracle
+
+The capacity oracle was run with:
+
+```bash
+nebius capacity resource-advice list \
+  --parent-id <capacity-tenant-id> \
+  --all \
+  --format json \
+| jq -r '
+  .items[] |
+  [
+    .spec.region,
+    .spec.fabric,
+    .spec.compute_instance.platform,
+    .spec.compute_instance.preset.name,
+    .status.reserved.available,
+    .status.ondemand.available,
+    .status.preemptible.available
+  ] | @tsv'
+```
+
+Available 1-GPU VM candidates were preemptible only:
+
+| Priority | GPU | Region | Platform | Preset | Preemptible |
+| --- | --- | --- | --- | --- | --- |
+| 1 | H100 | `eu-north1` | `gpu-h100-sxm` | `1gpu-16vcpu-200gb` | 75 per listed fabric |
+| 2 | H200 | `eu-north1` | `gpu-h200-sxm` | `1gpu-16vcpu-200gb` | 75 |
+| 3 | L40S | `eu-north1` | `gpu-l40s-a` | `1gpu-16vcpu-64gb` | 9 |
+| 4 | B200 | `us-central1` / `me-west1` | `gpu-b200-sxm*` | `1gpu-20vcpu-224gb` | 81 / 55 |
+
+B200 remained last because it is an untested architecture for this SONIC image
+and the available capacity was outside the launchable `eu-north1` project path.
+
+## Live submit attempts
+
+All attempts used:
+
+- `NPA_SKYPILOT_BIN=/home/ubuntu/.npa/skypilot-venv/bin/sky`
+- `npa/.venv/bin/npa workbench workflow submit`
+- `--tool sonic`
+- `--controller-backend nebius`
+- `--registry cr.eu-north1.nebius.cloud/<registry-id>`
+- `--use-spot`
+- S3 proof prefixes under
+  `s3://npa-sim2real-d87cf691/sonic-submit-proof/<run-id>/`
+- scoped cleanup per attempt with `sky jobs cancel <id> --yes`, `sky down
+  <cluster> --yes` when SkyPilot had a cluster handle, and Nebius instance
+  polling for the run-specific name.
+
+| Attempt | Managed job | Placement | Result |
+| --- | --- | --- | --- |
+| `sonic-proof-h100-20260605t220047z` | 1 | H100 | Failed SkyPilot precheck before launch because the previous H100 default used `mem=64`; this PR updates H100/H200 VM defaults to `mem=200`. |
+| `sonic-proof-h100b-20260605t221200z` | 2 | `eu-north1`, `gpu-h100-sxm_1gpu-16vcpu-200gb[Spot]` | Instance came up and SkyPilot reported "Docker container is up", so the private-image pull path progressed past the prior registry-auth seam. SkyPilot then failed runtime setup with repeated `stdio forwarding failed` and `mkdir -p ~/.sky/.runtime_files` returning 255 before the SONIC entrypoint ran. The worker was cancelled and reached absence in Nebius. |
+| `sonic-proof-h200-20260605t222900z` | 3 | `eu-north1`, `gpu-h200-sxm_1gpu-16vcpu-200gb[Spot]` | Instance came up but did not reach task execution or S3 output during the bounded proof window. The worker was cancelled and reached absence in Nebius. |
+| `sonic-proof-l40s-20260605t223800z` | 4 | `eu-north1`, `gpu-l40s-a_1gpu-16vcpu-64gb[Spot]` | Instance came up but did not reach task execution or S3 output during the bounded proof window. The worker was cancelled and reached absence in Nebius. |
+| `sonic-proof-b200-20260605t223959z` | 5 | SkyPilot selected `me-west1`, `gpu-b200-sxm-a_1gpu-20vcpu-224gb[Spot]` | Failed before provisioning because the configured SkyPilot/Nebius project has no project mapping for `me-west1`. Nebius showed no run-scoped B200 instance. SkyPilot's managed-job state settled at `FAILED_CONTROLLER`. |
+
+## Tier
+
+The registry-auth seam is fixed in the materialized VM YAML: H100 progressed to
+SkyPilot's Docker-container-up stage with a private `cr.eu-north1.nebius.cloud`
+image, whereas the previous live blocker was private-registry pre-pull auth. The
+full SONIC entrypoint and S3 proof artifact did not complete on 2026-06-05
+because each launchable GPU then hit SkyPilot VM runtime setup before task
+execution; B200 additionally selected a non-launchable region for this project.
+
+No successful S3 artifact exists under the attempted proof prefixes. The next
+live-proof step is to resolve the SkyPilot VM runtime setup failure or constrain
+B200 placement to a configured project region before rerunning the same submit
+command. The SkyPilot-on-k8s image compatibility seam remains out of scope for
+this VM/H100 MVP proof.

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -99,6 +99,29 @@ def submit_cmd(
         "--npa-image",
         help="Generic NPA helper image override for multi-tool workflows.",
     ),
+    registry_auth: bool = typer.Option(
+        True,
+        "--registry-auth/--no-registry-auth",
+        help=(
+            "For VM SONIC image pulls, materialize SkyPilot Docker registry "
+            "auth envs. Nebius CR defaults to a fresh IAM token."
+        ),
+    ),
+    registry_username: str = typer.Option(
+        "",
+        "--registry-username",
+        help="BYO Docker registry username for SONIC VM image pulls.",
+    ),
+    registry_password: str = typer.Option(
+        "",
+        "--registry-password",
+        help="BYO Docker registry password/token for SONIC VM image pulls.",
+    ),
+    registry_server: str = typer.Option(
+        "",
+        "--registry-server",
+        help="BYO Docker registry server for SONIC VM image pulls.",
+    ),
     gpu_target: str = typer.Option(
         "",
         "--gpu-target",
@@ -119,6 +142,11 @@ def submit_cmd(
         "",
         "--cloud",
         help="Cloud value for materialized GPU tasks.",
+    ),
+    use_spot: bool | None = typer.Option(
+        None,
+        "--use-spot/--no-use-spot",
+        help="Optional SkyPilot spot/preemptible setting for materialized SONIC VM GPU tasks.",
     ),
     s3_endpoint: str = typer.Option(
         "",
@@ -180,6 +208,10 @@ def submit_cmd(
                     registry=registry,
                     image=image,
                     npa_image=npa_image,
+                    registry_auth=registry_auth,
+                    registry_username=registry_username,
+                    registry_password=registry_password,
+                    registry_server=registry_server,
                     gpu_target=gpu_target,
                     image_variant=image_variant,
                     s3_endpoint=s3_endpoint,
@@ -187,6 +219,7 @@ def submit_cmd(
                     s3_prefix=s3_prefix,
                     accelerators=accelerators,
                     cloud=cloud,
+                    use_spot=use_spot,
                     env_overrides=substitutions,
                 )
             except ValueError as exc:

--- a/npa/src/npa/workbench/sonic/workflow.py
+++ b/npa/src/npa/workbench/sonic/workflow.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import re
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Sequence
@@ -21,13 +22,21 @@ DEFAULT_S3_ENDPOINT = "https://storage.eu-north1.nebius.cloud"
 DEFAULT_GPU_TARGET = "l40s"
 DEFAULT_SONIC_WORKFLOW_PREFIX = "sonic-locomotion"
 UNRESOLVED_SUBMIT_TOKENS = ("<your-", "<sonic-image-tag>", "<npa-image-tag>", "example.invalid")
+SKYPILOT_DOCKER_USERNAME = "SKYPILOT_DOCKER_USERNAME"
+SKYPILOT_DOCKER_PASSWORD = "SKYPILOT_DOCKER_PASSWORD"
+SKYPILOT_DOCKER_SERVER = "SKYPILOT_DOCKER_SERVER"
+DEFAULT_NEBIUS_REGISTRY_USERNAME = "iam"
+NEBIUS_REGISTRY_SERVER_SUFFIX = ".nebius.cloud"
+REGISTRY_AUTH_USERNAME_ENVS = ("NPA_REGISTRY_USERNAME", SKYPILOT_DOCKER_USERNAME)
+REGISTRY_AUTH_PASSWORD_ENVS = ("NPA_REGISTRY_PASSWORD", SKYPILOT_DOCKER_PASSWORD)
+REGISTRY_AUTH_SERVER_ENVS = ("NPA_REGISTRY_SERVER", SKYPILOT_DOCKER_SERVER)
 
 
 @dataclass(frozen=True)
 class SonicWorkflowPlan:
     """Resolved values used to submit a SONIC workflow YAML."""
 
-    yaml_text: str
+    yaml_text: str = field(repr=False)
     run_id: str
     policy_image: str
     npa_image: str
@@ -38,6 +47,18 @@ class SonicWorkflowPlan:
     s3_prefix: str
     accelerators: str
     cloud: str
+    use_spot: bool | None = None
+    registry_auth_server: str = ""
+    registry_auth_username: str = ""
+    registry_auth_source: str = ""
+
+
+@dataclass(frozen=True)
+class _RegistryAuthConfig:
+    username: str
+    password: str = field(repr=False)
+    server: str
+    source: str
 
 
 def materialize_sonic_workflow(
@@ -47,6 +68,10 @@ def materialize_sonic_workflow(
     registry: str = "",
     image: str = "",
     npa_image: str = "",
+    registry_auth: bool = True,
+    registry_username: str = "",
+    registry_password: str = "",
+    registry_server: str = "",
     gpu_target: str = DEFAULT_GPU_TARGET,
     image_variant: str = "",
     s3_endpoint: str = "",
@@ -54,6 +79,7 @@ def materialize_sonic_workflow(
     s3_prefix: str = "",
     accelerators: str = "",
     cloud: str = "",
+    use_spot: bool | None = None,
     env_overrides: dict[str, str] | None = None,
 ) -> SonicWorkflowPlan:
     """Return a concrete SONIC workflow YAML with no submit-time env indirection."""
@@ -78,6 +104,14 @@ def materialize_sonic_workflow(
     resolved_prefix = _resolve_s3_prefix(s3_prefix, resolved_run_id)
     resolved_accelerators = accelerators or _default_accelerators(resolved_gpu_target)
     resolved_cloud = cloud or _default_cloud(resolved_gpu_target)
+    resolved_registry_auth = _resolve_registry_auth(
+        enabled=registry_auth and resolved_cloud.strip().lower() != "kubernetes",
+        policy_image=resolved_policy_image,
+        npa_image=resolved_npa_image,
+        username=registry_username,
+        password=registry_password,
+        server=registry_server,
+    )
 
     replacements = {
         "sonic-locomotion/<run-id>/": resolved_prefix,
@@ -105,6 +139,8 @@ def materialize_sonic_workflow(
                 s3_prefix=resolved_prefix,
                 accelerators=resolved_accelerators,
                 cloud=resolved_cloud,
+                use_spot=use_spot,
+                registry_auth=resolved_registry_auth,
                 env_overrides=env_overrides or {},
             )
 
@@ -121,6 +157,10 @@ def materialize_sonic_workflow(
         s3_prefix=resolved_prefix,
         accelerators=resolved_accelerators,
         cloud=resolved_cloud,
+        use_spot=use_spot,
+        registry_auth_server=resolved_registry_auth.server if resolved_registry_auth else "",
+        registry_auth_username=resolved_registry_auth.username if resolved_registry_auth else "",
+        registry_auth_source=resolved_registry_auth.source if resolved_registry_auth else "",
     )
 
 
@@ -131,6 +171,10 @@ def submit_sonic_workflow(
     registry: str = "",
     image: str = "",
     npa_image: str = "",
+    registry_auth: bool = True,
+    registry_username: str = "",
+    registry_password: str = "",
+    registry_server: str = "",
     gpu_target: str = DEFAULT_GPU_TARGET,
     image_variant: str = "",
     s3_endpoint: str = "",
@@ -138,6 +182,7 @@ def submit_sonic_workflow(
     s3_prefix: str = "",
     accelerators: str = "",
     cloud: str = "",
+    use_spot: bool | None = None,
     env_overrides: dict[str, str] | None = None,
     isolated_config_dir: Path | None = None,
     config_path: Path | None = None,
@@ -154,6 +199,10 @@ def submit_sonic_workflow(
         registry=registry,
         image=image,
         npa_image=npa_image,
+        registry_auth=registry_auth,
+        registry_username=registry_username,
+        registry_password=registry_password,
+        registry_server=registry_server,
         gpu_target=gpu_target,
         image_variant=image_variant,
         s3_endpoint=s3_endpoint,
@@ -161,6 +210,7 @@ def submit_sonic_workflow(
         s3_prefix=s3_prefix,
         accelerators=accelerators,
         cloud=cloud,
+        use_spot=use_spot,
         env_overrides=env_overrides,
     )
     unresolved = unresolved_submit_placeholders(plan.yaml_text)
@@ -219,6 +269,14 @@ def _default_accelerators(gpu_target: str) -> str:
     normalized = gpu_target.strip().lower().replace("_", "-")
     if "rtx" in normalized or "blackwell" in normalized or "sm-120" in normalized:
         return "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
+    if "b200" in normalized:
+        return "B200:1"
+    if "h200" in normalized:
+        return "H200:1"
+    if "h100" in normalized:
+        return "H100:1"
+    if "l40s" in normalized:
+        return "L40S:1"
     return "L40S:1"
 
 
@@ -227,6 +285,24 @@ def _default_cloud(gpu_target: str) -> str:
     if "rtx" in normalized or "blackwell" in normalized or "sm-120" in normalized:
         return "kubernetes"
     return "nebius"
+
+
+def _default_cpus(gpu_target: str) -> int:
+    normalized = gpu_target.strip().lower().replace("_", "-")
+    if "b200" in normalized:
+        return 20
+    return 16
+
+
+def _default_memory(gpu_target: str) -> int:
+    normalized = gpu_target.strip().lower().replace("_", "-")
+    if "b200" in normalized:
+        return 224
+    if "h100" in normalized or "h200" in normalized:
+        return 200
+    if "l40s" in normalized:
+        return 64
+    return 64
 
 
 def _replace_strings(value: Any, replacements: dict[str, str]) -> Any:
@@ -254,6 +330,8 @@ def _materialize_task_doc(
     s3_prefix: str,
     accelerators: str,
     cloud: str,
+    use_spot: bool | None,
+    registry_auth: _RegistryAuthConfig | None,
     env_overrides: dict[str, str],
 ) -> None:
     envs = doc.get("envs")
@@ -267,6 +345,10 @@ def _materialize_task_doc(
     if uses_sonic_runtime_image:
         resources["cloud"] = cloud
         resources["image_id"] = f"docker:{policy_image}"
+        resources["cpus"] = _default_cpus(gpu_target)
+        resources["memory"] = _default_memory(gpu_target)
+        if use_spot is not None and cloud.strip().lower() != "kubernetes":
+            resources["use_spot"] = use_spot
         if resources.get("accelerators"):
             resources["accelerators"] = accelerators
     elif npa_image and _looks_like_npa_helper_image(image_id):
@@ -290,6 +372,10 @@ def _materialize_task_doc(
         envs["NPA_PIPELINE_RUN_ID"] = run_id
     if "SONIC_OUTPUT_PREFIX" in envs:
         envs["SONIC_OUTPUT_PREFIX"] = s3_prefix
+    if registry_auth and _uses_registry_auth_target(doc, registry_auth.server):
+        envs[SKYPILOT_DOCKER_USERNAME] = registry_auth.username
+        envs[SKYPILOT_DOCKER_PASSWORD] = registry_auth.password
+        envs[SKYPILOT_DOCKER_SERVER] = registry_auth.server
     for key, value in env_overrides.items():
         if key in envs:
             envs[key] = value
@@ -315,3 +401,135 @@ def _uses_sonic_runtime_image(doc: dict[str, Any]) -> bool:
 
 def _looks_like_npa_helper_image(image_id: str) -> bool:
     return "/npa:" in image_id or image_id.endswith("/npa:<npa-image-tag>")
+
+
+def _resolve_registry_auth(
+    *,
+    enabled: bool,
+    policy_image: str,
+    npa_image: str,
+    username: str,
+    password: str,
+    server: str,
+) -> _RegistryAuthConfig | None:
+    if not enabled:
+        return None
+
+    explicit = any(value.strip() for value in (username, password, server))
+    env_username = _first_env(REGISTRY_AUTH_USERNAME_ENVS)
+    env_password = _first_env(REGISTRY_AUTH_PASSWORD_ENVS)
+    env_server = _first_env(REGISTRY_AUTH_SERVER_ENVS)
+    env_provided = any(value for value in (env_username, env_password, env_server))
+
+    resolved_server = _normalize_registry_server(
+        server or env_server or _registry_server_for_images(policy_image, npa_image)
+    )
+    resolved_username = username or env_username
+    resolved_password = password or env_password
+    source = "explicit" if explicit else "env" if env_provided else ""
+
+    if resolved_server and _is_nebius_registry_server(resolved_server):
+        if not resolved_username:
+            resolved_username = DEFAULT_NEBIUS_REGISTRY_USERNAME
+        if not resolved_password:
+            resolved_password = _mint_nebius_registry_token()
+            source = "nebius-iam-token"
+    elif explicit or env_provided:
+        source = source or "explicit"
+    else:
+        return None
+
+    missing = [
+        name
+        for name, value in (
+            ("username", resolved_username),
+            ("password", resolved_password),
+            ("server", resolved_server),
+        )
+        if not value
+    ]
+    if missing:
+        raise ValueError(
+            "Registry auth requires username, password, and server; missing "
+            + ", ".join(missing)
+        )
+
+    return _RegistryAuthConfig(
+        username=resolved_username,
+        password=resolved_password,
+        server=resolved_server,
+        source=source or "explicit",
+    )
+
+
+def _first_env(names: Sequence[str]) -> str:
+    for name in names:
+        value = os.environ.get(name, "")
+        if value:
+            return value
+    return ""
+
+
+def _mint_nebius_registry_token() -> str:
+    cli = os.environ.get("NEBIUS_CLI", "nebius")
+    try:
+        result = subprocess.run(
+            [cli, "iam", "get-access-token"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(
+            "Could not mint Nebius registry token with `nebius iam get-access-token`"
+        ) from exc
+
+    token = result.stdout.strip()
+    if result.returncode != 0 or not token:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise ValueError(
+            "Could not mint Nebius registry token with `nebius iam get-access-token`: "
+            + detail
+        )
+    return token
+
+
+def _registry_server_for_images(*images: str) -> str:
+    for image in images:
+        server = _registry_server_from_image(image)
+        if server:
+            return server
+    return ""
+
+
+def _registry_server_from_image(image: str) -> str:
+    image_ref = image.removeprefix("docker:").strip()
+    if "/" not in image_ref:
+        return ""
+    candidate = image_ref.split("/", 1)[0]
+    if "." in candidate or ":" in candidate or candidate == "localhost":
+        return _normalize_registry_server(candidate)
+    return ""
+
+
+def _normalize_registry_server(server: str) -> str:
+    normalized = server.strip()
+    normalized = normalized.removeprefix("https://").removeprefix("http://")
+    return normalized.rstrip("/")
+
+
+def _is_nebius_registry_server(server: str) -> bool:
+    normalized = _normalize_registry_server(server)
+    return normalized.startswith("cr.") and normalized.endswith(NEBIUS_REGISTRY_SERVER_SUFFIX)
+
+
+def _uses_registry_auth_target(doc: dict[str, Any], server: str) -> bool:
+    resources = doc.get("resources")
+    if not isinstance(resources, dict):
+        return False
+    if str(resources.get("cloud", "")).strip().lower() == "kubernetes":
+        return False
+    image_server = _registry_server_from_image(str(resources.get("image_id", "")))
+    return image_server == _normalize_registry_server(server)

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -225,6 +225,60 @@ def test_workbench_workflow_submit_materializes_sonic_yaml(mocker) -> None:
     assert "${" not in "\n".join(str(value) for value in envs.values())
 
 
+def test_workbench_workflow_submit_materializes_byo_registry_auth(mocker) -> None:
+    yaml_path = REPO_ROOT / "workflows/workbench/skypilot/sonic-train-standalone.yaml"
+    captured: dict[str, object] = {}
+
+    def fake_submit_workflow(path, run_id, **kwargs):
+        captured["content"] = path.read_text(encoding="utf-8")
+        captured["run_id"] = run_id
+        captured["kwargs"] = kwargs
+        return WorkflowResult(status="SUBMITTED", job_id="42", returncode=0)
+
+    mocker.patch(
+        "npa.orchestration.skypilot.workflow.submit_workflow",
+        side_effect=fake_submit_workflow,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(yaml_path),
+            "--run-id",
+            "sonic-run",
+            "--registry",
+            "registry.example/workbench",
+            "--registry-server",
+            "registry.example",
+            "--registry-username",
+            "customer",
+            "--registry-password",
+            "customer-token",
+            "--gpu-target",
+            "h100",
+            "--use-spot",
+            "--s3-endpoint",
+            "https://storage.example",
+            "--s3-bucket",
+            "proof-bucket",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "customer-token" not in result.output
+    docs = [doc for doc in yaml.safe_load_all(str(captured["content"])) if doc]
+    task = docs[1]
+    assert task["resources"]["accelerators"] == "H100:1"
+    assert task["resources"]["memory"] == 200
+    assert task["resources"]["use_spot"] is True
+    assert task["envs"]["SKYPILOT_DOCKER_USERNAME"] == "customer"
+    assert task["envs"]["SKYPILOT_DOCKER_PASSWORD"] == "customer-token"
+    assert task["envs"]["SKYPILOT_DOCKER_SERVER"] == "registry.example"
+
+
 def test_workbench_workflow_submit_blocks_unresolved_sonic_placeholders(mocker) -> None:
     yaml_path = REPO_ROOT / "workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml"
     submit_mock = mocker.patch("npa.orchestration.skypilot.workflow.submit_workflow")

--- a/npa/tests/workbench/test_sonic_workflow_registry_auth.py
+++ b/npa/tests/workbench/test_sonic_workflow_registry_auth.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SONIC_TRAIN_STANDALONE_YAML = (
+    ROOT
+    / "npa"
+    / "workflows"
+    / "workbench"
+    / "skypilot"
+    / "sonic-train-standalone.yaml"
+)
+
+
+def _task_envs(plan) -> tuple[dict, dict]:
+    docs = [doc for doc in yaml.safe_load_all(plan.yaml_text) if doc is not None]
+    task = docs[1]
+    return task["resources"], task["envs"]
+
+
+def _patch_nebius_token(monkeypatch: pytest.MonkeyPatch, token: str = "fresh-token") -> list[list[str]]:
+    from npa.workbench.sonic import workflow as sonic_workflow
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout=f"{token}\n", stderr="")
+
+    monkeypatch.setattr(sonic_workflow.subprocess, "run", fake_run)
+    return calls
+
+
+def test_sonic_materializer_adds_nebius_registry_auth_for_vm_tasks(monkeypatch) -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    calls = _patch_nebius_token(monkeypatch)
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="cr.eu-north1.nebius.cloud/registry-id",
+        gpu_target="h100",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, envs = _task_envs(plan)
+    assert calls == [["nebius", "iam", "get-access-token"]]
+    assert resources["cloud"] == "nebius"
+    assert resources["accelerators"] == "H100:1"
+    assert resources["cpus"] == 16
+    assert resources["memory"] == 200
+    assert envs["SKYPILOT_DOCKER_USERNAME"] == "iam"
+    assert envs["SKYPILOT_DOCKER_PASSWORD"] == "fresh-token"
+    assert envs["SKYPILOT_DOCKER_SERVER"] == "cr.eu-north1.nebius.cloud"
+    assert plan.registry_auth_username == "iam"
+    assert plan.registry_auth_server == "cr.eu-north1.nebius.cloud"
+    assert plan.registry_auth_source == "nebius-iam-token"
+    assert "fresh-token" not in repr(plan)
+
+
+def test_sonic_materializer_honors_byo_registry_auth_for_vm_tasks() -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        registry_username="customer",
+        registry_password="customer-token",
+        registry_server="https://registry.example/",
+        gpu_target="l40s",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    _, envs = _task_envs(plan)
+    assert envs["SKYPILOT_DOCKER_USERNAME"] == "customer"
+    assert envs["SKYPILOT_DOCKER_PASSWORD"] == "customer-token"
+    assert envs["SKYPILOT_DOCKER_SERVER"] == "registry.example"
+    assert plan.registry_auth_source == "explicit"
+
+
+def test_sonic_materializer_can_enable_spot_for_vm_tasks() -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        gpu_target="h100",
+        use_spot=True,
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, _ = _task_envs(plan)
+    assert resources["use_spot"] is True
+
+
+def test_sonic_materializer_skips_registry_auth_for_kubernetes_targets(monkeypatch) -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    calls = _patch_nebius_token(monkeypatch)
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="cr.eu-north1.nebius.cloud/registry-id",
+        gpu_target="gpu-rtx6000",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, envs = _task_envs(plan)
+    assert resources["cloud"] == "kubernetes"
+    assert "SKYPILOT_DOCKER_PASSWORD" not in envs
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("gpu_target", "accelerators", "cpus", "memory"),
+    [
+        ("h100", "H100:1", 16, 200),
+        ("H200", "H200:1", 16, 200),
+        ("L40S", "L40S:1", 16, 64),
+        ("b200", "B200:1", 20, 224),
+    ],
+)
+def test_sonic_materializer_defaults_vm_accelerators_by_gpu_target(
+    gpu_target: str,
+    accelerators: str,
+    cpus: int,
+    memory: int,
+) -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        gpu_target=gpu_target,
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, _ = _task_envs(plan)
+    assert resources["cloud"] == "nebius"
+    assert resources["accelerators"] == accelerators
+    assert resources["cpus"] == cpus
+    assert resources["memory"] == memory

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -63,4 +63,11 @@ run: |
   printf 'SONIC_WORKFLOW_IMAGE policy_image=%s gpu_type=%s image_variant=%s\n' \
     "${POLICY_IMAGE}" "${SONIC_GPU_TYPE}" "${SONIC_IMAGE_VARIANT}"
 
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader \
+      | tee "${NPA_LOCAL_OUTPUT_DIR}/sonic_gpu_info.txt"
+  else
+    echo "nvidia-smi unavailable" | tee "${NPA_LOCAL_OUTPUT_DIR}/sonic_gpu_info.txt"
+  fi
+
   /entrypoint.sh train


### PR DESCRIPTION
## Summary

- Add VM-only SkyPilot Docker registry auth materialization for SONIC workflow submit, defaulting Nebius Container Registry pulls to `iam` plus a fresh `nebius iam get-access-token` password.
- Add BYO registry overrides across CLI, SDK/materializer, and rendered YAML, plus `--use-spot` and VM GPU sizing defaults for H100/H200/L40S/B200.
- Document the raw SkyPilot YAML auth path and add a 2026-06-05 live-proof evidence note.

## Live proof / tier

- Capacity oracle was run before submit attempts; available 1-GPU VM capacity was preemptible-only across H100, H200, L40S, and B200.
- H100 retry selected `eu-north1 gpu-h100-sxm_1gpu-16vcpu-200gb[Spot]` and reached SkyPilot's `Docker container is up` stage with the private `cr.eu-north1.nebius.cloud/<registry-id>/npa-sonic:0.1.2` image, showing the prior private-registry pre-pull auth seam is fixed.
- H100 then failed before the SONIC entrypoint with SkyPilot runtime setup errors: repeated `stdio forwarding failed` and `mkdir -p ~/.sky/.runtime_files` returning 255.
- H200 and L40S both reached instance-up but did not reach task execution/S3 in the bounded proof window; both were cancelled and verified absent in Nebius.
- B200 was attempted last; SkyPilot selected `me-west1`, but the configured project has no `me-west1` mapping, so it failed before provisioning and settled at `FAILED_CONTROLLER`. Nebius listed no scoped B200 instance.
- No successful S3 artifact exists yet; the exact per-candidate blockers are recorded in `docs/workbench/proofs/sonic-registry-auth-submit-proof-20260605.md`.

## Tests

- `npa/.venv/bin/python -m pytest npa/tests/workbench/test_sonic_workflow_registry_auth.py npa/tests/cli/test_workflow_cli.py npa/tests/workflows/test_sonic_locomotion_finetuning.py npa/tests/orchestration/skypilot/test_workflow.py -q`
- `gitleaks detect --source . --config .gitleaks.toml --redact --no-banner --log-opts="origin/main..HEAD" --verbose`
- `git diff --check`

## Guardrails

- No `.github/workflows` changes.
- Avoided #47 overlap files: `docs/workbench/cookbooks/sonic-locomotion-finetuning.md`, `docs/workbench/sonic-image-catalog.md`, and `npa/tests/workflows/test_sonic_locomotion_finetuning.py` were not edited.
- No global SkyPilot teardown; only run-scoped cancel/down/poll was used.
- LeRobot cluster was not touched.
- No credentials or Nebius IDs are included in docs or PR text.

