### PR TITLE
feat(sim2real): load BYO mesh/SceneSpec assets into the held-out Genesis rollout

### DIFF
--- a/npa/src/npa/cli/cluster/terraform_lifecycle.py
+++ b/npa/src/npa/cli/cluster/terraform_lifecycle.py
@@ -190,10 +190,25 @@ def _require_bin(binary: str) -> str:
 
 def _terraform_env(nebius_bin: str) -> dict[str, str]:
     env = os.environ.copy()
-    if not env.get("TF_VAR_iam_token"):
-        token = _run_capture([nebius_bin, "iam", "get-access-token"], env=env).stdout.strip()
-        env["TF_VAR_iam_token"] = token
-        env["NEBIUS_IAM_TOKEN"] = token
+    # A stale ambient IAM token (e.g. a cloud-env token) silently shadows the
+    # intended Nebius profile and mints kubeconfig/registry credentials for the
+    # wrong principal -- the cause of Forbidden jobs/pods/nodes and 401 image
+    # pulls. Mint a fresh token by default after clearing any stale token; opt
+    # back into reuse only when NPA_REUSE_IAM_TOKEN is explicitly set (e.g. CI
+    # that injects a short-lived token intentionally).
+    reuse = env.get("NPA_REUSE_IAM_TOKEN", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if reuse and env.get("TF_VAR_iam_token"):
+        return env
+    env.pop("TF_VAR_iam_token", None)
+    env.pop("NEBIUS_IAM_TOKEN", None)
+    token = _run_capture([nebius_bin, "iam", "get-access-token"], env=env).stdout.strip()
+    env["TF_VAR_iam_token"] = token
+    env["NEBIUS_IAM_TOKEN"] = token
     return env
 
 

--- a/npa/src/npa/cli/skypilot/__init__.py
+++ b/npa/src/npa/cli/skypilot/__init__.py
@@ -139,6 +139,23 @@ def verify_cmd(
         "--path",
         help=f"SkyPilot venv path. Defaults to {VENV_PATH_ENV} or ~/.npa/skypilot-venv.",
     ),
+    kubeconfig: Path | None = typer.Option(
+        None,
+        "--kubeconfig",
+        help=(
+            "Kubeconfig to verify against. Sets KUBECONFIG for `sky check` so "
+            "verify does not silently run against an ambient/empty context and "
+            "report a misleading 403 anonymous 'missing context'."
+        ),
+    ),
+    cluster: str | None = typer.Option(
+        None,
+        "--cluster",
+        help=(
+            "NPA cluster name. Resolves ~/.npa/clusters/<name>/kubeconfig when "
+            "--kubeconfig is not given."
+        ),
+    ),
 ) -> None:
     """Run `sky check` against the isolated SkyPilot runtime."""
 
@@ -148,12 +165,40 @@ def verify_cmd(
         _fail(f"SkyPilot {SKYPILOT_VERSION} is not ready in {state.path}: {detail}. Run `npa skypilot bootstrap`.")
         return
 
-    result = _run_no_raise([str(state.sky_bin), "check"])
+    check_env = _verify_kube_env(kubeconfig=kubeconfig, cluster=cluster)
+    result = _run_no_raise([str(state.sky_bin), "check"], env=check_env)
     if result.stdout:
         typer.echo(result.stdout.rstrip())
     if result.stderr:
         console.print(result.stderr.rstrip())
     raise typer.Exit(result.returncode)
+
+
+def _verify_kube_env(
+    *, kubeconfig: Path | None, cluster: str | None
+) -> dict[str, str] | None:
+    """Build the env for `sky check`, pinning KUBECONFIG when known.
+
+    Without an explicit kubeconfig/cluster the behavior is unchanged (inherits
+    the ambient environment).
+    """
+
+    resolved = kubeconfig
+    if resolved is None and cluster:
+        from npa.cluster.state import kubeconfig_file
+
+        resolved = kubeconfig_file(cluster)
+    if resolved is None:
+        return None
+    resolved = resolved.expanduser()
+    if not resolved.exists():
+        _fail(
+            f"Kubeconfig not found: {resolved}. Run `npa cluster up`/`deploy` first "
+            "or pass an explicit --kubeconfig."
+        )
+    env = os.environ.copy()
+    env["KUBECONFIG"] = str(resolved)
+    return env
 
 
 def bootstrap_skypilot(
@@ -340,9 +385,13 @@ def _sky_importable(python_bin: Path) -> bool:
     return result.returncode == 0
 
 
-def _run_no_raise(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+def _run_no_raise(
+    cmd: list[str], *, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=False, env=env
+        )
     except FileNotFoundError as exc:
         return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
     except OSError as exc:

--- a/npa/src/npa/genesis/env_pick_place.py
+++ b/npa/src/npa/genesis/env_pick_place.py
@@ -19,6 +19,16 @@ from typing import Any
 import numpy as np
 import torch
 
+from npa.genesis.scene_assets import (
+    PRIMITIVE_BOX,
+    PRIMITIVE_CYLINDER,
+    PRIMITIVE_SPHERE,
+    ROLE_MANIPULAND,
+    ObjectSpec,
+    SceneSpec,
+    SceneSpecError,
+)
+
 
 @dataclass
 class EnvConfig:
@@ -48,6 +58,10 @@ class EnvConfig:
     # Target zone
     target_pos: tuple[float, float, float] = (0.5, 0.3, 0.04)
     target_threshold: float = 0.05
+    # BYO scene: when set, the manipulated object(s) are built from this parsed
+    # SceneSpec (mesh / primitive) instead of the hardcoded red Box. When None,
+    # the default Franka + red-Box scene is reproduced exactly.
+    scene_spec: SceneSpec | None = None
     # Domain randomization ranges
     cube_pos_noise: float = 0.1
     friction_range: tuple[float, float] = (0.3, 1.2)
@@ -69,6 +83,22 @@ class EnvConfig:
 
 # Franka Panda home joint configuration (ready pose)
 FRANKA_HOME = [0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785, 0.04, 0.04]
+
+
+def _euler_deg_to_quat_wxyz(
+    euler_deg: tuple[float, float, float],
+) -> tuple[float, float, float, float]:
+    """Convert extrinsic x-y-z Euler degrees to a (w, x, y, z) quaternion."""
+
+    rx, ry, rz = (np.deg2rad(float(a)) for a in euler_deg)
+    cx, sx = np.cos(rx / 2.0), np.sin(rx / 2.0)
+    cy, sy = np.cos(ry / 2.0), np.sin(ry / 2.0)
+    cz, sz = np.cos(rz / 2.0), np.sin(rz / 2.0)
+    w = cx * cy * cz + sx * sy * sz
+    x = sx * cy * cz - cx * sy * sz
+    y = cx * sy * cz + sx * cy * sz
+    z = cx * cy * sz - sx * sy * cz
+    return (float(w), float(x), float(y), float(z))
 
 
 class FrankaPickPlaceEnv:
@@ -107,6 +137,14 @@ class FrankaPickPlaceEnv:
         else:
             self._n_actions = 8  # delta joints (7) + gripper (1)
 
+        # When a BYO SceneSpec is supplied, derive the manipuland init pose,
+        # primitive cube size, and target zone from it so the existing reset /
+        # reward / success logic operates on the spec's manipulated object.
+        self._manip_quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+        self.scene_provenance: dict[str, Any] | None = None
+        if self.cfg.scene_spec is not None:
+            self._apply_scene_spec(self.cfg.scene_spec)
+
         self._step_count: torch.Tensor | None = None
         self._scene = None
         self._robot = None
@@ -129,8 +167,20 @@ class FrankaPickPlaceEnv:
                 3, device=self.device, dtype=torch.float32,
             ).unsqueeze(0)  # (1, 3, 3) — broadcasts over n_envs
 
+    def _apply_scene_spec(self, spec: SceneSpec) -> None:
+        """Derive cube/target config from a BYO SceneSpec before building."""
+
+        manip = spec.manipuland()
+        self.cfg.cube_init_pos = tuple(manip.pos)
+        self._manip_quat = _euler_deg_to_quat_wxyz(manip.euler)
+        if manip.asset_source == "primitive" and manip.primitive == PRIMITIVE_BOX:
+            # Keep the scalar cube_size contract in sync for the primitive path.
+            self.cfg.cube_size = float(manip.size[0])
+        self.cfg.target_pos = tuple(spec.goal_pos)
+        self.cfg.target_threshold = float(spec.goal_threshold)
+
     def _build_scene(self) -> None:
-        """Construct the Genesis scene with robot, cube, cameras."""
+        """Construct the Genesis scene with robot, manipulated object, cameras."""
         import genesis as gs
 
         if not gs._initialized:
@@ -166,14 +216,24 @@ class FrankaPickPlaceEnv:
             ),
         )
 
-        # Cube to pick and place
-        self._cube = self._scene.add_entity(
-            gs.morphs.Box(
-                size=(self.cfg.cube_size, self.cfg.cube_size, self.cfg.cube_size),
-                pos=self.cfg.cube_init_pos,
-            ),
-            surface=gs.surfaces.Rough(color=(1.0, 0.0, 0.0)),
-        )
+        if self.cfg.scene_spec is not None:
+            # BYO scene: build each object from the parsed SceneSpec. The
+            # manipuland entity replaces self._cube so all downstream reset /
+            # reward / contact / success logic operates on it unchanged.
+            self._cube = self._build_scene_objects(gs, self.cfg.scene_spec)
+        else:
+            # Default scene (unchanged): a 4cm red Box primitive.
+            self._cube = self._scene.add_entity(
+                gs.morphs.Box(
+                    size=(
+                        self.cfg.cube_size,
+                        self.cfg.cube_size,
+                        self.cfg.cube_size,
+                    ),
+                    pos=self.cfg.cube_init_pos,
+                ),
+                surface=gs.surfaces.Rough(color=(1.0, 0.0, 0.0)),
+            )
 
         # Cameras (only if needed — rendering slows simulation significantly)
         if self.cfg.enable_cameras:
@@ -220,6 +280,74 @@ class FrankaPickPlaceEnv:
             FRANKA_HOME, device=self.device, dtype=torch.float32,
         )
 
+    def _build_scene_objects(self, gs: Any, spec: SceneSpec) -> Any:
+        """Add every SceneSpec object; return the manipuland entity.
+
+        Records per-object provenance (loaded=true once add_entity succeeds)
+        and a scene-level asset_fallback_used flag. A requested mesh that fails
+        to load raises SceneSpecError — there is NO silent primitive fallback.
+        """
+
+        manipuland_entity = None
+        for obj in spec.objects:
+            entity = self._add_object_entity(gs, obj)
+            if obj.role == ROLE_MANIPULAND and manipuland_entity is None:
+                manipuland_entity = entity
+        if manipuland_entity is None:
+            raise SceneSpecError("SceneSpec produced no manipuland entity")
+        self.scene_provenance = spec.provenance_block()
+        return manipuland_entity
+
+    def _add_object_entity(self, gs: Any, obj: ObjectSpec) -> Any:
+        """Build one Genesis entity from an ObjectSpec, honoring source/pose."""
+
+        if obj.is_mesh():
+            if not obj.local_path:
+                raise SceneSpecError(
+                    f"object {obj.name!r} ({obj.asset_source}) has no resolved "
+                    "local_path; assets must be downloaded before building"
+                )
+            morph = gs.morphs.Mesh(
+                file=obj.local_path,
+                scale=obj.scale,
+                pos=tuple(obj.pos),
+                euler=tuple(obj.euler),
+                fixed=obj.fixed,
+            )
+        elif obj.primitive == PRIMITIVE_BOX:
+            morph = gs.morphs.Box(
+                size=tuple(obj.size),
+                pos=tuple(obj.pos),
+                euler=tuple(obj.euler),
+                fixed=obj.fixed,
+            )
+        elif obj.primitive == PRIMITIVE_SPHERE:
+            morph = gs.morphs.Sphere(
+                radius=obj.radius,
+                pos=tuple(obj.pos),
+                fixed=obj.fixed,
+            )
+        elif obj.primitive == PRIMITIVE_CYLINDER:
+            morph = gs.morphs.Cylinder(
+                radius=obj.radius,
+                height=obj.height,
+                pos=tuple(obj.pos),
+                euler=tuple(obj.euler),
+                fixed=obj.fixed,
+            )
+        else:  # pragma: no cover - parser restricts primitive values
+            raise SceneSpecError(f"unsupported primitive {obj.primitive!r}")
+
+        kwargs: dict[str, Any] = {"surface": gs.surfaces.Rough(color=tuple(obj.color))}
+        if obj.friction is not None:
+            try:
+                kwargs["material"] = gs.materials.Rigid(friction=float(obj.friction))
+            except Exception:  # noqa: BLE001 - material is best-effort physics
+                pass
+        entity = self._scene.add_entity(morph, **kwargs)
+        obj.loaded = True
+        return entity
+
     def reset(self, env_ids: torch.Tensor | None = None) -> dict[str, torch.Tensor]:
         """Reset environments and return initial observations.
 
@@ -255,7 +383,7 @@ class FrankaPickPlaceEnv:
             cube_pos += noise
 
         cube_quat = torch.tensor(
-            [1.0, 0.0, 0.0, 0.0], device=self.device, dtype=torch.float32,
+            list(self._manip_quat), device=self.device, dtype=torch.float32,
         ).unsqueeze(0).expand(n, -1)
         self._cube.set_pos(cube_pos, envs_idx=env_ids)
         self._cube.set_quat(cube_quat, envs_idx=env_ids)

--- a/npa/src/npa/genesis/scene_assets.py
+++ b/npa/src/npa/genesis/scene_assets.py
@@ -1,0 +1,468 @@
+"""SceneSpec schema, parser, asset download, and provenance for BYO sim assets.
+
+This module describes the manipulated object(s) of a Genesis pick-and-place
+scene independently of the simulator. It is deliberately free of ``torch`` /
+``genesis`` imports at module level so it can be unit-tested without a GPU.
+
+A SceneSpec is a JSON document (downloaded from ``scene_spec_uri`` or
+synthesized from ``assets_uri`` / ``byo_mesh_uri``) describing one or more
+objects. Each object has an ``asset_source``:
+
+- ``byo_mesh``: a customer mesh fetched from an S3/URI (.obj/.glb/.urdf/.ply…),
+  loaded with ``gs.morphs.Mesh(file=<local_path>)``.
+- ``genesis_builtin``: a mesh shipped inside the Genesis package
+  (a path relative to ``<genesis>/assets``), also loaded via ``gs.morphs.Mesh``.
+- ``primitive``: a box/sphere/cylinder built from primitive morphs. The current
+  default red ``gs.morphs.Box`` cube is the primitive fallback.
+
+Provenance: every object records ``{uri, local_path, sha256, asset_source,
+loaded}`` and the scene records a single ``asset_fallback_used`` flag, so a run
+can prove the requested mesh actually loaded and that nothing silently fell
+back to a primitive. If a requested mesh cannot be resolved, resolution and the
+build raise ``SceneSpecError`` rather than substituting a primitive.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCENE_SPEC_SCHEMA = "npa.sim2real.manip_scene_spec.v1"
+
+ASSET_SOURCE_BYO_MESH = "byo_mesh"
+ASSET_SOURCE_GENESIS_BUILTIN = "genesis_builtin"
+ASSET_SOURCE_PRIMITIVE = "primitive"
+ASSET_SOURCES = (
+    ASSET_SOURCE_BYO_MESH,
+    ASSET_SOURCE_GENESIS_BUILTIN,
+    ASSET_SOURCE_PRIMITIVE,
+)
+
+ROLE_MANIPULAND = "manipuland"
+ROLE_TARGET = "target"
+ROLE_STATIC = "static"
+ROLES = (ROLE_MANIPULAND, ROLE_TARGET, ROLE_STATIC)
+
+PRIMITIVE_BOX = "box"
+PRIMITIVE_SPHERE = "sphere"
+PRIMITIVE_CYLINDER = "cylinder"
+PRIMITIVES = (PRIMITIVE_BOX, PRIMITIVE_SPHERE, PRIMITIVE_CYLINDER)
+
+MESH_SUFFIXES = (".obj", ".glb", ".gltf", ".ply", ".stl", ".urdf", ".xml", ".dae")
+
+# The exact default object that today's hardcoded scene builds: a 4cm red cube.
+DEFAULT_CUBE_SIZE = 0.04
+DEFAULT_CUBE_POS = (0.5, 0.0, 0.04)
+DEFAULT_TARGET_POS = (0.5, 0.3, 0.04)
+DEFAULT_TARGET_THRESHOLD = 0.05
+DEFAULT_COLOR = (1.0, 0.0, 0.0)
+
+
+class SceneSpecError(RuntimeError):
+    """Raised when a SceneSpec is malformed or an asset cannot be resolved."""
+
+
+@dataclass
+class ObjectSpec:
+    """One physical object in the scene (manipuland, target, or static)."""
+
+    name: str
+    asset_source: str
+    role: str = ROLE_MANIPULAND
+    # Source references
+    uri: str = ""  # byo_mesh source (s3:// or local path)
+    builtin_path: str = ""  # genesis_builtin path relative to <genesis>/assets
+    primitive: str = PRIMITIVE_BOX
+    # Geometry
+    scale: float | tuple[float, float, float] = 1.0  # mesh scale
+    size: tuple[float, float, float] = (
+        DEFAULT_CUBE_SIZE,
+        DEFAULT_CUBE_SIZE,
+        DEFAULT_CUBE_SIZE,
+    )  # box
+    radius: float = 0.02  # sphere/cylinder
+    height: float = 0.04  # cylinder
+    # Pose
+    pos: tuple[float, float, float] = DEFAULT_CUBE_POS
+    euler: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    # Appearance / physics
+    color: tuple[float, float, float] = DEFAULT_COLOR
+    mass: float | None = None
+    friction: float | None = None
+    fixed: bool = False
+    # Resolved fields (populated by resolve_scene_assets)
+    local_path: str = ""
+    sha256: str = ""
+    loaded: bool = False
+
+    def is_mesh(self) -> bool:
+        return self.asset_source in (
+            ASSET_SOURCE_BYO_MESH,
+            ASSET_SOURCE_GENESIS_BUILTIN,
+        )
+
+    def provenance(self) -> dict[str, Any]:
+        """Per-object provenance record (mirrors #84's image_digests pattern)."""
+
+        return {
+            "name": self.name,
+            "role": self.role,
+            "asset_source": self.asset_source,
+            "uri": self.uri,
+            "builtin_path": self.builtin_path,
+            "local_path": self.local_path,
+            "sha256": self.sha256,
+            "loaded": bool(self.loaded),
+        }
+
+
+@dataclass
+class SceneSpec:
+    """A parsed, simulator-agnostic scene description for the pick-place env."""
+
+    objects: list[ObjectSpec] = field(default_factory=list)
+    schema: str = SCENE_SPEC_SCHEMA
+    goal_pos: tuple[float, float, float] = DEFAULT_TARGET_POS
+    goal_threshold: float = DEFAULT_TARGET_THRESHOLD
+    source_uri: str = ""
+    asset_fallback_used: bool = False
+
+    def manipuland(self) -> ObjectSpec:
+        for obj in self.objects:
+            if obj.role == ROLE_MANIPULAND:
+                return obj
+        if self.objects:
+            return self.objects[0]
+        raise SceneSpecError("SceneSpec has no objects")
+
+    def provenance_block(self) -> dict[str, Any]:
+        """Scene-level provenance written into report.json / consumed spec."""
+
+        objects = [obj.provenance() for obj in self.objects]
+        return {
+            "schema": "npa.sim2real.asset_provenance.v1",
+            "scene_spec_schema": self.schema,
+            "source_uri": self.source_uri,
+            "asset_fallback_used": bool(self.asset_fallback_used),
+            "goal_pos": list(self.goal_pos),
+            "goal_threshold": self.goal_threshold,
+            "objects": objects,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "goal_pos": list(self.goal_pos),
+            "goal_threshold": self.goal_threshold,
+            "source_uri": self.source_uri,
+            "objects": [_object_to_dict(obj) for obj in self.objects],
+        }
+
+
+def default_scene_spec() -> SceneSpec:
+    """Return the SceneSpec that reproduces today's red-Box primitive cube."""
+
+    return SceneSpec(
+        objects=[
+            ObjectSpec(
+                name="cube",
+                asset_source=ASSET_SOURCE_PRIMITIVE,
+                role=ROLE_MANIPULAND,
+                primitive=PRIMITIVE_BOX,
+                size=(DEFAULT_CUBE_SIZE, DEFAULT_CUBE_SIZE, DEFAULT_CUBE_SIZE),
+                pos=DEFAULT_CUBE_POS,
+                color=DEFAULT_COLOR,
+            )
+        ],
+        goal_pos=DEFAULT_TARGET_POS,
+        goal_threshold=DEFAULT_TARGET_THRESHOLD,
+    )
+
+
+def _coerce_triple(value: Any, name: str) -> tuple[float, float, float]:
+    if not isinstance(value, (list, tuple)) or len(value) != 3:
+        raise SceneSpecError(f"{name} must be a 3-element list, got {value!r}")
+    try:
+        return (float(value[0]), float(value[1]), float(value[2]))
+    except (TypeError, ValueError) as exc:
+        raise SceneSpecError(f"{name} must be numeric: {value!r}") from exc
+
+
+def _coerce_scale(value: Any) -> float | tuple[float, float, float]:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, (list, tuple)) and len(value) == 3:
+        return _coerce_triple(value, "scale")
+    raise SceneSpecError(f"scale must be a number or 3-element list, got {value!r}")
+
+
+def _object_from_dict(raw: dict[str, Any], index: int) -> ObjectSpec:
+    if not isinstance(raw, dict):
+        raise SceneSpecError(f"object[{index}] must be a JSON object, got {raw!r}")
+    asset_source = str(raw.get("asset_source") or "").strip()
+    if asset_source not in ASSET_SOURCES:
+        raise SceneSpecError(
+            f"object[{index}] asset_source must be one of {ASSET_SOURCES}, "
+            f"got {asset_source!r}"
+        )
+    role = str(raw.get("role") or ROLE_MANIPULAND).strip()
+    if role not in ROLES:
+        raise SceneSpecError(
+            f"object[{index}] role must be one of {ROLES}, got {role!r}"
+        )
+    name = str(raw.get("name") or f"object-{index:02d}").strip()
+    obj = ObjectSpec(name=name, asset_source=asset_source, role=role)
+
+    if asset_source == ASSET_SOURCE_BYO_MESH:
+        uri = str(raw.get("uri") or "").strip()
+        if not uri:
+            raise SceneSpecError(f"object[{index}] byo_mesh requires a non-empty uri")
+        obj.uri = uri
+    elif asset_source == ASSET_SOURCE_GENESIS_BUILTIN:
+        builtin = str(raw.get("builtin_path") or raw.get("file") or "").strip()
+        if not builtin:
+            raise SceneSpecError(
+                f"object[{index}] genesis_builtin requires builtin_path"
+            )
+        obj.builtin_path = builtin
+    else:  # primitive
+        primitive = str(raw.get("primitive") or PRIMITIVE_BOX).strip()
+        if primitive not in PRIMITIVES:
+            raise SceneSpecError(
+                f"object[{index}] primitive must be one of {PRIMITIVES}, "
+                f"got {primitive!r}"
+            )
+        obj.primitive = primitive
+
+    if "scale" in raw:
+        obj.scale = _coerce_scale(raw["scale"])
+    if "size" in raw:
+        obj.size = _coerce_triple(raw["size"], "size")
+    if "radius" in raw:
+        obj.radius = float(raw["radius"])
+    if "height" in raw:
+        obj.height = float(raw["height"])
+    if "pos" in raw:
+        obj.pos = _coerce_triple(raw["pos"], "pos")
+    if "euler" in raw:
+        obj.euler = _coerce_triple(raw["euler"], "euler")
+    if "color" in raw:
+        obj.color = _coerce_triple(raw["color"], "color")
+    if raw.get("mass") is not None:
+        obj.mass = float(raw["mass"])
+    if raw.get("friction") is not None:
+        obj.friction = float(raw["friction"])
+    obj.fixed = bool(raw.get("fixed", role == ROLE_STATIC))
+    return obj
+
+
+def _object_to_dict(obj: ObjectSpec) -> dict[str, Any]:
+    scale = list(obj.scale) if isinstance(obj.scale, tuple) else obj.scale
+    return {
+        "name": obj.name,
+        "asset_source": obj.asset_source,
+        "role": obj.role,
+        "uri": obj.uri,
+        "builtin_path": obj.builtin_path,
+        "primitive": obj.primitive,
+        "scale": scale,
+        "size": list(obj.size),
+        "radius": obj.radius,
+        "height": obj.height,
+        "pos": list(obj.pos),
+        "euler": list(obj.euler),
+        "color": list(obj.color),
+        "mass": obj.mass,
+        "friction": obj.friction,
+        "fixed": obj.fixed,
+    }
+
+
+def parse_scene_spec(doc: dict[str, Any], *, source_uri: str = "") -> SceneSpec:
+    """Parse and validate a SceneSpec JSON document into a SceneSpec."""
+
+    if not isinstance(doc, dict):
+        raise SceneSpecError(f"SceneSpec must be a JSON object, got {type(doc)!r}")
+    raw_objects = doc.get("objects")
+    if not isinstance(raw_objects, list) or not raw_objects:
+        raise SceneSpecError("SceneSpec must include a non-empty 'objects' list")
+    objects = [_object_from_dict(raw, index) for index, raw in enumerate(raw_objects)]
+    manipulands = [obj for obj in objects if obj.role == ROLE_MANIPULAND]
+    if not manipulands:
+        raise SceneSpecError("SceneSpec must include at least one manipuland object")
+    goal_pos = (
+        _coerce_triple(doc["goal_pos"], "goal_pos")
+        if doc.get("goal_pos") is not None
+        else DEFAULT_TARGET_POS
+    )
+    goal_threshold = float(doc.get("goal_threshold", DEFAULT_TARGET_THRESHOLD))
+    if goal_threshold <= 0:
+        raise SceneSpecError("goal_threshold must be positive")
+    return SceneSpec(
+        objects=objects,
+        schema=str(doc.get("schema") or SCENE_SPEC_SCHEMA),
+        goal_pos=goal_pos,
+        goal_threshold=goal_threshold,
+        source_uri=source_uri or str(doc.get("source_uri") or ""),
+    )
+
+
+def synthesize_scene_spec(
+    *,
+    assets_uri: str = "",
+    byo_mesh_uri: str = "",
+    scale: float | tuple[float, float, float] = 1.0,
+    pos: tuple[float, float, float] = DEFAULT_CUBE_POS,
+    goal_pos: tuple[float, float, float] = DEFAULT_TARGET_POS,
+    goal_threshold: float = DEFAULT_TARGET_THRESHOLD,
+) -> SceneSpec:
+    """Build a single-manipuland SceneSpec from a bare mesh URI.
+
+    Used when only ``assets_uri`` / ``byo_mesh_uri`` is provided (no full
+    SceneSpec JSON). Keeps the Franka robot and the documented target zone.
+    """
+
+    mesh_uri = (byo_mesh_uri or assets_uri or "").strip()
+    if not mesh_uri:
+        raise SceneSpecError(
+            "synthesize_scene_spec requires byo_mesh_uri or assets_uri"
+        )
+    return SceneSpec(
+        objects=[
+            ObjectSpec(
+                name="byo_object",
+                asset_source=ASSET_SOURCE_BYO_MESH,
+                role=ROLE_MANIPULAND,
+                uri=mesh_uri,
+                scale=scale,
+                pos=pos,
+                color=DEFAULT_COLOR,
+            )
+        ],
+        goal_pos=goal_pos,
+        goal_threshold=goal_threshold,
+        source_uri=mesh_uri,
+    )
+
+
+def sha256_file(path: str | Path) -> str:
+    """Return the hex SHA-256 of a file (streamed)."""
+
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_local_asset(path: Path, *, what: str) -> None:
+    if not path.is_file():
+        raise SceneSpecError(f"{what} did not produce a file at {path}")
+    if path.stat().st_size == 0:
+        raise SceneSpecError(f"{what} produced an empty file at {path}")
+
+
+def download_asset(
+    uri: str,
+    dest_dir: str | Path,
+    *,
+    client: Any = None,
+    endpoint_url: str = "",
+) -> Path:
+    """Fetch a mesh asset (s3:// or local path) to ``dest_dir``; validate it.
+
+    Returns the local path. Raises ``SceneSpecError`` if the asset is missing
+    or empty. The S3 client follows the repo's ``StorageClient`` patterns.
+    """
+
+    uri = str(uri or "").strip()
+    if not uri:
+        raise SceneSpecError("download_asset requires a non-empty uri")
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    filename = Path(uri.split("?", 1)[0].rstrip("/")).name or "asset.bin"
+    dest = dest_dir / filename
+
+    if uri.startswith("s3://"):
+        if client is None:
+            from npa.clients.storage import StorageClient
+
+            client = StorageClient.from_environment(endpoint_url=endpoint_url)
+        client.download_path(uri, str(dest))
+    elif uri.startswith("file://"):
+        src = Path(uri[len("file://") :])
+        _validate_local_asset(src, what=f"asset source {uri}")
+        dest.write_bytes(src.read_bytes())
+    else:
+        src = Path(uri)
+        _validate_local_asset(src, what=f"asset source {uri}")
+        if src.resolve() != dest.resolve():
+            dest.write_bytes(src.read_bytes())
+
+    _validate_local_asset(dest, what=f"download of {uri}")
+    return dest
+
+
+def resolve_genesis_builtin_path(builtin_path: str) -> Path:
+    """Resolve a builtin asset path relative to the installed Genesis package.
+
+    Imported lazily so this module stays importable without genesis-world.
+    """
+
+    builtin_path = str(builtin_path or "").strip().lstrip("/")
+    if not builtin_path:
+        raise SceneSpecError("genesis_builtin requires a builtin_path")
+    import genesis as gs  # noqa: PLC0415 - lazy, GPU image only
+
+    assets_root = Path(gs.__file__).resolve().parent / "assets"
+    candidate = assets_root / builtin_path
+    if not candidate.is_file():
+        raise SceneSpecError(
+            f"genesis_builtin asset not found under {assets_root}: {builtin_path}"
+        )
+    return candidate
+
+
+def resolve_scene_assets(
+    spec: SceneSpec,
+    *,
+    dest_dir: str | Path,
+    client: Any = None,
+    endpoint_url: str = "",
+    downloader: Any = None,
+    builtin_resolver: Any = None,
+) -> SceneSpec:
+    """Download/resolve every object's asset, computing local_path + sha256.
+
+    Mutates ``spec`` objects in place (sets ``local_path`` / ``sha256``) and
+    returns it. Mesh assets that fail to resolve raise ``SceneSpecError`` —
+    there is no silent primitive fallback.
+    """
+
+    downloader = downloader or download_asset
+    builtin_resolver = builtin_resolver or resolve_genesis_builtin_path
+    dest_dir = Path(dest_dir)
+    for obj in spec.objects:
+        if obj.asset_source == ASSET_SOURCE_BYO_MESH:
+            local = downloader(
+                obj.uri,
+                dest_dir / _safe_name(obj.name),
+                client=client,
+                endpoint_url=endpoint_url,
+            )
+            obj.local_path = str(local)
+            obj.sha256 = sha256_file(local)
+        elif obj.asset_source == ASSET_SOURCE_GENESIS_BUILTIN:
+            local = builtin_resolver(obj.builtin_path)
+            _validate_local_asset(Path(local), what=f"genesis_builtin {obj.builtin_path}")
+            obj.local_path = str(local)
+            obj.sha256 = sha256_file(local)
+        # primitives: nothing to download; local_path/sha256 stay empty.
+    return spec
+
+
+def _safe_name(value: str) -> str:
+    chars = [c if c.isalnum() or c in ("-", "_", ".") else "-" for c in str(value)]
+    return "".join(chars) or "object"

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -574,31 +574,47 @@ def run_full_loop(
         )
     )
 
-    stage_records.append(
-        _write_stage(
-            local_dir,
-            2,
-            "assets",
-            {
-                "schema": "npa.sim2real.external_stub.v1",
-                "stage": 2,
-                "name": "external real assets and SceneSpec",
-                "status": "documented_external_stub",
-                "assets_uri": config.assets_uri,
-                "scene_spec_uri": config.scene_spec_uri,
-                "next_action": "CONTINUE",
-            },
-            filename="external_stub.json",
+    if config.scene_spec_uri or config.assets_uri:
+        consumed = _consume_stage_assets(config, local_dir)
+        stage_records.append(consumed["stage_record"])
+        components.append(
+            ComponentRecord(
+                "stage_02_assets",
+                "WORKS",
+                (
+                    "Downloaded and validated the BYO mesh/SceneSpec and emitted a "
+                    "consumed scene spec with per-object provenance for the "
+                    "held-out Genesis rollout."
+                ),
+                {"local": consumed["consumed_spec_path"]},
+            )
         )
-    )
-    components.append(
-        ComponentRecord(
-            "stage_02_assets",
-            "SEAM",
-            "External assets and SceneSpec are documented BYO inputs for this reference run.",
-            {"local": str(local_dir / "stage_02_assets" / "external_stub.json")},
+    else:
+        stage_records.append(
+            _write_stage(
+                local_dir,
+                2,
+                "assets",
+                {
+                    "schema": "npa.sim2real.external_stub.v1",
+                    "stage": 2,
+                    "name": "external real assets and SceneSpec",
+                    "status": "documented_external_stub",
+                    "assets_uri": config.assets_uri,
+                    "scene_spec_uri": config.scene_spec_uri,
+                    "next_action": "CONTINUE",
+                },
+                filename="external_stub.json",
+            )
         )
-    )
+        components.append(
+            ComponentRecord(
+                "stage_02_assets",
+                "SEAM",
+                "External assets and SceneSpec are documented BYO inputs for this reference run.",
+                {"local": str(local_dir / "stage_02_assets" / "external_stub.json")},
+            )
+        )
 
     stage_records.append(
         _write_json_artifact(
@@ -1410,7 +1426,9 @@ def _component_job_script(component: str) -> str:
             "--inner-evidence-uri \"${NPA_SIM2REAL_INNER_EVIDENCE_URI}\" "
             "--output-uri \"${NPA_SIM2REAL_OUTPUT_URI}\" "
             "--threshold \"${NPA_SIM2REAL_THRESHOLD}\" "
-            "--limit \"${NPA_SIM2REAL_HELDOUT_EVAL_LIMIT:-0}\""
+            "--limit \"${NPA_SIM2REAL_HELDOUT_EVAL_LIMIT:-0}\" "
+            "--scene-spec-uri \"${NPA_SIM2REAL_SCENE_SPEC_URI:-}\" "
+            "--assets-uri \"${NPA_SIM2REAL_ASSETS_URI:-}\""
         )
     else:
         raise Sim2RealLoopError(f"unsupported image component: {component}")
@@ -1833,6 +1851,8 @@ def run_heldout_eval(
             "NPA_SIM2REAL_INNER_EVIDENCE_JSON": str(inner_path),
             "NPA_SIM2REAL_THRESHOLD": str(config.threshold),
             "NPA_SIM2REAL_EVAL_IMAGE": config.eval_image,
+            "NPA_SIM2REAL_SCENE_SPEC_URI": config.scene_spec_uri,
+            "NPA_SIM2REAL_ASSETS_URI": config.assets_uri,
         },
     )
     if config.byo_eval_command.strip():
@@ -1926,7 +1946,7 @@ def _normalize_heldout_report(
             }
         )
     success_rate = passed / float(len(per_env))
-    return {
+    report = {
         "schema": SCHEMA_HELDOUT_REPORT,
         "stage": 10,
         "outer_iteration": outer_iteration,
@@ -1940,6 +1960,15 @@ def _normalize_heldout_report(
         "component_invocation": _public_invocation(invocation),
         "generated_at": _utc_now(),
     }
+    if "asset_provenance" in payload:
+        report["asset_provenance"] = payload["asset_provenance"]
+        report["asset_fallback_used"] = bool(
+            payload.get(
+                "asset_fallback_used",
+                payload["asset_provenance"].get("asset_fallback_used", False),
+            )
+        )
+    return report
 
 
 def threshold_decision(
@@ -2061,8 +2090,17 @@ def run_heldout_eval_component_from_s3(
     output_uri: str,
     threshold: float = DEFAULT_THRESHOLD,
     limit: int = 0,
+    scene_spec_uri: str = "",
+    assets_uri: str = "",
+    byo_mesh_uri: str = "",
 ) -> dict[str, Any]:
-    """Run the image-local held-out eval contract against env records in S3."""
+    """Run the image-local held-out eval contract against env records in S3.
+
+    When ``scene_spec_uri`` (a SceneSpec JSON) or ``assets_uri`` /
+    ``byo_mesh_uri`` (a bare mesh URI) is provided, the scene's manipulated
+    object(s) are downloaded, validated, and loaded into the Genesis sim, and
+    per-object asset provenance is recorded into the report.
+    """
 
     with tempfile.TemporaryDirectory(prefix="sim2real-heldout-component-") as tmp:
         root = Path(tmp)
@@ -2078,24 +2116,138 @@ def run_heldout_eval_component_from_s3(
             envs = envs[:limit]
         if not envs:
             raise Sim2RealLoopError("held-out component found no env records")
+        scene = _resolve_heldout_scene(
+            scene_spec_uri=scene_spec_uri,
+            assets_uri=assets_uri,
+            byo_mesh_uri=byo_mesh_uri,
+            dest_dir=root / "assets",
+            client=client,
+        )
         payload = _component_heldout_payload(
             envs,
             inner_evidence=inner_evidence,
             threshold=threshold,
+            scene=scene,
         )
         _write_json_artifact(output_path, payload)
         client.upload_file(str(output_path), output_uri)
+        if scene is not None:
+            spec_path = root / "consumed-scene-spec.json"
+            _write_json_artifact(spec_path, scene.provenance_block())
+            client.upload_file(
+                str(spec_path),
+                _sibling_uri(output_uri, "consumed-scene-spec.json"),
+            )
         print(
             json.dumps(
                 {
                     "component": "heldout_eval",
                     "env_count": len(payload["per_env"]),
                     "output_uri": output_uri,
+                    "asset_fallback_used": payload.get("asset_fallback_used"),
                 },
                 sort_keys=True,
             )
         )
         return payload
+
+
+def _resolve_heldout_scene(
+    *,
+    scene_spec_uri: str,
+    assets_uri: str,
+    byo_mesh_uri: str,
+    dest_dir: Path,
+    client: Any,
+) -> Any:
+    """Download/synthesize and resolve a SceneSpec for the held-out rollout.
+
+    Returns a resolved ``SceneSpec`` (with local asset paths + sha256) or
+    ``None`` when no BYO scene/asset URIs are provided (documented-stub path).
+    """
+
+    from npa.genesis import scene_assets
+
+    scene_spec_uri = (scene_spec_uri or "").strip()
+    mesh_uri = (byo_mesh_uri or assets_uri or "").strip()
+    if not scene_spec_uri and not mesh_uri:
+        return None
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    if scene_spec_uri:
+        spec_local = dest_dir / "scene-spec.json"
+        client.download_path(scene_spec_uri, str(spec_local))
+        doc = json.loads(spec_local.read_text(encoding="utf-8"))
+        scene = scene_assets.parse_scene_spec(doc, source_uri=scene_spec_uri)
+    else:
+        scene = scene_assets.synthesize_scene_spec(byo_mesh_uri=mesh_uri)
+    scene_assets.resolve_scene_assets(scene, dest_dir=dest_dir, client=client)
+    return scene
+
+
+def _sibling_uri(uri: str, filename: str) -> str:
+    base = uri.rsplit("/", 1)[0] if "/" in uri else uri
+    return f"{base.rstrip('/')}/{filename}"
+
+
+def _consume_stage_assets(
+    config: Sim2RealLoopConfig, local_dir: Path
+) -> dict[str, Any]:
+    """Stage 2: download + validate BYO mesh/SceneSpec and write a consumed spec.
+
+    Unlike the documented stub, this actually fetches the asset(s) referenced by
+    ``scene_spec_uri`` / ``assets_uri`` and records per-object provenance
+    (sha256, asset_source, downloaded). byo_mesh objects are downloaded and
+    validated here; genesis_builtin objects are resolved at rollout time inside
+    the GPU image. A failed download raises (no silent fallback).
+    """
+
+    from npa.genesis import scene_assets
+
+    stage_dir = local_dir / "stage_02_assets"
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    client = _storage_client(config)
+    scene_spec_uri = (config.scene_spec_uri or "").strip()
+    mesh_uri = (config.assets_uri or "").strip()
+    if scene_spec_uri:
+        spec_local = stage_dir / "scene-spec.json"
+        client.download_path(scene_spec_uri, str(spec_local))
+        doc = json.loads(spec_local.read_text(encoding="utf-8"))
+        scene = scene_assets.parse_scene_spec(doc, source_uri=scene_spec_uri)
+    else:
+        scene = scene_assets.synthesize_scene_spec(byo_mesh_uri=mesh_uri)
+
+    assets_dir = stage_dir / "assets"
+    for obj in scene.objects:
+        if obj.asset_source == scene_assets.ASSET_SOURCE_BYO_MESH:
+            local = scene_assets.download_asset(
+                obj.uri,
+                assets_dir / obj.name,
+                client=client,
+                endpoint_url=config.s3_endpoint,
+            )
+            obj.local_path = str(local)
+            obj.sha256 = scene_assets.sha256_file(local)
+
+    consumed = {
+        "schema": "npa.sim2real.consumed_scene_spec.v1",
+        "stage": 2,
+        "name": "external real assets and SceneSpec",
+        "status": "consumed",
+        "assets_uri": config.assets_uri,
+        "scene_spec_uri": config.scene_spec_uri,
+        "scene_spec": scene.to_dict(),
+        "asset_provenance": scene.provenance_block(),
+        "next_action": "CONTINUE",
+    }
+    stage_record = _write_stage(
+        local_dir, 2, "assets", consumed, filename="consumed_scene_spec.json"
+    )
+    return {
+        "stage_record": stage_record,
+        "consumed_spec_path": str(stage_dir / "consumed_scene_spec.json"),
+        "scene": scene,
+    }
 
 
 def _component_vlm_payload(
@@ -2135,19 +2287,32 @@ def _component_heldout_payload(
     *,
     inner_evidence: dict[str, Any],
     threshold: float,
+    scene: Any = None,
 ) -> dict[str, Any]:
     per_env = _run_genesis_heldout_rollouts(
         envs,
         inner_evidence=inner_evidence,
         threshold=threshold,
+        scene=scene,
     )
-    return {
+    payload = {
         "schema": SCHEMA_HELDOUT_REPORT,
         "per_env": per_env,
         "component_source": "genesis_rollout",
         "rollout_backend": "npa.genesis.env_pick_place.FrankaPickPlaceEnv",
         "policy_source": "inner_evidence_adapter",
     }
+    if scene is not None:
+        provenance = scene.provenance_block()
+        manipuland = scene.manipuland()
+        if manipuland.is_mesh() and not manipuland.loaded:
+            raise Sim2RealLoopError(
+                "BYO scene manipuland mesh was not loaded into the simulator "
+                "(no silent fallback is permitted)"
+            )
+        payload["asset_provenance"] = provenance
+        payload["asset_fallback_used"] = provenance["asset_fallback_used"]
+    return payload
 
 
 def _rollout_image_paths(rollout_root: Path, observations: list[Any]) -> list[Path]:
@@ -2467,8 +2632,16 @@ def _run_genesis_heldout_rollouts(
     *,
     inner_evidence: dict[str, Any],
     threshold: float,
+    scene: Any = None,
 ) -> list[dict[str, Any]]:
-    """Run the trained adapter policy through real Genesis held-out episodes."""
+    """Run the trained adapter policy through real Genesis held-out episodes.
+
+    When ``scene`` (a parsed ``npa.genesis.scene_assets.SceneSpec`` with
+    resolved local asset paths) is provided, the manipulated object(s) are
+    built from it (mesh / primitive) instead of the default red Box. The
+    SceneSpec objects' ``loaded`` provenance flags are set as a side effect of
+    building the env, so the caller can prove the requested mesh loaded.
+    """
 
     try:
         import torch
@@ -2479,6 +2652,23 @@ def _run_genesis_heldout_rollouts(
         ) from exc
     if not torch.cuda.is_available():
         raise Sim2RealLoopError("Genesis rollout eval requires a CUDA GPU")
+
+    if scene is not None:
+        manip = scene.manipuland()
+        print(
+            json.dumps(
+                {
+                    "component": "heldout_eval",
+                    "event": "byo_scene_loading",
+                    "asset_source": manip.asset_source,
+                    "manipuland": manip.name,
+                    "local_path": manip.local_path,
+                    "sha256": manip.sha256,
+                    "object_count": len(scene.objects),
+                },
+                sort_keys=True,
+            )
+        )
 
     adapter = _policy_adapter_from_inner_evidence(inner_evidence)
     batch_size = max(1, int(os.environ.get("NPA_SIM2REAL_GENESIS_BATCH_SIZE", "16")))
@@ -2495,8 +2685,23 @@ def _run_genesis_heldout_rollouts(
             max_episode_steps=max_steps,
             action_space="cartesian",
             action_scale=float(os.environ.get("NPA_SIM2REAL_GENESIS_ACTION_SCALE", "0.045")),
+            scene_spec=scene,
         )
         env = FrankaPickPlaceEnv(cfg)
+        if scene is not None and start == 0:
+            print(
+                json.dumps(
+                    {
+                        "component": "heldout_eval",
+                        "event": "byo_scene_loaded",
+                        "asset_fallback_used": scene.asset_fallback_used,
+                        "loaded_objects": [
+                            obj.name for obj in scene.objects if obj.loaded
+                        ],
+                    },
+                    sort_keys=True,
+                )
+            )
         obs = env.reset()
         active = torch.ones(len(batch), device="cuda", dtype=torch.bool)
         success = torch.zeros(len(batch), device="cuda", dtype=torch.bool)
@@ -2673,6 +2878,9 @@ def main(argv: list[str] | None = None) -> int:
     component_heldout.add_argument("--output-uri", required=True)
     component_heldout.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
     component_heldout.add_argument("--limit", type=int, default=0)
+    component_heldout.add_argument("--scene-spec-uri", default="")
+    component_heldout.add_argument("--assets-uri", default="")
+    component_heldout.add_argument("--byo-mesh-uri", default="")
     args = parser.parse_args(argv)
 
     if args.command == "convert-signal":
@@ -2695,6 +2903,9 @@ def main(argv: list[str] | None = None) -> int:
             output_uri=args.output_uri,
             threshold=args.threshold,
             limit=args.limit,
+            scene_spec_uri=args.scene_spec_uri,
+            assets_uri=args.assets_uri,
+            byo_mesh_uri=args.byo_mesh_uri,
         )
         return 0
 

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -848,6 +848,7 @@ def run_inner_loop(
     iteration_records: list[dict[str, Any]] = []
     reward_trend: list[float] = []
     policy_deltas: list[float] = []
+    all_signals: list[dict[str, Any]] = []
     quality = float(initial_quality)
     reward_head = 0.0
     action_bias = 0.0
@@ -892,6 +893,7 @@ def run_inner_loop(
             _write_json_artifact(signal_dir / f"{signal['rollout_id']}.json", signal)
             evals.append(evaluation)
             signals.append(signal)
+            all_signals.append(signal)
         signal_batch_path = (
             local_dir
             / "inner_loop"
@@ -959,11 +961,25 @@ def run_inner_loop(
             }
         )
 
+    signal_diversity = _signal_diversity_report(all_signals)
+    if signal_diversity["degenerate"] and _bool_value(
+        os.environ.get("NPA_SIM2REAL_REQUIRE_SIGNAL_DIVERSITY", "0")
+    ):
+        raise Sim2RealLoopError(
+            "VLM->RL signal is degenerate: "
+            f"{signal_diversity['distinct_scores']} distinct score(s) and "
+            f"{signal_diversity['distinct_mean_rewards']} distinct mean-reward(s) "
+            f"across {signal_diversity['total_rollouts']} rollout(s) "
+            f"(scores={signal_diversity['score_values']}). "
+            "Unset NPA_SIM2REAL_REQUIRE_SIGNAL_DIVERSITY to downgrade this gate to a "
+            "diagnostic."
+        )
     evidence = {
         "schema": "npa.sim2real.inner_loop_evidence.v1",
         "outer_iteration": outer_iteration,
         "status": "closed",
         "reward_trend": reward_trend,
+        "signal_diversity": signal_diversity,
         "policy_delta_vs_no_signal_control": policy_deltas,
         "attribution": (
             "The reference update and no-signal control share initial adapter state. "
@@ -1267,6 +1283,7 @@ def _run_kubernetes_image_component(
         "mode": "kubernetes_job",
         "component": component,
         "image": image,
+        "image_digests": pod_info.get("image_digests", []),
         "namespace": namespace,
         "job_name": job_name,
         "pod": pod_info,
@@ -1313,7 +1330,7 @@ def _component_job_manifest(
             {
                 "name": "component",
                 "image": image,
-                "imagePullPolicy": "IfNotPresent",
+                "imagePullPolicy": _image_pull_policy(image),
                 "command": ["bash", "-lc"],
                 "args": [_component_job_script(component)],
                 "env": [
@@ -1485,20 +1502,27 @@ def _component_pod_info(
     container = (pod.get("spec", {}).get("containers") or [{}])[0]
     resources = container.get("resources", {})
     statuses = pod.get("status", {}).get("containerStatuses") or []
+    container_statuses = [
+        {
+            "name": item.get("name", ""),
+            "ready": item.get("ready", False),
+            "restart_count": item.get("restartCount", 0),
+            "image": item.get("image", ""),
+            "image_id": item.get("imageID", ""),
+            "state": item.get("state", {}),
+        }
+        for item in statuses
+    ]
+    image_digests = [
+        status["image_id"] for status in container_statuses if status["image_id"]
+    ]
     return {
         "name": pod.get("metadata", {}).get("name", ""),
         "node_name": pod.get("spec", {}).get("nodeName", ""),
         "phase": pod.get("status", {}).get("phase", ""),
         "resources": resources,
-        "container_statuses": [
-            {
-                "name": item.get("name", ""),
-                "ready": item.get("ready", False),
-                "restart_count": item.get("restartCount", 0),
-                "state": item.get("state", {}),
-            }
-            for item in statuses
-        ],
+        "container_statuses": container_statuses,
+        "image_digests": image_digests,
     }
 
 
@@ -2328,11 +2352,16 @@ def _parse_cosmos_reason_output(
             or model_text
         ).strip()
         tags = payload.get("error_tags") or _tags_from_text(critique)
+        # The model returned no per-step breakdown, so the single summary critique
+        # is broadcast across every action step. Mark it as such so a degenerate
+        # (all-identical) per-step signal is visible rather than masquerading as
+        # genuine per-step granularity.
         raw_steps = [
             {
                 "step": int(action.get("step", index)),
                 "critique_text": critique,
                 "error_tags": tags,
+                "critique_source": "summary_broadcast",
                 "camera_observation": f"camera-{int(action.get('step', index)):03d}.ppm",
             }
             for index, action in enumerate(actions)
@@ -2512,7 +2541,9 @@ def _run_genesis_heldout_rollouts(
             env_success = bool(success[index].detach().item())
             distance_score = max(0.0, min(1.0, 1.0 - dist / 0.5))
             reward_score = max(0.0, min(1.0, reward_value / 10.0))
-            score = 1.0 if env_success else round(0.7 * distance_score + 0.3 * reward_score, 6)
+            score = _heldout_env_score(
+                distance_score, reward_score, env_success=env_success
+            )
             per_env.append(
                 {
                     "env_id": str(env_record.get("env_id") or f"heldout-{start + index:04d}"),
@@ -2997,6 +3028,68 @@ def _merge_targets(tags: list[str]) -> dict[str, Any]:
 def _signal_mean_reward(signal: dict[str, Any]) -> float:
     steps = signal.get("per_step") or []
     return sum(float(step["reward"]) for step in steps) / float(len(steps))
+
+
+def _heldout_env_score(
+    distance_score: float, reward_score: float, *, env_success: bool
+) -> float:
+    """Map per-env distance/reward to a continuous held-out score.
+
+    Successful and failed envs occupy separate bands, but the score stays
+    continuous in the env's own distance/reward so the held-out report keeps a
+    gradient instead of collapsing to a flat ``1.0`` across every env (which
+    produced an uninformative, incoherent signal).
+    """
+
+    quality = max(0.0, min(1.0, 0.7 * distance_score + 0.3 * reward_score))
+    if env_success:
+        return round(0.75 + 0.25 * quality, 6)
+    return round(0.6 * quality, 6)
+
+
+def _signal_diversity_report(signals: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize cross-rollout diversity of the VLM->RL signal.
+
+    A genuine signal varies across rollouts; a single distinct score/reward
+    across every rollout is the degenerate ("hollow") pattern. These metrics
+    (``distinct_scores``, ``coherent``) are emitted into loop evidence so a run
+    is self-describing instead of requiring an external validator to infer them.
+    """
+
+    scores = [round(float(signal.get("score") or 0.0), 4) for signal in signals]
+    mean_rewards = [round(_signal_mean_reward(signal), 4) for signal in signals]
+    distinct_scores = sorted({score for score in scores})
+    distinct_rewards = sorted({reward for reward in mean_rewards})
+    total = len(signals)
+    coherent = total > 1 and len(distinct_scores) > 1 and len(distinct_rewards) > 1
+    return {
+        "total_rollouts": total,
+        "distinct_scores": len(distinct_scores),
+        "distinct_mean_rewards": len(distinct_rewards),
+        "score_values": distinct_scores,
+        "mean_reward_values": distinct_rewards,
+        "coherent": coherent,
+        "degenerate": not coherent,
+    }
+
+
+def _image_pull_policy(image: str) -> str:
+    """Choose the imagePullPolicy for a sibling component image.
+
+    Provenance-sensitive ``-genuine-`` builds are pulled fresh so a stale image
+    cached under the same tag cannot silently masquerade as the genuine build.
+    A digest-pinned reference (``@sha256:``) is already immutable.
+    """
+
+    override = os.environ.get("NPA_SIM2REAL_IMAGE_PULL_POLICY", "").strip()
+    if override:
+        return override
+    if "@sha256:" in image:
+        return "IfNotPresent"
+    tag = image.rsplit(":", 1)[-1] if ":" in image.rsplit("/", 1)[-1] else ""
+    if "genuine" in tag:
+        return "Always"
+    return "IfNotPresent"
 
 
 def _write_ppm(path: Path, *, red: int, green: int, blue: int) -> None:

--- a/npa/tests/cli/test_skypilot_bootstrap.py
+++ b/npa/tests/cli/test_skypilot_bootstrap.py
@@ -161,3 +161,80 @@ def test_skypilot_bootstrap_can_install_local_tiny_package(tmp_path: Path) -> No
     assert result.reused is False
     assert result.sky_bin.is_file()
     assert '"extras": [\n    "test"\n  ]' in result.marker_path.read_text(encoding="utf-8")
+
+
+def _intercept_sky_check(monkeypatch: pytest.MonkeyPatch, captured: dict[str, object]):
+    """Capture only the `sky check` invocation; delegate other calls.
+
+    ``_run_no_raise`` is also used by ``inspect_venv`` for version/import probes,
+    so a blanket stub would make the venv look uninstalled.
+    """
+
+    original = skypilot_cli._run_no_raise
+
+    def fake_run(cmd, *, env=None):  # noqa: ANN001 - test stub
+        if cmd[-1] == "check":
+            captured["cmd"] = cmd
+            captured["env"] = env
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="checks passed", stderr=""
+            )
+        return original(cmd, env=env)
+
+    monkeypatch.setattr(skypilot_cli, "_run_no_raise", fake_run)
+
+
+def test_verify_pins_kubeconfig_from_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    kubeconfig = tmp_path / "kube.yaml"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+    _intercept_sky_check(monkeypatch, captured)
+
+    result = runner.invoke(
+        app,
+        ["skypilot", "verify", "--path", str(venv), "--kubeconfig", str(kubeconfig)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["cmd"][-1] == "check"
+    assert captured["env"]["KUBECONFIG"] == str(kubeconfig)
+
+
+def test_verify_without_kubeconfig_inherits_ambient_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    captured: dict[str, object] = {}
+    _intercept_sky_check(monkeypatch, captured)
+
+    result = runner.invoke(app, ["skypilot", "verify", "--path", str(venv)])
+
+    assert result.exit_code == 0, result.output
+    assert captured["env"] is None
+
+
+def test_verify_fails_clearly_on_missing_kubeconfig(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    missing = tmp_path / "absent" / "kube.yaml"
+
+    original = skypilot_cli._run_no_raise
+
+    def fake_run(cmd, *, env=None):  # noqa: ANN001 - test stub
+        if cmd[-1] == "check":
+            raise AssertionError("sky check must not run when kubeconfig is missing")
+        return original(cmd, env=env)
+
+    monkeypatch.setattr(skypilot_cli, "_run_no_raise", fake_run)
+
+    result = runner.invoke(
+        app,
+        ["skypilot", "verify", "--path", str(venv), "--kubeconfig", str(missing)],
+    )
+
+    assert result.exit_code == 1
+    assert "Kubeconfig not found" in result.output

--- a/npa/tests/test_scene_assets.py
+++ b/npa/tests/test_scene_assets.py
@@ -1,0 +1,405 @@
+"""Unit tests for BYO SceneSpec parsing, asset download, and env build dispatch.
+
+These tests never import torch or genesis at module level. The env build
+dispatch is exercised against a fake ``gs`` module and a fake torch installed
+into ``sys.modules`` (mirroring tests/test_genesis.py).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from npa.genesis import scene_assets as sa
+
+
+# --------------------------------------------------------------------------- #
+# SceneSpec parse / validate
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_scene_spec_byo_mesh_object() -> None:
+    doc = {
+        "schema": sa.SCENE_SPEC_SCHEMA,
+        "goal_pos": [0.5, 0.3, 0.04],
+        "goal_threshold": 0.05,
+        "objects": [
+            {
+                "name": "widget",
+                "asset_source": "byo_mesh",
+                "role": "manipuland",
+                "uri": "s3://bucket/sim2real-assets/run/object.obj",
+                "scale": 1.5,
+                "pos": [0.5, 0.0, 0.05],
+                "color": [0.1, 0.8, 0.2],
+                "mass": 0.3,
+                "friction": 0.9,
+            }
+        ],
+    }
+    spec = sa.parse_scene_spec(doc, source_uri="s3://bucket/spec.json")
+
+    assert len(spec.objects) == 1
+    obj = spec.manipuland()
+    assert obj.asset_source == sa.ASSET_SOURCE_BYO_MESH
+    assert obj.uri.endswith("object.obj")
+    assert obj.scale == 1.5
+    assert obj.pos == (0.5, 0.0, 0.05)
+    assert obj.mass == 0.3
+    assert obj.friction == 0.9
+    assert spec.goal_pos == (0.5, 0.3, 0.04)
+    assert spec.source_uri == "s3://bucket/spec.json"
+
+
+def test_parse_scene_spec_supports_multiple_objects_and_target() -> None:
+    doc = {
+        "objects": [
+            {"name": "cube", "asset_source": "primitive", "primitive": "box"},
+            {
+                "name": "table",
+                "asset_source": "genesis_builtin",
+                "role": "static",
+                "builtin_path": "meshes/table.obj",
+            },
+        ],
+        "goal_pos": [0.4, 0.2, 0.04],
+    }
+    spec = sa.parse_scene_spec(doc)
+
+    assert [o.name for o in spec.objects] == ["cube", "table"]
+    table = spec.objects[1]
+    assert table.asset_source == sa.ASSET_SOURCE_GENESIS_BUILTIN
+    assert table.role == sa.ROLE_STATIC
+    assert table.fixed is True  # static defaults to fixed
+    assert spec.manipuland().name == "cube"
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        {},  # no objects
+        {"objects": []},  # empty objects
+        {"objects": [{"name": "x", "asset_source": "bogus"}]},  # bad source
+        {"objects": [{"name": "x", "asset_source": "byo_mesh"}]},  # missing uri
+        {"objects": [{"name": "x", "asset_source": "genesis_builtin"}]},  # missing path
+        {"objects": [{"name": "x", "asset_source": "primitive", "primitive": "cone"}]},
+        {
+            "objects": [
+                {"name": "t", "asset_source": "primitive", "role": "target"}
+            ]
+        },  # no manipuland
+        {
+            "objects": [{"name": "x", "asset_source": "primitive"}],
+            "goal_pos": [0.1, 0.2],
+        },  # bad goal_pos
+    ],
+)
+def test_parse_scene_spec_rejects_malformed(doc: dict) -> None:
+    with pytest.raises(sa.SceneSpecError):
+        sa.parse_scene_spec(doc)
+
+
+def test_synthesize_scene_spec_from_mesh_uri() -> None:
+    spec = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    obj = spec.manipuland()
+    assert obj.asset_source == sa.ASSET_SOURCE_BYO_MESH
+    assert obj.uri == "s3://bucket/run/object.obj"
+    assert spec.source_uri == "s3://bucket/run/object.obj"
+
+
+def test_synthesize_scene_spec_requires_uri() -> None:
+    with pytest.raises(sa.SceneSpecError):
+        sa.synthesize_scene_spec()
+
+
+def test_default_scene_spec_matches_red_box_primitive() -> None:
+    spec = sa.default_scene_spec()
+    obj = spec.manipuland()
+    assert obj.asset_source == sa.ASSET_SOURCE_PRIMITIVE
+    assert obj.primitive == sa.PRIMITIVE_BOX
+    assert obj.size == (0.04, 0.04, 0.04)
+    assert obj.pos == (0.5, 0.0, 0.04)
+    assert obj.color == (1.0, 0.0, 0.0)
+    assert spec.goal_pos == (0.5, 0.3, 0.04)
+
+
+# --------------------------------------------------------------------------- #
+# Asset download + resolve + provenance
+# --------------------------------------------------------------------------- #
+
+
+class _FakeStorageClient:
+    """Records download_path calls and writes a fake mesh file."""
+
+    def __init__(self, *, payload: bytes = b"OBJ-DATA") -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.payload = payload
+
+    def download_path(self, uri: str, local_path: str) -> str:
+        self.calls.append((uri, local_path))
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(local_path).write_bytes(self.payload)
+        return local_path
+
+
+def test_download_asset_s3_uses_client_and_validates(tmp_path: Path) -> None:
+    client = _FakeStorageClient()
+    dest = sa.download_asset(
+        "s3://bucket/run/object.obj", tmp_path / "obj", client=client
+    )
+    assert dest.is_file()
+    assert dest.name == "object.obj"
+    assert dest.read_bytes() == b"OBJ-DATA"
+    assert client.calls[0][0] == "s3://bucket/run/object.obj"
+
+
+def test_download_asset_local_path(tmp_path: Path) -> None:
+    src = tmp_path / "src.obj"
+    src.write_bytes(b"v 0 0 0\n")
+    dest = sa.download_asset(str(src), tmp_path / "out")
+    assert dest.read_bytes() == b"v 0 0 0\n"
+
+
+def test_download_asset_rejects_empty_file(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.obj"
+    empty.write_bytes(b"")
+    with pytest.raises(sa.SceneSpecError):
+        sa.download_asset(str(empty), tmp_path / "out")
+
+
+def test_resolve_scene_assets_byo_records_sha_source_and_no_fallback(
+    tmp_path: Path,
+) -> None:
+    client = _FakeStorageClient(payload=b"MESH-BYTES")
+    spec = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    sa.resolve_scene_assets(spec, dest_dir=tmp_path, client=client)
+
+    obj = spec.manipuland()
+    assert obj.local_path
+    assert obj.sha256 == sa.sha256_file(obj.local_path)
+    block = spec.provenance_block()
+    assert block["asset_fallback_used"] is False
+    assert block["objects"][0]["asset_source"] == "byo_mesh"
+    assert block["objects"][0]["sha256"] == obj.sha256
+    # Not yet loaded into the sim until the env builds it.
+    assert block["objects"][0]["loaded"] is False
+
+
+def test_resolve_scene_assets_genesis_builtin_uses_resolver(tmp_path: Path) -> None:
+    builtin_file = tmp_path / "builtin" / "duck.obj"
+    builtin_file.parent.mkdir(parents=True)
+    builtin_file.write_bytes(b"BUILTIN-MESH")
+
+    doc = {
+        "objects": [
+            {
+                "name": "duck",
+                "asset_source": "genesis_builtin",
+                "builtin_path": "meshes/duck.obj",
+            }
+        ]
+    }
+    spec = sa.parse_scene_spec(doc)
+    sa.resolve_scene_assets(
+        spec,
+        dest_dir=tmp_path,
+        builtin_resolver=lambda path: builtin_file,
+    )
+    obj = spec.manipuland()
+    assert obj.asset_source == "genesis_builtin"
+    assert obj.local_path == str(builtin_file)
+    assert obj.sha256 == sa.sha256_file(builtin_file)
+
+
+def test_resolve_scene_assets_raises_when_download_fails(tmp_path: Path) -> None:
+    def boom(*args, **kwargs):
+        raise sa.SceneSpecError("download exploded")
+
+    spec = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    with pytest.raises(sa.SceneSpecError):
+        sa.resolve_scene_assets(spec, dest_dir=tmp_path, downloader=boom)
+
+
+# --------------------------------------------------------------------------- #
+# Env build dispatch (fake gs + fake torch)
+# --------------------------------------------------------------------------- #
+
+
+class _RecordingMorph:
+    def __init__(self, kind: str, **kwargs) -> None:
+        self.kind = kind
+        self.kwargs = kwargs
+
+
+class _FakeEntity:
+    def __init__(self, morph, **kwargs) -> None:
+        self.morph = morph
+        self.kwargs = kwargs
+
+
+class _FakeScene:
+    def __init__(self) -> None:
+        self.added: list[_FakeEntity] = []
+
+    def add_entity(self, morph, **kwargs) -> _FakeEntity:
+        entity = _FakeEntity(morph, **kwargs)
+        self.added.append(entity)
+        return entity
+
+
+def _fake_gs() -> types.SimpleNamespace:
+    morphs = types.SimpleNamespace(
+        Mesh=lambda **kw: _RecordingMorph("Mesh", **kw),
+        Box=lambda **kw: _RecordingMorph("Box", **kw),
+        Sphere=lambda **kw: _RecordingMorph("Sphere", **kw),
+        Cylinder=lambda **kw: _RecordingMorph("Cylinder", **kw),
+    )
+    surfaces = types.SimpleNamespace(Rough=lambda **kw: ("Rough", kw))
+    materials = types.SimpleNamespace(Rigid=lambda **kw: ("Rigid", kw))
+    return types.SimpleNamespace(morphs=morphs, surfaces=surfaces, materials=materials)
+
+
+@pytest.fixture()
+def env_module(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", types.ModuleType("torch"))
+    sys.modules.pop("npa.genesis.env_pick_place", None)
+    module = importlib.import_module("npa.genesis.env_pick_place")
+    yield module
+    sys.modules.pop("npa.genesis.env_pick_place", None)
+
+
+def _bare_env(env_module):
+    env = env_module.FrankaPickPlaceEnv.__new__(env_module.FrankaPickPlaceEnv)
+    env._scene = _FakeScene()
+    env.scene_provenance = None
+    return env
+
+
+def test_build_dispatch_byo_mesh_calls_mesh_with_local_path(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="widget",
+        asset_source=sa.ASSET_SOURCE_BYO_MESH,
+        uri="s3://bucket/object.obj",
+        local_path="/tmp/resolved/object.obj",
+        scale=2.0,
+        pos=(0.5, 0.0, 0.05),
+    )
+    entity = env._add_object_entity(_fake_gs(), obj)
+
+    assert entity.morph.kind == "Mesh"
+    assert entity.morph.kwargs["file"] == "/tmp/resolved/object.obj"
+    assert entity.morph.kwargs["scale"] == 2.0
+    assert obj.loaded is True
+
+
+def test_build_dispatch_genesis_builtin_calls_mesh(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="duck",
+        asset_source=sa.ASSET_SOURCE_GENESIS_BUILTIN,
+        builtin_path="meshes/duck.obj",
+        local_path="/opt/genesis/assets/meshes/duck.obj",
+    )
+    entity = env._add_object_entity(_fake_gs(), obj)
+    assert entity.morph.kind == "Mesh"
+    assert entity.morph.kwargs["file"].endswith("duck.obj")
+    assert obj.loaded is True
+
+
+def test_build_dispatch_primitive_box_calls_box(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="cube",
+        asset_source=sa.ASSET_SOURCE_PRIMITIVE,
+        primitive=sa.PRIMITIVE_BOX,
+        size=(0.04, 0.04, 0.04),
+        pos=(0.5, 0.0, 0.04),
+    )
+    entity = env._add_object_entity(_fake_gs(), obj)
+    assert entity.morph.kind == "Box"
+    assert entity.morph.kwargs["size"] == (0.04, 0.04, 0.04)
+    assert obj.loaded is True
+
+
+def test_build_dispatch_primitive_sphere_calls_sphere(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="ball",
+        asset_source=sa.ASSET_SOURCE_PRIMITIVE,
+        primitive=sa.PRIMITIVE_SPHERE,
+        radius=0.03,
+    )
+    entity = env._add_object_entity(_fake_gs(), obj)
+    assert entity.morph.kind == "Sphere"
+    assert entity.morph.kwargs["radius"] == 0.03
+
+
+def test_build_dispatch_mesh_without_local_path_raises(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="widget",
+        asset_source=sa.ASSET_SOURCE_BYO_MESH,
+        uri="s3://bucket/object.obj",
+        local_path="",  # not resolved -> must fail loudly
+    )
+    with pytest.raises(sa.SceneSpecError):
+        env._add_object_entity(_fake_gs(), obj)
+
+
+def test_build_scene_objects_records_provenance_and_manipuland(env_module) -> None:
+    env = _bare_env(env_module)
+    spec = sa.SceneSpec(
+        objects=[
+            sa.ObjectSpec(
+                name="widget",
+                asset_source=sa.ASSET_SOURCE_BYO_MESH,
+                role=sa.ROLE_MANIPULAND,
+                uri="s3://bucket/object.obj",
+                local_path="/tmp/object.obj",
+                sha256="abc123",
+            ),
+            sa.ObjectSpec(
+                name="table",
+                asset_source=sa.ASSET_SOURCE_PRIMITIVE,
+                role=sa.ROLE_STATIC,
+                primitive=sa.PRIMITIVE_BOX,
+            ),
+        ]
+    )
+    manip = env._build_scene_objects(_fake_gs(), spec)
+
+    assert manip.morph.kind == "Mesh"
+    assert env.scene_provenance["asset_fallback_used"] is False
+    objs = {o["name"]: o for o in env.scene_provenance["objects"]}
+    assert objs["widget"]["loaded"] is True
+    assert objs["widget"]["sha256"] == "abc123"
+    assert objs["table"]["loaded"] is True
+
+
+def test_apply_scene_spec_overrides_cube_and_target(env_module) -> None:
+    env = env_module.FrankaPickPlaceEnv.__new__(env_module.FrankaPickPlaceEnv)
+    env.cfg = env_module.EnvConfig()
+    env._manip_quat = (1.0, 0.0, 0.0, 0.0)
+    spec = sa.SceneSpec(
+        objects=[
+            sa.ObjectSpec(
+                name="cube",
+                asset_source=sa.ASSET_SOURCE_PRIMITIVE,
+                primitive=sa.PRIMITIVE_BOX,
+                size=(0.06, 0.06, 0.06),
+                pos=(0.55, 0.01, 0.06),
+            )
+        ],
+        goal_pos=(0.4, 0.25, 0.04),
+        goal_threshold=0.07,
+    )
+    env._apply_scene_spec(spec)
+    assert env.cfg.cube_init_pos == (0.55, 0.01, 0.06)
+    assert env.cfg.cube_size == 0.06
+    assert env.cfg.target_pos == (0.4, 0.25, 0.04)
+    assert env.cfg.target_threshold == 0.07

--- a/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
+++ b/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
@@ -316,3 +316,54 @@ def test_down_runs_terraform_destroy(monkeypatch, tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert ["terraform", "init"] in stream_calls
     assert ["terraform", "destroy", "-auto-approve"] in stream_calls
+
+
+def test_terraform_env_refreshes_stale_token_by_default(monkeypatch) -> None:
+    # A stale ambient token must NOT shadow the freshly minted profile token.
+    monkeypatch.setenv("TF_VAR_iam_token", "stale-cloud-env-token")
+    monkeypatch.setenv("NEBIUS_IAM_TOKEN", "stale-cloud-env-token")
+    monkeypatch.delenv("NPA_REUSE_IAM_TOKEN", raising=False)
+
+    captured_env: dict[str, str] = {}
+
+    def fake_capture(args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return _completed("fresh-token\n")
+
+    monkeypatch.setattr(tf_mod, "_run_capture", fake_capture)
+
+    env = tf_mod._terraform_env("nebius")
+
+    assert env["TF_VAR_iam_token"] == "fresh-token"
+    assert env["NEBIUS_IAM_TOKEN"] == "fresh-token"
+    # The stale token is cleared before minting so it cannot leak into the mint call.
+    assert captured_env.get("TF_VAR_iam_token") in (None, "")
+    assert captured_env.get("NEBIUS_IAM_TOKEN") in (None, "")
+
+
+def test_terraform_env_reuses_token_when_opted_in(monkeypatch) -> None:
+    monkeypatch.setenv("TF_VAR_iam_token", "intentional-ci-token")
+    monkeypatch.setenv("NPA_REUSE_IAM_TOKEN", "1")
+
+    def fail_capture(args, **kwargs):
+        raise AssertionError("must not mint a new token when reuse is opted in")
+
+    monkeypatch.setattr(tf_mod, "_run_capture", fail_capture)
+
+    env = tf_mod._terraform_env("nebius")
+
+    assert env["TF_VAR_iam_token"] == "intentional-ci-token"
+
+
+def test_terraform_env_mints_when_no_token_present(monkeypatch) -> None:
+    monkeypatch.delenv("TF_VAR_iam_token", raising=False)
+    monkeypatch.delenv("NEBIUS_IAM_TOKEN", raising=False)
+    monkeypatch.setenv("NPA_REUSE_IAM_TOKEN", "1")
+
+    monkeypatch.setattr(
+        tf_mod, "_run_capture", lambda *a, **k: _completed("minted-token\n")
+    )
+
+    env = tf_mod._terraform_env("nebius")
+
+    assert env["TF_VAR_iam_token"] == "minted-token"

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 import npa.workflows.sim2real_loop as loop_module
@@ -515,8 +516,9 @@ def test_component_heldout_payload_uses_genesis_rollout_backend(monkeypatch) -> 
     ]
     captured = {}
 
-    def fake_genesis_rollouts(env_payload, *, inner_evidence, threshold):
+    def fake_genesis_rollouts(env_payload, *, inner_evidence, threshold, scene=None):
         captured["envs"] = env_payload
+        captured["scene"] = scene
         captured["inner_evidence"] = inner_evidence
         captured["threshold"] = threshold
         return [
@@ -550,6 +552,203 @@ def test_component_heldout_payload_uses_genesis_rollout_backend(monkeypatch) -> 
     assert payload["rollout_backend"] == "npa.genesis.env_pick_place.FrankaPickPlaceEnv"
     assert payload["policy_source"] == "inner_evidence_adapter"
     assert "synthetic_signature" not in payload
+
+
+class _FakeMeshClient:
+    """Fake StorageClient that writes JSON/mesh bytes for download_path."""
+
+    def __init__(self, *, spec_doc: dict | None = None, mesh: bytes = b"MESH") -> None:
+        self.spec_doc = spec_doc
+        self.mesh = mesh
+        self.downloads: list[tuple[str, str]] = []
+        self.uploads: list[tuple[str, str]] = []
+
+    def download_path(self, uri: str, local_path: str) -> str:
+        self.downloads.append((uri, local_path))
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        if uri.endswith(".json"):
+            Path(local_path).write_text(json.dumps(self.spec_doc or {}))
+        else:
+            Path(local_path).write_bytes(self.mesh)
+        return local_path
+
+    def upload_file(self, local_file: str, bucket_uri: str) -> str:
+        self.uploads.append((local_file, bucket_uri))
+        return bucket_uri
+
+
+def test_resolve_heldout_scene_byo_mesh_records_provenance(tmp_path: Path) -> None:
+    from npa.genesis import scene_assets as sa
+
+    client = _FakeMeshClient(mesh=b"OBJ-BYTES")
+    scene = loop_module._resolve_heldout_scene(
+        scene_spec_uri="",
+        assets_uri="s3://bucket/run/object.obj",
+        byo_mesh_uri="",
+        dest_dir=tmp_path,
+        client=client,
+    )
+    assert scene is not None
+    obj = scene.manipuland()
+    assert obj.asset_source == sa.ASSET_SOURCE_BYO_MESH
+    assert obj.sha256 == sa.sha256_file(obj.local_path)
+    assert scene.provenance_block()["asset_fallback_used"] is False
+
+
+def test_resolve_heldout_scene_none_without_uris(tmp_path: Path) -> None:
+    scene = loop_module._resolve_heldout_scene(
+        scene_spec_uri="",
+        assets_uri="",
+        byo_mesh_uri="",
+        dest_dir=tmp_path,
+        client=_FakeMeshClient(),
+    )
+    assert scene is None
+
+
+def test_resolve_heldout_scene_from_scene_spec_json(tmp_path: Path) -> None:
+    doc = {
+        "objects": [
+            {
+                "name": "widget",
+                "asset_source": "byo_mesh",
+                "uri": "s3://bucket/run/widget.glb",
+            }
+        ],
+        "goal_pos": [0.5, 0.3, 0.04],
+    }
+    client = _FakeMeshClient(spec_doc=doc)
+    scene = loop_module._resolve_heldout_scene(
+        scene_spec_uri="s3://bucket/run/scene-spec.json",
+        assets_uri="",
+        byo_mesh_uri="",
+        dest_dir=tmp_path,
+        client=client,
+    )
+    assert scene is not None
+    assert scene.manipuland().uri.endswith("widget.glb")
+    assert scene.manipuland().sha256
+
+
+def test_component_heldout_payload_with_scene_attaches_provenance(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from npa.genesis import scene_assets as sa
+
+    client = _FakeMeshClient(mesh=b"OBJ-BYTES")
+    scene = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    sa.resolve_scene_assets(scene, dest_dir=tmp_path, client=client)
+
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None):
+        # Simulate the env building the mesh and marking it loaded.
+        if scene is not None:
+            for obj in scene.objects:
+                obj.loaded = True
+        return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
+
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_rollouts)
+    payload = loop_module._component_heldout_payload(
+        [{"env_id": "heldout-0000", "seed": 1}],
+        inner_evidence={"reward_trend": [0.2, 0.6]},
+        threshold=0.75,
+        scene=scene,
+    )
+    assert payload["asset_fallback_used"] is False
+    prov = payload["asset_provenance"]
+    assert prov["objects"][0]["asset_source"] == "byo_mesh"
+    assert prov["objects"][0]["loaded"] is True
+    assert prov["objects"][0]["sha256"] == scene.manipuland().sha256
+
+
+def test_component_heldout_payload_raises_when_mesh_not_loaded(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from npa.genesis import scene_assets as sa
+
+    client = _FakeMeshClient(mesh=b"OBJ-BYTES")
+    scene = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    sa.resolve_scene_assets(scene, dest_dir=tmp_path, client=client)
+
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None):
+        return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
+
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_rollouts)
+    with pytest.raises(loop_module.Sim2RealLoopError):
+        loop_module._component_heldout_payload(
+            [{"env_id": "heldout-0000", "seed": 1}],
+            inner_evidence={},
+            threshold=0.75,
+            scene=scene,
+        )
+
+
+def test_normalize_heldout_report_propagates_provenance() -> None:
+    payload = {
+        "per_env": [{"env_id": "h-0", "score": 0.9, "success": True}],
+        "asset_provenance": {
+            "schema": "npa.sim2real.asset_provenance.v1",
+            "asset_fallback_used": False,
+            "objects": [{"name": "widget", "asset_source": "byo_mesh", "loaded": True}],
+        },
+        "asset_fallback_used": False,
+    }
+    config = Sim2RealLoopConfig(run_id="r", threshold=0.5)
+    report = loop_module._normalize_heldout_report(
+        payload,
+        config=config,
+        outer_iteration=1,
+        inner_evidence_uri="inner.json",
+        invocation={"component": "heldout_eval"},
+    )
+    assert report["asset_fallback_used"] is False
+    assert report["asset_provenance"]["objects"][0]["asset_source"] == "byo_mesh"
+
+
+def test_run_heldout_eval_component_from_s3_writes_provenance(
+    monkeypatch, tmp_path: Path
+) -> None:
+    client = _FakeMeshClient(mesh=b"OBJ-BYTES")
+    monkeypatch.setattr(
+        loop_module.StorageClient, "from_environment", staticmethod(lambda **kw: client)
+    )
+
+    # Seed the env records the component downloads.
+    def download_path(uri, local_path):
+        client.downloads.append((uri, local_path))
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        if uri.endswith("heldout/"):
+            Path(local_path).mkdir(parents=True, exist_ok=True)
+            (Path(local_path) / "envs.jsonl").write_text(
+                json.dumps({"env_id": "heldout-0000", "seed": 7}) + "\n"
+            )
+        elif uri.endswith(".json"):
+            Path(local_path).write_text(json.dumps({"reward_trend": [0.2, 0.6]}))
+        else:
+            Path(local_path).write_bytes(b"OBJ-BYTES")
+        return local_path
+
+    monkeypatch.setattr(client, "download_path", download_path)
+
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None):
+        if scene is not None:
+            for obj in scene.objects:
+                obj.loaded = True
+        return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
+
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_rollouts)
+
+    payload = loop_module.run_heldout_eval_component_from_s3(
+        heldout_envs_uri="s3://bucket/run/heldout/",
+        inner_evidence_uri="s3://bucket/run/inner-evidence.json",
+        output_uri="s3://bucket/run/output/report.json",
+        threshold=0.75,
+        assets_uri="s3://bucket/run/object.obj",
+    )
+    assert payload["asset_fallback_used"] is False
+    assert payload["asset_provenance"]["objects"][0]["asset_source"] == "byo_mesh"
+    # A consumed scene spec is uploaded alongside the report.
+    uploaded = [u[1] for u in client.uploads]
+    assert any(u.endswith("consumed-scene-spec.json") for u in uploaded)
 
 
 def test_sdk_exposes_sim2real_run(tmp_path: Path) -> None:

--- a/npa/tests/workflows/test_sim2real_signal_rca.py
+++ b/npa/tests/workflows/test_sim2real_signal_rca.py
@@ -1,0 +1,132 @@
+"""Regression tests for the sim2real genuine-signal RCA fixes.
+
+Covers the degenerate-signal root causes:
+- held-out scores collapsing to a flat ``1.0`` (no gradient),
+- cross-rollout diversity diagnostics / anti-hollow gate,
+- ``-genuine-`` image pull policy, and
+- image-digest provenance captured from the running pod.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+import npa.workflows.sim2real_loop as loop_module
+from npa.workflows.sim2real_loop import (
+    Sim2RealLoopConfig,
+    _heldout_env_score,
+    _image_pull_policy,
+    _signal_diversity_report,
+)
+
+
+def _signal(score: float, reward: float) -> dict[str, object]:
+    return {
+        "schema": loop_module.SCHEMA_RL_SIGNAL,
+        "score": score,
+        "per_step": [{"reward": reward}],
+    }
+
+
+def test_heldout_env_score_success_band_is_continuous_not_flat_one() -> None:
+    # Two successful envs with different distance/reward must NOT both be 1.0.
+    high = _heldout_env_score(1.0, 1.0, env_success=True)
+    low = _heldout_env_score(0.2, 0.0, env_success=True)
+
+    assert high == 1.0
+    assert low < high
+    assert 0.75 <= low <= 1.0
+
+
+def test_heldout_env_score_success_outranks_failure() -> None:
+    success = _heldout_env_score(0.5, 0.5, env_success=True)
+    failure = _heldout_env_score(0.5, 0.5, env_success=False)
+
+    assert success > failure
+    assert 0.0 <= failure <= 0.6
+
+
+def test_signal_diversity_report_flags_degenerate_batch() -> None:
+    degenerate = [_signal(1.0, 0.5) for _ in range(6)]
+
+    report = _signal_diversity_report(degenerate)
+
+    assert report["total_rollouts"] == 6
+    assert report["distinct_scores"] == 1
+    assert report["coherent"] is False
+    assert report["degenerate"] is True
+
+
+def test_signal_diversity_report_accepts_varied_batch() -> None:
+    varied = [_signal(0.2, -0.3), _signal(0.6, 0.1), _signal(0.9, 0.7)]
+
+    report = _signal_diversity_report(varied)
+
+    assert report["distinct_scores"] == 3
+    assert report["distinct_mean_rewards"] == 3
+    assert report["coherent"] is True
+    assert report["degenerate"] is False
+
+
+@pytest.mark.parametrize(
+    ("image", "expected"),
+    [
+        ("npa-cosmos3-reason:3.0.1-genuine-sm120", "Always"),
+        ("npa-sim2real-eval:0.1.1-genuine-sm120", "Always"),
+        ("npa-sim2real-eval:0.1.1", "IfNotPresent"),
+        ("registry.example/team/npa-sim2real-eval:0.1.1", "IfNotPresent"),
+        ("npa-sim2real-eval@sha256:" + "a" * 64, "IfNotPresent"),
+    ],
+)
+def test_image_pull_policy(image: str, expected: str) -> None:
+    assert _image_pull_policy(image) == expected
+
+
+def test_image_pull_policy_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NPA_SIM2REAL_IMAGE_PULL_POLICY", "Never")
+    assert _image_pull_policy("npa-cosmos3-reason:3.0.1-genuine-sm120") == "Never"
+
+
+def test_component_pod_info_captures_image_digests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    digest = "registry.example/npa-cosmos3-reason@sha256:" + "b" * 64
+    pod_payload = {
+        "items": [
+            {
+                "metadata": {"name": "pod-1"},
+                "spec": {"nodeName": "node-1", "containers": [{"resources": {}}]},
+                "status": {
+                    "phase": "Succeeded",
+                    "containerStatuses": [
+                        {
+                            "name": "component",
+                            "ready": False,
+                            "restartCount": 0,
+                            "image": "npa-cosmos3-reason:3.0.1-genuine-sm120",
+                            "imageID": digest,
+                            "state": {"terminated": {"exitCode": 0}},
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+    def fake_kubectl(config, args, **kwargs):  # noqa: ANN001 - test stub
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=json.dumps(pod_payload), stderr=""
+        )
+
+    monkeypatch.setattr(loop_module, "_kubectl", fake_kubectl)
+    config = Sim2RealLoopConfig(run_id="rca-test")
+
+    info = loop_module._component_pod_info(
+        config, namespace="default", job_name="job-1"
+    )
+
+    assert info["image_digests"] == [digest]
+    assert info["container_statuses"][0]["image_id"] == digest


### PR DESCRIPTION
## Summary

Closes the BYO simulation-asset gap (**Path B**). Previously `--assets-uri` / `--scene-spec-uri` / `--byo-mesh-uri` were echoed into JSON but **never downloaded or loaded into the simulator** — `gs.morphs.Mesh(file=...)` was never called, and the held-out Genesis rollout always built a hardcoded Franka + red `gs.morphs.Box` cube. This PR makes an uploaded mesh actually load into the sim, with provenance that proves it.

> Stacks on **#84** (`fix/sim2real-genuine-signal-and-rbac`). Review/merge #84 first; this branch is cut from its tip. The Genesis-generated Path A is unchanged.

### SceneSpec design (`npa/genesis/scene_assets.py`)
A real, simulator-agnostic SceneSpec schema + parser (no `torch`/`genesis` import at module load):
- A JSON doc describing the manipulated object(s): mesh source, pose (`pos`/`euler`), `scale`, and physics (`mass`/`friction`), plus an optional goal/target and multiple objects (`manipuland` / `target` / `static`).
- Asset sources: `byo_mesh` (download from S3/URI), `genesis_builtin` (a path under Genesis's shipped `assets/`), and `primitive` (box/sphere/cylinder — the current default Box is the primitive fallback). The Franka robot is always kept.
- Synthesizes a single-manipuland spec from a bare `assets_uri`/`byo_mesh_uri`, or parses a full SceneSpec JSON from `scene_spec_uri`.
- S3/URI download helper (reuses the repo `StorageClient` patterns) that validates the file exists + is non-empty, plus `sha256_file`.
- Per-object provenance `{uri, local_path, sha256, asset_source, loaded}` and a scene-level `asset_fallback_used` flag (mirrors #84's `image_digests` proof pattern).

### Files changed
- `npa/src/npa/genesis/scene_assets.py` (new): schema, parser/validator, synthesizer, download + sha256, builtin resolver, provenance.
- `npa/src/npa/genesis/env_pick_place.py`: `EnvConfig.scene_spec`; `_build_scene` builds each object via `gs.morphs.Mesh(file=<local_path>, scale=...)` for meshes and `Box`/`Sphere`/`Cylinder` otherwise, honoring pose/scale/physics. **With no spec the default Franka + red-Box scene is reproduced exactly**; the manipuland entity replaces `self._cube` so all reset/reward/contact/success logic is unchanged. A requested mesh that fails to load **raises** (no silent fallback).
- `npa/src/npa/workflows/sim2real_loop.py`: threads the scene/asset spec through the held-out eval component (`run_heldout_eval_component_from_s3` downloads + resolves assets and passes the resolved scene to the Genesis rollout); Stage 2 now actually **downloads + validates** assets and emits a **consumed** scene spec (with provenance) instead of a stub when URIs are provided (keeps the documented stub when absent); `report.json` and a `consumed-scene-spec.json` artifact carry the per-object provenance + `asset_fallback_used`. Fails loudly if a requested mesh did not load.
- Tests: `npa/tests/test_scene_assets.py` (new) and additions to `npa/tests/workflows/test_sim2real_loop.py`. Genesis is mocked with a fake `gs`; S3 mocked at the call site; no `torch`/`genesis` import at module level.

### Test results
- `ruff check` on all changed files: **clean**.
- `pytest tests/workflows`: **99 passed**.
- `pytest tests/test_scene_assets.py tests/test_genesis.py tests/workflows/test_sim2real_loop.py`: **56 passed** (26 new SceneSpec/build-dispatch + existing). Covers: parse/validate incl. malformed; build dispatch (`byo_mesh`/`genesis_builtin` -> `Mesh` with the resolved path, `primitive`/default -> `Box`); provenance (sha256 + `asset_source=byo_mesh` + `fallback=false`); missing/failed mesh raises (no fallback); S3 download helper mocked.

### Getting branch code into the GPU container
Used the **source-ref clone** path (preferred, no image rebuild): the held-out component job clones `NPA_SOURCE_REPO`@`NPA_SOURCE_REF` at runtime and prepends `npa/src` to `PYTHONPATH`. Verified in-container that the branch clones and `npa.genesis.scene_assets` imports, then ran the held-out eval component directly with this branch on a stock eval image.

### Validation evidence (real GPU run)
Ran the held-out Genesis eval component on a Blackwell (sm_120) GPU for both cases. Both produced `component_source=genesis_rollout` with 4 real per-env rollouts; Genesis ran on GPU (~500 FPS, 4 envs). Infra identifiers redacted per policy; the `sha256` values below are **mesh-content** hashes (the actual provenance proof).

**Case A — uploaded custom mesh** (a distinctive non-cube tetrahedron `.obj` uploaded to S3, referenced via `assets_uri`):
```json
{
  "asset_source": "byo_mesh",
  "loaded": true,
  "sha256": "c46cac87f6ac85b1703df8812450b86246dafdfafa7f88d530bd44d9577c8296",
  "role": "manipuland"
}
```
- `asset_fallback_used: false`; the report `sha256` **matches the uploaded file's sha256** (`c46cac87f6ac…`).

**Case C — Genesis built-in mesh** (`meshes/duck.obj`, referenced via a `scene_spec_uri` SceneSpec):
```json
{
  "asset_source": "genesis_builtin",
  "builtin_path": "meshes/duck.obj",
  "loaded": true,
  "sha256": "b0df328abab9362dba4318669ca7f5137aec462fadeeb5e46c2588ab5ed68e82",
  "role": "manipuland"
}
```
- `asset_fallback_used: false`; `local_path` resolved inside the Genesis package `assets/` dir; loaded into the sim.

Pod logs for both cases show the mesh loading and Genesis stepping on GPU, e.g.:
```
{"component": "heldout_eval", "event": "genesis_rollout_batch_complete", "env_count": 4, "max_steps": 80, "successes": 0}
[Genesis] [INFO] Running at 566.31 FPS (141.58 FPS per env, 4 envs)
{"component": "heldout_eval", "asset_fallback_used": false, "env_count": 4}
```

### Honest notes
- The held-out rollout was driven by the existing inner-evidence policy adapter (the same one Path A uses); 0/4 task successes is expected for a non-trained adapter on novel geometry — the point of this validation is **mesh load + provenance + no fallback**, which is proven.
- `mass` is recorded in the spec/provenance but not pushed through a Genesis mass API (version-dependent); `friction` is applied best-effort via `gs.materials.Rigid`. Pose, scale, primitive kind, and color are fully honored.

## Test plan
- [x] `ruff check` clean on changed files
- [x] `pytest tests/workflows` green (99)
- [x] New SceneSpec / build-dispatch / provenance / no-fallback tests green
- [x] GPU validation: case A (byo_mesh) provenance + sha match + no fallback
- [x] GPU validation: case C (genesis_builtin) provenance + loaded + no fallback

Made with [Cursor](https://cursor.com)