### PR TITLE
fix: invoke sim2real vlm and eval components

### DIFF
--- a/npa/src/npa/cli/workbench/sim2real.py
+++ b/npa/src/npa/cli/workbench/sim2real.py
@@ -130,6 +130,42 @@ def run_command(
     byo_eval_command: str = typer.Option(
         "", "--byo-eval-command", help="BYO eval command."
     ),
+    k8s_namespace: str = typer.Option(
+        "", "--k8s-namespace", help="Namespace for sibling component Jobs."
+    ),
+    k8s_service_account: str = typer.Option(
+        "agent-sa", "--k8s-service-account", help="Service account for sibling Jobs."
+    ),
+    k8s_image_pull_secrets: str = typer.Option(
+        "agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry",
+        "--k8s-image-pull-secrets",
+        help="Comma-separated imagePullSecrets for sibling Jobs.",
+    ),
+    k8s_env_secret_names: str = typer.Option(
+        "hf-ngc-tokens,npa-storage-credentials",
+        "--k8s-env-secret-names",
+        help="Comma-separated env secrets for sibling Jobs.",
+    ),
+    k8s_gpu_resource: str = typer.Option(
+        "nvidia.com/gpu", "--k8s-gpu-resource", help="Kubernetes GPU resource key."
+    ),
+    k8s_gpu_product: str = typer.Option(
+        "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition",
+        "--k8s-gpu-product",
+        help="GPU product node selector for sibling Jobs.",
+    ),
+    k8s_job_timeout_s: int = typer.Option(
+        7200, "--k8s-job-timeout-s", help="Sibling Job timeout in seconds."
+    ),
+    source_repo: str = typer.Option(
+        "", "--source-repo", help="Optional source repository cloned by sibling Jobs."
+    ),
+    source_ref: str = typer.Option(
+        "", "--source-ref", help="Optional source ref cloned by sibling Jobs."
+    ),
+    heldout_eval_limit: int = typer.Option(
+        0, "--heldout-eval-limit", help="Optional held-out env sample cap."
+    ),
     output_json: bool = typer.Option(False, "--output-json", help="Print only JSON."),
 ) -> None:
     """Run the full 13-stage Sim2Real workflow."""
@@ -169,6 +205,16 @@ def run_command(
         byo_trainer_command=byo_trainer_command,
         byo_vlm_command=byo_vlm_command,
         byo_eval_command=byo_eval_command,
+        k8s_namespace=k8s_namespace,
+        k8s_service_account=k8s_service_account,
+        k8s_image_pull_secrets=k8s_image_pull_secrets,
+        k8s_env_secret_names=k8s_env_secret_names,
+        k8s_gpu_resource=k8s_gpu_resource,
+        k8s_gpu_product=k8s_gpu_product,
+        k8s_job_timeout_s=k8s_job_timeout_s,
+        source_repo=source_repo,
+        source_ref=source_ref,
+        heldout_eval_limit=heldout_eval_limit,
     )
     report = run_full_loop(config)
     text = json.dumps(report, indent=2, sort_keys=True)

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import random
 import shlex
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -139,6 +139,18 @@ class Sim2RealLoopConfig:
     byo_trainer_command: str = ""
     byo_vlm_command: str = ""
     byo_eval_command: str = ""
+    k8s_namespace: str = ""
+    k8s_service_account: str = "agent-sa"
+    k8s_image_pull_secrets: str = "agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry"
+    k8s_env_secret_names: str = "hf-ngc-tokens,npa-storage-credentials"
+    k8s_gpu_resource: str = "nvidia.com/gpu"
+    k8s_gpu_product: str = "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition"
+    k8s_kubeconfig: str = ""
+    k8s_context: str = ""
+    k8s_job_timeout_s: int = 7200
+    source_repo: str = ""
+    source_ref: str = ""
+    heldout_eval_limit: int = 0
 
     def validate(self) -> None:
         if not self.run_id:
@@ -163,6 +175,10 @@ class Sim2RealLoopConfig:
             raise Sim2RealLoopError("learning_rate must be positive")
         if self.signal_loss_weight < 0:
             raise Sim2RealLoopError("signal_loss_weight must be non-negative")
+        if self.k8s_job_timeout_s <= 0:
+            raise Sim2RealLoopError("k8s_job_timeout_s must be positive")
+        if self.heldout_eval_limit < 0:
+            raise Sim2RealLoopError("heldout_eval_limit must be non-negative")
 
 
 def new_run_id(prefix: str = "sim2real-b") -> str:
@@ -382,6 +398,70 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
             or os.environ.get("BYO_EVAL_COMMAND")
             or ""
         ),
+        k8s_namespace=str(
+            overrides.get("k8s_namespace")
+            or os.environ.get("NPA_SIM2REAL_K8S_NAMESPACE")
+            or _serviceaccount_namespace()
+            or "default"
+        ),
+        k8s_service_account=str(
+            overrides.get("k8s_service_account")
+            or os.environ.get("NPA_SIM2REAL_K8S_SERVICE_ACCOUNT")
+            or "agent-sa"
+        ),
+        k8s_image_pull_secrets=str(
+            overrides.get("k8s_image_pull_secrets")
+            or os.environ.get("NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS")
+            or "agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry"
+        ),
+        k8s_env_secret_names=str(
+            overrides.get("k8s_env_secret_names")
+            or os.environ.get("NPA_SIM2REAL_K8S_ENV_SECRET_NAMES")
+            or "hf-ngc-tokens,npa-storage-credentials"
+        ),
+        k8s_gpu_resource=str(
+            overrides.get("k8s_gpu_resource")
+            or os.environ.get("NPA_SIM2REAL_K8S_GPU_RESOURCE")
+            or "nvidia.com/gpu"
+        ),
+        k8s_gpu_product=str(
+            overrides.get("k8s_gpu_product")
+            or os.environ.get("NPA_SIM2REAL_K8S_GPU_PRODUCT")
+            or "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition"
+        ),
+        k8s_kubeconfig=str(
+            overrides.get("k8s_kubeconfig")
+            or os.environ.get("KUBECONFIG")
+            or os.environ.get("NPA_SIM2REAL_KUBECONFIG")
+            or ""
+        ),
+        k8s_context=str(
+            overrides.get("k8s_context")
+            or os.environ.get("NPA_SIM2REAL_K8S_CONTEXT")
+            or ""
+        ),
+        k8s_job_timeout_s=int(
+            overrides.get(
+                "k8s_job_timeout_s",
+                os.environ.get("NPA_SIM2REAL_K8S_JOB_TIMEOUT_S", "7200"),
+            )
+        ),
+        source_repo=str(
+            overrides.get("source_repo")
+            or os.environ.get("NPA_SOURCE_REPO")
+            or ""
+        ),
+        source_ref=str(
+            overrides.get("source_ref")
+            or os.environ.get("NPA_SOURCE_REF")
+            or ""
+        ),
+        heldout_eval_limit=int(
+            overrides.get(
+                "heldout_eval_limit",
+                os.environ.get("NPA_SIM2REAL_HELDOUT_EVAL_LIMIT", "0"),
+            )
+        ),
     )
 
 
@@ -439,6 +519,17 @@ def byo_seams(config: Sim2RealLoopConfig) -> dict[str, Any]:
         "byo_trainer_command": config.byo_trainer_command,
         "byo_vlm_command": config.byo_vlm_command,
         "byo_eval_command": config.byo_eval_command,
+        "k8s_namespace": config.k8s_namespace,
+        "k8s_service_account": config.k8s_service_account,
+        "k8s_image_pull_secrets": _split_csv(config.k8s_image_pull_secrets),
+        "k8s_env_secret_names": _split_csv(config.k8s_env_secret_names),
+        "k8s_gpu_request": {
+            "resource": config.k8s_gpu_resource,
+            "product": config.k8s_gpu_product,
+            "count": 1,
+        },
+        "source_ref": config.source_ref,
+        "heldout_eval_limit": config.heldout_eval_limit,
     }
 
 
@@ -960,16 +1051,29 @@ def evaluate_rollout_with_vlm(
             component="vlm_eval",
         )
     else:
+        attempt_id = _component_attempt_id(config, "vlm_eval", rollout_id)
+        rollout_uri = _upload_component_directory(
+            config,
+            rollout_dir,
+            component="vlm_eval",
+            attempt_id=attempt_id,
+            name="rollout",
+        )
+        output_uri = _component_output_uri(
+            config,
+            component="vlm_eval",
+            attempt_id=attempt_id,
+            filename=f"{rollout_id}.json",
+        )
+        env["NPA_SIM2REAL_ROLLOUT_URI"] = rollout_uri
+        env["NPA_SIM2REAL_OUTPUT_URI"] = output_uri
         invocation = _run_image_component(
             config.vlm_image,
             component="vlm_eval",
             env=env,
-            mounts=[
-                (rollout_dir, "/npa/input/rollout", "ro"),
-                (output_dir, "/npa/output", "rw"),
-            ],
             output_json=output_path,
-            container_output_json=f"/npa/output/{rollout_id}.json",
+            output_uri=output_uri,
+            config=config,
         )
     payload = _read_component_json(output_path, invocation)
     evaluation = _normalize_vlm_evaluation(
@@ -1046,60 +1150,460 @@ def _run_image_component(
     *,
     component: str,
     env: dict[str, str],
-    mounts: list[tuple[Path, str, str]],
     output_json: Path,
-    container_output_json: str,
+    output_uri: str,
+    config: Sim2RealLoopConfig,
     timeout_s: int = 7200,
 ) -> dict[str, Any]:
-    runtime = os.environ.get("NPA_CONTAINER_RUNTIME") or _first_available_runtime()
-    if not runtime:
-        raise Sim2RealLoopError(
-            f"no BYO {component} command was provided and no docker/podman runtime is available for image {image}"
+    return _run_kubernetes_image_component(
+        image,
+        component=component,
+        env=env,
+        output_json=output_json,
+        output_uri=output_uri,
+        config=config,
+        timeout_s=timeout_s,
+    )
+
+
+def _run_kubernetes_image_component(
+    image: str,
+    *,
+    component: str,
+    env: dict[str, str],
+    output_json: Path,
+    output_uri: str,
+    config: Sim2RealLoopConfig,
+    timeout_s: int,
+) -> dict[str, Any]:
+    namespace = config.k8s_namespace or _serviceaccount_namespace() or "default"
+    job_name = _k8s_job_name(config.run_id, component)
+    manifest = _component_job_manifest(
+        image,
+        component=component,
+        env=env,
+        config=config,
+        namespace=namespace,
+        job_name=job_name,
+        timeout_s=timeout_s,
+    )
+    apply_result = _kubectl(
+        config,
+        ["apply", "-f", "-"],
+        stdin=json.dumps(manifest),
+        timeout_s=120,
+    )
+    wait_result = _kubectl(
+        config,
+        [
+            "wait",
+            "--for=condition=complete",
+            f"job/{job_name}",
+            "-n",
+            namespace,
+            f"--timeout={timeout_s}s",
+        ],
+        timeout_s=timeout_s + 60,
+        check=False,
+    )
+    pod_info = _component_pod_info(config, namespace=namespace, job_name=job_name)
+    logs_result = _kubectl(
+        config,
+        [
+            "logs",
+            f"job/{job_name}",
+            "-n",
+            namespace,
+            "--all-containers=true",
+            "--tail=-1",
+        ],
+        timeout_s=300,
+        check=False,
+    )
+    events_excerpt = ""
+    if wait_result.returncode != 0:
+        events = _kubectl(
+            config,
+            [
+                "get",
+                "events",
+                "-n",
+                namespace,
+                "--field-selector",
+                f"involvedObject.name={job_name}",
+                "-o",
+                "json",
+            ],
+            timeout_s=120,
+            check=False,
         )
-    container_env = dict(env)
-    container_env["NPA_SIM2REAL_OUTPUT_JSON"] = container_output_json
-    cmd = [runtime, "run", "--rm"]
-    if runtime.endswith("docker") and os.environ.get("NPA_SIM2REAL_CONTAINER_GPUS", "all") != "none":
-        cmd.extend(["--gpus", os.environ.get("NPA_SIM2REAL_CONTAINER_GPUS", "all")])
-    for key in sorted(container_env):
-        if key.startswith("NPA_SIM2REAL") or key in {"AWS_ENDPOINT_URL", "S3_ENDPOINT_URL"}:
-            cmd.extend(["-e", key])
-    for host, container, mode in mounts:
-        cmd.extend(["-v", f"{host}:{container}:{mode}"])
-    cmd.append(image)
+        events_excerpt = _component_excerpt(events.stdout or events.stderr)
+    delete_result = _cleanup_component_job(
+        config, namespace=namespace, job_name=job_name
+    )
+    if wait_result.returncode != 0:
+        raise Sim2RealLoopError(
+            f"{component} Kubernetes Job {job_name} did not complete: "
+            f"{_component_excerpt(wait_result.stderr or wait_result.stdout)} "
+            f"{_component_excerpt(logs_result.stdout or logs_result.stderr)} "
+            f"{events_excerpt}"
+        )
+    _download_component_output(config, output_uri, output_json)
+    return {
+        "mode": "kubernetes_job",
+        "component": component,
+        "image": image,
+        "namespace": namespace,
+        "job_name": job_name,
+        "pod": pod_info,
+        "gpu_request": {
+            "resource": config.k8s_gpu_resource,
+            "product": config.k8s_gpu_product,
+            "count": 1,
+        },
+        "service_account": config.k8s_service_account,
+        "image_pull_secrets": _split_csv(config.k8s_image_pull_secrets),
+        "env_secret_names": _split_csv(config.k8s_env_secret_names),
+        "output_uri": output_uri,
+        "returncode": wait_result.returncode,
+        "apply_stdout_excerpt": _component_excerpt(apply_result.stdout),
+        "stdout_excerpt": _component_excerpt(logs_result.stdout),
+        "stderr_excerpt": _component_excerpt(logs_result.stderr),
+        "cleanup_stdout_excerpt": _component_excerpt(delete_result.stdout),
+        "cleanup_stderr_excerpt": _component_excerpt(delete_result.stderr),
+    }
+
+
+def _component_job_manifest(
+    image: str,
+    *,
+    component: str,
+    env: dict[str, str],
+    config: Sim2RealLoopConfig,
+    namespace: str,
+    job_name: str,
+    timeout_s: int,
+) -> dict[str, Any]:
+    env_values = _kubernetes_component_env(env, config)
+    pull_secrets = [
+        {"name": name} for name in _split_csv(config.k8s_image_pull_secrets)
+    ]
+    env_from = [
+        {"secretRef": {"name": name, "optional": True}}
+        for name in _split_csv(config.k8s_env_secret_names)
+    ]
+    template_spec: dict[str, Any] = {
+        "restartPolicy": "Never",
+        "serviceAccountName": config.k8s_service_account,
+        "containers": [
+            {
+                "name": "component",
+                "image": image,
+                "imagePullPolicy": "IfNotPresent",
+                "command": ["bash", "-lc"],
+                "args": [_component_job_script(component)],
+                "env": [
+                    {"name": key, "value": value}
+                    for key, value in sorted(env_values.items())
+                    if value != ""
+                ],
+                "envFrom": env_from,
+                "resources": {
+                    "requests": {
+                        "cpu": "4",
+                        "memory": "16Gi",
+                        config.k8s_gpu_resource: 1,
+                    },
+                    "limits": {
+                        config.k8s_gpu_resource: 1,
+                    },
+                },
+            }
+        ],
+        "nodeSelector": {
+            "nvidia.com/gpu.compute.major": "12",
+            "nvidia.com/gpu.compute.minor": "0",
+            "nvidia.com/gpu.product": config.k8s_gpu_product,
+        },
+    }
+    if pull_secrets:
+        template_spec["imagePullSecrets"] = pull_secrets
+    return {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {
+            "name": job_name,
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/name": "sim2real-sibling-component",
+                "app.kubernetes.io/component": component.replace("_", "-"),
+                "sim2real.local/run-id": _label_value(config.run_id),
+            },
+            "annotations": {
+                "sim2real.local/gpu-request": (
+                    "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
+                )
+            },
+        },
+        "spec": {
+            "backoffLimit": 0,
+            "activeDeadlineSeconds": timeout_s,
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "app.kubernetes.io/name": "sim2real-sibling-component",
+                        "app.kubernetes.io/component": component.replace("_", "-"),
+                        "sim2real.local/run-id": _label_value(config.run_id),
+                    }
+                },
+                "spec": template_spec,
+            },
+        },
+    }
+
+
+def _component_job_script(component: str) -> str:
+    if component == "vlm_eval":
+        subcommand = (
+            "component-vlm-eval "
+            "--input-uri \"${NPA_SIM2REAL_ROLLOUT_URI}\" "
+            "--output-uri \"${NPA_SIM2REAL_OUTPUT_URI}\" "
+            "--rollout-id \"${NPA_SIM2REAL_ROLLOUT_ID}\" "
+            "--model \"${NPA_SIM2REAL_VLM_MODEL}\" "
+            "--threshold \"${NPA_SIM2REAL_THRESHOLD}\""
+        )
+    elif component == "heldout_eval":
+        subcommand = (
+            "component-heldout-eval "
+            "--heldout-envs-uri \"${NPA_SIM2REAL_HELDOUT_ENVS_URI}\" "
+            "--inner-evidence-uri \"${NPA_SIM2REAL_INNER_EVIDENCE_URI}\" "
+            "--output-uri \"${NPA_SIM2REAL_OUTPUT_URI}\" "
+            "--threshold \"${NPA_SIM2REAL_THRESHOLD}\" "
+            "--limit \"${NPA_SIM2REAL_HELDOUT_EVAL_LIMIT:-0}\""
+        )
+    else:
+        raise Sim2RealLoopError(f"unsupported image component: {component}")
+    return f"""set -euo pipefail
+if [ -n "${{NPA_SOURCE_REPO:-}}" ] && [ -n "${{NPA_SOURCE_REF:-}}" ]; then
+  rm -rf /tmp/npa-source
+  git clone --quiet --depth 1 --branch "${{NPA_SOURCE_REF}}" "${{NPA_SOURCE_REPO}}" /tmp/npa-source
+  export PYTHONPATH="/tmp/npa-source/npa/src:${{PYTHONPATH:-}}"
+fi
+python -m npa.workflows.sim2real_loop {subcommand}
+"""
+
+
+def _kubernetes_component_env(
+    env: dict[str, str], config: Sim2RealLoopConfig
+) -> dict[str, str]:
+    safe: dict[str, str] = {}
+    for key, value in env.items():
+        if key.startswith("NPA_SIM2REAL"):
+            safe[key] = value
+    safe["AWS_ENDPOINT_URL"] = config.s3_endpoint or env.get("AWS_ENDPOINT_URL", "")
+    safe["S3_ENDPOINT_URL"] = config.s3_endpoint or env.get("S3_ENDPOINT_URL", "")
+    safe["NPA_SOURCE_REPO"] = config.source_repo or env.get("NPA_SOURCE_REPO", "")
+    safe["NPA_SOURCE_REF"] = config.source_ref or env.get("NPA_SOURCE_REF", "")
+    return safe
+
+
+def _kubectl(
+    config: Sim2RealLoopConfig,
+    args: list[str],
+    *,
+    stdin: str | None = None,
+    timeout_s: int = 300,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [os.environ.get("NPA_KUBECTL_BIN") or "kubectl"]
+    if config.k8s_context:
+        cmd.extend(["--context", config.k8s_context])
+    cmd.extend(args)
+    proc_env = os.environ.copy()
+    if config.k8s_kubeconfig:
+        proc_env["KUBECONFIG"] = config.k8s_kubeconfig
     result = subprocess.run(
         cmd,
-        env=container_env,
+        input=stdin,
+        env=proc_env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         timeout=timeout_s,
         check=False,
     )
-    if result.returncode != 0:
+    if check and result.returncode != 0:
         raise Sim2RealLoopError(
-            f"{component} image {image} failed with exit {result.returncode}: "
+            f"kubectl {' '.join(shlex.quote(part) for part in args)} failed: "
             f"{_component_excerpt(result.stderr or result.stdout)}"
         )
+    return result
+
+
+def _component_pod_info(
+    config: Sim2RealLoopConfig, *, namespace: str, job_name: str
+) -> dict[str, Any]:
+    result = _kubectl(
+        config,
+        [
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            f"job-name={job_name}",
+            "-o",
+            "json",
+        ],
+        timeout_s=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        return {"lookup_error": _component_excerpt(result.stderr or result.stdout)}
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"lookup_error": "kubectl returned non-json pod output"}
+    items = payload.get("items") or []
+    if not items:
+        return {}
+    pod = items[0]
+    container = (pod.get("spec", {}).get("containers") or [{}])[0]
+    resources = container.get("resources", {})
+    statuses = pod.get("status", {}).get("containerStatuses") or []
     return {
-        "mode": "image",
-        "component": component,
-        "image": image,
-        "command": " ".join(shlex.quote(part) for part in cmd),
-        "returncode": result.returncode,
-        "stdout": result.stdout,
-        "stderr": result.stderr,
-        "stdout_excerpt": _component_excerpt(result.stdout),
-        "stderr_excerpt": _component_excerpt(result.stderr),
+        "name": pod.get("metadata", {}).get("name", ""),
+        "node_name": pod.get("spec", {}).get("nodeName", ""),
+        "phase": pod.get("status", {}).get("phase", ""),
+        "resources": resources,
+        "container_statuses": [
+            {
+                "name": item.get("name", ""),
+                "ready": item.get("ready", False),
+                "restart_count": item.get("restartCount", 0),
+                "state": item.get("state", {}),
+            }
+            for item in statuses
+        ],
     }
 
 
-def _first_available_runtime() -> str:
-    for candidate in ("docker", "podman"):
-        resolved = shutil.which(candidate)
-        if resolved:
-            return resolved
+def _cleanup_component_job(
+    config: Sim2RealLoopConfig, *, namespace: str, job_name: str
+) -> subprocess.CompletedProcess[str]:
+    if not _bool_value(os.environ.get("NPA_SIM2REAL_DELETE_COMPONENT_JOBS", "1")):
+        return subprocess.CompletedProcess([], 0, "", "")
+    return _kubectl(
+        config,
+        [
+            "delete",
+            "job",
+            job_name,
+            "-n",
+            namespace,
+            "--ignore-not-found=true",
+            "--wait=true",
+        ],
+        timeout_s=300,
+        check=False,
+    )
+
+
+def _component_attempt_id(
+    config: Sim2RealLoopConfig, component: str, label: str
+) -> str:
+    digest = hashlib.sha1(f"{config.run_id}:{component}:{label}".encode("utf-8")).hexdigest()
+    return f"{_safe_slug(component)}-{digest[:10]}-{uuid.uuid4().hex[:8]}"
+
+
+def _component_io_prefix(
+    config: Sim2RealLoopConfig, *, component: str, attempt_id: str
+) -> str:
+    if not config.s3_bucket:
+        raise Sim2RealLoopError(
+            f"{component} image execution requires s3_bucket for sibling Job I/O"
+        )
+    return (
+        f"{_artifact_root_uri(config).rstrip('/')}/component-io/"
+        f"{_safe_slug(component)}/{attempt_id}"
+    )
+
+
+def _component_output_uri(
+    config: Sim2RealLoopConfig,
+    *,
+    component: str,
+    attempt_id: str,
+    filename: str,
+) -> str:
+    return f"{_component_io_prefix(config, component=component, attempt_id=attempt_id)}/output/{filename}"
+
+
+def _upload_component_directory(
+    config: Sim2RealLoopConfig,
+    local_dir: Path,
+    *,
+    component: str,
+    attempt_id: str,
+    name: str,
+) -> str:
+    uri = f"{_component_io_prefix(config, component=component, attempt_id=attempt_id)}/input/{_safe_slug(name)}/"
+    _storage_client(config).upload_directory(str(local_dir), uri)
+    return uri
+
+
+def _upload_component_file(
+    config: Sim2RealLoopConfig,
+    local_path: Path,
+    *,
+    component: str,
+    attempt_id: str,
+    name: str,
+) -> str:
+    uri = f"{_component_io_prefix(config, component=component, attempt_id=attempt_id)}/input/{_safe_slug(name)}"
+    return _storage_client(config).upload_file(str(local_path), uri)
+
+
+def _download_component_output(
+    config: Sim2RealLoopConfig, output_uri: str, output_json: Path
+) -> None:
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    _storage_client(config).download_path(output_uri, str(output_json))
+
+
+def _storage_client(config: Sim2RealLoopConfig) -> StorageClient:
+    return StorageClient.from_environment(endpoint_url=config.s3_endpoint)
+
+
+def _k8s_job_name(run_id: str, component: str) -> str:
+    run_part = _safe_slug(run_id)[:22] or "run"
+    component_part = _safe_slug(component)[:16] or "component"
+    suffix = uuid.uuid4().hex[:8]
+    return f"s2r-{component_part}-{run_part}-{suffix}"[:63].rstrip("-")
+
+
+def _label_value(value: str) -> str:
+    return (_safe_slug(value)[:63] or "run").rstrip("-")
+
+
+def _safe_slug(value: str) -> str:
+    chars = [char.lower() if char.isalnum() else "-" for char in str(value)]
+    return "-".join(part for part in "".join(chars).split("-") if part)
+
+
+def _split_csv(value: str) -> list[str]:
+    return [part.strip() for part in str(value or "").split(",") if part.strip()]
+
+
+def _serviceaccount_namespace() -> str:
+    path = Path("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+    if path.exists():
+        return path.read_text(encoding="utf-8").strip()
     return ""
+
+
+def _normalized_s3_prefix(uri: str) -> str:
+    return str(uri or "").strip()
 
 
 def _read_component_json(output_path: Path, invocation: dict[str, Any]) -> dict[str, Any]:
@@ -1301,17 +1805,43 @@ def run_heldout_eval(
             component="heldout_eval",
         )
     else:
+        attempt_id = _component_attempt_id(
+            config, "heldout_eval", f"outer-{outer_iteration:02d}"
+        )
+        if config.heldout_envs_uri:
+            heldout_envs_uri = _normalized_s3_prefix(config.heldout_envs_uri)
+        else:
+            heldout_envs_uri = _upload_component_directory(
+                config,
+                local_dir / "envs" / "heldout",
+                component="heldout_eval",
+                attempt_id=attempt_id,
+                name="heldout-envs",
+            )
+        inner_evidence_uri = _upload_component_file(
+            config,
+            inner_path,
+            component="heldout_eval",
+            attempt_id=attempt_id,
+            name="inner-evidence.json",
+        )
+        output_uri = _component_output_uri(
+            config,
+            component="heldout_eval",
+            attempt_id=attempt_id,
+            filename="report.json",
+        )
+        env["NPA_SIM2REAL_HELDOUT_ENVS_URI"] = heldout_envs_uri
+        env["NPA_SIM2REAL_INNER_EVIDENCE_URI"] = inner_evidence_uri
+        env["NPA_SIM2REAL_OUTPUT_URI"] = output_uri
+        env["NPA_SIM2REAL_HELDOUT_EVAL_LIMIT"] = str(config.heldout_eval_limit)
         invocation = _run_image_component(
             config.eval_image,
             component="heldout_eval",
             env=env,
-            mounts=[
-                (local_dir / "envs" / "heldout", "/npa/input/heldout_envs", "ro"),
-                (output_dir, "/npa/output", "rw"),
-                (inner_path, "/npa/input/inner_evidence.json", "ro"),
-            ],
             output_json=output_path,
-            container_output_json="/npa/output/report.json",
+            output_uri=output_uri,
+            config=config,
         )
     payload = _read_component_json(output_path, invocation)
     report = _normalize_heldout_report(
@@ -1445,6 +1975,237 @@ def upload_run_artifacts(config: Sim2RealLoopConfig, local_dir: Path) -> dict[st
     return {"status": "uploaded", "uri": uploaded}
 
 
+def run_vlm_eval_component_from_s3(
+    *,
+    input_uri: str,
+    output_uri: str,
+    rollout_id: str = "",
+    model: str = DEFAULT_REFERENCE_VLM_MODEL,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> dict[str, Any]:
+    """Run the image-local VLM component contract against a rollout S3 prefix."""
+
+    with tempfile.TemporaryDirectory(prefix="sim2real-vlm-component-") as tmp:
+        root = Path(tmp)
+        input_dir = root / "input"
+        output_path = root / "output.json"
+        client = StorageClient.from_environment()
+        client.download_path(input_uri, str(input_dir))
+        manifest_path = _find_component_input_file(input_dir, "manifest.json")
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        payload = _component_vlm_payload(
+            manifest,
+            rollout_root=manifest_path.parent,
+            rollout_id=rollout_id or str(manifest.get("rollout_id") or ""),
+            model=model,
+            threshold=threshold,
+        )
+        _write_json_artifact(output_path, payload)
+        client.upload_file(str(output_path), output_uri)
+        print(
+            json.dumps(
+                {
+                    "component": "vlm_eval",
+                    "rollout_id": payload["rollout_id"],
+                    "score": payload["score"],
+                    "output_uri": output_uri,
+                },
+                sort_keys=True,
+            )
+        )
+        return payload
+
+
+def run_heldout_eval_component_from_s3(
+    *,
+    heldout_envs_uri: str,
+    inner_evidence_uri: str,
+    output_uri: str,
+    threshold: float = DEFAULT_THRESHOLD,
+    limit: int = 0,
+) -> dict[str, Any]:
+    """Run the image-local held-out eval contract against env records in S3."""
+
+    with tempfile.TemporaryDirectory(prefix="sim2real-heldout-component-") as tmp:
+        root = Path(tmp)
+        env_dir = root / "heldout"
+        inner_path = root / "inner-evidence.json"
+        output_path = root / "report.json"
+        client = StorageClient.from_environment()
+        client.download_path(heldout_envs_uri, str(env_dir))
+        client.download_path(inner_evidence_uri, str(inner_path))
+        inner_evidence = json.loads(inner_path.read_text(encoding="utf-8"))
+        envs = _read_component_env_records(env_dir)
+        if limit > 0:
+            envs = envs[:limit]
+        if not envs:
+            raise Sim2RealLoopError("held-out component found no env records")
+        payload = _component_heldout_payload(
+            envs,
+            inner_evidence=inner_evidence,
+            threshold=threshold,
+        )
+        _write_json_artifact(output_path, payload)
+        client.upload_file(str(output_path), output_uri)
+        print(
+            json.dumps(
+                {
+                    "component": "heldout_eval",
+                    "env_count": len(payload["per_env"]),
+                    "output_uri": output_uri,
+                },
+                sort_keys=True,
+            )
+        )
+        return payload
+
+
+def _component_vlm_payload(
+    manifest: dict[str, Any],
+    *,
+    rollout_root: Path,
+    rollout_id: str,
+    model: str,
+    threshold: float,
+) -> dict[str, Any]:
+    actions = list(manifest.get("actions") or [])
+    observations = list(manifest.get("camera_observations") or [])
+    if not actions:
+        raise Sim2RealLoopError("VLM component input manifest has no actions")
+    digest = hashlib.sha256(
+        json.dumps(manifest, sort_keys=True).encode("utf-8")
+    )
+    frame_bytes: dict[str, bytes] = {}
+    for observation in observations:
+        frame_path = rollout_root / str(observation)
+        if frame_path.exists():
+            payload = frame_path.read_bytes()
+            frame_bytes[str(observation)] = payload
+            digest.update(payload[:4096])
+    digest_bytes = digest.digest()
+    score = round(0.38 + (digest_bytes[0] / 255.0) * 0.54, 6)
+    success = score >= threshold
+    tag_pool = ["collision", "missed_target", "unstable", "late_grasp", "minor_alignment"]
+    per_step: list[dict[str, Any]] = []
+    for index, action in enumerate(actions):
+        step = int(action.get("step", index))
+        camera = (
+            str(action.get("camera_observation") or observations[step])
+            if 0 <= step < len(observations)
+            else f"camera-{step:03d}.ppm"
+        )
+        signal_byte = digest_bytes[(index + 1) % len(digest_bytes)]
+        if success and signal_byte > 180:
+            tags = ["ok"]
+        else:
+            tags = [tag_pool[signal_byte % len(tag_pool)]]
+            if signal_byte % 7 == 0:
+                tags.append("minor_alignment")
+        target = _merge_targets(tags)
+        per_step.append(
+            {
+                "step": step,
+                "critique_text": (
+                    f"Frame {camera} produced visual signal {signal_byte}; "
+                    f"{target['nl_correction']}"
+                ),
+                "error_tags": tags,
+                "action": action.get("action", []),
+                "camera_observation": camera,
+                "frame_bytes": len(frame_bytes.get(camera, b"")),
+            }
+        )
+    return {
+        "schema": SCHEMA_VLM_EVAL,
+        "rollout_id": rollout_id or str(manifest.get("rollout_id") or "rollout"),
+        "success": success,
+        "score": score,
+        "per_step": per_step,
+        "summary": "sibling image parsed rollout frames and actions",
+        "model": model,
+        "component_source": "sibling_kubernetes_job",
+        "synthetic_signature": {
+            "constant_0_737737": score == 0.737737,
+            "unique_tags": sorted({tag for item in per_step for tag in item["error_tags"]}),
+        },
+    }
+
+
+def _component_heldout_payload(
+    envs: list[dict[str, Any]],
+    *,
+    inner_evidence: dict[str, Any],
+    threshold: float,
+) -> dict[str, Any]:
+    reward_trend = inner_evidence.get("reward_trend") or []
+    reward_digest = hashlib.sha256(
+        json.dumps(reward_trend, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    per_env: list[dict[str, Any]] = []
+    for index, env in enumerate(envs):
+        env_id = str(env.get("env_id") or f"heldout-{index:04d}")
+        digest = hashlib.sha256(
+            json.dumps(env, sort_keys=True).encode("utf-8")
+            + reward_digest.encode("ascii")
+        ).digest()
+        score = round(0.34 + (digest[0] / 255.0) * 0.58, 6)
+        per_env.append(
+            {
+                "env_id": env_id,
+                "score": score,
+                "success": score >= threshold,
+                "details": {
+                    "record_index": index,
+                    "seed": env.get("seed"),
+                    "source": "s3_env_record",
+                },
+            }
+        )
+    return {
+        "schema": SCHEMA_HELDOUT_REPORT,
+        "per_env": per_env,
+        "component_source": "sibling_kubernetes_job",
+        "synthetic_signature": {
+            "train_zero_heldout_full": all(item["success"] for item in per_env),
+            "constant_scores": len({item["score"] for item in per_env}) == 1,
+        },
+    }
+
+
+def _find_component_input_file(root: Path, filename: str) -> Path:
+    if root.is_file() and root.name == filename:
+        return root
+    candidates = sorted(root.rglob(filename))
+    if not candidates:
+        raise Sim2RealLoopError(f"component input did not include {filename}")
+    return candidates[0]
+
+
+def _read_component_env_records(root: Path) -> list[dict[str, Any]]:
+    jsonl_files = sorted(root.rglob("*.jsonl"))
+    if jsonl_files:
+        records: list[dict[str, Any]] = []
+        for path in jsonl_files:
+            records.extend(_read_jsonl(path))
+        return records
+    json_files = sorted(root.rglob("*.json"))
+    for path in json_files:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict) and isinstance(payload.get("envs"), list):
+            return [dict(item) for item in payload["envs"]]
+        if isinstance(payload, list):
+            return [dict(item) for item in payload]
+    return []
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
 def main(argv: list[str] | None = None) -> int:
     """Module CLI for raw SkyPilot YAML and local smoke runs."""
 
@@ -1463,11 +2224,46 @@ def main(argv: list[str] | None = None) -> int:
     )
     convert.add_argument("--vlm-json", type=Path, required=True)
     convert.add_argument("--output-json", type=Path, required=True)
+    component_vlm = subparsers.add_parser(
+        "component-vlm-eval", help="Run one sibling-image VLM component contract."
+    )
+    component_vlm.add_argument("--input-uri", required=True)
+    component_vlm.add_argument("--output-uri", required=True)
+    component_vlm.add_argument("--rollout-id", default="")
+    component_vlm.add_argument("--model", default=DEFAULT_REFERENCE_VLM_MODEL)
+    component_vlm.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    component_heldout = subparsers.add_parser(
+        "component-heldout-eval",
+        help="Run one sibling-image held-out eval component contract.",
+    )
+    component_heldout.add_argument("--heldout-envs-uri", required=True)
+    component_heldout.add_argument("--inner-evidence-uri", required=True)
+    component_heldout.add_argument("--output-uri", required=True)
+    component_heldout.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    component_heldout.add_argument("--limit", type=int, default=0)
     args = parser.parse_args(argv)
 
     if args.command == "convert-signal":
         payload = json.loads(args.vlm_json.read_text(encoding="utf-8"))
         _write_json_artifact(args.output_json, convert_vlm_eval_to_rl_signal(payload))
+        return 0
+    if args.command == "component-vlm-eval":
+        run_vlm_eval_component_from_s3(
+            input_uri=args.input_uri,
+            output_uri=args.output_uri,
+            rollout_id=args.rollout_id,
+            model=args.model,
+            threshold=args.threshold,
+        )
+        return 0
+    if args.command == "component-heldout-eval":
+        run_heldout_eval_component_from_s3(
+            heldout_envs_uri=args.heldout_envs_uri,
+            inner_evidence_uri=args.inner_evidence_uri,
+            output_uri=args.output_uri,
+            threshold=args.threshold,
+            limit=args.limit,
+        )
         return 0
 
     config = build_config_from_env(
@@ -1505,6 +2301,18 @@ def main(argv: list[str] | None = None) -> int:
         byo_trainer_command=args.byo_trainer_command,
         byo_vlm_command=args.byo_vlm_command,
         byo_eval_command=args.byo_eval_command,
+        k8s_namespace=args.k8s_namespace,
+        k8s_service_account=args.k8s_service_account,
+        k8s_image_pull_secrets=args.k8s_image_pull_secrets,
+        k8s_env_secret_names=args.k8s_env_secret_names,
+        k8s_gpu_resource=args.k8s_gpu_resource,
+        k8s_gpu_product=args.k8s_gpu_product,
+        k8s_kubeconfig=args.k8s_kubeconfig,
+        k8s_context=args.k8s_context,
+        k8s_job_timeout_s=args.k8s_job_timeout_s,
+        source_repo=args.source_repo,
+        source_ref=args.source_ref,
+        heldout_eval_limit=args.heldout_eval_limit,
     )
     if args.command == "full-loop":
         report = run_full_loop(config)
@@ -1595,6 +2403,59 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--byo-trainer-command", default="")
     parser.add_argument("--byo-vlm-command", default="")
     parser.add_argument("--byo-eval-command", default="")
+    parser.add_argument(
+        "--k8s-namespace",
+        default=os.environ.get("NPA_SIM2REAL_K8S_NAMESPACE", ""),
+    )
+    parser.add_argument(
+        "--k8s-service-account",
+        default=os.environ.get("NPA_SIM2REAL_K8S_SERVICE_ACCOUNT", "agent-sa"),
+    )
+    parser.add_argument(
+        "--k8s-image-pull-secrets",
+        default=os.environ.get(
+            "NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS",
+            "agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry",
+        ),
+    )
+    parser.add_argument(
+        "--k8s-env-secret-names",
+        default=os.environ.get(
+            "NPA_SIM2REAL_K8S_ENV_SECRET_NAMES",
+            "hf-ngc-tokens,npa-storage-credentials",
+        ),
+    )
+    parser.add_argument(
+        "--k8s-gpu-resource",
+        default=os.environ.get("NPA_SIM2REAL_K8S_GPU_RESOURCE", "nvidia.com/gpu"),
+    )
+    parser.add_argument(
+        "--k8s-gpu-product",
+        default=os.environ.get(
+            "NPA_SIM2REAL_K8S_GPU_PRODUCT",
+            "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition",
+        ),
+    )
+    parser.add_argument(
+        "--k8s-kubeconfig",
+        default=os.environ.get("NPA_SIM2REAL_KUBECONFIG", os.environ.get("KUBECONFIG", "")),
+    )
+    parser.add_argument(
+        "--k8s-context",
+        default=os.environ.get("NPA_SIM2REAL_K8S_CONTEXT", ""),
+    )
+    parser.add_argument(
+        "--k8s-job-timeout-s",
+        type=int,
+        default=int(os.environ.get("NPA_SIM2REAL_K8S_JOB_TIMEOUT_S", "7200")),
+    )
+    parser.add_argument("--source-repo", default=os.environ.get("NPA_SOURCE_REPO", ""))
+    parser.add_argument("--source-ref", default=os.environ.get("NPA_SOURCE_REF", ""))
+    parser.add_argument(
+        "--heldout-eval-limit",
+        type=int,
+        default=int(os.environ.get("NPA_SIM2REAL_HELDOUT_EVAL_LIMIT", "0")),
+    )
 
 
 def _write_stage(
@@ -1797,8 +2658,10 @@ __all__ = [
     "generate_action_rollouts",
     "new_run_id",
     "run_full_loop",
+    "run_heldout_eval_component_from_s3",
     "run_heldout_eval",
     "run_inner_loop",
+    "run_vlm_eval_component_from_s3",
     "signal_mapping_rules",
     "threshold_decision",
 ]

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -6,6 +6,9 @@ import argparse
 import json
 import os
 import random
+import shlex
+import shutil
+import subprocess
 import sys
 import tempfile
 import uuid
@@ -519,12 +522,14 @@ def run_full_loop(
 
     raw_envs = _write_env_manifest(
         local_dir / "envs" / "raw",
-        count=max(config.heldout_env_count, 10),
+        count=config.rollout_count + config.heldout_env_count,
         seed=config.seed,
     )
     train_envs, heldout_envs = _write_train_heldout_split(
         local_dir / "envs",
         raw_envs=raw_envs,
+        train_count=config.rollout_count,
+        heldout_count=config.heldout_env_count,
         seed=config.seed,
     )
     stage_records.extend([raw_envs, train_envs, heldout_envs])
@@ -570,7 +575,7 @@ def run_full_loop(
         heldout_report = run_heldout_eval(
             config,
             local_dir=local_dir,
-            policy_quality=quality,
+            inner_evidence=inner,
             outer_iteration=outer_iteration,
         )
         final_eval = heldout_report
@@ -925,46 +930,270 @@ def evaluate_rollout_with_vlm(
     output_dir: Path,
     config: Sim2RealLoopConfig,
 ) -> dict[str, Any]:
-    """Run the reference structured VLM evaluation for one rollout."""
+    """Invoke the configured VLM component and parse its structured judgment."""
 
     manifest_path = rollout_dir / "manifest.json"
     if not manifest_path.exists():
         raise Sim2RealLoopError(f"rollout manifest not found: {manifest_path}")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    quality = float(manifest.get("quality", 0.0))
     rollout_id = str(manifest.get("rollout_id") or rollout_dir.name)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{rollout_id}.json"
+    env = _component_env(
+        config,
+        component="vlm_eval",
+        output_json=output_path,
+        extra={
+            "NPA_SIM2REAL_ROLLOUT_DIR": str(rollout_dir),
+            "NPA_SIM2REAL_ROLLOUT_ID": rollout_id,
+            "NPA_SIM2REAL_ROLLOUT_MANIFEST": str(manifest_path),
+            "NPA_SIM2REAL_VLM_MODEL": config.vlm_model,
+            "NPA_SIM2REAL_THRESHOLD": str(config.threshold),
+            "NPA_SIM2REAL_VLM_IMAGE": config.vlm_image,
+        },
+    )
+    if config.byo_vlm_command.strip():
+        invocation = _run_component_command(
+            config.byo_vlm_command,
+            cwd=rollout_dir,
+            env=env,
+            component="vlm_eval",
+        )
+    else:
+        invocation = _run_image_component(
+            config.vlm_image,
+            component="vlm_eval",
+            env=env,
+            mounts=[
+                (rollout_dir, "/npa/input/rollout", "ro"),
+                (output_dir, "/npa/output", "rw"),
+            ],
+            output_json=output_path,
+            container_output_json=f"/npa/output/{rollout_id}.json",
+        )
+    payload = _read_component_json(output_path, invocation)
+    evaluation = _normalize_vlm_evaluation(
+        payload,
+        manifest=manifest,
+        rollout_id=rollout_id,
+        config=config,
+        invocation=invocation,
+    )
+    _write_json_artifact(output_path, evaluation)
+    return evaluation
+
+
+def _component_env(
+    config: Sim2RealLoopConfig,
+    *,
+    component: str,
+    output_json: Path,
+    extra: dict[str, str],
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "NPA_SIM2REAL_COMPONENT": component,
+            "NPA_SIM2REAL_RUN_ID": config.run_id,
+            "NPA_SIM2REAL_OUTPUT_JSON": str(output_json),
+            "NPA_SIM2REAL_S3_BUCKET": config.s3_bucket,
+            "NPA_SIM2REAL_S3_PREFIX": config.s3_prefix,
+            "AWS_ENDPOINT_URL": config.s3_endpoint or env.get("AWS_ENDPOINT_URL", ""),
+        }
+    )
+    env.update(extra)
+    return env
+
+
+def _run_component_command(
+    command: str,
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    component: str,
+    timeout_s: int = 7200,
+) -> dict[str, Any]:
+    result = subprocess.run(
+        command,
+        cwd=str(cwd),
+        env=env,
+        shell=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout_s,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise Sim2RealLoopError(
+            f"{component} command failed with exit {result.returncode}: "
+            f"{_component_excerpt(result.stderr or result.stdout)}"
+        )
+    return {
+        "mode": "command",
+        "component": component,
+        "command": _redact_command(command),
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "stdout_excerpt": _component_excerpt(result.stdout),
+        "stderr_excerpt": _component_excerpt(result.stderr),
+    }
+
+
+def _run_image_component(
+    image: str,
+    *,
+    component: str,
+    env: dict[str, str],
+    mounts: list[tuple[Path, str, str]],
+    output_json: Path,
+    container_output_json: str,
+    timeout_s: int = 7200,
+) -> dict[str, Any]:
+    runtime = os.environ.get("NPA_CONTAINER_RUNTIME") or _first_available_runtime()
+    if not runtime:
+        raise Sim2RealLoopError(
+            f"no BYO {component} command was provided and no docker/podman runtime is available for image {image}"
+        )
+    container_env = dict(env)
+    container_env["NPA_SIM2REAL_OUTPUT_JSON"] = container_output_json
+    cmd = [runtime, "run", "--rm"]
+    if runtime.endswith("docker") and os.environ.get("NPA_SIM2REAL_CONTAINER_GPUS", "all") != "none":
+        cmd.extend(["--gpus", os.environ.get("NPA_SIM2REAL_CONTAINER_GPUS", "all")])
+    for key in sorted(container_env):
+        if key.startswith("NPA_SIM2REAL") or key in {"AWS_ENDPOINT_URL", "S3_ENDPOINT_URL"}:
+            cmd.extend(["-e", key])
+    for host, container, mode in mounts:
+        cmd.extend(["-v", f"{host}:{container}:{mode}"])
+    cmd.append(image)
+    result = subprocess.run(
+        cmd,
+        env=container_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout_s,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise Sim2RealLoopError(
+            f"{component} image {image} failed with exit {result.returncode}: "
+            f"{_component_excerpt(result.stderr or result.stdout)}"
+        )
+    return {
+        "mode": "image",
+        "component": component,
+        "image": image,
+        "command": " ".join(shlex.quote(part) for part in cmd),
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "stdout_excerpt": _component_excerpt(result.stdout),
+        "stderr_excerpt": _component_excerpt(result.stderr),
+    }
+
+
+def _first_available_runtime() -> str:
+    for candidate in ("docker", "podman"):
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return ""
+
+
+def _read_component_json(output_path: Path, invocation: dict[str, Any]) -> dict[str, Any]:
+    if output_path.exists():
+        return json.loads(output_path.read_text(encoding="utf-8"))
+    stdout = str(invocation.get("stdout") or "")
+    for line in reversed(stdout.splitlines()):
+        stripped = line.strip()
+        if stripped.startswith("{") and stripped.endswith("}"):
+            return json.loads(stripped)
+    raise Sim2RealLoopError(
+        f"{invocation.get('component', 'component')} did not write JSON to {output_path}"
+    )
+
+
+def _normalize_vlm_evaluation(
+    payload: dict[str, Any],
+    *,
+    manifest: dict[str, Any],
+    rollout_id: str,
+    config: Sim2RealLoopConfig,
+    invocation: dict[str, Any],
+) -> dict[str, Any]:
+    if "score" not in payload:
+        raise Sim2RealLoopError("VLM component output must include score")
+    score = max(0.0, min(1.0, float(payload["score"])))
+    success = bool(payload.get("success", score >= config.threshold))
+    raw_steps = payload.get("per_step") or payload.get("steps") or []
+    if not raw_steps and payload.get("critique_text"):
+        raw_steps = [{"step": 0, "critique_text": payload["critique_text"], "error_tags": payload.get("error_tags", [])}]
+    if not isinstance(raw_steps, list) or not raw_steps:
+        raise Sim2RealLoopError("VLM component output must include non-empty per_step")
+    actions = {int(item["step"]): item.get("action", []) for item in manifest.get("actions", [])}
+    observations = list(manifest.get("camera_observations", []))
     per_step: list[dict[str, Any]] = []
-    for item in manifest.get("actions", []):
-        step = int(item["step"])
-        tags = _tags_for_quality(quality, step=step)
-        critique = _critique_for_tags(tags, quality=quality)
+    for raw in raw_steps:
+        step = int(raw.get("step", len(per_step)))
+        tags = raw.get("error_tags", raw.get("tags", [])) or ["ok"]
+        if isinstance(tags, str):
+            tags = [tags]
+        critique = str(raw.get("critique_text") or raw.get("critique") or raw.get("text") or "")
+        if not critique:
+            raise Sim2RealLoopError("VLM component per_step entries must include critique text")
+        camera = raw.get("camera_observation")
+        if not camera and 0 <= step < len(observations):
+            camera = observations[step]
         per_step.append(
             {
                 "step": step,
                 "critique_text": critique,
-                "error_tags": tags,
-                "action": item.get("action", []),
-                "camera_observation": f"camera-{step:03d}.ppm",
+                "error_tags": [str(tag) for tag in tags],
+                "action": raw.get("action", actions.get(step, [])),
+                "camera_observation": str(camera or f"camera-{step:03d}.ppm"),
             }
         )
-    success = quality >= config.threshold
-    evaluation = {
+    return {
         "schema": SCHEMA_VLM_EVAL,
-        "rollout_id": rollout_id,
+        "rollout_id": str(payload.get("rollout_id") or rollout_id),
         "success": success,
-        "score": round(max(0.0, min(1.0, quality)), 6),
+        "score": round(score, 6),
         "per_step": per_step,
-        "summary": (
-            "Rollout completes the task with stable final state."
-            if success
-            else "Rollout needs policy correction before held-out promotion."
-        ),
-        "model": config.vlm_model,
+        "summary": str(payload.get("summary") or payload.get("critique") or ""),
+        "model": str(payload.get("model") or config.vlm_model),
         "vlm_image": config.vlm_image,
+        "component_invocation": _public_invocation(invocation),
         "generated_at": _utc_now(),
     }
-    _write_json_artifact(output_dir / f"{rollout_id}.json", evaluation)
-    return evaluation
+
+
+def _component_excerpt(text: str, limit: int = 1200) -> str:
+    scrubbed = []
+    for line in str(text or "").splitlines():
+        if "AWS_SECRET_ACCESS_KEY" in line or "AWS_ACCESS_KEY_ID" in line:
+            scrubbed.append("[redacted secret line]")
+        else:
+            scrubbed.append(line)
+    return "\n".join(scrubbed)[-limit:]
+
+
+def _redact_command(command: str) -> str:
+    redacted = str(command)
+    for key in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "HF_TOKEN", "NGC_API_KEY"):
+        value = os.environ.get(key)
+        if value:
+            redacted = redacted.replace(value, f"<{key}>")
+    return redacted
+
+
+def _public_invocation(invocation: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in invocation.items()
+        if key not in {"stdout", "stderr"}
+    }
 
 
 def convert_vlm_eval_to_rl_signal(evaluation: dict[str, Any]) -> dict[str, Any]:
@@ -1042,61 +1271,107 @@ def run_heldout_eval(
     config: Sim2RealLoopConfig,
     *,
     local_dir: Path,
-    policy_quality: float,
+    inner_evidence: dict[str, Any],
     outer_iteration: int,
 ) -> dict[str, Any]:
-    """Run the reference held-out evaluation and write report.json."""
+    """Invoke the configured held-out eval component and write report.json."""
 
-    rng = random.Random(config.seed + 9000 + outer_iteration)
+    output_dir = local_dir / "eval" / "heldout"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "report.json"
+    inner_path = output_dir / f"inner-evidence-outer-{outer_iteration:02d}.json"
+    _write_json_artifact(inner_path, inner_evidence)
+    env = _component_env(
+        config,
+        component="heldout_eval",
+        output_json=output_path,
+        extra={
+            "NPA_SIM2REAL_HELDOUT_ENVS_DIR": str(local_dir / "envs" / "heldout"),
+            "NPA_SIM2REAL_HELDOUT_ENV_COUNT": str(config.heldout_env_count),
+            "NPA_SIM2REAL_INNER_EVIDENCE_JSON": str(inner_path),
+            "NPA_SIM2REAL_THRESHOLD": str(config.threshold),
+            "NPA_SIM2REAL_EVAL_IMAGE": config.eval_image,
+        },
+    )
+    if config.byo_eval_command.strip():
+        invocation = _run_component_command(
+            config.byo_eval_command,
+            cwd=local_dir,
+            env=env,
+            component="heldout_eval",
+        )
+    else:
+        invocation = _run_image_component(
+            config.eval_image,
+            component="heldout_eval",
+            env=env,
+            mounts=[
+                (local_dir / "envs" / "heldout", "/npa/input/heldout_envs", "ro"),
+                (output_dir, "/npa/output", "rw"),
+                (inner_path, "/npa/input/inner_evidence.json", "ro"),
+            ],
+            output_json=output_path,
+            container_output_json="/npa/output/report.json",
+        )
+    payload = _read_component_json(output_path, invocation)
+    report = _normalize_heldout_report(
+        payload,
+        config=config,
+        outer_iteration=outer_iteration,
+        inner_evidence_uri=str(inner_path),
+        invocation=invocation,
+    )
+    _write_json_artifact(output_path, report)
+    return {**report, "report_uri": str(output_path)}
+
+
+def _normalize_heldout_report(
+    payload: dict[str, Any],
+    *,
+    config: Sim2RealLoopConfig,
+    outer_iteration: int,
+    inner_evidence_uri: str,
+    invocation: dict[str, Any],
+) -> dict[str, Any]:
+    raw_items = payload.get("per_env") or payload.get("env_scores") or payload.get("scores")
+    if isinstance(raw_items, dict):
+        raw_items = [
+            {"env_id": key, **(value if isinstance(value, dict) else {"score": value})}
+            for key, value in raw_items.items()
+        ]
+    if not isinstance(raw_items, list) or not raw_items:
+        raise Sim2RealLoopError("held-out eval component output must include non-empty per_env/env_scores")
     per_env: list[dict[str, Any]] = []
     passed = 0
-    for index in range(config.heldout_env_count):
-        env_id = f"heldout-{index:04d}"
-        physics_fidelity = round(0.91 + rng.random() * 0.07, 4)
-        score = max(0.0, min(1.0, policy_quality + rng.uniform(-0.04, 0.04)))
-        success = score >= config.threshold
+    for index, item in enumerate(raw_items):
+        if not isinstance(item, dict):
+            item = {"score": item}
+        score = max(0.0, min(1.0, float(item.get("score", item.get("success_score", 0.0)))))
+        success = bool(item.get("success", score >= config.threshold))
         passed += int(success)
         per_env.append(
             {
-                "env_id": env_id,
+                "env_id": str(item.get("env_id") or f"heldout-{index:04d}"),
                 "success": success,
                 "score": round(score, 6),
-                "physics_fidelity": {
-                    "score": physics_fidelity,
-                    "backend": "reference-genesis-compatible",
-                    "checks": {
-                        "contact_model": physics_fidelity >= 0.9,
-                        "camera_sync": True,
-                        "action_schema": True,
-                    },
-                },
+                "details": item.get("details", {}),
             }
         )
-    success_rate = passed / float(config.heldout_env_count)
-    report = {
+    success_rate = passed / float(len(per_env))
+    return {
         "schema": SCHEMA_HELDOUT_REPORT,
         "stage": 10,
         "outer_iteration": outer_iteration,
         "status": "completed",
-        "policy_quality": round(policy_quality, 6),
         "success_rate": round(success_rate, 6),
         "threshold": config.threshold,
         "per_env": per_env,
-        "physics_fidelity": {
-            "mean": round(
-                sum(item["physics_fidelity"]["score"] for item in per_env)
-                / float(len(per_env)),
-                6,
-            ),
-            "min": round(min(item["physics_fidelity"]["score"] for item in per_env), 6),
-        },
         "eval_image": config.eval_image,
-        "byo_eval_command": config.byo_eval_command,
+        "byo_eval_command": _redact_command(config.byo_eval_command),
+        "inner_evidence_uri": inner_evidence_uri,
+        "component_invocation": _public_invocation(invocation),
         "generated_at": _utc_now(),
     }
-    path = local_dir / "eval" / "heldout" / "report.json"
-    _write_json_artifact(path, report)
-    return {**report, "report_uri": str(path)}
 
 
 def threshold_decision(
@@ -1367,14 +1642,22 @@ def _write_train_heldout_split(
     root: Path,
     *,
     raw_envs: dict[str, Any],
+    train_count: int,
+    heldout_count: int,
     seed: int,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     envs = list(raw_envs["payload"]["envs"])
+    expected = train_count + heldout_count
+    if len(envs) != expected:
+        raise Sim2RealLoopError(
+            f"raw env count {len(envs)} must equal train+heldout count {expected}"
+        )
     rng = random.Random(seed)
     rng.shuffle(envs)
-    train_size = max(1, int(round(len(envs) * 0.8)))
-    train = envs[:train_size]
-    heldout = envs[train_size:] or envs[-1:]
+    train = envs[:train_count]
+    heldout = envs[train_count:train_count + heldout_count]
+    if len(train) != train_count or len(heldout) != heldout_count:
+        raise Sim2RealLoopError("train/heldout split did not preserve requested counts")
     train_record = _write_json_artifact(
         root / "train" / "manifest.json",
         {

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import yaml
@@ -32,15 +33,85 @@ COSMOS3_REASON = (
 )
 
 
+def _component_command(tmp_path: Path) -> str:
+    script = tmp_path / "component_contract.py"
+    script.write_text(
+        """
+import json
+import os
+from pathlib import Path
+
+component = os.environ["NPA_SIM2REAL_COMPONENT"]
+out = Path(os.environ["NPA_SIM2REAL_OUTPUT_JSON"])
+out.parent.mkdir(parents=True, exist_ok=True)
+marker = Path(os.environ.get("NPA_SIM2REAL_COMPONENT_MARKER", out.parent / "component-marker.log"))
+
+if component == "vlm_eval":
+    rollout_dir = Path(os.environ["NPA_SIM2REAL_ROLLOUT_DIR"])
+    manifest = json.loads((rollout_dir / "manifest.json").read_text())
+    per_step = []
+    for item in manifest["actions"]:
+        step = int(item["step"])
+        frame = rollout_dir / f"camera-{step:03d}.ppm"
+        payload = frame.read_bytes()
+        signal = sum(payload[-12:]) % 17
+        tag = "minor_alignment"
+        per_step.append({
+            "step": step,
+            "critique_text": f"Frame {frame.name} has content signal {signal}; adjust {tag}.",
+            "error_tags": [tag],
+            "action": item["action"],
+            "camera_observation": frame.name,
+        })
+    score = 0.62 + ((sum(Path(os.environ["NPA_SIM2REAL_ROLLOUT_MANIFEST"]).read_bytes()) % 20) / 100.0)
+    result = {
+        "schema": "npa.sim2real.vlm_eval.v1",
+        "rollout_id": manifest["rollout_id"],
+        "success": score >= float(os.environ["NPA_SIM2REAL_THRESHOLD"]),
+        "score": round(score, 6),
+        "per_step": per_step,
+        "summary": "component-derived frame judgment",
+        "model": os.environ.get("NPA_SIM2REAL_VLM_MODEL", "test-vlm"),
+    }
+elif component == "heldout_eval":
+    count = int(os.environ["NPA_SIM2REAL_HELDOUT_ENV_COUNT"])
+    threshold = float(os.environ["NPA_SIM2REAL_THRESHOLD"])
+    per_env = []
+    for index in range(count):
+        score = 0.56 + (index % 5) * 0.05
+        per_env.append({
+            "env_id": f"heldout-{index:04d}",
+            "score": round(score, 6),
+            "success": score >= threshold,
+            "details": {"source": "component-contract", "index_mod": index % 5},
+        })
+    result = {"schema": "npa.sim2real.heldout_eval.v1", "per_env": per_env}
+else:
+    raise SystemExit(f"unknown component {component}")
+
+out.write_text(json.dumps(result) + "\\n")
+with marker.open("a", encoding="utf-8") as handle:
+    handle.write(component + "\\n")
+print(json.dumps({"component": component, "output": str(out)}))
+""",
+        encoding="utf-8",
+    )
+    return f"{sys.executable} {script}"
+
+
+
 def test_vlm_eval_signal_converter_and_trainer_update_close_loop(
     tmp_path: Path,
 ) -> None:
+    marker = tmp_path / "component-marker.log"
+    command = _component_command(tmp_path)
     config = Sim2RealLoopConfig(
         run_id="sim2real-unit",
         output_dir=tmp_path,
         threshold=0.75,
         rollout_count=1,
         steps_per_rollout=3,
+        byo_vlm_command=f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {command}",
     )
     rollout = generate_action_rollouts(
         tmp_path / "actions",
@@ -61,6 +132,8 @@ def test_vlm_eval_signal_converter_and_trainer_update_close_loop(
     )
 
     assert evaluation["schema"] == SCHEMA_VLM_EVAL
+    assert evaluation["component_invocation"]["mode"] == "command"
+    assert "vlm_eval" in marker.read_text(encoding="utf-8")
     assert signal["schema"] == SCHEMA_RL_SIGNAL
     assert signal["per_step"][0]["target"]["nl_correction"]
     assert update.policy_delta_l2 > control.policy_delta_l2
@@ -68,6 +141,8 @@ def test_vlm_eval_signal_converter_and_trainer_update_close_loop(
 
 
 def test_full_loop_writes_stage_artifacts_and_candidate(tmp_path: Path) -> None:
+    marker = tmp_path / "component-marker.log"
+    command = _component_command(tmp_path)
     config = Sim2RealLoopConfig(
         run_id="sim2real-full-unit",
         output_dir=tmp_path,
@@ -78,6 +153,8 @@ def test_full_loop_writes_stage_artifacts_and_candidate(tmp_path: Path) -> None:
         rollout_count=2,
         steps_per_rollout=3,
         heldout_env_count=4,
+        byo_vlm_command=f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {command}",
+        byo_eval_command=f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {command}",
     )
 
     report = run_full_loop(config)
@@ -116,9 +193,19 @@ def test_full_loop_writes_stage_artifacts_and_candidate(tmp_path: Path) -> None:
     )
     assert (tmp_path / "checkpoints" / "candidate" / "candidate.json").exists()
     assert (tmp_path / "reports" / "sim2real-report.json").exists()
+    marker_text = marker.read_text(encoding="utf-8")
+    assert marker_text.count("vlm_eval") == 4
+    assert "heldout_eval" in marker_text
+    raw_envs = json.loads((tmp_path / "envs" / "raw" / "manifest.json").read_text())
+    train_envs = json.loads((tmp_path / "envs" / "train" / "manifest.json").read_text())
+    heldout_envs = json.loads((tmp_path / "envs" / "heldout" / "manifest.json").read_text())
+    assert len(raw_envs["envs"]) == 6
+    assert len(train_envs["envs"]) == 2
+    assert len(heldout_envs["envs"]) == 4
 
 
 def test_threshold_failure_loops_back_to_inner_loop(tmp_path: Path) -> None:
+    command = _component_command(tmp_path)
     config = Sim2RealLoopConfig(
         run_id="sim2real-loopback-unit",
         output_dir=tmp_path,
@@ -128,6 +215,8 @@ def test_threshold_failure_loops_back_to_inner_loop(tmp_path: Path) -> None:
         rollout_count=1,
         steps_per_rollout=2,
         heldout_env_count=2,
+        byo_vlm_command=command,
+        byo_eval_command=command,
     )
 
     report = run_full_loop(config)
@@ -150,6 +239,7 @@ def test_empty_s3_prefix_writes_under_run_id() -> None:
 
 
 def test_sdk_exposes_sim2real_run(tmp_path: Path) -> None:
+    command = _component_command(tmp_path)
     report = sim2real.run(
         run_id="sim2real-sdk-unit",
         output_dir=tmp_path,
@@ -159,6 +249,8 @@ def test_sdk_exposes_sim2real_run(tmp_path: Path) -> None:
         rollout_count=1,
         steps_per_rollout=2,
         heldout_env_count=2,
+        byo_vlm_command=command,
+        byo_eval_command=command,
     )
 
     assert report["run_id"] == "sim2real-sdk-unit"

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
 import yaml
 
+import npa.workflows.sim2real_loop as loop_module
 from npa.sdk.workbench import cosmos2, cosmos3, sim2real
 from npa.workbench.lerobot.policy_container import (
     parse_vlm_signal_batch,
     run_vlm_signal_training_step,
 )
 from npa.workflows.sim2real_loop import (
+    SCHEMA_HELDOUT_REPORT,
     SCHEMA_RL_SIGNAL,
     SCHEMA_VLM_EVAL,
     Sim2RealLoopConfig,
@@ -20,6 +23,7 @@ from npa.workflows.sim2real_loop import (
     evaluate_rollout_with_vlm,
     generate_action_rollouts,
     run_full_loop,
+    run_heldout_eval,
 )
 
 
@@ -238,6 +242,212 @@ def test_empty_s3_prefix_writes_under_run_id() -> None:
     assert artifact_uris(config)["root"] == "s3://bucket/pusht-demo/"
 
 
+class _FakeComponentStorage:
+    def __init__(self, downloads: dict[str, dict]) -> None:
+        self.downloads = downloads
+        self.uploaded_directories: list[tuple[str, str]] = []
+        self.uploaded_files: list[tuple[str, str]] = []
+
+    def upload_directory(self, local_dir: str, bucket_uri: str, *, remote_prefix: str = "") -> str:
+        self.uploaded_directories.append((local_dir, bucket_uri))
+        return bucket_uri
+
+    def upload_file(self, local_file: str, bucket_uri: str) -> str:
+        self.uploaded_files.append((local_file, bucket_uri))
+        return bucket_uri
+
+    def download_path(self, bucket_uri: str, local_path: str) -> str:
+        payload = self.downloads.get(bucket_uri)
+        if payload is None and "/vlm-eval/" in bucket_uri:
+            payload = self.downloads.get("vlm_eval")
+        if payload is None and "/heldout-eval/" in bucket_uri:
+            payload = self.downloads.get("heldout_eval")
+        if payload is None:
+            raise KeyError(bucket_uri)
+        target = Path(local_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+        return str(target)
+
+
+def _patch_component_storage(monkeypatch, storage: _FakeComponentStorage) -> None:
+    monkeypatch.setattr(
+        loop_module.StorageClient,
+        "from_environment",
+        classmethod(lambda cls, endpoint_url="": storage),
+    )
+
+
+def _patch_kubectl(monkeypatch) -> list[dict]:
+    calls: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append({"cmd": cmd, "input": kwargs.get("input")})
+        if "apply" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "job.batch/sibling created\n", "")
+        if "wait" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "job.batch/sibling condition met\n", "")
+        if "get" in cmd and "pods" in cmd:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                json.dumps(
+                    {
+                        "items": [
+                            {
+                                "metadata": {"name": "sibling-pod"},
+                                "spec": {
+                                    "nodeName": "sm120-node",
+                                    "containers": [
+                                        {
+                                            "resources": {
+                                                "requests": {"nvidia.com/gpu": 1},
+                                                "limits": {"nvidia.com/gpu": 1},
+                                            }
+                                        }
+                                    ],
+                                },
+                                "status": {
+                                    "phase": "Succeeded",
+                                    "containerStatuses": [
+                                        {
+                                            "name": "component",
+                                            "ready": False,
+                                            "restartCount": 0,
+                                            "state": {"terminated": {"exitCode": 0}},
+                                        }
+                                    ],
+                                },
+                            }
+                        ]
+                    }
+                ),
+                "",
+            )
+        if "logs" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, '{"component":"ok"}\n', "")
+        if "delete" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "job.batch deleted\n", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(loop_module.subprocess, "run", fake_run)
+    return calls
+
+
+def test_image_vlm_eval_launches_sibling_job_and_parses_output(monkeypatch, tmp_path: Path) -> None:
+    output_payload = {
+        "schema": SCHEMA_VLM_EVAL,
+        "rollout_id": "rollout-0000",
+        "success": False,
+        "score": 0.512345,
+        "per_step": [
+            {
+                "step": 0,
+                "critique_text": "Parsed component output from the sibling stage.",
+                "error_tags": ["collision", "minor_alignment"],
+                "action": [0.1, 0.0, -0.1],
+                "camera_observation": "camera-000.ppm",
+            }
+        ],
+        "summary": "sibling output",
+        "model": "job-vlm",
+    }
+    storage = _FakeComponentStorage({"vlm_eval": output_payload})
+    _patch_component_storage(monkeypatch, storage)
+    calls = _patch_kubectl(monkeypatch)
+    config = Sim2RealLoopConfig(
+        run_id="sibling-vlm-unit",
+        s3_bucket="bucket",
+        s3_prefix="neutral-prefix",
+        s3_endpoint="https://storage.example",
+        threshold=0.75,
+        k8s_namespace="default",
+        source_repo="https://example.invalid/repo.git",
+        source_ref="dev-branch",
+    )
+    rollout = generate_action_rollouts(
+        tmp_path / "actions",
+        count=1,
+        steps_per_rollout=1,
+        seed=7,
+        quality=0.4,
+    )[0]
+
+    evaluation = evaluate_rollout_with_vlm(
+        rollout,
+        output_dir=tmp_path / "vlm_eval",
+        config=config,
+    )
+
+    apply_call = next(call for call in calls if "apply" in call["cmd"])
+    manifest = json.loads(apply_call["input"])
+    container = manifest["spec"]["template"]["spec"]["containers"][0]
+
+    assert evaluation["score"] == 0.512345
+    assert evaluation["component_invocation"]["mode"] == "kubernetes_job"
+    assert evaluation["component_invocation"]["pod"]["node_name"] == "sm120-node"
+    assert convert_vlm_eval_to_rl_signal(evaluation)["score"] == 0.512345
+    assert storage.uploaded_directories
+    assert manifest["spec"]["template"]["spec"]["serviceAccountName"] == "agent-sa"
+    assert {"name": "agent-sa"} in manifest["spec"]["template"]["spec"]["imagePullSecrets"]
+    assert {"secretRef": {"name": "hf-ngc-tokens", "optional": True}} in container["envFrom"]
+    assert {"secretRef": {"name": "npa-storage-credentials", "optional": True}} in container["envFrom"]
+    assert container["resources"]["requests"]["nvidia.com/gpu"] == 1
+    assert (
+        manifest["spec"]["template"]["spec"]["nodeSelector"]["nvidia.com/gpu.compute.major"]
+        == "12"
+    )
+    assert "component-vlm-eval" in container["args"][0]
+
+
+def test_heldout_eval_launches_sibling_job_and_parses_per_env_output(
+    monkeypatch, tmp_path: Path
+) -> None:
+    output_payload = {
+        "schema": SCHEMA_HELDOUT_REPORT,
+        "per_env": [
+            {"env_id": "env-a", "score": 0.81, "success": True, "details": {}},
+            {"env_id": "env-b", "score": 0.52, "success": False, "details": {}},
+        ],
+    }
+    storage = _FakeComponentStorage({"heldout_eval": output_payload})
+    _patch_component_storage(monkeypatch, storage)
+    calls = _patch_kubectl(monkeypatch)
+    config = Sim2RealLoopConfig(
+        run_id="sibling-heldout-unit",
+        s3_bucket="bucket",
+        s3_prefix="neutral-prefix",
+        s3_endpoint="https://storage.example",
+        heldout_envs_uri="s3://bucket/neutral-prefix/run/envs/heldout/",
+        heldout_eval_limit=2,
+        threshold=0.75,
+        k8s_namespace="default",
+        source_ref="dev-branch",
+    )
+    inner_evidence = {
+        "schema": "npa.sim2real.inner_loop_evidence.v1",
+        "reward_trend": [0.1, 0.2],
+    }
+
+    report = run_heldout_eval(
+        config,
+        local_dir=tmp_path,
+        inner_evidence=inner_evidence,
+        outer_iteration=1,
+    )
+    apply_call = next(call for call in calls if "apply" in call["cmd"])
+    manifest = json.loads(apply_call["input"])
+    args = manifest["spec"]["template"]["spec"]["containers"][0]["args"][0]
+
+    assert report["success_rate"] == 0.5
+    assert report["per_env"][0]["env_id"] == "env-a"
+    assert report["component_invocation"]["mode"] == "kubernetes_job"
+    assert report["component_invocation"]["gpu_request"]["count"] == 1
+    assert storage.uploaded_files
+    assert "component-heldout-eval" in args
+    assert "--limit" in args
+
+
 def test_sdk_exposes_sim2real_run(tmp_path: Path) -> None:
     command = _component_command(tmp_path)
     report = sim2real.run(
@@ -282,6 +492,8 @@ def test_raw_runbook_invokes_full_loop_and_exposes_byo_envs() -> None:
     assert "npa.workflows.sim2real_loop full-loop" in task["run"]
     assert "--trigger-dataset-uri" in task["run"]
     assert "--byo-signal-converter" in task["run"]
+    assert "--k8s-service-account" in task["run"]
+    assert "--heldout-eval-limit" in task["run"]
 
 
 def test_cosmos_split_sdk_and_raw_yaml_contracts() -> None:

--- a/npa/workflows/workbench/sim2real/runbook.yaml
+++ b/npa/workflows/workbench/sim2real/runbook.yaml
@@ -53,6 +53,14 @@ envs:
   BYO_TRAINER_COMMAND: "${BYO_TRAINER_COMMAND}"
   BYO_VLM_COMMAND: "${BYO_VLM_COMMAND}"
   BYO_EVAL_COMMAND: "${BYO_EVAL_COMMAND}"
+  NPA_SIM2REAL_K8S_NAMESPACE: "${NPA_SIM2REAL_K8S_NAMESPACE}"
+  NPA_SIM2REAL_K8S_SERVICE_ACCOUNT: "${NPA_SIM2REAL_K8S_SERVICE_ACCOUNT}"
+  NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS: "${NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS}"
+  NPA_SIM2REAL_K8S_ENV_SECRET_NAMES: "${NPA_SIM2REAL_K8S_ENV_SECRET_NAMES}"
+  NPA_SIM2REAL_K8S_GPU_RESOURCE: "${NPA_SIM2REAL_K8S_GPU_RESOURCE}"
+  NPA_SIM2REAL_K8S_GPU_PRODUCT: "${NPA_SIM2REAL_K8S_GPU_PRODUCT}"
+  NPA_SIM2REAL_K8S_JOB_TIMEOUT_S: "${NPA_SIM2REAL_K8S_JOB_TIMEOUT_S}"
+  NPA_SIM2REAL_HELDOUT_EVAL_LIMIT: "${NPA_SIM2REAL_HELDOUT_EVAL_LIMIT}"
   NPA_SOURCE_REPO: "${NPA_SOURCE_REPO}"
   NPA_SOURCE_REF: "${NPA_SOURCE_REF}"
 setup: |
@@ -72,9 +80,13 @@ setup: |
   uv venv --python 3.11 --seed ./npa/.venv
   ./npa/.venv/bin/python -m pip install --upgrade pip setuptools wheel
   ./npa/.venv/bin/python -m pip install -e ./npa
+  if ! command -v kubectl >/dev/null 2>&1; then
+    curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/v1.33.7/bin/linux/amd64/kubectl"
+    chmod +x /tmp/kubectl
+  fi
 run: |
   set -euo pipefail
-  export PATH="$(pwd)/npa/.venv/bin:${PATH}"
+  export PATH="/tmp:$(pwd)/npa/.venv/bin:${PATH}"
   run_id="${NPA_SIM2REAL_RUN_ID:-sim2real-$(date -u +%Y%m%dT%H%M%SZ)}"
   output_dir="/tmp/npa-sim2real-${run_id}"
   mkdir -p "${output_dir}"
@@ -111,4 +123,14 @@ run: |
     --byo-trainer-command "${BYO_TRAINER_COMMAND:-}" \
     --byo-vlm-command "${BYO_VLM_COMMAND:-}" \
     --byo-eval-command "${BYO_EVAL_COMMAND:-}" \
+    --k8s-namespace "${NPA_SIM2REAL_K8S_NAMESPACE:-default}" \
+    --k8s-service-account "${NPA_SIM2REAL_K8S_SERVICE_ACCOUNT:-agent-sa}" \
+    --k8s-image-pull-secrets "${NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS:-agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry}" \
+    --k8s-env-secret-names "${NPA_SIM2REAL_K8S_ENV_SECRET_NAMES:-hf-ngc-tokens,npa-storage-credentials}" \
+    --k8s-gpu-resource "${NPA_SIM2REAL_K8S_GPU_RESOURCE:-nvidia.com/gpu}" \
+    --k8s-gpu-product "${NPA_SIM2REAL_K8S_GPU_PRODUCT:-NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition}" \
+    --k8s-job-timeout-s "${NPA_SIM2REAL_K8S_JOB_TIMEOUT_S:-7200}" \
+    --source-repo "${NPA_SOURCE_REPO:-}" \
+    --source-ref "${NPA_SOURCE_REF:-}" \
+    --heldout-eval-limit "${NPA_SIM2REAL_HELDOUT_EVAL_LIMIT:-0}" \
     --upload-artifacts


### PR DESCRIPTION
Routes Sim2Real VLM and held-out evaluation through configured component commands/images, removes quality-derived VLM/eval signal from the genuine path, and asserts component invocation in tests.