### PR TITLE
Build and validate sm120 runtime images

### DIFF
--- a/docs/security/image-reproducibility.md
+++ b/docs/security/image-reproducibility.md
@@ -34,14 +34,14 @@ npa-published runtime images use two tag families:
 
 - `cuda12`: CUDA 12.x runtime for H200, L40S, A100, and earlier supported GPUs.
   This is the production tag family for current H200/L40S validation.
-- `cuda13-b300`: CUDA 13.x runtime for future B300/Blackwell GPUs. This is not
-  production-ready until upstream Taichi and flash-attn Blackwell support is
-  stable and the target fleet has a CUDA 13-compatible host driver.
+- `cuda13-b300`: CUDA 13.x runtime for Blackwell validation images, including
+  B300 and RTX PRO 6000 `sm_120` targets. Production readiness still depends on
+  each upstream framework and the target fleet's CUDA 13-compatible host driver.
 
 Customers should select the tag family by target GPU:
 
 - H200 / L40S: `cuda12`
-- Future B300: `cuda13-b300` when that path is declared stable
+- B300 / RTX PRO 6000 Blackwell: `cuda13-b300` when that path is declared stable
 
 The canonical mapping is maintained in `npa/docker/workbench/tags.yaml`, and CI runs
 `npa/docker/workbench/check_tag_consistency.py` to reject tag-family drift.

--- a/docs/workbench/sm120-image-catalog.md
+++ b/docs/workbench/sm120-image-catalog.md
@@ -1,0 +1,67 @@
+# sm_120 Image Catalog
+
+This catalog records the first-party images used for RTX PRO 6000 Blackwell
+(`sm_120`) validation. The registry IDs can be replaced with a customer registry
+when rebuilding the same Dockerfiles.
+
+Manifest source: `npa/docker/workbench/sm120-images.json`.
+
+## Required Images
+
+| Image | Tag | Purpose |
+| --- | --- | --- |
+| `npa-base` | `cuda13-b300-sm80-sm90-sm120-latest` | CUDA 13 / PyTorch 2.9 base with sm_120-capable runtime dependencies. |
+| `npa-genesis` | `0.4.6-sm80-sm90-sm120-latest` | Genesis and Sim2Real base layered on the sm_120 runtime. |
+| `npa-sim2real-envgen` | `0.1.1` | Sim2Real environment generation. |
+| `npa-sim2real-reference-policy` | `0.1.1` | Reference BYO-compatible action policy. |
+| `npa-sim2real-eval` | `0.1.0` | Sim2Real evaluation. |
+| `npa-lerobot-vlm-rl` | `0.1.0` | LeRobot VLM/RL runtime layered on the sm_120 Genesis base. |
+| `npa-cosmos3-reason` | `3.0.0` | Cosmos3 reasoning on the sm_120 CUDA 13 base. |
+| `npa-sonic` | `0.1.2-k8s-runtime` | SONIC Kubernetes runtime using GPU-operator-mounted NVIDIA driver libraries. |
+
+## Build Commands
+
+Build the base image:
+
+```bash
+npa/docker/workbench/base/cuda13-b300/build.sh \
+  --registry "${NPA_REGISTRY}" \
+  --tag sm80-sm90-sm120-<timestamp> \
+  --push
+```
+
+Build the Genesis sm_120 image:
+
+```bash
+npa/docker/workbench/genesis/build_sm120.sh \
+  --base-image "${NPA_REGISTRY}/npa-base:cuda13-b300-sm80-sm90-sm120-latest" \
+  --registry "${NPA_REGISTRY}" \
+  --tag 0.4.6-sm80-sm90-sm120-<timestamp> \
+  --push
+```
+
+Build the Sim2Real and Cosmos3 images:
+
+```bash
+BASE_IMAGE="${NPA_REGISTRY}/npa-base:cuda13-b300-sm80-sm90-sm120-latest" \
+GENESIS_IMAGE="${NPA_REGISTRY}/npa-genesis:0.4.6-sm80-sm90-sm120-latest" \
+npa/docker/workbench/sim2real-build.sh --registry "${NPA_REGISTRY}" --push
+```
+
+Build the SONIC RTX PRO 6000 Kubernetes runtime:
+
+```bash
+npa/docker/workbench/sonic/build.sh \
+  --registry "${NPA_REGISTRY}" \
+  --variant k8s \
+  --tag 0.1.2-k8s-runtime \
+  --push
+```
+
+## Live Smoke
+
+Live validation should run on a Kubernetes cluster with schedulable RTX PRO 6000
+GPUs and assert `torch.cuda.get_device_capability() == (12, 0)` for the images
+that carry PyTorch. SONIC uses `/isaac-sim/python.sh` for the same torch check.
+After validation, explicitly tear down the SkyPilot job cluster and confirm no
+clusters, managed jobs, or services remain.

--- a/npa/docker/workbench/cosmos3-reason/Dockerfile
+++ b/npa/docker/workbench/cosmos3-reason/Dockerfile
@@ -16,6 +16,8 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /workspace
 
+USER root
+
 COPY --chown=ubuntu:ubuntu pyproject.toml /opt/npa/pyproject.toml
 COPY --chown=ubuntu:ubuntu src/npa /opt/npa/src/npa
 
@@ -31,7 +33,7 @@ RUN mkdir -p /models/cosmos-reason1 \
       "transformers>=4.51,<5" \
     && python -m pip install --no-deps -e /opt/npa \
     && python -m py_compile /opt/npa/src/npa/workflows/sim2real_loop.py \
-    && chown -R ubuntu:ubuntu /workspace /models/cosmos-reason1
+    && chown -R ubuntu:ubuntu /workspace /models/cosmos-reason1 /opt/npa/src /opt/npa/pyproject.toml
 
 USER ubuntu
 

--- a/npa/docker/workbench/genesis/Dockerfile.sm120
+++ b/npa/docker/workbench/genesis/Dockerfile.sm120
@@ -1,0 +1,83 @@
+# Additive Blackwell Genesis image. This Dockerfile is intentionally separate
+# from the proven CUDA 12.4 npa-genesis:0.4.6 path so sm_120 validation never
+# overwrites the production tag.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG BASE_IMAGE
+ARG GENESIS_VERSION=0.4.6
+ARG LEROBOT_VERSION=0.4.4
+ARG RSL_RL_VERSION=2.2.4
+
+LABEL npa.tool="genesis" \
+      npa.version="${GENESIS_VERSION}" \
+      npa.image.flavor="sm80-sm90-sm120" \
+      npa.base.image="${BASE_IMAGE}"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    GENESIS_VERSION=${GENESIS_VERSION} \
+    LEROBOT_VERSION=${LEROBOT_VERSION} \
+    MUJOCO_GL=egl \
+    PYOPENGL_PLATFORM=egl \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    NPA_GENESIS_HOME=/opt/genesis \
+    NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility \
+    EGL_PLATFORM=device \
+    PATH=/opt/npa/venv/bin:$PATH \
+    PYTHONPATH=/opt/npa/src
+
+SHELL ["/bin/bash", "-lc"]
+
+USER root
+
+RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 ubuntu; \
+    install -d -m 0755 -o ubuntu -g ubuntu \
+      /opt/genesis \
+      /opt/genesis/outputs \
+      /opt/npa/src/npa \
+      /opt/npa/docker/workbench/genesis; \
+    groupadd -g 44 video 2>/dev/null || true; \
+    groupadd -g 992 render 2>/dev/null || true; \
+    usermod -aG video,render ubuntu
+
+RUN python -m pip install --upgrade pip setuptools wheel \
+    && python -m pip install \
+      "genesis-world==${GENESIS_VERSION}" \
+      "rsl-rl-lib==${RSL_RL_VERSION}" \
+      "tensorboard==2.20.0" \
+      "lerobot==${LEROBOT_VERSION}" \
+      "typer==0.24.1" \
+      "httpx==0.28.1" \
+      "paramiko==4.0.0" \
+      "pyyaml==6.0.3" \
+      "rich==15.0.0" \
+      "boto3==1.42.91" \
+      "jinja2==3.1.6" \
+      "pyarrow==22.0.0"
+
+COPY --chown=ubuntu:ubuntu pyproject.toml /opt/npa/pyproject.toml
+COPY --chown=ubuntu:ubuntu src/npa /opt/npa/src/npa
+COPY --chown=ubuntu:ubuntu docker/workbench/genesis/smoke_env.py /opt/npa/docker/workbench/genesis/smoke_env.py
+COPY --chown=ubuntu:ubuntu docker/workbench/genesis/smoke_functional.py /opt/npa/docker/workbench/genesis/smoke_functional.py
+
+RUN python -m pip install --no-deps -e /opt/npa \
+    && python - <<'PY'
+import os
+from importlib import metadata
+
+import genesis
+import torch
+
+expected = os.environ["GENESIS_VERSION"]
+actual = getattr(genesis, "__version__", metadata.version("genesis-world"))
+if actual != expected:
+    raise RuntimeError(f"expected genesis-world {expected}, found {actual}")
+print(f"GENESIS_BUILD_IMPORT_OK {actual}")
+print(f"TORCH_BUILD_CUDA {torch.__version__} cuda={torch.version.cuda}")
+PY
+
+USER ubuntu
+WORKDIR /opt/genesis
+ENTRYPOINT ["/bin/bash"]

--- a/npa/docker/workbench/genesis/build_sm120.sh
+++ b/npa/docker/workbench/genesis/build_sm120.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+NPA_DIR="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+
+REGISTRY=""
+BASE_IMAGE=""
+TAG=""
+PUSH=0
+
+usage() {
+  cat <<'EOF'
+Usage: build_sm120.sh --base-image IMAGE [--registry REGISTRY] [--tag TAG] [--push]
+
+Builds an additive Genesis image for Blackwell sm_120 validation. The default
+tag is npa-genesis:0.4.6-sm80-sm90-sm120-<UTC>. Registry pushes use the same
+tag under REGISTRY/npa-genesis.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-image)
+      BASE_IMAGE="${2:?missing --base-image value}"
+      shift 2
+      ;;
+    --registry)
+      REGISTRY="${2:?missing --registry value}"
+      shift 2
+      ;;
+    --tag)
+      TAG="${2:?missing --tag value}"
+      shift 2
+      ;;
+    --push)
+      PUSH=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${BASE_IMAGE}" ]]; then
+  echo "--base-image is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ -z "${TAG}" ]]; then
+  TAG="0.4.6-sm80-sm90-sm120-$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+
+LOCAL_IMAGE="npa-genesis:${TAG}"
+BUILD_ARGS=(
+  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+  -f "${SCRIPT_DIR}/Dockerfile.sm120"
+  -t "${LOCAL_IMAGE}"
+)
+
+if [[ -n "${REGISTRY}" ]]; then
+  REGISTRY_IMAGE="${REGISTRY}/npa-genesis:${TAG}"
+  BUILD_ARGS+=(-t "${REGISTRY_IMAGE}")
+fi
+
+docker build "${BUILD_ARGS[@]}" "${NPA_DIR}"
+
+if [[ "${PUSH}" == "1" ]]; then
+  if [[ -z "${REGISTRY}" ]]; then
+    echo "--push requires --registry" >&2
+    exit 2
+  fi
+  docker push "${REGISTRY_IMAGE}"
+  echo "${REGISTRY_IMAGE}"
+else
+  echo "${LOCAL_IMAGE}"
+fi

--- a/npa/docker/workbench/lerobot-vlm-rl/Dockerfile
+++ b/npa/docker/workbench/lerobot-vlm-rl/Dockerfile
@@ -7,9 +7,11 @@ LABEL npa.tool="lerobot-vlm-rl" \
       npa.version="${LEROBOT_VLM_RL_VERSION}"
 
 ENV PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/opt/npa/src:$PYTHONPATH
+    PYTHONPATH=/opt/npa/src
 
 WORKDIR /workspace
+
+USER root
 
 COPY --chown=ubuntu:ubuntu pyproject.toml /opt/npa/pyproject.toml
 COPY --chown=ubuntu:ubuntu src/npa /opt/npa/src/npa
@@ -27,7 +29,7 @@ payload = {
 assert parse_vlm_signal_batch(payload)[0].rollout_id == "build-smoke"
 PY
 
-RUN chown -R ubuntu:ubuntu /workspace /opt/npa
+RUN chown -R ubuntu:ubuntu /workspace /opt/npa/src /opt/npa/pyproject.toml
 
 USER ubuntu
 

--- a/npa/docker/workbench/sim2real-eval/Dockerfile
+++ b/npa/docker/workbench/sim2real-eval/Dockerfile
@@ -13,6 +13,8 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /workspace
 
+USER root
+
 COPY --chown=ubuntu:ubuntu pyproject.toml /opt/npa/pyproject.toml
 COPY --chown=ubuntu:ubuntu src/npa /opt/npa/src/npa
 
@@ -22,7 +24,7 @@ RUN python -m pip install tomli \
     && python -m pip install --no-deps -e /opt/npa \
     && python -m py_compile /opt/npa/src/npa/workflows/sim2real_loop.py \
     && python -c "from npa.genesis.env_pick_place import EnvConfig, FrankaPickPlaceEnv; assert EnvConfig(action_space='cartesian').action_space == 'cartesian'; assert FrankaPickPlaceEnv.__name__ == 'FrankaPickPlaceEnv'" \
-    && chown -R ubuntu:ubuntu /workspace
+    && chown -R ubuntu:ubuntu /workspace /opt/npa/src /opt/npa/pyproject.toml
 
 USER ubuntu
 

--- a/npa/docker/workbench/sm120-images.json
+++ b/npa/docker/workbench/sm120-images.json
@@ -1,0 +1,63 @@
+{
+  "format": "npa_sm120_image_manifest_v1",
+  "as_of": "2026-06-07T06:51:11Z",
+  "registry": "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw",
+  "target": {
+    "gpu": "RTX PRO 6000 Blackwell",
+    "compute_capability": "sm_120"
+  },
+  "images": [
+    {
+      "name": "npa-base",
+      "tag": "cuda13-b300-sm80-sm90-sm120-latest",
+      "source_tag": "cuda13-b300-sm80-sm90-sm120-20260605T203555Z",
+      "digest": "sha256:629bb75b4b763ff99a164f66fb029c5b82178ab19c21c7d82e063b7f0c60090e",
+      "purpose": "CUDA 13/PyTorch 2.9 base with sm_120-capable runtime dependencies."
+    },
+    {
+      "name": "npa-genesis",
+      "tag": "0.4.6-sm80-sm90-sm120-latest",
+      "source_tag": "0.4.6-sm80-sm90-sm120-20260605T205847Z",
+      "digest": "sha256:88d1a9d7eea8ba03a5988b24c5b25f2e698585b78036f09d7929479a42a12ba9",
+      "purpose": "Genesis/Sim2Real base layered on the sm_120 CUDA 13 runtime."
+    },
+    {
+      "name": "npa-sim2real-envgen",
+      "tag": "0.1.1",
+      "source_tag": "0.1.1-sm120-20260605T2248Z",
+      "digest": "sha256:c1593689b1df1d5eaac6c6c130cd28589038c40645a06aaea310c989631c738e",
+      "purpose": "Sim2Real environment generation image."
+    },
+    {
+      "name": "npa-sim2real-reference-policy",
+      "tag": "0.1.1",
+      "source_tag": "0.1.1-sm120-20260605T2248Z",
+      "digest": "sha256:0f0523d8964f98bc7be77962d96217095c3cff90b0dd19d4c94e6e4b367f3cec",
+      "purpose": "Reference BYO-compatible Sim2Real action policy image."
+    },
+    {
+      "name": "npa-sim2real-eval",
+      "tag": "0.1.0",
+      "digest": "sha256:d38e06dd07fa47f0d30be1efce5b80e249feb04423013fcc6b53706ed38a1a03",
+      "purpose": "Sim2Real evaluation image."
+    },
+    {
+      "name": "npa-lerobot-vlm-rl",
+      "tag": "0.1.0",
+      "digest": "sha256:1500fea2eae5dd9520942339405161bb148fe0bd093e888645b7389c69347dfc",
+      "purpose": "LeRobot VLM/RL image layered on the sm_120 Genesis runtime."
+    },
+    {
+      "name": "npa-cosmos3-reason",
+      "tag": "3.0.0",
+      "digest": "sha256:d862dfd5371b4f73255acefabfe70d1932e57fec61f980ae5c855c62ec10022d",
+      "purpose": "Cosmos3 reasoning image layered on the sm_120 CUDA 13 runtime."
+    },
+    {
+      "name": "npa-sonic",
+      "tag": "0.1.2-k8s-runtime",
+      "digest": "sha256:f58443705a1d98303d52526dc27dc3918d374afb1de563bd0f34d5fa5187eabf",
+      "purpose": "SONIC host-mounted-driver Kubernetes runtime for RTX PRO 6000."
+    }
+  ]
+}

--- a/npa/docker/workbench/tags.yaml
+++ b/npa/docker/workbench/tags.yaml
@@ -16,9 +16,11 @@ tag_families:
     status: production
 
   cuda13-b300:
-    description: CUDA 13.x runtime for B300 and future Blackwell GPUs
+    description: CUDA 13.x runtime for Blackwell validation images
     gpu_targets:
       - B300
+      - RTX PRO 6000
+      - sm_120
     cuda_version: "13.x"
     pytorch_version_min: "2.9"
     status: blocked-on-upstream

--- a/npa/tests/test_sm120_image_manifest.py
+++ b/npa/tests/test_sm120_image_manifest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_sm120_image_manifest_has_required_images() -> None:
+    manifest_path = Path(__file__).resolve().parents[1] / "docker" / "workbench" / "sm120-images.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["format"] == "npa_sm120_image_manifest_v1"
+    assert manifest["target"]["compute_capability"] == "sm_120"
+    assert "cluster_context" not in manifest["target"]
+
+    images = {(item["name"], item["tag"]): item for item in manifest["images"]}
+    expected = {
+        ("npa-base", "cuda13-b300-sm80-sm90-sm120-latest"),
+        ("npa-genesis", "0.4.6-sm80-sm90-sm120-latest"),
+        ("npa-sim2real-envgen", "0.1.1"),
+        ("npa-sim2real-reference-policy", "0.1.1"),
+        ("npa-sim2real-eval", "0.1.0"),
+        ("npa-lerobot-vlm-rl", "0.1.0"),
+        ("npa-cosmos3-reason", "3.0.0"),
+        ("npa-sonic", "0.1.2-k8s-runtime"),
+    }
+
+    assert set(images) == expected
+    for image in images.values():
+        assert image["digest"].startswith("sha256:")
+        assert image["purpose"]


### PR DESCRIPTION
## Summary
- add a committed sm_120 image manifest and catalog for the first-party Blackwell runtime images
- add an additive Genesis sm_120 Dockerfile/build helper
- patch the Cosmos3, LeRobot VLM/RL, and Sim2Real eval Dockerfiles so build-time installs run as root while runtime remains `ubuntu`
- refresh the CUDA 13 tag-family docs for RTX PRO 6000 / `sm_120`

## Tier
PARTIAL.

The image objective itself is working: the required images are built/pushed and digest-pinned live Kubernetes jobs ran a CUDA kernel successfully on RTX PRO 6000 GPUs. The remaining seam is SkyPilot queue execution with private registry images: direct `sky launch` still fails before the user command during SkyPilot runtime setup, even with an explicit one-secret pod config, and earlier managed-job attempts were cancelled cleanly after private image pull setup failures.

## Live evidence
As of 2026-06-07 UTC:

- Rebuilt and pushed:
  - `npa-cosmos3-reason:3.0.0@sha256:d862dfd5371b4f73255acefabfe70d1932e57fec61f980ae5c855c62ec10022d`
  - `npa-lerobot-vlm-rl:0.1.0@sha256:1500fea2eae5dd9520942339405161bb148fe0bd093e888645b7389c69347dfc`
  - `npa-sim2real-eval:0.1.0@sha256:d38e06dd07fa47f0d30be1efce5b80e249feb04423013fcc6b53706ed38a1a03`
- Verified by digest-pinned Kubernetes Jobs on RTX PRO 6000: `npa-base`, `npa-genesis`, `npa-sim2real-envgen`, `npa-sim2real-reference-policy`, `npa-sim2real-eval`, `npa-lerobot-vlm-rl`, `npa-cosmos3-reason`, and `npa-sonic` all printed `SM120_KERNEL_OK` with compute capability `(12, 0)`.
- SONIC uses `/isaac-sim/python.sh` for the torch kernel smoke; bare `python` is not present in that runtime image.
- Clean teardown completed: all sm_120 Kubernetes Jobs were deleted, the temporary registry pull secret was removed, the default service account was restored, and the SkyPilot controller/cluster resources were torn down.

## Tests
- `npa/.venv/bin/python -m pytest npa/tests/test_sm120_image_manifest.py npa/tests/test_deploy_images.py -q`
- `npa/.venv/bin/python npa/docker/workbench/check_tag_consistency.py`
- `npa/.venv/bin/python -m ruff check npa/tests/test_sm120_image_manifest.py`
- `git diff --cached --check`
- `gitleaks protect --staged --redact --verbose`
