### PR TITLE
feat(sim2real): wire trainer/signal-converter BYO swaps + Rerun loop visualization

### DIFF
--- a/npa/src/npa/cli/cluster/terraform_lifecycle.py
+++ b/npa/src/npa/cli/cluster/terraform_lifecycle.py
@@ -190,10 +190,25 @@ def _require_bin(binary: str) -> str:
 
 def _terraform_env(nebius_bin: str) -> dict[str, str]:
     env = os.environ.copy()
-    if not env.get("TF_VAR_iam_token"):
-        token = _run_capture([nebius_bin, "iam", "get-access-token"], env=env).stdout.strip()
-        env["TF_VAR_iam_token"] = token
-        env["NEBIUS_IAM_TOKEN"] = token
+    # A stale ambient IAM token (e.g. a cloud-env token) silently shadows the
+    # intended Nebius profile and mints kubeconfig/registry credentials for the
+    # wrong principal -- the cause of Forbidden jobs/pods/nodes and 401 image
+    # pulls. Mint a fresh token by default after clearing any stale token; opt
+    # back into reuse only when NPA_REUSE_IAM_TOKEN is explicitly set (e.g. CI
+    # that injects a short-lived token intentionally).
+    reuse = env.get("NPA_REUSE_IAM_TOKEN", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if reuse and env.get("TF_VAR_iam_token"):
+        return env
+    env.pop("TF_VAR_iam_token", None)
+    env.pop("NEBIUS_IAM_TOKEN", None)
+    token = _run_capture([nebius_bin, "iam", "get-access-token"], env=env).stdout.strip()
+    env["TF_VAR_iam_token"] = token
+    env["NEBIUS_IAM_TOKEN"] = token
     return env
 
 

--- a/npa/src/npa/cli/skypilot/__init__.py
+++ b/npa/src/npa/cli/skypilot/__init__.py
@@ -139,6 +139,23 @@ def verify_cmd(
         "--path",
         help=f"SkyPilot venv path. Defaults to {VENV_PATH_ENV} or ~/.npa/skypilot-venv.",
     ),
+    kubeconfig: Path | None = typer.Option(
+        None,
+        "--kubeconfig",
+        help=(
+            "Kubeconfig to verify against. Sets KUBECONFIG for `sky check` so "
+            "verify does not silently run against an ambient/empty context and "
+            "report a misleading 403 anonymous 'missing context'."
+        ),
+    ),
+    cluster: str | None = typer.Option(
+        None,
+        "--cluster",
+        help=(
+            "NPA cluster name. Resolves ~/.npa/clusters/<name>/kubeconfig when "
+            "--kubeconfig is not given."
+        ),
+    ),
 ) -> None:
     """Run `sky check` against the isolated SkyPilot runtime."""
 
@@ -148,12 +165,40 @@ def verify_cmd(
         _fail(f"SkyPilot {SKYPILOT_VERSION} is not ready in {state.path}: {detail}. Run `npa skypilot bootstrap`.")
         return
 
-    result = _run_no_raise([str(state.sky_bin), "check"])
+    check_env = _verify_kube_env(kubeconfig=kubeconfig, cluster=cluster)
+    result = _run_no_raise([str(state.sky_bin), "check"], env=check_env)
     if result.stdout:
         typer.echo(result.stdout.rstrip())
     if result.stderr:
         console.print(result.stderr.rstrip())
     raise typer.Exit(result.returncode)
+
+
+def _verify_kube_env(
+    *, kubeconfig: Path | None, cluster: str | None
+) -> dict[str, str] | None:
+    """Build the env for `sky check`, pinning KUBECONFIG when known.
+
+    Without an explicit kubeconfig/cluster the behavior is unchanged (inherits
+    the ambient environment).
+    """
+
+    resolved = kubeconfig
+    if resolved is None and cluster:
+        from npa.cluster.state import kubeconfig_file
+
+        resolved = kubeconfig_file(cluster)
+    if resolved is None:
+        return None
+    resolved = resolved.expanduser()
+    if not resolved.exists():
+        _fail(
+            f"Kubeconfig not found: {resolved}. Run `npa cluster up`/`deploy` first "
+            "or pass an explicit --kubeconfig."
+        )
+    env = os.environ.copy()
+    env["KUBECONFIG"] = str(resolved)
+    return env
 
 
 def bootstrap_skypilot(
@@ -340,9 +385,13 @@ def _sky_importable(python_bin: Path) -> bool:
     return result.returncode == 0
 
 
-def _run_no_raise(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+def _run_no_raise(
+    cmd: list[str], *, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=False, env=env
+        )
     except FileNotFoundError as exc:
         return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
     except OSError as exc:

--- a/npa/src/npa/workbench/lerobot/policy_container.py
+++ b/npa/src/npa/workbench/lerobot/policy_container.py
@@ -115,6 +115,60 @@ class VlmSignalUpdateResult:
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> VlmSignalUpdateResult:
+        """Parse a BYO trainer-command JSON result into a structured update.
+
+        Required fields (a BYO trainer-command MUST emit these): ``reward_head_after``,
+        ``policy_output_after`` (non-empty list), and ``policy_delta_l2``. Every other
+        field falls back to a safe default so a minimal customer trainer hook still
+        produces a usable, attributable update record.
+        """
+
+        if not isinstance(payload, dict):
+            raise PolicyContainerError(
+                "VlmSignalUpdateResult.from_dict requires a JSON object payload"
+            )
+        for required in ("reward_head_after", "policy_output_after", "policy_delta_l2"):
+            if required not in payload:
+                raise PolicyContainerError(
+                    f"trainer update payload missing required field: {required}"
+                )
+        policy_output_after = payload["policy_output_after"]
+        if not isinstance(policy_output_after, list) or not policy_output_after:
+            raise PolicyContainerError(
+                "trainer update policy_output_after must be a non-empty list"
+            )
+        policy_output_after = [float(item) for item in policy_output_after]
+        raw_before = payload.get("policy_output_before")
+        if isinstance(raw_before, list) and raw_before:
+            policy_output_before = [float(item) for item in raw_before]
+        else:
+            policy_output_before = [0.0 for _ in policy_output_after]
+        loss_before = float(payload.get("loss_before", 0.0))
+        loss_after = float(payload.get("loss_after", loss_before))
+        return cls(
+            status=str(payload.get("status", "updated")),
+            backend=str(payload.get("backend", "byo_command")),
+            steps=int(payload.get("steps", 1)),
+            loss_before=loss_before,
+            loss_after=loss_after,
+            reward_head_before=float(payload.get("reward_head_before", 0.0)),
+            reward_head_after=float(payload["reward_head_after"]),
+            policy_output_before=policy_output_before,
+            policy_output_after=policy_output_after,
+            policy_delta_l2=float(payload["policy_delta_l2"]),
+            mean_reward=float(payload.get("mean_reward", 0.0)),
+            mean_advantage=float(payload.get("mean_advantage", 0.0)),
+            checkpoint_path=str(payload.get("checkpoint_path", "")),
+            signal_count=int(payload.get("signal_count", 0)),
+            control=bool(payload.get("control", False)),
+            loss_integration_point=str(
+                payload.get("loss_integration_point", "byo_trainer_command")
+            ),
+            duration_ms=float(payload.get("duration_ms", 0.0)),
+        )
+
 
 @dataclass(frozen=True)
 class LeRobotImportResult:

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 from npa.clients.storage import StorageClient
 from npa.deploy.images import container_image_for_tool
 from npa.workbench.lerobot.policy_container import (
+    VlmSignalUpdateResult,
     parse_vlm_signal_batch,
     run_vlm_signal_training_step,
 )
@@ -143,6 +144,8 @@ class Sim2RealLoopConfig:
     byo_trainer_command: str = ""
     byo_vlm_command: str = ""
     byo_eval_command: str = ""
+    byo_rerun_command: str = ""
+    rerun_enabled: bool = True
     k8s_namespace: str = ""
     k8s_service_account: str = "agent-sa"
     k8s_image_pull_secrets: str = "agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry"
@@ -410,6 +413,14 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
             or os.environ.get("BYO_EVAL_COMMAND")
             or ""
         ),
+        byo_rerun_command=str(
+            overrides.get("byo_rerun_command")
+            or os.environ.get("BYO_RERUN_COMMAND")
+            or ""
+        ),
+        rerun_enabled=_bool_value(
+            overrides.get("rerun_enabled", os.environ.get("NPA_SIM2REAL_RERUN", "1"))
+        ),
         k8s_namespace=str(
             overrides.get("k8s_namespace")
             or os.environ.get("NPA_SIM2REAL_K8S_NAMESPACE")
@@ -531,6 +542,8 @@ def byo_seams(config: Sim2RealLoopConfig) -> dict[str, Any]:
         "byo_trainer_command": config.byo_trainer_command,
         "byo_vlm_command": config.byo_vlm_command,
         "byo_eval_command": config.byo_eval_command,
+        "byo_rerun_command": config.byo_rerun_command,
+        "rerun_enabled": config.rerun_enabled,
         "k8s_namespace": config.k8s_namespace,
         "k8s_service_account": config.k8s_service_account,
         "k8s_image_pull_secrets": _split_csv(config.k8s_image_pull_secrets),
@@ -761,6 +774,14 @@ def run_full_loop(
         )
     )
 
+    viz_component, viz_info = _run_sim2real_viz_stage(
+        config,
+        local_dir=local_dir,
+        inner_evidence=final_inner,
+        heldout_report=final_eval,
+    )
+    components.append(viz_component)
+
     components.extend(
         [
             ComponentRecord(
@@ -801,6 +822,7 @@ def run_full_loop(
             "latest_heldout_report": final_eval,
             "latest_decision": final_decision,
         },
+        "visualization": viz_info,
         "image_completeness": {
             "required": [
                 config.augment_image,
@@ -834,6 +856,126 @@ def run_full_loop(
         }
         _write_json_artifact(report_path, report)
     return report
+
+
+def _run_sim2real_viz_stage(
+    config: Sim2RealLoopConfig,
+    *,
+    local_dir: Path,
+    inner_evidence: dict[str, Any],
+    heldout_report: dict[str, Any] | None,
+) -> tuple[ComponentRecord, dict[str, Any]]:
+    """Produce ``reports/sim2real.rrd`` and a status ComponentRecord.
+
+    Degrades gracefully (WARN, not hard-fail) when ``rerun`` is unavailable or the
+    toggle is off, but produces a real ``.rrd`` whenever rerun is installed. If a
+    ``byo_rerun_command`` is set it runs that customer hook instead, reading the
+    run dir from ``NPA_SIM2REAL_RUN_DIR`` / report from ``NPA_SIM2REAL_REPORT_JSON``
+    and writing to ``NPA_SIM2REAL_OUTPUT_RRD``.
+    """
+
+    rrd_path = local_dir / "reports" / "sim2real.rrd"
+    if not config.rerun_enabled:
+        info = {"status": "disabled", "reason": "rerun_enabled is false"}
+        return (
+            ComponentRecord(
+                "stage_14_rerun_viz",
+                "SEAM",
+                "Rerun visualization disabled via toggle (NPA_SIM2REAL_RERUN=0 / --no-rerun).",
+                {},
+                next_action="CONTINUE",
+            ),
+            info,
+        )
+
+    if config.byo_rerun_command.strip():
+        return _run_byo_rerun_command(config, local_dir=local_dir, rrd_path=rrd_path)
+
+    try:
+        from npa.workflows.sim2real_viz import (
+            RerunUnavailableError,
+            emit_sim2real_rerun,
+        )
+
+        result = emit_sim2real_rerun(
+            local_dir=local_dir,
+            inner_evidence=inner_evidence,
+            heldout_report=heldout_report,
+            output_rrd=rrd_path,
+            write_mp4=_bool_value(os.environ.get("NPA_SIM2REAL_RERUN_MP4", "0")),
+        )
+    except RerunUnavailableError as exc:
+        info = {"status": "skipped", "reason": str(exc), "source": "reference"}
+        return (
+            ComponentRecord(
+                "stage_14_rerun_viz",
+                "WARN",
+                "rerun-sdk not installed locally; skipped .rrd emission (install rerun-sdk to enable).",
+                {},
+                next_action="CONTINUE",
+            ),
+            info,
+        )
+    info = {"source": "reference", **result.to_dict()}
+    return (
+        ComponentRecord(
+            "stage_14_rerun_viz",
+            "WORKS",
+            (
+                f"Wrote Rerun recording with {result.rollout_count} rollout(s), "
+                f"{result.frame_count} camera frame(s), and {result.heldout_env_count} "
+                "held-out env score(s); camera streams, VLM critiques, RL signal, and "
+                "held-out scores are logged."
+            ),
+            {"rrd": str(rrd_path)},
+        ),
+        info,
+    )
+
+
+def _run_byo_rerun_command(
+    config: Sim2RealLoopConfig,
+    *,
+    local_dir: Path,
+    rrd_path: Path,
+) -> tuple[ComponentRecord, dict[str, Any]]:
+    rrd_path.parent.mkdir(parents=True, exist_ok=True)
+    report_json = local_dir / "reports" / "sim2real-report.json"
+    env = _component_env(
+        config,
+        component="rerun_viz",
+        output_json=rrd_path,
+        extra={
+            "NPA_SIM2REAL_RUN_DIR": str(local_dir),
+            "NPA_SIM2REAL_REPORT_JSON": str(report_json),
+            "NPA_SIM2REAL_OUTPUT_RRD": str(rrd_path),
+        },
+    )
+    invocation = _run_component_command(
+        config.byo_rerun_command,
+        cwd=local_dir,
+        env=env,
+        component="rerun_viz",
+    )
+    if not rrd_path.exists() or rrd_path.stat().st_size == 0:
+        raise Sim2RealLoopError(
+            f"byo_rerun_command did not write a non-empty recording to {rrd_path}"
+        )
+    info = {
+        "source": "byo_command",
+        "status": "written",
+        "output_rrd_path": str(rrd_path),
+        "component_invocation": _public_invocation(invocation),
+    }
+    return (
+        ComponentRecord(
+            "stage_14_rerun_viz",
+            "WORKS",
+            "Customer byo_rerun_command produced the Rerun recording.",
+            {"rrd": str(rrd_path)},
+        ),
+        info,
+    )
 
 
 def run_inner_loop(
@@ -883,13 +1025,20 @@ def run_inner_loop(
         )
         evals: list[dict[str, Any]] = []
         signals: list[dict[str, Any]] = []
+        signal_converter_source = (
+            "byo_command" if config.byo_signal_converter.strip() else "reference"
+        )
         for rollout in rollouts:
             evaluation = evaluate_rollout_with_vlm(
                 rollout,
                 output_dir=eval_dir,
                 config=config,
             )
-            signal = convert_vlm_eval_to_rl_signal(evaluation)
+            signal = _convert_eval_to_signal(
+                evaluation,
+                config=config,
+                output_dir=signal_dir,
+            )
             _write_json_artifact(signal_dir / f"{signal['rollout_id']}.json", signal)
             evals.append(evaluation)
             signals.append(signal)
@@ -904,18 +1053,35 @@ def run_inner_loop(
             signal_batch_path, {"schema": SCHEMA_RL_SIGNAL, "signals": signals}
         )
         parsed_signals = parse_vlm_signal_batch({"signals": signals})
-        update = run_vlm_signal_training_step(
-            parsed_signals,
-            output_dir=local_dir
+        trainer_dir = (
+            local_dir
             / "inner_loop"
             / f"outer-{outer_iteration:02d}"
             / "trainer"
-            / f"iter-{iteration:02d}",
-            learning_rate=config.learning_rate,
-            signal_loss_weight=config.signal_loss_weight,
-            initial_reward_head=reward_head,
-            initial_action_bias=action_bias,
+            / f"iter-{iteration:02d}"
         )
+        if config.byo_trainer_command.strip():
+            update = _run_trainer_via_command(
+                signal_batch_path,
+                config=config,
+                output_dir=trainer_dir,
+                initial_reward_head=reward_head,
+                initial_action_bias=action_bias,
+            )
+            trainer_source = "byo_command"
+        else:
+            update = run_vlm_signal_training_step(
+                parsed_signals,
+                output_dir=trainer_dir,
+                learning_rate=config.learning_rate,
+                signal_loss_weight=config.signal_loss_weight,
+                initial_reward_head=reward_head,
+                initial_action_bias=action_bias,
+            )
+            trainer_source = "reference"
+        # The no-signal control always runs the in-process reference trainer so the
+        # policy-delta attribution baseline stays honest even when a BYO trainer
+        # produces the signal-driven update.
         control = run_vlm_signal_training_step(
             parsed_signals,
             output_dir=local_dir
@@ -952,6 +1118,8 @@ def run_inner_loop(
                 "signal_dir": str(signal_dir),
                 "signal_batch": str(signal_batch_path),
                 "mean_reward": mean_reward,
+                "trainer_source": trainer_source,
+                "signal_converter_source": signal_converter_source,
                 "update": update.to_dict(),
                 "no_signal_control": control.to_dict(),
                 "policy_delta_vs_control": round(delta_vs_control, 8),
@@ -978,6 +1146,12 @@ def run_inner_loop(
         "schema": "npa.sim2real.inner_loop_evidence.v1",
         "outer_iteration": outer_iteration,
         "status": "closed",
+        "trainer_source": (
+            "byo_command" if config.byo_trainer_command.strip() else "reference"
+        ),
+        "signal_converter_source": (
+            "byo_command" if config.byo_signal_converter.strip() else "reference"
+        ),
         "reward_trend": reward_trend,
         "signal_diversity": signal_diversity,
         "policy_delta_vs_no_signal_control": policy_deltas,
@@ -1807,6 +1981,136 @@ def signal_mapping_rules() -> dict[str, Any]:
         "nl_corrective_targets": CORRECTIVE_TARGETS,
         "error_severity": ERROR_SEVERITY,
     }
+
+
+def _convert_eval_to_signal(
+    evaluation: dict[str, Any],
+    *,
+    config: Sim2RealLoopConfig,
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Convert a VLM eval to an RL signal via the BYO command or the reference.
+
+    BYO signal-converter contract: the command reads the VLM evaluation JSON from
+    ``NPA_SIM2REAL_EVALUATION_JSON`` and writes an ``npa.sim2real.rl_signal.v1``
+    document to ``NPA_SIM2REAL_OUTPUT_JSON``. A missing, empty, non-conforming, or
+    failing command raises ``Sim2RealLoopError`` -- the loop never silently falls
+    back to the in-process reference converter.
+    """
+
+    if not config.byo_signal_converter.strip():
+        return convert_vlm_eval_to_rl_signal(evaluation)
+
+    rollout_id = str(evaluation.get("rollout_id") or "rollout")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    eval_path = output_dir / f"{rollout_id}.evaluation.json"
+    _write_json_artifact(eval_path, evaluation)
+    output_path = output_dir / f"{rollout_id}.byo-signal.json"
+    env = _component_env(
+        config,
+        component="signal_converter",
+        output_json=output_path,
+        extra={
+            "NPA_SIM2REAL_EVALUATION_JSON": str(eval_path),
+            "NPA_SIM2REAL_ROLLOUT_ID": rollout_id,
+            "NPA_SIM2REAL_RL_SIGNAL_SCHEMA": SCHEMA_RL_SIGNAL,
+        },
+    )
+    invocation = _run_component_command(
+        config.byo_signal_converter,
+        cwd=output_dir,
+        env=env,
+        component="signal_converter",
+    )
+    payload = _read_component_json(output_path, invocation)
+    return _normalize_byo_rl_signal(
+        payload,
+        rollout_id=rollout_id,
+        invocation=invocation,
+    )
+
+
+def _normalize_byo_rl_signal(
+    payload: dict[str, Any],
+    *,
+    rollout_id: str,
+    invocation: dict[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise Sim2RealLoopError("signal_converter output must be a JSON object")
+    if payload.get("schema") != SCHEMA_RL_SIGNAL:
+        raise Sim2RealLoopError(
+            "signal_converter output must use schema "
+            f"{SCHEMA_RL_SIGNAL}, got {payload.get('schema')!r}"
+        )
+    per_step = payload.get("per_step")
+    if not isinstance(per_step, list) or not per_step:
+        raise Sim2RealLoopError(
+            "signal_converter output must include non-empty per_step"
+        )
+    payload.setdefault("rollout_id", rollout_id)
+    payload.setdefault("source", "byo")
+    try:
+        parse_vlm_signal_batch(payload)
+    except Exception as exc:
+        raise Sim2RealLoopError(
+            f"signal_converter output is not a valid {SCHEMA_RL_SIGNAL}: {exc}"
+        ) from exc
+    payload["component_invocation"] = _public_invocation(invocation)
+    return payload
+
+
+def _run_trainer_via_command(
+    signal_batch_path: Path,
+    *,
+    config: Sim2RealLoopConfig,
+    output_dir: Path,
+    initial_reward_head: float,
+    initial_action_bias: float,
+) -> VlmSignalUpdateResult:
+    """Run the BYO trainer command and parse its update result.
+
+    BYO trainer contract: the command reads the parsed signal batch JSON from
+    ``NPA_SIM2REAL_SIGNAL_JSON`` and writes an update JSON to
+    ``NPA_SIM2REAL_OUTPUT_JSON`` containing at least ``reward_head_after``,
+    ``policy_output_after`` (list), and ``policy_delta_l2`` (optional
+    ``loss_before``/``loss_after``). A missing, empty, non-conforming, or failing
+    command raises ``Sim2RealLoopError`` -- the loop never silently falls back to
+    the in-process reference trainer.
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "byo-trainer-update.json"
+    env = _component_env(
+        config,
+        component="trainer",
+        output_json=output_path,
+        extra={
+            "NPA_SIM2REAL_SIGNAL_JSON": str(signal_batch_path),
+            "NPA_SIM2REAL_INITIAL_REWARD_HEAD": str(initial_reward_head),
+            "NPA_SIM2REAL_INITIAL_ACTION_BIAS": str(initial_action_bias),
+            "NPA_SIM2REAL_LEARNING_RATE": str(config.learning_rate),
+            "NPA_SIM2REAL_SIGNAL_LOSS_WEIGHT": str(config.signal_loss_weight),
+            "NPA_SIM2REAL_TRAINER_IMAGE": config.trainer_image,
+        },
+    )
+    invocation = _run_component_command(
+        config.byo_trainer_command,
+        cwd=output_dir,
+        env=env,
+        component="trainer",
+    )
+    payload = _read_component_json(output_path, invocation)
+    if not isinstance(payload, dict):
+        raise Sim2RealLoopError("trainer command output must be a JSON object")
+    try:
+        result = VlmSignalUpdateResult.from_dict(payload)
+    except Exception as exc:
+        raise Sim2RealLoopError(
+            f"trainer command output is not a valid update result: {exc}"
+        ) from exc
+    _write_json_artifact(output_path, result.to_dict())
+    return result
 
 
 def run_heldout_eval(
@@ -2733,6 +3037,8 @@ def main(argv: list[str] | None = None) -> int:
         byo_trainer_command=args.byo_trainer_command,
         byo_vlm_command=args.byo_vlm_command,
         byo_eval_command=args.byo_eval_command,
+        byo_rerun_command=args.byo_rerun_command,
+        rerun_enabled=args.rerun,
         k8s_namespace=args.k8s_namespace,
         k8s_service_account=args.k8s_service_account,
         k8s_image_pull_secrets=args.k8s_image_pull_secrets,
@@ -2835,6 +3141,20 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--byo-trainer-command", default="")
     parser.add_argument("--byo-vlm-command", default="")
     parser.add_argument("--byo-eval-command", default="")
+    parser.add_argument("--byo-rerun-command", default="")
+    parser.add_argument(
+        "--rerun",
+        dest="rerun",
+        action="store_true",
+        default=_bool_value(os.environ.get("NPA_SIM2REAL_RERUN", "1")),
+        help="Emit a Rerun .rrd visualization after the loop (default on).",
+    )
+    parser.add_argument(
+        "--no-rerun",
+        dest="rerun",
+        action="store_false",
+        help="Disable Rerun .rrd visualization emission.",
+    )
     parser.add_argument(
         "--k8s-namespace",
         default=os.environ.get("NPA_SIM2REAL_K8S_NAMESPACE", ""),

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -848,6 +848,7 @@ def run_inner_loop(
     iteration_records: list[dict[str, Any]] = []
     reward_trend: list[float] = []
     policy_deltas: list[float] = []
+    all_signals: list[dict[str, Any]] = []
     quality = float(initial_quality)
     reward_head = 0.0
     action_bias = 0.0
@@ -892,6 +893,7 @@ def run_inner_loop(
             _write_json_artifact(signal_dir / f"{signal['rollout_id']}.json", signal)
             evals.append(evaluation)
             signals.append(signal)
+            all_signals.append(signal)
         signal_batch_path = (
             local_dir
             / "inner_loop"
@@ -959,11 +961,25 @@ def run_inner_loop(
             }
         )
 
+    signal_diversity = _signal_diversity_report(all_signals)
+    if signal_diversity["degenerate"] and _bool_value(
+        os.environ.get("NPA_SIM2REAL_REQUIRE_SIGNAL_DIVERSITY", "0")
+    ):
+        raise Sim2RealLoopError(
+            "VLM->RL signal is degenerate: "
+            f"{signal_diversity['distinct_scores']} distinct score(s) and "
+            f"{signal_diversity['distinct_mean_rewards']} distinct mean-reward(s) "
+            f"across {signal_diversity['total_rollouts']} rollout(s) "
+            f"(scores={signal_diversity['score_values']}). "
+            "Unset NPA_SIM2REAL_REQUIRE_SIGNAL_DIVERSITY to downgrade this gate to a "
+            "diagnostic."
+        )
     evidence = {
         "schema": "npa.sim2real.inner_loop_evidence.v1",
         "outer_iteration": outer_iteration,
         "status": "closed",
         "reward_trend": reward_trend,
+        "signal_diversity": signal_diversity,
         "policy_delta_vs_no_signal_control": policy_deltas,
         "attribution": (
             "The reference update and no-signal control share initial adapter state. "
@@ -1267,6 +1283,7 @@ def _run_kubernetes_image_component(
         "mode": "kubernetes_job",
         "component": component,
         "image": image,
+        "image_digests": pod_info.get("image_digests", []),
         "namespace": namespace,
         "job_name": job_name,
         "pod": pod_info,
@@ -1313,7 +1330,7 @@ def _component_job_manifest(
             {
                 "name": "component",
                 "image": image,
-                "imagePullPolicy": "IfNotPresent",
+                "imagePullPolicy": _image_pull_policy(image),
                 "command": ["bash", "-lc"],
                 "args": [_component_job_script(component)],
                 "env": [
@@ -1485,20 +1502,27 @@ def _component_pod_info(
     container = (pod.get("spec", {}).get("containers") or [{}])[0]
     resources = container.get("resources", {})
     statuses = pod.get("status", {}).get("containerStatuses") or []
+    container_statuses = [
+        {
+            "name": item.get("name", ""),
+            "ready": item.get("ready", False),
+            "restart_count": item.get("restartCount", 0),
+            "image": item.get("image", ""),
+            "image_id": item.get("imageID", ""),
+            "state": item.get("state", {}),
+        }
+        for item in statuses
+    ]
+    image_digests = [
+        status["image_id"] for status in container_statuses if status["image_id"]
+    ]
     return {
         "name": pod.get("metadata", {}).get("name", ""),
         "node_name": pod.get("spec", {}).get("nodeName", ""),
         "phase": pod.get("status", {}).get("phase", ""),
         "resources": resources,
-        "container_statuses": [
-            {
-                "name": item.get("name", ""),
-                "ready": item.get("ready", False),
-                "restart_count": item.get("restartCount", 0),
-                "state": item.get("state", {}),
-            }
-            for item in statuses
-        ],
+        "container_statuses": container_statuses,
+        "image_digests": image_digests,
     }
 
 
@@ -2328,11 +2352,16 @@ def _parse_cosmos_reason_output(
             or model_text
         ).strip()
         tags = payload.get("error_tags") or _tags_from_text(critique)
+        # The model returned no per-step breakdown, so the single summary critique
+        # is broadcast across every action step. Mark it as such so a degenerate
+        # (all-identical) per-step signal is visible rather than masquerading as
+        # genuine per-step granularity.
         raw_steps = [
             {
                 "step": int(action.get("step", index)),
                 "critique_text": critique,
                 "error_tags": tags,
+                "critique_source": "summary_broadcast",
                 "camera_observation": f"camera-{int(action.get('step', index)):03d}.ppm",
             }
             for index, action in enumerate(actions)
@@ -2512,7 +2541,9 @@ def _run_genesis_heldout_rollouts(
             env_success = bool(success[index].detach().item())
             distance_score = max(0.0, min(1.0, 1.0 - dist / 0.5))
             reward_score = max(0.0, min(1.0, reward_value / 10.0))
-            score = 1.0 if env_success else round(0.7 * distance_score + 0.3 * reward_score, 6)
+            score = _heldout_env_score(
+                distance_score, reward_score, env_success=env_success
+            )
             per_env.append(
                 {
                     "env_id": str(env_record.get("env_id") or f"heldout-{start + index:04d}"),
@@ -2997,6 +3028,68 @@ def _merge_targets(tags: list[str]) -> dict[str, Any]:
 def _signal_mean_reward(signal: dict[str, Any]) -> float:
     steps = signal.get("per_step") or []
     return sum(float(step["reward"]) for step in steps) / float(len(steps))
+
+
+def _heldout_env_score(
+    distance_score: float, reward_score: float, *, env_success: bool
+) -> float:
+    """Map per-env distance/reward to a continuous held-out score.
+
+    Successful and failed envs occupy separate bands, but the score stays
+    continuous in the env's own distance/reward so the held-out report keeps a
+    gradient instead of collapsing to a flat ``1.0`` across every env (which
+    produced an uninformative, incoherent signal).
+    """
+
+    quality = max(0.0, min(1.0, 0.7 * distance_score + 0.3 * reward_score))
+    if env_success:
+        return round(0.75 + 0.25 * quality, 6)
+    return round(0.6 * quality, 6)
+
+
+def _signal_diversity_report(signals: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize cross-rollout diversity of the VLM->RL signal.
+
+    A genuine signal varies across rollouts; a single distinct score/reward
+    across every rollout is the degenerate ("hollow") pattern. These metrics
+    (``distinct_scores``, ``coherent``) are emitted into loop evidence so a run
+    is self-describing instead of requiring an external validator to infer them.
+    """
+
+    scores = [round(float(signal.get("score") or 0.0), 4) for signal in signals]
+    mean_rewards = [round(_signal_mean_reward(signal), 4) for signal in signals]
+    distinct_scores = sorted({score for score in scores})
+    distinct_rewards = sorted({reward for reward in mean_rewards})
+    total = len(signals)
+    coherent = total > 1 and len(distinct_scores) > 1 and len(distinct_rewards) > 1
+    return {
+        "total_rollouts": total,
+        "distinct_scores": len(distinct_scores),
+        "distinct_mean_rewards": len(distinct_rewards),
+        "score_values": distinct_scores,
+        "mean_reward_values": distinct_rewards,
+        "coherent": coherent,
+        "degenerate": not coherent,
+    }
+
+
+def _image_pull_policy(image: str) -> str:
+    """Choose the imagePullPolicy for a sibling component image.
+
+    Provenance-sensitive ``-genuine-`` builds are pulled fresh so a stale image
+    cached under the same tag cannot silently masquerade as the genuine build.
+    A digest-pinned reference (``@sha256:``) is already immutable.
+    """
+
+    override = os.environ.get("NPA_SIM2REAL_IMAGE_PULL_POLICY", "").strip()
+    if override:
+        return override
+    if "@sha256:" in image:
+        return "IfNotPresent"
+    tag = image.rsplit(":", 1)[-1] if ":" in image.rsplit("/", 1)[-1] else ""
+    if "genuine" in tag:
+        return "Always"
+    return "IfNotPresent"
 
 
 def _write_ppm(path: Path, *, red: int, green: int, blue: int) -> None:

--- a/npa/src/npa/workflows/sim2real_viz.py
+++ b/npa/src/npa/workflows/sim2real_viz.py
@@ -1,0 +1,401 @@
+"""Rerun visualization emitter for completed Sim2Real loop runs.
+
+This module turns a completed Sim2Real run's artifact tree into a single Rerun
+``.rrd`` recording (and, optionally, per-rollout MP4s) so the VLM->RL loop can be
+inspected visually: rollout camera frames as image streams, per-rollout VLM
+critique text and score overlays, the per-step reward/advantage signal as scalar
+timeseries, and the held-out per-env scores as a scalar/bar view.
+
+It reuses the repo's existing Rerun capability (the ``rerun-sdk`` recording API
+that ``npa.viz.adapters.lerobot_to_rerun`` and ``npa.viz.backends.rerun`` build
+on) rather than reinventing a logger. ``rerun`` is imported lazily so the loop
+degrades gracefully (WARN, not hard-fail) when the SDK is not installed locally,
+but it MUST produce a non-empty ``.rrd`` whenever the SDK is available.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+APPLICATION_ID = "npa_sim2real_loop"
+TIMELINE = "frame_time"
+ROLLOUT_FRAME_SECONDS = 0.5
+HELDOUT_STEP_SECONDS = 1.0
+CRITIQUE_COLOR = (255, 136, 0, 255)
+
+
+class Sim2RealVizError(Exception):
+    """Raised when the Sim2Real Rerun emitter cannot produce a recording."""
+
+
+class RerunUnavailableError(Sim2RealVizError):
+    """Raised when the ``rerun`` SDK is not importable (caller WARNs and skips)."""
+
+
+@dataclass(frozen=True)
+class Sim2RealVizResult:
+    """Result of emitting a Sim2Real Rerun recording."""
+
+    status: str
+    output_rrd_path: str
+    entity_counts: dict[str, int] = field(default_factory=dict)
+    rollout_count: int = 0
+    frame_count: int = 0
+    heldout_env_count: int = 0
+    mp4_paths: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "output_rrd_path": self.output_rrd_path,
+            "entity_counts": dict(self.entity_counts),
+            "rollout_count": self.rollout_count,
+            "frame_count": self.frame_count,
+            "heldout_env_count": self.heldout_env_count,
+            "mp4_paths": list(self.mp4_paths),
+        }
+
+
+def emit_sim2real_rerun(
+    *,
+    local_dir: Path,
+    inner_evidence: dict[str, Any],
+    heldout_report: dict[str, Any] | None,
+    output_rrd: Path | None = None,
+    write_mp4: bool = False,
+) -> Sim2RealVizResult:
+    """Write ``reports/sim2real.rrd`` for a completed run's artifacts.
+
+    Raises ``RerunUnavailableError`` when the ``rerun`` SDK is missing so the
+    caller can WARN and continue. Any other failure (rerun present but logging
+    failed) raises ``Sim2RealVizError`` so a broken recording is never silently
+    accepted.
+    """
+
+    rr, rrb = _import_rerun()
+    local_dir = Path(local_dir)
+    output_rrd = Path(output_rrd) if output_rrd is not None else local_dir / "reports" / "sim2real.rrd"
+    if output_rrd.suffix.lower() != ".rrd":
+        raise Sim2RealVizError(f"Rerun output path must end in .rrd, got: {output_rrd}")
+    output_rrd.parent.mkdir(parents=True, exist_ok=True)
+
+    blueprint = _build_blueprint(rrb)
+    recording = rr.RecordingStream(APPLICATION_ID)
+    rr.save(output_rrd, default_blueprint=blueprint, recording=recording)
+    _send_blueprint(rr, blueprint, recording)
+
+    counts: dict[str, int] = {}
+    seconds = 0.0
+    rollout_count = 0
+    frame_count = 0
+    mp4_paths: list[str] = []
+
+    iterations = inner_evidence.get("iterations") or []
+    for record in iterations:
+        iteration = int(record.get("iteration", len(mp4_paths) + 1))
+        actions_dir = _maybe_path(record.get("actions_dir"))
+        eval_dir = _maybe_path(record.get("vlm_eval_dir"))
+        signal_dir = _maybe_path(record.get("signal_dir"))
+        for rollout_dir in _rollout_dirs(actions_dir):
+            rollout_id = rollout_dir.name
+            iter_root = f"rollouts/iter_{iteration:02d}/{rollout_id}"
+            evaluation = _read_json(eval_dir / f"{rollout_id}.json") if eval_dir else {}
+            signal = _read_json(signal_dir / f"{rollout_id}.json") if signal_dir else {}
+            frames = _rollout_frames(rollout_dir)
+            seconds = _log_rollout(
+                rr,
+                recording,
+                root=iter_root,
+                frames=frames,
+                evaluation=evaluation,
+                signal=signal,
+                start_seconds=seconds,
+                counts=counts,
+            )
+            rollout_count += 1
+            frame_count += len(frames)
+            if write_mp4 and frames:
+                mp4_path = _maybe_write_mp4(rollout_dir, frames)
+                if mp4_path is not None:
+                    mp4_paths.append(str(mp4_path))
+
+    _log_reward_trend(rr, recording, inner_evidence.get("reward_trend") or [], counts)
+    heldout_env_count = _log_heldout(
+        rr,
+        recording,
+        (heldout_report or {}).get("per_env") or [],
+        counts,
+    )
+
+    _disconnect(rr, recording)
+
+    if not output_rrd.exists() or output_rrd.stat().st_size == 0:
+        raise Sim2RealVizError(f"Rerun recording was not written: {output_rrd}")
+    if frame_count == 0 and rollout_count == 0 and heldout_env_count == 0:
+        raise Sim2RealVizError(
+            "Sim2Real Rerun recording has no rollout frames, signal, or held-out content"
+        )
+
+    return Sim2RealVizResult(
+        status="written",
+        output_rrd_path=str(output_rrd),
+        entity_counts=counts,
+        rollout_count=rollout_count,
+        frame_count=frame_count,
+        heldout_env_count=heldout_env_count,
+        mp4_paths=mp4_paths,
+    )
+
+
+def _log_rollout(
+    rr: Any,
+    recording: Any,
+    *,
+    root: str,
+    frames: list[np.ndarray],
+    evaluation: dict[str, Any],
+    signal: dict[str, Any],
+    start_seconds: float,
+    counts: dict[str, int],
+) -> float:
+    seconds = start_seconds
+    per_step_eval = {int(item.get("step", index)): item for index, item in enumerate(evaluation.get("per_step") or [])}
+    per_step_signal = {int(item.get("step", index)): item for index, item in enumerate(signal.get("per_step") or [])}
+    score = evaluation.get("score")
+    summary = str(evaluation.get("summary") or "")
+
+    for step, frame in enumerate(frames):
+        _set_time(rr, recording, seconds)
+        rr.log(f"{root}/camera", rr.Image(frame), recording=recording)
+        _bump(counts, f"{root}/camera")
+
+        eval_step = per_step_eval.get(step, {})
+        critique = str(eval_step.get("critique_text") or summary or "")
+        tags = eval_step.get("error_tags") or []
+        if critique:
+            overlay = critique if not tags else f"{critique}\n\nerror_tags: {', '.join(str(tag) for tag in tags)}"
+            rr.log(
+                f"{root}/critique",
+                rr.TextDocument(overlay, media_type="text/markdown"),
+                recording=recording,
+            )
+            _bump(counts, f"{root}/critique")
+        if score is not None:
+            rr.log(f"{root}/score", _scalar(rr, float(score)), recording=recording)
+            _bump(counts, f"{root}/score")
+
+        signal_step = per_step_signal.get(step, {})
+        if "reward" in signal_step:
+            rr.log("signal/reward", _scalar(rr, float(signal_step["reward"])), recording=recording)
+            _bump(counts, "signal/reward")
+        if signal_step.get("advantage") is not None:
+            rr.log("signal/advantage", _scalar(rr, float(signal_step["advantage"])), recording=recording)
+            _bump(counts, "signal/advantage")
+        seconds += ROLLOUT_FRAME_SECONDS
+    return seconds
+
+
+def _log_reward_trend(rr: Any, recording: Any, reward_trend: list[Any], counts: dict[str, int]) -> None:
+    for index, value in enumerate(reward_trend):
+        _set_time(rr, recording, float(index))
+        rr.log("signal/reward_trend", _scalar(rr, float(value)), recording=recording)
+        _bump(counts, "signal/reward_trend")
+
+
+def _log_heldout(rr: Any, recording: Any, per_env: list[dict[str, Any]], counts: dict[str, int]) -> int:
+    seconds = 0.0
+    logged = 0
+    for index, item in enumerate(per_env):
+        if not isinstance(item, dict):
+            continue
+        env_id = str(item.get("env_id") or f"heldout-{index:04d}")
+        score = float(item.get("score", 0.0))
+        _set_time(rr, recording, seconds)
+        rr.log("heldout/scores", _scalar(rr, score), recording=recording)
+        rr.log(f"heldout/per_env/{env_id}", _scalar(rr, score), recording=recording)
+        _bump(counts, "heldout/scores")
+        _bump(counts, f"heldout/per_env/{env_id}")
+        seconds += HELDOUT_STEP_SECONDS
+        logged += 1
+    return logged
+
+
+def _build_blueprint(rrb: Any) -> Any:
+    return rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.Spatial2DView(origin="rollouts", contents="rollouts/**", name="Rollout cameras"),
+            rrb.TextDocumentView(origin="rollouts", contents="rollouts/**/critique", name="VLM critiques"),
+            rrb.Vertical(
+                rrb.TimeSeriesView(origin="signal", contents="signal/**", name="VLM->RL signal"),
+                rrb.TimeSeriesView(origin="heldout", contents="heldout/**", name="Held-out scores"),
+            ),
+            column_shares=[2.0, 1.5, 1.5],
+        ),
+        rrb.TimePanel(state=rrb.PanelState.Expanded, timeline=TIMELINE),
+        auto_layout=False,
+    )
+
+
+def _rollout_dirs(actions_dir: Path | None) -> list[Path]:
+    if actions_dir is None or not actions_dir.exists():
+        return []
+    return sorted(path for path in actions_dir.iterdir() if path.is_dir() and path.name.startswith("rollout-"))
+
+
+def _rollout_frames(rollout_dir: Path) -> list[np.ndarray]:
+    frames: list[np.ndarray] = []
+    for frame_path in sorted(rollout_dir.glob("camera-*.ppm")):
+        frame = _read_ppm(frame_path)
+        if frame is not None:
+            frames.append(frame)
+    return frames
+
+
+def _read_ppm(path: Path) -> np.ndarray | None:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    if not data.startswith(b"P6"):
+        return None
+    fields: list[bytes] = []
+    index = 2
+    while len(fields) < 3 and index < len(data):
+        while index < len(data) and data[index] in b" \t\r\n":
+            index += 1
+        if index < len(data) and data[index:index + 1] == b"#":
+            while index < len(data) and data[index] not in b"\r\n":
+                index += 1
+            continue
+        start = index
+        while index < len(data) and data[index] not in b" \t\r\n":
+            index += 1
+        fields.append(data[start:index])
+    if len(fields) < 3:
+        return None
+    width, height, _maxval = (int(field) for field in fields)
+    index += 1  # single whitespace separator after maxval
+    pixels = data[index:index + width * height * 3]
+    if len(pixels) < width * height * 3:
+        return None
+    return np.frombuffer(pixels, dtype=np.uint8).reshape(height, width, 3).copy()
+
+
+def _maybe_write_mp4(rollout_dir: Path, frames: list[np.ndarray]) -> Path | None:
+    """Best-effort per-rollout MP4 via ffmpeg; returns None if ffmpeg is missing."""
+
+    import shutil
+    import subprocess
+    import tempfile
+
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return None
+    output_path = rollout_dir / "rollout.mp4"
+    with tempfile.TemporaryDirectory(prefix="npa-sim2real-mp4-") as tmp:
+        tmp_dir = Path(tmp)
+        for index, frame in enumerate(frames):
+            _write_png(tmp_dir / f"frame_{index:06d}.png", frame)
+        command = [
+            ffmpeg,
+            "-y",
+            "-loglevel",
+            "error",
+            "-framerate",
+            "2",
+            "-i",
+            str(tmp_dir / "frame_%06d.png"),
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(output_path),
+        ]
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0 or not output_path.exists():
+        return None
+    return output_path
+
+
+def _write_png(path: Path, frame: np.ndarray) -> None:
+    import struct
+    import zlib
+
+    height, width = int(frame.shape[0]), int(frame.shape[1])
+    raw = bytearray()
+    for row in range(height):
+        raw.append(0)
+        raw.extend(frame[row].tobytes())
+
+    def _chunk(tag: bytes, payload: bytes) -> bytes:
+        return struct.pack("!I", len(payload)) + tag + payload + struct.pack("!I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+
+    header = struct.pack("!IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", header)
+    png += _chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+    png += _chunk(b"IEND", b"")
+    path.write_bytes(png)
+
+
+def _scalar(rr: Any, value: float) -> Any:
+    if hasattr(rr, "Scalars"):
+        return rr.Scalars(value)
+    return rr.Scalar(value)
+
+
+def _set_time(rr: Any, recording: Any, seconds: float) -> None:
+    if hasattr(rr, "set_time_seconds"):
+        rr.set_time_seconds(TIMELINE, seconds, recording=recording)
+    else:
+        rr.set_time(TIMELINE, duration=seconds, recording=recording)
+
+
+def _send_blueprint(rr: Any, blueprint: Any, recording: Any) -> None:
+    sender = getattr(rr, "send_blueprint", None)
+    if callable(sender):
+        sender(blueprint, recording=recording)
+
+
+def _disconnect(rr: Any, recording: Any) -> None:
+    disconnect = getattr(rr, "disconnect", None)
+    if callable(disconnect):
+        try:
+            disconnect(recording=recording)
+        except Exception:
+            pass
+
+
+def _bump(counts: dict[str, int], entity: str) -> None:
+    normalized = "/" + entity.strip("/")
+    counts[normalized] = counts.get(normalized, 0) + 1
+
+
+def _maybe_path(value: Any) -> Path | None:
+    if not value:
+        return None
+    return Path(str(value))
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _import_rerun() -> tuple[Any, Any]:
+    try:
+        import rerun as rr
+        import rerun.blueprint as rrb
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch in tests
+        raise RerunUnavailableError(
+            "rerun-sdk is not installed; skipping Sim2Real Rerun visualization"
+        ) from exc
+    return rr, rrb

--- a/npa/tests/cli/test_skypilot_bootstrap.py
+++ b/npa/tests/cli/test_skypilot_bootstrap.py
@@ -161,3 +161,80 @@ def test_skypilot_bootstrap_can_install_local_tiny_package(tmp_path: Path) -> No
     assert result.reused is False
     assert result.sky_bin.is_file()
     assert '"extras": [\n    "test"\n  ]' in result.marker_path.read_text(encoding="utf-8")
+
+
+def _intercept_sky_check(monkeypatch: pytest.MonkeyPatch, captured: dict[str, object]):
+    """Capture only the `sky check` invocation; delegate other calls.
+
+    ``_run_no_raise`` is also used by ``inspect_venv`` for version/import probes,
+    so a blanket stub would make the venv look uninstalled.
+    """
+
+    original = skypilot_cli._run_no_raise
+
+    def fake_run(cmd, *, env=None):  # noqa: ANN001 - test stub
+        if cmd[-1] == "check":
+            captured["cmd"] = cmd
+            captured["env"] = env
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="checks passed", stderr=""
+            )
+        return original(cmd, env=env)
+
+    monkeypatch.setattr(skypilot_cli, "_run_no_raise", fake_run)
+
+
+def test_verify_pins_kubeconfig_from_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    kubeconfig = tmp_path / "kube.yaml"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+    _intercept_sky_check(monkeypatch, captured)
+
+    result = runner.invoke(
+        app,
+        ["skypilot", "verify", "--path", str(venv), "--kubeconfig", str(kubeconfig)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["cmd"][-1] == "check"
+    assert captured["env"]["KUBECONFIG"] == str(kubeconfig)
+
+
+def test_verify_without_kubeconfig_inherits_ambient_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    captured: dict[str, object] = {}
+    _intercept_sky_check(monkeypatch, captured)
+
+    result = runner.invoke(app, ["skypilot", "verify", "--path", str(venv)])
+
+    assert result.exit_code == 0, result.output
+    assert captured["env"] is None
+
+
+def test_verify_fails_clearly_on_missing_kubeconfig(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    missing = tmp_path / "absent" / "kube.yaml"
+
+    original = skypilot_cli._run_no_raise
+
+    def fake_run(cmd, *, env=None):  # noqa: ANN001 - test stub
+        if cmd[-1] == "check":
+            raise AssertionError("sky check must not run when kubeconfig is missing")
+        return original(cmd, env=env)
+
+    monkeypatch.setattr(skypilot_cli, "_run_no_raise", fake_run)
+
+    result = runner.invoke(
+        app,
+        ["skypilot", "verify", "--path", str(venv), "--kubeconfig", str(missing)],
+    )
+
+    assert result.exit_code == 1
+    assert "Kubeconfig not found" in result.output

--- a/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
+++ b/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
@@ -316,3 +316,54 @@ def test_down_runs_terraform_destroy(monkeypatch, tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert ["terraform", "init"] in stream_calls
     assert ["terraform", "destroy", "-auto-approve"] in stream_calls
+
+
+def test_terraform_env_refreshes_stale_token_by_default(monkeypatch) -> None:
+    # A stale ambient token must NOT shadow the freshly minted profile token.
+    monkeypatch.setenv("TF_VAR_iam_token", "stale-cloud-env-token")
+    monkeypatch.setenv("NEBIUS_IAM_TOKEN", "stale-cloud-env-token")
+    monkeypatch.delenv("NPA_REUSE_IAM_TOKEN", raising=False)
+
+    captured_env: dict[str, str] = {}
+
+    def fake_capture(args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return _completed("fresh-token\n")
+
+    monkeypatch.setattr(tf_mod, "_run_capture", fake_capture)
+
+    env = tf_mod._terraform_env("nebius")
+
+    assert env["TF_VAR_iam_token"] == "fresh-token"
+    assert env["NEBIUS_IAM_TOKEN"] == "fresh-token"
+    # The stale token is cleared before minting so it cannot leak into the mint call.
+    assert captured_env.get("TF_VAR_iam_token") in (None, "")
+    assert captured_env.get("NEBIUS_IAM_TOKEN") in (None, "")
+
+
+def test_terraform_env_reuses_token_when_opted_in(monkeypatch) -> None:
+    monkeypatch.setenv("TF_VAR_iam_token", "intentional-ci-token")
+    monkeypatch.setenv("NPA_REUSE_IAM_TOKEN", "1")
+
+    def fail_capture(args, **kwargs):
+        raise AssertionError("must not mint a new token when reuse is opted in")
+
+    monkeypatch.setattr(tf_mod, "_run_capture", fail_capture)
+
+    env = tf_mod._terraform_env("nebius")
+
+    assert env["TF_VAR_iam_token"] == "intentional-ci-token"
+
+
+def test_terraform_env_mints_when_no_token_present(monkeypatch) -> None:
+    monkeypatch.delenv("TF_VAR_iam_token", raising=False)
+    monkeypatch.delenv("NEBIUS_IAM_TOKEN", raising=False)
+    monkeypatch.setenv("NPA_REUSE_IAM_TOKEN", "1")
+
+    monkeypatch.setattr(
+        tf_mod, "_run_capture", lambda *a, **k: _completed("minted-token\n")
+    )
+
+    env = tf_mod._terraform_env("nebius")
+
+    assert env["TF_VAR_iam_token"] == "minted-token"

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -7,9 +7,13 @@ from pathlib import Path
 
 import yaml
 
+import pytest
+
 import npa.workflows.sim2real_loop as loop_module
 from npa.sdk.workbench import cosmos2, cosmos3, sim2real
 from npa.workbench.lerobot.policy_container import (
+    PolicyContainerError,
+    VlmSignalUpdateResult,
     parse_vlm_signal_batch,
     run_vlm_signal_training_step,
 )
@@ -18,6 +22,7 @@ from npa.workflows.sim2real_loop import (
     SCHEMA_RL_SIGNAL,
     SCHEMA_VLM_EVAL,
     Sim2RealLoopConfig,
+    Sim2RealLoopError,
     artifact_uris,
     build_config_from_env,
     convert_vlm_eval_to_rl_signal,
@@ -26,6 +31,7 @@ from npa.workflows.sim2real_loop import (
     generate_action_rollouts,
     run_full_loop,
     run_heldout_eval,
+    run_inner_loop,
 )
 
 
@@ -636,6 +642,324 @@ def test_raw_runbook_invokes_full_loop_and_exposes_byo_envs() -> None:
     assert "--k8s-service-account" in task["run"]
     assert "--heldout-eval-limit" in task["run"]
     assert "nebius.cloud" not in RUNBOOK.read_text(encoding="utf-8")
+
+
+def _signal_converter_command(tmp_path: Path, *, valid: bool = True) -> str:
+    script = tmp_path / "byo_signal_converter.py"
+    body = (
+        '''
+import json, os
+from pathlib import Path
+
+ev = json.loads(Path(os.environ["NPA_SIM2REAL_EVALUATION_JSON"]).read_text())
+out = Path(os.environ["NPA_SIM2REAL_OUTPUT_JSON"])
+out.parent.mkdir(parents=True, exist_ok=True)
+marker = Path(os.environ["NPA_SIM2REAL_SWAP_MARKER"])
+with marker.open("a", encoding="utf-8") as handle:
+    handle.write("signal_converter\\n")
+'''
+    )
+    if valid:
+        body += (
+            '''
+per_step = [
+    {
+        "step": int(s["step"]),
+        "reward": 0.5,
+        "advantage": 0.1,
+        "target": {"nl_correction": "byo correction", "action_delta": [0.0, 0.0, 0.0]},
+        "error_tags": s.get("error_tags", ["ok"]),
+    }
+    for s in ev["per_step"]
+]
+out.write_text(json.dumps({
+    "schema": os.environ["NPA_SIM2REAL_RL_SIGNAL_SCHEMA"],
+    "rollout_id": ev["rollout_id"],
+    "source": "byo-test",
+    "per_step": per_step,
+}))
+'''
+        )
+    else:
+        body += '\nout.write_text(json.dumps({"schema": "wrong.schema", "per_step": []}))\n'
+    script.write_text(body, encoding="utf-8")
+    return f"{sys.executable} {script}"
+
+
+def _trainer_command(tmp_path: Path, *, valid: bool = True) -> str:
+    script = tmp_path / "byo_trainer.py"
+    body = (
+        '''
+import json, os
+from pathlib import Path
+
+batch = json.loads(Path(os.environ["NPA_SIM2REAL_SIGNAL_JSON"]).read_text())
+out = Path(os.environ["NPA_SIM2REAL_OUTPUT_JSON"])
+out.parent.mkdir(parents=True, exist_ok=True)
+marker = Path(os.environ["NPA_SIM2REAL_SWAP_MARKER"])
+with marker.open("a", encoding="utf-8") as handle:
+    handle.write("trainer\\n")
+n = len(batch.get("signals", []))
+'''
+    )
+    if valid:
+        body += (
+            '''
+out.write_text(json.dumps({
+    "reward_head_after": 0.25 + 0.01 * n,
+    "policy_output_after": [0.06, 0.0, -0.03],
+    "policy_delta_l2": 0.42,
+    "loss_before": 1.0,
+    "loss_after": 0.4,
+    "backend": "byo-test",
+}))
+'''
+        )
+    else:
+        body += '\nout.write_text(json.dumps({"reward_head_after": 0.1}))\n'
+    script.write_text(body, encoding="utf-8")
+    return f"{sys.executable} {script}"
+
+
+def test_byo_signal_converter_swap_invoked_and_recorded(tmp_path: Path) -> None:
+    marker = tmp_path / "swap-marker.log"
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-signal-swap",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=(
+            f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {_component_command(tmp_path)}"
+        ),
+        byo_signal_converter=(
+            f"NPA_SIM2REAL_SWAP_MARKER={marker} {_signal_converter_command(tmp_path)}"
+        ),
+    )
+
+    evidence = run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+    assert evidence["signal_converter_source"] == "byo_command"
+    assert evidence["trainer_source"] == "reference"
+    assert evidence["iterations"][0]["signal_converter_source"] == "byo_command"
+    assert "signal_converter" in marker.read_text(encoding="utf-8")
+    sample_signal = evidence["iterations"][0]["sample_signal"]
+    assert sample_signal["schema"] == SCHEMA_RL_SIGNAL
+    assert sample_signal["source"] == "byo-test"
+    # The BYO signal must remain parseable by the downstream trainer contract.
+    parse_vlm_signal_batch(sample_signal)
+
+
+def test_byo_signal_converter_malformed_raises_no_fallback(tmp_path: Path) -> None:
+    marker = tmp_path / "swap-marker.log"
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-signal-bad",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=(
+            f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {_component_command(tmp_path)}"
+        ),
+        byo_signal_converter=(
+            f"NPA_SIM2REAL_SWAP_MARKER={marker} "
+            f"{_signal_converter_command(tmp_path, valid=False)}"
+        ),
+    )
+
+    with pytest.raises(Sim2RealLoopError, match="rl_signal"):
+        run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+
+def test_byo_trainer_command_swap_invoked_and_recorded(tmp_path: Path) -> None:
+    marker = tmp_path / "swap-marker.log"
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-trainer-swap",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=(
+            f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {_component_command(tmp_path)}"
+        ),
+        byo_trainer_command=(
+            f"NPA_SIM2REAL_SWAP_MARKER={marker} {_trainer_command(tmp_path)}"
+        ),
+    )
+
+    evidence = run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+    assert evidence["trainer_source"] == "byo_command"
+    assert evidence["signal_converter_source"] == "reference"
+    iteration = evidence["iterations"][0]
+    assert iteration["trainer_source"] == "byo_command"
+    update = iteration["update"]
+    assert update["reward_head_after"] == pytest.approx(0.26)
+    assert update["policy_output_after"] == [0.06, 0.0, -0.03]
+    assert update["policy_delta_l2"] == pytest.approx(0.42)
+    assert update["backend"] == "byo-test"
+    # The no-signal control still runs the in-process reference trainer.
+    assert iteration["no_signal_control"]["backend"] != "byo-test"
+    assert "trainer" in marker.read_text(encoding="utf-8")
+
+
+def test_byo_trainer_command_missing_fields_raises_no_fallback(tmp_path: Path) -> None:
+    marker = tmp_path / "swap-marker.log"
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-trainer-bad",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=(
+            f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {_component_command(tmp_path)}"
+        ),
+        byo_trainer_command=(
+            f"NPA_SIM2REAL_SWAP_MARKER={marker} "
+            f"{_trainer_command(tmp_path, valid=False)}"
+        ),
+    )
+
+    with pytest.raises(Sim2RealLoopError, match="policy_output_after"):
+        run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+
+def test_default_inner_loop_provenance_is_reference(tmp_path: Path) -> None:
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-default-prov",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=_component_command(tmp_path),
+    )
+
+    evidence = run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+    assert evidence["trainer_source"] == "reference"
+    assert evidence["signal_converter_source"] == "reference"
+
+
+def test_full_loop_writes_rerun_recording_by_default(tmp_path: Path) -> None:
+    command = _component_command(tmp_path)
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-rerun-default",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        outer_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        heldout_env_count=2,
+        byo_vlm_command=command,
+        byo_eval_command=command,
+    )
+
+    report = run_full_loop(config)
+
+    viz = report["visualization"]
+    assert viz["status"] == "written"
+    assert viz["source"] == "reference"
+    rrd = tmp_path / "reports" / "sim2real.rrd"
+    assert rrd.exists() and rrd.stat().st_size > 0
+    components = {c["name"]: c for c in report["components"]}
+    assert components["stage_14_rerun_viz"]["tier"] == "WORKS"
+
+
+def test_full_loop_rerun_disabled_toggle(tmp_path: Path) -> None:
+    command = _component_command(tmp_path)
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-rerun-off",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        outer_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        heldout_env_count=2,
+        byo_vlm_command=command,
+        byo_eval_command=command,
+        rerun_enabled=False,
+    )
+
+    report = run_full_loop(config)
+
+    assert report["visualization"]["status"] == "disabled"
+    assert not (tmp_path / "reports" / "sim2real.rrd").exists()
+    components = {c["name"]: c for c in report["components"]}
+    assert components["stage_14_rerun_viz"]["tier"] == "SEAM"
+
+
+def test_full_loop_rerun_warns_when_sdk_missing(monkeypatch, tmp_path: Path) -> None:
+    import npa.workflows.sim2real_viz as viz_module
+
+    def _raise(**_kwargs):
+        raise viz_module.RerunUnavailableError("rerun-sdk is not installed")
+
+    monkeypatch.setattr(viz_module, "emit_sim2real_rerun", _raise)
+    command = _component_command(tmp_path)
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-rerun-warn",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        outer_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        heldout_env_count=2,
+        byo_vlm_command=command,
+        byo_eval_command=command,
+    )
+
+    report = run_full_loop(config)
+
+    assert report["visualization"]["status"] == "skipped"
+    components = {c["name"]: c for c in report["components"]}
+    assert components["stage_14_rerun_viz"]["tier"] == "WARN"
+
+
+def test_vlm_signal_update_result_from_dict_defaults_and_required() -> None:
+    result = VlmSignalUpdateResult.from_dict(
+        {
+            "reward_head_after": 0.3,
+            "policy_output_after": [0.1, -0.2],
+            "policy_delta_l2": 0.5,
+        }
+    )
+
+    assert result.reward_head_after == 0.3
+    assert result.policy_output_after == [0.1, -0.2]
+    assert result.policy_delta_l2 == 0.5
+    # Safe defaults fill the rest.
+    assert result.policy_output_before == [0.0, 0.0]
+    assert result.backend == "byo_command"
+    assert result.status == "updated"
+    assert result.loss_integration_point == "byo_trainer_command"
+    assert result.to_dict()["policy_delta_l2"] == 0.5
+
+    for missing in ("reward_head_after", "policy_output_after", "policy_delta_l2"):
+        payload = {
+            "reward_head_after": 0.3,
+            "policy_output_after": [0.1],
+            "policy_delta_l2": 0.5,
+        }
+        del payload[missing]
+        with pytest.raises(PolicyContainerError):
+            VlmSignalUpdateResult.from_dict(payload)
+
+    with pytest.raises(PolicyContainerError):
+        VlmSignalUpdateResult.from_dict(
+            {
+                "reward_head_after": 0.3,
+                "policy_output_after": [],
+                "policy_delta_l2": 0.5,
+            }
+        )
 
 
 def test_cosmos_split_sdk_and_raw_yaml_contracts() -> None:

--- a/npa/tests/workflows/test_sim2real_signal_rca.py
+++ b/npa/tests/workflows/test_sim2real_signal_rca.py
@@ -1,0 +1,132 @@
+"""Regression tests for the sim2real genuine-signal RCA fixes.
+
+Covers the degenerate-signal root causes:
+- held-out scores collapsing to a flat ``1.0`` (no gradient),
+- cross-rollout diversity diagnostics / anti-hollow gate,
+- ``-genuine-`` image pull policy, and
+- image-digest provenance captured from the running pod.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+import npa.workflows.sim2real_loop as loop_module
+from npa.workflows.sim2real_loop import (
+    Sim2RealLoopConfig,
+    _heldout_env_score,
+    _image_pull_policy,
+    _signal_diversity_report,
+)
+
+
+def _signal(score: float, reward: float) -> dict[str, object]:
+    return {
+        "schema": loop_module.SCHEMA_RL_SIGNAL,
+        "score": score,
+        "per_step": [{"reward": reward}],
+    }
+
+
+def test_heldout_env_score_success_band_is_continuous_not_flat_one() -> None:
+    # Two successful envs with different distance/reward must NOT both be 1.0.
+    high = _heldout_env_score(1.0, 1.0, env_success=True)
+    low = _heldout_env_score(0.2, 0.0, env_success=True)
+
+    assert high == 1.0
+    assert low < high
+    assert 0.75 <= low <= 1.0
+
+
+def test_heldout_env_score_success_outranks_failure() -> None:
+    success = _heldout_env_score(0.5, 0.5, env_success=True)
+    failure = _heldout_env_score(0.5, 0.5, env_success=False)
+
+    assert success > failure
+    assert 0.0 <= failure <= 0.6
+
+
+def test_signal_diversity_report_flags_degenerate_batch() -> None:
+    degenerate = [_signal(1.0, 0.5) for _ in range(6)]
+
+    report = _signal_diversity_report(degenerate)
+
+    assert report["total_rollouts"] == 6
+    assert report["distinct_scores"] == 1
+    assert report["coherent"] is False
+    assert report["degenerate"] is True
+
+
+def test_signal_diversity_report_accepts_varied_batch() -> None:
+    varied = [_signal(0.2, -0.3), _signal(0.6, 0.1), _signal(0.9, 0.7)]
+
+    report = _signal_diversity_report(varied)
+
+    assert report["distinct_scores"] == 3
+    assert report["distinct_mean_rewards"] == 3
+    assert report["coherent"] is True
+    assert report["degenerate"] is False
+
+
+@pytest.mark.parametrize(
+    ("image", "expected"),
+    [
+        ("npa-cosmos3-reason:3.0.1-genuine-sm120", "Always"),
+        ("npa-sim2real-eval:0.1.1-genuine-sm120", "Always"),
+        ("npa-sim2real-eval:0.1.1", "IfNotPresent"),
+        ("registry.example/team/npa-sim2real-eval:0.1.1", "IfNotPresent"),
+        ("npa-sim2real-eval@sha256:" + "a" * 64, "IfNotPresent"),
+    ],
+)
+def test_image_pull_policy(image: str, expected: str) -> None:
+    assert _image_pull_policy(image) == expected
+
+
+def test_image_pull_policy_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NPA_SIM2REAL_IMAGE_PULL_POLICY", "Never")
+    assert _image_pull_policy("npa-cosmos3-reason:3.0.1-genuine-sm120") == "Never"
+
+
+def test_component_pod_info_captures_image_digests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    digest = "registry.example/npa-cosmos3-reason@sha256:" + "b" * 64
+    pod_payload = {
+        "items": [
+            {
+                "metadata": {"name": "pod-1"},
+                "spec": {"nodeName": "node-1", "containers": [{"resources": {}}]},
+                "status": {
+                    "phase": "Succeeded",
+                    "containerStatuses": [
+                        {
+                            "name": "component",
+                            "ready": False,
+                            "restartCount": 0,
+                            "image": "npa-cosmos3-reason:3.0.1-genuine-sm120",
+                            "imageID": digest,
+                            "state": {"terminated": {"exitCode": 0}},
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+    def fake_kubectl(config, args, **kwargs):  # noqa: ANN001 - test stub
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=json.dumps(pod_payload), stderr=""
+        )
+
+    monkeypatch.setattr(loop_module, "_kubectl", fake_kubectl)
+    config = Sim2RealLoopConfig(run_id="rca-test")
+
+    info = loop_module._component_pod_info(
+        config, namespace="default", job_name="job-1"
+    )
+
+    assert info["image_digests"] == [digest]
+    assert info["container_statuses"][0]["image_id"] == digest

--- a/npa/tests/workflows/test_sim2real_viz.py
+++ b/npa/tests/workflows/test_sim2real_viz.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import npa.workflows.sim2real_viz as viz_module
+from npa.workflows.sim2real_loop import generate_action_rollouts
+from npa.workflows.sim2real_viz import (
+    RerunUnavailableError,
+    Sim2RealVizError,
+    emit_sim2real_rerun,
+)
+
+
+class _FakeRecording:
+    pass
+
+
+class _FakeRerun:
+    """In-memory Rerun sink that records every logged entity for assertions."""
+
+    def __init__(self) -> None:
+        self.logged: list[tuple[str, str]] = []
+        self.times: list[float] = []
+        self.saved_path: Path | None = None
+        self.disconnected = False
+
+    # Archetype factories ---------------------------------------------------
+    def Scalars(self, value: float) -> dict[str, Any]:
+        return {"kind": "scalar", "value": float(value)}
+
+    def Image(self, array: Any) -> dict[str, Any]:
+        return {"kind": "image", "shape": getattr(array, "shape", None)}
+
+    def TextDocument(self, text: str, media_type: str = "") -> dict[str, Any]:
+        return {"kind": "text", "text": text}
+
+    # Recording lifecycle ---------------------------------------------------
+    def RecordingStream(self, application_id: str) -> _FakeRecording:
+        self.application_id = application_id
+        return _FakeRecording()
+
+    def save(self, path: Any, default_blueprint: Any = None, recording: Any = None) -> None:
+        self.saved_path = Path(path)
+        Path(path).write_bytes(b"FAKE_RRD_CONTENT")
+
+    def send_blueprint(self, blueprint: Any, recording: Any = None) -> None:
+        return None
+
+    def set_time_seconds(self, timeline: str, seconds: float, recording: Any = None) -> None:
+        self.times.append(float(seconds))
+
+    def log(self, entity_path: str, archetype: dict[str, Any], recording: Any = None) -> None:
+        self.logged.append((entity_path, archetype.get("kind", "?")))
+
+    def disconnect(self, recording: Any = None) -> None:
+        self.disconnected = True
+
+
+def _build_run_tree(tmp_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    actions_dir = tmp_path / "actions" / "train" / "outer-01" / "iter-01"
+    rollouts = generate_action_rollouts(
+        actions_dir, count=2, steps_per_rollout=3, seed=11, quality=0.4
+    )
+    eval_dir = tmp_path / "vlm_eval" / "train" / "outer-01" / "iter-01"
+    signal_dir = tmp_path / "training_signal" / "train" / "outer-01" / "iter-01"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    signal_dir.mkdir(parents=True, exist_ok=True)
+    for rollout in rollouts:
+        rollout_id = rollout.name
+        per_step = [
+            {
+                "step": step,
+                "critique_text": f"{rollout_id} step {step} drifted",
+                "error_tags": ["minor_alignment"],
+            }
+            for step in range(3)
+        ]
+        (eval_dir / f"{rollout_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema": "npa.sim2real.vlm_eval.v1",
+                    "rollout_id": rollout_id,
+                    "success": False,
+                    "score": 0.6,
+                    "per_step": per_step,
+                    "summary": "summary",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (signal_dir / f"{rollout_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema": "npa.sim2real.rl_signal.v1",
+                    "rollout_id": rollout_id,
+                    "per_step": [
+                        {"step": step, "reward": 0.1 * step, "advantage": 0.05 * step}
+                        for step in range(3)
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+    inner_evidence = {
+        "schema": "npa.sim2real.inner_loop_evidence.v1",
+        "reward_trend": [0.2, 0.45],
+        "iterations": [
+            {
+                "iteration": 1,
+                "actions_dir": str(actions_dir),
+                "vlm_eval_dir": str(eval_dir),
+                "signal_dir": str(signal_dir),
+            }
+        ],
+    }
+    heldout_report = {
+        "schema": "npa.sim2real.heldout_eval.v1",
+        "per_env": [
+            {"env_id": "heldout-0000", "score": 0.7, "success": True},
+            {"env_id": "heldout-0001", "score": 0.5, "success": False},
+        ],
+    }
+    return inner_evidence, heldout_report
+
+
+def test_emit_logs_frames_critiques_signal_and_heldout(monkeypatch, tmp_path: Path) -> None:
+    inner_evidence, heldout_report = _build_run_tree(tmp_path)
+    fake = _FakeRerun()
+    monkeypatch.setattr(viz_module, "_import_rerun", lambda: (fake, MagicMock()))
+
+    rrd_path = tmp_path / "reports" / "sim2real.rrd"
+    result = emit_sim2real_rerun(
+        local_dir=tmp_path,
+        inner_evidence=inner_evidence,
+        heldout_report=heldout_report,
+        output_rrd=rrd_path,
+    )
+
+    assert result.status == "written"
+    assert rrd_path.exists() and rrd_path.stat().st_size > 0
+    assert result.rollout_count == 2
+    assert result.frame_count == 6
+    assert result.heldout_env_count == 2
+    assert fake.disconnected is True
+
+    entities = [entity for entity, _kind in fake.logged]
+    kinds = {entity: kind for entity, kind in fake.logged}
+    # Rollout camera frames as image streams.
+    assert any(e.endswith("/camera") and kinds[e] == "image" for e in entities)
+    # VLM critique overlays.
+    assert any(e.endswith("/critique") and kinds[e] == "text" for e in entities)
+    # RL signal scalar timeseries.
+    assert "signal/reward" in entities
+    assert "signal/advantage" in entities
+    assert "signal/reward_trend" in entities
+    # Held-out scores.
+    assert "heldout/scores" in entities
+    assert any(e.startswith("heldout/per_env/") for e in entities)
+
+    counts = result.entity_counts
+    assert counts["/signal/reward"] == 6
+    assert counts["/heldout/scores"] == 2
+
+
+def test_emit_raises_when_rerun_unavailable(monkeypatch, tmp_path: Path) -> None:
+    inner_evidence, heldout_report = _build_run_tree(tmp_path)
+
+    def _raise() -> Any:
+        raise RerunUnavailableError("rerun-sdk is not installed")
+
+    monkeypatch.setattr(viz_module, "_import_rerun", _raise)
+
+    with pytest.raises(RerunUnavailableError):
+        emit_sim2real_rerun(
+            local_dir=tmp_path,
+            inner_evidence=inner_evidence,
+            heldout_report=heldout_report,
+            output_rrd=tmp_path / "reports" / "sim2real.rrd",
+        )
+
+
+def test_emit_raises_when_no_content(monkeypatch, tmp_path: Path) -> None:
+    fake = _FakeRerun()
+    monkeypatch.setattr(viz_module, "_import_rerun", lambda: (fake, MagicMock()))
+
+    with pytest.raises(Sim2RealVizError):
+        emit_sim2real_rerun(
+            local_dir=tmp_path,
+            inner_evidence={"iterations": [], "reward_trend": []},
+            heldout_report={"per_env": []},
+            output_rrd=tmp_path / "reports" / "sim2real.rrd",
+        )

--- a/npa/workflows/workbench/sim2real/README.md
+++ b/npa/workflows/workbench/sim2real/README.md
@@ -90,6 +90,7 @@ eval/heldout/
 outer_loop/decision.json
 stage_13_retrigger/retrigger.json
 reports/sim2real-report.json
+reports/sim2real.rrd
 ```
 
 ## Prerequisites
@@ -156,6 +157,37 @@ config field. Set what you need; the rest fall back to reference defaults.
 | Rollout count | `--rollout-count` | `rollout_count=` | `ROLLOUT_COUNT` |
 | Steps per rollout | `--steps-per-rollout` | `steps_per_rollout=` | `STEPS_PER_ROLLOUT` |
 | Held-out env count | `--heldout-env-count` | `heldout_env_count=` | `HELDOUT_ENV_COUNT` |
+| VLM command swap | `--byo-vlm-command` | `byo_vlm_command=` | `BYO_VLM_COMMAND` |
+| Signal-converter swap | `--byo-signal-converter` | `byo_signal_converter=` | `BYO_SIGNAL_CONVERTER` |
+| Trainer command swap | `--byo-trainer-command` | `byo_trainer_command=` | `BYO_TRAINER_COMMAND` |
+| Held-out eval swap | `--byo-eval-command` | `byo_eval_command=` | `BYO_EVAL_COMMAND` |
+| Rerun viz toggle | `--rerun` / `--no-rerun` | `rerun_enabled=` | `NPA_SIM2REAL_RERUN` |
+| Rerun command swap | `--byo-rerun-command` | `byo_rerun_command=` | `BYO_RERUN_COMMAND` |
+
+### Command-Swap I/O Contracts
+
+Each `byo_*_command` is a shell command the loop runs at the matching seam. They
+all share the same convention: inputs arrive as JSON file paths in environment
+variables, and the command writes its result JSON to `NPA_SIM2REAL_OUTPUT_JSON`.
+A command that exits non-zero, writes nothing, or emits a non-conforming /empty
+document fails the run loudly — the loop never silently falls back to the
+reference implementation. Each run records which path executed
+(`trainer_source` / `signal_converter_source` = `byo_command` | `reference`) in
+the inner-loop evidence so a run can prove the customer hook actually ran.
+
+| Seam | Reads | Writes (`NPA_SIM2REAL_OUTPUT_JSON`) |
+| --- | --- | --- |
+| `byo_vlm_command` | `NPA_SIM2REAL_ROLLOUT_DIR`, `NPA_SIM2REAL_ROLLOUT_MANIFEST` | `npa.sim2real.vlm_eval.v1` (score + per_step critiques) |
+| `byo_signal_converter` | `NPA_SIM2REAL_EVALUATION_JSON` | `npa.sim2real.rl_signal.v1` (non-empty `per_step` of `{step, reward, advantage?, target?, error_tags?}`) |
+| `byo_trainer_command` | `NPA_SIM2REAL_SIGNAL_JSON` (+ `NPA_SIM2REAL_INITIAL_REWARD_HEAD`, `NPA_SIM2REAL_INITIAL_ACTION_BIAS`, `NPA_SIM2REAL_LEARNING_RATE`, `NPA_SIM2REAL_SIGNAL_LOSS_WEIGHT`) | trainer update with at least `reward_head_after`, `policy_output_after` (list), `policy_delta_l2` (optional `loss_before`/`loss_after`) |
+| `byo_eval_command` | `NPA_SIM2REAL_HELDOUT_ENVS_DIR`, `NPA_SIM2REAL_INNER_EVIDENCE_JSON` | `npa.sim2real.heldout_eval.v1` (non-empty `per_env`) |
+| `byo_rerun_command` | `NPA_SIM2REAL_RUN_DIR`, `NPA_SIM2REAL_REPORT_JSON` | non-empty `.rrd` at `NPA_SIM2REAL_OUTPUT_RRD` |
+
+When a `byo_trainer_command` is set, the per-iteration no-signal **control** still
+runs the in-process reference trainer. This keeps the policy-delta attribution
+honest: the BYO trainer produces the signal-driven update, and the reference
+control provides the shared-initial-state, no-signal baseline that the delta is
+measured against.
 
 ## Run All Three Tiers
 
@@ -262,6 +294,32 @@ npa workbench sim2real inner-loop \
     `stage_12_external_validation/external_stub.json`.
 13. Retrigger: writes `stage_13_retrigger/retrigger.json`, targeting Stage 1
     when a new real-world LeRobot dataset lands in the trigger path.
+14. Rerun visualization: writes `reports/sim2real.rrd` (a single Rerun recording)
+    from the completed run's artifacts. Default on (`NPA_SIM2REAL_RERUN=1` /
+    `--rerun`); set `NPA_SIM2REAL_RERUN=0` / `--no-rerun` to skip. Degrades to a
+    WARN (not a hard failure) when `rerun-sdk` is not installed locally, but
+    always produces the `.rrd` when it is available.
+
+### Rerun Visualization
+
+The `.rrd` reuses the repo's existing Rerun capability (the same `rerun-sdk`
+recording API the LeRobot/GR00T adapters build on) and logs, on a shared
+`frame_time` timeline:
+
+- `rollouts/iter_NN/<rollout_id>/camera` — rollout camera frames as image streams.
+- `rollouts/iter_NN/<rollout_id>/critique` — per-step VLM critique text + error
+  tags as a text document overlay.
+- `rollouts/iter_NN/<rollout_id>/score` — the VLM success score.
+- `signal/reward` and `signal/advantage` — the per-step VLM->RL signal as scalar
+  timeseries, plus `signal/reward_trend` across iterations.
+- `heldout/scores` and `heldout/per_env/<env_id>` — held-out per-env scores as a
+  scalar/bar view.
+
+Open it with `rerun reports/sim2real.rrd`, or load it headlessly with
+`rerun.recording.load_recording(...)` to inspect entity counts. Set
+`NPA_SIM2REAL_RERUN_MP4=1` to also emit best-effort per-rollout `rollout.mp4`
+files (skipped when `ffmpeg` is not on PATH). When `--upload-artifacts` is set,
+the `.rrd` uploads with the rest of the run tree.
 
 ## Loops
 
@@ -341,6 +399,7 @@ options:
 - `byo_signal_converter`
 - `trainer_image`, `byo_trainer_command`
 - `eval_image`, `byo_eval_command`
+- `rerun_enabled`, `byo_rerun_command`
 - `threshold`
 - `inner_iterations`, `outer_iterations`, `loop_of_loops_iterations`
 - `rollout_count`, `steps_per_rollout`, `heldout_env_count`

--- a/npa/workflows/workbench/sim2real/runbook.yaml
+++ b/npa/workflows/workbench/sim2real/runbook.yaml
@@ -62,10 +62,31 @@ envs:
   SIGNAL_LOSS_WEIGHT: "1.0"
   LEARNING_RATE: "0.05"
   NO_GUARDRAILS: "0"
+  # BYO_SIGNAL_CONVERTER: shell command run once per rollout instead of the
+  # in-process critique->reward converter. Contract: it reads the VLM evaluation
+  # JSON from $NPA_SIM2REAL_EVALUATION_JSON and writes an
+  # npa.sim2real.rl_signal.v1 document to $NPA_SIM2REAL_OUTPUT_JSON (object with a
+  # non-empty per_step list of {step, reward, advantage?, target?, error_tags?}).
+  # A failing/empty/non-conforming command fails the run; it never falls back.
   BYO_SIGNAL_CONVERTER: ""
+  # BYO_TRAINER_COMMAND: shell command run once per inner iteration instead of the
+  # in-process reference trainer. Contract: it reads the parsed signal batch from
+  # $NPA_SIM2REAL_SIGNAL_JSON and writes an update JSON to
+  # $NPA_SIM2REAL_OUTPUT_JSON containing at least reward_head_after,
+  # policy_output_after (list), and policy_delta_l2 (optional loss_before/after).
+  # The no-signal control always uses the in-process reference trainer so policy-
+  # delta attribution stays honest. A failing/empty/non-conforming command fails
+  # the run; it never falls back.
   BYO_TRAINER_COMMAND: ""
   BYO_VLM_COMMAND: ""
   BYO_EVAL_COMMAND: ""
+  # BYO_RERUN_COMMAND: optional shell command run instead of the in-process Rerun
+  # emitter. Contract: reads the run dir from $NPA_SIM2REAL_RUN_DIR and report from
+  # $NPA_SIM2REAL_REPORT_JSON, writes a non-empty .rrd to $NPA_SIM2REAL_OUTPUT_RRD.
+  BYO_RERUN_COMMAND: ""
+  # NPA_SIM2REAL_RERUN: "1" (default) emits reports/sim2real.rrd after the loop;
+  # "0" disables it. Degrades to a WARN if rerun-sdk is not installed locally.
+  NPA_SIM2REAL_RERUN: "1"
   NPA_SIM2REAL_K8S_NAMESPACE: "default"
   NPA_SIM2REAL_K8S_SERVICE_ACCOUNT: "agent-sa"
   NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS: "agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry"
@@ -145,6 +166,7 @@ run: |
     --byo-trainer-command "${BYO_TRAINER_COMMAND:-}" \
     --byo-vlm-command "${BYO_VLM_COMMAND:-}" \
     --byo-eval-command "${BYO_EVAL_COMMAND:-}" \
+    --byo-rerun-command "${BYO_RERUN_COMMAND:-}" \
     --k8s-namespace "${NPA_SIM2REAL_K8S_NAMESPACE:-default}" \
     --k8s-service-account "${NPA_SIM2REAL_K8S_SERVICE_ACCOUNT:-agent-sa}" \
     --k8s-image-pull-secrets "${NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS:-agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry}" \


### PR DESCRIPTION
> **Stacks on #84** (`fix/sim2real-genuine-signal-and-rbac`). This branch was cut from #84's tip; review/merge #84 first. The diff against `main` will shrink to just this branch's changes once #84 lands.

## Summary

Two related features for the sim2real VLM->RL loop.

### Feature 1 — functional trainer + signal-converter YAML swaps

`byo_trainer_command` and `byo_signal_converter` were declared in `Sim2RealLoopConfig`, loaded, and echoed into `byo_seams()` but never executed. They are now wired to the same `_run_component_command` + `NPA_SIM2REAL_OUTPUT_JSON` contract as the already-functional VLM/eval seams.

**I/O contract (documented in README + runbook):**

| Seam | Reads | Writes (`NPA_SIM2REAL_OUTPUT_JSON`) |
| --- | --- | --- |
| `byo_signal_converter` | `NPA_SIM2REAL_EVALUATION_JSON` | `npa.sim2real.rl_signal.v1` (validated + re-parsed) |
| `byo_trainer_command` | `NPA_SIM2REAL_SIGNAL_JSON` (+ initial reward-head/action-bias, LR, loss weight) | update with `reward_head_after`, `policy_output_after` (list), `policy_delta_l2` (optional `loss_before`/`loss_after`) |

- New `VlmSignalUpdateResult.from_dict(...)` parses the BYO trainer JSON, requiring the three fields above and filling safe defaults for the rest.
- **Control / attribution:** when a BYO trainer is set, the per-iteration no-signal **control** still runs the in-process reference trainer, so the policy-delta-vs-control baseline stays honest (BYO produces the signal-driven update; reference control is the shared-initial-state, no-signal baseline).
- **Anti-stub provenance:** each run records `trainer_source` / `signal_converter_source` (`byo_command` | `reference`) in the inner-loop evidence.
- **Fail loudly:** a failing, empty, or non-conforming BYO output raises `Sim2RealLoopError` — never a silent fallback. Default (no BYO) numerics are byte-for-byte unchanged.

### Feature 2 — Rerun visualization integrated into the loop

New `npa.workflows.sim2real_viz` emitter reuses the repo's existing `rerun-sdk` recording API (the same one the LeRobot/GR00T adapters build on) and writes `reports/sim2real.rrd` after the loop, logging on a shared `frame_time` timeline:

- `rollouts/iter_NN/<rollout_id>/camera` — rollout camera frames as image streams
- `rollouts/iter_NN/<rollout_id>/critique` — per-step VLM critique text + error tags
- `rollouts/iter_NN/<rollout_id>/score` — VLM success score
- `signal/reward`, `signal/advantage`, `signal/reward_trend` — VLM->RL signal scalar timeseries
- `heldout/scores`, `heldout/per_env/<env_id>` — held-out per-env scores

Default on (`NPA_SIM2REAL_RERUN=1` / `--rerun`), with a `byo_rerun_command` seam consistent with the others. Degrades to a WARN (not hard-fail) when `rerun-sdk` is not installed, but always produces the `.rrd` when it is available. The `.rrd` uploads with the rest of the run tree under `--upload-artifacts`. Optional best-effort per-rollout MP4s via `NPA_SIM2REAL_RERUN_MP4=1`.

## Files changed

- `npa/src/npa/workbench/lerobot/policy_container.py` — `VlmSignalUpdateResult.from_dict`
- `npa/src/npa/workflows/sim2real_loop.py` — swap wiring, provenance, viz stage (`stage_14_rerun_viz`), config fields, CLI flags, `byo_seams`
- `npa/src/npa/workflows/sim2real_viz.py` — new Rerun emitter
- `npa/workflows/workbench/sim2real/{runbook.yaml,README.md}` — inline I/O contracts + stage docs
- `npa/tests/workflows/{test_sim2real_loop.py,test_sim2real_viz.py}` — swap, `from_dict`, and emitter tests

## Test plan

- [x] `ruff check` clean on all changed files
- [x] `pytest tests/workflows` green (104 passed)
- [x] Full suite green (1555 passed, 39 skipped, 1 xpassed, 0 failures)
- [x] Emitter test mocks `rerun` with a fake recording sink; asserts frames/critiques/signal/heldout logged + `.rrd` written; asserts graceful WARN when rerun import fails
- [x] Swap tests: BYO invoked + provenance + schema validation; malformed/missing-field -> raises (no fallback); default path unchanged

## GPU validation (real cluster, detached, anti-hollow, signal-diversity gate on)

Direct-Kubernetes, `NPA_SIM2REAL_REQUIRE_SIGNAL_DIVERSITY=1`, preflight `workbench health sim2real` PASS (S3, registry, tokens, 16 schedulable GPUs, 20 BYO seams map 1:1).

- **Default run** (`rc=0`): `trainer_source=reference`, `signal_converter_source=reference`; genuine signal (distinct_scores=3, distinct_mean_rewards=6, non-degenerate; policy_delta_vs_no_signal_control `[0.0042, 0.0030] > 0`); `reports/sim2real.rrd` written (~180 KB), loaded headlessly = 30 dynamic entities (camera 24, critique 24, signal/reward 24, reward_trend 2, heldout/scores 8); uploaded to the run's own prefix.
- **BYO trainer swap** (`rc=0`): trivial hook reading `NPA_SIM2REAL_SIGNAL_JSON` -> valid update JSON; evidence shows `trainer_source=byo_command` (both iterations), `update.backend=byo-command-test`, `control.backend=python` (honest baseline); genuine non-degenerate signal; `.rrd` written (~179 KB).
- Pod-log snippets confirm genuine components: VLM eval pod `Succeeded` loading real Cosmos-Reason checkpoint shards; held-out eval pod `Succeeded` running real Genesis simulation (~1.2k FPS, 8 envs).

**Honesty note:** the first default-case attempt failed once on a transient apiserver `jobs.batch ... NotFound` during a sibling VLM-eval `kubectl wait` (pre-existing K8s plumbing from #84, unrelated to these changes); a clean standalone re-run succeeded. No infra identifiers are present in the code, docs, or this PR.

Made with [Cursor](https://cursor.com)