### PR TITLE
Make CLI docs index tolerate indented headings

### DIFF
--- a/npa/tests/cli/test_generate_docs_index.py
+++ b/npa/tests/cli/test_generate_docs_index.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = ROOT / "scripts" / "_generate_docs_index.py"
+
+
+def _load_docs_index_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_generate_docs_index", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_title_accepts_indented_markdown_h1(tmp_path: Path) -> None:
+    page = tmp_path / "fallback-name.md"
+    page.write_text("  # npa demo\n\ncontent\n")
+
+    module = _load_docs_index_module()
+
+    assert module._title(page) == "npa demo"

--- a/scripts/_generate_docs_index.py
+++ b/scripts/_generate_docs_index.py
@@ -28,8 +28,9 @@ def main() -> int:
 
 def _title(path: Path) -> str:
     for line in path.read_text().splitlines():
-        if line.startswith("# "):
-            return line[2:].strip().strip("`")
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip().strip("`")
     return path.stem
 
 


### PR DESCRIPTION
Temporary validation PR. This should be closed unmerged after checks complete.

Targeted behavior:
- The docs CLI index title helper now accepts Markdown H1 lines with leading whitespace while preserving the filename fallback.
- A focused pytest covers an indented H1 returning `npa demo`.

Validation run:
- `.venv/bin/python -m pytest --collect-only -q` -> 1524 tests collected.
- `.venv/bin/python -m pytest npa/tests/cli/test_generate_docs_index.py -q` -> 1 passed.
- Confidentiality diff scan using the repository guardrail scanner -> hits=0.
- Redacted secret-like diff scan -> hits=0.

Base and rebase evidence:
- Initial base `origin/main`: e9fd53fc1e48608292f3d6d2844188001e874e58.
- Pre-push fetch/rebase merge-base with `origin/main`: e9fd53fc1e48608292f3d6d2844188001e874e58.

Changed files:
- `scripts/_generate_docs_index.py`
- `npa/tests/cli/test_generate_docs_index.py`