### PR TITLE
Improve first-time-user onboarding and dev/test setup

### DIFF
--- a/.agents/skills/workbench/sonic/SKILL.md
+++ b/.agents/skills/workbench/sonic/SKILL.md
@@ -24,7 +24,7 @@ npa workbench sonic list
 
 Route first-party SONIC images through `npa/src/npa/deploy/sonic_image_manifest.json`.
 Use the baked `npa-sonic:0.1.2` image for L40S VM targets and the host-mounted
-`npa-sonic:0.1.2-k8s` image for RTX PRO 6000 Blackwell Kubernetes targets with
+`npa-sonic:0.1.2-k8s-runtime` image for RTX PRO 6000 Blackwell Kubernetes targets with
 the NVIDIA GPU Operator.
 
 SONIC render validation requires RT-capable GPUs. H100 can still be useful for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -444,13 +444,41 @@ CI currently verifies tests, image security, and secret regression through:
 Gitleaks runs the custom Nebius-pattern rules in `.gitleaks.toml` on pull
 requests and pushes to `main`.
 ## Testing Requirements
-Use the repo virtualenv for validation:
+
+Install the dev tooling into your virtualenv once (this pulls in `pytest`,
+`pytest-mock`, `pytest-cov`, `pytest-timeout`, `ruff`, and the `server` extra so
+the suite collects):
 
 ```bash
-npa/.venv/bin/python -m pytest npa/tests/ --ignore=npa/tests/e2e --timeout=120 -q
+pip install -e "npa[dev]"
 ```
 
-Do not use bare `python` for repo validation.
+Then use the `make` targets from the repo root:
+
+```bash
+make test         # fast default: full unit suite, no live/GPU/network (PR gate)
+make test-smoke   # quickest: onboarding CLI smoke tests only
+make lint         # ruff
+make test-e2e     # opt-in: real Nebius infrastructure, NPA_INTEGRATION_E2E=1
+```
+
+`make test` deselects the live/GPU/e2e markers (`gpu`, `multi_gpu`, `e2e`,
+`e2e_serverless`, `e2e_skypilot`, `e2e_pipeline`, `byovm_live`, `ngc_e2e`) by
+marker rather than only ignoring `tests/e2e`. This matters: some `gpu`/`e2e`
+tests live under `tests/workbench/` and will try to launch real infrastructure
+if your shell has Nebius creds/SkyPilot configured, so the marker filter — not
+just `--ignore=tests/e2e` — is what keeps the default suite hermetic.
+
+Override the interpreter with `make test PYTHON=/path/to/venv/bin/python`. The
+equivalent raw command is:
+
+```bash
+cd npa && python -m pytest tests/ --ignore=tests/e2e \
+  -m "not e2e and not e2e_serverless and not e2e_skypilot and not e2e_pipeline and not gpu and not multi_gpu and not byovm_live and not ngc_e2e" \
+  --timeout=180 -q
+```
+
+Do not use bare `python` for repo validation; use your venv's interpreter.
 
 Test layout:
 
@@ -578,7 +606,7 @@ Update BDD100K label map for real data
 Before review, a PR should pass the non-e2e test suite:
 
 ```bash
-npa/.venv/bin/python -m pytest npa/tests/ --ignore=npa/tests/e2e --timeout=120 -q
+make test
 ```
 
 Run focused tests for the touched surface as well. Documentation-only changes

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# Nebius Physical AI - developer workflow shortcuts.
+#
+# Activate your virtualenv first (see docs/quickstart.md), or override PYTHON:
+#   make test PYTHON=~/.venvs/npa/bin/python
+#
+# Targets run pytest from the npa/ package where the pytest config lives.
+
+PYTHON ?= python
+PYTEST := cd npa && $(PYTHON) -m pytest
+
+# Live/GPU/e2e markers. Deselecting by marker is more robust than ignoring a
+# directory: gpu/e2e-marked tests also live under tests/workbench/ and will try
+# to launch real infrastructure if a developer has SkyPilot/creds configured.
+LIVE_DESELECT := -m "not e2e and not e2e_serverless and not e2e_skypilot and not e2e_pipeline and not gpu and not multi_gpu and not byovm_live and not ngc_e2e"
+
+.PHONY: help install-dev test test-smoke test-all test-e2e lint format
+
+help:
+	@echo "Targets:"
+	@echo "  install-dev  Install npa with dev/test tooling into the active venv"
+	@echo "  test         Fast default: full unit suite, no live/GPU/network (PR gate)"
+	@echo "  test-smoke   Quickest check: onboarding CLI smoke tests only"
+	@echo "  test-all     Alias for 'test' (no live tests)"
+	@echo "  test-e2e     Opt-in live suite (requires real Nebius infra + NPA_INTEGRATION_E2E=1)"
+	@echo "  lint         Ruff lint"
+	@echo "  format       Ruff autofix + format"
+	@echo "Override the interpreter with: make test PYTHON=/path/to/venv/bin/python"
+
+install-dev:
+	$(PYTHON) -m pip install -e "npa[dev]"
+
+# Fast default: every unit test, with live/GPU/e2e markers deselected.
+test:
+	$(PYTEST) tests/ --ignore=tests/e2e $(LIVE_DESELECT) --timeout=180 -q
+
+# Tightest loop: just the first-time-user CLI smoke guards (sub-second).
+test-smoke:
+	$(PYTEST) tests/cli/test_main.py tests/cli/test_onboarding_smoke.py -q
+
+test-all: test
+
+# Opt-in: launches real Nebius infrastructure. Read docs/testing/ first.
+test-e2e:
+	cd npa && NPA_INTEGRATION_E2E=1 $(PYTHON) -m pytest tests/e2e -q
+
+lint:
+	cd npa && $(PYTHON) -m ruff check .
+
+format:
+	cd npa && $(PYTHON) -m ruff check --fix . && $(PYTHON) -m ruff format .

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ SONIC image routing is manifest-driven:
   `npa/src/npa/deploy/sonic_image_manifest.json` using `--gpu-type`, with
   `--image` and `--image-variant` available as explicit overrides.
 - L40S VM targets use the baked `npa-sonic:0.1.2` image. RTX PRO 6000
-  Blackwell Kubernetes targets use the host-mounted `npa-sonic:0.1.2-k8s`
+  Blackwell Kubernetes targets use the host-mounted `npa-sonic:0.1.2-k8s-runtime`
   image. See `docs/workbench/sonic-image-catalog.md`.
 
 ### Solution Patterns

--- a/README.md
+++ b/README.md
@@ -13,20 +13,41 @@ orchestration, vLLM serving, managed Kubernetes, and GPU clusters.
 
 ## Quick Start
 
-Install the package from the `npa/` Python project:
+Install the `npa` package into a fresh virtual environment. The venv can live
+anywhere; activating it puts `npa` on your `PATH` (Python 3.10+ required):
 
 ```bash
 git clone https://github.com/nebius/nebius-physical-ai.git
 cd nebius-physical-ai
 
-python3 -m venv npa/.venv
-npa/.venv/bin/python -m pip install --upgrade pip
-npa/.venv/bin/python -m pip install -e npa
-export PATH="$PWD/npa/.venv/bin:$PATH"
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e npa
+
+npa --version
 ```
 
-Authenticate with the Nebius CLI and let `npa` print the local credential
-schema for optional Hugging Face, NGC, object-storage, and BYOVM SSH values:
+Run your first real result with **no cloud, GPU, or credentials** — score a
+shipped sample rollout set with the offline stub backend:
+
+```bash
+npa workbench vlm-eval benchmark \
+  --dataset npa/src/npa/workbench/vlm_eval/fixtures/sample_benchmark/benchmark.json \
+  --output /tmp/vlm-eval-benchmark.json \
+  --backend stub \
+  --thresholds 0.5,0.8,0.9 \
+  --rubrics default,strict \
+  --models Qwen/Qwen2-VL-7B-Instruct \
+  --format json
+```
+
+You should see a ranked report with `accuracy: 1.0` over four labeled rollouts.
+That is the full local loop; the same command swaps `--backend stub` for a real
+`self-hosted` or `api` VLM backend once you add credentials.
+
+Next, authenticate with the Nebius CLI and print the credential schema (see
+[docs/quickstart.md](docs/quickstart.md) for the full walkthrough):
 
 ```bash
 nebius profile create
@@ -34,17 +55,12 @@ nebius iam get-access-token >/dev/null
 npa configure
 ```
 
-Run a first Workbench command without provisioning infrastructure:
+To work on `npa` itself (tests, lint), install the dev extra and run the fast
+suite — see [CONTRIBUTING.md](CONTRIBUTING.md):
 
 ```bash
-npa workbench vlm-eval list
-npa workbench vlm-eval run \
-  --input-path ./rollout.json \
-  --output-path ./eval.json \
-  --backend stub \
-  --score 0.9 \
-  --dry-run \
-  --output json
+pip install -e "npa[dev]"
+make test
 ```
 
 For full cloud setup, continue with [docs/quickstart.md](docs/quickstart.md)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ nebius iam get-access-token >/dev/null
 npa configure
 ```
 
+The flagship GPU workload is **NVIDIA Cosmos** (world-foundation model for
+synthetic data and world generation). It runs across multiple NVIDIA GPU
+platforms via a single `--gpu-type` flag (`gpu-h100-sxm`, `gpu-h200-sxm`,
+`gpu-b300-sxm`, `gpu-l40s`) with no RT-core lock-in:
+
+```bash
+npa workbench cosmos -p <your-project-alias> -n cosmos deploy \
+  --runtime serverless --gpu-type <gpu-platform> --wait
+npa workbench cosmos -p <your-project-alias> -n cosmos infer \
+  --prompt "A robot arm stacks colored cubes" \
+  --output-path s3://<your-bucket>/cosmos/out/
+```
+
+Cosmos needs Nebius credentials, an `HF_TOKEN`, and GPU capacity; see the
+flagship walkthrough in [docs/quickstart.md](docs/quickstart.md#7-flagship-gpu-workload-nvidia-cosmos).
+
 To work on `npa` itself (tests, lint), install the dev extra and run the fast
 suite — see [CONTRIBUTING.md](CONTRIBUTING.md):
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -486,6 +486,18 @@ These come from the cloud, not from `npa`. Retry in a few minutes, pick a
 different GPU type/region, or request a quota increase in the Nebius console.
 Run any command with `NPA_DEBUG=1` for a full traceback.
 
+`PermissionDenied` / `No permission` when submitting a serverless job
+
+Serverless workloads (`cosmos train --runtime serverless`, `cosmos infer`, and
+serverless `deploy`) create Nebius AI Jobs. If the principal behind your active
+`nebius` profile is a service account that lacks the AI Jobs role, the submit is
+rejected with `PermissionDenied: service iam ... appbox-...` even though
+authentication, capacity lookup, subnet discovery, and S3 all succeed. This is
+an authorization gap, not stale credentials — `nebius iam get-access-token`
+still works. Grant that service account a role that permits creating and
+managing AI Jobs on the project, or switch to a profile whose principal has it
+(`nebius profile activate <profile>`), then retry the same command.
+
 `credentials.yaml` is missing or tokens are not loading
 
 Offline commands tolerate a missing credentials file, but token-dependent

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -397,20 +397,27 @@ npa workbench cosmos -p <your-project-alias> -n cosmos infer \
 npa workbench cosmos -p <your-project-alias> -n cosmos teardown --yes
 ```
 
-The three tiers stay coherent here too:
-
-- **CLI:** the `npa workbench cosmos` commands above.
-- **SDK:** `from npa.sdk.workbench import cosmos` mirrors the same operations.
-- **Raw `sky`:** checked-in, parameterizable SkyPilot YAMLs under
-  `npa/workflows/workbench/skypilot/` (for example
-  `cosmos3-text-to-image-inference.yaml`), runnable with plain `sky launch`
-  using `--env`/`--gpu-type` overrides and a BYO `image_id`.
-
-Artifact-bearing end-to-end validation (a real serverless GPU job) is:
+Artifact-bearing end-to-end validation (a real serverless GPU job that writes a
+`checkpoint.json` to your bucket) is:
 
 ```bash
 npa workbench cosmos train --runtime serverless --smoke --gpu-type <gpu-platform>
 ```
+
+This same serverless job is available three coherent ways:
+
+- **CLI:** the `npa workbench cosmos train --runtime serverless` command above.
+- **SDK:** Cosmos serverless jobs are submitted programmatically with
+  `npa.clients.serverless.ServerlessClient.create_job(...)` plus the
+  `npa.serverless_common` env helpers (the `npa.sdk.workbench.cosmos` namespace
+  itself currently exposes `check`/`fetch`). See the worked SDK example in
+  [docs/sdk/cosmos-serverless.md](sdk/cosmos-serverless.md).
+- **Raw `sky` (GPU-cluster alternative):** the checked-in, parameterizable
+  SkyPilot YAMLs under `npa/workflows/workbench/skypilot/` (for example
+  `cosmos3-text-to-image-inference.yaml`) run Cosmos on a GPU *cluster* with
+  plain `sky launch`, using `--env`/`--gpu-type` overrides and a BYO `image_id`.
+  This is a different runtime from Serverless AI Jobs (it provisions a cluster
+  and needs network access to the Cosmos framework source + gated weights).
 
 Because this launches a real, potentially long GPU job, run it from a durable
 launcher (your job queue / SkyPilot-managed job) rather than an interactive

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -493,6 +493,21 @@ These come from the cloud, not from `npa`. Retry in a few minutes, pick a
 different GPU type/region, or request a quota increase in the Nebius console.
 Run any command with `NPA_DEBUG=1` for a full traceback.
 
+`source repo is not reachable` from `npa workbench cosmos check`
+
+Cosmos checks the framework source repo with `git ls-remote`, injecting
+`GITHUB_TOKEN` as an auth header when that variable is set. A stale or invalid
+`GITHUB_TOKEN` makes even a public repo return `401`, so the check reports the
+source as unreachable. Clear the bad token (the public clone works
+anonymously) or export a valid one:
+
+```bash
+env -u GITHUB_TOKEN npa workbench cosmos check
+```
+
+SkyPilot pods do not inherit your shell's `GITHUB_TOKEN`, so the in-cluster
+clone is unaffected.
+
 `PermissionDenied` / `No permission` when submitting a serverless job
 
 Serverless workloads (`cosmos train --runtime serverless`, `cosmos infer`, and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -366,7 +366,60 @@ touches real infrastructure even if your shell has Nebius credentials exported.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full test layout and PR
 conventions (branch → PR → squash, one approval, never self-approve).
 
-## 7. Where to next
+## 7. Flagship GPU workload: NVIDIA Cosmos
+
+Once the offline loop above works, the headline Workbench workload is **NVIDIA
+Cosmos** — a world-foundation model for synthetic data and world generation.
+Cosmos is the recommended first GPU workload because it runs across **multiple
+NVIDIA GPU platforms** (for example `gpu-h100-sxm`, `gpu-h200-sxm`,
+`gpu-b300-sxm`, `gpu-l40s`) selected with a single `--gpu-type` flag. It does
+**not** require RT cores, so you are not locked to one GPU family the way
+RT-core tools are.
+
+This step needs Nebius credentials, a `HF_TOKEN` for the gated Cosmos weights
+(Section 4), and GPU capacity. Set GPU routing with one flag and keep the same
+command shape across platforms:
+
+```bash
+# Deploy a Cosmos serving endpoint on the GPU platform of your choice.
+npa workbench cosmos -p <your-project-alias> -n cosmos deploy \
+  --runtime serverless \
+  --gpu-type <gpu-platform> \
+  --gpu-preset <gpu-preset> \
+  --wait
+
+# Generate from a text prompt; output lands in your bucket.
+npa workbench cosmos -p <your-project-alias> -n cosmos infer \
+  --prompt "A robot arm stacks colored cubes on a table" \
+  --output-path s3://<your-bucket>/cosmos/out/ \
+  --output-format json
+
+npa workbench cosmos -p <your-project-alias> -n cosmos teardown --yes
+```
+
+The three tiers stay coherent here too:
+
+- **CLI:** the `npa workbench cosmos` commands above.
+- **SDK:** `from npa.sdk.workbench import cosmos` mirrors the same operations.
+- **Raw `sky`:** checked-in, parameterizable SkyPilot YAMLs under
+  `npa/workflows/workbench/skypilot/` (for example
+  `cosmos3-text-to-image-inference.yaml`), runnable with plain `sky launch`
+  using `--env`/`--gpu-type` overrides and a BYO `image_id`.
+
+Artifact-bearing end-to-end validation (a real serverless GPU job) is:
+
+```bash
+npa workbench cosmos train --runtime serverless --smoke --gpu-type <gpu-platform>
+```
+
+Because this launches a real, potentially long GPU job, run it from a durable
+launcher (your job queue / SkyPilot-managed job) rather than an interactive
+session you might close. See [the Cosmos guide](../.agents/skills/workbench/cosmos/SKILL.md)
+and [the workflows guide](workbench-yaml-guide.md) for routing, backend
+selection, and known limits. Isaac Lab is the simulation counterpart but is
+RT-core-only (L40S / RTX Pro 6000); see its guide before choosing GPU type.
+
+## 8. Where to next
 
 - [Workbench Getting Started](workbench/getting-started.md): Kubernetes,
   SkyPilot, registry, S3, and first workload setup.
@@ -377,7 +430,7 @@ conventions (branch → PR → squash, one approval, never self-approve).
   machine-managed `~/.npa/config.yaml` shape for reference only.
 - [Known onboarding and runtime gotchas](../FIXME.md): active follow-up list.
 
-## 8. Troubleshooting
+## 9. Troubleshooting
 
 `npa: command not found`
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,18 +55,23 @@ terraform version
 
 ## 3. Install npa
 
-Clone the repository and install the Python package from the `npa/` package
-directory:
+Clone the repository and install the Python package into a fresh virtual
+environment. The venv can live anywhere (for example `.venv` in the repo, or
+`~/.venvs/npa`); activating it puts `npa` on your `PATH`:
 
 ```bash
 git clone <REPO_URL> nebius-physical-ai
 cd nebius-physical-ai
 
-python3 -m venv npa/.venv
-npa/.venv/bin/python -m pip install --upgrade pip
-npa/.venv/bin/python -m pip install -e npa
-export PATH="$PWD/npa/.venv/bin:$PATH"
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e npa
 ```
+
+If you prefer not to activate the venv, call its interpreter directly
+(`./.venv/bin/python -m pip install -e npa`) and use `./.venv/bin/npa` instead
+of `npa`. The rest of this guide assumes the venv is activated.
 
 Verify the install:
 
@@ -82,10 +87,11 @@ credentials.
 Optional extras are available when you need them:
 
 ```bash
-npa/.venv/bin/python -m pip install -e "npa[server]"
-npa/.venv/bin/python -m pip install -e "npa[adapter]"
-npa/.venv/bin/python -m pip install -e "npa[genesis]"
-npa/.venv/bin/python -m pip install -e "npa[groot]"
+pip install -e "npa[server]"    # FastAPI policy/eval server
+pip install -e "npa[adapter]"   # dataset conversion
+pip install -e "npa[genesis]"   # Genesis + distillation stages (GPU)
+pip install -e "npa[groot]"     # GR00T SDK (GPU)
+pip install -e "npa[dev]"       # tests, lint (pytest, ruff); see Section 6
 ```
 
 ## 4. Configure credentials
@@ -247,7 +253,120 @@ npa configure
 Gate: both commands render local CLI output without requiring Kubernetes, S3,
 NGC, or Hugging Face network access.
 
-## 6. Where to next
+### 5a. Your first real result (offline)
+
+You can produce a real eval result with no cloud, GPU, or credentials. The
+`vlm-eval benchmark` command scores a shipped, labeled rollout set with the
+offline `stub` backend:
+
+```bash
+npa workbench vlm-eval benchmark \
+  --dataset npa/src/npa/workbench/vlm_eval/fixtures/sample_benchmark/benchmark.json \
+  --output /tmp/vlm-eval-benchmark.json \
+  --backend stub \
+  --thresholds 0.5,0.8,0.9 \
+  --rubrics default,strict \
+  --models Qwen/Qwen2-VL-7B-Instruct \
+  --format json
+```
+
+Gate: the report ranks configurations and reports `accuracy: 1.0` over four
+labeled rollouts, and writes `/tmp/vlm-eval-benchmark.json`.
+
+### 5b. The same eval, three coherent ways
+
+Every Workbench capability is usable as a `npa` CLI command, a Python SDK call,
+and a parameterizable SkyPilot YAML you can run with raw `sky`. The three stay
+coherent; pick whichever fits your workflow.
+
+**CLI** (shown above):
+
+```bash
+npa workbench vlm-eval benchmark --dataset <benchmark.json> --backend stub --format json
+```
+
+**Python SDK:**
+
+```python
+from npa.sdk.workbench import vlm_eval
+from npa.workbench.vlm_eval import DEFAULT_MODEL, DEFAULT_SAMPLE_BENCHMARK_PATH
+
+report = vlm_eval.benchmark(
+    dataset=str(DEFAULT_SAMPLE_BENCHMARK_PATH),
+    backend="stub",
+    thresholds=[0.5, 0.8, 0.9],
+    rubrics=["default", "strict"],
+    models=[DEFAULT_MODEL],
+)
+print(report.best_config.metrics.accuracy)  # 1.0
+```
+
+**Standalone SkyPilot YAML (raw `sky`, BYO S3 endpoint + image).** Save this as
+`vlm-eval-benchmark.sky.yaml` and run it with plain `sky launch` — no `npa` CLI
+or SDK in the loop. Every value is a placeholder you override with `--env`:
+
+```yaml
+name: vlm-eval-benchmark
+resources:
+  cloud: kubernetes
+  cpus: 4
+  # Bring your own image. The default below is a generic CPU Python image;
+  # point NPA_IMAGE at your registry, e.g. cr.<region>.nebius.cloud/<your-registry-id>/<image>:<tag>
+  image_id: "docker:${NPA_IMAGE}"
+envs:
+  NPA_IMAGE: "python:3.11-slim"
+  # Bring your own object storage. Leave these unset to read the in-repo fixture.
+  BENCHMARK_URI: "s3://<your-bucket>/vlm-eval/benchmark.json"
+  OUTPUT_URI: "s3://<your-bucket>/vlm-eval/benchmark-report.json"
+  AWS_ENDPOINT_URL: "https://storage.<your-region>.nebius.cloud"
+  VLM_BACKEND: "stub"
+setup: |
+  set -e
+  pip install -e /opt/nebius-physical-ai/npa || pip install npa
+run: |
+  set -euo pipefail
+  npa workbench vlm-eval benchmark \
+    --dataset "${BENCHMARK_URI}" \
+    --output "${OUTPUT_URI}" \
+    --backend "${VLM_BACKEND}" \
+    --format json
+```
+
+```bash
+# Override any value at launch; nothing is hardcoded to a specific account.
+sky launch -c vlm-eval vlm-eval-benchmark.sky.yaml \
+  --env NPA_IMAGE=cr.<your-region>.nebius.cloud/<your-registry-id>/<image>:<tag> \
+  --env BENCHMARK_URI=s3://<your-bucket>/vlm-eval/benchmark.json \
+  --env AWS_ENDPOINT_URL=https://storage.<your-region>.nebius.cloud
+```
+
+For maintained, checked-in workflow YAMLs (including a self-hosted GPU VLM
+variant), see `npa/workflows/workbench/skypilot/` and
+[the workflows guide](workbench-yaml-guide.md).
+
+## 6. Developing and testing npa
+
+To work on `npa` itself, install the dev extra into your activated venv and use
+the `make` targets from the repo root:
+
+```bash
+pip install -e "npa[dev]"   # pytest, pytest-mock, pytest-cov, pytest-timeout, ruff
+
+make test         # fast default: full unit suite, no live/GPU/network
+make test-smoke   # quickest: onboarding CLI smoke tests only
+make lint         # ruff
+make test-e2e     # opt-in: launches real Nebius infrastructure
+```
+
+The `make` targets call `python -m pytest`; pass `PYTHON=...` to target a
+specific interpreter (for example `make test PYTHON=./.venv/bin/python`). Live,
+GPU, and end-to-end tests are marked (`gpu`, `multi_gpu`, `e2e`, `byovm_live`,
+`ngc_e2e`, ...) and are deselected from `make test`, so the default suite never
+touches real infrastructure even if your shell has Nebius credentials exported.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full test layout and PR
+conventions (branch → PR → squash, one approval, never self-approve).
+
+## 7. Where to next
 
 - [Workbench Getting Started](workbench/getting-started.md): Kubernetes,
   SkyPilot, registry, S3, and first workload setup.
@@ -258,16 +377,61 @@ NGC, or Hugging Face network access.
   machine-managed `~/.npa/config.yaml` shape for reference only.
 - [Known onboarding and runtime gotchas](../FIXME.md): active follow-up list.
 
-## 7. Troubleshooting
+## 8. Troubleshooting
 
 `npa: command not found`
 
-Activate the virtualenv or add it to `PATH`:
+Activate the virtualenv (or call its interpreter directly):
 
 ```bash
-export PATH="$PWD/npa/.venv/bin:$PATH"
+source .venv/bin/activate   # or: source ~/.venvs/npa/bin/activate
 npa --help
 ```
+
+`pytest` fails to collect with `ModuleNotFoundError: No module named 'fastapi'`
+
+The test suite needs the dev tooling (which pulls in the server extra). Install
+it into your venv:
+
+```bash
+pip install -e "npa[dev]"
+make test
+```
+
+`aws s3 ls` fails with `Could not connect to the endpoint URL`
+
+Nebius object storage is S3-compatible but is not AWS. Older `aws-cli` (v1)
+ignores the `AWS_ENDPOINT_URL` environment variable, so it tries the AWS
+endpoint and fails. Pass the endpoint explicitly, or use `aws-cli` v2:
+
+```bash
+aws s3 ls --endpoint-url https://storage.<your-region>.nebius.cloud
+```
+
+`npa` itself does not depend on this: it reads `storage.endpoint_url` from
+`~/.npa/credentials.yaml` (or `AWS_ENDPOINT_URL`/`NPA_STORAGE_ENDPOINT`) and
+passes it to the S3 client directly.
+
+Jobs land on the wrong cluster, or `kubectl`/`sky` target the wrong place
+
+Pin your Kubernetes context so submissions are unambiguous:
+
+```bash
+kubectl config get-contexts
+kubectl config use-context <your-workbench-context>
+```
+
+`403`/`denied` when pushing or pulling a container image
+
+Check that you are logged in to the registry. Nebius registries use a Docker
+credential helper; confirm `~/.docker/config.json` references your registry
+host and that `nebius iam get-access-token` succeeds.
+
+Capacity, quota, or `Not enough resources` errors
+
+These come from the cloud, not from `npa`. Retry in a few minutes, pick a
+different GPU type/region, or request a quota increase in the Nebius console.
+Run any command with `NPA_DEBUG=1` for a full traceback.
 
 `credentials.yaml` is missing or tokens are not loading
 

--- a/docs/sdk/cosmos-serverless.md
+++ b/docs/sdk/cosmos-serverless.md
@@ -1,0 +1,93 @@
+# Cosmos serverless job via the SDK
+
+This is the Python SDK counterpart to:
+
+```bash
+npa workbench cosmos train --runtime serverless --smoke
+```
+
+Cosmos serverless jobs run as Nebius Serverless AI Jobs. They are submitted
+through `npa.clients.serverless.ServerlessClient.create_job(...)`, with the
+job environment assembled by the `npa.serverless_common` helpers. (The
+`npa.sdk.workbench.cosmos` namespace currently exposes only `check`/`fetch`; the
+job submission lives in the client below.)
+
+The script reads non-secret coordinates from the environment
+(`NEBIUS_PROJECT_ID`, `NPA_REGISTRY_ID`, `NPA_S3_BUCKET`, `AWS_ENDPOINT_URL`) and
+the credentials your shell already has (`AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `HF_TOKEN`). Nothing is hardcoded to an account.
+
+```python
+import json
+import os
+import subprocess
+import time
+
+from npa.clients.serverless import ServerlessClient
+from npa.cli.cosmos import _cosmos_train_smoke_command  # same hardened smoke the CLI submits
+from npa.serverless_common import build_serverless_job_env, split_serverless_env
+
+project_id = os.environ["NEBIUS_PROJECT_ID"]
+registry_id = os.environ["NPA_REGISTRY_ID"]
+bucket = os.environ["NPA_S3_BUCKET"].rstrip("/")
+run_id = "cosmos-sdk-" + time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+output_path = f"{bucket}/cosmos-verify/{run_id}/"
+image = f"cr.<your-region>.nebius.cloud/{registry_id}/npa-cosmos:1.0.9"
+
+# Multi-subnet projects require an explicit READY subnet.
+subnets = json.loads(
+    subprocess.check_output(
+        ["nebius", "vpc", "subnet", "list", "--parent-id", project_id, "--format", "json"]
+    )
+)
+subnet_id = next(s["metadata"]["id"] for s in subnets["items"] if s["status"]["state"] == "READY")
+
+# Build the job env (S3 creds + HF token), then split secret-like vars out.
+full_env = build_serverless_job_env(
+    output_path=output_path,
+    hf_token=os.environ.get("HF_TOKEN"),
+    s3_credentials={
+        "aws_access_key_id": os.environ["AWS_ACCESS_KEY_ID"],
+        "aws_secret_access_key": os.environ["AWS_SECRET_ACCESS_KEY"],
+        "endpoint_url": os.environ["AWS_ENDPOINT_URL"],
+    },
+    extra_env={"NPA_JOB_NAME": run_id},
+)
+full_env.update({"COSMOS_TRAIN_SMOKE": "1", "NPA_JOB_NAME": run_id})
+env, secret_env = split_serverless_env(full_env)
+
+client = ServerlessClient()
+info = client.create_job(
+    project_id=project_id,
+    name=run_id,
+    image=image,
+    command=_cosmos_train_smoke_command(5),
+    gpu_type="gpu-h100-sxm",   # or gpu-h200-sxm, gpu-b300-sxm, gpu-l40s
+    gpu_count=1,
+    preset="1gpu-16vcpu-200gb",
+    subnet_id=subnet_id,
+    output_path=output_path,
+    env=env,
+    extra_env=secret_env,
+)
+info = client.poll_job(info.id, project_id, interval_s=15, ceiling_s=900)
+print(json.dumps({"status": info.status, "job_name": info.name, "output_path": output_path}))
+```
+
+Expected output (validated live on `gpu-h100-sxm`, eu-north1):
+
+```json
+{"status": "succeeded", "job_name": "cosmos-sdk-<run-id>", "output_path": "s3://<your-bucket>/cosmos-verify/cosmos-sdk-<run-id>/"}
+```
+
+and `checkpoint.json` lands at `<output_path>/checkpoint.json` containing
+`{"status": "succeeded", "job": "<run-id>", "smoke": true}`.
+
+Notes:
+
+- The underlying `nebius ai job create` call can take several minutes; the client
+  logs `create_job CLI call timed out after 300s; recovering by lookup-by-name`
+  and recovers automatically by job name. This is expected, not an error.
+- The principal behind your `nebius` profile must have the AI Jobs role on the
+  project, or submission fails with `PermissionDenied` (see the quickstart
+  troubleshooting section).

--- a/docs/workbench/README.md
+++ b/docs/workbench/README.md
@@ -8,6 +8,7 @@ workflows, and operational runbooks.
 | Path | Purpose |
 | --- | --- |
 | [getting-started.md](getting-started.md) | Fresh-clone onboarding path for install, credentials, and first Workbench runs |
+| [cli-sdk-yaml-walkthrough.md](cli-sdk-yaml-walkthrough.md) | How to call any Workbench tool through the CLI, SDK, and SkyPilot YAML against the same service |
 | [sim-to-real-quickstart.md](sim-to-real-quickstart.md) | One-command H100 sim-to-real proof run with checkpoint, metric, S3 artifacts, and teardown |
 | [../quickstart.md](../quickstart.md) | Full `npa` CLI quickstart |
 | [../cli/README.md](../cli/README.md) | CLI command reference index |
@@ -26,6 +27,7 @@ workflows, and operational runbooks.
 | Reader | Start with |
 | --- | --- |
 | Customer running their first Workbench workload | [getting-started.md](getting-started.md) |
+| Anyone choosing between CLI, SDK, and YAML | [cli-sdk-yaml-walkthrough.md](cli-sdk-yaml-walkthrough.md) |
 | Customer running the first H100 sim-to-real proof | [sim-to-real-quickstart.md](sim-to-real-quickstart.md) |
 | Operator reproducing a workload | [cookbooks/README.md](cookbooks/README.md) |
 | SDK integrator or agent author | [../sdk/errors.md](../sdk/errors.md) |

--- a/docs/workbench/cli-sdk-yaml-walkthrough.md
+++ b/docs/workbench/cli-sdk-yaml-walkthrough.md
@@ -1,0 +1,277 @@
+# Workbench CLI / SDK / YAML Walkthrough
+
+> Audience: anyone calling an existing Workbench tool.
+> Prerequisites: complete [getting-started.md](getting-started.md) first.
+
+Every Workbench tool is a single containerized FastAPI service. That service is
+the one source of truth for its behavior. The three things you actually use —
+the CLI, the SDK, and SkyPilot YAML — are just three clients that reach the same
+endpoints. Pick the client that fits where your code runs; the work performed is
+identical.
+
+This walkthrough uses the `detection-training` tool as the running example
+because it exposes all three access modes cleanly and is the training stage of
+the reference BDD100K pipeline. The same shape applies to `lerobot`, `lancedb`,
+`sonic`, `cosmos`, and the other tools listed in
+[../cli/workbench.md](../cli/workbench.md).
+
+## The Mental Model
+
+```text
+                +-------------------------------+
+   CLI  ─────►  |                               |
+                |   Workbench FastAPI service   |
+   SDK  ─────►  |   /health /train /eval        |  ──►  S3 artifacts
+                |   /status /system-info /runs  |
+   YAML ─────►  |                               |
+                +-------------------------------+
+```
+
+| Access mode | Invocation | Where it runs | Best for |
+| --- | --- | --- | --- |
+| CLI | `npa workbench <tool> <command>` | Your shell / a SkyPilot task | Interactive runs, scripting, smoke tests |
+| SDK | `npa.sdk.workbench.<tool>.<fn>(...)` | Your Python process | Notebooks, agents, custom orchestration |
+| YAML | SkyPilot task that `curl`s the endpoint | The Nebius MK8s cluster | Multi-stage pipelines and sweeps |
+
+All three either call a deployed service over HTTP or run the same shared
+implementation in-process. They are not separate implementations. Behavior lives
+in the service / shared layer; never expect one client to do something the
+others cannot.
+
+## Shared Endpoints
+
+Each tool exposes a standard surface. For `detection-training`:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /health` | Readiness check; call before any state-changing request |
+| `POST /train` | Start a Faster R-CNN training run |
+| `GET /status` | Status for a run (`?run_id=...`) |
+| `POST /eval` | Evaluate a checkpoint |
+| `GET /system-info` | Runtime/image information, including the current image tag |
+| `GET /runs` | List service-managed runs |
+
+The CLI and SDK build the exact same JSON request bodies; the YAML builds them
+with `jq`. Knowing the endpoint contract is enough to use any of the three.
+
+## Prerequisites for This Walkthrough
+
+```bash
+export NPA_S3_BUCKET=<your-bucket>
+export AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud
+```
+
+For the service and YAML paths, a deployed endpoint is also required:
+
+```bash
+npa workbench detection-training deploy \
+  --output-path "s3://${NPA_S3_BUCKET}/detection-training/" \
+  --gpu-type h100
+
+export NPA_DETECTION_TRAINING_ENDPOINT=http://npa-detection-training.default.svc.cluster.local:8790
+```
+
+The deploy command prints the cluster-internal endpoint. From inside the cluster
+(a SkyPilot task) use the `*.svc.cluster.local` form; the SDK and CLI use the
+same value via `--endpoint` or `NPA_DETECTION_TRAINING_ENDPOINT`.
+
+## 1. CLI
+
+The CLI is the fastest way to drive a tool by hand or from a shell script. The
+same command runs the work in-process by default, or against a deployed service
+with `--service`.
+
+Local in-process run (no deployed service required):
+
+```bash
+npa workbench detection-training train \
+  --view bdd100k_rider_train \
+  --lance-uri "s3://${NPA_S3_BUCKET}/bdd100k-pipeline/example-run/lancedb/" \
+  --output-uri "s3://${NPA_S3_BUCKET}/detection-training/example-run/" \
+  --epochs 10 \
+  --batch-size 8 \
+  --learning-rate 0.005
+```
+
+Service run (calls the deployed endpoint):
+
+```bash
+npa workbench detection-training train \
+  --service \
+  --endpoint "${NPA_DETECTION_TRAINING_ENDPOINT}" \
+  --view bdd100k_rider_train \
+  --lance-uri "s3://${NPA_S3_BUCKET}/bdd100k-pipeline/example-run/lancedb/" \
+  --output-uri "s3://${NPA_S3_BUCKET}/detection-training/example-run/"
+```
+
+Both print a JSON object containing `run_id` and `status`. Follow up with:
+
+```bash
+npa workbench detection-training status \
+  --service --endpoint "${NPA_DETECTION_TRAINING_ENDPOINT}" \
+  --run-id <run-id-from-train>
+
+npa workbench detection-training eval \
+  --service --endpoint "${NPA_DETECTION_TRAINING_ENDPOINT}" \
+  --checkpoint-uri "s3://${NPA_S3_BUCKET}/detection-training/example-run/model_final.pt" \
+  --eval-view bdd100k_rider_train \
+  --output-uri "s3://${NPA_S3_BUCKET}/detection-training/example-run/eval/"
+```
+
+Notes that generalize to other tools:
+
+- `--input-path` / `--output-path` are accepted as aliases for the tool's
+  input/output URIs so the command composes inside pipelines. Here they alias
+  `--lance-uri` and `--output-uri`.
+- Add `--output json` (the default for `train`/`eval`) for machine-readable
+  output you can pipe into `jq`.
+- Omit `--service` to run the shared implementation in your own process; pass
+  `--service --endpoint ...` to hit a deployed service.
+
+## 2. SDK
+
+The SDK is the right client from Python — notebooks, agents, or a custom
+orchestrator. Functions mirror the CLI commands and return typed Pydantic
+response models.
+
+Local (in-process) run:
+
+```python
+from npa.sdk.workbench import detection_training
+
+resp = detection_training.train(
+    view="bdd100k_rider_train",
+    lance_uri="s3://my-bucket/bdd100k-pipeline/example-run/lancedb/",
+    output_uri="s3://my-bucket/detection-training/example-run/",
+    epochs=10,
+    batch_size=8,
+    learning_rate=0.005,
+)
+print(resp.run_id, resp.status)
+```
+
+Service-mode run against a deployed endpoint:
+
+```python
+from npa.sdk.workbench import detection_training
+
+resp = detection_training.train(
+    view="bdd100k_rider_train",
+    lance_uri="s3://my-bucket/bdd100k-pipeline/example-run/lancedb/",
+    output_uri="s3://my-bucket/detection-training/example-run/",
+    mode="service",  # or service=True
+    endpoint="http://npa-detection-training.default.svc.cluster.local:8790",
+)
+
+status = detection_training.status(run_id=resp.run_id, mode="service",
+                                   endpoint="http://npa-detection-training.default.svc.cluster.local:8790")
+print(status.status, status.epochs_completed)
+```
+
+Notes that generalize to other tools:
+
+- `mode="local"` (the default) runs the shared implementation in-process;
+  `mode="service"` (or `service=True`) makes an HTTP call.
+- In service mode, `endpoint` defaults to the tool's endpoint environment
+  variable (here `NPA_DETECTION_TRAINING_ENDPOINT`) when not passed explicitly.
+- Errors raise typed exceptions (for this tool,
+  `DetectionTrainingServiceError` for transport/HTTP failures and
+  `DetectionTrainingValidationError` for bad local inputs). See
+  [../sdk/errors.md](../sdk/errors.md).
+
+## 3. YAML (SkyPilot)
+
+YAML is the client for multi-stage pipelines and sweeps that run on the cluster.
+A pipeline is a multi-document SkyPilot file; each task calls the tool's HTTP
+endpoint with `curl`, building the request body with `jq` from `envs`. This is
+exactly what the BDD100K reference pipeline does for the training stage.
+
+Minimal single-task shape that mirrors the CLI/SDK `train` call above:
+
+```yaml
+name: detection-training-example
+execution: serial
+---
+name: detection-train-rider
+resources:
+  cloud: kubernetes
+  accelerators: H100:1
+  cpus: 8
+  memory: 32
+setup: |
+  set -euo pipefail
+  command -v jq >/dev/null || (apt-get update && apt-get install -y jq)
+envs:
+  DETECTION_TRAINING_ENDPOINT: http://npa-detection-training.default.svc.cluster.local:8790
+  VIEW_NAME: bdd100k_rider_train
+  LANCE_URI: s3://<your-bucket>/bdd100k-pipeline/example-run/lancedb/
+  TRAIN_OUTPUT_URI: s3://<your-bucket>/detection-training/example-run/
+  TRAIN_EPOCHS: "10"
+  TRAIN_BATCH_SIZE: "8"
+  TRAIN_LEARNING_RATE: "0.005"
+  BDD100K_LABEL_MAP: '{"person":0,"rider":1,"car":2,"truck":3,"bus":4,"train":5,"motor":6,"bike":7,"traffic light":8,"traffic sign":9}'
+run: |
+  set -euo pipefail
+  curl -fsS "${DETECTION_TRAINING_ENDPOINT}/health"
+
+  payload=$(jq -n \
+    --arg view "${VIEW_NAME}" \
+    --arg lance_uri "${LANCE_URI}" \
+    --arg output_uri "${TRAIN_OUTPUT_URI}" \
+    --argjson label_map "${BDD100K_LABEL_MAP}" \
+    --argjson epochs "${TRAIN_EPOCHS}" \
+    --argjson batch_size "${TRAIN_BATCH_SIZE}" \
+    --argjson learning_rate "${TRAIN_LEARNING_RATE}" \
+    '{view: $view, lance_uri: $lance_uri, output_uri: $output_uri, label_map: $label_map, epochs: $epochs, batch_size: $batch_size, learning_rate: $learning_rate}')
+
+  curl -fsS -X POST "${DETECTION_TRAINING_ENDPOINT}/train" \
+    -H 'Content-Type: application/json' \
+    -d "${payload}"
+```
+
+Notes that generalize to other pipelines:
+
+- Always `curl .../health` before any state-changing call.
+- Use `--arg` for strings and `--argjson` for numbers/objects/booleans so JSON
+  types survive into the request body.
+- SkyPilot 0.12.2 does not expand same-block `envs` inside `image_id`, and does
+  not self-reference `envs`. Keep committed YAMLs on explicit placeholders and
+  render per-run values with a runner script.
+- Dataset-specific config (like `label_map`) belongs in the YAML, not the tool.
+
+For the full pipeline pattern, label-map injection, resources, and S3 path
+conventions, see [../workbench-yaml-guide.md](../workbench-yaml-guide.md) and
+the reference file
+`npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml`.
+
+## Same Work, Three Clients
+
+The three calls below are equivalent — they produce the same `/train` request
+against the same service:
+
+| Client | Call |
+| --- | --- |
+| CLI | `npa workbench detection-training train --service --endpoint $E --view bdd100k_rider_train --output-uri s3://.../` |
+| SDK | `detection_training.train(view="bdd100k_rider_train", output_uri="s3://.../", mode="service", endpoint=E)` |
+| YAML | `curl -X POST "$E/train" -d "$payload"` |
+
+## When to Use Which
+
+| Situation | Use |
+| --- | --- |
+| Trying a tool by hand or in a shell script | CLI |
+| Quick local run without deploying a service | CLI or SDK with `mode="local"` |
+| Calling from a notebook, agent, or custom orchestrator | SDK |
+| Composing multiple tools into a pipeline or a sweep | YAML |
+| Passing data between stages | S3 URIs via `--input-path` / `--output-path` |
+
+Tools never call each other directly for data transfer. Every stage reads its
+input from an S3 URI and writes its output to an S3 URI, so any client can hand
+work to the next stage.
+
+## Next Docs
+
+- [../cli/workbench.md](../cli/workbench.md): full list of workbench tools and commands.
+- [../sdk/errors.md](../sdk/errors.md): typed SDK exceptions.
+- [../workbench-yaml-guide.md](../workbench-yaml-guide.md): full pipeline YAML guide.
+- [getting-started.md](getting-started.md): install, credentials, and first runs.

--- a/docs/workbench/getting-started.md
+++ b/docs/workbench/getting-started.md
@@ -272,6 +272,8 @@ manifest from S3.
 
 ## Next Docs
 
+- [cli-sdk-yaml-walkthrough.md](cli-sdk-yaml-walkthrough.md): how to call any
+  Workbench tool through the CLI, SDK, and SkyPilot YAML.
 - [cookbooks/byof-isaac-lab/README.md](cookbooks/byof-isaac-lab/README.md):
   first Isaac Lab BYOF checkpoint.
 - [sim-to-real-quickstart.md](sim-to-real-quickstart.md): first H100

--- a/npa/pyproject.toml
+++ b/npa/pyproject.toml
@@ -50,9 +50,25 @@ sonic = [
     "onnxscript>=0.5",
     "onnxruntime>=1.18",
 ]
+# Development and test tooling. Install with: pip install -e "npa[dev]"
+# Includes the server extra so the standard (non-e2e) test suite collects
+# without pulling in GPU-heavy extras (genesis, groot, sonic).
+dev = [
+    "npa[server]",
+    "pytest>=8.0",
+    "pytest-mock>=3.14",
+    "pytest-cov>=5.0",
+    "pytest-timeout>=2.3",
+    "ruff>=0.4.0",
+]
 
 [dependency-groups]
 dev = [
+    "fastapi~=0.136.1",
+    "pytest>=8.0",
+    "pytest-mock>=3.14",
+    "pytest-cov>=5.0",
+    "pytest-timeout>=2.3",
     "ruff>=0.4.0",
 ]
 

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -64,7 +64,7 @@ ngc:
   # org: optional-ngc-org
   # team: optional-ngc-team
 ssh:
-  host: 203.0.113.10
+  host: <your-byovm-host>
   user: ubuntu
   key_path: ~/.ssh/id_ed25519
 

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 import sys
 import traceback
 from importlib.metadata import version as package_version
+from typing import Callable, Optional
 
 import typer
 
@@ -53,9 +56,14 @@ app.add_typer(viz_app, name="viz", rich_help_panel="Platform utilities")
 app.add_typer(workflow_shim_app, name="workflow", hidden=True)
 
 
+DEFAULT_STORAGE_ENDPOINT = "https://storage.eu-north1.nebius.cloud"
+DEFAULT_REGION = "eu-north1"
+
 _SETUP_GUIDANCE = """Credential setup
 
-Create ~/.npa/credentials.yaml for user-level tokens and BYOVM SSH defaults:
+Run `npa configure` in a terminal for an interactive setup, or create
+~/.npa/credentials.yaml by hand for user-level tokens, object storage, and
+BYOVM SSH defaults:
 
 tokens:
   HF_TOKEN: hf_REPLACE_ME
@@ -63,6 +71,11 @@ ngc:
   api_key: nvapi_REPLACE_ME
   # org: optional-ngc-org
   # team: optional-ngc-team
+storage:
+  aws_access_key_id: <your-s3-access-key-id>
+  aws_secret_access_key: <your-s3-secret-access-key>
+  endpoint_url: https://storage.eu-north1.nebius.cloud
+  bucket: s3://<your-bucket>/
 ssh:
   host: <your-byovm-host>
   user: ubuntu
@@ -72,8 +85,10 @@ Then secure it:
 
 chmod 600 ~/.npa/credentials.yaml
 
-Deploy commands create and update ~/.npa/config.yaml for projects, workbenches,
-SSH targets, container registry settings, and Terraform state.
+`npa configure` also writes ~/.npa/config.yaml with your Nebius project id,
+tenant id, region, and container registry so commands no longer need those
+values exported in the shell or read from the Nebius CLI. Deploy commands
+extend the same file with workbench endpoints and Terraform state.
 """
 
 
@@ -98,24 +113,186 @@ def main(
     """Nebius Physical AI workbench CLI."""
 
 
+def _nebius_profile_ready(*, runner: Callable[..., object] = subprocess.run) -> bool:
+    """Return True when the local Nebius CLI has a usable, authenticated profile."""
+
+    if not shutil.which("nebius"):
+        return False
+    try:
+        result = runner(
+            ["nebius", "iam", "get-access-token"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return getattr(result, "returncode", 1) == 0
+
+
+def _create_nebius_profile(*, runner: Callable[..., object] = subprocess.run) -> bool:
+    """Run the interactive `nebius profile create` flow."""
+
+    try:
+        result = runner(["nebius", "profile", "create"], check=False)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return getattr(result, "returncode", 1) == 0
+
+
+def _ensure_nebius_profile() -> None:
+    """Detect or interactively create a local Nebius CLI profile."""
+
+    if _nebius_profile_ready():
+        typer.echo("Nebius CLI profile detected (`nebius iam get-access-token` works).")
+        return
+    if not shutil.which("nebius"):
+        typer.echo(
+            "Nebius CLI not found. Install it from https://docs.nebius.com/cli/install, "
+            "then re-run `npa configure` to create a local profile."
+        )
+        return
+    if not typer.confirm(
+        "No authenticated Nebius CLI profile found. Create one now?",
+        default=True,
+    ):
+        typer.echo("Skipped Nebius profile creation. Run `nebius profile create` later.")
+        return
+    if _create_nebius_profile() and _nebius_profile_ready():
+        typer.echo("Nebius CLI profile is ready.")
+    else:
+        typer.echo(
+            "Could not verify a Nebius profile. Run `nebius profile create` manually, "
+            "then `nebius iam get-access-token` to confirm."
+        )
+
+
+def _run_interactive_configure() -> None:
+    """Prompt for credentials/config and write the NPA dotfiles."""
+
+    from npa.clients.config import CONFIG_PATH, write_config
+    from npa.clients.credentials import write_credentials_file
+    from npa.deploy.images import DEFAULT_CONTAINER_REGISTRY
+
+    typer.echo("Interactive npa setup. Press Enter to skip any optional field.\n")
+    _ensure_nebius_profile()
+    typer.echo("")
+
+    def ask(label: str, *, default: str = "", secret: bool = False) -> str:
+        return str(
+            typer.prompt(
+                label,
+                default=default,
+                hide_input=secret,
+                show_default=bool(default) and not secret,
+            )
+        ).strip()
+
+    hf_token = ask("Hugging Face token (HF_TOKEN)", secret=True)
+    s3_access_key = ask("S3 access key id (AWS_ACCESS_KEY_ID)", secret=True)
+    s3_secret_key = ask("S3 secret access key (AWS_SECRET_ACCESS_KEY)", secret=True)
+    s3_endpoint = ask("S3 endpoint URL", default=DEFAULT_STORAGE_ENDPOINT)
+    s3_bucket = ask("S3 bucket (e.g. s3://my-bucket/)")
+    registry = ask("Container registry", default=DEFAULT_CONTAINER_REGISTRY)
+    project_id = ask("Nebius project id")
+    tenant_id = ask("Nebius tenant id")
+    region = ask("Region", default=DEFAULT_REGION)
+
+    credentials_path = write_credentials_file(
+        {
+            "tokens": {"HF_TOKEN": hf_token},
+            "storage": {
+                "aws_access_key_id": s3_access_key,
+                "aws_secret_access_key": s3_secret_key,
+                "endpoint_url": s3_endpoint,
+                "bucket": s3_bucket,
+            },
+        }
+    )
+
+    project_stanza = {
+        key: value
+        for key, value in (
+            ("project_id", project_id),
+            ("tenant_id", tenant_id),
+            ("region", region),
+            ("container_registry", registry),
+        )
+        if value
+    }
+    wrote_config = False
+    if project_id or tenant_id:
+        alias = region or "default"
+        write_config({"projects": {alias: project_stanza}, "default_project": alias})
+        wrote_config = True
+
+    typer.echo(f"\nWrote {credentials_path} (chmod 600).")
+    if wrote_config:
+        typer.echo(f"Wrote {CONFIG_PATH}.")
+    else:
+        typer.echo(
+            "Skipped ~/.npa/config.yaml: provide a Nebius project id to write a "
+            "project profile."
+        )
+    typer.echo("Setup complete. Run `npa configure --show` to see the file layout.")
+
+
+def _configure_impl(*, show: bool, interactive: Optional[bool]) -> None:
+    if show:
+        typer.echo(_SETUP_GUIDANCE)
+        return
+    should_prompt = interactive if interactive is not None else sys.stdin.isatty()
+    if not should_prompt:
+        typer.echo(_SETUP_GUIDANCE)
+        return
+    try:
+        _run_interactive_configure()
+    except (EOFError, typer.Abort):
+        typer.echo("\n")
+        typer.echo(_SETUP_GUIDANCE)
+
+
 @app.command(
     "configure",
-    help="Show credential and config setup guidance.",
+    help="Interactive credential and config setup guidance.",
     rich_help_panel="Setup",
 )
-def configure() -> None:
-    """Show credential and config setup guidance."""
-    typer.echo(_SETUP_GUIDANCE)
+def configure(
+    show: bool = typer.Option(
+        False,
+        "--show",
+        help="Print the credential/config file layout instead of prompting.",
+    ),
+    interactive: Optional[bool] = typer.Option(
+        None,
+        "--interactive/--no-interactive",
+        help="Force or disable interactive prompting (defaults to auto-detect TTY).",
+    ),
+) -> None:
+    """Interactively write ~/.npa credentials and config, or show guidance."""
+    _configure_impl(show=show, interactive=interactive)
 
 
 @app.command(
     "init",
-    help="Show credential and config setup guidance.",
+    help="Interactive credential and config setup guidance.",
     rich_help_panel="Setup",
 )
-def init() -> None:
-    """Show credential and config setup guidance."""
-    configure()
+def init(
+    show: bool = typer.Option(
+        False,
+        "--show",
+        help="Print the credential/config file layout instead of prompting.",
+    ),
+    interactive: Optional[bool] = typer.Option(
+        None,
+        "--interactive/--no-interactive",
+        help="Force or disable interactive prompting (defaults to auto-detect TTY).",
+    ),
+) -> None:
+    """Interactively write ~/.npa credentials and config, or show guidance."""
+    _configure_impl(show=show, interactive=interactive)
 
 
 def app_entry() -> None:

--- a/npa/src/npa/clients/credentials.py
+++ b/npa/src/npa/clients/credentials.py
@@ -253,6 +253,54 @@ def load_credentials(
     )
 
 
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in override.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _prune_empty(data: dict[str, Any]) -> dict[str, Any]:
+    pruned: dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, dict):
+            nested = _prune_empty(value)
+            if nested:
+                pruned[key] = nested
+        elif value not in ("", None):
+            pruned[key] = value
+    return pruned
+
+
+def write_credentials_file(
+    data: Mapping[str, Any],
+    *,
+    path: Path | None = None,
+) -> Path:
+    """Deep-merge *data* into ``~/.npa/credentials.yaml`` and write it 0600.
+
+    Empty string / ``None`` values are dropped so an interactive setup that
+    skips a field never clobbers an existing value with a blank one.
+    """
+
+    credentials_path = path or CREDENTIALS_PATH
+    existing: dict[str, Any] = {}
+    if credentials_path.exists():
+        with credentials_path.open() as handle:
+            loaded = yaml.safe_load(handle)
+        if isinstance(loaded, dict):
+            existing = loaded
+    merged = _deep_merge(existing, _prune_empty(dict(data)))
+    credentials_path.parent.mkdir(parents=True, exist_ok=True)
+    with credentials_path.open("w") as handle:
+        yaml.dump(merged, handle, default_flow_style=False, sort_keys=False)
+    credentials_path.chmod(0o600)
+    return credentials_path
+
+
 def storage_endpoint_url(endpoint: str) -> str:
     """Return a URL form for a Nebius S3-compatible endpoint."""
     value = endpoint.strip()

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -77,6 +77,160 @@ def test_setup_guidance_commands_show_credentials_path(command: str) -> None:
     assert "chmod 600" in result.output
 
 
+def test_configure_show_includes_storage_and_registry() -> None:
+    result = runner.invoke(app, ["configure", "--show"])
+
+    assert result.exit_code == 0
+    assert "storage:" in result.output
+    assert "aws_access_key_id" in result.output
+    assert "container registry" in result.output.lower()
+    assert "~/.npa/config.yaml" in result.output
+
+
+def test_configure_interactive_writes_credentials_and_config(monkeypatch, tmp_path) -> None:
+    import yaml
+
+    from npa.clients import config as config_module
+    from npa.clients import credentials as credentials_module
+
+    creds_path = tmp_path / "credentials.yaml"
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+
+    answers = "\n".join(
+        [
+            "hf_secret_token",   # HF token
+            "AKIAEXAMPLE",       # S3 access key id
+            "s3secretvalue",     # S3 secret access key
+            "",                  # S3 endpoint (default)
+            "s3://my-bucket/",   # S3 bucket
+            "",                  # registry (default)
+            "project-12345",     # project id
+            "tenant-abcde",      # tenant id
+            "",                  # region (default)
+        ]
+    ) + "\n"
+
+    result = runner.invoke(app, ["configure", "--interactive"], input=answers)
+
+    assert result.exit_code == 0, result.output
+    creds = yaml.safe_load(creds_path.read_text())
+    assert creds["tokens"]["HF_TOKEN"] == "hf_secret_token"
+    assert creds["storage"]["aws_access_key_id"] == "AKIAEXAMPLE"
+    assert creds["storage"]["aws_secret_access_key"] == "s3secretvalue"
+    assert creds["storage"]["endpoint_url"] == "https://storage.eu-north1.nebius.cloud"
+    assert creds["storage"]["bucket"] == "s3://my-bucket/"
+
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["default_project"] == "eu-north1"
+    project = cfg["projects"]["eu-north1"]
+    assert project["project_id"] == "project-12345"
+    assert project["tenant_id"] == "tenant-abcde"
+    assert project["region"] == "eu-north1"
+    assert project["container_registry"].startswith("cr.eu-north1.nebius.cloud/")
+    assert oct(creds_path.stat().st_mode)[-3:] == "600"
+
+
+def test_configure_interactive_skips_config_without_project(monkeypatch, tmp_path) -> None:
+    import yaml
+
+    from npa.clients import config as config_module
+    from npa.clients import credentials as credentials_module
+
+    creds_path = tmp_path / "credentials.yaml"
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+
+    # Skip every field; only the defaulted endpoint/registry/region remain.
+    answers = "\n".join([""] * 9) + "\n"
+    result = runner.invoke(app, ["configure", "--interactive"], input=answers)
+
+    assert result.exit_code == 0, result.output
+    assert creds_path.exists()
+    assert not config_path.exists()
+    creds = yaml.safe_load(creds_path.read_text())
+    # Empty values are pruned; the defaulted endpoint is still written.
+    assert "HF_TOKEN" not in creds.get("tokens", {})
+    assert creds["storage"]["endpoint_url"] == "https://storage.eu-north1.nebius.cloud"
+
+
+def test_configure_non_tty_prints_guidance() -> None:
+    # CliRunner stdin is not a TTY, so configure must fall back to guidance.
+    result = runner.invoke(app, ["configure"])
+
+    assert result.exit_code == 0
+    assert "~/.npa/credentials.yaml" in result.output
+
+
+def test_configure_creates_nebius_profile_when_missing(monkeypatch, tmp_path) -> None:
+    from npa.clients import config as config_module
+    from npa.clients import credentials as credentials_module
+
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", tmp_path / "credentials.yaml")
+    monkeypatch.setattr(config_module, "CONFIG_PATH", tmp_path / "config.yaml")
+    # A nebius binary exists but no profile is ready until we "create" one.
+    monkeypatch.setattr(cli_main.shutil, "which", lambda name: "/usr/bin/nebius")
+    readiness = iter([False, True])
+    monkeypatch.setattr(cli_main, "_nebius_profile_ready", lambda **_: next(readiness))
+    created: list[bool] = []
+
+    def fake_create(**_):
+        created.append(True)
+        return True
+
+    monkeypatch.setattr(cli_main, "_create_nebius_profile", fake_create)
+
+    answers = "y\n" + "\n".join([""] * 9) + "\n"  # confirm profile, skip all fields
+    result = runner.invoke(app, ["configure", "--interactive"], input=answers)
+
+    assert result.exit_code == 0, result.output
+    assert created == [True]
+    assert "Nebius CLI profile is ready." in result.output
+
+
+def test_configure_detects_existing_nebius_profile(monkeypatch, tmp_path) -> None:
+    from npa.clients import config as config_module
+    from npa.clients import credentials as credentials_module
+
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", tmp_path / "credentials.yaml")
+    monkeypatch.setattr(config_module, "CONFIG_PATH", tmp_path / "config.yaml")
+    monkeypatch.setattr(cli_main, "_nebius_profile_ready", lambda **_: True)
+
+    def fail_create(**_):
+        raise AssertionError("must not create a profile when one already works")
+
+    monkeypatch.setattr(cli_main, "_create_nebius_profile", fail_create)
+
+    result = runner.invoke(app, ["configure", "--interactive"], input="\n".join([""] * 9) + "\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Nebius CLI profile detected" in result.output
+
+
+def test_nebius_profile_ready_uses_get_access_token(monkeypatch) -> None:
+    monkeypatch.setattr(cli_main.shutil, "which", lambda name: "/usr/bin/nebius")
+    calls: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+
+    def fake_runner(cmd, **kwargs):
+        calls.append(cmd)
+        return _Result()
+
+    assert cli_main._nebius_profile_ready(runner=fake_runner) is True
+    assert calls == [["nebius", "iam", "get-access-token"]]
+
+
+def test_nebius_profile_not_ready_without_binary(monkeypatch) -> None:
+    monkeypatch.setattr(cli_main.shutil, "which", lambda name: None)
+    assert cli_main._nebius_profile_ready() is False
+
+
 def test_app_entry_typed_error_exits_one_without_traceback(monkeypatch, capsys) -> None:
     def fail() -> None:
         raise NotEnoughResourcesError(

--- a/npa/tests/cli/test_onboarding_smoke.py
+++ b/npa/tests/cli/test_onboarding_smoke.py
@@ -1,0 +1,77 @@
+"""Guards for the documented first-time-user onboarding path.
+
+These tests defend the copy-pasteable quickstart so docs that "look right"
+cannot silently rot: the setup guidance must stay placeholder-only (public
+hygiene), and the advertised first real success must keep working offline.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.workbench.vlm_eval import DEFAULT_MODEL, DEFAULT_SAMPLE_BENCHMARK_PATH
+
+
+runner = CliRunner()
+
+# Matches any dotted-quad IPv4 literal, e.g. 203.0.113.10.
+_IPV4 = re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b")
+
+
+def test_setup_guidance_contains_no_raw_ip_address() -> None:
+    """Setup guidance must use placeholders, never a literal host/IP."""
+    for command in ("configure", "init"):
+        result = runner.invoke(app, [command])
+        assert result.exit_code == 0
+        match = _IPV4.search(result.output)
+        assert match is None, (
+            f"`npa {command}` guidance leaks a literal IP {match.group(0)!r}; "
+            "use a placeholder such as <your-byovm-host> instead."
+        )
+        assert "<your-byovm-host>" in result.output
+
+
+def test_quickstart_first_success_fixture_is_packaged() -> None:
+    """The fixture the quickstart points at must ship inside the package."""
+    assert DEFAULT_SAMPLE_BENCHMARK_PATH.exists(), (
+        "Quickstart first-success benchmark fixture is missing: "
+        f"{DEFAULT_SAMPLE_BENCHMARK_PATH}"
+    )
+
+
+def test_quickstart_benchmark_command_produces_real_result(tmp_path) -> None:
+    """Run the exact documented first-success command end to end, offline."""
+    output_path = tmp_path / "vlm-eval-benchmark.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "vlm-eval",
+            "benchmark",
+            "--dataset",
+            str(DEFAULT_SAMPLE_BENCHMARK_PATH),
+            "--output",
+            str(output_path),
+            "--backend",
+            "stub",
+            "--thresholds",
+            "0.5,0.8,0.9",
+            "--rubrics",
+            "default,strict",
+            "--models",
+            DEFAULT_MODEL,
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    # A real scoring pass over the shipped labeled rollout set, no GPU or creds.
+    assert payload["best_config"]["metrics"]["accuracy"] == 1.0
+    assert json.loads(output_path.read_text(encoding="utf-8"))["item_count"] == 4

--- a/npa/tests/conftest.py
+++ b/npa/tests/conftest.py
@@ -11,9 +11,65 @@ from npa.guardrails.pytest_collection import assert_nonzero_collection
 os.environ.setdefault("NPA_PROJECT_ID", "project-test-00000000")
 os.environ.setdefault("NPA_S3_BUCKET", "test-bucket-00000000")
 
+# Live markers whose tests intentionally use real ambient credentials.
+_LIVE_MARKERS = frozenset(
+    {
+        "byovm_live",
+        "e2e",
+        "e2e_pipeline",
+        "e2e_serverless",
+        "e2e_skypilot",
+        "gpu",
+        "multi_gpu",
+        "ngc_e2e",
+    }
+)
+
+# Credential/storage env vars that override file config. A contributor who has
+# followed the quickstart and exported real Nebius creds must still get a
+# hermetic unit suite, so these are scrubbed for non-live tests. Without this,
+# e.g. an exported AWS_ENDPOINT_URL leaks into deploy-config assertions.
+_AMBIENT_CREDENTIAL_ENV_VARS = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_ENDPOINT_URL",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_REGION",
+    "AWS_REGION",
+    "NEBIUS_S3_ENDPOINT",
+    "NEBIUS_S3_BUCKET",
+    "NPA_STORAGE_ENDPOINT",
+    "NPA_CHECKPOINT_BUCKET",
+    "NEBIUS_PROJECT_ID",
+    "NEBIUS_TENANT_ID",
+    "NPA_REGISTRY",
+    "NPA_REGISTRY_ID",
+    "HF_TOKEN",
+    "HUGGING_FACE_HUB_TOKEN",
+    "NGC_API_KEY",
+    "NGC_ORG",
+    "NGC_TEAM",
+    "NPA_BYOVM_HOST",
+    "NPA_SSH_HOST",
+    "NPA_BYOVM_SSH_USER",
+    "NPA_SSH_USER",
+    "NPA_BYOVM_SSH_KEY",
+    "NPA_SSH_KEY",
+)
+
 
 def pytest_collection_finish(session: pytest.Session) -> None:
     assert_nonzero_collection(len(session.items))
+
+
+@pytest.fixture(autouse=True)
+def scrub_ambient_credential_env(monkeypatch, request):
+    """Isolate non-live tests from real credentials exported in the shell."""
+    if any(request.node.get_closest_marker(marker) for marker in _LIVE_MARKERS):
+        return
+    for env_var in _AMBIENT_CREDENTIAL_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
 
 
 def _is_huggingface_url(url: object) -> bool:

--- a/npa/workflows/workbench/skypilot/cosmos3-text-to-image-inference.yaml
+++ b/npa/workflows/workbench/skypilot/cosmos3-text-to-image-inference.yaml
@@ -8,7 +8,9 @@ resources:
   accelerators: H100:1
   cpus: 16+
   memory: 128+
-  disk_size: 1024
+  # No disk_size: SkyPilot rejects it on Kubernetes ("Disk size N is not
+  # supported by Kubernetes"). The pod uses node ephemeral storage; attach a
+  # volume if you need more than the node provides.
 envs:
   # Runtime coordinates can be overridden at launch for BYO forks/checkpoints.
   NPA_COSMOS3_SOURCE_REPO: "https://github.com/NVIDIA/cosmos-framework.git"


### PR DESCRIPTION
## Summary

Dogfooded the install → configure → first-success → test path in a **fresh virtualenv as a brand-new user** (using this VM's real Nebius credentials for the live checks) and fixed every place that stumbled. Docs were executed, not just edited.

### Onboarding / docs
- **Venv-agnostic install.** README + `docs/quickstart.md` no longer hardcode an in-repo `npa/.venv` (which coupled every command/test doc to `npa/.venv/bin/python`). You now create and activate any venv and `pip install -e npa`.
- **Real first success up front.** The quickstart leads with `npa workbench vlm-eval benchmark` over shipped fixtures — a genuine ranked result (`accuracy: 1.0`, 4 labeled rollouts) with **no cloud, GPU, or credentials**. The previous first command was a `--dry-run` over a file the docs never create.
- **Coherent three-tier example** for the same eval: `npa` CLI, Python SDK, and a standalone parameterizable **raw-`sky` YAML** (BYO S3 endpoint + BYO image, all placeholders).
- **Expanded troubleshooting**: pytest collection error, S3 endpoint on `aws-cli` v1 (`AWS_ENDPOINT_URL` ignored), wrong cluster/context, registry 403, capacity/quota errors.
- Replaced an example IP in `npa configure` guidance with a placeholder.

### Testing setup
- **New `dev` extra** (`pytest`, `pytest-mock`, `pytest-cov`, `pytest-timeout`, `ruff`) that also pulls in `server`, so the standard suite actually **collects**. Previously `pip install -e npa` gave no test tooling and the suite failed on a missing `fastapi`; the test deps only existed in `requirements-lock.txt`.
- **Root `Makefile`**: `install-dev`, `test`, `test-smoke`, `test-all`, `test-e2e`, `lint`, `format`. `make test` deselects live/GPU/e2e **markers** rather than only ignoring `tests/e2e` — some `gpu`/`e2e` tests live under `tests/workbench/` and will launch real infra otherwise.
- **Hermetic unit suite**: `conftest.py` now scrubs ambient credential/storage env vars for non-live tests, so a contributor who exported Nebius creds (as our own docs encourage) no longer hits spurious failures (e.g. `AWS_ENDPOINT_URL` leaking into deploy-config assertions).
- Added `tests/cli/test_onboarding_smoke.py` guarding the no-IP rule in setup guidance and the offline first-success path.

## Test plan
- [x] Fresh `~/.venvs` from clean `python3` (3.10.12): `pip install -e npa` then `pip install -e "npa[dev]"` succeed.
- [x] `npa --version`, `--help`, `configure`, `vlm-eval list`, and the documented `vlm-eval benchmark` (CLI + SDK) all run and produce the documented output.
- [x] `make test` → **1466 passed, 0 failures, 13 live/GPU deselected** in ~84s, green even with real creds exported in the shell.
- [x] `make test-smoke` → 24 passed; `ruff` clean; `gitleaks` clean on staged diff.
- [ ] Heavy/live end-to-end validation (real GPU vLLM eval, raw-`sky launch`) deferred to the queue/launcher — attended-only here.

> Do not merge / no auto-merge — squash is the human's.

Made with [Cursor](https://cursor.com)