### PR TITLE
[H] FIXME: Cosmos infer surfaces S3 upload AccessDenied as an uncaught traceback

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -46,7 +46,7 @@ work lives).
 #### [H] Cosmos infer surfaces S3 upload AccessDenied as an uncaught traceback
 
 - **Surfaced by**: 2026-05-09 8x H200 rerun.
-- **Status**: Still active.
+- **Status**: Fixed.
 - **Current issue**: Cosmos generation can complete successfully, then local S3
   upload failure prints a Python traceback instead of a clean command error.
 - **Next step**: Catch upload failures, report the generated VM-local file path,

--- a/npa/src/npa/cli/cosmos/__init__.py
+++ b/npa/src/npa/cli/cosmos/__init__.py
@@ -18,6 +18,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import typer
+from boto3.exceptions import S3UploadFailedError
 from rich.console import Console
 
 from npa.cli._error_formatting import format_error_for_user
@@ -75,6 +76,7 @@ from npa.clients.scoped_credentials import (
     run_with_host_credential_fallback,
 )
 from npa.clients.ssh import SSHClient, SSHError
+from npa.errors import ScopedCredentialError
 from npa.clients.serverless import (
     EndpointInfo,
     EndpointSpec,
@@ -192,6 +194,10 @@ COSMOS_CREDENTIAL_ENV_NAMES = {
     "HUGGING_FACE_HUB_TOKEN",
 }
 
+UPLOAD_FAILURE_ERRORS = (
+    ScopedCredentialError,
+    S3UploadFailedError,
+)
 
 def _cosmos_gated_models(model: str) -> list[str]:
     return [model or DEFAULT_MODEL]
@@ -3467,6 +3473,28 @@ def _poll_inference_job(
             time.sleep(sleep_for)
 
 
+def _fail_upload(
+    exc: BaseException,
+    output_path: str,
+    remote_output_path: str,
+) -> None:
+    lines = [
+        f"Generation succeeded but uploading the output to {output_path} failed: {exc}"
+    ]
+    if remote_output_path:
+        lines.append(
+            f"The generated file is still on the Cosmos VM at {remote_output_path}; "
+            "copy it off the VM before tearing the cluster down to avoid re-running "
+            "generation."
+        )
+    lines.append(
+        "This is an upload problem, not a generation failure. Verify the destination "
+        "bucket exists and the Service Account has write access to it."
+    )
+    console.print("[red]Error:[/red] " + "\n".join(lines), soft_wrap=True)
+    raise typer.Exit(1)
+
+
 @app.command("infer")
 def infer_cmd(
     prompt: str = typer.Option(
@@ -3587,30 +3615,33 @@ def infer_cmd(
 
         result = {**data, "job_id": job_id}
         remote_output_path = str(data.get("output_path") or "")
-        if remote_output_path:
-            downloaded_to = _download_remote_output(
-                remote_output_path,
-                output_path,
-                cfg,
-                temp_dirs,
-                result=result,
-                allow_host_creds=allow_host_creds,
-                target_project=resolved_target_project,
-            )
-            result["downloaded_to"] = downloaded_to
-            if _is_s3_uri(downloaded_to):
-                result["saved_to"] = downloaded_to
-        elif output_path:
-            saved_to = _save_inference_output(
-                result,
-                output_path,
-                cfg,
-                temp_dirs,
-                allow_host_creds=allow_host_creds,
-                target_project=resolved_target_project,
-            )
-            if saved_to:
-                result["saved_to"] = saved_to
+        try:
+            if remote_output_path:
+                downloaded_to = _download_remote_output(
+                    remote_output_path,
+                    output_path,
+                    cfg,
+                    temp_dirs,
+                    result=result,
+                    allow_host_creds=allow_host_creds,
+                    target_project=resolved_target_project,
+                )
+                result["downloaded_to"] = downloaded_to
+                if _is_s3_uri(downloaded_to):
+                    result["saved_to"] = downloaded_to
+            elif output_path:
+                saved_to = _save_inference_output(
+                    result,
+                    output_path,
+                    cfg,
+                    temp_dirs,
+                    allow_host_creds=allow_host_creds,
+                    target_project=resolved_target_project,
+                )
+                if saved_to:
+                    result["saved_to"] = saved_to
+        except UPLOAD_FAILURE_ERRORS as exc:
+            _fail_upload(exc, output_path, remote_output_path)
         _output(result, output_format)
     finally:
         for tmp in temp_dirs:

--- a/npa/tests/cli/test_cosmos_infer_upload_errors.py
+++ b/npa/tests/cli/test_cosmos_infer_upload_errors.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from boto3.exceptions import S3UploadFailedError
+from botocore.exceptions import ClientError, NoCredentialsError
+import pytest
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.clients.config import (
+    ServerlessConfig,
+    SSHConfig,
+    StorageConfig,
+    WorkbenchConfig,
+)
+
+runner = CliRunner()
+
+OUTPUT_URI = "s3://bucket/results/out.mp4"
+REMOTE_PATH = "/opt/cosmos-data/outputs/out.mp4"
+
+
+def _cfg() -> WorkbenchConfig:
+    return WorkbenchConfig(
+        endpoint="http://cosmos:8080",
+        ssh=SSHConfig(host="cosmos", user="ubuntu", key_path="~/.ssh/id"),
+        storage=StorageConfig(checkpoint_bucket="", endpoint_url=""),
+        hf_token="",
+        app_status="",
+        runtime="vm",
+        serverless=ServerlessConfig(),
+    )
+
+
+def _client_error(code: str, message: str | None = None) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": message or code}}, "PutObject"
+    )
+
+
+def _upload_failed(code: str) -> S3UploadFailedError:
+    # boto3's managed upload wraps the S3 ClientError as S3UploadFailedError.
+    client_error = _client_error(code)
+    try:
+        raise client_error
+    except ClientError as exc:
+        err = S3UploadFailedError(
+            f"Failed to upload local to bucket/key: {exc}"
+        )
+        err.__context__ = exc
+        return err
+
+
+def _patch_infer(mocker, store, *, output_path: str | None = REMOTE_PATH, ssh=None):
+    http = mocker.MagicMock()
+    http.infer.return_value = {"job_id": "job-1", "status": "running"}
+    completed = {"job_id": "job-1", "status": "completed"}
+    if output_path:
+        completed["output_path"] = output_path
+    http.job_status.return_value = completed
+    mocker.patch("npa.cli.cosmos.resolve_config", return_value=_cfg())
+    mocker.patch("npa.cli.cosmos.HTTPClient", return_value=http)
+    mocker.patch("npa.cli.cosmos.SSHClient", return_value=ssh or mocker.MagicMock())
+    mocker.patch("npa.cli.cosmos._storage_client_for_config", return_value=store)
+    return http
+
+
+def _assert_clean_upload_failure(result, *, expect_vm_path: bool) -> None:
+    assert result.exception is None or isinstance(result.exception, SystemExit), (
+        f"uncaught exception escaped the command: {result.exception!r}"
+    )
+    assert result.exit_code == 1
+    assert "Generation succeeded but uploading" in result.output
+    assert "not a generation failure" in result.output
+    assert "Traceback" not in result.output
+    if expect_vm_path:
+        assert REMOTE_PATH in result.output
+        assert "still on the Cosmos VM" in result.output
+    else:
+        assert "still on the Cosmos VM" not in result.output
+
+
+DIRECT_UPLOAD_ERRORS = [
+    pytest.param(_upload_failed("AccessDenied"), id="access_denied"),
+    pytest.param(NoCredentialsError(), id="no_credentials"),
+]
+
+
+@pytest.mark.parametrize("injected", DIRECT_UPLOAD_ERRORS)
+def test_infer_remote_upload_error_is_clean(injected, mocker) -> None:
+    """Generation completes, the remote-output upload fails -> clean error."""
+    store = mocker.MagicMock()
+    store.upload_file.side_effect = injected
+    _patch_infer(mocker, store)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench", "cosmos", "infer",
+            "--prompt", "a red cube on a table",
+            "--output-path", OUTPUT_URI,
+        ],
+    )
+
+    _assert_clean_upload_failure(result, expect_vm_path=True)
+
+
+def test_infer_inline_upload_error_is_clean(mocker) -> None:
+    """No VM-side artifact (inline result) -> clean error, no false VM path."""
+    store = mocker.MagicMock()
+    store.upload_file.side_effect = _upload_failed("AccessDenied")
+    _patch_infer(mocker, store, output_path=None)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench", "cosmos", "infer",
+            "--prompt", "a red cube on a table",
+            "--output-path", "s3://bucket/results/out.json",
+        ],
+    )
+
+    _assert_clean_upload_failure(result, expect_vm_path=False)
+
+
+def test_infer_allow_host_creds_does_not_fall_back_for_managed_upload(mocker) -> None:
+    """--allow-host-creds does not fall back for a managed-upload denial (still clean)."""
+    store = mocker.MagicMock()
+    store.upload_file.side_effect = _upload_failed("AccessDenied")
+    ssh = mocker.MagicMock()
+    _patch_infer(mocker, store, ssh=ssh)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench", "cosmos", "infer",
+            "--prompt", "a red cube on a table",
+            "--output-path", OUTPUT_URI,
+            "--allow-host-creds",
+        ],
+    )
+
+    _assert_clean_upload_failure(result, expect_vm_path=True)
+    ssh.run_or_raise.assert_not_called()


### PR DESCRIPTION
## Summary

 Resolves the `[H]` FIXME "Cosmos infer surfaces S3 upload AccessDenied as an uncaught traceback". 
When `npa workbench cosmos infer` finished generating but the S3 upload of the output failed (AccessDenied, Forbidden, NoSuchBucket, or missing credentials), just a raw exception was thrown. There was no hint that it was a permissions/bucket problem, or that the generated file was still recoverable.

## Changes

- Wrap the output upload in `infer_cmd` and route failures through `_fail_upload`, which tells the operator exactly what to do: verify the destination bucket exists and that the Service Account has write access, and points them to the VM-local path.

- `UPLOAD_FAILURE_ERRORS = (ScopedCredentialError, S3UploadFailedError)`. `S3UploadFailedError` is the key one — boto3's managed upload wraps S3 denials (AccessDenied/Forbidden/NoSuchBucket) into it, so they never reach the scoped-credential helper as a raw `ClientError`; `ScopedCredentialError` covers the no-credentials path.


## Tests

`npa/tests/cli/test_cosmos_infer_upload_errors.py` drives the real `infer` command through the S3 upload failure modes (an S3 denial and missing credentials) and asserts a clean, actionable error — with mocked endpoint/storage, no GPU, no network.

