### PR TITLE
fix(skypilot): pin sky invocations to a durable cwd

### DIFF
--- a/npa/src/npa/orchestration/skypilot/workflow.py
+++ b/npa/src/npa/orchestration/skypilot/workflow.py
@@ -35,6 +35,31 @@ JOBS_CONTROLLER_PREFIX = "sky-jobs-controller-"
 HEALTHY_CONTROLLER_STATUS = "UP"
 
 
+def _stable_sky_cwd(isolated_config_dir: Path | None) -> str:
+    """Return a durable directory to run the ``sky`` CLI from.
+
+    SkyPilot runs a long-lived local API server daemon that performs all
+    provisioning and file sync, and it inherits the working directory of the
+    process that first starts it. NPA workflows frequently execute from
+    short-lived temp directories (e.g. ``tempfile.mkdtemp``). If the daemon
+    auto-starts with such a cwd and that directory is later cleaned up, every
+    later operation fails with ``getcwd() failed: No such file or directory``
+    and ``rsync`` exits with code 3 ("Failed to set up SkyPilot runtime").
+    Pinning sky invocations to a durable directory keeps the daemon's cwd valid.
+    """
+
+    for candidate in (isolated_config_dir, Path.home()):
+        if candidate is None:
+            continue
+        try:
+            path = Path(candidate)
+            if path.is_dir():
+                return str(path)
+        except OSError:
+            continue
+    return str(Path.home())
+
+
 @dataclass
 class WorkflowResult:
     """Result of submitting or querying a SkyPilot managed workflow."""
@@ -114,16 +139,19 @@ def submit_workflow(
         for secret_name in secret_envs or ():
             if os.environ.get(secret_name):
                 cmd[-1:-1] = ["--secret", secret_name]
+        stable_cwd = _stable_sky_cwd(runtime_config.isolated_config_dir)
         _wait_for_healthy_jobs_controller(
             sky_executable,
             env=env,
             timeout=controller_preflight_timeout,
             interval=controller_preflight_interval,
             require_existing=require_controller_up,
+            cwd=stable_cwd,
         )
         result = subprocess.run(
             cmd,
             env=env,
+            cwd=stable_cwd,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -185,6 +213,7 @@ def workflow_status(
     result = subprocess.run(
         cmd,
         env=sky_environment(runtime_config.isolated_config_dir),
+        cwd=_stable_sky_cwd(runtime_config.isolated_config_dir),
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -218,6 +247,7 @@ def _wait_for_healthy_jobs_controller(
     timeout: int,
     interval: float,
     require_existing: bool = False,
+    cwd: str | None = None,
 ) -> None:
     """Block launch while an existing managed-jobs controller is not ready."""
 
@@ -227,6 +257,7 @@ def _wait_for_healthy_jobs_controller(
         result = subprocess.run(
             [sky_executable, "status", "--refresh", "--output", "json"],
             env=env,
+            cwd=cwd,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/npa/tests/orchestration/skypilot/test_workflow.py
+++ b/npa/tests/orchestration/skypilot/test_workflow.py
@@ -11,6 +11,7 @@ from npa.orchestration.skypilot import _bin as bin_module
 from npa.orchestration.skypilot import workflow as workflow_module
 from npa.orchestration.skypilot.workflow import (
     SkyPilotSubmitError,
+    _stable_sky_cwd,
     _status_from_queue_payload,
     submit_workflow,
     workflow_status,
@@ -75,6 +76,45 @@ def test_submit_workflow_loads_yaml_applies_controller_and_calls_subprocess(monk
         "memory": 16,
         "autostop": False,
     }
+
+
+def test_submit_workflow_runs_sky_from_stable_cwd(monkeypatch, tmp_path) -> None:
+    """All sky invocations must run from a durable cwd so the auto-started
+    API server daemon never inherits an ephemeral (later-deleted) directory."""
+    yaml_path = tmp_path / "workflow.yaml"
+    yaml_path.write_text("name: demo\nresources:\n  cloud: kubernetes\n", encoding="utf-8")
+    sky_bin = _fake_sky(tmp_path)
+    isolated = tmp_path / "sky-state"
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if _is_status_cmd(cmd):
+            return _healthy_status(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="Job submitted, ID: 7\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    submit_workflow(yaml_path, "run-cwd", isolated_config_dir=isolated, sky_bin=sky_bin)
+
+    assert calls, "expected sky to be invoked"
+    for cmd, kwargs in calls:
+        cwd = kwargs.get("cwd")
+        assert cwd, f"sky command missing stable cwd: {cmd}"
+        assert Path(cwd).is_dir(), f"sky cwd is not an existing directory: {cwd}"
+        assert cwd == str(isolated)
+
+
+def test_stable_sky_cwd_falls_back_to_home_when_dir_missing(tmp_path) -> None:
+    missing = tmp_path / "does-not-exist"
+    assert _stable_sky_cwd(missing) == str(Path.home())
+    assert _stable_sky_cwd(None) == str(Path.home())
+
+
+def test_stable_sky_cwd_prefers_existing_isolated_dir(tmp_path) -> None:
+    isolated = tmp_path / "sky-state"
+    isolated.mkdir()
+    assert _stable_sky_cwd(isolated) == str(isolated)
 
 
 def test_submit_workflow_network_failure_raises_typed_error(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
Fixes a class of failure where **every** SkyPilot launch (`sky jobs launch`, raw `sky launch` on k8s) fails at runtime setup with `getcwd() failed: No such file or directory` and `rsync` exit code 3 ("Failed to set up SkyPilot runtime on cluster"), while serverless paths keep working.

**Root cause:** SkyPilot runs a long-lived local API server daemon that performs all provisioning + file sync and **inherits the working directory of the process that first starts it**. NPA workflows frequently run from short-lived temp dirs (`tempfile.mkdtemp(prefix="npa-{run_id}-")`). If the daemon auto-starts with such a cwd and that dir is later cleaned up, the daemon is left with a **deleted working directory**, and all subsequent rsync/file-sync ops fail. Observed live: the daemon was running with cwd `/tmp/npa-…-workflow-… (deleted)`.

**Fix:** Run sky invocations from a durable directory (the isolated SkyPilot config dir, falling back to `~`) so the daemon's cwd is always valid. Applied to the launch path (controller health check + `sky jobs launch`) and `jobs queue`. Adds `_stable_sky_cwd` + unit tests.

This is the code-level counterpart to the operational mitigation (`sky api stop && sky api start` from a valid cwd), so the issue can't recur from NPA-initiated workflows.

## Test plan
- [x] `pytest npa/tests/orchestration/skypilot/` → 85 passed, 1 skipped
- [x] New tests assert all sky subprocess calls receive an existing, durable `cwd`, and cover `_stable_sky_cwd` fallback
- [x] `ruff check` clean
- [x] Verified live separately: after restarting the daemon from a valid cwd, `sky launch` on k8s runs end-to-end (`nvidia-smi` on H100, job SUCCEEDED)

Made with [Cursor](https://cursor.com)