### PR TITLE
fix(sonic): add Blackwell SkyPilot runtime image path

### DIFF
--- a/docs/architecture/contributor-context.md
+++ b/docs/architecture/contributor-context.md
@@ -147,7 +147,7 @@ historical baseline.
 
 SONIC image selection is now manifest-driven. The baked `npa-sonic:0.1.2`
 variant is used for L40S VM targets, while the host-mounted
-`npa-sonic:0.1.2-k8s` variant is used for RTX PRO 6000 Blackwell Kubernetes
+`npa-sonic:0.1.2-k8s-runtime` variant is used for RTX PRO 6000 Blackwell Kubernetes
 targets with NVIDIA GPU Operator mounted drivers. The source of truth is
 `npa/src/npa/deploy/sonic_image_manifest.json`.
 

--- a/docs/cli/workflow.md
+++ b/docs/cli/workflow.md
@@ -67,7 +67,7 @@ For RTX PRO 6000 Kubernetes targets, use the same command with
 `--gpu-target gpu-rtx6000` and an accelerator string accepted by your SkyPilot
 Kubernetes GPU catalog, for example
 `--accelerators RTXPRO-6000-BLACKWELL-SERVER-EDITION:1`. The SONIC
-materializer resolves `gpu-rtx6000` to `npa-sonic:0.1.2-k8s`; L40S resolves to
+materializer resolves `gpu-rtx6000` to `npa-sonic:0.1.2-k8s-runtime`; L40S resolves to
 `npa-sonic:0.1.2`.
 
 When a Kubernetes target pulls from a private registry, provide a SkyPilot config

--- a/docs/cli/workflow.md
+++ b/docs/cli/workflow.md
@@ -63,6 +63,35 @@ npa workbench workflow submit \
   --secret-env AWS_SECRET_ACCESS_KEY
 ```
 
+For Nebius Container Registry VM pulls, the SONIC materializer adds SkyPilot's
+Docker login envs to the submitted YAML:
+
+```yaml
+envs:
+  SKYPILOT_DOCKER_USERNAME: iam
+  SKYPILOT_DOCKER_PASSWORD: <fresh-nebius-iam-token>
+  SKYPILOT_DOCKER_SERVER: cr.eu-north1.nebius.cloud
+```
+
+By default the password is minted at submit time with
+`nebius iam get-access-token`, matching Nebius Container Registry's
+short-lived-token login flow. BYO private registries can override the three
+values with:
+
+```bash
+npa workbench workflow submit ... \
+  --registry registry.example/workbench \
+  --registry-server registry.example \
+  --registry-username <username> \
+  --registry-password <token>
+```
+
+Prefer `NPA_REGISTRY_USERNAME`, `NPA_REGISTRY_PASSWORD`, and
+`NPA_REGISTRY_SERVER` when you do not want the token in shell history. Use
+`--no-registry-auth` only for public images or environments that preconfigure
+Docker auth outside SkyPilot. In `SONIC_PAYLOAD_MODE=docker`, the standalone
+SONIC task uses the same envs for an in-task `docker login` before `docker pull`.
+
 For RTX PRO 6000 Kubernetes targets, use the same command with
 `--gpu-target gpu-rtx6000` and an accelerator string accepted by your SkyPilot
 Kubernetes GPU catalog, for example

--- a/docs/workbench/cookbooks/sonic-eval-runbook.md
+++ b/docs/workbench/cookbooks/sonic-eval-runbook.md
@@ -24,15 +24,15 @@ The SkyPilot blueprint is
 - Object storage credentials are available to the task, and the endpoint is
   `https://storage.eu-north1.nebius.cloud`.
 - The first-party SONIC image is built and pushed with the variant that matches
-  your GPU target. Use `0.1.2` for L40S VM targets and `0.1.2-k8s` for
+  your GPU target. Use `0.1.2` for L40S VM targets and `0.1.2-k8s-runtime` for
   RTX PRO 6000 Blackwell Kubernetes targets:
 
   ```bash
   export NPA_REGISTRY=cr.eu-north1.nebius.cloud/${NPA_REGISTRY_ID}
   npa/docker/workbench/sonic/build.sh --registry "${NPA_REGISTRY}" --push --variant baked
-  npa/docker/workbench/sonic/build.sh --registry "${NPA_REGISTRY}" --push --variant k8s
+  npa/docker/workbench/sonic/build.sh --registry "${NPA_REGISTRY}" --push --variant k8s --tag 0.1.2-k8s-runtime
   docker manifest inspect "${NPA_REGISTRY}/npa-sonic:0.1.2"
-  docker manifest inspect "${NPA_REGISTRY}/npa-sonic:0.1.2-k8s"
+  docker manifest inspect "${NPA_REGISTRY}/npa-sonic:0.1.2-k8s-runtime"
   ```
 
   See `docs/workbench/sonic-image-catalog.md` for the compatibility matrix.

--- a/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
+++ b/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
@@ -107,7 +107,7 @@ For RTX PRO 6000 Kubernetes targets, use:
 --accelerators RTXPRO-6000-BLACKWELL-SERVER-EDITION:1
 ```
 
-This resolves the SONIC stage to `npa-sonic:0.1.2-k8s`. L40S resolves to
+This resolves the SONIC stage to `npa-sonic:0.1.2-k8s-runtime`. L40S resolves to
 `npa-sonic:0.1.2`.
 
 For Kubernetes targets that pull private images, pass a SkyPilot config with the

--- a/docs/workbench/cookbooks/sonic-train-runbook.md
+++ b/docs/workbench/cookbooks/sonic-train-runbook.md
@@ -55,7 +55,7 @@ launch it directly:
 
 | YAML field | L40S value | RTX PRO 6000 Kubernetes value |
 | --- | --- | --- |
-| `resources.image_id` and `POLICY_IMAGE` | `cr.eu-north1.nebius.cloud/<registry-id>/npa-sonic:0.1.2` | `cr.eu-north1.nebius.cloud/<registry-id>/npa-sonic:0.1.2-k8s` |
+| `resources.image_id` and `POLICY_IMAGE` | `cr.eu-north1.nebius.cloud/<registry-id>/npa-sonic:0.1.2` | `cr.eu-north1.nebius.cloud/<registry-id>/npa-sonic:0.1.2-k8s-runtime` |
 | `SONIC_GPU_TYPE` | `l40s` | `gpu-rtx6000` |
 | `SONIC_IMAGE_VARIANT` | `sonic-l40s-baked` | `sonic-k8s-host-mounted` |
 | `S3_ENDPOINT_URL` | your S3-compatible endpoint | your S3-compatible endpoint |
@@ -134,8 +134,12 @@ For RTX PRO 6000 Blackwell on Kubernetes with the NVIDIA GPU Operator, use the
 host-mounted variant:
 
 ```bash
-npa/docker/workbench/sonic/build.sh --registry "${NPA_REGISTRY}" --push --variant k8s
-docker manifest inspect "${NPA_REGISTRY}/npa-sonic:0.1.2-k8s"
+npa/docker/workbench/sonic/build.sh \
+  --registry "${NPA_REGISTRY}" \
+  --push \
+  --variant k8s \
+  --tag 0.1.2-k8s-runtime
+docker manifest inspect "${NPA_REGISTRY}/npa-sonic:0.1.2-k8s-runtime"
 ```
 
 Expected output artifacts:

--- a/docs/workbench/cookbooks/sonic-whole-body-control.md
+++ b/docs/workbench/cookbooks/sonic-whole-body-control.md
@@ -42,13 +42,13 @@ SONIC publishes two first-party image variants. The compatibility source of
 truth is `npa/src/npa/deploy/sonic_image_manifest.json`, with the human catalog
 in `docs/workbench/sonic-image-catalog.md`. The default L40S VM image is
 `${NPA_REGISTRY}/npa-sonic:0.1.2`; the Kubernetes GPU-operator image for
-RTX PRO 6000 Blackwell is `${NPA_REGISTRY}/npa-sonic:0.1.2-k8s`.
+RTX PRO 6000 Blackwell is `${NPA_REGISTRY}/npa-sonic:0.1.2-k8s-runtime`.
 
 Verify the pushed image before launch with:
 
 ```bash
 docker manifest inspect "${NPA_REGISTRY}/npa-sonic:0.1.2"
-docker manifest inspect "${NPA_REGISTRY}/npa-sonic:0.1.2-k8s"
+docker manifest inspect "${NPA_REGISTRY}/npa-sonic:0.1.2-k8s-runtime"
 ```
 
 The default embodiment is Unitree G1:

--- a/docs/workbench/sonic-image-catalog.md
+++ b/docs/workbench/sonic-image-catalog.md
@@ -11,7 +11,7 @@ driver-coupled userspace are provided.
 | Variant | Tag | Driver provisioning | Use for | Why |
 | --- | --- | --- | --- | --- |
 | `sonic-l40s-baked` | `npa-sonic:0.1.2` | `baked` | L40S VM or compute-only host driver targets | The host does not mount the NVIDIA graphics userspace needed by Isaac Lab, so the image carries the matching NVML, GL, and Vulkan libraries. |
-| `sonic-k8s-host-mounted` | `npa-sonic:0.1.2-k8s` | `host-mounted` | RTX PRO 6000 Blackwell on Kubernetes with the NVIDIA GPU Operator | The GPU Operator mounts driver-matched NVML, GL, and Vulkan libraries from the node, so the image must not carry conflicting driver libraries. |
+| `sonic-k8s-host-mounted` | `npa-sonic:0.1.2-k8s-runtime` | `host-mounted` | RTX PRO 6000 Blackwell on Kubernetes with the NVIDIA GPU Operator | The GPU Operator mounts driver-matched NVML, GL, and Vulkan libraries from the node, so the image must not carry conflicting driver libraries. |
 
 Use `${NPA_REGISTRY}/npa-sonic:<tag>` for a concrete registry reference:
 
@@ -93,8 +93,12 @@ npa/docker/workbench/sonic/build.sh --registry "${NPA_REGISTRY}" --push --varian
 Kubernetes host-mounted variant:
 
 ```bash
-npa/docker/workbench/sonic/build.sh --registry "${NPA_REGISTRY}" --push --variant k8s
+npa/docker/workbench/sonic/build.sh \
+  --registry "${NPA_REGISTRY}" \
+  --push \
+  --variant k8s \
+  --tag 0.1.2-k8s-runtime
 ```
 
-Do not overwrite existing `0.1.2`, `0.1.1`, or `0.1.0` tags. New compatibility
-variants must use additive tags.
+Do not overwrite existing `0.1.2`, `0.1.2-k8s`, `0.1.1`, or `0.1.0` tags. New
+compatibility variants must use additive tags.

--- a/npa/docker/workbench/sonic/Dockerfile
+++ b/npa/docker/workbench/sonic/Dockerfile
@@ -9,11 +9,13 @@ ARG SONIC_VERSION=0.1.2
 ARG NVIDIA_DRIVER_PACKAGE_VERSION=580.126.09-1ubuntu1
 ARG INSTALL_NVIDIA_DRIVER_USERSPACE=1
 ARG NPA_DRIVER_PROVISIONING=baked
+ARG NPA_RUNTIME_USER=ubuntu
 ARG BUILD_SONIC_DEPLOY=0
 
 LABEL npa.tool="sonic" \
       npa.version="${SONIC_VERSION}" \
       npa.driver_provisioning="${NPA_DRIVER_PROVISIONING}" \
+      npa.runtime_user="${NPA_RUNTIME_USER}" \
       npa.architecture="self-contained-isaac-lab"
 
 ENV ACCEPT_EULA=Y \
@@ -162,6 +164,6 @@ RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 ubuntu \
       /tmp/isaac-sim-cache
 
 WORKDIR /opt/sonic
-USER ubuntu
+USER ${NPA_RUNTIME_USER}
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["smoke"]

--- a/npa/docker/workbench/sonic/build.sh
+++ b/npa/docker/workbench/sonic/build.sh
@@ -7,13 +7,15 @@ NPA_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 REGISTRY=""
 PUSH=0
 VARIANT="baked"
+IMAGE_TAG_OVERRIDE=""
 
 usage() {
   cat <<'EOF'
-Usage: build.sh [--registry REGISTRY] [--push] [--variant baked|k8s]
+Usage: build.sh [--registry REGISTRY] [--push] [--variant baked|k8s] [--tag TAG]
 
 Builds the SONIC runtime image as npa-sonic:<version> for --variant baked, or
 npa-sonic:<version>-k8s for --variant k8s.
+When --tag is provided, it overrides the final image tag.
 When --registry is provided, also tags REGISTRY/npa-sonic:<tag>.
 Use --registry cr.eu-north1.nebius.cloud/<your-registry-id> --push to publish.
 EOF
@@ -41,6 +43,14 @@ while [ "$#" -gt 0 ]; do
       VARIANT="$2"
       shift 2
       ;;
+    --tag)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --tag requires a value" >&2
+        exit 2
+      fi
+      IMAGE_TAG_OVERRIDE="$2"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -63,11 +73,13 @@ case "$VARIANT" in
     TAG_SUFFIX=""
     INSTALL_NVIDIA_DRIVER_USERSPACE=1
     NPA_DRIVER_PROVISIONING="baked"
+    NPA_RUNTIME_USER="ubuntu"
     ;;
   k8s)
     TAG_SUFFIX="-k8s"
     INSTALL_NVIDIA_DRIVER_USERSPACE=0
     NPA_DRIVER_PROVISIONING="host-mounted"
+    NPA_RUNTIME_USER="root"
     ;;
   *)
     echo "ERROR: --variant must be baked or k8s, got: $VARIANT" >&2
@@ -124,7 +136,7 @@ else:
 PY
 )"
 
-IMAGE_TAG="${VERSION}${TAG_SUFFIX}"
+IMAGE_TAG="${IMAGE_TAG_OVERRIDE:-${VERSION}${TAG_SUFFIX}}"
 LOCAL_IMAGE="npa-sonic:${IMAGE_TAG}"
 BUILD_ARGS=(
   --platform linux/amd64
@@ -133,6 +145,7 @@ BUILD_ARGS=(
   --build-arg "ISAAC_LAB_VERSION=${ISAAC_LAB_VERSION}"
   --build-arg "INSTALL_NVIDIA_DRIVER_USERSPACE=${INSTALL_NVIDIA_DRIVER_USERSPACE}"
   --build-arg "NPA_DRIVER_PROVISIONING=${NPA_DRIVER_PROVISIONING}"
+  --build-arg "NPA_RUNTIME_USER=${NPA_RUNTIME_USER}"
 )
 
 if [ -n "$REGISTRY" ]; then

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -99,6 +99,29 @@ def submit_cmd(
         "--npa-image",
         help="Generic NPA helper image override for multi-tool workflows.",
     ),
+    registry_auth: bool = typer.Option(
+        True,
+        "--registry-auth/--no-registry-auth",
+        help=(
+            "For VM SONIC image pulls, materialize Docker registry auth envs. "
+            "Nebius Container Registry defaults to a fresh IAM token."
+        ),
+    ),
+    registry_username: str = typer.Option(
+        "",
+        "--registry-username",
+        help="BYO Docker registry username for SONIC VM image pulls.",
+    ),
+    registry_password: str = typer.Option(
+        "",
+        "--registry-password",
+        help="BYO Docker registry password/token for SONIC VM image pulls.",
+    ),
+    registry_server: str = typer.Option(
+        "",
+        "--registry-server",
+        help="BYO Docker registry server for SONIC VM image pulls.",
+    ),
     gpu_target: str = typer.Option(
         "",
         "--gpu-target",
@@ -119,6 +142,11 @@ def submit_cmd(
         "",
         "--cloud",
         help="Cloud value for materialized GPU tasks.",
+    ),
+    use_spot: bool | None = typer.Option(
+        None,
+        "--use-spot/--no-use-spot",
+        help="Optional SkyPilot spot/preemptible setting for materialized SONIC VM GPU tasks.",
     ),
     s3_endpoint: str = typer.Option(
         "",
@@ -180,6 +208,10 @@ def submit_cmd(
                     registry=registry,
                     image=image,
                     npa_image=npa_image,
+                    registry_auth=registry_auth,
+                    registry_username=registry_username,
+                    registry_password=registry_password,
+                    registry_server=registry_server,
                     gpu_target=gpu_target,
                     image_variant=image_variant,
                     s3_endpoint=s3_endpoint,
@@ -187,6 +219,7 @@ def submit_cmd(
                     s3_prefix=s3_prefix,
                     accelerators=accelerators,
                     cloud=cloud,
+                    use_spot=use_spot,
                     env_overrides=substitutions,
                 )
             except ValueError as exc:

--- a/npa/src/npa/deploy/sonic_image_manifest.json
+++ b/npa/src/npa/deploy/sonic_image_manifest.json
@@ -39,7 +39,7 @@
     {
       "id": "sonic-k8s-host-mounted",
       "name": "npa-sonic",
-      "tag": "0.1.2-k8s",
+      "tag": "0.1.2-k8s-runtime",
       "purpose": "SONIC runtime for GPU-operator-managed Kubernetes nodes where the NVIDIA host driver is mounted into the container.",
       "base": {
         "cuda": "12.8",
@@ -61,7 +61,7 @@
         }
       ],
       "build": {
-        "command": "npa/docker/workbench/sonic/build.sh --registry ${NPA_REGISTRY} --push --variant k8s",
+        "command": "npa/docker/workbench/sonic/build.sh --registry ${NPA_REGISTRY} --push --variant k8s --tag 0.1.2-k8s-runtime",
         "dockerfile": "npa/docker/workbench/sonic/Dockerfile",
         "driver_coupled_packages": []
       },

--- a/npa/src/npa/workbench/sonic/workflow.py
+++ b/npa/src/npa/workbench/sonic/workflow.py
@@ -261,12 +261,18 @@ def _materialize_task_doc(
     if not isinstance(envs, dict) or not isinstance(resources, dict):
         return
 
+    payload_mode = str(
+        env_overrides.get("SONIC_PAYLOAD_MODE", envs.get("SONIC_PAYLOAD_MODE", "direct"))
+    ).strip().lower()
     has_sonic_env = _has_sonic_env(doc)
     uses_sonic_runtime_image = _uses_sonic_runtime_image(doc)
     image_id = str(resources.get("image_id", ""))
     if uses_sonic_runtime_image:
         resources["cloud"] = cloud
-        resources["image_id"] = f"docker:{policy_image}"
+        if payload_mode == "docker":
+            resources.pop("image_id", None)
+        else:
+            resources["image_id"] = f"docker:{policy_image}"
         if resources.get("accelerators"):
             resources["accelerators"] = accelerators
     elif npa_image and _looks_like_npa_helper_image(image_id):

--- a/npa/src/npa/workbench/sonic/workflow.py
+++ b/npa/src/npa/workbench/sonic/workflow.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import re
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Sequence
@@ -21,13 +22,21 @@ DEFAULT_S3_ENDPOINT = "https://storage.eu-north1.nebius.cloud"
 DEFAULT_GPU_TARGET = "l40s"
 DEFAULT_SONIC_WORKFLOW_PREFIX = "sonic-locomotion"
 UNRESOLVED_SUBMIT_TOKENS = ("<your-", "<sonic-image-tag>", "<npa-image-tag>", "example.invalid")
+SKYPILOT_DOCKER_USERNAME = "SKYPILOT_DOCKER_USERNAME"
+SKYPILOT_DOCKER_PASSWORD = "SKYPILOT_DOCKER_PASSWORD"
+SKYPILOT_DOCKER_SERVER = "SKYPILOT_DOCKER_SERVER"
+DEFAULT_NEBIUS_REGISTRY_USERNAME = "iam"
+NEBIUS_REGISTRY_SERVER_SUFFIX = ".nebius.cloud"
+REGISTRY_AUTH_USERNAME_ENVS = ("NPA_REGISTRY_USERNAME", SKYPILOT_DOCKER_USERNAME)
+REGISTRY_AUTH_PASSWORD_ENVS = ("NPA_REGISTRY_PASSWORD", SKYPILOT_DOCKER_PASSWORD)
+REGISTRY_AUTH_SERVER_ENVS = ("NPA_REGISTRY_SERVER", SKYPILOT_DOCKER_SERVER)
 
 
 @dataclass(frozen=True)
 class SonicWorkflowPlan:
     """Resolved values used to submit a SONIC workflow YAML."""
 
-    yaml_text: str
+    yaml_text: str = field(repr=False)
     run_id: str
     policy_image: str
     npa_image: str
@@ -38,6 +47,18 @@ class SonicWorkflowPlan:
     s3_prefix: str
     accelerators: str
     cloud: str
+    use_spot: bool | None = None
+    registry_auth_server: str = ""
+    registry_auth_username: str = ""
+    registry_auth_source: str = ""
+
+
+@dataclass(frozen=True)
+class _RegistryAuthConfig:
+    username: str
+    password: str
+    server: str
+    source: str
 
 
 def materialize_sonic_workflow(
@@ -47,6 +68,10 @@ def materialize_sonic_workflow(
     registry: str = "",
     image: str = "",
     npa_image: str = "",
+    registry_auth: bool = True,
+    registry_username: str = "",
+    registry_password: str = "",
+    registry_server: str = "",
     gpu_target: str = DEFAULT_GPU_TARGET,
     image_variant: str = "",
     s3_endpoint: str = "",
@@ -54,6 +79,7 @@ def materialize_sonic_workflow(
     s3_prefix: str = "",
     accelerators: str = "",
     cloud: str = "",
+    use_spot: bool | None = None,
     env_overrides: dict[str, str] | None = None,
 ) -> SonicWorkflowPlan:
     """Return a concrete SONIC workflow YAML with no submit-time env indirection."""
@@ -78,6 +104,14 @@ def materialize_sonic_workflow(
     resolved_prefix = _resolve_s3_prefix(s3_prefix, resolved_run_id)
     resolved_accelerators = accelerators or _default_accelerators(resolved_gpu_target)
     resolved_cloud = cloud or _default_cloud(resolved_gpu_target)
+    resolved_registry_auth = _resolve_registry_auth(
+        enabled=registry_auth and resolved_cloud.strip().lower() != "kubernetes",
+        username=registry_username,
+        password=registry_password,
+        server=registry_server,
+        policy_image=resolved_policy_image,
+        npa_image=resolved_npa_image,
+    )
 
     replacements = {
         "sonic-locomotion/<run-id>/": resolved_prefix,
@@ -105,6 +139,8 @@ def materialize_sonic_workflow(
                 s3_prefix=resolved_prefix,
                 accelerators=resolved_accelerators,
                 cloud=resolved_cloud,
+                use_spot=use_spot,
+                registry_auth=resolved_registry_auth,
                 env_overrides=env_overrides or {},
             )
 
@@ -121,6 +157,10 @@ def materialize_sonic_workflow(
         s3_prefix=resolved_prefix,
         accelerators=resolved_accelerators,
         cloud=resolved_cloud,
+        use_spot=use_spot,
+        registry_auth_server=resolved_registry_auth.server if resolved_registry_auth else "",
+        registry_auth_username=resolved_registry_auth.username if resolved_registry_auth else "",
+        registry_auth_source=resolved_registry_auth.source if resolved_registry_auth else "",
     )
 
 
@@ -131,6 +171,10 @@ def submit_sonic_workflow(
     registry: str = "",
     image: str = "",
     npa_image: str = "",
+    registry_auth: bool = True,
+    registry_username: str = "",
+    registry_password: str = "",
+    registry_server: str = "",
     gpu_target: str = DEFAULT_GPU_TARGET,
     image_variant: str = "",
     s3_endpoint: str = "",
@@ -138,6 +182,7 @@ def submit_sonic_workflow(
     s3_prefix: str = "",
     accelerators: str = "",
     cloud: str = "",
+    use_spot: bool | None = None,
     env_overrides: dict[str, str] | None = None,
     isolated_config_dir: Path | None = None,
     config_path: Path | None = None,
@@ -154,6 +199,10 @@ def submit_sonic_workflow(
         registry=registry,
         image=image,
         npa_image=npa_image,
+        registry_auth=registry_auth,
+        registry_username=registry_username,
+        registry_password=registry_password,
+        registry_server=registry_server,
         gpu_target=gpu_target,
         image_variant=image_variant,
         s3_endpoint=s3_endpoint,
@@ -161,6 +210,7 @@ def submit_sonic_workflow(
         s3_prefix=s3_prefix,
         accelerators=accelerators,
         cloud=cloud,
+        use_spot=use_spot,
         env_overrides=env_overrides,
     )
     unresolved = unresolved_submit_placeholders(plan.yaml_text)
@@ -219,6 +269,12 @@ def _default_accelerators(gpu_target: str) -> str:
     normalized = gpu_target.strip().lower().replace("_", "-")
     if "rtx" in normalized or "blackwell" in normalized or "sm-120" in normalized:
         return "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
+    if "h200" in normalized:
+        return "H200:1"
+    if "h100" in normalized:
+        return "H100:1"
+    if "b200" in normalized:
+        return "B200:1"
     return "L40S:1"
 
 
@@ -227,6 +283,22 @@ def _default_cloud(gpu_target: str) -> str:
     if "rtx" in normalized or "blackwell" in normalized or "sm-120" in normalized:
         return "kubernetes"
     return "nebius"
+
+
+def _default_cpus(gpu_target: str) -> int:
+    normalized = gpu_target.strip().lower().replace("_", "-")
+    if "b200" in normalized:
+        return 20
+    return 16
+
+
+def _default_memory(gpu_target: str) -> int:
+    normalized = gpu_target.strip().lower().replace("_", "-")
+    if "h100" in normalized or "h200" in normalized:
+        return 200
+    if "b200" in normalized:
+        return 224
+    return 64
 
 
 def _replace_strings(value: Any, replacements: dict[str, str]) -> Any:
@@ -254,6 +326,8 @@ def _materialize_task_doc(
     s3_prefix: str,
     accelerators: str,
     cloud: str,
+    use_spot: bool | None,
+    registry_auth: _RegistryAuthConfig | None,
     env_overrides: dict[str, str],
 ) -> None:
     envs = doc.get("envs")
@@ -275,6 +349,11 @@ def _materialize_task_doc(
             resources["image_id"] = f"docker:{policy_image}"
         if resources.get("accelerators"):
             resources["accelerators"] = accelerators
+        if cloud.strip().lower() != "kubernetes":
+            resources["cpus"] = _default_cpus(gpu_target)
+            resources["memory"] = _default_memory(gpu_target)
+            if use_spot is not None:
+                resources["use_spot"] = use_spot
     elif npa_image and _looks_like_npa_helper_image(image_id):
         resources["image_id"] = f"docker:{npa_image}"
 
@@ -299,6 +378,10 @@ def _materialize_task_doc(
     for key, value in env_overrides.items():
         if key in envs:
             envs[key] = value
+    if registry_auth and _uses_registry_auth_target(doc, registry_auth.server, policy_image):
+        envs[SKYPILOT_DOCKER_USERNAME] = registry_auth.username
+        envs[SKYPILOT_DOCKER_PASSWORD] = registry_auth.password
+        envs[SKYPILOT_DOCKER_SERVER] = registry_auth.server
 
 
 def _has_sonic_env(doc: dict[str, Any]) -> bool:
@@ -321,3 +404,138 @@ def _uses_sonic_runtime_image(doc: dict[str, Any]) -> bool:
 
 def _looks_like_npa_helper_image(image_id: str) -> bool:
     return "/npa:" in image_id or image_id.endswith("/npa:<npa-image-tag>")
+
+
+def _resolve_registry_auth(
+    *,
+    enabled: bool,
+    username: str,
+    password: str,
+    server: str,
+    policy_image: str,
+    npa_image: str,
+) -> _RegistryAuthConfig | None:
+    if not enabled:
+        return None
+
+    explicit = any(value.strip() for value in (username, password, server))
+    env_username = _first_env(REGISTRY_AUTH_USERNAME_ENVS)
+    env_password = _first_env(REGISTRY_AUTH_PASSWORD_ENVS)
+    env_server = _first_env(REGISTRY_AUTH_SERVER_ENVS)
+    env_provided = any(value for value in (env_username, env_password, env_server))
+
+    resolved_server = _normalize_registry_server(
+        server or env_server or _registry_server_for_images(policy_image, npa_image)
+    )
+    resolved_username = username or env_username
+    resolved_password = password or env_password
+    source = "explicit" if explicit else "env" if env_provided else ""
+
+    if resolved_server and _is_nebius_registry_server(resolved_server):
+        if not resolved_username:
+            resolved_username = DEFAULT_NEBIUS_REGISTRY_USERNAME
+        if not resolved_password:
+            resolved_password = _mint_nebius_registry_token()
+            source = "nebius-iam-token"
+    elif explicit or env_provided:
+        source = source or "explicit"
+    else:
+        return None
+
+    missing = [
+        name
+        for name, value in (
+            ("username", resolved_username),
+            ("password", resolved_password),
+            ("server", resolved_server),
+        )
+        if not value
+    ]
+    if missing:
+        raise ValueError(
+            "Registry auth requires username, password, and server; missing "
+            + ", ".join(missing)
+        )
+
+    return _RegistryAuthConfig(
+        username=resolved_username,
+        password=resolved_password,
+        server=resolved_server,
+        source=source or "explicit",
+    )
+
+
+def _first_env(names: Sequence[str]) -> str:
+    for name in names:
+        value = os.environ.get(name, "")
+        if value:
+            return value
+    return ""
+
+
+def _mint_nebius_registry_token() -> str:
+    cli = os.environ.get("NEBIUS_CLI", "nebius")
+    try:
+        result = subprocess.run(
+            [cli, "iam", "get-access-token"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(
+            "Could not mint Nebius registry token with `nebius iam get-access-token`"
+        ) from exc
+
+    token = result.stdout.strip()
+    if result.returncode != 0 or not token:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise ValueError(
+            "Could not mint Nebius registry token with `nebius iam get-access-token`: "
+            + detail
+        )
+    return token
+
+
+def _registry_server_for_images(*images: str) -> str:
+    for image in images:
+        server = _registry_server_from_image(image)
+        if server:
+            return server
+    return ""
+
+
+def _registry_server_from_image(image: str) -> str:
+    image_ref = image.removeprefix("docker:").strip()
+    if "/" not in image_ref:
+        return ""
+    candidate = image_ref.split("/", 1)[0]
+    if "." in candidate or ":" in candidate or candidate == "localhost":
+        return _normalize_registry_server(candidate)
+    return ""
+
+
+def _normalize_registry_server(server: str) -> str:
+    normalized = server.strip()
+    normalized = normalized.removeprefix("https://").removeprefix("http://")
+    return normalized.rstrip("/")
+
+
+def _is_nebius_registry_server(server: str) -> bool:
+    normalized = _normalize_registry_server(server)
+    return normalized.startswith("cr.") and normalized.endswith(NEBIUS_REGISTRY_SERVER_SUFFIX)
+
+
+def _uses_registry_auth_target(doc: dict[str, Any], server: str, policy_image: str) -> bool:
+    resources = doc.get("resources")
+    envs = doc.get("envs")
+    if not isinstance(resources, dict) or not isinstance(envs, dict):
+        return False
+    if str(resources.get("cloud", "")).strip().lower() == "kubernetes":
+        return False
+    normalized_server = _normalize_registry_server(server)
+    image_server = _registry_server_from_image(str(resources.get("image_id", "")))
+    policy_server = _registry_server_from_image(str(envs.get("POLICY_IMAGE", policy_image)))
+    return normalized_server in {image_server, policy_server}

--- a/npa/tests/cli/test_sonic_cli.py
+++ b/npa/tests/cli/test_sonic_cli.py
@@ -524,7 +524,7 @@ def test_sonic_container_image_name_resolves() -> None:
     ) == ("registry.example/npa-sonic:0.1.2")
     assert container_image_for_tool(
         "sonic", registry="registry.example", gpu_target="gpu-rtx6000"
-    ) == ("registry.example/npa-sonic:0.1.2-k8s")
+    ) == ("registry.example/npa-sonic:0.1.2-k8s-runtime")
     assert sonic_image_variant_for_gpu("NVIDIA RTX PRO 6000 Blackwell") == (
         "sonic-k8s-host-mounted"
     )

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -225,6 +225,60 @@ def test_workbench_workflow_submit_materializes_sonic_yaml(mocker) -> None:
     assert "${" not in "\n".join(str(value) for value in envs.values())
 
 
+def test_workbench_workflow_submit_materializes_registry_auth(mocker) -> None:
+    yaml_path = REPO_ROOT / "workflows/workbench/skypilot/sonic-train-standalone.yaml"
+    captured: dict[str, object] = {}
+
+    def fake_submit_workflow(path, run_id, **kwargs):
+        captured["content"] = path.read_text(encoding="utf-8")
+        captured["run_id"] = run_id
+        captured["kwargs"] = kwargs
+        return WorkflowResult(status="SUBMITTED", job_id="42", returncode=0)
+
+    mocker.patch(
+        "npa.orchestration.skypilot.workflow.submit_workflow",
+        side_effect=fake_submit_workflow,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(yaml_path),
+            "--run-id",
+            "sonic-run",
+            "--registry",
+            "registry.example/workbench",
+            "--registry-server",
+            "registry.example",
+            "--registry-username",
+            "operator",
+            "--registry-password",
+            "redacted-test-token",
+            "--gpu-target",
+            "h100",
+            "--use-spot",
+            "--s3-endpoint",
+            "https://storage.example",
+            "--s3-bucket",
+            "proof-bucket",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "redacted-test-token" not in result.output
+    docs = [doc for doc in yaml.safe_load_all(str(captured["content"])) if doc]
+    task = docs[1]
+    assert task["resources"]["accelerators"] == "H100:1"
+    assert task["resources"]["memory"] == 200
+    assert task["resources"]["use_spot"] is True
+    assert task["envs"]["SKYPILOT_DOCKER_USERNAME"] == "operator"
+    assert task["envs"]["SKYPILOT_DOCKER_PASSWORD"] == "redacted-test-token"
+    assert task["envs"]["SKYPILOT_DOCKER_SERVER"] == "registry.example"
+
+
 def test_workbench_workflow_submit_blocks_unresolved_sonic_placeholders(mocker) -> None:
     yaml_path = REPO_ROOT / "workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml"
     submit_mock = mocker.patch("npa.orchestration.skypilot.workflow.submit_workflow")

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -211,10 +211,10 @@ def test_workbench_workflow_submit_materializes_sonic_yaml(mocker) -> None:
     docs = [doc for doc in yaml.safe_load_all(str(captured["content"])) if doc]
     task = docs[1]
     envs = task["envs"]
-    assert task["resources"]["image_id"] == "docker:registry.example/workbench/npa-sonic:0.1.2-k8s"
+    assert task["resources"]["image_id"] == "docker:registry.example/workbench/npa-sonic:0.1.2-k8s-runtime"
     assert task["resources"]["cloud"] == "kubernetes"
     assert task["resources"]["accelerators"] == "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
-    assert envs["POLICY_IMAGE"] == "registry.example/workbench/npa-sonic:0.1.2-k8s"
+    assert envs["POLICY_IMAGE"] == "registry.example/workbench/npa-sonic:0.1.2-k8s-runtime"
     assert envs["SONIC_GPU_TYPE"] == "gpu-rtx6000"
     assert envs["SONIC_IMAGE_VARIANT"] == "sonic-k8s-host-mounted"
     assert envs["S3_ENDPOINT_URL"] == "https://storage.example"

--- a/npa/tests/workbench/test_sonic_workflow_registry_auth.py
+++ b/npa/tests/workbench/test_sonic_workflow_registry_auth.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SONIC_TRAIN_STANDALONE_YAML = (
+    ROOT
+    / "npa"
+    / "workflows"
+    / "workbench"
+    / "skypilot"
+    / "sonic-train-standalone.yaml"
+)
+
+
+def _task_docs(plan) -> tuple[dict, dict]:
+    docs = [doc for doc in yaml.safe_load_all(plan.yaml_text) if doc is not None]
+    task = docs[1]
+    return task["resources"], task["envs"]
+
+
+def _patch_nebius_token(monkeypatch: pytest.MonkeyPatch, token: str = "fresh-test-token") -> list[list[str]]:
+    from npa.workbench.sonic import workflow as sonic_workflow
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout=f"{token}\n", stderr="")
+
+    monkeypatch.setattr(sonic_workflow.subprocess, "run", fake_run)
+    return calls
+
+
+def test_sonic_materializer_adds_nebius_registry_auth_for_vm_image_pull(monkeypatch) -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    calls = _patch_nebius_token(monkeypatch)
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="cr.eu-north1.nebius.cloud/registry-id",
+        gpu_target="h100",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, envs = _task_docs(plan)
+    assert calls == [["nebius", "iam", "get-access-token"]]
+    assert resources["cloud"] == "nebius"
+    assert resources["accelerators"] == "H100:1"
+    assert resources["cpus"] == 16
+    assert resources["memory"] == 200
+    assert envs["SKYPILOT_DOCKER_USERNAME"] == "iam"
+    assert envs["SKYPILOT_DOCKER_PASSWORD"] == "fresh-test-token"
+    assert envs["SKYPILOT_DOCKER_SERVER"] == "cr.eu-north1.nebius.cloud"
+    assert plan.registry_auth_username == "iam"
+    assert plan.registry_auth_server == "cr.eu-north1.nebius.cloud"
+    assert plan.registry_auth_source == "nebius-iam-token"
+    assert "fresh-test-token" not in repr(plan)
+
+
+def test_sonic_materializer_adds_byo_registry_auth_for_docker_payload() -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        registry_username="operator",
+        registry_password="redacted-test-token",
+        registry_server="https://registry.example/",
+        gpu_target="l40s",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+        env_overrides={"SONIC_PAYLOAD_MODE": "docker"},
+    )
+
+    resources, envs = _task_docs(plan)
+    assert "image_id" not in resources
+    assert envs["SONIC_PAYLOAD_MODE"] == "docker"
+    assert envs["SKYPILOT_DOCKER_USERNAME"] == "operator"
+    assert envs["SKYPILOT_DOCKER_PASSWORD"] == "redacted-test-token"
+    assert envs["SKYPILOT_DOCKER_SERVER"] == "registry.example"
+    assert plan.registry_auth_source == "explicit"
+    assert "docker_login_if_configured" in plan.yaml_text
+    assert "docker login" in plan.yaml_text
+
+
+def test_sonic_materializer_skips_registry_auth_for_kubernetes_targets(monkeypatch) -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    calls = _patch_nebius_token(monkeypatch)
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="cr.eu-north1.nebius.cloud/registry-id",
+        gpu_target="gpu-rtx6000",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, envs = _task_docs(plan)
+    assert resources["cloud"] == "kubernetes"
+    assert "SKYPILOT_DOCKER_PASSWORD" not in envs
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("gpu_target", "accelerators", "cpus", "memory"),
+    [
+        ("h100", "H100:1", 16, 200),
+        ("H200", "H200:1", 16, 200),
+        ("L40S", "L40S:1", 16, 64),
+        ("b200", "B200:1", 20, 224),
+    ],
+)
+def test_sonic_materializer_defaults_vm_resources_by_gpu_target(
+    gpu_target: str,
+    accelerators: str,
+    cpus: int,
+    memory: int,
+) -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        gpu_target=gpu_target,
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, _ = _task_docs(plan)
+    assert resources["cloud"] == "nebius"
+    assert resources["accelerators"] == accelerators
+    assert resources["cpus"] == cpus
+    assert resources["memory"] == memory
+
+
+def test_sonic_materializer_can_enable_spot_for_vm_tasks() -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-proof",
+        registry="registry.example/workbench",
+        gpu_target="h100",
+        use_spot=True,
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+    )
+
+    resources, _ = _task_docs(plan)
+    assert resources["use_spot"] is True

--- a/npa/tests/workflows/test_sonic_locomotion_finetuning.py
+++ b/npa/tests/workflows/test_sonic_locomotion_finetuning.py
@@ -102,7 +102,7 @@ def test_sonic_workflow_materializer_resolves_images_and_s3_literals() -> None:
     retarget, train, eval_task = docs[1:]
 
     assert retarget["resources"]["image_id"] == "docker:registry.example/workbench/npa:tools"
-    assert train["resources"]["image_id"] == "docker:registry.example/workbench/npa-sonic:0.1.2-k8s"
+    assert train["resources"]["image_id"] == "docker:registry.example/workbench/npa-sonic:0.1.2-k8s-runtime"
     assert train["resources"]["cloud"] == "kubernetes"
     assert train["resources"]["accelerators"] == "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
     assert eval_task["resources"]["image_id"] == "docker:registry.example/workbench/npa:tools"
@@ -149,6 +149,27 @@ def test_sonic_sdk_submit_passes_secret_envs(mocker) -> None:
     assert captured["run_id"] == "sonic-run"
     assert captured["kwargs"]["secret_envs"] == ["AWS_ACCESS_KEY_ID"]
     assert "registry.example/workbench/npa-sonic:0.1.2" in str(captured["content"])
+
+
+def test_sonic_workflow_materializer_supports_docker_payload_mode() -> None:
+    from npa.workbench.sonic.workflow import materialize_sonic_workflow
+
+    plan = materialize_sonic_workflow(
+        SONIC_TRAIN_STANDALONE_YAML,
+        run_id="sonic-run",
+        registry="registry.example/workbench",
+        gpu_target="l40s",
+        s3_endpoint="https://storage.example",
+        s3_bucket="proof-bucket",
+        env_overrides={"SONIC_PAYLOAD_MODE": "docker"},
+    )
+    docs = [doc for doc in yaml.safe_load_all(plan.yaml_text) if doc is not None]
+    task = docs[1]
+
+    assert "image_id" not in task["resources"]
+    assert task["envs"]["POLICY_IMAGE"] == "registry.example/workbench/npa-sonic:0.1.2"
+    assert task["envs"]["SONIC_PAYLOAD_MODE"] == "docker"
+    assert "docker run --rm --gpus all" in task["run"]
 
 
 def test_tool_yamls_match_registered_cli_surfaces() -> None:

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -3,6 +3,8 @@
 # Operator-provided parameters:
 # - POLICY_IMAGE: image containing the SONIC /entrypoint.sh runtime. Use the
 #   manifest variant selected by SONIC_GPU_TYPE and SONIC_IMAGE_VARIANT.
+# - SONIC_PAYLOAD_MODE: direct runs inside POLICY_IMAGE; docker runs POLICY_IMAGE
+#   from SkyPilot's default VM runtime.
 # - S3_ENDPOINT_URL: S3-compatible endpoint for artifact writes.
 # - S3_BUCKET: destination bucket name, without s3://.
 name: sonic-train-standalone
@@ -17,6 +19,7 @@ resources:
   image_id: "docker:example.invalid/npa-sonic:0.1.2"
 envs:
   POLICY_IMAGE: "example.invalid/npa-sonic:0.1.2"
+  SONIC_PAYLOAD_MODE: "direct"
   SONIC_GPU_TYPE: "l40s"
   SONIC_IMAGE_VARIANT: "sonic-l40s-baked"
   S3_ENDPOINT_URL: ""
@@ -32,7 +35,13 @@ envs:
   SONIC_OUTPUT_PREFIX: "sonic-train/sonic-train-smoke/"
 setup: |
   set -euo pipefail
-  if [ ! -x /entrypoint.sh ]; then
+  if [ "${SONIC_PAYLOAD_MODE}" = "docker" ]; then
+    command -v docker >/dev/null 2>&1 || {
+      echo "SONIC_PAYLOAD_MODE=docker requires docker in the SkyPilot runtime" >&2
+      exit 2
+    }
+    docker pull "${POLICY_IMAGE}"
+  elif [ ! -x /entrypoint.sh ]; then
     echo "The selected POLICY_IMAGE must provide the SONIC /entrypoint.sh runtime" >&2
     exit 2
   fi
@@ -63,4 +72,22 @@ run: |
   printf 'SONIC_WORKFLOW_IMAGE policy_image=%s gpu_type=%s image_variant=%s\n' \
     "${POLICY_IMAGE}" "${SONIC_GPU_TYPE}" "${SONIC_IMAGE_VARIANT}"
 
-  /entrypoint.sh train
+  if [ "${SONIC_PAYLOAD_MODE}" = "docker" ]; then
+    docker run --rm --gpus all --ipc=host --network=host \
+      -e AWS_ACCESS_KEY_ID \
+      -e AWS_SECRET_ACCESS_KEY \
+      -e AWS_ENDPOINT_URL \
+      -e NEBIUS_S3_ENDPOINT \
+      -e NPA_OUTPUT_PATH \
+      -e NPA_LOCAL_OUTPUT_DIR \
+      -e SONIC_CHECKPOINT \
+      -e SONIC_DATA_PATH \
+      -e SONIC_SAMPLE_DATA \
+      -e SONIC_EMBODIMENT \
+      -e SONIC_NUM_ENVS \
+      -e SONIC_HEADLESS \
+      -e SONIC_MAX_ITERATIONS \
+      "${POLICY_IMAGE}" train
+  else
+    /entrypoint.sh train
+  fi

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -35,11 +35,25 @@ envs:
   SONIC_OUTPUT_PREFIX: "sonic-train/sonic-train-smoke/"
 setup: |
   set -euo pipefail
+  docker_login_if_configured() {
+    local username="${SKYPILOT_DOCKER_USERNAME:-}"
+    local password="${SKYPILOT_DOCKER_PASSWORD:-}"
+    local server="${SKYPILOT_DOCKER_SERVER:-}"
+    if [ -z "${username}${password}${server}" ]; then
+      return 0
+    fi
+    if [ -z "${username}" ] || [ -z "${password}" ] || [ -z "${server}" ]; then
+      echo "Docker registry auth requires SKYPILOT_DOCKER_USERNAME, SKYPILOT_DOCKER_PASSWORD, and SKYPILOT_DOCKER_SERVER" >&2
+      exit 2
+    fi
+    printf '%s\n' "${password}" | docker login "${server}" --username "${username}" --password-stdin >/dev/null
+  }
   if [ "${SONIC_PAYLOAD_MODE}" = "docker" ]; then
     command -v docker >/dev/null 2>&1 || {
       echo "SONIC_PAYLOAD_MODE=docker requires docker in the SkyPilot runtime" >&2
       exit 2
     }
+    docker_login_if_configured
     docker pull "${POLICY_IMAGE}"
   elif [ ! -x /entrypoint.sh ]; then
     echo "The selected POLICY_IMAGE must provide the SONIC /entrypoint.sh runtime" >&2


### PR DESCRIPTION
## Summary
- publish an additive SONIC Kubernetes runtime tag for RTX PRO 6000 Blackwell targets
- keep the manifest, CLI/SDK materialization, standalone SkyPilot YAML, and docs coherent on the new tag
- add docker payload mode for standalone SkyPilot runs while preserving direct image mode for Kubernetes runtime images

## Verification
- `npa/.venv/bin/python -m ruff check npa/src/npa/workbench/sonic/workflow.py npa/tests/cli/test_sonic_cli.py npa/tests/cli/test_workflow_cli.py npa/tests/workflows/test_sonic_locomotion_finetuning.py`
- `npa/.venv/bin/python -m pytest npa/tests/workflows/test_sonic_locomotion_finetuning.py npa/tests/cli/test_workflow_cli.py npa/tests/cli/test_sonic_cli.py -q` (57 passed, 1 skipped)
- operator live proof: built and pushed the additive SONIC Kubernetes runtime image, confirmed cluster pullability, and ran an 8-frame Isaac Lab headless Vulkan render on RTX PRO 6000 Blackwell with artifact upload
- `npa/.venv/bin/python -m npa.guardrails.confidentiality --repo-root . --diff-range origin/main..HEAD --pattern-env CUSTOMER_DENYLIST` (hits=0)
- `gitleaks detect --source . --config .gitleaks.toml --redact --no-banner --log-opts="origin/main..HEAD"` (no leaks found)
