### PR TITLE
PARTIAL: fix(sonic): build sm120 Kubernetes runtime image

### DIFF
--- a/npa/docker/workbench/sonic/Dockerfile
+++ b/npa/docker/workbench/sonic/Dockerfile
@@ -1,21 +1,33 @@
-# Self-contained SONIC image. It uses NVIDIA's Isaac Lab distribution directly,
-# not the Workbench Isaac Lab image, then installs SONIC as an application layer.
-FROM --platform=linux/amd64 nvcr.io/nvidia/isaac-lab:2.3.2@sha256:388dbc806f48359a964cb9f807feb226da95d0a107f470fdcad9780ea10fe6f2
+# Self-contained SONIC image. The default L40S build starts from NVIDIA's
+# Isaac Lab image. The k8s/Blackwell build overrides BASE_IMAGE to the CUDA 13
+# sm_120 base and installs the Isaac Sim/Lab Python layer on top.
+ARG BASE_IMAGE=nvcr.io/nvidia/isaac-lab:2.3.2@sha256:388dbc806f48359a964cb9f807feb226da95d0a107f470fdcad9780ea10fe6f2
+FROM --platform=linux/amd64 ${BASE_IMAGE}
 
+ARG BASE_IMAGE=nvcr.io/nvidia/isaac-lab:2.3.2@sha256:388dbc806f48359a964cb9f807feb226da95d0a107f470fdcad9780ea10fe6f2
 ARG ISAAC_LAB_VERSION=2.3.2.post1
+ARG ISAAC_SIM_VERSION=5.1.0.0
 ARG SONIC_REPO_URL=https://github.com/NVlabs/GR00T-WholeBodyControl.git
 ARG SONIC_REPO_REF=0a87181c9106d0e49293400714b157676e0ec664
 ARG SONIC_VERSION=0.1.2
 ARG NVIDIA_DRIVER_PACKAGE_VERSION=580.126.09-1ubuntu1
+ARG ISAAC_LAB_PYTHON=/isaac-sim/python.sh
 ARG INSTALL_NVIDIA_DRIVER_USERSPACE=1
+ARG INSTALL_ISAACSIM_EXTRA=0
+ARG REQUIRE_TORCH_SM120=0
 ARG NPA_DRIVER_PROVISIONING=baked
+ARG NPA_CUDA_ARCHITECTURES=sm80,sm90
+ARG NPA_ISAAC_LAB_INSTALL_MODE=base
 ARG NPA_RUNTIME_USER=ubuntu
 ARG BUILD_SONIC_DEPLOY=0
 
 LABEL npa.tool="sonic" \
       npa.version="${SONIC_VERSION}" \
+      npa.base_image="${BASE_IMAGE}" \
       npa.driver_provisioning="${NPA_DRIVER_PROVISIONING}" \
       npa.runtime_user="${NPA_RUNTIME_USER}" \
+      npa.cuda_architectures="${NPA_CUDA_ARCHITECTURES}" \
+      npa.isaac_lab_install="${NPA_ISAAC_LAB_INSTALL_MODE}" \
       npa.architecture="self-contained-isaac-lab"
 
 ENV ACCEPT_EULA=Y \
@@ -23,9 +35,9 @@ ENV ACCEPT_EULA=Y \
     OMNI_KIT_ACCEPT_EULA=YES \
     PRIVACY_CONSENT=Y \
     ISAAC_LAB_VERSION=${ISAAC_LAB_VERSION} \
-    ISAAC_LAB_PYTHON=/isaac-sim/python.sh \
     SONIC_HOME=/opt/sonic \
     SONIC_REPO_REF=${SONIC_REPO_REF} \
+    NPA_CUDA_ARCHITECTURES=${NPA_CUDA_ARCHITECTURES} \
     NVIDIA_DRIVER_CAPABILITIES=all \
     VK_ICD_FILENAMES=/etc/vulkan/icd.d/nvidia_icd.json \
     VK_DRIVER_FILES=/etc/vulkan/icd.d/nvidia_icd.json \
@@ -35,6 +47,9 @@ ENV ACCEPT_EULA=Y \
     XDG_RUNTIME_DIR=/tmp/xdg-runtime \
     PYTHONUNBUFFERED=1 \
     PIP_EXTRA_INDEX_URL=https://pypi.nvidia.com
+
+ENV ISAAC_LAB_PYTHON=${ISAAC_LAB_PYTHON} \
+    REQUIRE_TORCH_SM120=${REQUIRE_TORCH_SM120}
 
 SHELL ["/bin/bash", "-lc"]
 USER root
@@ -47,7 +62,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
       curl \
       git \
       git-lfs \
+      libegl1 \
       libgtest-dev \
+      libgl1 \
+      libglvnd0 \
+      libglu1-mesa \
       nlohmann-json3-dev \
       pkg-config \
       python3 \
@@ -86,9 +105,53 @@ RUN if [ "${INSTALL_NVIDIA_DRIVER_USERSPACE}" = "1" ]; then \
 RUN mkdir -p /opt/npa/docker/workbench/sonic /tmp/npa-sonic-output
 COPY docker/workbench/sonic/requirements.txt /opt/npa/docker/workbench/sonic/requirements.txt
 
-RUN "${ISAAC_LAB_PYTHON}" -m pip install --no-cache-dir --no-deps --ignore-installed \
-      "isaaclab==${ISAAC_LAB_VERSION}" \
-      --extra-index-url https://pypi.nvidia.com
+RUN "${ISAAC_LAB_PYTHON}" - <<'PY' > /tmp/npa-torch-constraints.txt
+from importlib import metadata
+
+for dist in metadata.distributions():
+    name = dist.metadata.get("Name", "")
+    canonical = name.lower().replace("_", "-")
+    if canonical in {"torch", "torchvision", "torchaudio", "triton"} or canonical.startswith("nvidia-"):
+        print(f"{canonical}==={dist.version}")
+PY
+
+RUN if [ "${INSTALL_ISAACSIM_EXTRA}" = "1" ]; then \
+      "${ISAAC_LAB_PYTHON}" -m pip install --no-cache-dir \
+        -c /tmp/npa-torch-constraints.txt \
+        "isaaclab[all]==${ISAAC_LAB_VERSION}" \
+        --extra-index-url https://pypi.nvidia.com \
+      && "${ISAAC_LAB_PYTHON}" -m pip install --no-cache-dir --no-deps --ignore-installed \
+        "isaacsim==${ISAAC_SIM_VERSION}" \
+        "isaacsim-kernel==${ISAAC_SIM_VERSION}" \
+        "isaacsim-extscache-kit==${ISAAC_SIM_VERSION}" \
+        "isaacsim-extscache-kit-sdk==${ISAAC_SIM_VERSION}" \
+        "isaacsim-extscache-physics==${ISAAC_SIM_VERSION}" \
+        "isaacsim-app==${ISAAC_SIM_VERSION}" \
+        "isaacsim-asset==${ISAAC_SIM_VERSION}" \
+        "isaacsim-benchmark==${ISAAC_SIM_VERSION}" \
+        "isaacsim-code-editor==${ISAAC_SIM_VERSION}" \
+        "isaacsim-core==${ISAAC_SIM_VERSION}" \
+        "isaacsim-cortex==${ISAAC_SIM_VERSION}" \
+        "isaacsim-example==${ISAAC_SIM_VERSION}" \
+        "isaacsim-gui==${ISAAC_SIM_VERSION}" \
+        "isaacsim-replicator==${ISAAC_SIM_VERSION}" \
+        "isaacsim-rl==${ISAAC_SIM_VERSION}" \
+        "isaacsim-robot==${ISAAC_SIM_VERSION}" \
+        "isaacsim-robot-motion==${ISAAC_SIM_VERSION}" \
+        "isaacsim-robot-setup==${ISAAC_SIM_VERSION}" \
+        "isaacsim-ros1==${ISAAC_SIM_VERSION}" \
+        "isaacsim-ros2==${ISAAC_SIM_VERSION}" \
+        "isaacsim-sensor==${ISAAC_SIM_VERSION}" \
+        "isaacsim-storage==${ISAAC_SIM_VERSION}" \
+        "isaacsim-template==${ISAAC_SIM_VERSION}" \
+        "isaacsim-test==${ISAAC_SIM_VERSION}" \
+        "isaacsim-utils==${ISAAC_SIM_VERSION}" \
+        --extra-index-url https://pypi.nvidia.com; \
+    else \
+      "${ISAAC_LAB_PYTHON}" -m pip install --no-cache-dir --no-deps --ignore-installed \
+        "isaaclab==${ISAAC_LAB_VERSION}" \
+        --extra-index-url https://pypi.nvidia.com; \
+    fi
 
 RUN "${ISAAC_LAB_PYTHON}" -m pip install --no-cache-dir \
       -r /opt/npa/docker/workbench/sonic/requirements.txt
@@ -102,7 +165,18 @@ RUN git clone "${SONIC_REPO_URL}" "${SONIC_HOME}" \
     && (git lfs pull --include="download_from_hf.py,gear_sonic/**,gear_sonic_deploy/**,decoupled_wbc/**" --exclude="motionbricks/out/**" || true) \
     && rm -rf "${SONIC_HOME}/.git" "${SONIC_HOME}/docs"
 
+RUN "${ISAAC_LAB_PYTHON}" - <<'PY' > /tmp/npa-torch-constraints.txt
+from importlib import metadata
+
+for dist in metadata.distributions():
+    name = dist.metadata.get("Name", "")
+    canonical = name.lower().replace("_", "-")
+    if canonical in {"torch", "torchvision", "torchaudio", "triton"} or canonical.startswith("nvidia-"):
+        print(f"{canonical}==={dist.version}")
+PY
+
 RUN "${ISAAC_LAB_PYTHON}" -m pip install --no-cache-dir \
+      -c /tmp/npa-torch-constraints.txt \
       -e "${SONIC_HOME}/gear_sonic[training,teleop,sim]" \
     && "${ISAAC_LAB_PYTHON}" - <<'PY'
 import pathlib
@@ -110,19 +184,29 @@ import site
 
 for site_dir in site.getsitepackages():
     path = pathlib.Path(site_dir) / "sonic.py"
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("from gear_sonic import *\n", encoding="utf-8")
 PY
 
 RUN "${ISAAC_LAB_PYTHON}" - <<'PY'
 import importlib
+import os
 from importlib import metadata
 
 expected = "2.3.2.post1"
 actual = metadata.version("isaaclab")
 if actual != expected:
     raise RuntimeError(f"expected isaaclab {expected}, found {actual}")
-for module in ("gear_sonic", "sonic", "isaaclab"):
+for module in ("gear_sonic", "sonic", "isaaclab", "isaaclab.app"):
     importlib.import_module(module)
+if os.environ.get("REQUIRE_TORCH_SM120") == "1":
+    import torch
+
+    arch_flags = getattr(torch._C, "_cuda_getArchFlags", lambda: "")()
+    arches = set(arch_flags.split()) or set(torch.cuda.get_arch_list())
+    if "sm_120" not in arches:
+        raise RuntimeError(f"expected PyTorch with sm_120 kernels, found {sorted(arches)}")
+    print(f"NPA_SONIC_TORCH_SM120_OK torch={torch.__version__} cuda={torch.version.cuda}")
 print("NPA_SONIC_BUILD_IMPORTS_OK")
 PY
 
@@ -141,6 +225,7 @@ COPY docker/workbench/sonic/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 ubuntu \
+    && (getent group isaac-sim >/dev/null 2>&1 || groupadd -r isaac-sim) \
     && usermod -aG isaac-sim ubuntu \
     && install -d -m 775 -o root -g isaac-sim \
       /isaac-sim/kit/logs \

--- a/npa/docker/workbench/sonic/build.sh
+++ b/npa/docker/workbench/sonic/build.sh
@@ -8,16 +8,18 @@ REGISTRY=""
 PUSH=0
 VARIANT="baked"
 IMAGE_TAG_OVERRIDE=""
+BASE_IMAGE_OVERRIDE=""
 
 usage() {
   cat <<'EOF'
-Usage: build.sh [--registry REGISTRY] [--push] [--variant baked|k8s|mujoco] [--tag TAG]
+Usage: build.sh [--registry REGISTRY] [--push] [--variant baked|k8s|mujoco] [--tag TAG] [--base-image IMAGE]
 
 Builds the SONIC runtime image as npa-sonic:<version> for --variant baked, or
-npa-sonic:<version>-k8s for --variant k8s. The mujoco variant builds the
+npa-sonic:<version>-k8s-runtime for --variant k8s. The mujoco variant builds the
 additive npa-sonic-mujoco:<tag> image from an existing SONIC base image.
 When --tag is provided, it overrides the final image tag.
-When --registry is provided, also tags REGISTRY/npa-sonic:<tag>.
+When --base-image is provided, it overrides the variant default base image.
+When --registry is provided, also tags REGISTRY/<image-name>:<tag>.
 Use --registry cr.eu-north1.nebius.cloud/<your-registry-id> --push to publish.
 EOF
 }
@@ -52,6 +54,14 @@ while [ "$#" -gt 0 ]; do
       IMAGE_TAG_OVERRIDE="$2"
       shift 2
       ;;
+    --base-image)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --base-image requires a value" >&2
+        exit 2
+      fi
+      BASE_IMAGE_OVERRIDE="$2"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -72,14 +82,30 @@ fi
 case "$VARIANT" in
   baked)
     TAG_SUFFIX=""
+    BASE_IMAGE_DEFAULT="nvcr.io/nvidia/isaac-lab:2.3.2@sha256:388dbc806f48359a964cb9f807feb226da95d0a107f470fdcad9780ea10fe6f2"
+    ISAAC_LAB_PYTHON="/isaac-sim/python.sh"
     INSTALL_NVIDIA_DRIVER_USERSPACE=1
+    INSTALL_ISAACSIM_EXTRA=0
+    REQUIRE_TORCH_SM120=0
     NPA_DRIVER_PROVISIONING="baked"
+    NPA_CUDA_ARCHITECTURES="sm80,sm90"
+    NPA_ISAAC_LAB_INSTALL_MODE="preinstalled-isaac-sim"
     NPA_RUNTIME_USER="ubuntu"
     ;;
   k8s)
-    TAG_SUFFIX="-k8s"
+    TAG_SUFFIX="-k8s-runtime"
+    if [ -n "$REGISTRY" ]; then
+      BASE_IMAGE_DEFAULT="${REGISTRY}/npa-base:cuda13-b300-sm80-sm90-sm120-latest"
+    else
+      BASE_IMAGE_DEFAULT="npa-base:cuda13-b300-sm80-sm90-sm120-latest"
+    fi
+    ISAAC_LAB_PYTHON="/opt/npa/venv/bin/python"
     INSTALL_NVIDIA_DRIVER_USERSPACE=0
+    INSTALL_ISAACSIM_EXTRA=1
+    REQUIRE_TORCH_SM120=1
     NPA_DRIVER_PROVISIONING="host-mounted"
+    NPA_CUDA_ARCHITECTURES="sm80,sm90,sm120"
+    NPA_ISAAC_LAB_INSTALL_MODE="pip-isaacsim-on-cuda13-sm120"
     NPA_RUNTIME_USER="root"
     IMAGE_NAME="npa-sonic"
     DOCKERFILE="$SCRIPT_DIR/Dockerfile"
@@ -87,8 +113,14 @@ case "$VARIANT" in
     ;;
   mujoco)
     TAG_SUFFIX=""
+    BASE_IMAGE_DEFAULT=""
+    ISAAC_LAB_PYTHON="/isaac-sim/python.sh"
     INSTALL_NVIDIA_DRIVER_USERSPACE=0
+    INSTALL_ISAACSIM_EXTRA=0
+    REQUIRE_TORCH_SM120=0
     NPA_DRIVER_PROVISIONING="inherited"
+    NPA_CUDA_ARCHITECTURES="inherited"
+    NPA_ISAAC_LAB_INSTALL_MODE="inherited"
     NPA_RUNTIME_USER="ubuntu"
     IMAGE_NAME="npa-sonic-mujoco"
     DOCKERFILE="$SCRIPT_DIR/Dockerfile.mujoco"
@@ -159,20 +191,8 @@ if [ -z "${DEFAULT_IMAGE_TAG:-}" ]; then
   DEFAULT_IMAGE_TAG="${VERSION}${TAG_SUFFIX}"
 fi
 
-IMAGE_TAG="${IMAGE_TAG_OVERRIDE:-${DEFAULT_IMAGE_TAG}}"
-LOCAL_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
-BUILD_ARGS=(
-  --platform linux/amd64
-  -f "$DOCKERFILE"
-  --build-arg "SONIC_VERSION=${VERSION}"
-  --build-arg "ISAAC_LAB_VERSION=${ISAAC_LAB_VERSION}"
-  --build-arg "INSTALL_NVIDIA_DRIVER_USERSPACE=${INSTALL_NVIDIA_DRIVER_USERSPACE}"
-  --build-arg "NPA_DRIVER_PROVISIONING=${NPA_DRIVER_PROVISIONING}"
-  --build-arg "NPA_RUNTIME_USER=${NPA_RUNTIME_USER}"
-)
-
 if [ "$VARIANT" = "mujoco" ]; then
-  BASE_IMAGE="${NPA_SONIC_MUJOCO_BASE_IMAGE:-}"
+  BASE_IMAGE="${BASE_IMAGE_OVERRIDE:-${NPA_SONIC_MUJOCO_BASE_IMAGE:-}}"
   if [ -z "$BASE_IMAGE" ]; then
     if [ -n "$REGISTRY" ]; then
       BASE_IMAGE="${REGISTRY}/npa-sonic:${VERSION}"
@@ -180,7 +200,30 @@ if [ "$VARIANT" = "mujoco" ]; then
       BASE_IMAGE="npa-sonic:${VERSION}"
     fi
   fi
-  BUILD_ARGS+=(--build-arg "BASE_IMAGE=${BASE_IMAGE}" --build-arg "SONIC_MUJOCO_VERSION=${IMAGE_TAG}")
+else
+  BASE_IMAGE="${BASE_IMAGE_OVERRIDE:-$BASE_IMAGE_DEFAULT}"
+fi
+
+IMAGE_TAG="${IMAGE_TAG_OVERRIDE:-${DEFAULT_IMAGE_TAG}}"
+LOCAL_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+BUILD_ARGS=(
+  --platform linux/amd64
+  -f "$DOCKERFILE"
+  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+  --build-arg "SONIC_VERSION=${VERSION}"
+  --build-arg "ISAAC_LAB_VERSION=${ISAAC_LAB_VERSION}"
+  --build-arg "ISAAC_LAB_PYTHON=${ISAAC_LAB_PYTHON}"
+  --build-arg "INSTALL_NVIDIA_DRIVER_USERSPACE=${INSTALL_NVIDIA_DRIVER_USERSPACE}"
+  --build-arg "INSTALL_ISAACSIM_EXTRA=${INSTALL_ISAACSIM_EXTRA}"
+  --build-arg "REQUIRE_TORCH_SM120=${REQUIRE_TORCH_SM120}"
+  --build-arg "NPA_DRIVER_PROVISIONING=${NPA_DRIVER_PROVISIONING}"
+  --build-arg "NPA_CUDA_ARCHITECTURES=${NPA_CUDA_ARCHITECTURES}"
+  --build-arg "NPA_ISAAC_LAB_INSTALL_MODE=${NPA_ISAAC_LAB_INSTALL_MODE}"
+  --build-arg "NPA_RUNTIME_USER=${NPA_RUNTIME_USER}"
+)
+
+if [ "$VARIANT" = "mujoco" ]; then
+  BUILD_ARGS+=(--build-arg "SONIC_MUJOCO_VERSION=${IMAGE_TAG}")
 fi
 
 if [ -n "$REGISTRY" ]; then
@@ -199,7 +242,12 @@ if [ "$PUSH" -eq 1 ]; then
   exit 0
 fi
 
-docker build "${BUILD_ARGS[@]}" -t "$LOCAL_IMAGE" "$NPA_ROOT"
+LOCAL_BUILD_TAGS=(-t "$LOCAL_IMAGE")
+if [ -n "$REGISTRY_IMAGE" ]; then
+  LOCAL_BUILD_TAGS+=(-t "$REGISTRY_IMAGE")
+fi
+
+docker build "${BUILD_ARGS[@]}" "${LOCAL_BUILD_TAGS[@]}" "$NPA_ROOT"
 
 SIZE_BYTES="$(docker image inspect "$LOCAL_IMAGE" --format '{{.Size}}')"
 if command -v numfmt >/dev/null 2>&1; then

--- a/npa/docker/workbench/sonic/entrypoint.sh
+++ b/npa/docker/workbench/sonic/entrypoint.sh
@@ -5,6 +5,8 @@ PYTHON_BIN="${NPA_PYTHON_BIN:-}"
 if [ -z "$PYTHON_BIN" ]; then
   if [ -x /isaac-sim/python.sh ]; then
     PYTHON_BIN=/isaac-sim/python.sh
+  elif [ -x /opt/npa/venv/bin/python ]; then
+    PYTHON_BIN=/opt/npa/venv/bin/python
   elif [ -x /opt/isaac-lab/venv/bin/python ]; then
     PYTHON_BIN=/opt/isaac-lab/venv/bin/python
   else

--- a/npa/src/npa/deploy/sonic_image_manifest.json
+++ b/npa/src/npa/deploy/sonic_image_manifest.json
@@ -42,10 +42,11 @@
       "tag": "0.1.2-k8s-runtime",
       "purpose": "SONIC runtime for GPU-operator-managed Kubernetes nodes where the NVIDIA host driver is mounted into the container.",
       "base": {
-        "cuda": "12.8",
-        "torch": "2.7.0+cu128",
+        "cuda": "13.0",
+        "torch": "2.9.0+cu130",
         "isaac_lab": "2.3.2.post1",
-        "image": "nvcr.io/nvidia/isaac-lab:2.3.2@sha256:388dbc806f48359a964cb9f807feb226da95d0a107f470fdcad9780ea10fe6f2"
+        "isaac_sim": "5.1.0",
+        "image": "npa-base:cuda13-b300-sm80-sm90-sm120-latest"
       },
       "driver_provisioning": "host-mounted",
       "gpu_compatibility": [
@@ -57,7 +58,7 @@
         {
           "gpu": "Blackwell sm_120",
           "provider_model": "Kubernetes with NVIDIA GPU Operator",
-          "why": "Use the operator-mounted driver stack and keep NVIDIA_DRIVER_CAPABILITIES=all."
+          "why": "Use the CUDA 13 sm_120 PyTorch base, the operator-mounted driver stack, and NVIDIA_DRIVER_CAPABILITIES=all."
         }
       ],
       "build": {
@@ -65,7 +66,7 @@
         "dockerfile": "npa/docker/workbench/sonic/Dockerfile",
         "driver_coupled_packages": []
       },
-      "digest": "sha256:ceb878ff19234866eab44a257f72c933039f336ac92d6e5c1cc066ba1a90e93d"
+      "digest": "sha256:bc246a1b2bc3038de5443107bb9ff34db9dddbe4cc15bac5b51a68b5e335e1d2"
     },
     {
       "id": "sonic-mujoco-h100-mvp",

--- a/npa/tests/cli/test_sonic_cli.py
+++ b/npa/tests/cli/test_sonic_cli.py
@@ -535,10 +535,20 @@ def test_sonic_container_build_script_uses_supported_version() -> None:
     build_script = (PACKAGE_ROOT / "docker/workbench/sonic/build.sh").read_text()
 
     assert "ARG SONIC_VERSION=0.1.2" in dockerfile
+    assert "ARG BASE_IMAGE=" in dockerfile
+    assert "ARG INSTALL_ISAACSIM_EXTRA=0" in dockerfile
+    assert "ARG REQUIRE_TORCH_SM120=0" in dockerfile
     assert "ARG INSTALL_NVIDIA_DRIVER_USERSPACE=1" in dockerfile
     assert "ARG NPA_DRIVER_PROVISIONING=baked" in dockerfile
+    assert 'npa.cuda_architectures="${NPA_CUDA_ARCHITECTURES}"' in dockerfile
     assert 'npa.version="${SONIC_VERSION}"' in dockerfile
     assert 'npa.driver_provisioning="${NPA_DRIVER_PROVISIONING}"' in dockerfile
+    assert '"isaaclab[all]==${ISAAC_LAB_VERSION}"' in dockerfile
+    assert "npa-torch-constraints.txt" in dockerfile
+    assert '"isaacsim-kernel==${ISAAC_SIM_VERSION}"' in dockerfile
+    assert "--no-deps --ignore-installed" in dockerfile
+    assert "_cuda_getArchFlags" in dockerfile
+    assert '"sm_120" not in arches' in dockerfile
     assert "COPY docker/workbench/sonic/requirements.txt" in dockerfile
     assert "COPY docker/workbench/sonic/entrypoint.sh" in dockerfile
     assert 'rm -rf "${SONIC_HOME}/.git" "${SONIC_HOME}/docs"' in dockerfile
@@ -546,10 +556,15 @@ def test_sonic_container_build_script_uses_supported_version() -> None:
     assert "--platform linux/amd64" in build_script
     assert "--variant" in build_script
     assert "--push" in build_script
+    assert "--base-image" in build_script
+    assert "cuda13-b300-sm80-sm90-sm120-latest" in build_script
+    assert 'TAG_SUFFIX="-k8s-runtime"' in build_script
+    assert 'REQUIRE_TORCH_SM120=1' in build_script
     assert "NPA_BUILDX_BUILDER" in build_script
     assert "--driver docker-container" in build_script
     assert 'docker buildx build --builder "$BUILDX_BUILDER"' in build_script
-    assert 'docker build "${BUILD_ARGS[@]}" -t "$LOCAL_IMAGE"' in build_script
     assert 'IMAGE_NAME="npa-sonic"' in build_script
     assert 'IMAGE_NAME="npa-sonic-mujoco"' in build_script
     assert 'LOCAL_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"' in build_script
+    assert 'docker build "${BUILD_ARGS[@]}" "${LOCAL_BUILD_TAGS[@]}" "$NPA_ROOT"' in build_script
+    assert 'REGISTRY_IMAGE="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"' in build_script

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -211,7 +211,7 @@ def test_workbench_workflow_submit_materializes_sonic_yaml(mocker) -> None:
     docs = [doc for doc in yaml.safe_load_all(str(captured["content"])) if doc]
     task = docs[1]
     envs = task["envs"]
-    assert task["resources"]["image_id"] == "docker:registry.example/workbench/npa-sonic:0.1.2-k8s-runtime"
+    assert "image_id" not in task["resources"]
     assert task["resources"]["cloud"] == "kubernetes"
     assert task["resources"]["accelerators"] == "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
     assert envs["POLICY_IMAGE"] == "registry.example/workbench/npa-sonic:0.1.2-k8s-runtime"
@@ -221,7 +221,7 @@ def test_workbench_workflow_submit_materializes_sonic_yaml(mocker) -> None:
     assert envs["S3_BUCKET"] == "proof-bucket"
     assert envs["SONIC_OUTPUT_PREFIX"] == "sonic-proof/sonic-run/"
     assert envs["SONIC_MAX_ITERATIONS"] == "2"
-    assert "${" not in task["resources"]["image_id"]
+    assert "image_id" not in task["resources"]
     assert "${" not in "\n".join(str(value) for value in envs.values())
 
 

--- a/npa/tests/guardrails/test_three_tier_contract.py
+++ b/npa/tests/guardrails/test_three_tier_contract.py
@@ -254,7 +254,7 @@ def test_standalone_policy_yaml_is_parameterized_and_endpoint_safe() -> None:
     task = docs[1]
     envs = task["envs"]
 
-    assert task["resources"]["image_id"] == "docker:example.invalid/npa-sonic:0.1.2"
+    assert "image_id" not in task["resources"]
     assert {
         "POLICY_IMAGE",
         "SONIC_GPU_TYPE",
@@ -267,6 +267,6 @@ def test_standalone_policy_yaml_is_parameterized_and_endpoint_safe() -> None:
     assert envs["SONIC_IMAGE_VARIANT"] == "sonic-l40s-baked"
     assert envs["S3_ENDPOINT_URL"] == ""
     assert envs["S3_BUCKET"] == "example-bucket"
-    assert "${" not in task["resources"]["image_id"]
+    assert "image_id" not in task["resources"]
     assert "${" not in "\n".join(str(value) for value in envs.values())
     assert "nebius.cloud" not in text

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -16,10 +16,9 @@ resources:
   accelerators: L40S:1
   cpus: 16
   memory: 64
-  image_id: "docker:example.invalid/npa-sonic:0.1.2"
 envs:
   POLICY_IMAGE: "example.invalid/npa-sonic:0.1.2"
-  SONIC_PAYLOAD_MODE: "direct"
+  SONIC_PAYLOAD_MODE: "docker"
   SONIC_GPU_TYPE: "l40s"
   SONIC_IMAGE_VARIANT: "sonic-l40s-baked"
   S3_ENDPOINT_URL: ""


### PR DESCRIPTION
## Summary

Follow-up to #42. That PR is already merged, so this PR carries the Blackwell sm_120 runtime update on current `main`.

- Builds the SONIC Kubernetes runtime image from the CUDA 13 sm80/sm90/sm120 base.
- Keeps PyTorch/CUDA packages constrained while installing Isaac Sim/Lab and SONIC.
- Adds a build-time sm_120 guard and records the proven k8s runtime digest in the manifest.
- Moves the standalone raw SkyPilot workflow to the docker-run-payload pattern by removing direct `resources.image_id`.

## Validation

- Built and pushed the exact k8s runtime image tag; pushed digest: `sha256:bc246a1b2bc3038de5443107bb9ff34db9dddbe4cc15bac5b51a68b5e335e1d2`.
- Verified the image is pullable from Kubernetes with the configured pull secret.
- Proved CUDA on RTX PRO 6000 Blackwell from the pushed image:
  - `NPA_SONIC_TORCH_ARCH_FLAGS sm_75 sm_80 sm_86 sm_90 sm_100 sm_120 compute_120`
  - `NPA_SONIC_TORCH_SM120_KERNEL_OK NVIDIA RTX PRO 6000 Blackwell Server Edition (12, 0)`
- Proved native Kubernetes Isaac Lab headless Vulkan render from the pushed image:
  - `NPA_SONIC_CONTAINER_EVAL_DONE`
  - `NPA_SONIC_RENDER_ASSERT_OK frames=8`
  - uploaded result JSON was confirmed with an object metadata check.

## Residual seam

SkyPilot 0.12.2 Kubernetes `enable_docker` launches a hard-coded `docker:29.3-dind` sidecar. In the live run that sidecar had no NVIDIA runtime/CDI integration, so `docker run --gpus all` failed with:

`failed to discover GPU vendor from CDI: no known GPU vendor found`

So the image/render path is proven, and the public workflow is moved to the docker payload pattern, but the live SkyPilot Kubernetes DIND GPU path remains a provider/runtime seam until the DIND sidecar supports NVIDIA runtime/CDI or the workflow uses native Kubernetes jobs for GPU payload execution.

## Tests

- `npa/.venv/bin/python -m pytest npa/tests/cli/test_sonic_cli.py::test_sonic_container_image_name_resolves npa/tests/cli/test_sonic_cli.py::test_sonic_container_build_script_uses_supported_version npa/tests/workflows/test_sonic_locomotion_finetuning.py::test_sonic_workflow_materializer_resolves_images_and_s3_literals npa/tests/workflows/test_sonic_locomotion_finetuning.py::test_sonic_workflow_materializer_supports_docker_payload_mode npa/tests/guardrails/test_three_tier_contract.py::test_standalone_policy_yaml_is_parameterized_and_endpoint_safe npa/tests/cli/test_workflow_cli.py::test_workbench_workflow_submit_materializes_sonic_yaml -q`
- `bash -n npa/docker/workbench/sonic/build.sh npa/docker/workbench/sonic/entrypoint.sh`
- `git diff --check`