### PR TITLE
Disable SkyPilot jobs controller autostop

### DIFF
--- a/docs/orchestration/skypilot-setup.md
+++ b/docs/orchestration/skypilot-setup.md
@@ -56,7 +56,14 @@ jobs:
       cloud: kubernetes
       cpus: 4
       memory: 16
+      autostop: false
 ```
+
+`autostop: false` is deliberate. Workbench and SONIC submissions generate a
+per-submit `SKYPILOT_GLOBAL_CONFIG`, so the generated config must carry the
+jobs-controller resource autostop policy instead of relying on the runner's
+default `~/.sky/config.yaml`. This keeps fresh managed-job submits from racing a
+shared controller that is already entering `AUTOSTOPPING`.
 
 Do not set `disk_size` for this controller mode. SkyPilot 0.12.2's Kubernetes
 backend does not apply custom controller disk sizing; it uses the cluster's

--- a/npa/src/npa/orchestration/skypilot/controller.py
+++ b/npa/src/npa/orchestration/skypilot/controller.py
@@ -22,7 +22,7 @@ DEFAULT_CONTROLLER_INSTANCE_TYPE = "cpu-e2_2vcpu-8gb"
 DEFAULT_CONTROLLER_CPUS = 2
 DEFAULT_CONTROLLER_MEMORY_GB = 8
 DEFAULT_CONTROLLER_DISK_SIZE_GB = 64
-DEFAULT_CONTROLLER_AUTOSTOP_IDLE_MINUTES = 5
+DEFAULT_JOBS_CONTROLLER_AUTOSTOP = False
 
 
 def controller_resources_kubernetes() -> dict[str, Any]:
@@ -32,6 +32,7 @@ def controller_resources_kubernetes() -> dict[str, Any]:
         "cloud": "kubernetes",
         "cpus": DEFAULT_K8S_CONTROLLER_CPUS,
         "memory": DEFAULT_K8S_CONTROLLER_MEMORY_GB,
+        "autostop": DEFAULT_JOBS_CONTROLLER_AUTOSTOP,
     }
 
 
@@ -45,10 +46,7 @@ def controller_resources_nebius_vm() -> dict[str, Any]:
         "cpus": DEFAULT_CONTROLLER_CPUS,
         "memory": DEFAULT_CONTROLLER_MEMORY_GB,
         "disk_size": DEFAULT_CONTROLLER_DISK_SIZE_GB,
-        "autostop": {
-            "idle_minutes": DEFAULT_CONTROLLER_AUTOSTOP_IDLE_MINUTES,
-            "down": False,
-        },
+        "autostop": DEFAULT_JOBS_CONTROLLER_AUTOSTOP,
     }
 
 
@@ -78,6 +76,7 @@ def apply_controller_override(
     default = _controller_resources_for_backend(controller_backend)
 
     if isinstance(existing, dict) and _is_at_least_default(existing, default):
+        existing["autostop"] = DEFAULT_JOBS_CONTROLLER_AUTOSTOP
         return updated
 
     merged = deepcopy(default)
@@ -87,11 +86,9 @@ def apply_controller_override(
                 key: value
                 for key, value in existing.items()
                 if key not in _unsupported_override_keys(controller_backend)
-                and not (controller_backend == "nebius" and key == "autostop")
             }
         )
-        if controller_backend == "nebius":
-            merged["autostop"] = _safe_autostop(existing.get("autostop"))
+        merged["autostop"] = DEFAULT_JOBS_CONTROLLER_AUTOSTOP
         if not _is_at_least_default(merged, default):
             merged = default
 
@@ -121,8 +118,7 @@ def _is_at_least_default(resources: dict[str, Any], default: dict[str, Any]) -> 
         if actual is None or minimum is None or actual < minimum:
             return False
     if "autostop" in default:
-        autostop = resources.get("autostop")
-        if isinstance(autostop, dict) and autostop.get("down") is True:
+        if resources.get("autostop") is not DEFAULT_JOBS_CONTROLLER_AUTOSTOP:
             return False
     return True
 
@@ -139,15 +135,8 @@ def _compatible_controller_cloud(resources: dict[str, Any], default: dict[str, A
 
 def _unsupported_override_keys(controller_backend: ControllerBackend) -> set[str]:
     if controller_backend == "kubernetes":
-        return {"autostop", "disk_size"}
+        return {"disk_size"}
     return set()
-
-
-def _safe_autostop(value: Any) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        return controller_resources_nebius_vm()["autostop"]
-    idle_minutes = value.get("idle_minutes", DEFAULT_CONTROLLER_AUTOSTOP_IDLE_MINUTES)
-    return {"idle_minutes": idle_minutes, "down": False}
 
 
 def _number(value: Any) -> float | None:

--- a/npa/src/npa/orchestration/skypilot/workflow.py
+++ b/npa/src/npa/orchestration/skypilot/workflow.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Sequence
@@ -28,6 +29,10 @@ from npa.orchestration.skypilot.controller import (
     ControllerBackend,
     apply_controller_override,
 )
+
+
+JOBS_CONTROLLER_PREFIX = "sky-jobs-controller-"
+HEALTHY_CONTROLLER_STATUS = "UP"
 
 
 @dataclass
@@ -62,6 +67,8 @@ def submit_workflow(
     controller_backend: ControllerBackend = DEFAULT_CONTROLLER_BACKEND,
     secret_envs: Sequence[str] | None = None,
     timeout: int = 1800,
+    controller_preflight_timeout: int = 300,
+    controller_preflight_interval: float = 15.0,
 ) -> WorkflowResult:
     """Submit a SkyPilot YAML through NPA's controller convention."""
 
@@ -106,6 +113,12 @@ def submit_workflow(
                 cmd[-1:-1] = ["--secret", secret_name]
         env = sky_environment(runtime_config.isolated_config_dir)
         env["SKYPILOT_GLOBAL_CONFIG"] = str(generated_config_path)
+        _wait_for_healthy_jobs_controller(
+            sky_executable,
+            env=env,
+            timeout=controller_preflight_timeout,
+            interval=controller_preflight_interval,
+        )
         result = subprocess.run(
             cmd,
             env=env,
@@ -132,6 +145,9 @@ def submit_workflow(
     except subprocess.TimeoutExpired as exc:
         _cleanup_owned_submission_dir(owned_submission_dir)
         raise SkyPilotSubmitError(f"sky jobs launch timed out after {timeout}s") from exc
+    except SkyPilotSubmitError:
+        _cleanup_owned_submission_dir(owned_submission_dir)
+        raise
     except (
         OSError,
         ValueError,
@@ -193,6 +209,61 @@ def workflow_status(
     )
 
 
+def _wait_for_healthy_jobs_controller(
+    sky_executable: str,
+    *,
+    env: dict[str, str],
+    timeout: int,
+    interval: float,
+) -> None:
+    """Block launch while an existing managed-jobs controller is not ready."""
+
+    deadline = time.monotonic() + max(timeout, 0)
+    last_summary = ""
+    while True:
+        result = subprocess.run(
+            [sky_executable, "status", "--refresh", "--output", "json"],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=min(max(timeout, 1), 300),
+            check=False,
+        )
+        if result.returncode != 0:
+            raise SkyPilotSubmitError(f"SkyPilot controller health check failed: {_command_detail(result)}")
+        controllers = _jobs_controller_statuses(result.stdout)
+        unhealthy = [
+            (name, status)
+            for name, status in controllers
+            if status.upper() != HEALTHY_CONTROLLER_STATUS
+        ]
+        if not unhealthy:
+            return
+        last_summary = ", ".join(f"{name}={status or 'UNKNOWN'}" for name, status in unhealthy)
+        if time.monotonic() >= deadline:
+            raise SkyPilotSubmitError(f"SkyPilot jobs controller not healthy before launch: {last_summary}")
+        time.sleep(max(interval, 0.1))
+
+
+def _jobs_controller_statuses(output: str) -> list[tuple[str, str]]:
+    try:
+        payload = json.loads(output or "[]")
+    except json.JSONDecodeError as exc:
+        raise SkyPilotSubmitError("SkyPilot controller health check returned non-json output") from exc
+    clusters = payload if isinstance(payload, list) else payload.get("clusters", [])
+    controllers = []
+    for cluster in clusters or []:
+        if not isinstance(cluster, dict):
+            continue
+        name = str(cluster.get("name") or cluster.get("cluster") or "")
+        if not name.startswith(JOBS_CONTROLLER_PREFIX):
+            continue
+        status = str(cluster.get("status") or cluster.get("cluster_status") or "")
+        controllers.append((name, status.upper()))
+    return controllers
+
+
 def _load_yaml_documents(path: Path) -> list[dict[str, Any]]:
     with path.open("r", encoding="utf-8") as handle:
         docs = [doc for doc in yaml.safe_load_all(handle) if doc is not None]
@@ -239,9 +310,13 @@ def _cleanup_owned_submission_dir(path: Path | None) -> None:
 
 
 def _format_submit_error(cmd: list[str], result: subprocess.CompletedProcess[str]) -> str:
-    detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+    detail = _command_detail(result)
     prefix = "SkyPilot auth failure during jobs launch" if _looks_like_auth_error(detail) else "sky jobs launch failed"
     return f"{prefix}: {' '.join(cmd)}: {detail}"
+
+
+def _command_detail(result: subprocess.CompletedProcess[str]) -> str:
+    return result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
 
 
 def _looks_like_auth_error(detail: str) -> bool:

--- a/npa/tests/orchestration/skypilot/test_controller.py
+++ b/npa/tests/orchestration/skypilot/test_controller.py
@@ -16,6 +16,7 @@ def test_default_controller_resources_returns_kubernetes_default() -> None:
         "cloud": "kubernetes",
         "cpus": 4,
         "memory": 16,
+        "autostop": False,
     }
     assert "disk_size" not in resources
 
@@ -30,7 +31,7 @@ def test_nebius_vm_controller_resources_remain_available() -> None:
         "cpus": 2,
         "memory": 8,
         "disk_size": 64,
-        "autostop": {"idle_minutes": 5, "down": False},
+        "autostop": False,
     }
 
 
@@ -62,7 +63,10 @@ def test_apply_controller_override_preserves_explicitly_larger_kubernetes_contro
         }
     }
 
-    assert apply_controller_override(existing) == existing
+    config = apply_controller_override(existing)
+
+    expected = {**existing["jobs"]["controller"]["resources"], "autostop": False}
+    assert config["jobs"]["controller"]["resources"] == expected
 
 
 def test_apply_controller_override_drops_kubernetes_disk_size() -> None:
@@ -101,4 +105,26 @@ def test_apply_controller_override_preserves_explicitly_larger_nebius_controller
         }
     }
 
-    assert apply_controller_override(existing, controller_backend="nebius") == existing
+    config = apply_controller_override(existing, controller_backend="nebius")
+
+    expected = {**existing["jobs"]["controller"]["resources"], "autostop": False}
+    assert config["jobs"]["controller"]["resources"] == expected
+
+
+def test_apply_controller_override_disables_existing_controller_autostop() -> None:
+    config = apply_controller_override(
+        {
+            "jobs": {
+                "controller": {
+                    "autostop": 10,
+                    "resources": {
+                        "cloud": "kubernetes",
+                        "cpus": 4,
+                        "memory": 16,
+                    },
+                }
+            }
+        }
+    )
+
+    assert config["jobs"]["controller"]["resources"]["autostop"] is False

--- a/npa/tests/orchestration/skypilot/test_workflow.py
+++ b/npa/tests/orchestration/skypilot/test_workflow.py
@@ -73,6 +73,7 @@ def test_submit_workflow_loads_yaml_applies_controller_and_calls_subprocess(monk
         "cloud": "kubernetes",
         "cpus": 4,
         "memory": 16,
+        "autostop": False,
     }
 
 
@@ -170,7 +171,7 @@ def test_submit_workflow_can_emit_nebius_controller_fallback(monkeypatch, tmp_pa
     resources = config["jobs"]["controller"]["resources"]
     assert resources["cloud"] == "nebius"
     assert resources["instance_type"] == "cpu-e2_2vcpu-8gb"
-    assert resources["autostop"]["down"] is False
+    assert resources["autostop"] is False
 
 
 def test_submit_workflow_passes_configured_secret_env_names(monkeypatch, tmp_path) -> None:

--- a/npa/tests/orchestration/skypilot/test_workflow.py
+++ b/npa/tests/orchestration/skypilot/test_workflow.py
@@ -26,6 +26,14 @@ def _fake_sky(tmp_path: Path) -> Path:
     return sky
 
 
+def _is_status_cmd(cmd: list[str]) -> bool:
+    return len(cmd) >= 2 and cmd[1] == "status"
+
+
+def _healthy_status(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(cmd, 0, stdout="[]", stderr="")
+
+
 @pytest.fixture(autouse=True)
 def _skip_version_check(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(workflow_module, "ensure_skypilot_version", lambda sky_bin: Path(sky_bin))
@@ -43,6 +51,8 @@ def test_submit_workflow_loads_yaml_applies_controller_and_calls_subprocess(monk
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs))
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 42\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -51,7 +61,8 @@ def test_submit_workflow_loads_yaml_applies_controller_and_calls_subprocess(monk
 
     assert result.status == "SUBMITTED"
     assert result.job_id == "42"
-    cmd, kwargs = calls[0]
+    assert calls[0][0] == [str(sky_bin), "status", "--refresh", "--output", "json"]
+    cmd, kwargs = calls[1]
     assert cmd[:5] == [str(sky_bin), "jobs", "launch", "--name", "run-abc"]
     assert "--config" not in cmd
     assert "--detach-run" in cmd
@@ -71,6 +82,8 @@ def test_submit_workflow_network_failure_raises_typed_error(monkeypatch, tmp_pat
     sky_bin = _fake_sky(tmp_path)
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="network connection failed")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -85,6 +98,8 @@ def test_submit_workflow_auth_failure_raises_typed_error(monkeypatch, tmp_path) 
     sky_bin = _fake_sky(tmp_path)
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="Authentication failed: credentials expired")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -118,6 +133,8 @@ def test_submit_workflow_cleans_owned_temp_dir_on_timeout(monkeypatch, tmp_path)
         return str(owned_dir)
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
 
     monkeypatch.setattr(workflow_module.tempfile, "mkdtemp", fake_mkdtemp)
@@ -135,6 +152,8 @@ def test_submit_workflow_can_emit_nebius_controller_fallback(monkeypatch, tmp_pa
     sky_bin = _fake_sky(tmp_path)
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 12\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -161,6 +180,8 @@ def test_submit_workflow_passes_configured_secret_env_names(monkeypatch, tmp_pat
     calls = []
 
     def fake_run(cmd, **kwargs):
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         calls.append(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 10\n", stderr="")
 
@@ -190,6 +211,8 @@ def test_submit_workflow_honors_isolated_config_dir(monkeypatch, tmp_path) -> No
 
     def fake_run(cmd, **kwargs):
         captured_env.update(kwargs["env"])
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 9", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -198,6 +221,40 @@ def test_submit_workflow_honors_isolated_config_dir(monkeypatch, tmp_path) -> No
 
     assert captured_env["HOME"] == str(tmp_path / "isolated" / "home")
     assert captured_env["SKY_RUNTIME_DIR"] == str(tmp_path / "isolated" / "sky-runtime")
+
+
+def test_submit_workflow_blocks_unhealthy_existing_jobs_controller(monkeypatch, tmp_path) -> None:
+    yaml_path = tmp_path / "workflow.yaml"
+    yaml_path.write_text("name: demo\n", encoding="utf-8")
+    sky_bin = _fake_sky(tmp_path)
+    owned_dir = tmp_path / "owned-autostop-submission"
+    calls = []
+
+    def fake_mkdtemp(prefix: str) -> str:
+        owned_dir.mkdir()
+        return str(owned_dir)
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if _is_status_cmd(cmd):
+            stdout = '[{"name": "sky-jobs-controller-64ce57a0", "status": "AUTOSTOPPING"}]'
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+        raise AssertionError("launch should be blocked until controller is healthy")
+
+    monkeypatch.setattr(workflow_module.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(SkyPilotSubmitError, match="sky-jobs-controller-64ce57a0=AUTOSTOPPING"):
+        submit_workflow(
+            yaml_path,
+            "run-autostop",
+            sky_bin=sky_bin,
+            controller_preflight_timeout=0,
+            controller_preflight_interval=0,
+        )
+
+    assert calls == [[str(sky_bin), "status", "--refresh", "--output", "json"]]
+    assert not owned_dir.exists()
 
 
 def test_workflow_status_reads_json_queue(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- restores the pre-submit SkyPilot jobs-controller health guard from the SONIC runtime branch
- disables jobs-controller autostop in generated SkyPilot controller resources with the non-deprecated resources.autostop key
- documents why generated SONIC/Workbench submit configs must carry the controller autostop policy

## Verification
- PYTHONPATH=npa/src /tmp/sonic-skypilot-npa-venv/bin/python -m pytest npa/tests/orchestration/skypilot/test_controller.py npa/tests/orchestration/skypilot/test_workflow.py
- live controller check: sky-jobs-controller-64ce57a0 was UP with autostop disabled; CPU no-op managed-job submit reached Managed Job ID 5 without AUTOSTOPPING

## Recommendation
Keep the shared controller for now, with autostop disabled and the pre-submit health guard. Move to an isolated SONIC controller only if shared-controller contention or policy isolation becomes more important than the extra controller cost and operational surface.