### PR TITLE
Fix SONIC nested Docker CDI GPU passthrough

### DIFF
--- a/docs/workbench/cookbooks/sonic-eval-runbook.md
+++ b/docs/workbench/cookbooks/sonic-eval-runbook.md
@@ -114,6 +114,11 @@ CONTAINER_OUTPUT_PATH: /npa/eval/output/sonic_eval_results.json
 
 The container receives:
 
+- Docker GPU injection defaults to `CONTAINER_GPUS=all`, which uses Docker's
+  `--gpus` flag. For NVIDIA CDI sidecars, set
+  `CONTAINER_GPUS=nvidia.com/gpu=all`; the CLI then uses the NVIDIA runtime and
+  passes that CDI device through `NVIDIA_VISIBLE_DEVICES` instead of `--gpus`.
+
 - `NPA_SONIC_ONNX`
 - `NPA_SONIC_METADATA`
 - `NPA_SONIC_OUTPUT`

--- a/docs/workbench/cookbooks/sonic-train-runbook.md
+++ b/docs/workbench/cookbooks/sonic-train-runbook.md
@@ -103,6 +103,17 @@ Then add `--config-path /path/to/skypilot-kubernetes.yaml` to the submit command
 Do not set `serviceAccountName` unless that account can also list Kubernetes
 nodes and pods for SkyPilot prechecks.
 
+When `SONIC_PAYLOAD_MODE=docker`, the default `SONIC_DOCKER_GPU_REQUEST=all`
+uses Docker's legacy `--gpus all` path. On Kubernetes sidecars where the NVIDIA
+runtime is configured for CDI, set
+`SONIC_DOCKER_GPU_REQUEST: nvidia.com/gpu=all` and ensure the SkyPilot runtime
+has `nvidia-ctk` from `nvidia-container-toolkit`. The workflow generates
+`/etc/cdi/nvidia.yaml` immediately before `docker run`, then starts the payload
+with `--runtime=nvidia`, `NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all`, and
+`NVIDIA_DRIVER_CAPABILITIES=all`. If the sidecar is unprivileged or lacks Docker
+and `nvidia-ctk`, use the direct Kubernetes host-mounted SONIC image path rather
+than the nested Docker payload.
+
 SDK equivalent:
 
 ```python

--- a/npa/src/npa/workbench/sonic/eval.py
+++ b/npa/src/npa/workbench/sonic/eval.py
@@ -43,6 +43,7 @@ DEFAULT_CONTAINER_OMNI_USER_DIR = "/tmp/isaac-sim-cache"
 DEFAULT_CONTAINER_OMNI_LOG_DIR = "/tmp/isaac-sim-cache/logs"
 REFERENCE_BACKEND = "reference"
 CONTAINER_BACKEND = "container"
+NVIDIA_CDI_DEVICE_PREFIX = "nvidia.com/"
 BACKENDS = {REFERENCE_BACKEND, CONTAINER_BACKEND}
 BUILTIN_REFERENCE_ENVS = {"locomotion-smoke", "sonic-locomotion-smoke"}
 BUILTIN_REFERENCE_STEPS = 32
@@ -678,10 +679,14 @@ def _container_command(
         (str(output_dir), output_parent, ""),
     ]
     command = [runtime, "run", "--rm"]
+    nvidia_visible_devices = ""
     if _is_docker_runtime(runtime):
         command.extend(["--runtime", "nvidia"])
         if container_gpus:
-            command.extend(["--gpus", container_gpus])
+            if _is_nvidia_cdi_device_request(container_gpus):
+                nvidia_visible_devices = container_gpus
+            else:
+                command.extend(["--gpus", container_gpus])
         for device in container_devices:
             if device:
                 command.extend(["--device", device])
@@ -702,6 +707,8 @@ def _container_command(
         "OMNI_USER_DIR": DEFAULT_CONTAINER_OMNI_USER_DIR,
         "OMNI_LOG_DIR": DEFAULT_CONTAINER_OMNI_LOG_DIR,
     }
+    if nvidia_visible_devices:
+        env_vars["NVIDIA_VISIBLE_DEVICES"] = nvidia_visible_devices
     if container_driver_capabilities:
         env_vars["NVIDIA_DRIVER_CAPABILITIES"] = container_driver_capabilities
     if container_vulkan_icd:
@@ -1099,6 +1106,10 @@ def _dedupe_mounts(mounts: list[tuple[str, str, str]]) -> list[tuple[str, str, s
 
 def _is_docker_runtime(runtime: str) -> bool:
     return Path(runtime).name == "docker"
+
+
+def _is_nvidia_cdi_device_request(gpu_request: str) -> bool:
+    return gpu_request.strip().startswith(NVIDIA_CDI_DEVICE_PREFIX)
 
 
 def _rate(episodes: list[dict[str, Any]], key: str) -> float:

--- a/npa/tests/workbench/test_sonic_eval.py
+++ b/npa/tests/workbench/test_sonic_eval.py
@@ -210,8 +210,48 @@ def test_sonic_eval_container_backend_uses_configured_io_contract(
     assert written["metrics"]["valid_action_rate"] == 1.0
 
 
-def _fake_container_runtime(tmp_path: Path) -> Path:
-    runtime = tmp_path / "fake-container-runtime.py"
+def test_sonic_eval_container_backend_accepts_nvidia_cdi_gpu_request(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "policy.onnx"
+    export = export_onnx(
+        checkpoint="in-memory-policy",
+        output=str(output),
+        policy=TinyEvalPolicy().eval(),
+        verify=False,
+    )
+    runtime = _fake_container_runtime(tmp_path, name="docker")
+
+    result = evaluate_onnx_policy(
+        onnx=export.onnx_path,
+        metadata=export.metadata_path,
+        backend="container",
+        episodes=1,
+        env="isaac-lab-headless-render",
+        container_image="mock-sonic-eval:latest",
+        container_runtime=str(runtime),
+        container_gpus="nvidia.com/gpu=all",
+        container_args=["eval"],
+    )
+
+    argv = result["diagnostics"]["argv"]
+    env = result["diagnostics"]["env"]
+    assert "--gpus" not in argv
+    assert argv[0:4] == ["run", "--rm", "--runtime", "nvidia"]
+    assert env["NVIDIA_VISIBLE_DEVICES"] == "nvidia.com/gpu=all"
+    assert env["NVIDIA_DRIVER_CAPABILITIES"] == "all"
+    assert result["container"]["gpus"] == "nvidia.com/gpu=all"
+    assert result["render"] == {
+        "backend": "mock",
+        "graphics_api": "vulkan",
+        "frames": 8,
+    }
+
+
+def _fake_container_runtime(
+    tmp_path: Path, *, name: str = "fake-container-runtime.py"
+) -> Path:
+    runtime = tmp_path / name
     runtime.write_text(
         textwrap.dedent(
             """\
@@ -267,6 +307,7 @@ def _fake_container_runtime(tmp_path: Path) -> Path:
                     {"episode_index": 1, "episode_return": 1.5, "distance": 3.0}
                 ],
                 "render": {"backend": "mock", "graphics_api": "vulkan", "frames": 8},
+                "diagnostics": {"argv": args, "env": env},
                 "warnings": []
             }), encoding="utf-8")
             """

--- a/npa/tests/workflows/test_sonic_locomotion_finetuning.py
+++ b/npa/tests/workflows/test_sonic_locomotion_finetuning.py
@@ -219,7 +219,11 @@ def test_sonic_workflow_materializer_supports_docker_payload_mode() -> None:
     assert "image_id" not in task["resources"]
     assert task["envs"]["POLICY_IMAGE"] == "registry.example/workbench/npa-sonic:0.1.2"
     assert task["envs"]["SONIC_PAYLOAD_MODE"] == "docker"
-    assert "docker run --rm --gpus all" in task["run"]
+    assert task["envs"]["SONIC_DOCKER_GPU_REQUEST"] == "all"
+    assert '--gpus "${SONIC_DOCKER_GPU_REQUEST}"' in task["run"]
+    assert "nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml" in task["run"]
+    assert "NVIDIA_VISIBLE_DEVICES=${SONIC_DOCKER_GPU_REQUEST}" in task["run"]
+    assert 'docker run --rm "${docker_gpu_args[@]}"' in task["run"]
 
 
 def test_tool_yamls_match_registered_cli_surfaces() -> None:

--- a/npa/workflows/workbench/skypilot/sonic-eval.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-eval.yaml
@@ -27,6 +27,7 @@ envs:
   SONIC_EVAL_CONTAINER_POLICY_PATH: "/npa/eval/input/policy.onnx"
   SONIC_EVAL_CONTAINER_METADATA_PATH: "/npa/eval/input/metadata.json"
   SONIC_EVAL_CONTAINER_OUTPUT_PATH: "/npa/eval/output/sonic_eval_results.json"
+  # Set to nvidia.com/gpu=all for NVIDIA CDI sidecars where Docker --gpus is unsupported.
   SONIC_EVAL_CONTAINER_GPUS: "all"
   SONIC_EVAL_CONTAINER_DRIVER_CAPABILITIES: "all"
   SONIC_EVAL_CONTAINER_VULKAN_ICD: "/etc/vulkan/icd.d/nvidia_icd.json"

--- a/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
@@ -6,6 +6,8 @@
 # - SONIC_PAYLOAD_MODE: direct runs inside POLICY_IMAGE; docker runs POLICY_IMAGE
 #   from SkyPilot's default VM runtime.
 # - AWS_PROFILE: profile name for S3-compatible storage access.
+# - SONIC_DOCKER_GPU_REQUEST: Docker --gpus request, or an NVIDIA CDI device
+#   such as nvidia.com/gpu=all for nested Docker sidecars.
 # - S3_ENDPOINT_URL: S3-compatible endpoint for artifact writes.
 # - S3_BUCKET: destination bucket name, without s3://.
 name: sonic-train-standalone
@@ -22,6 +24,8 @@ envs:
   POLICY_IMAGE: "example.invalid/npa-sonic:0.1.2"
   SONIC_PAYLOAD_MODE: "direct"
   SONIC_GPU_TYPE: "l40s"
+  SONIC_DOCKER_GPU_REQUEST: "all"
+  SONIC_DOCKER_DRIVER_CAPABILITIES: "all"
   SONIC_IMAGE_VARIANT: "sonic-l40s-baked"
   AWS_PROFILE: "nebius"
   S3_ENDPOINT_URL: ""
@@ -56,6 +60,11 @@ setup: |
       exit 2
     }
     docker_login_if_configured
+    if [[ "${SONIC_DOCKER_GPU_REQUEST}" == nvidia.com/* ]] && ! command -v nvidia-ctk >/dev/null 2>&1; then
+      echo "SONIC_DOCKER_GPU_REQUEST=${SONIC_DOCKER_GPU_REQUEST} requires nvidia-ctk in the SkyPilot runtime" >&2
+      echo "Install nvidia-container-toolkit or use a runtime image that includes it before launching the docker payload." >&2
+      exit 2
+    fi
     docker pull "${POLICY_IMAGE}"
   elif [ ! -x /entrypoint.sh ]; then
     echo "The selected POLICY_IMAGE must provide the SONIC /entrypoint.sh runtime" >&2
@@ -91,7 +100,25 @@ run: |
     "${POLICY_IMAGE}" "${SONIC_GPU_TYPE}" "${SONIC_IMAGE_VARIANT}"
 
   if [ "${SONIC_PAYLOAD_MODE}" = "docker" ]; then
-    docker run --rm --gpus all --ipc=host --network=host \
+    docker_gpu_args=()
+    if [ -n "${SONIC_DOCKER_GPU_REQUEST}" ]; then
+      if [[ "${SONIC_DOCKER_GPU_REQUEST}" == nvidia.com/* ]]; then
+        command -v nvidia-ctk >/dev/null 2>&1 || {
+          echo "SONIC_DOCKER_GPU_REQUEST=${SONIC_DOCKER_GPU_REQUEST} requires nvidia-ctk in the SkyPilot runtime" >&2
+          exit 2
+        }
+        sudo mkdir -p /etc/cdi
+        sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+        docker_gpu_args=(
+          --runtime=nvidia
+          -e "NVIDIA_VISIBLE_DEVICES=${SONIC_DOCKER_GPU_REQUEST}"
+          -e "NVIDIA_DRIVER_CAPABILITIES=${SONIC_DOCKER_DRIVER_CAPABILITIES}"
+        )
+      else
+        docker_gpu_args=(--gpus "${SONIC_DOCKER_GPU_REQUEST}")
+      fi
+    fi
+    docker run --rm "${docker_gpu_args[@]}" --ipc=host --network=host \
       -e AWS_ACCESS_KEY_ID \
       -e AWS_SECRET_ACCESS_KEY \
       -e AWS_PROFILE \


### PR DESCRIPTION
## Summary
- add an explicit NVIDIA CDI GPU request path for SONIC container eval
- update the standalone SkyPilot docker payload to generate /etc/cdi/nvidia.yaml and pass nvidia.com/gpu=all through NVIDIA_VISIBLE_DEVICES
- document the Blackwell nested-Docker requirement and keep legacy --gpus all as the default path

## Validation
- nested Docker proof on npa-rtxpro-mk8s: nvidia-smi saw RTX PRO 6000 Blackwell driver 580.95.05 and render produced 8 Vulkan frames
- S3: s3://npa-sim2real-d87cf691/sonic-proof/sonic42-skypilot-payload-20260608T214346Z/
- python3 -m pytest tests/workflows/test_sonic_locomotion_finetuning.py -q
- PYTHONPATH=src direct _container_command CDI check
- python3 -m pytest tests/guardrails -q
- gitleaks detect --source . --no-git --redact --verbose

## Notes
- CUSTOMER_DENYLIST/INFRA_DENYLIST operator-private sources were not configured on the Agent VM, so the repo confidentiality scanner failed closed before scanning.
- The Agent VM lacks torch/onnx/onnxruntime, so the full test_sonic_eval.py module is skipped there; the new command-construction behavior was validated directly.