### PR TITLE
Add durable S3 workflow monitoring

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -37,6 +37,9 @@ regexes = [
     '''e00h9xcpssv53b3y3n''',
     '''e00cm0vc6t09m0z5gw''',
     '''hf_123456789''',
+    '''hf_testsecret123456''',
+    '''hf_npae2eworkflowsecret1234567890''',
+    '''AKIAABCDEFGHIJKLMNOP''',
 ]
 paths = [
     '''SECURITY\.md''',

--- a/docs/cli/workflow.md
+++ b/docs/cli/workflow.md
@@ -12,8 +12,11 @@ Options
 Commands
 submit  Submit a SkyPilot workflow YAML through the NPA controller convention.
 run  Run a named workflow end-to-end.
+list  List durable S3 workflow runs.
 status  Check the status of a workflow run.
 logs  Show logs for a specific stage of a workflow run.
+artifacts  List durable S3 artifact URIs for a workflow run.
+cancel  Cancel a managed workflow job and explicitly tear down its cluster.
 teardown  Destroy both VMs from a distill workflow run.
 distill  Run expert distillation: L40S (Genesis) + H100 (LeRobot).
 ```
@@ -30,8 +33,11 @@ distill  Run expert distillation: L40S (Genesis) + H100 (LeRobot).
 | --- | --- |
 | `submit` | Submit a SkyPilot workflow YAML through the NPA controller convention. |
 | `run` | Run a named workflow end-to-end. |
+| `list` | List durable S3 workflow runs. |
 | `status` | Check the status of a workflow run. |
 | `logs` | Show logs for a specific stage of a workflow run. |
+| `artifacts` | List durable S3 artifact URIs for a workflow run. |
+| `cancel` | Cancel a managed workflow job and explicitly tear down its cluster. |
 | `teardown` | Destroy both VMs from a distill workflow run. |
 | `distill` | Run expert distillation: L40S (Genesis) + H100 (LeRobot). |
 
@@ -41,6 +47,62 @@ distill  Run expert distillation: L40S (Genesis) + H100 (LeRobot).
 npa workbench workflow --help
 npa workbench workflow submit --help
 ```
+
+## Durable S3 Monitoring
+
+`submit --durable-s3` instruments a SkyPilot workflow with a writable S3
+MOUNT-mode `file_mount`, redacted per-stage log teeing, and small JSON state
+files. The storage location is resolved from `--workflow-s3-uri`,
+`--workflow-s3-prefix`, `--s3-bucket`, project storage, or
+`~/.npa/credentials.yaml`. S3-compatible endpoint and credentials come from the
+same NPA storage config used by BYO S3 workflows; users do not need `aws
+configure`, and they do not need to call `sky` to inspect completed runs.
+
+```bash
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/<workflow>.yaml \
+  --run-id "$RUN_ID" \
+  --durable-s3 \
+  --workflow-s3-uri "s3://<bucket>/workflows/$RUN_ID/" \
+  --s3-endpoint "https://storage.eu-north1.nebius.cloud" \
+  --infra "k8s/<context>"
+```
+
+The run prefix is the source of truth:
+
+```text
+s3://<bucket>/<run-id>/
+  manifest.json
+  logs/<stage>/run.log
+  logs/<stage>/status.json
+  artifacts/<stage>/...
+```
+
+`manifest.json` maps the run to stages, SkyPilot job IDs, status URIs, log
+URIs, and artifact URIs. Each stage `status.json` includes `state`, `tier`,
+`start`, `end`, `sky_job_id`, `artifact_uri`, `log_uri`, and `error_summary`.
+Logs are scrubbed for common access-key and token patterns before they are
+written to S3.
+
+Monitor commands read the durable S3 state:
+
+```bash
+npa workbench workflow list --workflow-s3-uri "s3://<bucket>/workflows/"
+npa workbench workflow status "s3://<bucket>/workflows/$RUN_ID/" --watch
+npa workbench workflow logs "s3://<bucket>/workflows/$RUN_ID/" --stage train
+npa workbench workflow artifacts "s3://<bucket>/workflows/$RUN_ID/"
+npa workbench workflow cancel "s3://<bucket>/workflows/$RUN_ID/"
+```
+
+`status` opportunistically checks `sky jobs queue` when a SkyPilot binary and
+job ID are available, but completed-run status, logs, and artifacts come from
+S3. `logs --follow` tails live SkyPilot logs while the job is still running and
+falls back to the durable S3 log when the live stream is unavailable.
+
+Durable workflow state has no TTL in v1. Configure an S3 lifecycle policy on
+the workflow prefix when retention needs are known, for example deleting
+`logs/` and `artifacts/` objects after 30 or 90 days while keeping
+`manifest.json` longer for audit history.
 
 ## `submit` Materialization
 

--- a/docs/workbench-yaml-guide.md
+++ b/docs/workbench-yaml-guide.md
@@ -236,6 +236,33 @@ Derived paths:
 `envs` block. Cleanup is controlled by the runner's `--cleanup` flag, which calls
 the SkyPilot cleanup path for the run after terminal workflow status.
 
+## Durable Workflow State
+
+For long-running SkyPilot workflows, prefer the generic durable monitor instead
+of adding ad hoc log upload code to each YAML:
+
+```bash
+npa workbench workflow submit <workflow.yaml> \
+  --durable-s3 \
+  --workflow-s3-uri "s3://<bucket>/workflows/<run-id>/" \
+  --infra "k8s/<context>"
+```
+
+The submit command injects an S3 MOUNT-mode `file_mount` into every task and
+wraps each `run` block with redacted stdout/stderr teeing plus
+`manifest.json`, `logs/<stage>/status.json`, and `artifacts/<stage>/` state.
+The user-facing monitor is:
+
+```bash
+npa workbench workflow status "s3://<bucket>/workflows/<run-id>/"
+npa workbench workflow logs "s3://<bucket>/workflows/<run-id>/" --stage <stage>
+npa workbench workflow artifacts "s3://<bucket>/workflows/<run-id>/"
+```
+
+Keep committed raw SkyPilot YAMLs focused on task logic. Do not use SkyPilot
+`logs.store` or CloudWatch for the Workbench durable monitor path; the cluster
+pod writes the S3 state through the mounted run prefix.
+
 ## Standard Pipeline Stages (BDD100K Reference)
 
 The BDD100K pipeline is the canonical reference implementation:

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import tempfile
+import time
 from enum import Enum
 from pathlib import Path
 
@@ -68,6 +70,11 @@ def submit_cmd(
         ControllerBackendOption.kubernetes,
         "--controller-backend",
         help="Managed-jobs controller backend.",
+    ),
+    infra: str = typer.Option(
+        "",
+        "--infra",
+        help="SkyPilot infrastructure target, for example k8s/<context>.",
     ),
     submit_timeout: int = typer.Option(
         1800,
@@ -178,6 +185,27 @@ def submit_cmd(
         "--s3-prefix",
         help="S3 object prefix materialized into workflow envs.",
     ),
+    project: str = typer.Option(
+        "",
+        "--project",
+        "-p",
+        help="Project alias used to resolve durable workflow S3 credentials.",
+    ),
+    durable_s3: bool = typer.Option(
+        False,
+        "--durable-s3/--no-durable-s3",
+        help="Instrument the workflow with S3 manifest, status, artifacts, and redacted logs.",
+    ),
+    workflow_s3_uri: str = typer.Option(
+        "",
+        "--workflow-s3-uri",
+        help="Exact durable workflow run prefix, for example s3://bucket/run-id/.",
+    ),
+    workflow_s3_prefix: str = typer.Option(
+        "",
+        "--workflow-s3-prefix",
+        help="Parent prefix for durable workflow state. The run ID is appended.",
+    ),
     secret_env: list[str] = typer.Option(
         [],
         "--secret-env",
@@ -191,6 +219,13 @@ def submit_cmd(
 ) -> None:
     """Submit a SkyPilot workflow YAML through the NPA controller convention."""
     from npa.orchestration.skypilot.workflow import SkyPilotSubmitError, submit_workflow
+    from npa.orchestration.skypilot.workflow_state import (
+        SECRET_ENV_NAMES,
+        WorkflowStateError,
+        instrument_workflow_yaml,
+        resolve_workflow_s3_config,
+        write_manifest,
+    )
 
     if submit_timeout <= 0:
         _fail(f"--submit-timeout must be positive, got {submit_timeout}")
@@ -199,7 +234,11 @@ def submit_cmd(
     submitted_yaml_path = yaml_path
     submitted_yaml_context: tempfile.TemporaryDirectory[str] | None = None
     materializer = _resolve_materializer(tool, yaml_path)
-    if substitutions or materializer:
+    resolved_run_id = run_id or _default_submit_run_id(yaml_path)
+    workflow_state = None
+    instrumented = None
+    extra_env: dict[str, str] = {}
+    if substitutions or materializer or durable_s3:
         submitted_yaml_context = tempfile.TemporaryDirectory(prefix="npa-workflow-")
         submitted_yaml_path = Path(submitted_yaml_context.name) / yaml_path.name
 
@@ -219,7 +258,7 @@ def submit_cmd(
             try:
                 plan = materialize_sonic_workflow(
                     source_yaml_path,
-                    run_id=run_id or _default_submit_run_id(yaml_path),
+                    run_id=resolved_run_id,
                     registry=registry,
                     image=image,
                     npa_image=npa_image,
@@ -257,17 +296,53 @@ def submit_cmd(
         else:
             _warn_unresolved_placeholders(yaml_path.read_text(encoding="utf-8"))
 
+        if durable_s3:
+            try:
+                workflow_state = resolve_workflow_s3_config(
+                    run_id=resolved_run_id,
+                    project=project or None,
+                    workflow_s3_uri=workflow_s3_uri,
+                    workflow_s3_prefix=workflow_s3_prefix,
+                    s3_bucket=s3_bucket,
+                    s3_endpoint=s3_endpoint,
+                )
+                instrumented = instrument_workflow_yaml(
+                    submitted_yaml_path if submitted_yaml_path.exists() else source_yaml_path,
+                    run_id=resolved_run_id,
+                    state=workflow_state,
+                )
+                submitted_yaml_path.write_text(instrumented.yaml_text, encoding="utf-8")
+                write_manifest(instrumented.manifest, workflow_state)
+                extra_env.update(workflow_state.secret_env())
+                for name in SECRET_ENV_NAMES:
+                    if name not in secret_env:
+                        secret_env.append(name)
+            except WorkflowStateError as exc:
+                _fail(str(exc))
+                return
+
         result = submit_workflow(
             submitted_yaml_path,
-            run_id or _default_submit_run_id(yaml_path),
+            resolved_run_id,
             isolated_config_dir=isolated_config_dir,
             config_path=config_path,
             sky_bin=sky_bin or None,
             controller_backend=controller_backend.value,
+            infra=infra,
             secret_envs=secret_env,
             require_controller_up=require_controller_up,
+            extra_env=extra_env,
             timeout=submit_timeout,
         )
+        if workflow_state is not None and instrumented is not None:
+            instrumented_manifest = write_manifest(
+                instrumented.manifest,
+                workflow_state,
+                job_id=result.job_id,
+            )
+            result.log_paths["run_prefix_uri"] = workflow_state.uri
+            result.log_paths["manifest_uri"] = f"{workflow_state.uri.rstrip('/')}/manifest.json"
+            result.log_paths["stages"] = ",".join(instrumented_manifest.get("stages", {}).keys())
     except OSError as exc:
         _fail(f"SkyPilot workflow submission failed: {exc}")
         return
@@ -285,6 +360,8 @@ def submit_cmd(
     typer.echo(f"status: {result.status}")
     if result.job_id:
         typer.echo(f"job_id: {result.job_id}")
+    if workflow_state is not None:
+        typer.echo(f"run_prefix_uri: {workflow_state.uri}")
 
 
 def _default_submit_run_id(yaml_path: Path) -> str:
@@ -327,6 +404,214 @@ def _warn_unresolved_placeholders(content: str) -> None:
             f"Warning: unresolved placeholders remain: {', '.join(unresolved)}",
             err=True,
         )
+
+
+def _uses_s3_monitor(
+    run_id: str,
+    *,
+    project: str = "",
+    workflow_s3_uri: str = "",
+    workflow_s3_prefix: str = "",
+    s3_bucket: str = "",
+) -> bool:
+    return bool(
+        run_id.startswith("s3://")
+        or project
+        or workflow_s3_uri
+        or workflow_s3_prefix
+        or s3_bucket
+    )
+
+
+def _resolve_monitor_state(
+    run_id: str,
+    *,
+    project: str = "",
+    workflow_s3_uri: str = "",
+    workflow_s3_prefix: str = "",
+    s3_bucket: str = "",
+    s3_endpoint: str = "",
+):
+    from npa.orchestration.skypilot.workflow_state import resolve_workflow_s3_config
+
+    exact_uri = workflow_s3_uri or (run_id if run_id.startswith("s3://") else "")
+    resolved_run_id = _display_run_id(run_id)
+    return resolve_workflow_s3_config(
+        run_id=resolved_run_id,
+        project=project or None,
+        workflow_s3_uri=exact_uri,
+        workflow_s3_prefix=workflow_s3_prefix,
+        s3_bucket=s3_bucket,
+        s3_endpoint=s3_endpoint,
+    )
+
+
+def _resolve_monitor_parent_state(
+    *,
+    project: str = "",
+    workflow_s3_uri: str = "",
+    workflow_s3_prefix: str = "",
+    s3_bucket: str = "",
+    s3_endpoint: str = "",
+):
+    from npa.orchestration.skypilot.workflow_state import WorkflowS3Config, parse_s3_uri, resolve_workflow_s3_config
+
+    if workflow_s3_uri:
+        bucket, prefix = parse_s3_uri(workflow_s3_uri)
+        child = resolve_workflow_s3_config(
+            run_id=prefix.rsplit("/", 1)[-1] or "runs",
+            project=project or None,
+            workflow_s3_uri=workflow_s3_uri,
+            s3_endpoint=s3_endpoint,
+        )
+        return WorkflowS3Config(
+            bucket=bucket,
+            prefix=prefix,
+            endpoint_url=child.endpoint_url,
+            aws_access_key_id=child.aws_access_key_id,
+            aws_secret_access_key=child.aws_secret_access_key,
+            project=child.project,
+        )
+
+    sentinel = "__npa_workflow_parent__"
+    child = resolve_workflow_s3_config(
+        run_id=sentinel,
+        project=project or None,
+        workflow_s3_prefix=workflow_s3_prefix,
+        s3_bucket=s3_bucket,
+        s3_endpoint=s3_endpoint,
+    )
+    prefix = child.prefix.removesuffix("/" + sentinel)
+    if prefix == child.prefix and child.prefix == sentinel:
+        prefix = ""
+    return WorkflowS3Config(
+        bucket=child.bucket,
+        prefix=prefix,
+        endpoint_url=child.endpoint_url,
+        aws_access_key_id=child.aws_access_key_id,
+        aws_secret_access_key=child.aws_secret_access_key,
+        project=child.project,
+    )
+
+
+def _display_run_id(run_id: str) -> str:
+    if not run_id.startswith("s3://"):
+        return run_id
+    from npa.orchestration.skypilot.workflow_state import parse_s3_uri
+
+    _bucket, prefix = parse_s3_uri(run_id)
+    return prefix.rstrip("/").rsplit("/", 1)[-1] or run_id
+
+
+def _resolve_sky_bin(sky_bin: str = "") -> str:
+    resolved = sky_bin or shutil.which("sky") or ""
+    if resolved:
+        return resolved
+    env_value = str(Path.home() / ".npa" / "skypilot-venv" / "bin" / "sky")
+    return env_value
+
+
+def _durable_workflow_status(
+    run_id: str,
+    *,
+    project: str = "",
+    workflow_s3_uri: str = "",
+    workflow_s3_prefix: str = "",
+    s3_bucket: str = "",
+    s3_endpoint: str = "",
+    sky_bin: str = "",
+) -> dict[str, object]:
+    from npa.orchestration.skypilot.workflow import workflow_status
+    from npa.orchestration.skypilot.workflow_state import read_manifest, read_stage_status
+
+    state = _resolve_monitor_state(
+        run_id,
+        project=project,
+        workflow_s3_uri=workflow_s3_uri,
+        workflow_s3_prefix=workflow_s3_prefix,
+        s3_bucket=s3_bucket,
+        s3_endpoint=s3_endpoint,
+    )
+    manifest = read_manifest(state)
+    stages: dict[str, dict[str, object]] = {}
+    for stage, info in (manifest.get("stages", {}) or {}).items():
+        stage_info = dict(info) if isinstance(info, dict) else {"name": str(stage)}
+        status = read_stage_status(state, str(stage))
+        if status:
+            stage_info.update(status)
+        stages[str(stage)] = stage_info
+
+    job_id = str(manifest.get("sky_job_id") or "")
+    live_status = ""
+    if job_id:
+        try:
+            live = workflow_status(job_id, sky_bin=_resolve_sky_bin(sky_bin))
+            live_status = live.status if not live.error else ""
+        except Exception:
+            live_status = ""
+    status = _aggregate_stage_status(stages, live_status)
+    return {
+        "run_id": manifest.get("run_id") or _display_run_id(run_id),
+        "workflow_name": manifest.get("workflow_name", ""),
+        "status": status,
+        "live_status": live_status,
+        "sky_job_id": job_id,
+        "run_prefix_uri": manifest.get("run_prefix_uri") or state.uri,
+        "manifest_uri": f"{state.uri.rstrip('/')}/manifest.json",
+        "stages": stages,
+    }
+
+
+def _aggregate_stage_status(stages: dict[str, dict[str, object]], live_status: str) -> str:
+    stage_states = [str(info.get("state") or "").upper() for info in stages.values()]
+    if any(state.startswith("FAILED") or state in {"CANCELLED", "BLOCKED"} for state in stage_states):
+        return "FAILED"
+    if stage_states and all(state == "SUCCEEDED" for state in stage_states):
+        return "SUCCEEDED"
+    live = live_status.upper()
+    if live:
+        return live
+    if any(state == "RUNNING" for state in stage_states):
+        return "RUNNING"
+    return "UNKNOWN"
+
+
+def _workflow_status_is_terminal(status: str) -> bool:
+    normalized = status.upper()
+    return normalized == "SUCCEEDED" or normalized.startswith("FAILED") or normalized in {"CANCELLED", "BLOCKED"}
+
+
+def _emit_workflow_status(result: dict[str, object], output_format: OutputFormat) -> None:
+    if output_format == OutputFormat.json:
+        typer.echo(json.dumps(result, indent=2, sort_keys=True))
+        return
+    typer.echo(f"run_id: {result.get('run_id')}")
+    typer.echo(f"status: {result.get('status')}")
+    if result.get("sky_job_id"):
+        typer.echo(f"sky_job_id: {result.get('sky_job_id')}")
+    typer.echo(f"run_prefix_uri: {result.get('run_prefix_uri')}")
+    stages = result.get("stages", {})
+    if isinstance(stages, dict):
+        for stage, info in stages.items():
+            state = info.get("state", "UNKNOWN") if isinstance(info, dict) else "UNKNOWN"
+            tier = info.get("tier", "") if isinstance(info, dict) else ""
+            suffix = f" ({tier})" if tier else ""
+            typer.echo(f"{stage}: {state}{suffix}")
+
+
+def _resolve_stage_name(manifest: dict[str, object], requested: str) -> str:
+    stages = manifest.get("stages", {})
+    if not isinstance(stages, dict) or not stages:
+        if requested:
+            return requested
+        raise ValueError("manifest contains no stages")
+    if requested:
+        if requested not in stages:
+            raise ValueError(f"stage not found in manifest: {requested}")
+        return requested
+    if len(stages) == 1:
+        return next(iter(stages.keys()))
+    raise ValueError("--stage is required when a workflow has multiple stages")
 
 
 @app.command("run")
@@ -409,11 +694,79 @@ def run_cmd(
 @app.command("status")
 def status_cmd(
     run_id: str = typer.Argument(help="Run ID to check status of."),
+    project: str = typer.Option(
+        "",
+        "--project",
+        "-p",
+        help="Project alias used to resolve durable workflow S3 credentials.",
+    ),
+    workflow_s3_uri: str = typer.Option(
+        "",
+        "--workflow-s3-uri",
+        help="Exact durable workflow run prefix, for example s3://bucket/run-id/.",
+    ),
+    workflow_s3_prefix: str = typer.Option(
+        "",
+        "--workflow-s3-prefix",
+        help="Parent prefix for durable workflow state. The run ID is appended.",
+    ),
+    s3_bucket: str = typer.Option(
+        "",
+        "--s3-bucket",
+        help="S3 bucket name or URI for durable workflow state.",
+    ),
+    s3_endpoint: str = typer.Option(
+        "",
+        "--s3-endpoint",
+        help="S3-compatible endpoint for durable workflow state.",
+    ),
+    sky_bin: str = typer.Option(
+        "",
+        "--sky-bin",
+        help="SkyPilot executable path for live status.",
+    ),
+    watch: bool = typer.Option(
+        False,
+        "--watch/--no-watch",
+        help="Refresh status until the workflow reaches a terminal state.",
+    ),
+    interval: float = typer.Option(
+        10.0,
+        "--interval",
+        help="Watch refresh interval in seconds.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Shortcut for --output-format json."),
     output_format: OutputFormat = typer.Option(
         OutputFormat.text, "--output-format", help="Output format."
     ),
 ) -> None:
     """Check the status of a workflow run."""
+    if _uses_s3_monitor(
+        run_id,
+        project=project,
+        workflow_s3_uri=workflow_s3_uri,
+        workflow_s3_prefix=workflow_s3_prefix,
+        s3_bucket=s3_bucket,
+    ):
+        try:
+            while True:
+                result = _durable_workflow_status(
+                    run_id,
+                    project=project,
+                    workflow_s3_uri=workflow_s3_uri,
+                    workflow_s3_prefix=workflow_s3_prefix,
+                    s3_bucket=s3_bucket,
+                    s3_endpoint=s3_endpoint,
+                    sky_bin=sky_bin,
+                )
+                _emit_workflow_status(result, OutputFormat.json if json_output else output_format)
+                if not watch or _workflow_status_is_terminal(str(result.get("status", ""))):
+                    return
+                time.sleep(interval)
+        except Exception as exc:
+            _fail(str(exc))
+            return
+
     from npa.workflows.distill import DistillationError, get_run_status
 
     try:
@@ -422,7 +775,7 @@ def status_cmd(
         _fail(str(exc))
         return
 
-    if output_format == OutputFormat.json:
+    if json_output or output_format == OutputFormat.json:
         typer.echo(json.dumps(result, indent=2))
     else:
         console.print(f"  run_id: {result.get('run_id')}")
@@ -434,18 +787,228 @@ def status_cmd(
 @app.command("logs")
 def logs_cmd(
     run_id: str = typer.Argument(help="Run ID."),
-    stage: str = typer.Argument(help="Stage name (train_teacher, generate_demos, convert, train_student, eval_student)."),
+    stage: str | None = typer.Argument(
+        None,
+        help="Stage name. Legacy distill runs require this positional argument.",
+    ),
+    stage_option: str = typer.Option(
+        "",
+        "--stage",
+        help="Stage name for durable S3 workflow logs.",
+    ),
+    project: str = typer.Option(
+        "",
+        "--project",
+        "-p",
+        help="Project alias used to resolve durable workflow S3 credentials.",
+    ),
+    workflow_s3_uri: str = typer.Option(
+        "",
+        "--workflow-s3-uri",
+        help="Exact durable workflow run prefix, for example s3://bucket/run-id/.",
+    ),
+    workflow_s3_prefix: str = typer.Option(
+        "",
+        "--workflow-s3-prefix",
+        help="Parent prefix for durable workflow state. The run ID is appended.",
+    ),
+    s3_bucket: str = typer.Option(
+        "",
+        "--s3-bucket",
+        help="S3 bucket name or URI for durable workflow state.",
+    ),
+    s3_endpoint: str = typer.Option(
+        "",
+        "--s3-endpoint",
+        help="S3-compatible endpoint for durable workflow state.",
+    ),
+    sky_bin: str = typer.Option(
+        "",
+        "--sky-bin",
+        help="SkyPilot executable path for live --follow logs.",
+    ),
+    follow: bool = typer.Option(
+        False,
+        "--follow/--no-follow",
+        help="Tail live SkyPilot logs when the managed job is still running.",
+    ),
 ) -> None:
     """Show logs for a specific stage of a workflow run."""
+    selected_stage = stage_option or stage or ""
+    if _uses_s3_monitor(
+        run_id,
+        project=project,
+        workflow_s3_uri=workflow_s3_uri,
+        workflow_s3_prefix=workflow_s3_prefix,
+        s3_bucket=s3_bucket,
+    ):
+        try:
+            state = _resolve_monitor_state(
+                run_id,
+                project=project,
+                workflow_s3_uri=workflow_s3_uri,
+                workflow_s3_prefix=workflow_s3_prefix,
+                s3_bucket=s3_bucket,
+                s3_endpoint=s3_endpoint,
+            )
+            from npa.orchestration.skypilot.workflow_state import (
+                read_manifest,
+                read_stage_log,
+                tail_live_job_logs,
+            )
+
+            manifest = read_manifest(state)
+            selected_stage = _resolve_stage_name(manifest, selected_stage)
+            job_id = str(manifest.get("sky_job_id") or "")
+            if follow and job_id:
+                live = tail_live_job_logs(
+                    sky_bin=_resolve_sky_bin(sky_bin),
+                    job_id=job_id,
+                    stage=selected_stage,
+                    follow=True,
+                    timeout=86400,
+                )
+                if live.stdout:
+                    typer.echo(live.stdout, nl=False)
+                if live.stderr:
+                    typer.echo(live.stderr, err=True, nl=False)
+                if live.returncode == 0:
+                    return
+            typer.echo(read_stage_log(state, selected_stage), nl=False)
+            return
+        except Exception as exc:
+            _fail(str(exc))
+            return
+
+    if not selected_stage:
+        _fail("stage is required for legacy distill logs")
+        return
+
     from npa.workflows.distill import DistillationError, get_stage_logs
 
     try:
-        logs = get_stage_logs(run_id, stage)
+        logs = get_stage_logs(run_id, selected_stage)
     except DistillationError as exc:
         _fail(str(exc))
         return
 
     typer.echo(logs)
+
+
+@app.command("artifacts")
+def artifacts_cmd(
+    run_id: str = typer.Argument(help="Durable workflow run ID or s3:// run prefix."),
+    stage: str = typer.Option("", "--stage", help="Optional stage name."),
+    project: str = typer.Option("", "--project", "-p", help="Project alias for S3 credentials."),
+    workflow_s3_uri: str = typer.Option("", "--workflow-s3-uri", help="Exact durable workflow run prefix."),
+    workflow_s3_prefix: str = typer.Option("", "--workflow-s3-prefix", help="Parent prefix. The run ID is appended."),
+    s3_bucket: str = typer.Option("", "--s3-bucket", help="S3 bucket name or URI."),
+    s3_endpoint: str = typer.Option("", "--s3-endpoint", help="S3-compatible endpoint."),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON."),
+) -> None:
+    """List durable S3 artifact URIs for a workflow run."""
+    try:
+        from npa.orchestration.skypilot.workflow_state import list_artifacts
+
+        state = _resolve_monitor_state(
+            run_id,
+            project=project,
+            workflow_s3_uri=workflow_s3_uri,
+            workflow_s3_prefix=workflow_s3_prefix,
+            s3_bucket=s3_bucket,
+            s3_endpoint=s3_endpoint,
+        )
+        artifacts = list_artifacts(state, stage or None)
+    except Exception as exc:
+        _fail(str(exc))
+        return
+    if json_output:
+        typer.echo(json.dumps({"run_id": _display_run_id(run_id), "artifacts": artifacts}, indent=2))
+        return
+    for uri in artifacts:
+        typer.echo(uri)
+
+
+@app.command("list")
+def list_cmd(
+    project: str = typer.Option("", "--project", "-p", help="Project alias for S3 credentials."),
+    workflow_s3_uri: str = typer.Option("", "--workflow-s3-uri", help="Parent durable workflow prefix."),
+    workflow_s3_prefix: str = typer.Option("", "--workflow-s3-prefix", help="Parent prefix for durable workflow state."),
+    s3_bucket: str = typer.Option("", "--s3-bucket", help="S3 bucket name or URI."),
+    s3_endpoint: str = typer.Option("", "--s3-endpoint", help="S3-compatible endpoint."),
+    limit: int = typer.Option(50, "--limit", help="Maximum runs to list."),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON."),
+) -> None:
+    """List durable S3 workflow runs."""
+    try:
+        from npa.orchestration.skypilot.workflow_state import list_runs
+
+        parent_state = _resolve_monitor_parent_state(
+            project=project,
+            workflow_s3_uri=workflow_s3_uri,
+            workflow_s3_prefix=workflow_s3_prefix,
+            s3_bucket=s3_bucket,
+            s3_endpoint=s3_endpoint,
+        )
+        runs = list_runs(state_parent=parent_state, limit=limit)
+    except Exception as exc:
+        _fail(str(exc))
+        return
+    if json_output:
+        typer.echo(json.dumps({"runs": runs}, indent=2))
+        return
+    for item in runs:
+        typer.echo(
+            f"{item.get('run_id', '')}\t{item.get('workflow_name', '')}\t"
+            f"{item.get('sky_job_id', '')}\t{item.get('run_prefix_uri', '')}"
+        )
+
+
+@app.command("cancel")
+def cancel_cmd(
+    run_id: str = typer.Argument(help="Durable workflow run ID or s3:// run prefix."),
+    project: str = typer.Option("", "--project", "-p", help="Project alias for S3 credentials."),
+    workflow_s3_uri: str = typer.Option("", "--workflow-s3-uri", help="Exact durable workflow run prefix."),
+    workflow_s3_prefix: str = typer.Option("", "--workflow-s3-prefix", help="Parent prefix. The run ID is appended."),
+    s3_bucket: str = typer.Option("", "--s3-bucket", help="S3 bucket name or URI."),
+    s3_endpoint: str = typer.Option("", "--s3-endpoint", help="S3-compatible endpoint."),
+    sky_bin: str = typer.Option("", "--sky-bin", help="SkyPilot executable path."),
+    cluster: str = typer.Option("", "--cluster", help="SkyPilot cluster name to tear down. Defaults to run ID."),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON."),
+) -> None:
+    """Cancel a managed workflow job and explicitly tear down its cluster."""
+    try:
+        from npa.orchestration.skypilot.workflow_state import cancel_workflow_job, read_manifest
+
+        state = _resolve_monitor_state(
+            run_id,
+            project=project,
+            workflow_s3_uri=workflow_s3_uri,
+            workflow_s3_prefix=workflow_s3_prefix,
+            s3_bucket=s3_bucket,
+            s3_endpoint=s3_endpoint,
+        )
+        manifest = read_manifest(state)
+        job_id = str(manifest.get("sky_job_id") or "")
+        if not job_id:
+            _fail("manifest does not contain a sky_job_id")
+            return
+        result = cancel_workflow_job(
+            sky_bin=_resolve_sky_bin(sky_bin),
+            job_id=job_id,
+            run_id=str(manifest.get("run_id") or _display_run_id(run_id)),
+            cluster=cluster,
+        )
+    except Exception as exc:
+        _fail(str(exc))
+        return
+    if json_output:
+        typer.echo(json.dumps(result, indent=2, sort_keys=True))
+        return
+    typer.echo(f"job_id: {result['job_id']}")
+    typer.echo(f"cluster: {result['cluster']}")
+    typer.echo(f"cancel_returncode: {result['cancel_returncode']}")
+    typer.echo(f"down_returncode: {result['down_returncode']}")
 
 
 @app.command("teardown")

--- a/npa/src/npa/orchestration/skypilot/workflow.py
+++ b/npa/src/npa/orchestration/skypilot/workflow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import shutil
 import subprocess
@@ -11,7 +10,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 import yaml
 
@@ -90,8 +89,10 @@ def submit_workflow(
     config_path: Path | None = None,
     sky_bin: SkyBin = None,
     controller_backend: ControllerBackend = DEFAULT_CONTROLLER_BACKEND,
+    infra: str = "",
     secret_envs: Sequence[str] | None = None,
     require_controller_up: bool = False,
+    extra_env: Mapping[str, str] | None = None,
     timeout: int = 1800,
     controller_preflight_timeout: int = 300,
     controller_preflight_interval: float = 15.0,
@@ -124,6 +125,9 @@ def submit_workflow(
         generated_config_path = submission_dir / "skypilot-config.yaml"
         generated_config_path.write_text(yaml.safe_dump(global_config, sort_keys=False), encoding="utf-8")
         env = sky_environment(runtime_config.isolated_config_dir)
+        for key, value in (extra_env or {}).items():
+            if value:
+                env[key] = value
         env["SKYPILOT_GLOBAL_CONFIG"] = str(generated_config_path)
 
         cmd = [
@@ -136,8 +140,10 @@ def submit_workflow(
             "--yes",
             str(prepared_yaml),
         ]
+        if infra:
+            cmd[-1:-1] = ["--infra", infra]
         for secret_name in secret_envs or ():
-            if os.environ.get(secret_name):
+            if env.get(secret_name):
                 cmd[-1:-1] = ["--secret", secret_name]
         stable_cwd = _stable_sky_cwd(runtime_config.isolated_config_dir)
         _wait_for_healthy_jobs_controller(

--- a/npa/src/npa/orchestration/skypilot/workflow_state.py
+++ b/npa/src/npa/orchestration/skypilot/workflow_state.py
@@ -1,0 +1,707 @@
+"""Durable S3 state for SkyPilot workbench workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+import json
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
+
+import boto3
+import yaml
+from botocore.config import Config as BotoConfig
+
+from npa.clients.config import resolve_project_storage
+from npa.clients.credentials import load_credentials, storage_endpoint_url
+
+
+DEFAULT_WORKFLOW_MOUNT_PATH = "/mnt/npa-workflow-state"
+DEFAULT_WORKFLOW_STATE_PREFIX = ""
+WORKFLOW_SCHEMA_VERSION = 1
+SECRET_ENV_NAMES = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN")
+_SENSITIVE_ENV_NAMES = (
+    *SECRET_ENV_NAMES,
+    "HF_TOKEN",
+    "HUGGING_FACE_HUB_TOKEN",
+    "HUGGINGFACE_TOKEN",
+    "HUGGINGFACE_HUB_TOKEN",
+    "NGC_API_KEY",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "SKYPILOT_DOCKER_PASSWORD",
+)
+
+
+class WorkflowStateError(RuntimeError):
+    """Raised when durable workflow state cannot be read or written."""
+
+
+@dataclass(frozen=True)
+class WorkflowS3Config:
+    """Resolved S3 location and credentials for a workflow run prefix."""
+
+    bucket: str
+    prefix: str
+    endpoint_url: str
+    aws_access_key_id: str = field(default="", repr=False)
+    aws_secret_access_key: str = field(default="", repr=False)
+    project: str | None = None
+
+    @property
+    def uri(self) -> str:
+        return _join_s3_uri(self.bucket, self.prefix)
+
+    def client(self):
+        return boto3.client(
+            "s3",
+            endpoint_url=self.endpoint_url or None,
+            aws_access_key_id=self.aws_access_key_id or None,
+            aws_secret_access_key=self.aws_secret_access_key or None,
+            config=BotoConfig(signature_version="s3v4"),
+        )
+
+    def secret_env(self) -> dict[str, str]:
+        env: dict[str, str] = {}
+        if self.aws_access_key_id:
+            env["AWS_ACCESS_KEY_ID"] = self.aws_access_key_id
+        if self.aws_secret_access_key:
+            env["AWS_SECRET_ACCESS_KEY"] = self.aws_secret_access_key
+        if self.endpoint_url:
+            env["AWS_ENDPOINT_URL"] = self.endpoint_url
+            env["NEBIUS_S3_ENDPOINT"] = self.endpoint_url
+            # SkyPilot 0.12.2 S3 mounts use rclone/goofys. These env vars let
+            # rclone-backed S3-compatible mounts pick up a non-AWS endpoint
+            # while the normal AWS_* variables carry the access keys.
+            env["RCLONE_CONFIG_S3_TYPE"] = "s3"
+            env["RCLONE_CONFIG_S3_PROVIDER"] = "Other"
+            env["RCLONE_CONFIG_S3_ENV_AUTH"] = "true"
+            env["RCLONE_CONFIG_S3_ENDPOINT"] = self.endpoint_url
+            env["RCLONE_S3_ENDPOINT"] = self.endpoint_url
+        return env
+
+    @property
+    def sky_mount_source(self) -> str:
+        scheme = "nebius" if _is_nebius_endpoint(self.endpoint_url) else "s3"
+        return f"{scheme}://{self.bucket}"
+
+    @property
+    def sky_mount_store(self) -> str:
+        return "NEBIUS" if _is_nebius_endpoint(self.endpoint_url) else "S3"
+
+
+@dataclass(frozen=True)
+class InstrumentedWorkflow:
+    """A workflow YAML with S3 state/log instrumentation applied."""
+
+    yaml_text: str
+    manifest: dict[str, Any]
+    stages: tuple[str, ...]
+    mount_path: str = DEFAULT_WORKFLOW_MOUNT_PATH
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def resolve_workflow_s3_config(
+    *,
+    run_id: str,
+    project: str | None = None,
+    workflow_s3_uri: str = "",
+    workflow_s3_prefix: str = DEFAULT_WORKFLOW_STATE_PREFIX,
+    s3_bucket: str = "",
+    s3_endpoint: str = "",
+) -> WorkflowS3Config:
+    """Resolve an exact S3 run prefix from CLI args, env, and NPA config."""
+
+    if not run_id and not workflow_s3_uri:
+        raise WorkflowStateError("run_id or workflow_s3_uri is required")
+
+    storage = resolve_project_storage(project)
+    credentials = load_credentials()
+    endpoint = storage_endpoint_url(
+        s3_endpoint
+        or storage.endpoint_url
+        or credentials.s3_endpoint
+        or os.environ.get("AWS_ENDPOINT_URL", "")
+        or os.environ.get("NEBIUS_S3_ENDPOINT", "")
+    )
+    access_key = (
+        storage.aws_access_key_id
+        or credentials.s3_access_key_id
+        or os.environ.get("AWS_ACCESS_KEY_ID", "")
+    )
+    secret_key = (
+        storage.aws_secret_access_key
+        or credentials.s3_secret_access_key
+        or os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+    )
+
+    if workflow_s3_uri:
+        bucket, prefix = parse_s3_uri(workflow_s3_uri)
+    else:
+        bucket_source = s3_bucket or storage.checkpoint_bucket or credentials.s3_bucket
+        if not bucket_source:
+            raise WorkflowStateError(
+                "S3 bucket is not configured. Pass --s3-bucket, --workflow-s3-uri, "
+                "or configure project storage."
+            )
+        bucket, base_prefix = parse_s3_uri(bucket_source)
+        parent_prefix = workflow_s3_prefix.strip("/")
+        if not parent_prefix:
+            parent_prefix = base_prefix
+        prefix = "/".join(part for part in (parent_prefix, run_id) if part).strip("/")
+
+    if not bucket or not prefix:
+        raise WorkflowStateError("workflow S3 state requires a bucket and run prefix")
+    if not endpoint:
+        raise WorkflowStateError(
+            "S3 endpoint is not configured. Pass --s3-endpoint or configure project storage."
+        )
+    if not access_key or not secret_key:
+        raise WorkflowStateError(
+            "S3 access key and secret are not configured for workflow state."
+        )
+
+    return WorkflowS3Config(
+        bucket=bucket,
+        prefix=prefix.strip("/"),
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        project=project or None,
+    )
+
+
+def parse_s3_uri(value: str) -> tuple[str, str]:
+    """Parse either a bucket name or an s3://bucket/prefix URI."""
+
+    raw = value.strip().rstrip("/")
+    if not raw:
+        return "", ""
+    parsed = urlparse(raw)
+    if parsed.scheme == "s3":
+        return parsed.netloc, parsed.path.lstrip("/")
+    if "://" in raw:
+        raise WorkflowStateError(f"Expected an s3:// URI, got: {value}")
+    return raw, ""
+
+
+def instrument_workflow_yaml(
+    yaml_path: Path,
+    *,
+    run_id: str,
+    state: WorkflowS3Config,
+    job_id: str = "",
+    mount_path: str = DEFAULT_WORKFLOW_MOUNT_PATH,
+) -> InstrumentedWorkflow:
+    """Add writable S3 mounts, redacted tee logging, and status writes."""
+
+    docs = _load_yaml_documents(yaml_path)
+    if not docs:
+        raise WorkflowStateError("SkyPilot YAML is empty")
+
+    stages = _workflow_stage_names(docs)
+    manifest = build_manifest(
+        run_id=run_id,
+        state=state,
+        stages=stages,
+        workflow_name=_workflow_name(docs, yaml_path),
+        job_id=job_id,
+    )
+    manifest_json = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+    for index, doc in enumerate(docs):
+        if index not in _stage_doc_indexes(docs):
+            continue
+        stage = str(doc.get("name") or f"stage-{index}")
+        _instrument_stage_doc(
+            doc,
+            run_id=run_id,
+            stage=stage,
+            state=state,
+            manifest_json=manifest_json,
+            mount_path=mount_path,
+        )
+    return InstrumentedWorkflow(
+        yaml_text=yaml.safe_dump_all(docs, sort_keys=False),
+        manifest=manifest,
+        stages=tuple(stages),
+        mount_path=mount_path,
+    )
+
+
+def build_manifest(
+    *,
+    run_id: str,
+    state: WorkflowS3Config,
+    stages: Sequence[str],
+    workflow_name: str,
+    job_id: str = "",
+) -> dict[str, Any]:
+    now = utc_now()
+    return {
+        "schema_version": WORKFLOW_SCHEMA_VERSION,
+        "run_id": run_id,
+        "workflow_name": workflow_name,
+        "run_prefix_uri": state.uri,
+        "submitted_at": now,
+        "updated_at": now,
+        "sky_job_id": str(job_id or ""),
+        "stages": {
+            stage: {
+                "name": stage,
+                "sky_job_id": str(job_id or ""),
+                "sky_task_id": "",
+                "log_uri": _join_s3_uri(state.bucket, state.prefix, "logs", stage, "run.log"),
+                "status_uri": _join_s3_uri(state.bucket, state.prefix, "logs", stage, "status.json"),
+                "artifact_uri": _join_s3_uri(state.bucket, state.prefix, "artifacts", stage) + "/",
+            }
+            for stage in stages
+        },
+    }
+
+
+def write_manifest(
+    manifest: Mapping[str, Any],
+    state: WorkflowS3Config,
+    *,
+    job_id: str = "",
+) -> dict[str, Any]:
+    payload = dict(manifest)
+    payload["updated_at"] = utc_now()
+    if job_id:
+        payload["sky_job_id"] = str(job_id)
+    stages = dict(payload.get("stages", {}))
+    for stage, info in list(stages.items()):
+        if isinstance(info, dict) and job_id:
+            info = dict(info)
+            info["sky_job_id"] = str(job_id)
+            stages[stage] = info
+    payload["stages"] = stages
+    put_json(state, "manifest.json", payload=payload)
+    return payload
+
+
+def read_manifest(state: WorkflowS3Config) -> dict[str, Any]:
+    return get_json(state, "manifest.json")
+
+
+def read_stage_status(state: WorkflowS3Config, stage: str) -> dict[str, Any] | None:
+    try:
+        return get_json(state, "logs", stage, "status.json")
+    except WorkflowStateError as exc:
+        if "not found" in str(exc).lower():
+            return None
+        raise
+
+
+def read_stage_log(state: WorkflowS3Config, stage: str) -> str:
+    return get_text(state, "logs", stage, "run.log")
+
+
+def list_artifacts(state: WorkflowS3Config, stage: str | None = None) -> list[str]:
+    prefix = "/".join(part for part in (state.prefix, "artifacts", stage or "") if part).strip("/")
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    objects: list[str] = []
+    paginator = state.client().get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=state.bucket, Prefix=prefix):
+        for item in page.get("Contents", []):
+            key = item.get("Key", "")
+            if key and not key.endswith("/"):
+                objects.append(_join_s3_uri(state.bucket, key))
+    return sorted(objects)
+
+
+def list_runs(
+    *,
+    state_parent: WorkflowS3Config,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    prefix = state_parent.prefix.strip("/")
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    paginator = state_parent.client().get_paginator("list_objects_v2")
+    runs: list[dict[str, Any]] = []
+    for page in paginator.paginate(Bucket=state_parent.bucket, Prefix=prefix):
+        for item in page.get("Contents", []):
+            key = str(item.get("Key", ""))
+            if not key.endswith("/manifest.json"):
+                continue
+            run_prefix = key.removesuffix("/manifest.json")
+            run_state = WorkflowS3Config(
+                bucket=state_parent.bucket,
+                prefix=run_prefix,
+                endpoint_url=state_parent.endpoint_url,
+                aws_access_key_id=state_parent.aws_access_key_id,
+                aws_secret_access_key=state_parent.aws_secret_access_key,
+                project=state_parent.project,
+            )
+            try:
+                manifest = read_manifest(run_state)
+            except WorkflowStateError:
+                continue
+            runs.append(
+                {
+                    "run_id": manifest.get("run_id", run_prefix.rsplit("/", 1)[-1]),
+                    "workflow_name": manifest.get("workflow_name", ""),
+                    "run_prefix_uri": run_state.uri,
+                    "updated_at": manifest.get("updated_at", ""),
+                    "sky_job_id": manifest.get("sky_job_id", ""),
+                }
+            )
+            if len(runs) >= limit:
+                return sorted(runs, key=lambda item: str(item.get("updated_at", "")), reverse=True)
+    return sorted(runs, key=lambda item: str(item.get("updated_at", "")), reverse=True)
+
+
+def put_json(state: WorkflowS3Config, *parts: str, payload: Mapping[str, Any]) -> None:
+    key = _key(state.prefix, *parts)
+    state.client().put_object(
+        Bucket=state.bucket,
+        Key=key,
+        Body=(json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def get_json(state: WorkflowS3Config, *parts: str) -> dict[str, Any]:
+    text = get_text(state, *parts)
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise WorkflowStateError(f"Invalid JSON at {_join_s3_uri(state.bucket, _key(state.prefix, *parts))}") from exc
+    if not isinstance(payload, dict):
+        raise WorkflowStateError("Workflow state JSON must be an object")
+    return payload
+
+
+def get_text(state: WorkflowS3Config, *parts: str) -> str:
+    key = _key(state.prefix, *parts)
+    try:
+        response = state.client().get_object(Bucket=state.bucket, Key=key)
+    except Exception as exc:  # boto3 exposes provider-specific ClientError payloads.
+        raise WorkflowStateError(f"S3 object not found or unreadable: {_join_s3_uri(state.bucket, key)}") from exc
+    return response["Body"].read().decode("utf-8", errors="replace")
+
+
+def tail_live_job_logs(
+    *,
+    sky_bin: str,
+    job_id: str,
+    stage: str = "",
+    follow: bool = False,
+    timeout: int = 300,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [sky_bin, "jobs", "logs", str(job_id)]
+    if stage:
+        cmd.append(stage)
+    cmd.append("--follow" if follow else "--no-follow")
+    return subprocess.run(
+        cmd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def cancel_workflow_job(
+    *,
+    sky_bin: str,
+    job_id: str,
+    run_id: str,
+    cluster: str = "",
+    timeout: int = 900,
+    poll_seconds: float = 10.0,
+) -> dict[str, Any]:
+    cancel = subprocess.run(
+        [sky_bin, "jobs", "cancel", "--yes", str(job_id)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+    cluster_name = cluster or run_id
+    down = subprocess.run(
+        [sky_bin, "down", "--yes", cluster_name],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+    deadline = time.monotonic() + timeout
+    last_status = ""
+    while time.monotonic() < deadline:
+        status = subprocess.run(
+            [sky_bin, "status", "--refresh"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=min(timeout, 300),
+            check=False,
+        )
+        last_status = status.stdout + status.stderr
+        if cluster_name not in status.stdout:
+            break
+        time.sleep(poll_seconds)
+    return {
+        "job_id": str(job_id),
+        "cluster": cluster_name,
+        "cancel_returncode": cancel.returncode,
+        "cancel_stdout": redact_text(cancel.stdout),
+        "cancel_stderr": redact_text(cancel.stderr),
+        "down_returncode": down.returncode,
+        "down_stdout": redact_text(down.stdout),
+        "down_stderr": redact_text(down.stderr),
+        "status_after_down": redact_text(last_status),
+    }
+
+
+def redact_text(text: str, secrets: Sequence[str] | None = None) -> str:
+    redacted = text
+    for secret in secrets or ():
+        if secret:
+            redacted = redacted.replace(secret, "<redacted>")
+    for name in _SENSITIVE_ENV_NAMES:
+        redacted = re.sub(
+            rf"({re.escape(name)}\s*[:=]\s*)[^\s,;'\"]+",
+            r"\1<redacted>",
+            redacted,
+            flags=re.IGNORECASE,
+        )
+    patterns = (
+        r"hf_[A-Za-z0-9_=-]{8,}",
+        r"nvapi-[A-Za-z0-9_=-]{8,}",
+        r"gh[pousr]_[A-Za-z0-9_=-]{20,}",
+        r"(?:AKIA|ASIA)[A-Z0-9]{16}",
+    )
+    for pattern in patterns:
+        redacted = re.sub(pattern, "<redacted>", redacted)
+    return redacted
+
+
+def _load_yaml_documents(path: Path) -> list[dict[str, Any]]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        docs = [doc for doc in yaml.safe_load_all(handle) if doc is not None]
+    if not all(isinstance(doc, dict) for doc in docs):
+        raise WorkflowStateError("SkyPilot YAML documents must be mappings")
+    return docs
+
+
+def _workflow_name(docs: Sequence[Mapping[str, Any]], yaml_path: Path) -> str:
+    first = docs[0] if docs else {}
+    return str(first.get("name") or Path(yaml_path).stem)
+
+
+def _stage_doc_indexes(docs: Sequence[Mapping[str, Any]]) -> tuple[int, ...]:
+    indexes: list[int] = []
+    for index, doc in enumerate(docs):
+        if index == 0 and "execution" in doc and "run" not in doc:
+            continue
+        if "run" in doc or "resources" in doc:
+            indexes.append(index)
+    return tuple(indexes)
+
+
+def _workflow_stage_names(docs: Sequence[Mapping[str, Any]]) -> list[str]:
+    names: list[str] = []
+    for index in _stage_doc_indexes(docs):
+        names.append(str(docs[index].get("name") or f"stage-{index}"))
+    return names
+
+
+def _instrument_stage_doc(
+    doc: dict[str, Any],
+    *,
+    run_id: str,
+    stage: str,
+    state: WorkflowS3Config,
+    manifest_json: str,
+    mount_path: str,
+) -> None:
+    envs = doc.setdefault("envs", {})
+    if not isinstance(envs, dict):
+        raise WorkflowStateError(f"envs for stage {stage!r} must be a mapping")
+    envs.update(
+        {
+            "NPA_WORKFLOW_RUN_ID": run_id,
+            "NPA_WORKFLOW_STAGE": stage,
+            "NPA_WORKFLOW_S3_BUCKET": state.bucket,
+            "NPA_WORKFLOW_S3_PREFIX": state.prefix,
+            "NPA_WORKFLOW_RUN_PREFIX_URI": state.uri,
+            "NPA_WORKFLOW_MOUNT_ROOT": mount_path,
+            "NPA_WORKFLOW_MANIFEST_JSON": manifest_json,
+            "AWS_ENDPOINT_URL": state.endpoint_url,
+            "NEBIUS_S3_ENDPOINT": state.endpoint_url,
+            "RCLONE_CONFIG_S3_TYPE": "s3",
+            "RCLONE_CONFIG_S3_PROVIDER": "Other",
+            "RCLONE_CONFIG_S3_ENV_AUTH": "true",
+            "RCLONE_CONFIG_S3_ENDPOINT": state.endpoint_url,
+            "RCLONE_S3_ENDPOINT": state.endpoint_url,
+        }
+    )
+    file_mounts = doc.setdefault("file_mounts", {})
+    if not isinstance(file_mounts, dict):
+        raise WorkflowStateError(f"file_mounts for stage {stage!r} must be a mapping")
+    file_mounts.setdefault(
+        mount_path,
+        {
+            "source": state.sky_mount_source,
+            "store": state.sky_mount_store,
+            "mode": "MOUNT",
+            "persistent": True,
+        },
+    )
+    original_run = str(doc.get("run", ""))
+    doc["run"] = _instrumented_run_script(original_run)
+
+
+def _instrumented_run_script(original_run: str) -> str:
+    prelude = r'''set -euo pipefail
+npa_workflow_python="$(command -v python3 || command -v python || true)"
+npa_workflow_mount_root="${NPA_WORKFLOW_MOUNT_ROOT:-/mnt/npa-workflow-state}"
+npa_workflow_prefix="${NPA_WORKFLOW_S3_PREFIX:?NPA_WORKFLOW_S3_PREFIX is required}"
+npa_workflow_stage="${NPA_WORKFLOW_STAGE:?NPA_WORKFLOW_STAGE is required}"
+npa_workflow_log_dir="${npa_workflow_mount_root}/${npa_workflow_prefix}/logs/${npa_workflow_stage}"
+npa_workflow_artifact_dir="${npa_workflow_mount_root}/${npa_workflow_prefix}/artifacts/${npa_workflow_stage}"
+mkdir -p "${npa_workflow_log_dir}" "${npa_workflow_artifact_dir}" "${npa_workflow_mount_root}/${npa_workflow_prefix}"
+npa_workflow_stage_start="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+export NPA_WORKFLOW_STAGE_START="${npa_workflow_stage_start}"
+export NPA_WORKFLOW_MOUNT_ROOT_RESOLVED="${npa_workflow_mount_root}"
+export NPA_WORKFLOW_S3_PREFIX_RESOLVED="${npa_workflow_prefix}"
+export NPA_WORKFLOW_STAGE_RESOLVED="${npa_workflow_stage}"
+npa_workflow_redact_stream() {
+  sed -E \
+    -e 's/(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|HF_TOKEN|HUGGING_FACE_HUB_TOKEN|HUGGINGFACE_TOKEN|HUGGINGFACE_HUB_TOKEN|NGC_API_KEY|GITHUB_TOKEN|GH_TOKEN|SKYPILOT_DOCKER_PASSWORD)([=:])[A-Za-z0-9_+=\/.,:@-]+/\1\2<redacted>/Ig' \
+    -e 's/hf_[A-Za-z0-9_=-]{8,}/<redacted>/g' \
+    -e 's/nvapi-[A-Za-z0-9_=-]{8,}/<redacted>/g' \
+    -e 's/gh[pousr]_[A-Za-z0-9_=-]{20,}/<redacted>/g' \
+    -e 's/(AKIA|ASIA)[A-Z0-9]{16}/<redacted>/g'
+}
+npa_workflow_write_manifest() {
+  [ -n "${npa_workflow_python}" ] || return 0
+  "${npa_workflow_python}" -c '
+import json, os
+from pathlib import Path
+raw = os.environ.get("NPA_WORKFLOW_MANIFEST_JSON", "")
+if not raw:
+    raise SystemExit(0)
+manifest = json.loads(raw)
+task_id = os.environ.get("SKYPILOT_TASK_ID", "")
+stage = os.environ.get("NPA_WORKFLOW_STAGE", "")
+target = Path(os.environ["NPA_WORKFLOW_MOUNT_ROOT_RESOLVED"]) / os.environ["NPA_WORKFLOW_S3_PREFIX_RESOLVED"] / "manifest.json"
+existing = {}
+if target.exists():
+    try:
+        existing = json.loads(target.read_text(encoding="utf-8"))
+    except Exception:
+        existing = {}
+job_id = (
+    os.environ.get("SKYPILOT_MANAGED_JOB_ID", "")
+    or manifest.get("sky_job_id", "")
+    or existing.get("sky_job_id", "")
+)
+manifest["sky_job_id"] = str(job_id or "")
+manifest["updated_at"] = os.environ.get("NPA_WORKFLOW_STAGE_START", "")
+manifest["last_writer"] = "pod"
+manifest["pod_written_at"] = os.environ.get("NPA_WORKFLOW_STAGE_START", "")
+stages = manifest.setdefault("stages", {})
+for info in stages.values():
+    if isinstance(info, dict) and job_id:
+        info["sky_job_id"] = str(job_id)
+if stage in stages and isinstance(stages[stage], dict):
+    stages[stage]["sky_task_id"] = str(task_id or "")
+target.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+'
+}
+npa_workflow_write_status() {
+  local state="$1"
+  local tier="$2"
+  local error_summary="${3:-}"
+  local end_time="${4:-}"
+  [ -n "${npa_workflow_python}" ] || return 0
+  NPA_WORKFLOW_STATUS_STATE="${state}" \
+  NPA_WORKFLOW_STATUS_TIER="${tier}" \
+  NPA_WORKFLOW_STATUS_ERROR="${error_summary}" \
+  NPA_WORKFLOW_STATUS_END="${end_time}" \
+  "${npa_workflow_python}" -c '
+import json, os
+from pathlib import Path
+mount = Path(os.environ["NPA_WORKFLOW_MOUNT_ROOT_RESOLVED"])
+prefix = os.environ["NPA_WORKFLOW_S3_PREFIX_RESOLVED"]
+stage = os.environ["NPA_WORKFLOW_STAGE_RESOLVED"]
+manifest_path = mount / prefix / "manifest.json"
+manifest = {}
+if manifest_path.exists():
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        manifest = {}
+job_id = os.environ.get("SKYPILOT_MANAGED_JOB_ID", "") or manifest.get("sky_job_id", "")
+bucket = os.environ.get("NPA_WORKFLOW_S3_BUCKET", "")
+payload = {
+    "schema_version": 1,
+    "run_id": os.environ.get("NPA_WORKFLOW_RUN_ID", ""),
+    "stage": stage,
+    "state": os.environ["NPA_WORKFLOW_STATUS_STATE"],
+    "tier": os.environ["NPA_WORKFLOW_STATUS_TIER"],
+    "start": os.environ.get("NPA_WORKFLOW_STAGE_START", ""),
+    "end": os.environ.get("NPA_WORKFLOW_STATUS_END", ""),
+    "start_time": os.environ.get("NPA_WORKFLOW_STAGE_START", ""),
+    "end_time": os.environ.get("NPA_WORKFLOW_STATUS_END", ""),
+    "sky_job_id": str(job_id or ""),
+    "sky_task_id": os.environ.get("SKYPILOT_TASK_ID", ""),
+    "artifact_uri": "s3://{}/{}/artifacts/{}/".format(bucket, prefix, stage),
+    "log_uri": "s3://{}/{}/logs/{}/run.log".format(bucket, prefix, stage),
+    "error_summary": os.environ.get("NPA_WORKFLOW_STATUS_ERROR", ""),
+}
+target = mount / prefix / "logs" / stage / "status.json"
+target.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+'
+}
+npa_workflow_finalize() {
+  local rc="$?"
+  trap - EXIT
+  set +e
+  local end_time
+  end_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if [ "${rc}" -eq 0 ]; then
+    npa_workflow_write_status "SUCCEEDED" "WORKS" "" "${end_time}"
+  else
+    npa_workflow_write_status "FAILED" "PARTIAL" "exit ${rc}" "${end_time}"
+  fi
+  exit "${rc}"
+}
+npa_workflow_write_manifest
+npa_workflow_write_status "RUNNING" "SEAM" "" ""
+exec > >(npa_workflow_redact_stream | tee -a "${npa_workflow_log_dir}/run.log") 2>&1
+trap npa_workflow_finalize EXIT
+'''
+    if original_run.strip():
+        return prelude + "\n" + original_run.rstrip() + "\n"
+    return prelude + "\n"
+
+
+def _join_s3_uri(bucket: str, *parts: str) -> str:
+    key = "/".join(part.strip("/") for part in parts if part is not None and part.strip("/") != "")
+    if parts and str(parts[-1]).endswith("/"):
+        key = key.rstrip("/") + "/"
+    return f"s3://{bucket}/{key}" if key else f"s3://{bucket}/"
+
+
+def _key(prefix: str, *parts: str) -> str:
+    return "/".join(part.strip("/") for part in (prefix, *parts) if part and part.strip("/"))
+
+
+def _is_nebius_endpoint(endpoint_url: str) -> bool:
+    return "nebius.cloud" in endpoint_url.lower()

--- a/npa/src/npa/sdk/workbench/__init__.py
+++ b/npa/src/npa/sdk/workbench/__init__.py
@@ -17,6 +17,7 @@ from . import (
     sonic,
     trigger,
     vlm_eval,
+    workflow,
 )
 
 __all__ = [
@@ -33,4 +34,5 @@ __all__ = [
     "sonic",
     "trigger",
     "vlm_eval",
+    "workflow",
 ]

--- a/npa/src/npa/sdk/workbench/workflow.py
+++ b/npa/src/npa/sdk/workbench/workflow.py
@@ -1,0 +1,125 @@
+"""SDK helpers for durable Workbench workflow monitoring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from npa.orchestration.skypilot.workflow_state import (
+    WorkflowS3Config,
+    list_artifacts,
+    list_runs,
+    read_manifest,
+    read_stage_log,
+    read_stage_status,
+    resolve_workflow_s3_config,
+)
+
+
+def status(
+    run_id: str,
+    *,
+    project: str | None = None,
+    workflow_s3_uri: str = "",
+    workflow_s3_prefix: str = "",
+    s3_bucket: str = "",
+    s3_endpoint: str = "",
+) -> dict[str, Any]:
+    """Read durable workflow manifest and per-stage status from S3."""
+
+    state = _state(
+        run_id,
+        project=project,
+        workflow_s3_uri=workflow_s3_uri,
+        workflow_s3_prefix=workflow_s3_prefix,
+        s3_bucket=s3_bucket,
+        s3_endpoint=s3_endpoint,
+    )
+    manifest = read_manifest(state)
+    stages: dict[str, dict[str, Any]] = {}
+    for stage, info in (manifest.get("stages", {}) or {}).items():
+        merged = dict(info) if isinstance(info, dict) else {"name": str(stage)}
+        stage_status = read_stage_status(state, str(stage))
+        if stage_status:
+            merged.update(stage_status)
+        stages[str(stage)] = merged
+    return {
+        "run_id": manifest.get("run_id") or run_id,
+        "workflow_name": manifest.get("workflow_name", ""),
+        "sky_job_id": manifest.get("sky_job_id", ""),
+        "run_prefix_uri": manifest.get("run_prefix_uri") or state.uri,
+        "stages": stages,
+    }
+
+
+def logs(
+    run_id: str,
+    *,
+    stage: str,
+    project: str | None = None,
+    workflow_s3_uri: str = "",
+    workflow_s3_prefix: str = "",
+    s3_bucket: str = "",
+    s3_endpoint: str = "",
+) -> str:
+    """Read a stage's durable redacted run log from S3."""
+
+    state = _state(
+        run_id,
+        project=project,
+        workflow_s3_uri=workflow_s3_uri,
+        workflow_s3_prefix=workflow_s3_prefix,
+        s3_bucket=s3_bucket,
+        s3_endpoint=s3_endpoint,
+    )
+    return read_stage_log(state, stage)
+
+
+def artifacts(
+    run_id: str,
+    *,
+    stage: str | None = None,
+    project: str | None = None,
+    workflow_s3_uri: str = "",
+    workflow_s3_prefix: str = "",
+    s3_bucket: str = "",
+    s3_endpoint: str = "",
+) -> list[str]:
+    """List durable artifact URIs for a run or stage."""
+
+    state = _state(
+        run_id,
+        project=project,
+        workflow_s3_uri=workflow_s3_uri,
+        workflow_s3_prefix=workflow_s3_prefix,
+        s3_bucket=s3_bucket,
+        s3_endpoint=s3_endpoint,
+    )
+    return list_artifacts(state, stage)
+
+
+def runs(parent_state: WorkflowS3Config, *, limit: int = 50) -> list[dict[str, Any]]:
+    """List workflow manifests below a parent S3 prefix."""
+
+    return list_runs(state_parent=parent_state, limit=limit)
+
+
+def _state(
+    run_id: str,
+    *,
+    project: str | None,
+    workflow_s3_uri: str,
+    workflow_s3_prefix: str,
+    s3_bucket: str,
+    s3_endpoint: str,
+) -> WorkflowS3Config:
+    return resolve_workflow_s3_config(
+        run_id=run_id,
+        project=project,
+        workflow_s3_uri=workflow_s3_uri,
+        workflow_s3_prefix=workflow_s3_prefix,
+        s3_bucket=s3_bucket,
+        s3_endpoint=s3_endpoint,
+    )
+
+
+__all__ = ["artifacts", "logs", "runs", "status"]

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from typer.testing import CliRunner
@@ -9,6 +12,7 @@ import yaml
 from npa.cli.main import app
 from npa.clients.config import SSHConfig, StorageConfig, WorkbenchConfig
 from npa.orchestration.skypilot.workflow import WorkflowResult
+from npa.orchestration.skypilot.workflow_state import WorkflowS3Config
 from npa.workflows.distill import DistillationError
 from npa.workflows.distill_two_vm import TwoVMDistillError
 
@@ -19,13 +23,71 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 @pytest.mark.parametrize(
     "command",
-    ["submit", "run", "status", "logs", "teardown", "distill"],
+    ["submit", "run", "list", "status", "logs", "artifacts", "cancel", "teardown", "distill"],
 )
 def test_workflow_command_help(command: str) -> None:
     result = runner.invoke(app, ["workbench", "workflow", command, "--help"])
 
     assert result.exit_code == 0
     assert "Usage:" in result.output
+
+
+class FakeWorkflowS3:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, ContentType: str = "") -> None:
+        del ContentType
+        self.objects[(Bucket, Key)] = Body if isinstance(Body, bytes) else str(Body).encode("utf-8")
+
+    def get_object(self, *, Bucket: str, Key: str):
+        return {"Body": BytesIO(self.objects[(Bucket, Key)])}
+
+    def get_paginator(self, name: str):
+        assert name == "list_objects_v2"
+        client = self
+
+        class Paginator:
+            def paginate(self, *, Bucket: str, Prefix: str):
+                contents = [
+                    {"Key": key, "Size": len(body)}
+                    for (bucket, key), body in sorted(client.objects.items())
+                    if bucket == Bucket and key.startswith(Prefix)
+                ]
+                yield {"Contents": contents}
+
+        return Paginator()
+
+
+def _patch_workflow_s3(monkeypatch: pytest.MonkeyPatch, fake_s3: FakeWorkflowS3) -> None:
+    monkeypatch.setattr("npa.orchestration.skypilot.workflow_state.boto3.client", lambda *args, **kwargs: fake_s3)
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.workflow_state.resolve_project_storage",
+        lambda project=None: StorageConfig(checkpoint_bucket="", endpoint_url=""),
+    )
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.workflow_state.load_credentials",
+        lambda: SimpleNamespace(
+            s3_access_key_id="test-access",
+            s3_secret_access_key="test-secret",
+            s3_endpoint="https://storage.example",
+            s3_bucket="",
+        ),
+    )
+
+
+def test_workflow_s3_config_uses_nebius_mount_for_nebius_endpoint() -> None:
+    state = WorkflowS3Config(
+        bucket="bucket",
+        prefix="run-1",
+        endpoint_url="https://storage.eu-north1.nebius.cloud",
+        aws_access_key_id="access",
+        aws_secret_access_key="secret",
+    )
+
+    assert state.uri == "s3://bucket/run-1"
+    assert state.sky_mount_source == "nebius://bucket"
+    assert state.sky_mount_store == "NEBIUS"
 
 
 def test_workflow_run_dispatches(mocker) -> None:
@@ -86,6 +148,60 @@ def test_workbench_workflow_submit_dispatches_skypilot(mocker, tmp_path) -> None
     assert submit_mock.call_args.args == (yaml_path, "run-1")
     assert submit_mock.call_args.kwargs["timeout"] == 30
     assert submit_mock.call_args.kwargs["secret_envs"] == ["AWS_ACCESS_KEY_ID"]
+
+
+def test_workbench_workflow_submit_instruments_durable_s3(monkeypatch, mocker, tmp_path) -> None:
+    fake_s3 = FakeWorkflowS3()
+    _patch_workflow_s3(monkeypatch, fake_s3)
+    yaml_path = tmp_path / "workflow.yaml"
+    yaml_path.write_text(
+        "name: demo\nexecution: serial\n---\nname: train\nresources:\n  cloud: kubernetes\nrun: |\n  echo HF_TOKEN=hf_testsecret123456\n",
+        encoding="utf-8",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_submit_workflow(path, run_id, **kwargs):
+        captured["content"] = path.read_text(encoding="utf-8")
+        captured["run_id"] = run_id
+        captured["kwargs"] = kwargs
+        return WorkflowResult(status="SUBMITTED", job_id="42", returncode=0)
+
+    mocker.patch("npa.orchestration.skypilot.workflow.submit_workflow", side_effect=fake_submit_workflow)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(yaml_path),
+            "--run-id",
+            "run-1",
+            "--durable-s3",
+            "--s3-bucket",
+            "bucket",
+            "--s3-endpoint",
+            "https://storage.example",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "run_prefix_uri: s3://bucket/run-1" in result.output
+    assert captured["run_id"] == "run-1"
+    kwargs = captured["kwargs"]
+    assert kwargs["extra_env"]["AWS_ACCESS_KEY_ID"] == "test-access"
+    assert kwargs["extra_env"]["AWS_SECRET_ACCESS_KEY"] == "test-secret"
+    assert "AWS_ACCESS_KEY_ID" in kwargs["secret_envs"]
+    assert "AWS_SECRET_ACCESS_KEY" in kwargs["secret_envs"]
+    docs = [doc for doc in yaml.safe_load_all(str(captured["content"])) if doc]
+    task = docs[1]
+    assert task["file_mounts"]["/mnt/npa-workflow-state"]["source"] == "s3://bucket"
+    assert task["file_mounts"]["/mnt/npa-workflow-state"]["mode"] == "MOUNT"
+    assert task["envs"]["NPA_WORKFLOW_RUN_PREFIX_URI"] == "s3://bucket/run-1"
+    assert "npa_workflow_redact_stream" in task["run"]
+    manifest = json.loads(fake_s3.objects[("bucket", "run-1/manifest.json")].decode("utf-8"))
+    assert manifest["sky_job_id"] == "42"
+    assert manifest["stages"]["train"]["log_uri"] == "s3://bucket/run-1/logs/train/run.log"
 
 
 def test_workbench_workflow_submit_substitutes_vars(mocker, tmp_path) -> None:
@@ -399,6 +515,67 @@ def test_workflow_logs_prints_stage_logs(mocker) -> None:
 
     assert result.exit_code == 0
     assert "stage log text" in result.output
+
+
+def test_durable_workflow_status_logs_and_artifacts_read_s3(monkeypatch) -> None:
+    fake_s3 = FakeWorkflowS3()
+    _patch_workflow_s3(monkeypatch, fake_s3)
+    manifest = {
+        "schema_version": 1,
+        "run_id": "run-1",
+        "workflow_name": "demo",
+        "run_prefix_uri": "s3://bucket/run-1",
+        "sky_job_id": "42",
+        "stages": {
+            "train": {
+                "name": "train",
+                "sky_job_id": "42",
+                "log_uri": "s3://bucket/run-1/logs/train/run.log",
+                "status_uri": "s3://bucket/run-1/logs/train/status.json",
+                "artifact_uri": "s3://bucket/run-1/artifacts/train/",
+            }
+        },
+    }
+    status = {
+        "schema_version": 1,
+        "run_id": "run-1",
+        "stage": "train",
+        "state": "SUCCEEDED",
+        "tier": "WORKS",
+        "start_time": "2026-06-07T00:00:00Z",
+        "end_time": "2026-06-07T00:00:01Z",
+        "sky_job_id": "42",
+        "sky_task_id": "0",
+        "artifact_uri": "s3://bucket/run-1/artifacts/train/",
+        "log_uri": "s3://bucket/run-1/logs/train/run.log",
+        "error_summary": "",
+    }
+    fake_s3.put_object(Bucket="bucket", Key="run-1/manifest.json", Body=json.dumps(manifest).encode("utf-8"))
+    fake_s3.put_object(Bucket="bucket", Key="run-1/logs/train/status.json", Body=json.dumps(status).encode("utf-8"))
+    fake_s3.put_object(Bucket="bucket", Key="run-1/logs/train/run.log", Body=b"training complete\n")
+    fake_s3.put_object(Bucket="bucket", Key="run-1/artifacts/train/model.bin", Body=b"model")
+
+    status_result = runner.invoke(
+        app,
+        ["workbench", "workflow", "status", "s3://bucket/run-1", "--json"],
+    )
+    logs_result = runner.invoke(
+        app,
+        ["workbench", "workflow", "logs", "s3://bucket/run-1", "--stage", "train"],
+    )
+    artifacts_result = runner.invoke(
+        app,
+        ["workbench", "workflow", "artifacts", "s3://bucket/run-1"],
+    )
+
+    assert status_result.exit_code == 0
+    payload = json.loads(status_result.output)
+    assert payload["status"] == "SUCCEEDED"
+    assert payload["stages"]["train"]["tier"] == "WORKS"
+    assert logs_result.exit_code == 0
+    assert "training complete" in logs_result.output
+    assert artifacts_result.exit_code == 0
+    assert "s3://bucket/run-1/artifacts/train/model.bin" in artifacts_result.output
 
 
 def test_workflow_logs_maps_distillation_error(mocker) -> None:

--- a/npa/tests/e2e/test_workflow_durable_s3_e2e.py
+++ b/npa/tests/e2e/test_workflow_durable_s3_e2e.py
@@ -1,0 +1,617 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import pytest
+import boto3
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError
+
+from npa.clients.config import resolve_project_storage
+from npa.clients.credentials import load_credentials, storage_endpoint_url
+from npa.orchestration.skypilot.workflow_state import redact_text
+
+
+pytestmark = [pytest.mark.e2e, pytest.mark.e2e_skypilot]
+
+ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_ENDPOINT = "https://storage.eu-north1.nebius.cloud"
+DEFAULT_KUBE_CONTEXT = "npa-rtxpro-mk8s"
+SECRET_HF_MARKER = "hf_npae2eworkflowsecret1234567890"
+SECRET_AWS_MARKER = "AKIAABCDEFGHIJKLMNOP"
+
+
+def test_workbench_workflow_durable_s3_monitor_live(
+    tmp_path: Path,
+    e2e_project: str | None,
+) -> None:
+    """Submit a tiny managed workflow and verify durable S3 state after teardown."""
+
+    _require_live_mode()
+    sky_bin = _sky_bin()
+    cli_bin = _npa_bin()
+    kube_context = os.environ.get("NPA_E2E_KUBECONTEXT", DEFAULT_KUBE_CONTEXT)
+    kubeconfig = _kubeconfig_for_context(kube_context)
+    _assert_kube_context_ready(kube_context, kubeconfig)
+
+    endpoint = _s3_endpoint(e2e_project)
+    credentials_env = _s3_credentials_env(e2e_project)
+    s3_client = _s3_client(endpoint, credentials_env)
+    bucket, parent_prefix, cleanup_bucket = _workflow_bucket_and_prefix()
+    _ensure_bucket(s3_client, bucket)
+    run_id = f"workflow-s3-e2e-{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{uuid.uuid4().hex[:8]}"
+    run_prefix = "/".join(part for part in (parent_prefix, run_id) if part).strip("/")
+    run_uri = f"s3://{bucket}/{run_prefix}/"
+    evidence_dir = Path(
+        os.environ.get("NPA_E2E_WORKFLOW_S3_EVIDENCE_DIR", f"/tmp/npa-workflow-s3-e2e-{run_id}")
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    isolated_sky_dir = tmp_path / "sky-state"
+    yaml_path = tmp_path / "durable-workflow.yaml"
+    yaml_path.write_text(_workflow_yaml(), encoding="utf-8")
+    env = {**os.environ, **credentials_env, "NO_COLOR": "1"}
+    if kubeconfig is not None:
+        env["KUBECONFIG"] = str(kubeconfig)
+
+    submit_cmd = [
+        cli_bin,
+        "workbench",
+        "workflow",
+        "submit",
+        str(yaml_path),
+        "--run-id",
+        run_id,
+        "--durable-s3",
+        "--workflow-s3-uri",
+        run_uri,
+        "--s3-endpoint",
+        endpoint,
+        "--sky-bin",
+        sky_bin,
+        "--isolated-config-dir",
+        str(isolated_sky_dir),
+        "--infra",
+        f"k8s/{kube_context}",
+        "--submit-timeout",
+        os.environ.get("NPA_E2E_WORKFLOW_S3_SUBMIT_TIMEOUT_SECONDS", "1800"),
+        "--output-format",
+        "json",
+    ]
+
+    job_id = ""
+    terminal = False
+    teardown_done = False
+    attempts: list[dict[str, Any]] = []
+    try:
+        submit = _run(submit_cmd, env=env, cwd=ROOT, timeout=2400)
+        _write_command_evidence(evidence_dir, "submit", submit, submit_cmd, credentials_env)
+        assert submit.returncode == 0, redact_text(submit.stdout + submit.stderr, credentials_env.values())
+        submit_payload = json.loads(submit.stdout)
+        job_id = str(submit_payload.get("job_id") or "")
+        assert job_id
+        assert submit_payload["log_paths"]["run_prefix_uri"] == run_uri.rstrip("/")
+
+        status_payload = _poll_status(
+            cli_bin=cli_bin,
+            sky_bin=sky_bin,
+            run_uri=run_uri,
+            endpoint=endpoint,
+            env=env,
+            evidence_dir=evidence_dir,
+            attempts=attempts,
+        )
+        terminal = status_payload["status"] == "SUCCEEDED"
+        assert terminal, json.dumps(status_payload, indent=2)
+
+        sky_env = _isolated_sky_env(env, isolated_sky_dir)
+        _sky_down_and_poll(sky_bin, run_id, evidence_dir=evidence_dir, env=sky_env)
+        teardown_done = True
+
+        manifest = _get_json(s3_client, bucket, f"{run_prefix}/manifest.json")
+        stage_status = _get_json(s3_client, bucket, f"{run_prefix}/logs/smoke/status.json")
+        run_log = _get_text(s3_client, bucket, f"{run_prefix}/logs/smoke/run.log")
+        artifact = _get_json(s3_client, bucket, f"{run_prefix}/artifacts/smoke/pod-artifact.json")
+
+        assert manifest["last_writer"] == "pod"
+        assert manifest["run_id"] == run_id
+        assert manifest["stages"]["smoke"]["sky_job_id"] == job_id
+        assert manifest["stages"]["smoke"]["log_uri"] == f"{run_uri}logs/smoke/run.log"
+        assert manifest["stages"]["smoke"]["artifact_uri"] == f"{run_uri}artifacts/smoke/"
+        assert set(stage_status) >= {
+            "state",
+            "tier",
+            "start",
+            "end",
+            "sky_job_id",
+            "artifact_uri",
+            "log_uri",
+            "error_summary",
+        }
+        assert stage_status["state"] == "SUCCEEDED"
+        assert stage_status["tier"] == "WORKS"
+        assert stage_status["sky_job_id"] == job_id
+        assert stage_status["artifact_uri"] == f"{run_uri}artifacts/smoke/"
+        assert stage_status["log_uri"] == f"{run_uri}logs/smoke/run.log"
+        assert artifact == {"run_id": run_id, "source": "pod", "stage": "smoke"}
+        assert "durable workflow smoke complete" in run_log
+        assert "<redacted>" in run_log
+        assert SECRET_HF_MARKER not in run_log
+        assert SECRET_AWS_MARKER not in run_log
+
+        no_sky = str(tmp_path / "sky-not-available")
+        post_status = _run(
+            [
+                cli_bin,
+                "workbench",
+                "workflow",
+                "status",
+                run_uri,
+                "--s3-endpoint",
+                endpoint,
+                "--sky-bin",
+                no_sky,
+                "--json",
+            ],
+            env=env,
+            cwd=ROOT,
+            timeout=300,
+        )
+        post_logs = _run(
+            [
+                cli_bin,
+                "workbench",
+                "workflow",
+                "logs",
+                run_uri,
+                "--stage",
+                "smoke",
+                "--s3-endpoint",
+                endpoint,
+            ],
+            env=env,
+            cwd=ROOT,
+            timeout=300,
+        )
+        post_artifacts = _run(
+            [
+                cli_bin,
+                "workbench",
+                "workflow",
+                "artifacts",
+                run_uri,
+                "--stage",
+                "smoke",
+                "--s3-endpoint",
+                endpoint,
+                "--json",
+            ],
+            env=env,
+            cwd=ROOT,
+            timeout=300,
+        )
+        _write_command_evidence(evidence_dir, "post-status-no-sky", post_status, [], credentials_env)
+        _write_command_evidence(evidence_dir, "post-logs", post_logs, [], credentials_env)
+        _write_command_evidence(evidence_dir, "post-artifacts", post_artifacts, [], credentials_env)
+        assert post_status.returncode == 0, redact_text(post_status.stdout + post_status.stderr)
+        post_status_payload = json.loads(post_status.stdout)
+        assert post_status_payload["status"] == "SUCCEEDED"
+        assert post_logs.returncode == 0, redact_text(post_logs.stdout + post_logs.stderr)
+        assert "durable workflow smoke complete" in post_logs.stdout
+        assert post_artifacts.returncode == 0, redact_text(post_artifacts.stdout + post_artifacts.stderr)
+        assert f"{run_uri}artifacts/smoke/pod-artifact.json" in json.loads(post_artifacts.stdout)["artifacts"]
+
+        _write_evidence(
+            evidence_dir,
+            run_id=run_id,
+            job_id=job_id,
+            run_uri=run_uri,
+            endpoint=endpoint,
+            kube_context=kube_context,
+            status=post_status_payload,
+            attempts=attempts,
+        )
+    finally:
+        if job_id and not terminal:
+            cleanup = _run(
+                [sky_bin, "jobs", "cancel", "--yes", job_id],
+                env=_isolated_sky_env(env, isolated_sky_dir),
+                cwd=ROOT,
+                timeout=900,
+                check=False,
+            )
+            _write_command_evidence(evidence_dir, "jobs-cancel", cleanup, [], credentials_env)
+        if not teardown_done:
+            _sky_down_and_poll(
+                sky_bin,
+                run_id,
+                evidence_dir=evidence_dir,
+                env=_isolated_sky_env(env, isolated_sky_dir),
+            )
+        if cleanup_bucket:
+            _delete_bucket(s3_client, bucket)
+
+
+def _require_live_mode() -> None:
+    if os.environ.get("NPA_INTEGRATION_E2E") != "1":
+        pytest.skip("NPA_INTEGRATION_E2E not set")
+    if os.environ.get("NPA_DRY_RUN") in {"1", "true", "TRUE"}:
+        pytest.skip("durable workflow S3 e2e requires live writes")
+
+
+def _workflow_bucket_and_prefix() -> tuple[str, str, bool]:
+    configured = os.environ.get("NPA_E2E_WORKFLOW_S3_BUCKET", "").strip()
+    configured_prefix = os.environ.get("NPA_E2E_WORKFLOW_S3_PREFIX", "").strip("/")
+    if configured:
+        parsed = urlparse(configured.rstrip("/"))
+        if parsed.scheme == "s3":
+            prefix = configured_prefix or parsed.path.strip("/") or "npa-workflow-e2e"
+            return parsed.netloc, prefix, False
+        return configured, configured_prefix or "npa-workflow-e2e", False
+    timestamp = time.strftime("%Y%m%dt%H%M%Sz", time.gmtime())
+    bucket = f"npa-e2e-test-workflow-s3-{timestamp}"
+    return bucket[:63].strip("-"), configured_prefix or "npa-workflow-e2e", True
+
+
+def _s3_endpoint(project: str | None) -> str:
+    storage = resolve_project_storage(project)
+    credentials = load_credentials()
+    endpoint = storage_endpoint_url(
+        storage.endpoint_url
+        or credentials.s3_endpoint
+        or os.environ.get("AWS_ENDPOINT_URL", "")
+        or os.environ.get("NEBIUS_S3_ENDPOINT", "")
+        or DEFAULT_ENDPOINT
+    )
+    if not endpoint:
+        pytest.skip("S3 endpoint is not configured")
+    return endpoint
+
+
+def _s3_credentials_env(project: str | None) -> dict[str, str]:
+    storage = resolve_project_storage(project)
+    credentials = load_credentials()
+    access_key = (
+        storage.aws_access_key_id
+        or credentials.s3_access_key_id
+        or os.environ.get("AWS_ACCESS_KEY_ID", "")
+    )
+    secret_key = (
+        storage.aws_secret_access_key
+        or credentials.s3_secret_access_key
+        or os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+    )
+    if not access_key or not secret_key:
+        pytest.skip("S3 credentials are not configured")
+    return {
+        "AWS_ACCESS_KEY_ID": access_key,
+        "AWS_SECRET_ACCESS_KEY": secret_key,
+    }
+
+
+def _s3_client(endpoint: str, credentials_env: dict[str, str]):
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=credentials_env["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=credentials_env["AWS_SECRET_ACCESS_KEY"],
+        config=BotoConfig(signature_version="s3v4"),
+    )
+
+
+def _ensure_bucket(client: Any, bucket: str) -> None:
+    try:
+        client.head_bucket(Bucket=bucket)
+    except ClientError:
+        client.create_bucket(Bucket=bucket)
+    key = "preflight/workflow-state-write-check.txt"
+    client.put_object(Bucket=bucket, Key=key, Body=b"workflow state preflight\n")
+    body = client.get_object(Bucket=bucket, Key=key)["Body"].read()
+    assert body == b"workflow state preflight\n"
+
+
+def _delete_bucket(client: Any, bucket: str) -> None:
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket):
+        objects = [{"Key": item["Key"]} for item in page.get("Contents", [])]
+        if objects:
+            client.delete_objects(Bucket=bucket, Delete={"Objects": objects})
+    try:
+        client.delete_bucket(Bucket=bucket)
+    except ClientError:
+        pass
+
+
+def _workflow_yaml() -> str:
+    return f"""name: durable-s3-smoke
+execution: serial
+---
+name: smoke
+resources:
+  cloud: kubernetes
+  cpus: 1
+  memory: 2
+  image_id: docker:python:3.11-slim
+run: |
+  set -euo pipefail
+  echo "pod-host=$(hostname)"
+  echo "HF_TOKEN={SECRET_HF_MARKER}"
+  echo "AWS_ACCESS_KEY_ID={SECRET_AWS_MARKER}"
+  artifact_dir="$NPA_WORKFLOW_MOUNT_ROOT/$NPA_WORKFLOW_S3_PREFIX/artifacts/$NPA_WORKFLOW_STAGE"
+  mkdir -p "$artifact_dir"
+  printf '{{"run_id":"%s","source":"pod","stage":"%s"}}\\n' \\
+    "$NPA_WORKFLOW_RUN_ID" "$NPA_WORKFLOW_STAGE" > "$artifact_dir/pod-artifact.json"
+  test -s "$artifact_dir/pod-artifact.json"
+  echo "durable workflow smoke complete"
+"""
+
+
+def _poll_status(
+    *,
+    cli_bin: str,
+    sky_bin: str,
+    run_uri: str,
+    endpoint: str,
+    env: dict[str, str],
+    evidence_dir: Path,
+    attempts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    deadline = time.monotonic() + int(os.environ.get("NPA_E2E_WORKFLOW_S3_TIMEOUT_SECONDS", "3600"))
+    attempt = 0
+    while time.monotonic() < deadline:
+        attempt += 1
+        result = _run(
+            [
+                cli_bin,
+                "workbench",
+                "workflow",
+                "status",
+                run_uri,
+                "--s3-endpoint",
+                endpoint,
+                "--sky-bin",
+                sky_bin,
+                "--json",
+            ],
+            env=env,
+            cwd=ROOT,
+            timeout=300,
+        )
+        _write_command_evidence(evidence_dir, f"status-{attempt:03d}", result, [], {})
+        if result.returncode == 0:
+            payload = json.loads(result.stdout)
+            attempts.append({"attempt": attempt, "status": payload.get("status")})
+            if payload.get("status") in {"SUCCEEDED", "FAILED", "CANCELLED"}:
+                return payload
+        else:
+            attempts.append(
+                {
+                    "attempt": attempt,
+                    "returncode": result.returncode,
+                    "stderr": redact_text(result.stderr),
+                }
+            )
+        time.sleep(float(os.environ.get("NPA_E2E_WORKFLOW_S3_POLL_SECONDS", "20")))
+    pytest.fail(f"workflow did not finish before timeout; evidence={evidence_dir}")
+
+
+def _kubeconfig_for_context(context: str) -> Path | None:
+    configured = os.environ.get("NPA_E2E_KUBECONFIG", "")
+    if configured:
+        path = Path(configured)
+        if not path.exists():
+            pytest.skip(f"NPA_E2E_KUBECONFIG does not exist: {path}")
+        return path
+    cached = Path.home() / ".npa" / "clusters" / context / "kubeconfig"
+    return cached if cached.exists() else None
+
+
+def _assert_kube_context_ready(context: str, kubeconfig: Path | None) -> None:
+    kubectl = shutil.which("kubectl")
+    if kubectl is None:
+        pytest.skip("kubectl is required for durable workflow S3 e2e")
+    cmd = [kubectl]
+    if kubeconfig is not None:
+        cmd.extend(["--kubeconfig", str(kubeconfig)])
+    cmd.extend(["--context", context, "get", "nodes", "-o", "json"])
+    result = subprocess.run(
+        cmd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"Kubernetes context is not ready: {context}")
+    payload = json.loads(result.stdout)
+    schedulable_gpu_capacity = 0
+    for node in payload.get("items", []):
+        spec = node.get("spec", {})
+        if spec.get("unschedulable"):
+            continue
+        capacity = node.get("status", {}).get("capacity", {})
+        for key, value in capacity.items():
+            if "nvidia.com/gpu" in key.lower():
+                schedulable_gpu_capacity += int(value)
+    required = int(os.environ.get("NPA_E2E_WORKFLOW_S3_MIN_SCHEDULABLE_GPUS", "16"))
+    if schedulable_gpu_capacity < required:
+        pytest.skip(
+            f"{context} has {schedulable_gpu_capacity} schedulable GPUs; requires {required}"
+        )
+
+
+def _sky_bin() -> str:
+    sky_bin = os.environ.get("NPA_SKYPILOT_BIN", "/home/ubuntu/.npa/skypilot-venv/bin/sky")
+    if not Path(sky_bin).exists():
+        pytest.skip(f"SkyPilot binary not found: {sky_bin}")
+    return sky_bin
+
+
+def _npa_bin() -> str:
+    configured = os.environ.get("NPA_E2E_CLI_BIN", "")
+    if configured:
+        return configured
+    candidate = Path(sys.executable).with_name("npa")
+    if candidate.exists():
+        return str(candidate)
+    resolved = shutil.which("npa")
+    if resolved:
+        return resolved
+    pytest.skip("npa CLI executable not found")
+
+
+def _isolated_sky_env(env: dict[str, str], isolated_sky_dir: Path) -> dict[str, str]:
+    home = isolated_sky_dir / "home"
+    runtime = isolated_sky_dir / "sky-runtime"
+    home.mkdir(parents=True, exist_ok=True)
+    runtime.mkdir(parents=True, exist_ok=True)
+    return {
+        **env,
+        "HOME": str(home),
+        "SKY_RUNTIME_DIR": str(runtime),
+        "PYTHONUNBUFFERED": "1",
+    }
+
+
+def _run(
+    cmd: list[str],
+    *,
+    env: dict[str, str],
+    cwd: Path,
+    timeout: int,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def _sky_down_and_poll(
+    sky_bin: str,
+    cluster: str,
+    *,
+    evidence_dir: Path,
+    env: dict[str, str],
+) -> None:
+    down = subprocess.run(
+        [sky_bin, "down", "--yes", cluster],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=int(os.environ.get("NPA_E2E_WORKFLOW_S3_TEARDOWN_TIMEOUT_SECONDS", "900")),
+        check=False,
+    )
+    (evidence_dir / f"{cluster}.down.stdout.txt").write_text(
+        redact_text(down.stdout),
+        encoding="utf-8",
+    )
+    (evidence_dir / f"{cluster}.down.stderr.txt").write_text(
+        redact_text(down.stderr),
+        encoding="utf-8",
+    )
+    deadline = time.monotonic() + int(
+        os.environ.get("NPA_E2E_WORKFLOW_S3_TEARDOWN_POLL_TIMEOUT_SECONDS", "1200")
+    )
+    while time.monotonic() < deadline:
+        status = subprocess.run(
+            [sky_bin, "status", "--refresh"],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=300,
+            check=False,
+        )
+        combined = status.stdout + status.stderr
+        (evidence_dir / f"{cluster}.status-after-down.txt").write_text(
+            redact_text(combined),
+            encoding="utf-8",
+        )
+        if cluster not in status.stdout:
+            return
+        time.sleep(float(os.environ.get("NPA_E2E_WORKFLOW_S3_TEARDOWN_POLL_SECONDS", "30")))
+    pytest.fail(f"SkyPilot cluster still present after teardown timeout: {cluster}")
+
+
+def _get_json(client: Any, bucket: str, key: str) -> dict[str, Any]:
+    text = _get_text(client, bucket, key)
+    payload = json.loads(text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _get_text(client: Any, bucket: str, key: str) -> str:
+    response = client.get_object(Bucket=bucket, Key=key)
+    return response["Body"].read().decode("utf-8")
+
+
+def _write_command_evidence(
+    evidence_dir: Path,
+    name: str,
+    result: subprocess.CompletedProcess[str],
+    cmd: list[str],
+    secrets: dict[str, str] | Any,
+) -> None:
+    payload = {
+        "command": _redact_cmd(cmd),
+        "returncode": result.returncode,
+        "stdout": redact_text(result.stdout, list(secrets.values()) if isinstance(secrets, dict) else None),
+        "stderr": redact_text(result.stderr, list(secrets.values()) if isinstance(secrets, dict) else None),
+    }
+    (evidence_dir / f"{name}.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _redact_cmd(cmd: list[str]) -> list[str]:
+    redacted: list[str] = []
+    for part in cmd:
+        if part.endswith("/sky"):
+            redacted.append("<sky>")
+        else:
+            redacted.append(part)
+    return redacted
+
+
+def _write_evidence(
+    evidence_dir: Path,
+    *,
+    run_id: str,
+    job_id: str,
+    run_uri: str,
+    endpoint: str,
+    kube_context: str,
+    status: dict[str, Any],
+    attempts: list[dict[str, Any]],
+) -> None:
+    payload = {
+        "run_id": run_id,
+        "sky_job_id": job_id,
+        "run_prefix_uri": run_uri,
+        "s3_endpoint": endpoint,
+        "kube_context": kube_context,
+        "status": status,
+        "attempts": attempts,
+    }
+    (evidence_dir / "workflow-durable-s3-evidence.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/npa/tests/orchestration/skypilot/test_workflow.py
+++ b/npa/tests/orchestration/skypilot/test_workflow.py
@@ -244,6 +244,41 @@ def test_submit_workflow_passes_configured_secret_env_names(monkeypatch, tmp_pat
     assert "AWS_SECRET_ACCESS_KEY" not in cmd
 
 
+def test_submit_workflow_secrets_can_come_from_extra_env(monkeypatch, tmp_path) -> None:
+    yaml_path = tmp_path / "workflow.yaml"
+    yaml_path.write_text("name: demo\n", encoding="utf-8")
+    sky_bin = _fake_sky(tmp_path)
+    calls = []
+    captured_env = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs["env"])
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 10\n", stderr="")
+
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    submit_workflow(
+        yaml_path,
+        "run-config-secrets",
+        isolated_config_dir=tmp_path / "sky-state",
+        sky_bin=sky_bin,
+        infra="k8s/npa-rtxpro-mk8s",
+        secret_envs=("AWS_ACCESS_KEY_ID",),
+        extra_env={"AWS_ACCESS_KEY_ID": "from-config"},
+    )
+
+    cmd = calls[0]
+    assert "--infra" in cmd
+    assert cmd[cmd.index("--infra") + 1] == "k8s/npa-rtxpro-mk8s"
+    assert ["--secret", "AWS_ACCESS_KEY_ID"] == cmd[cmd.index("--secret") : cmd.index("--secret") + 2]
+    assert "from-config" not in cmd
+    assert captured_env["AWS_ACCESS_KEY_ID"] == "from-config"
+
+
 def test_submit_workflow_honors_isolated_config_dir(monkeypatch, tmp_path) -> None:
     yaml_path = tmp_path / "workflow.yaml"
     yaml_path.write_text("name: demo\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

- Add durable S3 workflow state/log instrumentation for `npa workbench workflow submit --durable-s3`.
- Add `npa workbench workflow list/status/logs/artifacts/cancel` S3 monitor paths plus SDK workflow helpers.
- Add a committed live e2e test that submits a tiny real workflow, validates pod-written S3 state/log/artifact objects, checks redaction, reads status/logs/artifacts after teardown with no `sky`, and cleans up resources.

## Tier

WORKS as of 2026-06-07T06:05:34Z UTC.

## Live Verification

- Live e2e command passed: `NPA_INTEGRATION_E2E=1 ... python -m pytest npa/tests/e2e/test_workflow_durable_s3_e2e.py -q -s`
- Runtime: 181.13s.
- Run ID: `workflow-s3-e2e-20260607T060342Z-e895d255`.
- SkyPilot managed job ID: `3`.
- Evidence directory: `/tmp/npa-workflow-s3-p0-live-20260607T000000Z`.
- Evidence files show `manifest.json`, `logs/smoke/status.json`, redacted `logs/smoke/run.log`, and `artifacts/smoke/pod-artifact.json` under the dedicated Nebius S3 run prefix.
- Post-teardown `status --json`, `logs`, and `artifacts` reads succeeded with `--sky-bin` pointed at a nonexistent binary for the status check.
- Cleanup verified: `sky status --refresh` reported no clusters, no in-progress managed jobs, and no live services; `skypilot-system` had no remaining SkyPilot resources after cleanup.

## Local Checks

- `python -m pytest npa/tests/cli/test_workflow_cli.py npa/tests/orchestration/skypilot/test_workflow.py npa/tests/cli/test_workflow_shim.py npa/tests/test_sdk_surface.py -q` -> 62 passed.
- `python -m ruff check ...` -> passed.
- `NPA_INTEGRATION_E2E=0 python -m pytest npa/tests/e2e/test_workflow_durable_s3_e2e.py -q` -> skipped cleanly.
