### PR TITLE
Move sim2real preflight under npa workbench health

### DIFF
--- a/FTUE-AUDIT.md
+++ b/FTUE-AUDIT.md
@@ -17,7 +17,7 @@ a "non-default S3-compatible endpoint."
    pointing at the wrong cluster, and a schedulable-GPU count of zero were all
    only discoverable *mid-run*, after provisioning. A first-time user had no way
    to confirm readiness up front.
-   **Fixed:** `npa doctor sim2real` runs these as explicit PASS/WARN/FAIL/SKIP
+   **Fixed:** `npa workbench health sim2real` runs these as explicit PASS/WARN/FAIL/SKIP
    checks (`config`, `coherence`, `s3`, `registry`, `tokens`, `cluster`), with
    `--checks`, `--json`, and `--warn-only`.
 
@@ -52,7 +52,7 @@ a "non-default S3-compatible endpoint."
    **Fixed:** a canonical seam table (`SIM2REAL_SEAMS`) plus a `coherence_failures`
    check now validate, for all 20 BYO seams, that the CLI flag exists on
    `sim2real run`, the SDK/config field exists, and the runbook env is both
-   declared and referenced. This guard runs inside `npa doctor` and as a
+   declared and referenced. This guard runs inside `npa workbench health` and as a
    guardrail test alongside the existing contracts.
 
 6. **No one-value BYO seam map.** A new user had to read code to learn which CLI

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -15,7 +15,6 @@ from npa.cli.adapter import app as adapter_app
 from npa.cli.cluster import app as cluster_app
 from npa.cli.convert import app as convert_app
 from npa.cli.demo import app as demo_app
-from npa.cli.doctor import app as doctor_app
 from npa.cli.network import app as network_app
 from npa.cli.rerun import app as rerun_app
 from npa.cli.skypilot import app as skypilot_app
@@ -43,12 +42,6 @@ app.add_typer(
 # migrate to appropriate namespaces in a future change. New commands should be
 # registered under a solution namespace, such as `npa workbench ...`, instead of
 # adding more top-level registrations here.
-app.add_typer(
-    doctor_app,
-    name="doctor",
-    short_help="Preflight checks for workbench workflows.",
-    rich_help_panel="Setup",
-)
 app.add_typer(adapter_app, name="adapter", rich_help_panel="Platform utilities")
 app.add_typer(cluster_app, name="cluster", rich_help_panel="Platform utilities")
 app.add_typer(convert_app, name="convert", rich_help_panel="Platform utilities")

--- a/npa/src/npa/cli/workbench/__init__.py
+++ b/npa/src/npa/cli/workbench/__init__.py
@@ -24,6 +24,7 @@ from npa.cli.workbench.detection_training import app as detection_training_app
 from npa.cli.workbench.vlm_eval import app as vlm_eval_app
 from npa.cli.workbench.workflow import app as workflow_app
 from npa.cli.workbench.trigger import app as trigger_app
+from npa.cli.workbench.health import app as health_app
 
 app = typer.Typer(
     name="workbench",
@@ -60,3 +61,4 @@ app.add_typer(detection_training_app, name="detection-training")
 app.add_typer(vlm_eval_app, name="vlm-eval")
 app.add_typer(workflow_app, name="workflow")
 app.add_typer(trigger_app, name="trigger")
+app.add_typer(health_app, name="health")

--- a/npa/src/npa/cli/workbench/health.py
+++ b/npa/src/npa/cli/workbench/health.py
@@ -1,4 +1,4 @@
-"""``npa doctor`` — preflight diagnostics for workbench workflows.
+"""``npa workbench health`` — preflight diagnostics for workbench workflows.
 
 Runs the recurring cold-start blockers as explicit PASS/WARN/FAIL/SKIP checks so
 a customer hits them as a clear preflight instead of a mid-pipeline failure.
@@ -18,7 +18,7 @@ import typer
 from npa.clients.credentials import load_credentials
 from npa.clients.storage import StorageClient
 from npa.guardrails.skypilot import inspect_image_exists
-from npa.workflows.sim2real_doctor import (
+from npa.workflows.sim2real_health import (
     ALL_CHECKS,
     DoctorProbes,
     FAIL,
@@ -32,8 +32,8 @@ from npa.workflows.sim2real_doctor import (
 from npa.workflows.sim2real_loop import build_config_from_env
 
 app = typer.Typer(
-    name="doctor",
-    help="Preflight checks for workbench workflows.",
+    name="health",
+    help="Preflight health checks for workbench workflows.",
     no_args_is_help=True,
 )
 
@@ -44,7 +44,7 @@ def _repo_root() -> Path:
     override = os.environ.get("NPA_REPO_ROOT")
     if override:
         return Path(override)
-    # src/npa/cli/doctor.py -> repo root is four parents up from this file's package.
+    # Walk up to the repo root that contains the workflow tree.
     here = Path(__file__).resolve()
     for parent in here.parents:
         if (parent / "npa" / "workflows" / "workbench").is_dir():

--- a/npa/src/npa/workflows/sim2real_health.py
+++ b/npa/src/npa/workflows/sim2real_health.py
@@ -1,8 +1,9 @@
 """Preflight diagnostics for the Sim2Real VLM-to-RL workflow.
 
-This module is the single source of truth for ``npa doctor sim2real``. It turns
-the recurring cold-start blockers into explicit PASS/WARN/FAIL/SKIP checks that a
-customer can run before launching anything, instead of discovering them mid-run.
+This module is the single source of truth for ``npa workbench health sim2real``.
+It turns the recurring cold-start blockers into explicit PASS/WARN/FAIL/SKIP
+checks that a customer can run before launching anything, instead of discovering
+them mid-run.
 
 Every check is a pure function that takes the resolved config plus an injectable
 probe. The CLI wires real probes (S3, registry, kubectl); unit tests inject

--- a/npa/tests/cli/test_workbench_health_cli.py
+++ b/npa/tests/cli/test_workbench_health_cli.py
@@ -9,50 +9,64 @@ from npa.cli.main import app
 runner = CliRunner()
 
 
-def test_doctor_registered_at_top_level() -> None:
-    result = runner.invoke(app, ["doctor", "--help"])
+def test_health_registered_under_workbench() -> None:
+    result = runner.invoke(app, ["workbench", "health", "--help"])
     assert result.exit_code == 0
-    assert "Preflight checks" in result.output
+    assert "Preflight health checks" in result.output
 
 
-def test_doctor_sim2real_help_lists_checks() -> None:
-    result = runner.invoke(app, ["doctor", "sim2real", "--help"])
+def test_health_not_registered_at_top_level() -> None:
+    result = runner.invoke(app, ["doctor", "--help"])
+    assert result.exit_code != 0
+
+
+def test_health_sim2real_help_lists_checks() -> None:
+    result = runner.invoke(app, ["workbench", "health", "sim2real", "--help"])
     assert result.exit_code == 0
     assert "--checks" in result.output
 
 
-def test_doctor_static_checks_pass_with_bucket() -> None:
+def test_health_static_checks_pass_with_bucket() -> None:
     result = runner.invoke(
         app,
-        ["doctor", "sim2real", "--checks", "config,coherence", "--s3-bucket", "real-bucket"],
+        [
+            "workbench",
+            "health",
+            "sim2real",
+            "--checks",
+            "config,coherence",
+            "--s3-bucket",
+            "real-bucket",
+        ],
     )
     assert result.exit_code == 0
     assert "three-tier-coherence" in result.output
     assert "PASS" in result.output
 
 
-def test_doctor_fails_without_required_bucket(monkeypatch) -> None:
+def test_health_fails_without_required_bucket(monkeypatch) -> None:
     for key in ("NPA_S3_BUCKET", "NPA_SIM2REAL_BUCKET", "S3_BUCKET"):
         monkeypatch.delenv(key, raising=False)
-    result = runner.invoke(app, ["doctor", "sim2real", "--checks", "config"])
+    result = runner.invoke(app, ["workbench", "health", "sim2real", "--checks", "config"])
     assert result.exit_code == 1
     assert "FAIL" in result.output
 
 
-def test_doctor_warn_only_suppresses_exit_code(monkeypatch) -> None:
+def test_health_warn_only_suppresses_exit_code(monkeypatch) -> None:
     for key in ("NPA_S3_BUCKET", "NPA_SIM2REAL_BUCKET", "S3_BUCKET"):
         monkeypatch.delenv(key, raising=False)
     result = runner.invoke(
-        app, ["doctor", "sim2real", "--checks", "config", "--warn-only"]
+        app, ["workbench", "health", "sim2real", "--checks", "config", "--warn-only"]
     )
     assert result.exit_code == 0
 
 
-def test_doctor_json_output_is_valid() -> None:
+def test_health_json_output_is_valid() -> None:
     result = runner.invoke(
         app,
         [
-            "doctor",
+            "workbench",
+            "health",
             "sim2real",
             "--checks",
             "config,coherence",
@@ -67,7 +81,7 @@ def test_doctor_json_output_is_valid() -> None:
     assert {c["name"] for c in payload["checks"]} == {"config", "three-tier-coherence"}
 
 
-def test_doctor_rejects_unknown_check() -> None:
-    result = runner.invoke(app, ["doctor", "sim2real", "--checks", "bogus"])
+def test_health_rejects_unknown_check() -> None:
+    result = runner.invoke(app, ["workbench", "health", "sim2real", "--checks", "bogus"])
     assert result.exit_code != 0
     assert "unknown check" in result.output.lower()

--- a/npa/tests/guardrails/test_three_tier_contract.py
+++ b/npa/tests/guardrails/test_three_tier_contract.py
@@ -237,7 +237,7 @@ def test_sim2real_headline_workflow_is_three_tier_coherent() -> None:
     # The sim2real headline workflow uses a **overrides SDK surface, so it cannot
     # use the inspect-based CapabilityContract. Its coherence is enforced through
     # the doctor seam table instead (CLI flag <-> config/SDK field <-> YAML env).
-    from npa.workflows.sim2real_doctor import coherence_failures
+    from npa.workflows.sim2real_health import coherence_failures
 
     failures = coherence_failures(REPO_ROOT)
     assert not failures, "\n".join(failures)
@@ -251,6 +251,7 @@ def test_new_workbench_tools_require_contract_or_explicit_seam() -> None:
         "fiftyone",
         "genesis",
         "groot",
+        "health",
         "isaac-lab",
         "lancedb",
         "lerobot",

--- a/npa/tests/workflows/test_sim2real_health.py
+++ b/npa/tests/workflows/test_sim2real_health.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 import pytest
 
-from npa.workflows import sim2real_doctor as doctor
-from npa.workflows.sim2real_doctor import (
+from npa.workflows import sim2real_health as health
+from npa.workflows.sim2real_health import (
     DoctorProbes,
     KubeResult,
     check_cluster,
@@ -32,17 +32,17 @@ class _Creds:
 
 
 def _config(**overrides):
-    return build_config_from_env(run_id="doctor-test", **overrides)
+    return build_config_from_env(run_id="health-test", **overrides)
 
 
 def test_coherence_passes_on_real_repo() -> None:
     assert coherence_failures(REPO_ROOT) == []
-    assert check_coherence(REPO_ROOT).status == doctor.PASS
+    assert check_coherence(REPO_ROOT).status == health.PASS
 
 
 def test_sdk_accepts_every_seam_as_config_field() -> None:
     field_names = {f for f in vars(_config()).keys()}
-    for seam in doctor.SIM2REAL_SEAMS:
+    for seam in health.SIM2REAL_SEAMS:
         assert seam.config_field in field_names
         # build_config_from_env applies the override keyed by config-field name.
         applied = build_config_from_env(**{seam.config_field: getattr(_config(), seam.config_field)})
@@ -53,13 +53,13 @@ def test_config_fails_without_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
     for key in ("NPA_S3_BUCKET", "NPA_SIM2REAL_BUCKET", "S3_BUCKET"):
         monkeypatch.delenv(key, raising=False)
     result = check_config(_config(s3_bucket=""))
-    assert result.status == doctor.FAIL
+    assert result.status == health.FAIL
     assert any("s3_bucket" in d for d in result.details)
 
 
 def test_config_warns_on_derived_optional_seams() -> None:
     result = check_config(_config(s3_bucket="real-bucket", trigger_dataset_uri="", assets_uri="", scene_spec_uri=""))
-    assert result.status == doctor.WARN
+    assert result.status == health.WARN
 
 
 def test_config_passes_when_seams_resolve() -> None:
@@ -70,21 +70,21 @@ def test_config_passes_when_seams_resolve() -> None:
             assets_uri="s3://real-bucket/assets/",
         )
     )
-    assert result.status == doctor.PASS
+    assert result.status == health.PASS
 
 
 def test_config_fails_on_invalid_schema() -> None:
     result = check_config(_config(s3_bucket="real-bucket", threshold=5.0))
-    assert result.status == doctor.FAIL
+    assert result.status == health.FAIL
 
 
 def test_s3_skips_without_endpoint_or_creds() -> None:
     probes = DoctorProbes(credentials=_Creds())
-    assert check_s3(_config(s3_bucket="b", s3_endpoint=""), probes=probes).status == doctor.SKIP
+    assert check_s3(_config(s3_bucket="b", s3_endpoint=""), probes=probes).status == health.SKIP
 
     probes_no_keys = DoctorProbes(credentials=_Creds())
     res = check_s3(_config(s3_bucket="b", s3_endpoint="https://endpoint.example"), probes=probes_no_keys)
-    assert res.status == doctor.SKIP
+    assert res.status == health.SKIP
 
 
 def test_s3_pass_and_fail_with_injected_client() -> None:
@@ -101,20 +101,20 @@ def test_s3_pass_and_fail_with_injected_client() -> None:
         _config(s3_bucket="b", s3_endpoint="https://endpoint.example"),
         probes=DoctorProbes(credentials=creds, s3_client_factory=_OkClient),
     )
-    assert ok.status == doctor.PASS
+    assert ok.status == health.PASS
 
     bad = check_s3(
         _config(s3_bucket="b", s3_endpoint="https://endpoint.example"),
         probes=DoctorProbes(credentials=creds, s3_client_factory=_BadClient),
     )
-    assert bad.status == doctor.FAIL
+    assert bad.status == health.FAIL
     assert "NoSuchBucket" in " ".join(bad.details)
 
 
 def test_registry_warns_on_unqualified_images() -> None:
     # Default reference images are bare npa-* names, not registry-qualified.
     result = check_registry(_config(), probes=DoctorProbes(image_inspector=lambda i: True))
-    assert result.status == doctor.WARN
+    assert result.status == health.WARN
 
 
 def test_registry_inspects_qualified_images() -> None:
@@ -127,22 +127,22 @@ def test_registry_inspects_qualified_images() -> None:
     }
     cfg = _config(**qualified)
     ok = check_registry(cfg, probes=DoctorProbes(image_inspector=lambda i: True))
-    assert ok.status == doctor.PASS
+    assert ok.status == health.PASS
 
     missing = check_registry(
         cfg, probes=DoctorProbes(image_inspector=lambda i: i.endswith("0.1.0"))
     )
-    assert missing.status == doctor.FAIL
+    assert missing.status == health.FAIL
 
     no_tool = check_registry(cfg, probes=DoctorProbes(image_inspector=lambda i: None))
-    assert no_tool.status == doctor.SKIP
+    assert no_tool.status == health.SKIP
 
 
 def test_tokens_warns_when_missing_and_passes_when_present() -> None:
     warn = check_tokens(_config(), probes=DoctorProbes(credentials=_Creds()))
-    assert warn.status == doctor.WARN
+    assert warn.status == health.WARN
     ok = check_tokens(_config(), probes=DoctorProbes(credentials=_Creds(hf="hf_x", ngc="nv_x")))
-    assert ok.status == doctor.PASS
+    assert ok.status == health.PASS
 
 
 def _kube_nodes(gpu_count: int, nodes: int = 1) -> str:
@@ -154,7 +154,7 @@ def _kube_nodes(gpu_count: int, nodes: int = 1) -> str:
 
 
 def test_cluster_skips_without_runner() -> None:
-    assert check_cluster(_config(), probes=DoctorProbes()).status == doctor.SKIP
+    assert check_cluster(_config(), probes=DoctorProbes()).status == health.SKIP
 
 
 def test_cluster_pass_counts_schedulable_gpus() -> None:
@@ -168,7 +168,7 @@ def test_cluster_pass_counts_schedulable_gpus() -> None:
         return KubeResult(1, "", "unexpected")
 
     result = check_cluster(_config(), probes=DoctorProbes(kube_runner=runner))
-    assert result.status == doctor.PASS
+    assert result.status == health.PASS
     assert "16 schedulable" in result.summary
 
 
@@ -183,7 +183,7 @@ def test_cluster_fails_on_zero_gpus() -> None:
         return KubeResult(1, "", "x")
 
     result = check_cluster(_config(), probes=DoctorProbes(kube_runner=runner))
-    assert result.status == doctor.FAIL
+    assert result.status == health.FAIL
     assert "0 schedulable" in result.summary
 
 
@@ -194,7 +194,7 @@ def test_cluster_fails_on_unpinned_context() -> None:
         return KubeResult(0, "yes")
 
     result = check_cluster(_config(), probes=DoctorProbes(kube_runner=runner))
-    assert result.status == doctor.FAIL
+    assert result.status == health.FAIL
     assert "context" in result.summary.lower()
 
 
@@ -207,7 +207,7 @@ def test_cluster_fails_without_pod_permission() -> None:
         return KubeResult(0, "")
 
     result = check_cluster(_config(), probes=DoctorProbes(kube_runner=runner))
-    assert result.status == doctor.FAIL
+    assert result.status == health.FAIL
 
 
 def test_run_preflight_selects_requested_checks() -> None:
@@ -222,4 +222,4 @@ def test_run_preflight_selects_requested_checks() -> None:
 
 @pytest.mark.parametrize("gpu_resource", ["nvidia.com/gpu"])
 def test_count_schedulable_handles_bad_json(gpu_resource: str) -> None:
-    assert doctor._count_schedulable_gpus("not-json", gpu_resource) == (0, 0)
+    assert health._count_schedulable_gpus("not-json", gpu_resource) == (0, 0)

--- a/npa/workflows/workbench/sim2real/README.md
+++ b/npa/workflows/workbench/sim2real/README.md
@@ -116,7 +116,7 @@ HF/NGC tokens, kube context, schedulable-GPU count, and three-tier coherence) as
 PASS/WARN/FAIL/SKIP so you hit them up front instead of mid-pipeline:
 
 ```bash
-npa doctor sim2real \
+npa workbench health sim2real \
   --s3-bucket <bucket> \
   --s3-endpoint <your-s3-compatible-endpoint> \
   --trigger-dataset-uri s3://<bucket>/sim2real-triggers/<run-id>/lerobot-pusht/ \


### PR DESCRIPTION
## Summary

Follow-up to #78. The sim2real preflight was registered as a top-level
`npa doctor sim2real`, which is too high in the command hierarchy and contradicts
the repo convention (the `main.py` FIXME: new commands should live under a
solution namespace like `npa workbench ...`, not as new top-level groups).

- Moves the command to **`npa workbench health sim2real`**, registered alongside
  the other workbench tools.
- Renames the CLI module, engine module, and tests from `doctor` to `health`
  (`cli/workbench/health.py`, `workflows/sim2real_health.py`) for consistency.
- Removes the top-level `npa doctor` registration from `main.py`.
- `health` is added to the workbench-tool seam set in the three-tier guardrail
  test; coherence enforcement is unchanged.
- Docs (`FTUE-AUDIT.md`, sim2real README) updated to the new command path.

The checks, behavior, flags (`--checks`, `--json`, `--warn-only`), and engine
logic are unchanged — this is a placement/naming change only.

## Test plan

- [x] `ruff check` clean.
- [x] `pytest npa/tests/cli npa/tests/guardrails` — 737 passed, 2 skipped, 1 xpassed.
- [x] `test_sim2real_health.py` + `test_workbench_health_cli.py` green; negative
      test confirms `npa doctor` is no longer top-level.
- [x] Smoke: `npa workbench health sim2real --checks config,coherence` PASS;
      `npa workbench --help` lists `health`; `npa doctor` exits non-zero.

Made with [Cursor](https://cursor.com)