### PR TITLE
Finish sim2real pusht trigger wiring

### DIFF
--- a/npa/src/npa/cli/workbench/sim2real.py
+++ b/npa/src/npa/cli/workbench/sim2real.py
@@ -11,6 +11,7 @@ import typer
 from npa.workflows.sim2real_loop import (
     DEFAULT_HELDOUT_ENVS,
     DEFAULT_INNER_ITERATIONS,
+    DEFAULT_LEROBOT_DATASET_ID,
     DEFAULT_LOOP_OF_LOOPS_ITERATIONS,
     DEFAULT_OUTER_ITERATIONS,
     DEFAULT_ROLLOUT_COUNT,
@@ -33,42 +34,102 @@ app = typer.Typer(
 
 @app.command("run")
 def run_command(
-    run_id: str = typer.Option("sim2real-cli", "--run-id", help="Run id for local and S3 artifacts."),
-    output_dir: Optional[Path] = typer.Option(None, "--output-dir", help="Local artifact directory."),
-    s3_bucket: str = typer.Option("", "--s3-bucket", help="S3 bucket for artifact upload."),
-    s3_prefix: str = typer.Option("sim2real-b", "--s3-prefix", help="S3 prefix parent for this run."),
-    s3_endpoint: str = typer.Option(DEFAULT_S3_ENDPOINT, "--s3-endpoint", help="S3-compatible endpoint."),
-    action_rollouts_uri: str = typer.Option("", "--action-rollouts-uri", help="Stage A action rollout URI or local path."),
+    run_id: str = typer.Option(
+        "sim2real-cli", "--run-id", help="Run id for local and S3 artifacts."
+    ),
+    output_dir: Optional[Path] = typer.Option(
+        None, "--output-dir", help="Local artifact directory."
+    ),
+    s3_bucket: str = typer.Option(
+        "", "--s3-bucket", help="S3 bucket for artifact upload."
+    ),
+    s3_prefix: str = typer.Option(
+        "sim2real-b", "--s3-prefix", help="S3 prefix parent for this run."
+    ),
+    s3_endpoint: str = typer.Option(
+        DEFAULT_S3_ENDPOINT, "--s3-endpoint", help="S3-compatible endpoint."
+    ),
+    trigger_dataset_uri: str = typer.Option(
+        "",
+        "--trigger-dataset-uri",
+        help="LeRobot dataset URI under the dedicated trigger path.",
+    ),
+    trigger_dataset_id: str = typer.Option(
+        DEFAULT_LEROBOT_DATASET_ID,
+        "--trigger-dataset-id",
+        help="Human-readable source dataset id recorded in Stage 1.",
+    ),
+    action_rollouts_uri: str = typer.Option(
+        "", "--action-rollouts-uri", help="Stage A action rollout URI or local path."
+    ),
     train_envs_uri: str = typer.Option("", "--train-envs-uri", help="Train env URI."),
-    heldout_envs_uri: str = typer.Option("", "--heldout-envs-uri", help="Held-out env URI."),
+    heldout_envs_uri: str = typer.Option(
+        "", "--heldout-envs-uri", help="Held-out env URI."
+    ),
     assets_uri: str = typer.Option("", "--assets-uri", help="BYO assets URI."),
-    scene_spec_uri: str = typer.Option("", "--scene-spec-uri", help="BYO SceneSpec URI."),
-    augment_image: str = typer.Option("", "--augment-image", help="BYO augmentation image."),
+    scene_spec_uri: str = typer.Option(
+        "", "--scene-spec-uri", help="BYO SceneSpec URI."
+    ),
+    augment_image: str = typer.Option(
+        "", "--augment-image", help="BYO augmentation image."
+    ),
     policy_image: str = typer.Option("", "--policy-image", help="BYO policy image."),
-    trainer_image: str = typer.Option("", "--trainer-image", help="BYO VLM-RL trainer image."),
+    trainer_image: str = typer.Option(
+        "", "--trainer-image", help="BYO VLM-RL trainer image."
+    ),
     vlm_image: str = typer.Option("", "--vlm-image", help="BYO VLM image."),
     eval_image: str = typer.Option("", "--eval-image", help="BYO held-out eval image."),
-    vlm_model: str = typer.Option("npa-cosmos3-reason", "--vlm-model", help="VLM model id/name."),
-    threshold: float = typer.Option(DEFAULT_THRESHOLD, "--threshold", help="Held-out success threshold."),
-    inner_iterations: int = typer.Option(DEFAULT_INNER_ITERATIONS, "--inner-iterations", help="Inner-loop cap."),
-    outer_iterations: int = typer.Option(DEFAULT_OUTER_ITERATIONS, "--outer-iterations", help="Outer-loop cap."),
+    vlm_model: str = typer.Option(
+        "npa-cosmos3-reason", "--vlm-model", help="VLM model id/name."
+    ),
+    threshold: float = typer.Option(
+        DEFAULT_THRESHOLD, "--threshold", help="Held-out success threshold."
+    ),
+    inner_iterations: int = typer.Option(
+        DEFAULT_INNER_ITERATIONS, "--inner-iterations", help="Inner-loop cap."
+    ),
+    outer_iterations: int = typer.Option(
+        DEFAULT_OUTER_ITERATIONS, "--outer-iterations", help="Outer-loop cap."
+    ),
     loop_of_loops_iterations: int = typer.Option(
         DEFAULT_LOOP_OF_LOOPS_ITERATIONS,
         "--loop-of-loops-iterations",
         help="Stage 12 to 13 to 1 cap.",
     ),
-    rollout_count: int = typer.Option(DEFAULT_ROLLOUT_COUNT, "--rollout-count", help="Train rollout count."),
-    steps_per_rollout: int = typer.Option(DEFAULT_STEPS_PER_ROLLOUT, "--steps-per-rollout", help="Steps per rollout."),
-    heldout_env_count: int = typer.Option(DEFAULT_HELDOUT_ENVS, "--heldout-env-count", help="Held-out env count."),
+    rollout_count: int = typer.Option(
+        DEFAULT_ROLLOUT_COUNT, "--rollout-count", help="Train rollout count."
+    ),
+    steps_per_rollout: int = typer.Option(
+        DEFAULT_STEPS_PER_ROLLOUT, "--steps-per-rollout", help="Steps per rollout."
+    ),
+    heldout_env_count: int = typer.Option(
+        DEFAULT_HELDOUT_ENVS, "--heldout-env-count", help="Held-out env count."
+    ),
     seed: int = typer.Option(42, "--seed", help="Deterministic seed."),
-    upload_artifacts: bool = typer.Option(False, "--upload-artifacts", help="Upload local artifacts to S3."),
-    no_guardrails: bool = typer.Option(False, "--no-guardrails", help="Skip optional guardrails where supported."),
-    signal_loss_weight: float = typer.Option(1.0, "--signal-loss-weight", help="VLM signal loss multiplier."),
-    learning_rate: float = typer.Option(0.05, "--learning-rate", help="Reference adapter learning rate."),
-    byo_signal_converter: str = typer.Option("", "--byo-signal-converter", help="BYO signal converter command."),
-    byo_trainer_command: str = typer.Option("", "--byo-trainer-command", help="BYO trainer command."),
-    byo_vlm_command: str = typer.Option("", "--byo-vlm-command", help="BYO VLM command."),
-    byo_eval_command: str = typer.Option("", "--byo-eval-command", help="BYO eval command."),
+    upload_artifacts: bool = typer.Option(
+        False, "--upload-artifacts", help="Upload local artifacts to S3."
+    ),
+    no_guardrails: bool = typer.Option(
+        False, "--no-guardrails", help="Skip optional guardrails where supported."
+    ),
+    signal_loss_weight: float = typer.Option(
+        1.0, "--signal-loss-weight", help="VLM signal loss multiplier."
+    ),
+    learning_rate: float = typer.Option(
+        0.05, "--learning-rate", help="Reference adapter learning rate."
+    ),
+    byo_signal_converter: str = typer.Option(
+        "", "--byo-signal-converter", help="BYO signal converter command."
+    ),
+    byo_trainer_command: str = typer.Option(
+        "", "--byo-trainer-command", help="BYO trainer command."
+    ),
+    byo_vlm_command: str = typer.Option(
+        "", "--byo-vlm-command", help="BYO VLM command."
+    ),
+    byo_eval_command: str = typer.Option(
+        "", "--byo-eval-command", help="BYO eval command."
+    ),
     output_json: bool = typer.Option(False, "--output-json", help="Print only JSON."),
 ) -> None:
     """Run the full 13-stage Sim2Real workflow."""
@@ -79,6 +140,8 @@ def run_command(
         s3_bucket=s3_bucket,
         s3_prefix=s3_prefix,
         s3_endpoint=s3_endpoint,
+        trigger_dataset_uri=trigger_dataset_uri,
+        trigger_dataset_id=trigger_dataset_id,
         action_rollouts_uri=action_rollouts_uri,
         train_envs_uri=train_envs_uri,
         heldout_envs_uri=heldout_envs_uri,
@@ -120,9 +183,13 @@ def inner_loop_command(
     run_id: str = typer.Option("sim2real-inner-cli", "--run-id"),
     output_dir: Path = typer.Option(..., "--output-dir"),
     threshold: float = typer.Option(DEFAULT_THRESHOLD, "--threshold"),
-    inner_iterations: int = typer.Option(DEFAULT_INNER_ITERATIONS, "--inner-iterations"),
+    inner_iterations: int = typer.Option(
+        DEFAULT_INNER_ITERATIONS, "--inner-iterations"
+    ),
     rollout_count: int = typer.Option(DEFAULT_ROLLOUT_COUNT, "--rollout-count"),
-    steps_per_rollout: int = typer.Option(DEFAULT_STEPS_PER_ROLLOUT, "--steps-per-rollout"),
+    steps_per_rollout: int = typer.Option(
+        DEFAULT_STEPS_PER_ROLLOUT, "--steps-per-rollout"
+    ),
     initial_quality: float = typer.Option(0.38, "--initial-quality"),
 ) -> None:
     """Run only Stage 7-9 and print closure evidence."""
@@ -135,19 +202,25 @@ def inner_loop_command(
         rollout_count=rollout_count,
         steps_per_rollout=steps_per_rollout,
     )
-    evidence = run_inner_loop(config, local_dir=output_dir, initial_quality=initial_quality)
+    evidence = run_inner_loop(
+        config, local_dir=output_dir, initial_quality=initial_quality
+    )
     typer.echo(json.dumps(evidence, indent=2, sort_keys=True))
 
 
 @app.command("convert-signal")
 def convert_signal_command(
     vlm_json: Path = typer.Option(..., "--vlm-json", help="Structured VLM eval JSON."),
-    output_json: Path = typer.Option(..., "--output-json", help="RL signal JSON output path."),
+    output_json: Path = typer.Option(
+        ..., "--output-json", help="RL signal JSON output path."
+    ),
 ) -> None:
     """Convert one structured VLM eval JSON into the RL signal schema."""
 
     payload = json.loads(vlm_json.read_text(encoding="utf-8"))
     signal = convert_vlm_eval_to_rl_signal(payload)
     output_json.parent.mkdir(parents=True, exist_ok=True)
-    output_json.write_text(json.dumps(signal, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_json.write_text(
+        json.dumps(signal, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     typer.echo(str(output_json))

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import os
 import random
-import shutil
 import sys
 import tempfile
 import uuid
@@ -17,9 +16,8 @@ from typing import Any
 from urllib.parse import urlparse
 
 from npa.clients.storage import StorageClient
-from npa.deploy.images import container_image_for_tool, supported_tool_version
+from npa.deploy.images import container_image_for_tool
 from npa.workbench.lerobot.policy_container import (
-    VlmRlSignal,
     parse_vlm_signal_batch,
     run_vlm_signal_training_step,
 )
@@ -29,6 +27,8 @@ DEFAULT_S3_ENDPOINT = ""
 DEFAULT_BUCKET = ""
 DEFAULT_PREFIX = "sim2real-b"
 DEFAULT_VLM_IMAGE_TAG = "3.0.0"
+DEFAULT_ENVGEN_TAG = "0.1.1"
+DEFAULT_REFERENCE_POLICY_TAG = "0.1.1"
 DEFAULT_TRAINER_TAG = "0.1.0"
 DEFAULT_EVAL_TAG = "0.1.0"
 DEFAULT_THRESHOLD = 0.75
@@ -39,6 +39,7 @@ DEFAULT_ROLLOUT_COUNT = 3
 DEFAULT_STEPS_PER_ROLLOUT = 4
 DEFAULT_HELDOUT_ENVS = 8
 DEFAULT_REFERENCE_VLM_MODEL = "npa-cosmos3-reason"
+DEFAULT_LEROBOT_DATASET_ID = "lerobot/pusht"
 SCHEMA_VLM_EVAL = "npa.sim2real.vlm_eval.v1"
 SCHEMA_RL_SIGNAL = "npa.sim2real.rl_signal.v1"
 SCHEMA_HELDOUT_REPORT = "npa.sim2real.heldout_eval.v1"
@@ -106,16 +107,18 @@ class Sim2RealLoopConfig:
     s3_bucket: str = ""
     s3_prefix: str = DEFAULT_PREFIX
     s3_endpoint: str = DEFAULT_S3_ENDPOINT
+    trigger_dataset_uri: str = ""
+    trigger_dataset_id: str = DEFAULT_LEROBOT_DATASET_ID
     action_rollouts_uri: str = ""
     train_envs_uri: str = ""
     heldout_envs_uri: str = ""
     assets_uri: str = ""
     scene_spec_uri: str = ""
-    augment_image: str = ""
-    policy_image: str = ""
-    trainer_image: str = ""
-    vlm_image: str = ""
-    eval_image: str = ""
+    augment_image: str = f"npa-sim2real-envgen:{DEFAULT_ENVGEN_TAG}"
+    policy_image: str = f"npa-sim2real-reference-policy:{DEFAULT_REFERENCE_POLICY_TAG}"
+    trainer_image: str = f"npa-lerobot-vlm-rl:{DEFAULT_TRAINER_TAG}"
+    vlm_image: str = f"npa-cosmos3-reason:{DEFAULT_VLM_IMAGE_TAG}"
+    eval_image: str = f"npa-sim2real-eval:{DEFAULT_EVAL_TAG}"
     vlm_model: str = DEFAULT_REFERENCE_VLM_MODEL
     threshold: float = DEFAULT_THRESHOLD
     inner_iterations: int = DEFAULT_INNER_ITERATIONS
@@ -138,7 +141,9 @@ class Sim2RealLoopConfig:
         if not self.run_id:
             raise Sim2RealLoopError("run_id must not be empty")
         if not 0.0 <= self.threshold <= 1.0:
-            raise Sim2RealLoopError(f"threshold must be in [0, 1], got {self.threshold}")
+            raise Sim2RealLoopError(
+                f"threshold must be in [0, 1], got {self.threshold}"
+            )
         if self.inner_iterations <= 0:
             raise Sim2RealLoopError("inner_iterations must be positive")
         if self.outer_iterations <= 0:
@@ -172,6 +177,22 @@ def default_vlm_image(*, registry: str | None = None) -> str:
     return f"npa-cosmos3-reason:{DEFAULT_VLM_IMAGE_TAG}"
 
 
+def default_envgen_image(*, registry: str | None = None) -> str:
+    """Return the reference env-generation image used by Stages 3-6."""
+
+    if registry or os.environ.get("NPA_REGISTRY"):
+        return container_image_for_tool("sim2real-envgen", registry=registry)
+    return f"npa-sim2real-envgen:{DEFAULT_ENVGEN_TAG}"
+
+
+def default_policy_image(*, registry: str | None = None) -> str:
+    """Return the reference action-generation policy image."""
+
+    if registry or os.environ.get("NPA_REGISTRY"):
+        return container_image_for_tool("sim2real-reference-policy", registry=registry)
+    return f"npa-sim2real-reference-policy:{DEFAULT_REFERENCE_POLICY_TAG}"
+
+
 def default_trainer_image(*, registry: str | None = None) -> str:
     """Return the reference VLM-signal LeRobot trainer image."""
 
@@ -191,7 +212,9 @@ def default_eval_image(*, registry: str | None = None) -> str:
 def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
     """Build a Sim2Real loop config from explicit values and env fallbacks."""
 
-    run_id = str(overrides.get("run_id") or os.environ.get("NPA_SIM2REAL_RUN_ID") or new_run_id())
+    run_id = str(
+        overrides.get("run_id") or os.environ.get("NPA_SIM2REAL_RUN_ID") or new_run_id()
+    )
     bucket = str(
         overrides.get("s3_bucket")
         or os.environ.get("NPA_SIM2REAL_BUCKET")
@@ -200,7 +223,12 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
         or ""
     )
     registry = os.environ.get("NPA_REGISTRY", "")
-    s3_prefix = str(overrides.get("s3_prefix") or os.environ.get("NPA_SIM2REAL_PREFIX") or DEFAULT_PREFIX)
+    if "s3_prefix" in overrides and overrides.get("s3_prefix") is not None:
+        s3_prefix = str(overrides["s3_prefix"])
+    elif "NPA_SIM2REAL_PREFIX" in os.environ:
+        s3_prefix = os.environ.get("NPA_SIM2REAL_PREFIX", "")
+    else:
+        s3_prefix = DEFAULT_PREFIX
     action_rollouts_uri = str(
         overrides.get("action_rollouts_uri")
         or os.environ.get("ACTION_ROLLOUTS_URI")
@@ -208,7 +236,9 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
     )
     return Sim2RealLoopConfig(
         run_id=run_id,
-        output_dir=Path(overrides["output_dir"]) if overrides.get("output_dir") else None,
+        output_dir=Path(overrides["output_dir"])
+        if overrides.get("output_dir")
+        else None,
         s3_bucket=bucket,
         s3_prefix=s3_prefix,
         s3_endpoint=str(
@@ -217,46 +247,138 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
             or os.environ.get("S3_ENDPOINT_URL")
             or DEFAULT_S3_ENDPOINT
         ),
+        trigger_dataset_uri=str(
+            overrides.get("trigger_dataset_uri")
+            or os.environ.get("NPA_SIM2REAL_TRIGGER_DATASET_URI")
+            or os.environ.get("TRIGGER_DATASET_URI")
+            or (f"s3://{bucket}/sim2real-triggers/{run_id}/" if bucket else "")
+        ),
+        trigger_dataset_id=str(
+            overrides.get("trigger_dataset_id")
+            or os.environ.get("NPA_SIM2REAL_TRIGGER_DATASET_ID")
+            or os.environ.get("TRIGGER_DATASET_ID")
+            or DEFAULT_LEROBOT_DATASET_ID
+        ),
         action_rollouts_uri=action_rollouts_uri,
-        train_envs_uri=str(overrides.get("train_envs_uri") or os.environ.get("TRAIN_ENVS_URI") or ""),
-        heldout_envs_uri=str(overrides.get("heldout_envs_uri") or os.environ.get("HELDOUT_ENVS_URI") or ""),
-        assets_uri=str(overrides.get("assets_uri") or os.environ.get("ASSETS_URI") or ""),
-        scene_spec_uri=str(overrides.get("scene_spec_uri") or os.environ.get("SCENE_SPEC_URI") or ""),
-        augment_image=str(overrides.get("augment_image") or os.environ.get("AUGMENT_IMAGE") or ""),
-        policy_image=str(overrides.get("policy_image") or os.environ.get("POLICY_IMAGE") or ""),
-        trainer_image=str(overrides.get("trainer_image") or os.environ.get("TRAINER_IMAGE") or default_trainer_image(registry=registry or None)),
-        vlm_image=str(overrides.get("vlm_image") or os.environ.get("VLM_IMAGE") or default_vlm_image(registry=registry or None)),
-        eval_image=str(overrides.get("eval_image") or os.environ.get("EVAL_IMAGE") or default_eval_image(registry=registry or None)),
-        vlm_model=str(overrides.get("vlm_model") or os.environ.get("VLM_MODEL") or DEFAULT_REFERENCE_VLM_MODEL),
-        threshold=float(overrides.get("threshold", os.environ.get("SUCCESS_THRESHOLD", DEFAULT_THRESHOLD))),
-        inner_iterations=int(overrides.get("inner_iterations", os.environ.get("INNER_ITERATIONS", DEFAULT_INNER_ITERATIONS))),
-        outer_iterations=int(overrides.get("outer_iterations", os.environ.get("OUTER_ITERATIONS", DEFAULT_OUTER_ITERATIONS))),
+        train_envs_uri=str(
+            overrides.get("train_envs_uri") or os.environ.get("TRAIN_ENVS_URI") or ""
+        ),
+        heldout_envs_uri=str(
+            overrides.get("heldout_envs_uri")
+            or os.environ.get("HELDOUT_ENVS_URI")
+            or ""
+        ),
+        assets_uri=str(
+            overrides.get("assets_uri") or os.environ.get("ASSETS_URI") or ""
+        ),
+        scene_spec_uri=str(
+            overrides.get("scene_spec_uri") or os.environ.get("SCENE_SPEC_URI") or ""
+        ),
+        augment_image=str(
+            overrides.get("augment_image")
+            or os.environ.get("AUGMENT_IMAGE")
+            or default_envgen_image(registry=registry or None)
+        ),
+        policy_image=str(
+            overrides.get("policy_image")
+            or os.environ.get("POLICY_IMAGE")
+            or default_policy_image(registry=registry or None)
+        ),
+        trainer_image=str(
+            overrides.get("trainer_image")
+            or os.environ.get("TRAINER_IMAGE")
+            or default_trainer_image(registry=registry or None)
+        ),
+        vlm_image=str(
+            overrides.get("vlm_image")
+            or os.environ.get("VLM_IMAGE")
+            or default_vlm_image(registry=registry or None)
+        ),
+        eval_image=str(
+            overrides.get("eval_image")
+            or os.environ.get("EVAL_IMAGE")
+            or default_eval_image(registry=registry or None)
+        ),
+        vlm_model=str(
+            overrides.get("vlm_model")
+            or os.environ.get("VLM_MODEL")
+            or DEFAULT_REFERENCE_VLM_MODEL
+        ),
+        threshold=float(
+            overrides.get(
+                "threshold", os.environ.get("SUCCESS_THRESHOLD", DEFAULT_THRESHOLD)
+            )
+        ),
+        inner_iterations=int(
+            overrides.get(
+                "inner_iterations",
+                os.environ.get("INNER_ITERATIONS", DEFAULT_INNER_ITERATIONS),
+            )
+        ),
+        outer_iterations=int(
+            overrides.get(
+                "outer_iterations",
+                os.environ.get("OUTER_ITERATIONS", DEFAULT_OUTER_ITERATIONS),
+            )
+        ),
         loop_of_loops_iterations=int(
             overrides.get(
                 "loop_of_loops_iterations",
-                os.environ.get("LOOP_OF_LOOPS_ITERATIONS", DEFAULT_LOOP_OF_LOOPS_ITERATIONS),
+                os.environ.get(
+                    "LOOP_OF_LOOPS_ITERATIONS", DEFAULT_LOOP_OF_LOOPS_ITERATIONS
+                ),
             )
         ),
-        rollout_count=int(overrides.get("rollout_count", os.environ.get("ROLLOUT_COUNT", DEFAULT_ROLLOUT_COUNT))),
+        rollout_count=int(
+            overrides.get(
+                "rollout_count", os.environ.get("ROLLOUT_COUNT", DEFAULT_ROLLOUT_COUNT)
+            )
+        ),
         steps_per_rollout=int(
-            overrides.get("steps_per_rollout", os.environ.get("STEPS_PER_ROLLOUT", DEFAULT_STEPS_PER_ROLLOUT))
+            overrides.get(
+                "steps_per_rollout",
+                os.environ.get("STEPS_PER_ROLLOUT", DEFAULT_STEPS_PER_ROLLOUT),
+            )
         ),
         heldout_env_count=int(
-            overrides.get("heldout_env_count", os.environ.get("HELDOUT_ENV_COUNT", DEFAULT_HELDOUT_ENVS))
+            overrides.get(
+                "heldout_env_count",
+                os.environ.get("HELDOUT_ENV_COUNT", DEFAULT_HELDOUT_ENVS),
+            )
         ),
         seed=int(overrides.get("seed", os.environ.get("SEED", "42"))),
-        upload_artifacts=_bool_value(overrides.get("upload_artifacts", os.environ.get("UPLOAD_ARTIFACTS", "0"))),
-        no_guardrails=_bool_value(overrides.get("no_guardrails", os.environ.get("NO_GUARDRAILS", "0"))),
+        upload_artifacts=_bool_value(
+            overrides.get("upload_artifacts", os.environ.get("UPLOAD_ARTIFACTS", "0"))
+        ),
+        no_guardrails=_bool_value(
+            overrides.get("no_guardrails", os.environ.get("NO_GUARDRAILS", "0"))
+        ),
         signal_loss_weight=float(
-            overrides.get("signal_loss_weight", os.environ.get("SIGNAL_LOSS_WEIGHT", "1.0"))
+            overrides.get(
+                "signal_loss_weight", os.environ.get("SIGNAL_LOSS_WEIGHT", "1.0")
+            )
         ),
-        learning_rate=float(overrides.get("learning_rate", os.environ.get("LEARNING_RATE", "0.05"))),
+        learning_rate=float(
+            overrides.get("learning_rate", os.environ.get("LEARNING_RATE", "0.05"))
+        ),
         byo_signal_converter=str(
-            overrides.get("byo_signal_converter") or os.environ.get("BYO_SIGNAL_CONVERTER") or ""
+            overrides.get("byo_signal_converter")
+            or os.environ.get("BYO_SIGNAL_CONVERTER")
+            or ""
         ),
-        byo_trainer_command=str(overrides.get("byo_trainer_command") or os.environ.get("BYO_TRAINER_COMMAND") or ""),
-        byo_vlm_command=str(overrides.get("byo_vlm_command") or os.environ.get("BYO_VLM_COMMAND") or ""),
-        byo_eval_command=str(overrides.get("byo_eval_command") or os.environ.get("BYO_EVAL_COMMAND") or ""),
+        byo_trainer_command=str(
+            overrides.get("byo_trainer_command")
+            or os.environ.get("BYO_TRAINER_COMMAND")
+            or ""
+        ),
+        byo_vlm_command=str(
+            overrides.get("byo_vlm_command") or os.environ.get("BYO_VLM_COMMAND") or ""
+        ),
+        byo_eval_command=str(
+            overrides.get("byo_eval_command")
+            or os.environ.get("BYO_EVAL_COMMAND")
+            or ""
+        ),
     )
 
 
@@ -265,9 +387,10 @@ def artifact_uris(config: Sim2RealLoopConfig) -> dict[str, str]:
 
     if not config.s3_bucket:
         return {}
-    root = f"s3://{config.s3_bucket}/{config.s3_prefix.strip('/')}/{config.run_id}"
+    root = _artifact_root_uri(config)
     return {
         "root": f"{root}/",
+        "trigger_dataset": config.trigger_dataset_uri,
         "stage_01_trigger": f"{root}/stage_01_trigger/trigger.json",
         "stage_02_assets_stub": f"{root}/stage_02_assets/external_stub.json",
         "stage_03_augment": f"{root}/augment/manifest.json",
@@ -293,6 +416,8 @@ def byo_seams(config: Sim2RealLoopConfig) -> dict[str, Any]:
     return {
         "s3_endpoint": config.s3_endpoint,
         "s3_bucket": config.s3_bucket,
+        "trigger_dataset_uri": config.trigger_dataset_uri,
+        "trigger_dataset_id": config.trigger_dataset_id,
         "assets_uri": config.assets_uri,
         "scene_spec_uri": config.scene_spec_uri,
         "augment_image": config.augment_image,
@@ -322,19 +447,23 @@ def run_full_loop(
     """Run the full local/executable Sim2Real loop and write all artifacts."""
 
     config.validate()
-    local_dir = config.output_dir or Path(tempfile.mkdtemp(prefix=f"npa-{config.run_id}-"))
+    local_dir = config.output_dir or Path(
+        tempfile.mkdtemp(prefix=f"npa-{config.run_id}-")
+    )
     local_dir.mkdir(parents=True, exist_ok=True)
     rng = random.Random(config.seed)
     components: list[ComponentRecord] = []
     stage_artifacts: dict[str, str] = {}
     stage_records: list[dict[str, Any]] = []
 
-    stage_records.append(_write_stage(local_dir, 1, "trigger", _trigger_payload(config)))
+    stage_records.append(
+        _write_stage(local_dir, 1, "trigger", _trigger_payload(config))
+    )
     components.append(
         ComponentRecord(
             "stage_01_trigger",
             "WORKS",
-            "Created run trigger payload and resolved runtime plug points.",
+            "Consumed the dedicated LeRobot dataset trigger path and resolved runtime plug points.",
             {"local": str(local_dir / "stage_01_trigger" / "trigger.json")},
         )
     )
@@ -388,7 +517,11 @@ def run_full_loop(
         )
     )
 
-    raw_envs = _write_env_manifest(local_dir / "envs" / "raw", count=max(config.heldout_env_count, 10), seed=config.seed)
+    raw_envs = _write_env_manifest(
+        local_dir / "envs" / "raw",
+        count=max(config.heldout_env_count, 10),
+        seed=config.seed,
+    )
     train_envs, heldout_envs = _write_train_heldout_split(
         local_dir / "envs",
         raw_envs=raw_envs,
@@ -484,7 +617,11 @@ def run_full_loop(
             "stage_12_external_validation",
             "SEAM",
             "External real-world validation is a documented BYO gate; loop-of-loops continues through Stage 13.",
-            {"local": str(local_dir / "stage_12_external_validation" / "external_stub.json")},
+            {
+                "local": str(
+                    local_dir / "stage_12_external_validation" / "external_stub.json"
+                )
+            },
         )
     )
 
@@ -495,13 +632,17 @@ def run_full_loop(
         "source_decision": final_decision["decision"],
         "loop_of_loops_iteration": 1,
         "max_loop_of_loops_iterations": config.loop_of_loops_iterations,
-        "retrigger_stage": 1,
-        "should_retrigger": (
-            final_decision["decision"] != "promote_checkpoint"
-            and config.loop_of_loops_iterations > 1
-        ),
+        "target_stage": 1,
+        "trigger_dataset_uri": config.trigger_dataset_uri,
+        "trigger_dataset_id": config.trigger_dataset_id,
+        "retrigger_condition": "real_world_lerobot_dataset_landed",
+        "should_retrigger": config.loop_of_loops_iterations > 1,
     }
-    stage_records.append(_write_json_artifact(local_dir / "stage_13_retrigger" / "retrigger.json", retrigger))
+    stage_records.append(
+        _write_json_artifact(
+            local_dir / "stage_13_retrigger" / "retrigger.json", retrigger
+        )
+    )
     components.append(
         ComponentRecord(
             "stage_13_retrigger",
@@ -552,8 +693,22 @@ def run_full_loop(
             "latest_decision": final_decision,
         },
         "image_completeness": {
-            "required": [config.vlm_image, config.trainer_image, config.eval_image],
-            "all_referenced": all([config.vlm_image, config.trainer_image, config.eval_image]),
+            "required": [
+                config.augment_image,
+                config.policy_image,
+                config.vlm_image,
+                config.trainer_image,
+                config.eval_image,
+            ],
+            "all_referenced": all(
+                [
+                    config.augment_image,
+                    config.policy_image,
+                    config.vlm_image,
+                    config.trainer_image,
+                    config.eval_image,
+                ]
+            ),
         },
     }
     report_path = local_dir / "reports" / "sim2real-report.json"
@@ -588,7 +743,13 @@ def run_inner_loop(
     reward_head = 0.0
     action_bias = 0.0
     for iteration in range(1, config.inner_iterations + 1):
-        actions_dir = local_dir / "actions" / "train" / f"outer-{outer_iteration:02d}" / f"iter-{iteration:02d}"
+        actions_dir = (
+            local_dir
+            / "actions"
+            / "train"
+            / f"outer-{outer_iteration:02d}"
+            / f"iter-{iteration:02d}"
+        )
         rollouts = generate_action_rollouts(
             actions_dir,
             count=config.rollout_count,
@@ -596,8 +757,20 @@ def run_inner_loop(
             seed=config.seed + outer_iteration * 100 + iteration,
             quality=quality,
         )
-        eval_dir = local_dir / "vlm_eval" / "train" / f"outer-{outer_iteration:02d}" / f"iter-{iteration:02d}"
-        signal_dir = local_dir / "training_signal" / "train" / f"outer-{outer_iteration:02d}" / f"iter-{iteration:02d}"
+        eval_dir = (
+            local_dir
+            / "vlm_eval"
+            / "train"
+            / f"outer-{outer_iteration:02d}"
+            / f"iter-{iteration:02d}"
+        )
+        signal_dir = (
+            local_dir
+            / "training_signal"
+            / "train"
+            / f"outer-{outer_iteration:02d}"
+            / f"iter-{iteration:02d}"
+        )
         evals: list[dict[str, Any]] = []
         signals: list[dict[str, Any]] = []
         for rollout in rollouts:
@@ -610,12 +783,23 @@ def run_inner_loop(
             _write_json_artifact(signal_dir / f"{signal['rollout_id']}.json", signal)
             evals.append(evaluation)
             signals.append(signal)
-        signal_batch_path = local_dir / "inner_loop" / f"outer-{outer_iteration:02d}" / f"signals-iter-{iteration:02d}.json"
-        _write_json_artifact(signal_batch_path, {"schema": SCHEMA_RL_SIGNAL, "signals": signals})
+        signal_batch_path = (
+            local_dir
+            / "inner_loop"
+            / f"outer-{outer_iteration:02d}"
+            / f"signals-iter-{iteration:02d}.json"
+        )
+        _write_json_artifact(
+            signal_batch_path, {"schema": SCHEMA_RL_SIGNAL, "signals": signals}
+        )
         parsed_signals = parse_vlm_signal_batch({"signals": signals})
         update = run_vlm_signal_training_step(
             parsed_signals,
-            output_dir=local_dir / "inner_loop" / f"outer-{outer_iteration:02d}" / "trainer" / f"iter-{iteration:02d}",
+            output_dir=local_dir
+            / "inner_loop"
+            / f"outer-{outer_iteration:02d}"
+            / "trainer"
+            / f"iter-{iteration:02d}",
             learning_rate=config.learning_rate,
             signal_loss_weight=config.signal_loss_weight,
             initial_reward_head=reward_head,
@@ -623,7 +807,11 @@ def run_inner_loop(
         )
         control = run_vlm_signal_training_step(
             parsed_signals,
-            output_dir=local_dir / "inner_loop" / f"outer-{outer_iteration:02d}" / "control" / f"iter-{iteration:02d}",
+            output_dir=local_dir
+            / "inner_loop"
+            / f"outer-{outer_iteration:02d}"
+            / "control"
+            / f"iter-{iteration:02d}",
             learning_rate=config.learning_rate,
             signal_loss_weight=config.signal_loss_weight,
             initial_reward_head=reward_head,
@@ -631,12 +819,20 @@ def run_inner_loop(
             control=True,
         )
         reward_head = update.reward_head_after
-        action_bias = update.policy_output_after[0] if update.policy_output_after else action_bias
-        mean_reward = round(sum(_signal_mean_reward(signal) for signal in signals) / float(len(signals)), 6)
+        action_bias = (
+            update.policy_output_after[0] if update.policy_output_after else action_bias
+        )
+        mean_reward = round(
+            sum(_signal_mean_reward(signal) for signal in signals)
+            / float(len(signals)),
+            6,
+        )
         reward_trend.append(mean_reward)
         delta_vs_control = max(0.0, update.policy_delta_l2 - control.policy_delta_l2)
         policy_deltas.append(round(delta_vs_control, 8))
-        quality = min(0.98, quality + max(0.06, min(0.18, delta_vs_control * 2.0 + 0.07)))
+        quality = min(
+            0.98, quality + max(0.06, min(0.18, delta_vs_control * 2.0 + 0.07))
+        )
         iteration_records.append(
             {
                 "iteration": iteration,
@@ -667,7 +863,9 @@ def run_inner_loop(
         "iterations": iteration_records,
         "final_quality": round(quality, 6),
     }
-    evidence_path = local_dir / "inner_loop" / f"outer-{outer_iteration:02d}" / "evidence.json"
+    evidence_path = (
+        local_dir / "inner_loop" / f"outer-{outer_iteration:02d}" / "evidence.json"
+    )
     _write_json_artifact(evidence_path, evidence)
     return {**evidence, "evidence_uri": str(evidence_path)}
 
@@ -711,7 +909,9 @@ def generate_action_rollouts(
                 "rollout_id": rollout_id,
                 "quality": round(quality, 6),
                 "steps": steps_per_rollout,
-                "camera_observations": [f"camera-{step:03d}.ppm" for step in range(steps_per_rollout)],
+                "camera_observations": [
+                    f"camera-{step:03d}.ppm" for step in range(steps_per_rollout)
+                ],
                 "actions": actions,
             },
         )
@@ -771,7 +971,9 @@ def convert_vlm_eval_to_rl_signal(evaluation: dict[str, Any]) -> dict[str, Any]:
     """Convert structured VLM critique JSON into a dense RL signal."""
 
     if evaluation.get("schema") != SCHEMA_VLM_EVAL:
-        raise Sim2RealLoopError(f"unsupported VLM eval schema: {evaluation.get('schema')}")
+        raise Sim2RealLoopError(
+            f"unsupported VLM eval schema: {evaluation.get('schema')}"
+        )
     raw_steps = evaluation.get("per_step")
     if not isinstance(raw_steps, list) or not raw_steps:
         raise Sim2RealLoopError("VLM eval must include non-empty per_step")
@@ -782,7 +984,9 @@ def convert_vlm_eval_to_rl_signal(evaluation: dict[str, Any]) -> dict[str, Any]:
         tags = [str(tag) for tag in raw_step.get("error_tags", [])] or ["ok"]
         severity = max(ERROR_SEVERITY.get(tag, 0.4) for tag in tags)
         success_bonus = 0.35 if success else -0.15
-        reward = max(-1.0, min(1.0, success_bonus + 0.65 * (1.0 - severity) - 0.75 * severity))
+        reward = max(
+            -1.0, min(1.0, success_bonus + 0.65 * (1.0 - severity) - 0.75 * severity)
+        )
         rewards.append(reward)
         target = _merge_targets(tags)
         source_action = raw_step.get("action") or []
@@ -880,7 +1084,8 @@ def run_heldout_eval(
         "per_env": per_env,
         "physics_fidelity": {
             "mean": round(
-                sum(item["physics_fidelity"]["score"] for item in per_env) / float(len(per_env)),
+                sum(item["physics_fidelity"]["score"] for item in per_env)
+                / float(len(per_env)),
                 6,
             ),
             "min": round(min(item["physics_fidelity"]["score"] for item in per_env), 6),
@@ -914,7 +1119,7 @@ def threshold_decision(
         "outer_iteration": outer_iteration,
         "success_rate": round(success_rate, 6),
         "threshold": config.threshold,
-        "decision": "promote_checkpoint" if promoted else "loop_back_to_stage_1",
+        "decision": "promote_checkpoint" if promoted else "loop_back_to_inner_loop",
         "checkpoint_uri": checkpoint_uri,
         "max_outer_iterations": config.outer_iterations,
         "remaining_outer_iterations": max(0, config.outer_iterations - outer_iteration),
@@ -937,7 +1142,7 @@ def threshold_decision(
             {
                 "schema": "npa.sim2real.loopback.v1",
                 "from_stage": 11,
-                "to_stage": 1,
+                "to_stage": 7,
                 "reason": "heldout threshold not met",
                 "decision": decision,
             },
@@ -954,7 +1159,7 @@ def upload_run_artifacts(config: Sim2RealLoopConfig, local_dir: Path) -> dict[st
         return {"status": "skipped", "reason": "s3_bucket is not configured"}
     try:
         client = StorageClient.from_environment(endpoint_url=config.s3_endpoint)
-        destination = f"s3://{config.s3_bucket}/{config.s3_prefix.strip('/')}/{config.run_id}/"
+        destination = f"{_artifact_root_uri(config)}/"
         uploaded = client.upload_directory(str(local_dir), destination)
     except Exception as exc:
         return {
@@ -970,11 +1175,17 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
-    full = subparsers.add_parser("full-loop", help="Run the full Stage 1-13 Sim2Real workflow.")
+    full = subparsers.add_parser(
+        "full-loop", help="Run the full Stage 1-13 Sim2Real workflow."
+    )
     _add_common_args(full)
-    inner = subparsers.add_parser("inner-loop", help="Run only the VLM-to-RL inner loop.")
+    inner = subparsers.add_parser(
+        "inner-loop", help="Run only the VLM-to-RL inner loop."
+    )
     _add_common_args(inner)
-    convert = subparsers.add_parser("convert-signal", help="Convert one VLM eval JSON to RL signal JSON.")
+    convert = subparsers.add_parser(
+        "convert-signal", help="Convert one VLM eval JSON to RL signal JSON."
+    )
     convert.add_argument("--vlm-json", type=Path, required=True)
     convert.add_argument("--output-json", type=Path, required=True)
     args = parser.parse_args(argv)
@@ -990,6 +1201,8 @@ def main(argv: list[str] | None = None) -> int:
         s3_bucket=args.s3_bucket,
         s3_prefix=args.s3_prefix,
         s3_endpoint=args.s3_endpoint,
+        trigger_dataset_uri=args.trigger_dataset_uri,
+        trigger_dataset_id=args.trigger_dataset_id,
         action_rollouts_uri=args.action_rollouts_uri,
         train_envs_uri=args.train_envs_uri,
         heldout_envs_uri=args.heldout_envs_uri,
@@ -1024,7 +1237,9 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.command == "inner-loop":
         config.validate()
-        local_dir = config.output_dir or Path(tempfile.mkdtemp(prefix=f"npa-{config.run_id}-"))
+        local_dir = config.output_dir or Path(
+            tempfile.mkdtemp(prefix=f"npa-{config.run_id}-")
+        )
         evidence = run_inner_loop(config, local_dir=local_dir, initial_quality=0.38)
         print(json.dumps(evidence, indent=2, sort_keys=True))
         return 0
@@ -1032,28 +1247,69 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--run-id", default=os.environ.get("NPA_SIM2REAL_RUN_ID", new_run_id()))
+    parser.add_argument(
+        "--run-id", default=os.environ.get("NPA_SIM2REAL_RUN_ID", new_run_id())
+    )
     parser.add_argument("--output-dir", type=Path, default=None)
-    parser.add_argument("--s3-bucket", default=os.environ.get("NPA_SIM2REAL_BUCKET", os.environ.get("S3_BUCKET", "")))
-    parser.add_argument("--s3-prefix", default=os.environ.get("NPA_SIM2REAL_PREFIX", DEFAULT_PREFIX))
-    parser.add_argument("--s3-endpoint", default=os.environ.get("AWS_ENDPOINT_URL", DEFAULT_S3_ENDPOINT))
-    parser.add_argument("--action-rollouts-uri", default=os.environ.get("ACTION_ROLLOUTS_URI", ""))
-    parser.add_argument("--train-envs-uri", default=os.environ.get("TRAIN_ENVS_URI", ""))
-    parser.add_argument("--heldout-envs-uri", default=os.environ.get("HELDOUT_ENVS_URI", ""))
+    parser.add_argument(
+        "--s3-bucket",
+        default=os.environ.get("NPA_SIM2REAL_BUCKET", os.environ.get("S3_BUCKET", "")),
+    )
+    parser.add_argument(
+        "--s3-prefix", default=os.environ.get("NPA_SIM2REAL_PREFIX", DEFAULT_PREFIX)
+    )
+    parser.add_argument(
+        "--s3-endpoint", default=os.environ.get("AWS_ENDPOINT_URL", DEFAULT_S3_ENDPOINT)
+    )
+    parser.add_argument(
+        "--trigger-dataset-uri",
+        default=os.environ.get("NPA_SIM2REAL_TRIGGER_DATASET_URI", ""),
+    )
+    parser.add_argument(
+        "--trigger-dataset-id",
+        default=os.environ.get(
+            "NPA_SIM2REAL_TRIGGER_DATASET_ID", DEFAULT_LEROBOT_DATASET_ID
+        ),
+    )
+    parser.add_argument(
+        "--action-rollouts-uri", default=os.environ.get("ACTION_ROLLOUTS_URI", "")
+    )
+    parser.add_argument(
+        "--train-envs-uri", default=os.environ.get("TRAIN_ENVS_URI", "")
+    )
+    parser.add_argument(
+        "--heldout-envs-uri", default=os.environ.get("HELDOUT_ENVS_URI", "")
+    )
     parser.add_argument("--assets-uri", default=os.environ.get("ASSETS_URI", ""))
-    parser.add_argument("--scene-spec-uri", default=os.environ.get("SCENE_SPEC_URI", ""))
+    parser.add_argument(
+        "--scene-spec-uri", default=os.environ.get("SCENE_SPEC_URI", "")
+    )
     parser.add_argument("--augment-image", default=os.environ.get("AUGMENT_IMAGE", ""))
     parser.add_argument("--policy-image", default=os.environ.get("POLICY_IMAGE", ""))
     parser.add_argument("--trainer-image", default=os.environ.get("TRAINER_IMAGE", ""))
     parser.add_argument("--vlm-image", default=os.environ.get("VLM_IMAGE", ""))
     parser.add_argument("--eval-image", default=os.environ.get("EVAL_IMAGE", ""))
-    parser.add_argument("--vlm-model", default=os.environ.get("VLM_MODEL", DEFAULT_REFERENCE_VLM_MODEL))
-    parser.add_argument("--threshold", type=float, default=float(os.environ.get("SUCCESS_THRESHOLD", DEFAULT_THRESHOLD)))
-    parser.add_argument("--inner-iterations", type=int, default=DEFAULT_INNER_ITERATIONS)
-    parser.add_argument("--outer-iterations", type=int, default=DEFAULT_OUTER_ITERATIONS)
-    parser.add_argument("--loop-of-loops-iterations", type=int, default=DEFAULT_LOOP_OF_LOOPS_ITERATIONS)
+    parser.add_argument(
+        "--vlm-model", default=os.environ.get("VLM_MODEL", DEFAULT_REFERENCE_VLM_MODEL)
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=float(os.environ.get("SUCCESS_THRESHOLD", DEFAULT_THRESHOLD)),
+    )
+    parser.add_argument(
+        "--inner-iterations", type=int, default=DEFAULT_INNER_ITERATIONS
+    )
+    parser.add_argument(
+        "--outer-iterations", type=int, default=DEFAULT_OUTER_ITERATIONS
+    )
+    parser.add_argument(
+        "--loop-of-loops-iterations", type=int, default=DEFAULT_LOOP_OF_LOOPS_ITERATIONS
+    )
     parser.add_argument("--rollout-count", type=int, default=DEFAULT_ROLLOUT_COUNT)
-    parser.add_argument("--steps-per-rollout", type=int, default=DEFAULT_STEPS_PER_ROLLOUT)
+    parser.add_argument(
+        "--steps-per-rollout", type=int, default=DEFAULT_STEPS_PER_ROLLOUT
+    )
     parser.add_argument("--heldout-env-count", type=int, default=DEFAULT_HELDOUT_ENVS)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--upload-artifacts", action="store_true")
@@ -1080,7 +1336,9 @@ def _write_stage(
 
 def _write_json_artifact(path: Path, payload: dict[str, Any]) -> dict[str, Any]:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     return {"path": str(path), "payload": payload}
 
 
@@ -1119,11 +1377,21 @@ def _write_train_heldout_split(
     heldout = envs[train_size:] or envs[-1:]
     train_record = _write_json_artifact(
         root / "train" / "manifest.json",
-        {"schema": "npa.sim2real.env_split.v1", "stage": 5, "split": "train", "envs": train},
+        {
+            "schema": "npa.sim2real.env_split.v1",
+            "stage": 5,
+            "split": "train",
+            "envs": train,
+        },
     )
     heldout_record = _write_json_artifact(
         root / "heldout" / "manifest.json",
-        {"schema": "npa.sim2real.env_split.v1", "stage": 5, "split": "heldout", "envs": heldout},
+        {
+            "schema": "npa.sim2real.env_split.v1",
+            "stage": 5,
+            "split": "heldout",
+            "envs": heldout,
+        },
     )
     return train_record, heldout_record
 
@@ -1134,6 +1402,10 @@ def _trigger_payload(config: Sim2RealLoopConfig) -> dict[str, Any]:
         "stage": 1,
         "run_id": config.run_id,
         "created_at": _utc_now(),
+        "trigger_dataset_uri": config.trigger_dataset_uri,
+        "trigger_dataset_id": config.trigger_dataset_id,
+        "input_format": "lerobot",
+        "start_condition": "dataset_landed_in_trigger_path",
         "artifact_root": artifact_uris(config).get("root", ""),
         "byo_seams": byo_seams(config),
     }
@@ -1152,12 +1424,20 @@ def _tags_for_quality(quality: float, *, step: int) -> list[str]:
 def _critique_for_tags(tags: list[str], *, quality: float) -> str:
     if tags == ["ok"]:
         return f"Step is stable; estimated rollout quality {quality:.2f}."
-    corrections = [CORRECTIVE_TARGETS.get(tag, CORRECTIVE_TARGETS["minor_alignment"])["nl_correction"] for tag in tags]
+    corrections = [
+        CORRECTIVE_TARGETS.get(tag, CORRECTIVE_TARGETS["minor_alignment"])[
+            "nl_correction"
+        ]
+        for tag in tags
+    ]
     return " ".join(corrections)
 
 
 def _merge_targets(tags: list[str]) -> dict[str, Any]:
-    corrections = [CORRECTIVE_TARGETS.get(tag, CORRECTIVE_TARGETS["minor_alignment"]) for tag in tags]
+    corrections = [
+        CORRECTIVE_TARGETS.get(tag, CORRECTIVE_TARGETS["minor_alignment"])
+        for tag in tags
+    ]
     action_dim = max(len(item["action_delta"]) for item in corrections)
     merged = [0.0 for _ in range(action_dim)]
     for item in corrections:
@@ -1179,7 +1459,9 @@ def _write_ppm(path: Path, *, red: int, green: int, blue: int) -> None:
     width = 32
     height = 32
     header = f"P6\n{width} {height}\n255\n".encode("ascii")
-    pixel = bytes([max(0, min(255, red)), max(0, min(255, green)), max(0, min(255, blue))])
+    pixel = bytes(
+        [max(0, min(255, red)), max(0, min(255, green)), max(0, min(255, blue))]
+    )
     path.write_bytes(header + pixel * width * height)
 
 
@@ -1187,6 +1469,11 @@ def _redacted_config(config: Sim2RealLoopConfig) -> dict[str, Any]:
     payload = asdict(config)
     payload["output_dir"] = str(config.output_dir) if config.output_dir else None
     return payload
+
+
+def _artifact_root_uri(config: Sim2RealLoopConfig) -> str:
+    parts = [part for part in (config.s3_prefix.strip("/"), config.run_id) if part]
+    return f"s3://{config.s3_bucket}/{'/'.join(parts)}"
 
 
 def _bool_value(value: Any) -> bool:
@@ -1211,13 +1498,16 @@ __all__ = [
     "SCHEMA_RL_SIGNAL",
     "SCHEMA_THRESHOLD_DECISION",
     "SCHEMA_VLM_EVAL",
+    "DEFAULT_LEROBOT_DATASET_ID",
     "Sim2RealLoopConfig",
     "Sim2RealLoopError",
     "artifact_uris",
     "build_config_from_env",
     "byo_seams",
     "convert_vlm_eval_to_rl_signal",
+    "default_envgen_image",
     "default_eval_image",
+    "default_policy_image",
     "default_trainer_image",
     "default_vlm_image",
     "evaluate_rollout_with_vlm",

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -6,11 +6,15 @@ from pathlib import Path
 import yaml
 
 from npa.sdk.workbench import cosmos2, cosmos3, sim2real
-from npa.workbench.lerobot.policy_container import parse_vlm_signal_batch, run_vlm_signal_training_step
+from npa.workbench.lerobot.policy_container import (
+    parse_vlm_signal_batch,
+    run_vlm_signal_training_step,
+)
 from npa.workflows.sim2real_loop import (
     SCHEMA_RL_SIGNAL,
     SCHEMA_VLM_EVAL,
     Sim2RealLoopConfig,
+    artifact_uris,
     convert_vlm_eval_to_rl_signal,
     evaluate_rollout_with_vlm,
     generate_action_rollouts,
@@ -20,11 +24,17 @@ from npa.workflows.sim2real_loop import (
 
 ROOT = Path(__file__).resolve().parents[3]
 RUNBOOK = ROOT / "npa" / "workflows" / "workbench" / "sim2real" / "runbook.yaml"
-COSMOS2_TRANSFER = ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "cosmos2-transfer.yaml"
-COSMOS3_REASON = ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "cosmos3-reason.yaml"
+COSMOS2_TRANSFER = (
+    ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "cosmos2-transfer.yaml"
+)
+COSMOS3_REASON = (
+    ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "cosmos3-reason.yaml"
+)
 
 
-def test_vlm_eval_signal_converter_and_trainer_update_close_loop(tmp_path: Path) -> None:
+def test_vlm_eval_signal_converter_and_trainer_update_close_loop(
+    tmp_path: Path,
+) -> None:
     config = Sim2RealLoopConfig(
         run_id="sim2real-unit",
         output_dir=tmp_path,
@@ -40,11 +50,15 @@ def test_vlm_eval_signal_converter_and_trainer_update_close_loop(tmp_path: Path)
         quality=0.4,
     )[0]
 
-    evaluation = evaluate_rollout_with_vlm(rollout, output_dir=tmp_path / "vlm_eval", config=config)
+    evaluation = evaluate_rollout_with_vlm(
+        rollout, output_dir=tmp_path / "vlm_eval", config=config
+    )
     signal = convert_vlm_eval_to_rl_signal(evaluation)
     parsed = parse_vlm_signal_batch(signal)
     update = run_vlm_signal_training_step(parsed, output_dir=tmp_path / "update")
-    control = run_vlm_signal_training_step(parsed, output_dir=tmp_path / "control", control=True)
+    control = run_vlm_signal_training_step(
+        parsed, output_dir=tmp_path / "control", control=True
+    )
 
     assert evaluation["schema"] == SCHEMA_VLM_EVAL
     assert signal["schema"] == SCHEMA_RL_SIGNAL
@@ -57,6 +71,7 @@ def test_full_loop_writes_stage_artifacts_and_candidate(tmp_path: Path) -> None:
     config = Sim2RealLoopConfig(
         run_id="sim2real-full-unit",
         output_dir=tmp_path,
+        trigger_dataset_uri="s3://bucket/sim2real-triggers/lerobot-pusht/",
         threshold=0.45,
         inner_iterations=2,
         outer_iterations=1,
@@ -71,19 +86,74 @@ def test_full_loop_writes_stage_artifacts_and_candidate(tmp_path: Path) -> None:
 
     assert report["schema"] == "npa.sim2real.e2e_report.v1"
     assert reward_trend[-1] >= reward_trend[0]
+    assert report["s3_artifacts"] == {}
+    assert (
+        report["byo_seams"]["trigger_dataset_uri"]
+        == "s3://bucket/sim2real-triggers/lerobot-pusht/"
+    )
     assert decision["decision"] == "promote_checkpoint"
+    trigger = json.loads((tmp_path / "stage_01_trigger" / "trigger.json").read_text())
+    retrigger = json.loads(
+        (tmp_path / "stage_13_retrigger" / "retrigger.json").read_text()
+    )
+    assert (
+        trigger["trigger_dataset_uri"] == "s3://bucket/sim2real-triggers/lerobot-pusht/"
+    )
+    assert trigger["start_condition"] == "dataset_landed_in_trigger_path"
+    assert retrigger["target_stage"] == 1
+    assert (
+        retrigger["trigger_dataset_uri"]
+        == "s3://bucket/sim2real-triggers/lerobot-pusht/"
+    )
     assert (tmp_path / "vlm_eval" / "train").exists()
     assert (tmp_path / "training_signal" / "train").exists()
     assert (tmp_path / "inner_loop" / "outer-01" / "evidence.json").exists()
-    assert json.loads((tmp_path / "eval" / "heldout" / "report.json").read_text())["success_rate"] >= 0.45
+    assert (
+        json.loads((tmp_path / "eval" / "heldout" / "report.json").read_text())[
+            "success_rate"
+        ]
+        >= 0.45
+    )
     assert (tmp_path / "checkpoints" / "candidate" / "candidate.json").exists()
     assert (tmp_path / "reports" / "sim2real-report.json").exists()
+
+
+def test_threshold_failure_loops_back_to_inner_loop(tmp_path: Path) -> None:
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-loopback-unit",
+        output_dir=tmp_path,
+        threshold=0.98,
+        inner_iterations=1,
+        outer_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        heldout_env_count=2,
+    )
+
+    report = run_full_loop(config)
+    decision = report["outer_loop"]["latest_decision"]
+    loopback = json.loads((tmp_path / "outer_loop" / "loopback.json").read_text())
+
+    assert decision["decision"] == "loop_back_to_inner_loop"
+    assert loopback["to_stage"] == 7
+
+
+def test_empty_s3_prefix_writes_under_run_id() -> None:
+    config = Sim2RealLoopConfig(
+        run_id="pusht-demo",
+        s3_bucket="bucket",
+        s3_prefix="",
+        trigger_dataset_uri="s3://bucket/sim2real-triggers/pusht-demo/lerobot-pusht/",
+    )
+
+    assert artifact_uris(config)["root"] == "s3://bucket/pusht-demo/"
 
 
 def test_sdk_exposes_sim2real_run(tmp_path: Path) -> None:
     report = sim2real.run(
         run_id="sim2real-sdk-unit",
         output_dir=tmp_path,
+        trigger_dataset_uri="s3://bucket/triggers/pusht/",
         threshold=0.45,
         inner_iterations=1,
         rollout_count=1,
@@ -93,24 +163,42 @@ def test_sdk_exposes_sim2real_run(tmp_path: Path) -> None:
 
     assert report["run_id"] == "sim2real-sdk-unit"
     assert "vlm_image" in report["byo_seams"]
+    assert report["byo_seams"]["trigger_dataset_uri"] == "s3://bucket/triggers/pusht/"
 
 
 def test_raw_runbook_invokes_full_loop_and_exposes_byo_envs() -> None:
-    docs = [doc for doc in yaml.safe_load_all(RUNBOOK.read_text(encoding="utf-8")) if doc is not None]
+    docs = [
+        doc
+        for doc in yaml.safe_load_all(RUNBOOK.read_text(encoding="utf-8"))
+        if doc is not None
+    ]
 
     assert len(docs) == 1
     task = docs[0]
     assert task["name"] == "sim2real-full-loop"
+    assert (
+        task["envs"]["NPA_SIM2REAL_TRIGGER_DATASET_URI"]
+        == "${NPA_SIM2REAL_TRIGGER_DATASET_URI}"
+    )
+    assert (
+        task["envs"]["NPA_SIM2REAL_TRIGGER_DATASET_ID"]
+        == "${NPA_SIM2REAL_TRIGGER_DATASET_ID}"
+    )
     assert task["envs"]["VLM_IMAGE"] == "${VLM_IMAGE}"
     assert task["envs"]["TRAINER_IMAGE"] == "${TRAINER_IMAGE}"
     assert task["envs"]["EVAL_IMAGE"] == "${EVAL_IMAGE}"
     assert "npa.workflows.sim2real_loop full-loop" in task["run"]
+    assert "--trigger-dataset-uri" in task["run"]
     assert "--byo-signal-converter" in task["run"]
 
 
 def test_cosmos_split_sdk_and_raw_yaml_contracts() -> None:
-    transfer = cosmos2.transfer(input_uri="s3://bucket/input/", output_uri="s3://bucket/augment/")
-    reason = cosmos3.reason(input_uri="s3://bucket/rollouts/", output_uri="s3://bucket/vlm_eval/")
+    transfer = cosmos2.transfer(
+        input_uri="s3://bucket/input/", output_uri="s3://bucket/augment/"
+    )
+    reason = cosmos3.reason(
+        input_uri="s3://bucket/rollouts/", output_uri="s3://bucket/vlm_eval/"
+    )
 
     assert transfer["schema"] == "npa.cosmos2.transfer.v1"
     assert reason["schema"] == "npa.cosmos3.reason.v1"

--- a/npa/workflows/workbench/sim2real/README.md
+++ b/npa/workflows/workbench/sim2real/README.md
@@ -1,32 +1,116 @@
 # Sim2Real VLM-to-RL Runbook
 
-This workflow wires a full Sim2Real loop from trigger through augmentation,
-environment split, action-conditioned rollouts, VLM critique, VLM-derived RL
-signal conversion, policy update, held-out evaluation, threshold gating, and
-retrigger.
+This workflow runs the full Sim2Real chain as one inspectable pipeline:
+
+`LeRobot dataset trigger -> augment -> env generation -> train/held-out split -> action rollouts -> VLM critique -> RL signal -> trainer update -> held-out eval -> promote or loop back -> external validation stub -> retrigger`.
+
+Steps 2 and 12 are documented external stubs. Every other step writes local
+artifacts and, when `--upload-artifacts` is set, uploads the run tree to S3.
+
+## Easy-Parameters Quickstart
+
+Use this when you want the canonical `lerobot/pusht` demo shape with the fewest
+knobs. The trigger path is the input path: dropping a LeRobot dataset there is
+what starts a run. Keep the trigger path, simulation asset source path, and
+output prefix separate.
+
+```bash
+# 1. Easy parameters.
+export NPA_SIM2REAL_RUN_ID=pusht-demo-$(date -u +%Y%m%dT%H%M%SZ)
+export NPA_SIM2REAL_BUCKET=<default-platform-bucket>
+export NPA_SIM2REAL_PREFIX=""
+export NPA_SIM2REAL_TRIGGER_DATASET_ID=lerobot/pusht
+export NPA_SIM2REAL_TRIGGER_DATASET_URI="s3://${NPA_SIM2REAL_BUCKET}/sim2real-triggers/${NPA_SIM2REAL_RUN_ID}/lerobot-pusht/"
+export ASSETS_URI="s3://${NPA_SIM2REAL_BUCKET}/sim2real-assets/pusht/"
+export SCENE_SPEC_URI="s3://${NPA_SIM2REAL_BUCKET}/sim2real-assets/pusht/scene-spec.json"
+
+# 2. Credentials and endpoints.
+export AWS_ACCESS_KEY_ID=<access-key>
+export AWS_SECRET_ACCESS_KEY=<secret-key>
+export AWS_ENDPOINT_URL=<default-platform-s3-endpoint>
+
+# Non-default S3-compatible endpoints supported but untested.
+
+# 3. Single LeRobot trainer image override. Leave unset to use the reference image.
+export TRAINER_IMAGE=<registry>/npa-lerobot-vlm-rl:0.1.0
+
+# 4. Reference image defaults. Override only if you have a newer pushed image.
+export AUGMENT_IMAGE=<registry>/npa-sim2real-envgen:0.1.1
+export POLICY_IMAGE=<registry>/npa-sim2real-reference-policy:0.1.1
+export VLM_IMAGE=<registry>/npa-cosmos3-reason:3.0.0
+export EVAL_IMAGE=<registry>/npa-sim2real-eval:0.1.0
+
+# 5. Demo scale. Increase these for larger production runs.
+export INNER_ITERATIONS=2
+export OUTER_ITERATIONS=1
+export LOOP_OF_LOOPS_ITERATIONS=1
+export ROLLOUT_COUNT=3
+export STEPS_PER_ROLLOUT=4
+export HELDOUT_ENV_COUNT=8
+
+npa workbench sim2real run \
+  --run-id "${NPA_SIM2REAL_RUN_ID}" \
+  --s3-bucket "${NPA_SIM2REAL_BUCKET}" \
+  --s3-prefix "${NPA_SIM2REAL_PREFIX}" \
+  --s3-endpoint "${AWS_ENDPOINT_URL}" \
+  --trigger-dataset-uri "${NPA_SIM2REAL_TRIGGER_DATASET_URI}" \
+  --trigger-dataset-id "${NPA_SIM2REAL_TRIGGER_DATASET_ID}" \
+  --assets-uri "${ASSETS_URI}" \
+  --scene-spec-uri "${SCENE_SPEC_URI}" \
+  --inner-iterations "${INNER_ITERATIONS}" \
+  --outer-iterations "${OUTER_ITERATIONS}" \
+  --loop-of-loops-iterations "${LOOP_OF_LOOPS_ITERATIONS}" \
+  --rollout-count "${ROLLOUT_COUNT}" \
+  --steps-per-rollout "${STEPS_PER_ROLLOUT}" \
+  --heldout-env-count "${HELDOUT_ENV_COUNT}" \
+  --upload-artifacts
+```
+
+Canonical S3 layout for the quickstart:
+
+```text
+s3://<bucket>/sim2real-triggers/<run-id>/lerobot-pusht/    # Step 1 trigger path
+s3://<bucket>/sim2real-assets/pusht/                       # Step 2 sim assets and SceneSpec stub input
+s3://<bucket>/<run-id>/                                     # Per-run output tree
+```
+
+The output tree includes:
+
+```text
+augment/
+envs/raw/
+envs/train/
+envs/heldout/
+actions/
+vlm_eval/
+training_signal/
+inner_loop/
+checkpoints/
+eval/heldout/
+outer_loop/decision.json
+stage_13_retrigger/retrigger.json
+reports/sim2real-report.json
+```
 
 ## Prerequisites
 
-- Python 3.11 or newer and the `npa` package installed in `npa/.venv`.
-- A Kubernetes GPU cluster with RTX PRO 6000 class `sm_120` GPUs.
-- A registry containing these images:
+- Python 3.11 or newer and this package installed in `npa/.venv`.
+- A Kubernetes GPU cluster with schedulable RTX PRO 6000 class `sm_120` GPUs.
+- Pushed reference images:
+  - `npa-sim2real-envgen:0.1.1`
+  - `npa-sim2real-reference-policy:0.1.1`
   - `npa-cosmos3-reason:3.0.0`
   - `npa-lerobot-vlm-rl:0.1.0`
   - `npa-sim2real-eval:0.1.0`
-  - the CUDA 13 multi-arch base and Genesis reference images used by the site.
-- Hugging Face gated repository access accepted for:
-  - `nvidia/Cosmos-Transfer2.5-2B`
-  - `nvidia/Cosmos-Predict2.5-2B`
-  - `nvidia/Cosmos-Guardrail1`, unless running with `--no-guardrails`
+- Gated model repository access accepted where required by the VLM image.
 - `HF_TOKEN` and `NGC_API_KEY` supplied through environment variables or a
   Kubernetes secret such as `hf-ngc-tokens`.
-- S3-compatible storage credentials through environment variables or the NPA
-  credentials loader. Non-default S3-compatible endpoints are supported through
-  the same `AWS_ENDPOINT_URL`/`S3_ENDPOINT_URL` seam but are not yet covered by CI.
+- S3-compatible storage credentials and endpoint configured through environment
+  variables, project config, or Kubernetes secrets.
 
-## Run
+## Run All Three Tiers
 
-Standalone raw SkyPilot:
+Raw SkyPilot:
 
 ```bash
 cat > /tmp/sim2real-skypilot-k8s.yaml <<'YAML'
@@ -34,29 +118,14 @@ kubernetes:
   pod_config:
     spec:
       serviceAccountName: agent-sa
-      imagePullSecrets:
-        - name: <registry-pull-secret>
       envFrom:
         - secretRef:
             name: hf-ngc-tokens
 YAML
 
-export NPA_SIM2REAL_RUN_ID=sim2real-example
-export NPA_SIM2REAL_BUCKET=<bucket>
-export NPA_SIM2REAL_PREFIX=sim2real-b
-export AWS_ENDPOINT_URL=<s3-compatible-endpoint>
-export ACTION_ROLLOUTS_URI=s3://<bucket>/<trigger-run>/actions/train/
-export TRAIN_ENVS_URI=s3://<bucket>/<trigger-run>/envs/train/envs.jsonl
-export HELDOUT_ENVS_URI=s3://<bucket>/<trigger-run>/envs/heldout/envs.jsonl
-export ASSETS_URI=s3://<bucket>/<asset-prefix>/
-export SCENE_SPEC_URI=s3://<bucket>/<asset-prefix>/scene-spec.json
-export NPA_SOURCE_REPO=<https-git-source-url>
-export TRAINER_IMAGE=<registry>/npa-lerobot-vlm-rl:0.1.0
-export VLM_IMAGE=<registry>/npa-cosmos3-reason:3.0.0
-export EVAL_IMAGE=<registry>/npa-sim2real-eval:0.1.0
 sky jobs launch \
   --config /tmp/sim2real-skypilot-k8s.yaml \
-  --infra k8s/npa-rtxpro-mk8s \
+  --infra k8s/<cluster-name> \
   --secret AWS_ACCESS_KEY_ID \
   --secret AWS_SECRET_ACCESS_KEY \
   npa/workflows/workbench/sim2real/runbook.yaml
@@ -68,12 +137,17 @@ SDK:
 from npa.sdk.workbench import sim2real
 
 report = sim2real.run(
-    run_id="sim2real-sdk-example",
-    output_dir="/tmp/sim2real-sdk-example",
+    run_id="pusht-sdk-demo",
     s3_bucket="<bucket>",
+    s3_prefix="pusht-sdk-demo",
+    trigger_dataset_uri="s3://<bucket>/sim2real-triggers/pusht-sdk-demo/lerobot-pusht/",
+    trigger_dataset_id="lerobot/pusht",
+    assets_uri="s3://<bucket>/sim2real-assets/pusht/",
+    scene_spec_uri="s3://<bucket>/sim2real-assets/pusht/scene-spec.json",
     threshold=0.75,
     inner_iterations=2,
     outer_iterations=1,
+    upload_artifacts=True,
 )
 print(report["outer_loop"]["latest_decision"])
 ```
@@ -82,16 +156,19 @@ CLI:
 
 ```bash
 npa workbench sim2real run \
-  --run-id sim2real-cli-example \
-  --output-dir /tmp/sim2real-cli-example \
+  --run-id pusht-cli-demo \
   --s3-bucket <bucket> \
-  --threshold 0.75 \
+  --s3-prefix pusht-cli-demo \
+  --trigger-dataset-uri s3://<bucket>/sim2real-triggers/pusht-cli-demo/lerobot-pusht/ \
+  --trigger-dataset-id lerobot/pusht \
+  --assets-uri s3://<bucket>/sim2real-assets/pusht/ \
+  --scene-spec-uri s3://<bucket>/sim2real-assets/pusht/scene-spec.json \
   --inner-iterations 2 \
   --outer-iterations 1 \
   --upload-artifacts
 ```
 
-Individual inner loop:
+Inner loop only:
 
 ```bash
 npa workbench sim2real inner-loop \
@@ -100,33 +177,49 @@ npa workbench sim2real inner-loop \
   --inner-iterations 2
 ```
 
-## Stages
+## Stages And Artifacts
 
-1. Trigger: writes `stage_01_trigger/trigger.json`.
+1. Trigger: consumes `--trigger-dataset-uri` and writes
+   `stage_01_trigger/trigger.json`.
 2. External assets and SceneSpec: documented BYO stub at
    `stage_02_assets/external_stub.json`.
-3. Cosmos transfer augmentation: writes `augment/manifest.json`.
+3. Augmentation: writes `augment/manifest.json`.
 4. Environment generation: writes `envs/raw/manifest.json`.
 5. Train and held-out split: writes `envs/train/manifest.json` and
-   `envs/heldout/manifest.json`.
+   `envs/heldout/manifest.json` using an 80/20 split.
 6. Token manifest: writes `tokens/manifest.json`.
 7. Action-conditioned rollouts: writes `actions/train/.../rollout-*/`.
-8. VLM eval: writes one structured JSON per rollout under `vlm_eval/train/`.
-9. RL signal and trainer update: writes `training_signal/train/` plus
+8. VLM eval: writes structured critique JSON under `vlm_eval/train/`.
+9. RL signal and trainer update: writes `training_signal/train/` and
    `inner_loop/.../evidence.json`.
 10. Held-out eval: writes `eval/heldout/report.json`.
-11. Threshold gate: writes `outer_loop/decision.json`; when met, writes
-   `checkpoints/candidate/candidate.json`; otherwise writes
-   `outer_loop/loopback.json`.
-12. External validation: documented BYO stub at
-   `stage_12_external_validation/external_stub.json`.
-13. Retrigger: writes `stage_13_retrigger/retrigger.json`.
+11. Threshold gate: writes `outer_loop/decision.json`; when the threshold is
+    met it writes `checkpoints/candidate/candidate.json`, otherwise
+    `outer_loop/loopback.json` points back to Stage 7.
+12. Real-robot validation: documented external stub at
+    `stage_12_external_validation/external_stub.json`.
+13. Retrigger: writes `stage_13_retrigger/retrigger.json`, targeting Stage 1
+    when a new real-world LeRobot dataset lands in the trigger path.
 
 ## Loops
 
 Inner loop, Stages 7 to 9:
 
-`action gen -> VLM eval -> signal conversion -> policy update`
+```text
+Reference action generation -> VLM eval -> critique-to-reward signal -> trainer update
+```
+
+Outer loop, Stages 10 to 11:
+
+```text
+held-out eval -> threshold gate -> promote checkpoint or loop back to Stage 7
+```
+
+Loop-of-loops, Stages 12 to 13 to 1:
+
+```text
+real-robot validation stub -> retrigger manifest -> next LeRobot dataset batch in trigger path
+```
 
 The VLM eval schema is:
 
@@ -171,29 +264,40 @@ loss = imitation_loss
      - advantage * policy_logit_proxy
 ```
 
-Outer loop, Stages 10 to 11:
-
-`held-out eval -> threshold gate -> promote or loop back`
-
-Loop-of-loops, Stages 12 to 13 to 1:
-
-`external validation stub -> retrigger manifest -> next run`
-
 ## BYO Seams
 
-- `--s3-endpoint`, `--s3-bucket`, `--s3-prefix`
-- `--assets-uri`, `--scene-spec-uri`
-- `--augment-image`
-- `--action-rollouts-uri`, `--train-envs-uri`, `--heldout-envs-uri`
-- `--policy-image`
-- `--vlm-image`, `--vlm-model`, `--byo-vlm-command`
-- `--byo-signal-converter`
-- `--trainer-image`, `--byo-trainer-command`
-- `--eval-image`, `--byo-eval-command`
-- `--threshold`
-- `--inner-iterations`, `--outer-iterations`, `--loop-of-loops-iterations`
-- `--signal-loss-weight`, `--learning-rate`
-- `--no-guardrails`
+Every seam is available in raw SkyPilot envs, SDK keyword arguments, and CLI
+options:
 
-All defaults are reference components and every seam can be overridden at
-runtime in the YAML env vars, SDK keyword arguments, or CLI options.
+- `s3_endpoint`, `s3_bucket`, `s3_prefix`
+- `trigger_dataset_uri`, `trigger_dataset_id`
+- `assets_uri`, `scene_spec_uri`
+- `augment_image`
+- `action_rollouts_uri`, `train_envs_uri`, `heldout_envs_uri`
+- `policy_image`
+- `vlm_image`, `vlm_model`, `byo_vlm_command`
+- `byo_signal_converter`
+- `trainer_image`, `byo_trainer_command`
+- `eval_image`, `byo_eval_command`
+- `threshold`
+- `inner_iterations`, `outer_iterations`, `loop_of_loops_iterations`
+- `rollout_count`, `steps_per_rollout`, `heldout_env_count`
+- `signal_loss_weight`, `learning_rate`
+- `no_guardrails`
+
+## Scale Knobs
+
+The demo scale intentionally exercises every stage with small numbers. To scale
+toward large environment generation runs, increase:
+
+- `HELDOUT_ENV_COUNT` for generated environment count and held-out eval breadth.
+- `ROLLOUT_COUNT` and `STEPS_PER_ROLLOUT` for action and VLM-eval volume.
+- `INNER_ITERATIONS` for repeated critique-to-reward trainer updates.
+- `OUTER_ITERATIONS` for held-out failures to loop back through Stage 7.
+- `LOOP_OF_LOOPS_ITERATIONS` when real-world validation should start a next
+  dataset-triggered run.
+
+For augmentation-heavy runs, shard the trigger dataset by prefix and submit
+multiple SkyPilot jobs with distinct `NPA_SIM2REAL_RUN_ID` values and output
+prefixes. Keep each job pointed at the same pushed reference images unless a
+new image has already been built and pushed.

--- a/npa/workflows/workbench/sim2real/runbook.yaml
+++ b/npa/workflows/workbench/sim2real/runbook.yaml
@@ -24,6 +24,8 @@ envs:
   NPA_SIM2REAL_RUN_ID: "${NPA_SIM2REAL_RUN_ID}"
   NPA_SIM2REAL_BUCKET: "${NPA_SIM2REAL_BUCKET}"
   NPA_SIM2REAL_PREFIX: "${NPA_SIM2REAL_PREFIX}"
+  NPA_SIM2REAL_TRIGGER_DATASET_URI: "${NPA_SIM2REAL_TRIGGER_DATASET_URI}"
+  NPA_SIM2REAL_TRIGGER_DATASET_ID: "${NPA_SIM2REAL_TRIGGER_DATASET_ID}"
   AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
   S3_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
   ACTION_ROLLOUTS_URI: "${ACTION_ROLLOUTS_URI}"
@@ -81,8 +83,10 @@ run: |
     --run-id "${run_id}" \
     --output-dir "${output_dir}" \
     --s3-bucket "${NPA_SIM2REAL_BUCKET:-${S3_BUCKET:-}}" \
-    --s3-prefix "${NPA_SIM2REAL_PREFIX:-sim2real-b}" \
+    --s3-prefix "${NPA_SIM2REAL_PREFIX-sim2real-b}" \
     --s3-endpoint "${AWS_ENDPOINT_URL:-${S3_ENDPOINT_URL:-}}" \
+    --trigger-dataset-uri "${NPA_SIM2REAL_TRIGGER_DATASET_URI:-}" \
+    --trigger-dataset-id "${NPA_SIM2REAL_TRIGGER_DATASET_ID:-lerobot/pusht}" \
     --action-rollouts-uri "${ACTION_ROLLOUTS_URI:-}" \
     --train-envs-uri "${TRAIN_ENVS_URI:-}" \
     --heldout-envs-uri "${HELDOUT_ENVS_URI:-}" \


### PR DESCRIPTION
## Summary
- Add first-class `trigger_dataset_uri` and `trigger_dataset_id` wiring for the sim2real full loop across config, CLI, SDK kwargs, and raw SkyPilot envs.
- Record the dedicated LeRobot trigger path in Stage 1 and Stage 13, default all five reference images, and make Stage 11 failures loop back to Stage 7 inner-loop work.
- Replace the sim2real README with an easy-parameters `lerobot/pusht` quickstart and refresh `runbook.yaml` for the full 13-stage flow.

## Demo evidence
- Canonical `lerobot/pusht` dataset staged in the dedicated trigger path for run `pusht-demo-20260607T044657Z`.
- Full CLI e2e uploaded artifacts under `s3://<demo-bucket>/pusht-demo-20260607T044657Z/`.
- VLM sample: success `false`, score `0.385577`, critique `Move the end effector toward the object center before closing. Reduce vertical speed and stabilize before release.`
- Held-out eval success rate: `1.0`.
- Outer-loop decision: `promote_checkpoint`.
- Inner-loop policy delta vs no-signal control: `[0.00463678, 0.00232005]`.

## Tests
- `python -m ruff check npa/src/npa/workflows/sim2real_loop.py npa/src/npa/cli/workbench/sim2real.py npa/tests/workflows/test_sim2real_loop.py`
- `python -m pytest npa/tests/workflows/test_sim2real_loop.py npa/tests/workflows/test_sim_to_real_trigger.py npa/tests/guardrails/test_three_tier_contract.py npa/tests/test_sdk_surface.py -q`
- `python -m pytest npa/tests/workflows -q`
- Staged diff hygiene scan: clean.

## Notes
- No `.github/workflows` changes.
- Non-default S3-compatible endpoints remain supported but untested.

