### PR TITLE
fix(sonic): sparse checkout upstream runtime sources

### DIFF
--- a/npa/docker/workbench/sonic/Dockerfile
+++ b/npa/docker/workbench/sonic/Dockerfile
@@ -96,11 +96,17 @@ RUN "${ISAAC_LAB_PYTHON}" -m pip install --no-cache-dir \
 RUN python3 -m pip install --break-system-packages --no-cache-dir uv \
     && curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
-RUN git clone "${SONIC_REPO_URL}" "${SONIC_HOME}" \
+RUN git clone --filter=blob:none --no-checkout "${SONIC_REPO_URL}" "${SONIC_HOME}" \
     && cd "${SONIC_HOME}" \
+    && git sparse-checkout init --no-cone \
+    && git sparse-checkout set \
+      "/download_from_hf.py" \
+      "/gear_sonic/**" \
+      "/gear_sonic_deploy/**" \
+      "/decoupled_wbc/**" \
     && git checkout "${SONIC_REPO_REF}" \
     && (git lfs pull --include="download_from_hf.py,gear_sonic/**,gear_sonic_deploy/**,decoupled_wbc/**" --exclude="motionbricks/out/**" || true) \
-    && rm -rf "${SONIC_HOME}/.git" "${SONIC_HOME}/docs"
+    && rm -rf "${SONIC_HOME}/.git"
 
 RUN "${ISAAC_LAB_PYTHON}" -m pip install --no-cache-dir \
       -e "${SONIC_HOME}/gear_sonic[training,teleop,sim]" \

--- a/npa/tests/cli/test_sonic_cli.py
+++ b/npa/tests/cli/test_sonic_cli.py
@@ -541,7 +541,10 @@ def test_sonic_container_build_script_uses_supported_version() -> None:
     assert 'npa.driver_provisioning="${NPA_DRIVER_PROVISIONING}"' in dockerfile
     assert "COPY docker/workbench/sonic/requirements.txt" in dockerfile
     assert "COPY docker/workbench/sonic/entrypoint.sh" in dockerfile
-    assert 'rm -rf "${SONIC_HOME}/.git" "${SONIC_HOME}/docs"' in dockerfile
+    assert 'git clone --filter=blob:none --no-checkout "${SONIC_REPO_URL}"' in dockerfile
+    assert "git sparse-checkout set" in dockerfile
+    assert '"/gear_sonic/**"' in dockerfile
+    assert 'rm -rf "${SONIC_HOME}/.git"' in dockerfile
     assert 'data["tool"]["npa"]["supported-tools"]["sonic"]' in build_script
     assert "--platform linux/amd64" in build_script
     assert "--variant" in build_script


### PR DESCRIPTION
## Summary
- Sparse-check out only the SONIC runtime source paths needed by the image build.
- Avoid materializing large upstream docs/media before cleanup.
- Update the SONIC build-script test to assert the sparse checkout contract.

## Validation
- Built and pushed the SONIC Kubernetes runtime image successfully from this Dockerfile.
- `npa/.venv/bin/python -m pytest npa/tests/cli/test_sonic_cli.py::test_sonic_container_build_script_uses_supported_version npa/tests/workbench/test_sonic_workflow_registry_auth.py npa/tests/workflows/test_sonic_locomotion_finetuning.py::test_sonic_workflow_materializer_supports_docker_payload_mode -q`
- `npa/.venv/bin/python -m ruff check npa/tests/cli/test_sonic_cli.py`
