### PR TITLE
Fix SONIC SkyPilot docker runtime payload

### DIFF
--- a/docs/cli/workflow.md
+++ b/docs/cli/workflow.md
@@ -55,7 +55,8 @@ npa workbench workflow submit \
   npa/workflows/workbench/skypilot/sonic-train-standalone.yaml \
   --run-id sonic-smoke-$(date -u +%Y%m%dT%H%M%SZ) \
   --registry cr.eu-north1.nebius.cloud/<registry-id> \
-  --gpu-target l40s \
+  --gpu-target h100 \
+  --use-spot \
   --s3-endpoint https://storage.eu-north1.nebius.cloud \
   --s3-bucket <bucket> \
   --s3-prefix sonic-workflow-proof/<run-id> \
@@ -63,12 +64,43 @@ npa workbench workflow submit \
   --secret-env AWS_SECRET_ACCESS_KEY
 ```
 
+For Nebius Container Registry VM pulls, the SONIC materializer adds SkyPilot's
+Docker login envs to the submitted YAML:
+
+```yaml
+envs:
+  SKYPILOT_DOCKER_USERNAME: iam
+  SKYPILOT_DOCKER_PASSWORD: <fresh-nebius-iam-token>
+  SKYPILOT_DOCKER_SERVER: cr.eu-north1.nebius.cloud
+```
+
+By default the password is minted at submit time with
+`nebius iam get-access-token`, matching Nebius Container Registry's
+short-lived-token login flow. BYO private registries can override the three
+values with:
+
+```bash
+npa workbench workflow submit ... \
+  --registry registry.example/workbench \
+  --registry-server registry.example \
+  --registry-username <username> \
+  --registry-password <token>
+```
+
+Prefer `NPA_REGISTRY_USERNAME`, `NPA_REGISTRY_PASSWORD`, and
+`NPA_REGISTRY_SERVER` when you do not want the token in shell history. Use
+`--no-registry-auth` only for public images or environments that preconfigure
+Docker auth outside SkyPilot.
+
 For RTX PRO 6000 Kubernetes targets, use the same command with
 `--gpu-target gpu-rtx6000` and an accelerator string accepted by your SkyPilot
 Kubernetes GPU catalog, for example
 `--accelerators RTXPRO-6000-BLACKWELL-SERVER-EDITION:1`. The SONIC
-materializer resolves `gpu-rtx6000` to `npa-sonic:0.1.2-k8s`; L40S resolves to
-`npa-sonic:0.1.2`.
+materializer resolves `gpu-rtx6000` to `npa-sonic:0.1.2-k8s`; H100, H200, L40S,
+and B200 VM targets resolve to `npa-sonic:0.1.2` with matching
+`accelerators: <GPU>:1` and the smallest known Nebius VM CPU/RAM preset for that
+GPU. Pass `--use-spot` when the capacity check only reports preemptible
+availability.
 
 When a Kubernetes target pulls from a private registry, provide a SkyPilot config
 through `--config-path` that adds the registry pull secret to worker pods:

--- a/docs/workbench-yaml-guide.md
+++ b/docs/workbench-yaml-guide.md
@@ -59,6 +59,45 @@ image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/<image>:<image-ta
 Use `npa workbench lancedb system-info` or the corresponding workbench tool's
 `system-info` command to find the current image tag for live submissions.
 
+For raw SkyPilot VM YAMLs that pull private images from Nebius Container
+Registry, add SkyPilot Docker login envs next to the task's other `envs`.
+Nebius Container Registry accepts username `iam` and a short-lived token from
+`nebius iam get-access-token`.
+
+```yaml
+resources:
+  cloud: nebius
+  accelerators: H100:1
+  cpus: 16
+  memory: 200
+  use_spot: true
+  image_id: "docker:cr.eu-north1.nebius.cloud/<registry-id>/<image>:<tag>"
+envs:
+  SKYPILOT_DOCKER_USERNAME: iam
+  SKYPILOT_DOCKER_PASSWORD: ""
+  SKYPILOT_DOCKER_SERVER: cr.eu-north1.nebius.cloud
+```
+
+Supply the token at launch time instead of committing it:
+
+```bash
+sky jobs launch raw-sonic.yaml \
+  --env SKYPILOT_DOCKER_PASSWORD="$(nebius iam get-access-token)"
+```
+
+For NPA's generic submit path, keep the same key in `envs` and pass:
+
+```bash
+npa workbench workflow submit raw-sonic.yaml \
+  --var SKYPILOT_DOCKER_PASSWORD="$(nebius iam get-access-token)"
+```
+
+Do not commit rendered tokens. When submitting through
+`npa workbench workflow submit --tool sonic`, the materializer fills these values
+for Nebius VM targets automatically and lets operators override them with
+`--registry-server`, `--registry-username`, and `--registry-password` for BYO
+registries.
+
 The BDD100K pipeline currently runs serially because the checked-in comment notes
 that SkyPilot `0.12.2` supports serial pipelines and all-parallel job groups, but
 not the mixed dependency graph needed to train and evaluate the three views in

--- a/docs/workbench/proofs/sonic-registry-auth-submit-proof-20260605.md
+++ b/docs/workbench/proofs/sonic-registry-auth-submit-proof-20260605.md
@@ -1,0 +1,107 @@
+# SONIC registry-auth submit proof, 2026-06-05
+
+This note records the live VM-GPU proof attempt for the SONIC `npa workbench
+workflow submit` path after adding SkyPilot Docker registry auth materialization.
+The proof used an isolated `/tmp` checkout on branch
+`dev-fix-sonic-registry-auth-proof`; it did not modify `.github/workflows`, did
+not touch the LeRobot cluster, and avoided the #47 overlap files.
+
+## Registry auth
+
+The SONIC materializer now emits SkyPilot Docker login environment variables for
+VM image pulls:
+
+- `SKYPILOT_DOCKER_USERNAME`
+- `SKYPILOT_DOCKER_PASSWORD`
+- `SKYPILOT_DOCKER_SERVER`
+
+For first-party Nebius Container Registry images, the default username is `iam`
+and the password is a fresh `nebius iam get-access-token` value minted at submit
+time. This follows the Nebius Container Registry short-lived token flow:
+`nebius iam get-access-token | docker login cr.<region>.nebius.cloud --username
+iam --password-stdin`. Customer BYO registry credentials can override the
+defaults through CLI flags, SDK parameters, or environment variables.
+
+Local auth sanity check:
+
+- `nebius iam get-access-token` succeeded.
+- `docker login cr.eu-north1.nebius.cloud` with username `iam` succeeded.
+- `docker manifest inspect cr.eu-north1.nebius.cloud/<registry-id>/npa-sonic:0.1.2`
+  succeeded after login.
+- S3 profile access to `s3://npa-sim2real-d87cf691/` succeeded with
+  `AWS_PROFILE=nebius`.
+
+Secrets were not written to this file or to PR text.
+
+## Capacity oracle
+
+The capacity oracle was run with:
+
+```bash
+nebius capacity resource-advice list \
+  --parent-id <capacity-tenant-id> \
+  --all \
+  --format json \
+| jq -r '
+  .items[] |
+  [
+    .spec.region,
+    .spec.fabric,
+    .spec.compute_instance.platform,
+    .spec.compute_instance.preset.name,
+    .status.reserved.available,
+    .status.ondemand.available,
+    .status.preemptible.available
+  ] | @tsv'
+```
+
+Available 1-GPU VM candidates were preemptible only:
+
+| Priority | GPU | Region | Platform | Preset | Preemptible |
+| --- | --- | --- | --- | --- | --- |
+| 1 | H100 | `eu-north1` | `gpu-h100-sxm` | `1gpu-16vcpu-200gb` | 75 per listed fabric |
+| 2 | H200 | `eu-north1` | `gpu-h200-sxm` | `1gpu-16vcpu-200gb` | 75 |
+| 3 | L40S | `eu-north1` | `gpu-l40s-a` | `1gpu-16vcpu-64gb` | 9 |
+| 4 | B200 | `us-central1` / `me-west1` | `gpu-b200-sxm*` | `1gpu-20vcpu-224gb` | 81 / 55 |
+
+B200 remained last because it is an untested architecture for this SONIC image
+and the available capacity was outside the launchable `eu-north1` project path.
+
+## Live submit attempts
+
+All attempts used:
+
+- `NPA_SKYPILOT_BIN=/home/ubuntu/.npa/skypilot-venv/bin/sky`
+- `npa/.venv/bin/npa workbench workflow submit`
+- `--tool sonic`
+- `--controller-backend nebius`
+- `--registry cr.eu-north1.nebius.cloud/<registry-id>`
+- `--use-spot`
+- S3 proof prefixes under
+  `s3://npa-sim2real-d87cf691/sonic-submit-proof/<run-id>/`
+- scoped cleanup per attempt with `sky jobs cancel <id> --yes`, `sky down
+  <cluster> --yes` when SkyPilot had a cluster handle, and Nebius instance
+  polling for the run-specific name.
+
+| Attempt | Managed job | Placement | Result |
+| --- | --- | --- | --- |
+| `sonic-proof-h100-20260605t220047z` | 1 | H100 | Failed SkyPilot precheck before launch because the previous H100 default used `mem=64`; this PR updates H100/H200 VM defaults to `mem=200`. |
+| `sonic-proof-h100b-20260605t221200z` | 2 | `eu-north1`, `gpu-h100-sxm_1gpu-16vcpu-200gb[Spot]` | Instance came up and SkyPilot reported "Docker container is up", so the private-image pull path progressed past the prior registry-auth seam. SkyPilot then failed runtime setup with repeated `stdio forwarding failed` and `mkdir -p ~/.sky/.runtime_files` returning 255 before the SONIC entrypoint ran. The worker was cancelled and reached absence in Nebius. |
+| `sonic-proof-h200-20260605t222900z` | 3 | `eu-north1`, `gpu-h200-sxm_1gpu-16vcpu-200gb[Spot]` | Instance came up but did not reach task execution or S3 output during the bounded proof window. The worker was cancelled and reached absence in Nebius. |
+| `sonic-proof-l40s-20260605t223800z` | 4 | `eu-north1`, `gpu-l40s-a_1gpu-16vcpu-64gb[Spot]` | Instance came up but did not reach task execution or S3 output during the bounded proof window. The worker was cancelled and reached absence in Nebius. |
+| `sonic-proof-b200-20260605t223959z` | 5 | SkyPilot selected `me-west1`, `gpu-b200-sxm-a_1gpu-20vcpu-224gb[Spot]` | Failed before provisioning because the configured SkyPilot/Nebius project has no project mapping for `me-west1`. Nebius showed no run-scoped B200 instance. SkyPilot's managed-job state settled at `FAILED_CONTROLLER`. |
+
+## Tier
+
+The registry-auth seam is fixed in the materialized VM YAML: H100 progressed to
+SkyPilot's Docker-container-up stage with a private `cr.eu-north1.nebius.cloud`
+image, whereas the previous live blocker was private-registry pre-pull auth. The
+full SONIC entrypoint and S3 proof artifact did not complete on 2026-06-05
+because each launchable GPU then hit SkyPilot VM runtime setup before task
+execution; B200 additionally selected a non-launchable region for this project.
+
+No successful S3 artifact exists under the attempted proof prefixes. The next
+live-proof step is to resolve the SkyPilot VM runtime setup failure or constrain
+B200 placement to a configured project region before rerunning the same submit
+command. The SkyPilot-on-k8s image compatibility seam remains out of scope for
+this VM/H100 MVP proof.

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -99,6 +99,29 @@ def submit_cmd(
         "--npa-image",
         help="Generic NPA helper image override for multi-tool workflows.",
     ),
+    registry_auth: bool = typer.Option(
+        True,
+        "--registry-auth/--no-registry-auth",
+        help=(
+            "For VM SONIC image pulls, materialize SkyPilot Docker registry "
+            "auth envs. Nebius CR defaults to a fresh IAM token."
+        ),
+    ),
+    registry_username: str = typer.Option(
+        "",
+        "--registry-username",
+        help="BYO Docker registry username for SONIC VM image pulls.",
+    ),
+    registry_password: str = typer.Option(
+        "",
+        "--registry-password",
+        help="BYO Docker registry password/token for SONIC VM image pulls.",
+    ),
+    registry_server: str = typer.Option(
+        "",
+        "--registry-server",
+        help="BYO Docker registry server for SONIC VM image pulls.",
+    ),
     gpu_target: str = typer.Option(
         "",
         "--gpu-target",
@@ -119,6 +142,11 @@ def submit_cmd(
         "",
         "--cloud",
         help="Cloud value for materialized GPU tasks.",
+    ),
+    use_spot: bool | None = typer.Option(
+        None,
+        "--use-spot/--no-use-spot",
+        help="Optional SkyPilot spot/preemptible setting for materialized SONIC VM GPU tasks.",
     ),
     s3_endpoint: str = typer.Option(
         "",
@@ -180,6 +208,10 @@ def submit_cmd(
                     registry=registry,
                     image=image,
                     npa_image=npa_image,
+                    registry_auth=registry_auth,
+                    registry_username=registry_username,
+                    registry_password=registry_password,
+                    registry_server=registry_server,
                     gpu_target=gpu_target,
                     image_variant=image_variant,
                     s3_endpoint=s3_endpoint,
@@ -187,6 +219,7 @@ def submit_cmd(
                     s3_prefix=s3_prefix,
                     accelerators=accelerators,
                     cloud=cloud,
+                    use_spot=use_spot,
                     env_overrides=substitutions,
                 )
             except ValueError as exc:

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -143,6 +143,11 @@ def submit_cmd(
         "--cloud",
         help="Cloud value for materialized GPU tasks.",
     ),
+    region: str = typer.Option(
+        "",
+        "--region",
+        help="Optional cloud region for materialized SONIC VM GPU tasks.",
+    ),
     use_spot: bool | None = typer.Option(
         None,
         "--use-spot/--no-use-spot",
@@ -219,6 +224,7 @@ def submit_cmd(
                     s3_prefix=s3_prefix,
                     accelerators=accelerators,
                     cloud=cloud,
+                    region=region,
                     use_spot=use_spot,
                     env_overrides=substitutions,
                 )

--- a/npa/src/npa/orchestration/skypilot/workflow.py
+++ b/npa/src/npa/orchestration/skypilot/workflow.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Sequence
@@ -28,6 +29,10 @@ from npa.orchestration.skypilot.controller import (
     ControllerBackend,
     apply_controller_override,
 )
+
+
+JOBS_CONTROLLER_PREFIX = "sky-jobs-controller-"
+HEALTHY_CONTROLLER_STATUS = "UP"
 
 
 @dataclass
@@ -62,6 +67,8 @@ def submit_workflow(
     controller_backend: ControllerBackend = DEFAULT_CONTROLLER_BACKEND,
     secret_envs: Sequence[str] | None = None,
     timeout: int = 1800,
+    controller_preflight_timeout: int = 300,
+    controller_preflight_interval: float = 15.0,
 ) -> WorkflowResult:
     """Submit a SkyPilot YAML through NPA's controller convention."""
 
@@ -106,6 +113,12 @@ def submit_workflow(
                 cmd[-1:-1] = ["--secret", secret_name]
         env = sky_environment(runtime_config.isolated_config_dir)
         env["SKYPILOT_GLOBAL_CONFIG"] = str(generated_config_path)
+        _wait_for_healthy_jobs_controller(
+            sky_executable,
+            env=env,
+            timeout=controller_preflight_timeout,
+            interval=controller_preflight_interval,
+        )
         result = subprocess.run(
             cmd,
             env=env,
@@ -132,6 +145,9 @@ def submit_workflow(
     except subprocess.TimeoutExpired as exc:
         _cleanup_owned_submission_dir(owned_submission_dir)
         raise SkyPilotSubmitError(f"sky jobs launch timed out after {timeout}s") from exc
+    except SkyPilotSubmitError:
+        _cleanup_owned_submission_dir(owned_submission_dir)
+        raise
     except (
         OSError,
         ValueError,
@@ -193,6 +209,61 @@ def workflow_status(
     )
 
 
+def _wait_for_healthy_jobs_controller(
+    sky_executable: str,
+    *,
+    env: dict[str, str],
+    timeout: int,
+    interval: float,
+) -> None:
+    """Block launch while an existing managed-jobs controller is not ready."""
+
+    deadline = time.monotonic() + max(timeout, 0)
+    last_summary = ""
+    while True:
+        result = subprocess.run(
+            [sky_executable, "status", "--refresh", "--output", "json"],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=min(max(timeout, 1), 300),
+            check=False,
+        )
+        if result.returncode != 0:
+            raise SkyPilotSubmitError(f"SkyPilot controller health check failed: {_command_detail(result)}")
+        controllers = _jobs_controller_statuses(result.stdout)
+        unhealthy = [
+            (name, status)
+            for name, status in controllers
+            if status.upper() != HEALTHY_CONTROLLER_STATUS
+        ]
+        if not unhealthy:
+            return
+        last_summary = ", ".join(f"{name}={status or 'UNKNOWN'}" for name, status in unhealthy)
+        if time.monotonic() >= deadline:
+            raise SkyPilotSubmitError(f"SkyPilot jobs controller not healthy before launch: {last_summary}")
+        time.sleep(max(interval, 0.1))
+
+
+def _jobs_controller_statuses(output: str) -> list[tuple[str, str]]:
+    try:
+        payload = json.loads(output or "[]")
+    except json.JSONDecodeError as exc:
+        raise SkyPilotSubmitError("SkyPilot controller health check returned non-json output") from exc
+    clusters = payload if isinstance(payload, list) else payload.get("clusters", [])
+    controllers = []
+    for cluster in clusters or []:
+        if not isinstance(cluster, dict):
+            continue
+        name = str(cluster.get("name") or cluster.get("cluster") or "")
+        if not name.startswith(JOBS_CONTROLLER_PREFIX):
+            continue
+        status = str(cluster.get("status") or cluster.get("cluster_status") or "")
+        controllers.append((name, status.upper()))
+    return controllers
+
+
 def _load_yaml_documents(path: Path) -> list[dict[str, Any]]:
     with path.open("r", encoding="utf-8") as handle:
         docs = [doc for doc in yaml.safe_load_all(handle) if doc is not None]
@@ -239,9 +310,13 @@ def _cleanup_owned_submission_dir(path: Path | None) -> None:
 
 
 def _format_submit_error(cmd: list[str], result: subprocess.CompletedProcess[str]) -> str:
-    detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+    detail = _command_detail(result)
     prefix = "SkyPilot auth failure during jobs launch" if _looks_like_auth_error(detail) else "sky jobs launch failed"
     return f"{prefix}: {' '.join(cmd)}: {detail}"
+
+
+def _command_detail(result: subprocess.CompletedProcess[str]) -> str:
+    return result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
 
 
 def _looks_like_auth_error(detail: str) -> bool:

--- a/npa/src/npa/workbench/sonic/workflow.py
+++ b/npa/src/npa/workbench/sonic/workflow.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import re
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Sequence
@@ -21,13 +22,21 @@ DEFAULT_S3_ENDPOINT = "https://storage.eu-north1.nebius.cloud"
 DEFAULT_GPU_TARGET = "l40s"
 DEFAULT_SONIC_WORKFLOW_PREFIX = "sonic-locomotion"
 UNRESOLVED_SUBMIT_TOKENS = ("<your-", "<sonic-image-tag>", "<npa-image-tag>", "example.invalid")
+SKYPILOT_DOCKER_USERNAME = "SKYPILOT_DOCKER_USERNAME"
+SKYPILOT_DOCKER_PASSWORD = "SKYPILOT_DOCKER_PASSWORD"
+SKYPILOT_DOCKER_SERVER = "SKYPILOT_DOCKER_SERVER"
+DEFAULT_NEBIUS_REGISTRY_USERNAME = "iam"
+NEBIUS_REGISTRY_SERVER_SUFFIX = ".nebius.cloud"
+REGISTRY_AUTH_USERNAME_ENVS = ("NPA_REGISTRY_USERNAME", SKYPILOT_DOCKER_USERNAME)
+REGISTRY_AUTH_PASSWORD_ENVS = ("NPA_REGISTRY_PASSWORD", SKYPILOT_DOCKER_PASSWORD)
+REGISTRY_AUTH_SERVER_ENVS = ("NPA_REGISTRY_SERVER", SKYPILOT_DOCKER_SERVER)
 
 
 @dataclass(frozen=True)
 class SonicWorkflowPlan:
     """Resolved values used to submit a SONIC workflow YAML."""
 
-    yaml_text: str
+    yaml_text: str = field(repr=False)
     run_id: str
     policy_image: str
     npa_image: str
@@ -38,6 +47,18 @@ class SonicWorkflowPlan:
     s3_prefix: str
     accelerators: str
     cloud: str
+    use_spot: bool | None = None
+    registry_auth_server: str = ""
+    registry_auth_username: str = ""
+    registry_auth_source: str = ""
+
+
+@dataclass(frozen=True)
+class _RegistryAuthConfig:
+    username: str
+    password: str = field(repr=False)
+    server: str
+    source: str
 
 
 def materialize_sonic_workflow(
@@ -47,6 +68,10 @@ def materialize_sonic_workflow(
     registry: str = "",
     image: str = "",
     npa_image: str = "",
+    registry_auth: bool = True,
+    registry_username: str = "",
+    registry_password: str = "",
+    registry_server: str = "",
     gpu_target: str = DEFAULT_GPU_TARGET,
     image_variant: str = "",
     s3_endpoint: str = "",
@@ -54,6 +79,7 @@ def materialize_sonic_workflow(
     s3_prefix: str = "",
     accelerators: str = "",
     cloud: str = "",
+    use_spot: bool | None = None,
     env_overrides: dict[str, str] | None = None,
 ) -> SonicWorkflowPlan:
     """Return a concrete SONIC workflow YAML with no submit-time env indirection."""
@@ -78,6 +104,14 @@ def materialize_sonic_workflow(
     resolved_prefix = _resolve_s3_prefix(s3_prefix, resolved_run_id)
     resolved_accelerators = accelerators or _default_accelerators(resolved_gpu_target)
     resolved_cloud = cloud or _default_cloud(resolved_gpu_target)
+    resolved_registry_auth = _resolve_registry_auth(
+        enabled=registry_auth and resolved_cloud.strip().lower() != "kubernetes",
+        policy_image=resolved_policy_image,
+        npa_image=resolved_npa_image,
+        username=registry_username,
+        password=registry_password,
+        server=registry_server,
+    )
 
     replacements = {
         "sonic-locomotion/<run-id>/": resolved_prefix,
@@ -105,6 +139,8 @@ def materialize_sonic_workflow(
                 s3_prefix=resolved_prefix,
                 accelerators=resolved_accelerators,
                 cloud=resolved_cloud,
+                use_spot=use_spot,
+                registry_auth=resolved_registry_auth,
                 env_overrides=env_overrides or {},
             )
 
@@ -121,6 +157,10 @@ def materialize_sonic_workflow(
         s3_prefix=resolved_prefix,
         accelerators=resolved_accelerators,
         cloud=resolved_cloud,
+        use_spot=use_spot,
+        registry_auth_server=resolved_registry_auth.server if resolved_registry_auth else "",
+        registry_auth_username=resolved_registry_auth.username if resolved_registry_auth else "",
+        registry_auth_source=resolved_registry_auth.source if resolved_registry_auth else "",
     )
 
 
@@ -131,6 +171,10 @@ def submit_sonic_workflow(
     registry: str = "",
     image: str = "",
     npa_image: str = "",
+    registry_auth: bool = True,
+    registry_username: str = "",
+    registry_password: str = "",
+    registry_server: str = "",
     gpu_target: str = DEFAULT_GPU_TARGET,
     image_variant: str = "",
     s3_endpoint: str = "",
@@ -138,6 +182,7 @@ def submit_sonic_workflow(
     s3_prefix: str = "",
     accelerators: str = "",
     cloud: str = "",
+    use_spot: bool | None = None,
     env_overrides: dict[str, str] | None = None,
     isolated_config_dir: Path | None = None,
     config_path: Path | None = None,
@@ -154,6 +199,10 @@ def submit_sonic_workflow(
         registry=registry,
         image=image,
         npa_image=npa_image,
+        registry_auth=registry_auth,
+        registry_username=registry_username,
+        registry_password=registry_password,
+        registry_server=registry_server,
         gpu_target=gpu_target,
         image_variant=image_variant,
         s3_endpoint=s3_endpoint,
@@ -161,6 +210,7 @@ def submit_sonic_workflow(
         s3_prefix=s3_prefix,
         accelerators=accelerators,
         cloud=cloud,
+        use_spot=use_spot,
         env_overrides=env_overrides,
     )
     unresolved = unresolved_submit_placeholders(plan.yaml_text)
@@ -219,6 +269,14 @@ def _default_accelerators(gpu_target: str) -> str:
     normalized = gpu_target.strip().lower().replace("_", "-")
     if "rtx" in normalized or "blackwell" in normalized or "sm-120" in normalized:
         return "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
+    if "b200" in normalized:
+        return "B200:1"
+    if "h200" in normalized:
+        return "H200:1"
+    if "h100" in normalized:
+        return "H100:1"
+    if "l40s" in normalized:
+        return "L40S:1"
     return "L40S:1"
 
 
@@ -227,6 +285,24 @@ def _default_cloud(gpu_target: str) -> str:
     if "rtx" in normalized or "blackwell" in normalized or "sm-120" in normalized:
         return "kubernetes"
     return "nebius"
+
+
+def _default_cpus(gpu_target: str) -> int:
+    normalized = gpu_target.strip().lower().replace("_", "-")
+    if "b200" in normalized:
+        return 20
+    return 16
+
+
+def _default_memory(gpu_target: str) -> int:
+    normalized = gpu_target.strip().lower().replace("_", "-")
+    if "b200" in normalized:
+        return 224
+    if "h100" in normalized or "h200" in normalized:
+        return 200
+    if "l40s" in normalized:
+        return 64
+    return 64
 
 
 def _replace_strings(value: Any, replacements: dict[str, str]) -> Any:
@@ -254,6 +330,8 @@ def _materialize_task_doc(
     s3_prefix: str,
     accelerators: str,
     cloud: str,
+    use_spot: bool | None,
+    registry_auth: _RegistryAuthConfig | None,
     env_overrides: dict[str, str],
 ) -> None:
     envs = doc.get("envs")
@@ -267,6 +345,10 @@ def _materialize_task_doc(
     if uses_sonic_runtime_image:
         resources["cloud"] = cloud
         resources["image_id"] = f"docker:{policy_image}"
+        resources["cpus"] = _default_cpus(gpu_target)
+        resources["memory"] = _default_memory(gpu_target)
+        if use_spot is not None and cloud.strip().lower() != "kubernetes":
+            resources["use_spot"] = use_spot
         if resources.get("accelerators"):
             resources["accelerators"] = accelerators
     elif npa_image and _looks_like_npa_helper_image(image_id):
@@ -290,6 +372,10 @@ def _materialize_task_doc(
         envs["NPA_PIPELINE_RUN_ID"] = run_id
     if "SONIC_OUTPUT_PREFIX" in envs:
         envs["SONIC_OUTPUT_PREFIX"] = s3_prefix
+    if registry_auth and _uses_registry_auth_target(doc, registry_auth.server):
+        envs[SKYPILOT_DOCKER_USERNAME] = registry_auth.username
+        envs[SKYPILOT_DOCKER_PASSWORD] = registry_auth.password
+        envs[SKYPILOT_DOCKER_SERVER] = registry_auth.server
     for key, value in env_overrides.items():
         if key in envs:
             envs[key] = value
@@ -315,3 +401,135 @@ def _uses_sonic_runtime_image(doc: dict[str, Any]) -> bool:
 
 def _looks_like_npa_helper_image(image_id: str) -> bool:
     return "/npa:" in image_id or image_id.endswith("/npa:<npa-image-tag>")
+
+
+def _resolve_registry_auth(
+    *,
+    enabled: bool,
+    policy_image: str,
+    npa_image: str,
+    username: str,
+    password: str,
+    server: str,
+) -> _RegistryAuthConfig | None:
+    if not enabled:
+        return None
+
+    explicit = any(value.strip() for value in (username, password, server))
+    env_username = _first_env(REGISTRY_AUTH_USERNAME_ENVS)
+    env_password = _first_env(REGISTRY_AUTH_PASSWORD_ENVS)
+    env_server = _first_env(REGISTRY_AUTH_SERVER_ENVS)
+    env_provided = any(value for value in (env_username, env_password, env_server))
+
+    resolved_server = _normalize_registry_server(
+        server or env_server or _registry_server_for_images(policy_image, npa_image)
+    )
+    resolved_username = username or env_username
+    resolved_password = password or env_password
+    source = "explicit" if explicit else "env" if env_provided else ""
+
+    if resolved_server and _is_nebius_registry_server(resolved_server):
+        if not resolved_username:
+            resolved_username = DEFAULT_NEBIUS_REGISTRY_USERNAME
+        if not resolved_password:
+            resolved_password = _mint_nebius_registry_token()
+            source = "nebius-iam-token"
+    elif explicit or env_provided:
+        source = source or "explicit"
+    else:
+        return None
+
+    missing = [
+        name
+        for name, value in (
+            ("username", resolved_username),
+            ("password", resolved_password),
+            ("server", resolved_server),
+        )
+        if not value
+    ]
+    if missing:
+        raise ValueError(
+            "Registry auth requires username, password, and server; missing "
+            + ", ".join(missing)
+        )
+
+    return _RegistryAuthConfig(
+        username=resolved_username,
+        password=resolved_password,
+        server=resolved_server,
+        source=source or "explicit",
+    )
+
+
+def _first_env(names: Sequence[str]) -> str:
+    for name in names:
+        value = os.environ.get(name, "")
+        if value:
+            return value
+    return ""
+
+
+def _mint_nebius_registry_token() -> str:
+    cli = os.environ.get("NEBIUS_CLI", "nebius")
+    try:
+        result = subprocess.run(
+            [cli, "iam", "get-access-token"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(
+            "Could not mint Nebius registry token with `nebius iam get-access-token`"
+        ) from exc
+
+    token = result.stdout.strip()
+    if result.returncode != 0 or not token:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise ValueError(
+            "Could not mint Nebius registry token with `nebius iam get-access-token`: "
+            + detail
+        )
+    return token
+
+
+def _registry_server_for_images(*images: str) -> str:
+    for image in images:
+        server = _registry_server_from_image(image)
+        if server:
+            return server
+    return ""
+
+
+def _registry_server_from_image(image: str) -> str:
+    image_ref = image.removeprefix("docker:").strip()
+    if "/" not in image_ref:
+        return ""
+    candidate = image_ref.split("/", 1)[0]
+    if "." in candidate or ":" in candidate or candidate == "localhost":
+        return _normalize_registry_server(candidate)
+    return ""
+
+
+def _normalize_registry_server(server: str) -> str:
+    normalized = server.strip()
+    normalized = normalized.removeprefix("https://").removeprefix("http://")
+    return normalized.rstrip("/")
+
+
+def _is_nebius_registry_server(server: str) -> bool:
+    normalized = _normalize_registry_server(server)
+    return normalized.startswith("cr.") and normalized.endswith(NEBIUS_REGISTRY_SERVER_SUFFIX)
+
+
+def _uses_registry_auth_target(doc: dict[str, Any], server: str) -> bool:
+    resources = doc.get("resources")
+    if not isinstance(resources, dict):
+        return False
+    if str(resources.get("cloud", "")).strip().lower() == "kubernetes":
+        return False
+    image_server = _registry_server_from_image(str(resources.get("image_id", "")))
+    return image_server == _normalize_registry_server(server)

--- a/npa/src/npa/workbench/sonic/workflow.py
+++ b/npa/src/npa/workbench/sonic/workflow.py
@@ -47,6 +47,7 @@ class SonicWorkflowPlan:
     s3_prefix: str
     accelerators: str
     cloud: str
+    region: str = ""
     use_spot: bool | None = None
     registry_auth_server: str = ""
     registry_auth_username: str = ""
@@ -79,6 +80,7 @@ def materialize_sonic_workflow(
     s3_prefix: str = "",
     accelerators: str = "",
     cloud: str = "",
+    region: str = "",
     use_spot: bool | None = None,
     env_overrides: dict[str, str] | None = None,
 ) -> SonicWorkflowPlan:
@@ -104,6 +106,7 @@ def materialize_sonic_workflow(
     resolved_prefix = _resolve_s3_prefix(s3_prefix, resolved_run_id)
     resolved_accelerators = accelerators or _default_accelerators(resolved_gpu_target)
     resolved_cloud = cloud or _default_cloud(resolved_gpu_target)
+    resolved_region = region.strip()
     resolved_registry_auth = _resolve_registry_auth(
         enabled=registry_auth and resolved_cloud.strip().lower() != "kubernetes",
         policy_image=resolved_policy_image,
@@ -139,6 +142,7 @@ def materialize_sonic_workflow(
                 s3_prefix=resolved_prefix,
                 accelerators=resolved_accelerators,
                 cloud=resolved_cloud,
+                region=resolved_region,
                 use_spot=use_spot,
                 registry_auth=resolved_registry_auth,
                 env_overrides=env_overrides or {},
@@ -157,6 +161,7 @@ def materialize_sonic_workflow(
         s3_prefix=resolved_prefix,
         accelerators=resolved_accelerators,
         cloud=resolved_cloud,
+        region=resolved_region,
         use_spot=use_spot,
         registry_auth_server=resolved_registry_auth.server if resolved_registry_auth else "",
         registry_auth_username=resolved_registry_auth.username if resolved_registry_auth else "",
@@ -182,6 +187,7 @@ def submit_sonic_workflow(
     s3_prefix: str = "",
     accelerators: str = "",
     cloud: str = "",
+    region: str = "",
     use_spot: bool | None = None,
     env_overrides: dict[str, str] | None = None,
     isolated_config_dir: Path | None = None,
@@ -210,6 +216,7 @@ def submit_sonic_workflow(
         s3_prefix=s3_prefix,
         accelerators=accelerators,
         cloud=cloud,
+        region=region,
         use_spot=use_spot,
         env_overrides=env_overrides,
     )
@@ -330,6 +337,7 @@ def _materialize_task_doc(
     s3_prefix: str,
     accelerators: str,
     cloud: str,
+    region: str,
     use_spot: bool | None,
     registry_auth: _RegistryAuthConfig | None,
     env_overrides: dict[str, str],
@@ -344,9 +352,14 @@ def _materialize_task_doc(
     image_id = str(resources.get("image_id", ""))
     if uses_sonic_runtime_image:
         resources["cloud"] = cloud
-        resources["image_id"] = f"docker:{policy_image}"
+        if cloud.strip().lower() == "kubernetes":
+            resources["image_id"] = f"docker:{policy_image}"
+        else:
+            resources.pop("image_id", None)
         resources["cpus"] = _default_cpus(gpu_target)
         resources["memory"] = _default_memory(gpu_target)
+        if region and cloud.strip().lower() != "kubernetes":
+            resources["region"] = region
         if use_spot is not None and cloud.strip().lower() != "kubernetes":
             resources["use_spot"] = use_spot
         if resources.get("accelerators"):
@@ -372,7 +385,11 @@ def _materialize_task_doc(
         envs["NPA_PIPELINE_RUN_ID"] = run_id
     if "SONIC_OUTPUT_PREFIX" in envs:
         envs["SONIC_OUTPUT_PREFIX"] = s3_prefix
-    if registry_auth and _uses_registry_auth_target(doc, registry_auth.server):
+    if registry_auth and _uses_registry_auth_target(
+        doc,
+        registry_auth.server,
+        policy_image=policy_image,
+    ):
         envs[SKYPILOT_DOCKER_USERNAME] = registry_auth.username
         envs[SKYPILOT_DOCKER_PASSWORD] = registry_auth.password
         envs[SKYPILOT_DOCKER_SERVER] = registry_auth.server
@@ -525,11 +542,22 @@ def _is_nebius_registry_server(server: str) -> bool:
     return normalized.startswith("cr.") and normalized.endswith(NEBIUS_REGISTRY_SERVER_SUFFIX)
 
 
-def _uses_registry_auth_target(doc: dict[str, Any], server: str) -> bool:
+def _uses_registry_auth_target(
+    doc: dict[str, Any],
+    server: str,
+    *,
+    policy_image: str = "",
+) -> bool:
     resources = doc.get("resources")
     if not isinstance(resources, dict):
         return False
     if str(resources.get("cloud", "")).strip().lower() == "kubernetes":
         return False
-    image_server = _registry_server_from_image(str(resources.get("image_id", "")))
-    return image_server == _normalize_registry_server(server)
+    envs = doc.get("envs")
+    image_servers = {
+        _registry_server_from_image(str(resources.get("image_id", ""))),
+        _registry_server_from_image(policy_image),
+    }
+    if isinstance(envs, dict):
+        image_servers.add(_registry_server_from_image(str(envs.get("POLICY_IMAGE", ""))))
+    return _normalize_registry_server(server) in image_servers

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -283,6 +283,9 @@ def test_workbench_workflow_submit_materializes_byo_registry_auth(mocker) -> Non
     assert "image_id" not in task["resources"]
     assert "--gpus all" in task["run"]
     assert "/entrypoint.sh train" in task["run"]
+    assert "sonic_proof_status.json" in task["run"]
+    assert "s3.upload_file" in task["run"]
+    assert 'exit "${docker_status}"' in task["run"]
     assert task["envs"]["SKYPILOT_DOCKER_USERNAME"] == "customer"
     assert task["envs"]["SKYPILOT_DOCKER_PASSWORD"] == "customer-token"
     assert task["envs"]["SKYPILOT_DOCKER_SERVER"] == "registry.example"

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -203,6 +203,8 @@ def test_workbench_workflow_submit_materializes_sonic_yaml(mocker) -> None:
             "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1",
             "--var",
             "SONIC_MAX_ITERATIONS=2",
+            "--var",
+            "SONIC_RUN_REAL_TRAIN=1",
         ],
     )
 
@@ -221,6 +223,7 @@ def test_workbench_workflow_submit_materializes_sonic_yaml(mocker) -> None:
     assert envs["S3_BUCKET"] == "proof-bucket"
     assert envs["SONIC_OUTPUT_PREFIX"] == "sonic-proof/sonic-run/"
     assert envs["SONIC_MAX_ITERATIONS"] == "2"
+    assert envs["SONIC_RUN_REAL_TRAIN"] == "1"
     assert "${" not in task["resources"]["image_id"]
     assert "${" not in "\n".join(str(value) for value in envs.values())
 
@@ -259,6 +262,8 @@ def test_workbench_workflow_submit_materializes_byo_registry_auth(mocker) -> Non
             "customer-token",
             "--gpu-target",
             "h100",
+            "--region",
+            "eu-north1",
             "--use-spot",
             "--s3-endpoint",
             "https://storage.example",
@@ -273,7 +278,11 @@ def test_workbench_workflow_submit_materializes_byo_registry_auth(mocker) -> Non
     task = docs[1]
     assert task["resources"]["accelerators"] == "H100:1"
     assert task["resources"]["memory"] == 200
+    assert task["resources"]["region"] == "eu-north1"
     assert task["resources"]["use_spot"] is True
+    assert "image_id" not in task["resources"]
+    assert "--gpus all" in task["run"]
+    assert "/entrypoint.sh train" in task["run"]
     assert task["envs"]["SKYPILOT_DOCKER_USERNAME"] == "customer"
     assert task["envs"]["SKYPILOT_DOCKER_PASSWORD"] == "customer-token"
     assert task["envs"]["SKYPILOT_DOCKER_SERVER"] == "registry.example"

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -225,6 +225,60 @@ def test_workbench_workflow_submit_materializes_sonic_yaml(mocker) -> None:
     assert "${" not in "\n".join(str(value) for value in envs.values())
 
 
+def test_workbench_workflow_submit_materializes_byo_registry_auth(mocker) -> None:
+    yaml_path = REPO_ROOT / "workflows/workbench/skypilot/sonic-train-standalone.yaml"
+    captured: dict[str, object] = {}
+
+    def fake_submit_workflow(path, run_id, **kwargs):
+        captured["content"] = path.read_text(encoding="utf-8")
+        captured["run_id"] = run_id
+        captured["kwargs"] = kwargs
+        return WorkflowResult(status="SUBMITTED", job_id="42", returncode=0)
+
+    mocker.patch(
+        "npa.orchestration.skypilot.workflow.submit_workflow",
+        side_effect=fake_submit_workflow,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(yaml_path),
+            "--run-id",
+            "sonic-run",
+            "--registry",
+            "registry.example/workbench",
+            "--registry-server",
+            "registry.example",
+            "--registry-username",
+            "customer",
+            "--registry-password",
+            "customer-token",
+            "--gpu-target",
+            "h100",
+            "--use-spot",
+            "--s3-endpoint",
+            "https://storage.example",
+            "--s3-bucket",
+            "proof-bucket",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "customer-token" not in result.output
+    docs = [doc for doc in yaml.safe_load_all(str(captured["content"])) if doc]
+    task = docs[1]
+    assert task["resources"]["accelerators"] == "H100:1"
+    assert task["resources"]["memory"] == 200
+    assert task["resources"]["use_spot"] is True
+    assert task["envs"]["SKYPILOT_DOCKER_USERNAME"] == "customer"
+    assert task["envs"]["SKYPILOT_DOCKER_PASSWORD"] == "customer-token"
+    assert task["envs"]["SKYPILOT_DOCKER_SERVER"] == "registry.example"
+
+
 def test_workbench_workflow_submit_blocks_unresolved_sonic_placeholders(mocker) -> None:
     yaml_path = REPO_ROOT / "workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml"
     submit_mock = mocker.patch("npa.orchestration.skypilot.workflow.submit_workflow")

--- a/npa/tests/guardrails/test_three_tier_contract.py
+++ b/npa/tests/guardrails/test_three_tier_contract.py
@@ -220,7 +220,12 @@ def test_standalone_policy_yaml_is_parameterized_and_endpoint_safe() -> None:
     task = docs[1]
     envs = task["envs"]
 
-    assert task["resources"]["image_id"] == "docker:example.invalid/npa-sonic:0.1.2"
+    assert "image_id" not in task["resources"]
+    assert '"${docker_cmd[@]}" login' in task["setup"]
+    assert '"${docker_cmd[@]}" pull "${POLICY_IMAGE}"' in task["setup"]
+    assert '"${docker_cmd[@]}" run' in task["run"]
+    assert "--gpus all" in task["run"]
+    assert "/entrypoint.sh train" in task["run"]
     assert {
         "POLICY_IMAGE",
         "SONIC_GPU_TYPE",
@@ -233,6 +238,5 @@ def test_standalone_policy_yaml_is_parameterized_and_endpoint_safe() -> None:
     assert envs["SONIC_IMAGE_VARIANT"] == "sonic-l40s-baked"
     assert envs["S3_ENDPOINT_URL"] == ""
     assert envs["S3_BUCKET"] == "example-bucket"
-    assert "${" not in task["resources"]["image_id"]
     assert "${" not in "\n".join(str(value) for value in envs.values())
     assert "nebius.cloud" not in text

--- a/npa/tests/guardrails/test_three_tier_contract.py
+++ b/npa/tests/guardrails/test_three_tier_contract.py
@@ -226,6 +226,9 @@ def test_standalone_policy_yaml_is_parameterized_and_endpoint_safe() -> None:
     assert '"${docker_cmd[@]}" run' in task["run"]
     assert "--gpus all" in task["run"]
     assert "/entrypoint.sh train" in task["run"]
+    assert "sonic_proof_status.json" in task["run"]
+    assert "s3.upload_file" in task["run"]
+    assert 'exit "${docker_status}"' in task["run"]
     assert {
         "POLICY_IMAGE",
         "SONIC_GPU_TYPE",

--- a/npa/tests/guardrails/test_three_tier_contract.py
+++ b/npa/tests/guardrails/test_three_tier_contract.py
@@ -238,5 +238,7 @@ def test_standalone_policy_yaml_is_parameterized_and_endpoint_safe() -> None:
     assert envs["SONIC_IMAGE_VARIANT"] == "sonic-l40s-baked"
     assert envs["S3_ENDPOINT_URL"] == ""
     assert envs["S3_BUCKET"] == "example-bucket"
+    assert envs["WANDB_MODE"] == "offline"
+    assert '--env "WANDB_MODE=${WANDB_MODE}"' in task["run"]
     assert "${" not in "\n".join(str(value) for value in envs.values())
     assert "nebius.cloud" not in text

--- a/npa/tests/orchestration/skypilot/test_workflow.py
+++ b/npa/tests/orchestration/skypilot/test_workflow.py
@@ -26,6 +26,14 @@ def _fake_sky(tmp_path: Path) -> Path:
     return sky
 
 
+def _is_status_cmd(cmd: list[str]) -> bool:
+    return len(cmd) >= 2 and cmd[1] == "status"
+
+
+def _healthy_status(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(cmd, 0, stdout="[]", stderr="")
+
+
 @pytest.fixture(autouse=True)
 def _skip_version_check(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(workflow_module, "ensure_skypilot_version", lambda sky_bin: Path(sky_bin))
@@ -43,6 +51,8 @@ def test_submit_workflow_loads_yaml_applies_controller_and_calls_subprocess(monk
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs))
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 42\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -51,7 +61,8 @@ def test_submit_workflow_loads_yaml_applies_controller_and_calls_subprocess(monk
 
     assert result.status == "SUBMITTED"
     assert result.job_id == "42"
-    cmd, kwargs = calls[0]
+    assert calls[0][0] == [str(sky_bin), "status", "--refresh", "--output", "json"]
+    cmd, kwargs = calls[1]
     assert cmd[:5] == [str(sky_bin), "jobs", "launch", "--name", "run-abc"]
     assert "--config" not in cmd
     assert "--detach-run" in cmd
@@ -71,6 +82,8 @@ def test_submit_workflow_network_failure_raises_typed_error(monkeypatch, tmp_pat
     sky_bin = _fake_sky(tmp_path)
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="network connection failed")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -85,6 +98,8 @@ def test_submit_workflow_auth_failure_raises_typed_error(monkeypatch, tmp_path) 
     sky_bin = _fake_sky(tmp_path)
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="Authentication failed: credentials expired")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -118,6 +133,8 @@ def test_submit_workflow_cleans_owned_temp_dir_on_timeout(monkeypatch, tmp_path)
         return str(owned_dir)
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
 
     monkeypatch.setattr(workflow_module.tempfile, "mkdtemp", fake_mkdtemp)
@@ -135,6 +152,8 @@ def test_submit_workflow_can_emit_nebius_controller_fallback(monkeypatch, tmp_pa
     sky_bin = _fake_sky(tmp_path)
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 12\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -161,6 +180,8 @@ def test_submit_workflow_passes_configured_secret_env_names(monkeypatch, tmp_pat
     calls = []
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         calls.append(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 10\n", stderr="")
 
@@ -190,6 +211,8 @@ def test_submit_workflow_honors_isolated_config_dir(monkeypatch, tmp_path) -> No
 
     def fake_run(cmd, **kwargs):
         captured_env.update(kwargs["env"])
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 9", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -198,6 +221,40 @@ def test_submit_workflow_honors_isolated_config_dir(monkeypatch, tmp_path) -> No
 
     assert captured_env["HOME"] == str(tmp_path / "isolated" / "home")
     assert captured_env["SKY_RUNTIME_DIR"] == str(tmp_path / "isolated" / "sky-runtime")
+
+
+def test_submit_workflow_blocks_unhealthy_existing_jobs_controller(monkeypatch, tmp_path) -> None:
+    yaml_path = tmp_path / "workflow.yaml"
+    yaml_path.write_text("name: demo\n", encoding="utf-8")
+    sky_bin = _fake_sky(tmp_path)
+    owned_dir = tmp_path / "owned-autostop-submission"
+    calls = []
+
+    def fake_mkdtemp(prefix: str) -> str:
+        owned_dir.mkdir()
+        return str(owned_dir)
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if _is_status_cmd(cmd):
+            stdout = '[{"name": "sky-jobs-controller-64ce57a0", "status": "AUTOSTOPPING"}]'
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+        raise AssertionError("launch should be blocked until controller is healthy")
+
+    monkeypatch.setattr(workflow_module.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(SkyPilotSubmitError, match="sky-jobs-controller-64ce57a0=AUTOSTOPPING"):
+        submit_workflow(
+            yaml_path,
+            "run-autostop",
+            sky_bin=sky_bin,
+            controller_preflight_timeout=0,
+            controller_preflight_interval=0,
+        )
+
+    assert calls == [[str(sky_bin), "status", "--refresh", "--output", "json"]]
+    assert not owned_dir.exists()
 
 
 def test_workflow_status_reads_json_queue(monkeypatch, tmp_path) -> None:

--- a/npa/tests/workbench/test_sonic_workflow_registry_auth.py
+++ b/npa/tests/workbench/test_sonic_workflow_registry_auth.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SONIC_TRAIN_STANDALONE_YAML = (
+    ROOT
+    / "npa"
+    / "workflows"
+    / "workbench"
+    / "skypilot"
+    / "sonic-train-standalone.yaml"
+)
+
+
+def _task_envs(plan) -> tuple[dict, dict]:
+    docs = [doc for doc in yaml.safe_load_all(plan.yaml_text) if doc is not None]
+    task = docs[1]
+    return task["resources"], task["envs"]
+
+
+def _patch_nebius_token(monkeypatch: pytest.MonkeyPatch, token: str = "fresh-token") -> list[list[str]]:
+    from npa.workbench.sonic import workflow as sonic_workflow
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout=f"{token}\n", stderr="")
+
+    monkeypatch.setattr(sonic_workflow.subprocess, "run", fake_run)
+    return calls
+
+
+def test_sonic_materializer_adds_nebius_registry_auth_for_vm_tasks(monkeypatch) -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    calls = _patch_nebius_token(monkeypatch)
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="cr.eu-north1.nebius.cloud/registry-id",
+        gpu_target="h100",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, envs = _task_envs(plan)
+    assert calls == [["nebius", "iam", "get-access-token"]]
+    assert resources["cloud"] == "nebius"
+    assert resources["accelerators"] == "H100:1"
+    assert resources["cpus"] == 16
+    assert resources["memory"] == 200
+    assert envs["SKYPILOT_DOCKER_USERNAME"] == "iam"
+    assert envs["SKYPILOT_DOCKER_PASSWORD"] == "fresh-token"
+    assert envs["SKYPILOT_DOCKER_SERVER"] == "cr.eu-north1.nebius.cloud"
+    assert plan.registry_auth_username == "iam"
+    assert plan.registry_auth_server == "cr.eu-north1.nebius.cloud"
+    assert plan.registry_auth_source == "nebius-iam-token"
+    assert "fresh-token" not in repr(plan)
+
+
+def test_sonic_materializer_honors_byo_registry_auth_for_vm_tasks() -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        registry_username="customer",
+        registry_password="customer-token",
+        registry_server="https://registry.example/",
+        gpu_target="l40s",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    _, envs = _task_envs(plan)
+    assert envs["SKYPILOT_DOCKER_USERNAME"] == "customer"
+    assert envs["SKYPILOT_DOCKER_PASSWORD"] == "customer-token"
+    assert envs["SKYPILOT_DOCKER_SERVER"] == "registry.example"
+    assert plan.registry_auth_source == "explicit"
+
+
+def test_sonic_materializer_can_enable_spot_for_vm_tasks() -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        gpu_target="h100",
+        use_spot=True,
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, _ = _task_envs(plan)
+    assert resources["use_spot"] is True
+
+
+def test_sonic_materializer_skips_registry_auth_for_kubernetes_targets(monkeypatch) -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    calls = _patch_nebius_token(monkeypatch)
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="cr.eu-north1.nebius.cloud/registry-id",
+        gpu_target="gpu-rtx6000",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, envs = _task_envs(plan)
+    assert resources["cloud"] == "kubernetes"
+    assert "SKYPILOT_DOCKER_PASSWORD" not in envs
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("gpu_target", "accelerators", "cpus", "memory"),
+    [
+        ("h100", "H100:1", 16, 200),
+        ("H200", "H200:1", 16, 200),
+        ("L40S", "L40S:1", 16, 64),
+        ("b200", "B200:1", 20, 224),
+    ],
+)
+def test_sonic_materializer_defaults_vm_accelerators_by_gpu_target(
+    gpu_target: str,
+    accelerators: str,
+    cpus: int,
+    memory: int,
+) -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        gpu_target=gpu_target,
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, _ = _task_envs(plan)
+    assert resources["cloud"] == "nebius"
+    assert resources["accelerators"] == accelerators
+    assert resources["cpus"] == cpus
+    assert resources["memory"] == memory

--- a/npa/tests/workbench/test_sonic_workflow_registry_auth.py
+++ b/npa/tests/workbench/test_sonic_workflow_registry_auth.py
@@ -196,6 +196,10 @@ def test_sonic_materializer_uses_default_vm_runtime_and_docker_payload() -> None
     assert '"${docker_cmd[@]}" run' in task["run"]
     assert "--entrypoint /bin/bash" in task["run"]
     assert "/entrypoint.sh train" in task["run"]
+    assert "sonic_proof_status.json" in task["run"]
+    assert "python3 -m pip install --quiet boto3" in task["run"]
+    assert "s3.upload_file" in task["run"]
+    assert 'exit "${docker_status}"' in task["run"]
     assert (
         "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE HF_TOKEN "
         "WANDB_API_KEY WANDB_DISABLED WANDB_DIR"

--- a/npa/tests/workbench/test_sonic_workflow_registry_auth.py
+++ b/npa/tests/workbench/test_sonic_workflow_registry_auth.py
@@ -201,6 +201,6 @@ def test_sonic_materializer_uses_default_vm_runtime_and_docker_payload() -> None
     assert "s3.upload_file" in task["run"]
     assert 'exit "${docker_status}"' in task["run"]
     assert (
-        "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE HF_TOKEN "
-        "WANDB_API_KEY WANDB_DISABLED WANDB_DIR"
+        "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN HF_TOKEN WANDB_API_KEY "
+        "WANDB_DISABLED WANDB_DIR"
     ) in task["run"]

--- a/npa/tests/workbench/test_sonic_workflow_registry_auth.py
+++ b/npa/tests/workbench/test_sonic_workflow_registry_auth.py
@@ -196,4 +196,7 @@ def test_sonic_materializer_uses_default_vm_runtime_and_docker_payload() -> None
     assert '"${docker_cmd[@]}" run' in task["run"]
     assert "--entrypoint /bin/bash" in task["run"]
     assert "/entrypoint.sh train" in task["run"]
-    assert "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE HF_TOKEN" in task["run"]
+    assert (
+        "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE HF_TOKEN "
+        "WANDB_API_KEY WANDB_DISABLED WANDB_DIR"
+    ) in task["run"]

--- a/npa/tests/workbench/test_sonic_workflow_registry_auth.py
+++ b/npa/tests/workbench/test_sonic_workflow_registry_auth.py
@@ -24,6 +24,11 @@ def _task_envs(plan) -> tuple[dict, dict]:
     return task["resources"], task["envs"]
 
 
+def _task_doc(plan) -> dict:
+    docs = [doc for doc in yaml.safe_load_all(plan.yaml_text) if doc is not None]
+    return docs[1]
+
+
 def _patch_nebius_token(monkeypatch: pytest.MonkeyPatch, token: str = "fresh-token") -> list[list[str]]:
     from npa.workbench.sonic import workflow as sonic_workflow
 
@@ -57,6 +62,7 @@ def test_sonic_materializer_adds_nebius_registry_auth_for_vm_tasks(monkeypatch) 
     assert resources["accelerators"] == "H100:1"
     assert resources["cpus"] == 16
     assert resources["memory"] == 200
+    assert "image_id" not in resources
     assert envs["SKYPILOT_DOCKER_USERNAME"] == "iam"
     assert envs["SKYPILOT_DOCKER_PASSWORD"] == "fresh-token"
     assert envs["SKYPILOT_DOCKER_SERVER"] == "cr.eu-north1.nebius.cloud"
@@ -96,6 +102,7 @@ def test_sonic_materializer_can_enable_spot_for_vm_tasks() -> None:
         run_id="sonic-proof",
         registry="registry.example/workbench",
         gpu_target="h100",
+        region="eu-north1",
         use_spot=True,
         s3_endpoint="https://storage.example",
         s3_bucket="proof-bucket",
@@ -103,6 +110,7 @@ def test_sonic_materializer_can_enable_spot_for_vm_tasks() -> None:
 
     resources, _ = _task_envs(plan)
     assert resources["use_spot"] is True
+    assert resources["region"] == "eu-north1"
 
 
 def test_sonic_materializer_skips_registry_auth_for_kubernetes_targets(monkeypatch) -> None:
@@ -121,6 +129,7 @@ def test_sonic_materializer_skips_registry_auth_for_kubernetes_targets(monkeypat
 
     resources, envs = _task_envs(plan)
     assert resources["cloud"] == "kubernetes"
+    assert resources["image_id"] == "docker:cr.eu-north1.nebius.cloud/registry-id/npa-sonic:0.1.2-k8s"
     assert "SKYPILOT_DOCKER_PASSWORD" not in envs
     assert calls == []
 
@@ -156,3 +165,35 @@ def test_sonic_materializer_defaults_vm_accelerators_by_gpu_target(
     assert resources["accelerators"] == accelerators
     assert resources["cpus"] == cpus
     assert resources["memory"] == memory
+
+
+def test_sonic_materializer_uses_default_vm_runtime_and_docker_payload() -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        registry_username="customer",
+        registry_password="customer-token",
+        registry_server="registry.example",
+        gpu_target="h100",
+        region="eu-north1",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+        env_overrides={"SONIC_RUN_REAL_TRAIN": "1", "SONIC_MAX_ITERATIONS": "1"},
+    )
+
+    task = _task_doc(plan)
+    assert "image_id" not in task["resources"]
+    assert task["resources"]["region"] == "eu-north1"
+    assert task["envs"]["POLICY_IMAGE"] == "registry.example/workbench/npa-sonic:0.1.2"
+    assert task["envs"]["SONIC_RUN_REAL_TRAIN"] == "1"
+    assert task["envs"]["SONIC_MAX_ITERATIONS"] == "1"
+    assert '"${docker_cmd[@]}" login' in task["setup"]
+    assert '"${docker_cmd[@]}" pull "registry.example/workbench/npa-sonic:0.1.2"' in task["setup"]
+    assert "--gpus all" in task["run"]
+    assert '"${docker_cmd[@]}" run' in task["run"]
+    assert "--entrypoint /bin/bash" in task["run"]
+    assert "/entrypoint.sh train" in task["run"]
+    assert "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE HF_TOKEN" in task["run"]

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -32,6 +32,7 @@ envs:
   SONIC_RUN_REAL_TRAIN: "0"
   SONIC_DOWNLOAD_SAMPLE_DATA: "0"
   SONIC_CHECKPOINT_PATH: "sonic_release/last.pt"
+  WANDB_MODE: "offline"
   SONIC_OUTPUT_PREFIX: "sonic-train/sonic-train-smoke/"
 setup: |
   set -euo pipefail
@@ -96,12 +97,13 @@ run: |
     --env "SONIC_RUN_REAL_TRAIN=${SONIC_RUN_REAL_TRAIN}"
     --env "SONIC_DOWNLOAD_SAMPLE_DATA=${SONIC_DOWNLOAD_SAMPLE_DATA}"
     --env "SONIC_CHECKPOINT_PATH=${SONIC_CHECKPOINT_PATH}"
+    --env "WANDB_MODE=${WANDB_MODE}"
     --env "NVIDIA_DRIVER_CAPABILITIES=all"
     --env "VK_ICD_FILENAMES=/etc/vulkan/icd.d/nvidia_icd.json"
     --env "VK_DRIVER_FILES=/etc/vulkan/icd.d/nvidia_icd.json"
     --env "__GLX_VENDOR_LIBRARY_NAME=nvidia"
   )
-  for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE HF_TOKEN; do
+  for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE HF_TOKEN WANDB_API_KEY WANDB_DISABLED WANDB_DIR; do
     if [ -n "${!name:-}" ]; then
       docker_env_args+=(--env "${name}=${!name}")
     fi

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -109,6 +109,7 @@ run: |
     fi
   done
 
+  set +e
   "${docker_cmd[@]}" run \
     --rm \
     --gpus all \
@@ -129,3 +130,54 @@ run: |
         echo "nvidia-smi unavailable" | tee "${NPA_LOCAL_OUTPUT_DIR}/sonic_gpu_info.txt"
       fi
       /entrypoint.sh train'
+  docker_status=$?
+  set -e
+
+  export SONIC_DOCKER_STATUS="${docker_status}"
+  python3 - <<'PY'
+  import datetime
+  import json
+  import os
+  from pathlib import Path
+
+  out = Path(os.environ["NPA_LOCAL_OUTPUT_DIR"])
+  out.mkdir(parents=True, exist_ok=True)
+  status = {
+      "run_id": os.environ.get("NPA_PIPELINE_RUN_ID", ""),
+      "policy_image": os.environ.get("POLICY_IMAGE", ""),
+      "gpu_type": os.environ.get("SONIC_GPU_TYPE", ""),
+      "image_variant": os.environ.get("SONIC_IMAGE_VARIANT", ""),
+      "output_path": os.environ.get("NPA_OUTPUT_PATH", ""),
+      "real_train_requested": os.environ.get("SONIC_RUN_REAL_TRAIN", ""),
+      "max_iterations": os.environ.get("SONIC_MAX_ITERATIONS", ""),
+      "docker_status": int(os.environ.get("SONIC_DOCKER_STATUS", "1")),
+      "written_at_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+  }
+  (out / "sonic_proof_status.json").write_text(json.dumps(status, indent=2, sort_keys=True) + "\n")
+  PY
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -m pip install --quiet boto3 >/dev/null 2>&1 || true
+    python3 - <<'PY' || echo "warning: failed to upload SONIC proof artifacts" >&2
+  import os
+  from pathlib import Path
+
+  import boto3
+
+  bucket = os.environ["S3_BUCKET"]
+  prefix = os.environ.get("SONIC_OUTPUT_PREFIX", "").strip("/")
+  out = Path(os.environ["NPA_LOCAL_OUTPUT_DIR"])
+  s3 = boto3.client(
+      "s3",
+      endpoint_url=os.environ.get("S3_ENDPOINT_URL") or os.environ.get("AWS_ENDPOINT_URL") or None,
+  )
+  for path in sorted(out.glob("sonic_*")):
+      if not path.is_file():
+          continue
+      key = "/".join(part for part in (prefix, path.name) if part)
+      s3.upload_file(str(path), bucket, key)
+      print(f"uploaded s3://{bucket}/{key}")
+  PY
+  fi
+
+  exit "${docker_status}"

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -103,7 +103,7 @@ run: |
     --env "VK_DRIVER_FILES=/etc/vulkan/icd.d/nvidia_icd.json"
     --env "__GLX_VENDOR_LIBRARY_NAME=nvidia"
   )
-  for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE HF_TOKEN WANDB_API_KEY WANDB_DISABLED WANDB_DIR; do
+  for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN HF_TOKEN WANDB_API_KEY WANDB_DISABLED WANDB_DIR; do
     if [ -n "${!name:-}" ]; then
       docker_env_args+=(--env "${name}=${!name}")
     fi
@@ -167,6 +167,8 @@ run: |
   bucket = os.environ["S3_BUCKET"]
   prefix = os.environ.get("SONIC_OUTPUT_PREFIX", "").strip("/")
   out = Path(os.environ["NPA_LOCAL_OUTPUT_DIR"])
+  if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
+      os.environ.pop("AWS_PROFILE", None)
   s3 = boto3.client(
       "s3",
       endpoint_url=os.environ.get("S3_ENDPOINT_URL") or os.environ.get("AWS_ENDPOINT_URL") or None,

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -14,7 +14,6 @@ resources:
   accelerators: L40S:1
   cpus: 16
   memory: 64
-  image_id: "docker:example.invalid/npa-sonic:0.1.2"
 envs:
   POLICY_IMAGE: "example.invalid/npa-sonic:0.1.2"
   SONIC_GPU_TYPE: "l40s"
@@ -29,13 +28,33 @@ envs:
   SONIC_NUM_ENVS: "16"
   SONIC_HEADLESS: "1"
   SONIC_MAX_ITERATIONS: "5"
+  SONIC_NUM_PROCESSES: "1"
+  SONIC_RUN_REAL_TRAIN: "0"
+  SONIC_DOWNLOAD_SAMPLE_DATA: "0"
+  SONIC_CHECKPOINT_PATH: "sonic_release/last.pt"
   SONIC_OUTPUT_PREFIX: "sonic-train/sonic-train-smoke/"
 setup: |
   set -euo pipefail
-  if [ ! -x /entrypoint.sh ]; then
-    echo "The selected POLICY_IMAGE must provide the SONIC /entrypoint.sh runtime" >&2
+  docker_cmd=(docker)
+  if ! docker ps >/dev/null 2>&1; then
+    docker_cmd=(sudo docker)
+  fi
+  if [ -n "${SKYPILOT_DOCKER_SERVER:-}" ]; then
+    if [ -z "${SKYPILOT_DOCKER_USERNAME:-}" ] || [ -z "${SKYPILOT_DOCKER_PASSWORD:-}" ]; then
+      echo "SKYPILOT_DOCKER_USERNAME and SKYPILOT_DOCKER_PASSWORD are required with SKYPILOT_DOCKER_SERVER" >&2
+      exit 2
+    fi
+    printf '%s' "${SKYPILOT_DOCKER_PASSWORD}" \
+      | "${docker_cmd[@]}" login \
+          --username "${SKYPILOT_DOCKER_USERNAME}" \
+          --password-stdin \
+          "${SKYPILOT_DOCKER_SERVER}"
+  fi
+  if [ -z "${POLICY_IMAGE}" ]; then
+    echo "POLICY_IMAGE must be provided by the operator" >&2
     exit 2
   fi
+  "${docker_cmd[@]}" pull "${POLICY_IMAGE}"
 run: |
   set -euo pipefail
   if [ -z "${S3_ENDPOINT_URL}" ]; then
@@ -52,22 +71,59 @@ run: |
   output_path="s3://${S3_BUCKET}/${SONIC_OUTPUT_PREFIX}"
   export NPA_OUTPUT_PATH="${output_path}"
   export NPA_LOCAL_OUTPUT_DIR="${NPA_LOCAL_OUTPUT_DIR:-/tmp/npa-sonic-output}"
-  export SONIC_CHECKPOINT="${SONIC_CHECKPOINT}"
-  export SONIC_DATA_PATH="${SONIC_DATA_PATH}"
-  export SONIC_SAMPLE_DATA="${SONIC_SAMPLE_DATA}"
-  export SONIC_EMBODIMENT="${SONIC_EMBODIMENT}"
-  export SONIC_NUM_ENVS="${SONIC_NUM_ENVS}"
-  export SONIC_HEADLESS="${SONIC_HEADLESS}"
-  export SONIC_MAX_ITERATIONS="${SONIC_MAX_ITERATIONS}"
+  mkdir -p "${NPA_LOCAL_OUTPUT_DIR}"
 
   printf 'SONIC_WORKFLOW_IMAGE policy_image=%s gpu_type=%s image_variant=%s\n' \
     "${POLICY_IMAGE}" "${SONIC_GPU_TYPE}" "${SONIC_IMAGE_VARIANT}"
 
-  if command -v nvidia-smi >/dev/null 2>&1; then
-    nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader \
-      | tee "${NPA_LOCAL_OUTPUT_DIR}/sonic_gpu_info.txt"
-  else
-    echo "nvidia-smi unavailable" | tee "${NPA_LOCAL_OUTPUT_DIR}/sonic_gpu_info.txt"
+  docker_cmd=(docker)
+  if ! docker ps >/dev/null 2>&1; then
+    docker_cmd=(sudo docker)
   fi
+  docker_env_args=(
+    --env "AWS_ENDPOINT_URL=${S3_ENDPOINT_URL}"
+    --env "NEBIUS_S3_ENDPOINT=${S3_ENDPOINT_URL}"
+    --env "NPA_OUTPUT_PATH=${NPA_OUTPUT_PATH}"
+    --env "NPA_LOCAL_OUTPUT_DIR=${NPA_LOCAL_OUTPUT_DIR}"
+    --env "SONIC_CHECKPOINT=${SONIC_CHECKPOINT}"
+    --env "SONIC_DATA_PATH=${SONIC_DATA_PATH}"
+    --env "SONIC_SAMPLE_DATA=${SONIC_SAMPLE_DATA}"
+    --env "SONIC_EMBODIMENT=${SONIC_EMBODIMENT}"
+    --env "SONIC_NUM_ENVS=${SONIC_NUM_ENVS}"
+    --env "SONIC_HEADLESS=${SONIC_HEADLESS}"
+    --env "SONIC_MAX_ITERATIONS=${SONIC_MAX_ITERATIONS}"
+    --env "SONIC_NUM_PROCESSES=${SONIC_NUM_PROCESSES}"
+    --env "SONIC_RUN_REAL_TRAIN=${SONIC_RUN_REAL_TRAIN}"
+    --env "SONIC_DOWNLOAD_SAMPLE_DATA=${SONIC_DOWNLOAD_SAMPLE_DATA}"
+    --env "SONIC_CHECKPOINT_PATH=${SONIC_CHECKPOINT_PATH}"
+    --env "NVIDIA_DRIVER_CAPABILITIES=all"
+    --env "VK_ICD_FILENAMES=/etc/vulkan/icd.d/nvidia_icd.json"
+    --env "VK_DRIVER_FILES=/etc/vulkan/icd.d/nvidia_icd.json"
+    --env "__GLX_VENDOR_LIBRARY_NAME=nvidia"
+  )
+  for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE HF_TOKEN; do
+    if [ -n "${!name:-}" ]; then
+      docker_env_args+=(--env "${name}=${!name}")
+    fi
+  done
 
-  /entrypoint.sh train
+  "${docker_cmd[@]}" run \
+    --rm \
+    --gpus all \
+    --ipc=host \
+    --network host \
+    --ulimit memlock=-1 \
+    --ulimit stack=67108864 \
+    --volume "${NPA_LOCAL_OUTPUT_DIR}:${NPA_LOCAL_OUTPUT_DIR}" \
+    "${docker_env_args[@]}" \
+    --entrypoint /bin/bash \
+    "${POLICY_IMAGE}" \
+    -lc 'set -euo pipefail
+      mkdir -p "${NPA_LOCAL_OUTPUT_DIR}"
+      if command -v nvidia-smi >/dev/null 2>&1; then
+        nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader \
+          | tee "${NPA_LOCAL_OUTPUT_DIR}/sonic_gpu_info.txt"
+      else
+        echo "nvidia-smi unavailable" | tee "${NPA_LOCAL_OUTPUT_DIR}/sonic_gpu_info.txt"
+      fi
+      /entrypoint.sh train'

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -63,4 +63,11 @@ run: |
   printf 'SONIC_WORKFLOW_IMAGE policy_image=%s gpu_type=%s image_variant=%s\n' \
     "${POLICY_IMAGE}" "${SONIC_GPU_TYPE}" "${SONIC_IMAGE_VARIANT}"
 
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader \
+      | tee "${NPA_LOCAL_OUTPUT_DIR}/sonic_gpu_info.txt"
+  else
+    echo "nvidia-smi unavailable" | tee "${NPA_LOCAL_OUTPUT_DIR}/sonic_gpu_info.txt"
+  fi
+
   /entrypoint.sh train


### PR DESCRIPTION
## Summary

- Remove VM `resources.image_id` for SONIC SkyPilot tasks so SkyPilot no longer depends on controller-side Docker pre-pull behavior.
- Add `--region` materialization support and preserve VM `--use-spot` support for the H100/H200/L40S proof path.
- Move private runtime image auth into the task payload with `docker login`, `docker pull`, and `docker run --gpus all`, while keeping Kubernetes `image_id` behavior unchanged.
- Add a SkyPilot managed-jobs controller pre-submit guard so stale `AUTOSTOPPING`/`INIT` controllers fail before launch instead of leaving worker jobs pending.
- Persist SONIC proof artifacts from the host after the container exits and avoid passing `AWS_PROFILE` into the container when explicit S3 keys are provided.

## Reconciliation with #56

- Reuses #56's credential derivation story for Nebius Container Registry: `iam` plus a fresh `nebius iam get-access-token` token inside the worker payload.
- For SONIC VM submits, this branch supersedes #56's SkyPilot `image_id` pre-pull path because the task now authenticates and pulls the policy image inside the worker VM.
- Recommended path: fold any reusable auth notes from #56 into this PR or close #56 after this lands; avoid merging both independently unless the final docs make the VM pre-pull path distinct from the SONIC docker-payload path.

## Live proof

- Controller blocker resolved: the previous shared controller was stuck `AUTOSTOPPING`; after confirming no active managed jobs, it was deliberately reset once. The fresh controller is `UP` in `eu-north1` with autostop 120.
- Submitted with the raw YAML path via `npa workbench workflow submit`, `--use-spot`, `--region eu-north1`, and `H100:1`. No `me-west1`.
- Clean proof job: `sonic-proof-h100-smoke-clean-20260606T203030Z`, SkyPilot job 4, status `SUCCEEDED`, runtime about 281s.
- Evidence observed in logs: in-task Docker login succeeded, private image pull completed by digest, H100 was detected, and the SONIC smoke entrypoint completed.
- GPU evidence: `NVIDIA H100 80GB HBM3, 580.126.09, 81559 MiB`.
- S3 artifacts: `s3://npa-sim2real-d87cf691/sonic-submit-proof/sonic-proof-h100-smoke-clean-20260606T203030Z/`
  - `sonic_gpu_info.txt`
  - `sonic_proof_status.json` (`docker_status: 0`, `gpu_type: h100`)
  - `sonic_smoke_result.json` (`status: success`, SONIC/IsaacLab imports available)
  - `sonic_train_summary.json`

## Honest tier

- Tier achieved: real H100 spot VM proof with worker-side registry auth, Docker pull/run, GPU visibility, SONIC smoke entrypoint execution, and persisted S3 artifacts.
- Full `SONIC_RUN_REAL_TRAIN=1` was attempted on H100 and got past controller scheduling, Docker auth/pull, W&B offline mode, IsaacLab startup, `cuda:0`, and config save, then failed inside the current runtime image because `open3d` is missing. That is a container dependency rebuild item, not a SkyPilot/controller/auth blocker.
- Kubernetes remains direct-kubectl and out of scope for this PR.

## Tests

- `git diff --check`
- `../npa/.venv/bin/python -m pytest tests/orchestration/skypilot/test_workflow.py tests/workbench/test_sonic_workflow_registry_auth.py tests/cli/test_workflow_cli.py tests/guardrails/test_three_tier_contract.py -q` (`51 passed`)

## Guardrails

- No `.github/workflows` changes.
- No generated SkyPilot configs or `submit.json` committed.
- #47 overlap docs/test files were not edited.
- LeRobot untouched.
- Credentials and registry/project IDs redacted from PR text.