### PR TITLE
Auto-serve models after cosmos/groot deploy

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -84,11 +84,23 @@ work lives).
 #### [M] Cosmos requires manual serve after deploy/restart with no auto-load
 
 - **Surfaced by**: 2026-05-09 demo runbook dry-run.
-- **Status**: Still active.
+- **Status**: Fixed.
 - **Current issue**: `cosmos status` reports unloaded after deploy or service
   restart until the operator manually runs `cosmos serve`.
 - **Next step**: Add an explicit deploy auto-serve option or make the post-deploy
   `serve` requirement prominent in CLI help and standard runbooks.
+
+#### [M] Cosmos deploy install failure dumps the full install script and traceback
+
+- **Surfaced by**: 2026-06-10 single-H200 Cosmos deploy (gated model download 403).
+- **Status**: Still active.
+- **Current issue**: When the remote install step fails (e.g. a gated Hugging Face
+  model download), `cosmos deploy` surfaces the entire multi-hundred-line install
+  bash command plus the raw remote Python traceback as the error, burying the
+  actual cause and remediation.
+- **Next step**: Catch install/SSH failures and report a concise, actionable error
+  (failing step plus remote stderr tail), keeping the full command and traceback
+  behind a verbose/debug flag.
 
 #### [M] Add standalone LeRobot library validation test
 
@@ -145,6 +157,19 @@ work lives).
   root can fail with `FileNotFoundError` for deploy template paths.
 - **Next step**: Resolve Terraform template fixture paths relative to the package
   root or test file instead of the process current working directory.
+
+#### [L] VM `deploy --destroy` runs Terraform destroy with no confirmation
+
+- **Surfaced by**: 2026-06-11 Cosmos VM teardown.
+- **Status**: Still active.
+- **Current issue**: For Terraform-managed (`--runtime vm`) aliases,
+  `cosmos deploy --destroy` proceeds straight to `terraform destroy` with no
+  confirmation prompt; `--yes` only gates `--replace`, so a mistyped `-n` alias
+  is destroyed immediately. BYOVM destroy is non-destructive (it only
+  unregisters the alias). The same unguarded VM-destroy path likely exists in the
+  other workbench deploy commands (groot, fiftyone, isaac-lab).
+- **Next step**: Prompt before VM destroy unless `--yes` (or `--dry-run`) is
+  passed, and apply the same guard consistently across the workbench tools.
 
 ## Resolved (recent)
 

--- a/docs/demo/8gpu-h200.md
+++ b/docs/demo/8gpu-h200.md
@@ -170,7 +170,8 @@ npa workbench groot -p "$PROJECT_ALIAS" -n "$GROOT_ALIAS" deploy \
   --gpu-preset "$H200_GPU_PRESET" \
   --gpu-count "$H200_GPU_COUNT" \
   --server-port "$GROOT_PORT" \
-  --model "$GROOT_MODEL"
+  --model "$GROOT_MODEL" \
+  --robot-embodiment "$GROOT_EMBODIMENT"
 
 npa workbench fiftyone -p "$PROJECT_ALIAS" -n "$FIFTYONE_ALIAS" deploy \
   --runtime byovm \
@@ -182,6 +183,11 @@ npa workbench fiftyone -p "$PROJECT_ALIAS" -n "$FIFTYONE_ALIAS" deploy \
   --region "$REGION" \
   --gpu-count "$H200_GPU_COUNT"
 ```
+
+> **Models load automatically:** `cosmos deploy` and `groot deploy` load the model
+> by default, so after each deploy `... status` reports `app_status: healthy`. Pass
+> `--no-auto-serve` to skip this, then run the tool's `serve` command when you want
+> the model loaded.
 
 Deploy or register Isaac Lab on the L40S host:
 

--- a/npa/src/npa/cli/cosmos/__init__.py
+++ b/npa/src/npa/cli/cosmos/__init__.py
@@ -1290,6 +1290,23 @@ sudo systemctl --no-pager status {COSMOS_SERVICE} || true
     return _remote_bash(script)
 
 
+def _build_load_command(port: int, model: str) -> str:
+    body = json.dumps({"model": model})
+    script = f"""\
+set -euo pipefail
+for _ in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:{port}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+curl -fsS -X POST "http://127.0.0.1:{port}/serve" \\
+  -H 'content-type: application/json' \\
+  -d {shlex.quote(body)}
+"""
+    return _remote_bash(script)
+
+
 def _deploy_step_count(skip_infra: bool, skip_app: bool, destroy: bool) -> int:
     if destroy:
         return 2
@@ -2044,6 +2061,15 @@ def deploy_cmd(
         "--verify-env/--no-verify-env",
         help="Audit deployed shared credentials after app deploy.",
     ),
+    auto_serve: bool = typer.Option(
+        True,
+        "--auto-serve/--no-auto-serve",
+        help=(
+            "After a healthy deploy, load the model so the server is ready "
+            "(status: healthy) without a manual serve. Use --no-auto-serve to "
+            "leave the model cold."
+        ),
+    ),
     model: str = typer.Option(
         DEFAULT_MODEL,
         "--model",
@@ -2765,6 +2791,22 @@ def deploy_cmd(
                 fail_app(f"Server not healthy at {endpoint}/health.")
                 return
 
+            if auto_serve:
+                console.print(
+                    f"    Loading model {model} so the server is ready (auto-serve)..."
+                )
+                try:
+                    ssh.run_or_raise(
+                        _build_load_command(server_port, model), stream=True
+                    )
+                    console.print("    Model loaded; server is ready.")
+                except SSHError as exc:
+                    console.print(
+                        "    [yellow]Warning:[/yellow] auto-serve could not load the "
+                        f"model: {exc}\n    The server is deployed; run `cosmos serve` "
+                        "to load it."
+                    )
+
         step += 1
         console.print(f"  [{step}/{total_steps}] Writing deployment manifest...")
         if not dry_run:
@@ -2966,7 +3008,13 @@ def serve_cmd(
         OutputFormat.text, "--output", help="Output format."
     ),
 ) -> None:
-    """Start or pre-warm the saved Cosmos model server."""
+    """Load (pre-warm) the saved Cosmos model so the server is ready to serve.
+
+    Deploy auto-serves by default, so you normally only need this after a service
+    restart (the server comes back up with the model unloaded) or after deploying
+    with --no-auto-serve. Run it whenever `cosmos status` reports `degraded` /
+    model not loaded.
+    """
     _ensure_basic_backend(backend)
     cfg = _get_config()
 
@@ -3016,6 +3064,7 @@ def serve_cmd(
             _, out, err = ssh.run_or_raise(
                 _build_serve_command(model, port, no_guardrails=no_guardrails)
             )
+            ssh.run_or_raise(_build_load_command(port, model))
         except SSHError as exc:
             _fail(f"SSH error: {exc}")
             return

--- a/npa/src/npa/cli/groot/__init__.py
+++ b/npa/src/npa/cli/groot/__init__.py
@@ -2366,10 +2366,24 @@ def deploy_cmd(
         "--verify-env/--no-verify-env",
         help="Audit deployed shared credentials after app deploy.",
     ),
+    auto_serve: bool = typer.Option(
+        True,
+        "--auto-serve/--no-auto-serve",
+        help=(
+            "After a healthy deploy, load the model so the server is ready "
+            "(status: healthy) without a manual serve. Use --no-auto-serve to "
+            "leave the model cold."
+        ),
+    ),
     model: str = typer.Option(
         DEFAULT_MODEL,
         "--model",
         help="Hugging Face GR00T model ID to validate and record.",
+    ),
+    robot_embodiment: str = typer.Option(
+        DEFAULT_EMBODIMENT_TAG,
+        "--robot-embodiment",
+        help="Embodiment tag to auto-serve (e.g. REAL_G1, UNITREE_G1, LIBERO_PANDA).",
     ),
     server_port: int = typer.Option(
         DEFAULT_SERVER_PORT, "--server-port", help="GR00T HTTP server port on the VM."
@@ -3063,6 +3077,34 @@ def deploy_cmd(
             else:
                 fail_app(f"Server not healthy at {endpoint}/health.")
                 return
+
+            if auto_serve:
+                serve_tag = _normalize_embodiment_tag(robot_embodiment)
+                if serve_tag == DEFAULT_EMBODIMENT_TAG:
+                    console.print(
+                        "    [yellow]Skipping auto-serve:[/yellow] pass "
+                        "--robot-embodiment (e.g. REAL_G1) to load the model, or run "
+                        "`groot serve --robot-embodiment <tag>` later."
+                    )
+                else:
+                    console.print(
+                        f"    Loading model {model} with embodiment {serve_tag} so the "
+                        "server is ready (auto-serve)..."
+                    )
+                    try:
+                        ssh.run_or_raise(
+                            _build_container_serve_command(
+                                model, serve_tag, server_port
+                            ),
+                            stream=True,
+                        )
+                        console.print("    Model loaded; server is ready.")
+                    except SSHError as exc:
+                        console.print(
+                            "    [yellow]Warning:[/yellow] auto-serve could not load "
+                            f"the model: {exc}\n    The server is deployed; run `groot "
+                            "serve` to load it."
+                        )
 
         step += 1
         console.print(f"  [{step}/{total_steps}] Writing deployment manifest...")

--- a/npa/src/npa/guardrails/confidentiality.py
+++ b/npa/src/npa/guardrails/confidentiality.py
@@ -6,6 +6,7 @@ The scanner intentionally reports only locations, never matched text.
 from __future__ import annotations
 
 import argparse
+import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 import os
@@ -139,6 +140,40 @@ def scan_git_diff(repo_root: Path, diff_range: str, denylist: re.Pattern[str]) -
     return scan_text(result.stdout, denylist, source=f"diff:{diff_range}")
 
 
+
+
+def should_skip_unconfigured_fork_pull_request(
+    pattern_env: str,
+    *,
+    environ: Mapping[str, str] = os.environ,
+) -> bool:
+    """Return True when a fork PR workflow cannot access repository secrets."""
+
+    if environ.get(pattern_env, "").strip():
+        return False
+    if environ.get("GITHUB_EVENT_NAME") != "pull_request":
+        return False
+
+    event_path = environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return False
+
+    try:
+        event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    except OSError:
+        return False
+
+    pull_request = event.get("pull_request") or {}
+    head_repo = (pull_request.get("head") or {}).get("repo") or {}
+    head_full_name = head_repo.get("full_name")
+    base_full_name = (event.get("repository") or {}).get("full_name") or environ.get(
+        "GITHUB_REPOSITORY"
+    )
+    if not head_full_name or not base_full_name:
+        return False
+    return head_full_name != base_full_name
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
@@ -164,6 +199,13 @@ def main(argv: list[str] | None = None) -> int:
         help="Match denylist regexes case-insensitively.",
     )
     args = parser.parse_args(argv)
+
+    if should_skip_unconfigured_fork_pull_request(args.pattern_env):
+        print(
+            "confidentiality scan skipped on fork pull request "
+            f"({args.pattern_env} secrets are unavailable to fork workflows)"
+        )
+        return 0
 
     try:
         source_pattern = load_denylist_pattern(

--- a/npa/src/npa/guardrails/confidentiality.py
+++ b/npa/src/npa/guardrails/confidentiality.py
@@ -200,7 +200,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if should_skip_unconfigured_fork_pull_request(args.pattern_env):
+    if (args.tree or args.diff_range) and should_skip_unconfigured_fork_pull_request(
+        args.pattern_env
+    ):
         print(
             "confidentiality scan skipped on fork pull request "
             f"({args.pattern_env} secrets are unavailable to fork workflows)"

--- a/npa/tests/cli/test_cosmos_cli.py
+++ b/npa/tests/cli/test_cosmos_cli.py
@@ -1581,7 +1581,8 @@ def test_cosmos_serve_builds_remote_restart_command(mocker) -> None:
     )
 
     assert result.exit_code == 0
-    cmd = ssh.run_or_raise.call_args.args[0]
+    # first SSH call restarts the service with the refreshed server.py/env
+    cmd = ssh.run_or_raise.call_args_list[0].args[0]
     assert "COSMOS_MODEL_ID=nvidia/Cosmos-Test" in cmd
     assert "COSMOS_SERVER_PORT=9090" in cmd
     assert "COSMOS_DISABLE_SAFETY=0" in cmd
@@ -1591,6 +1592,10 @@ def test_cosmos_serve_builds_remote_restart_command(mocker) -> None:
     assert "HF_TOKEN=%s" in cmd
     assert "sudo tee -a /etc/npa-cosmos-server/env >/dev/null" in cmd
     assert "sudo systemctl restart npa-cosmos-server" in cmd
+    # second SSH call loads the model so `serve` actually pre-warms it on vm runtime
+    load_cmd = ssh.run_or_raise.call_args_list[1].args[0]
+    assert "/serve" in load_cmd
+    assert "nvidia/Cosmos-Test" in load_cmd
 
 
 def test_cosmos_serve_allows_explicit_guardrail_opt_out(mocker) -> None:
@@ -1612,7 +1617,7 @@ def test_cosmos_serve_allows_explicit_guardrail_opt_out(mocker) -> None:
     )
 
     assert result.exit_code == 0
-    cmd = ssh.run_or_raise.call_args.args[0]
+    cmd = ssh.run_or_raise.call_args_list[0].args[0]
     assert "COSMOS_DISABLE_SAFETY=1" in cmd
 
 
@@ -2192,6 +2197,7 @@ def test_cosmos_byovm_deploy_fallback_then_status_uses_ssh_strategy(
             "--server-port",
             "8081",
             "--skip-model-check",
+            "--no-auto-serve",
         ],
     )
 
@@ -2214,6 +2220,54 @@ def test_cosmos_byovm_deploy_fallback_then_status_uses_ssh_strategy(
     endpoint.assert_called_once()
     assert endpoint.call_args.args[0].endpoint_strategy == "ssh_fallback"
     http_cls.assert_called_once_with("http://127.0.0.1:19081", timeout=10.0, retries=1)
+
+
+def test_cosmos_deploy_auto_serve_loads_model(tmp_path: Path, monkeypatch, mocker) -> None:
+    """A healthy deploy with auto-serve (default on) issues a /serve model load so
+    the server is ready without a manual serve."""
+    cfg_path = tmp_path / ".npa" / "config.yaml"
+    credentials_path = tmp_path / ".npa" / "credentials.yaml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", cfg_path)
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", credentials_path)
+    for env_var in config_module.ENV_MAP.values():
+        monkeypatch.delenv(env_var, raising=False)
+
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (0, "connected", "")
+    ssh.run_or_raise.return_value = (0, "ok", "")
+    mocker.patch("npa.cli.cosmos.SSHClient", return_value=ssh)
+    mocker.patch(
+        "npa.cli.cosmos.resolve_credentials",
+        return_value=CredentialsConfig(tokens={"HF_TOKEN": "PLACEHOLDER_HF_TOKEN"}),
+    )
+    mocker.patch("npa.deploy.configurator.deploy_workbench_container")
+    mocker.patch("npa.deploy.configurator.write_remote_docker_env_file")
+    mocker.patch("npa.cli.cosmos.write_manifest")
+    mocker.patch("npa.cli.cosmos.health_check_auto", return_value=(True, ""))
+
+    deploy = runner.invoke(
+        app,
+        [
+            "workbench", "cosmos", "-p", "proj", "-n", "cosmos", "deploy",
+            "--runtime", "byovm",
+            "--host", "203.0.113.10",
+            "--ssh-key", "~/.ssh/byovm",
+            "--region", "eu-north1",
+            "--gpu-type", "gpu-h200-sxm",
+            "--gpu-preset", "8gpu-160vcpu-1792gb",
+            "--server-port", "8081",
+            "--skip-model-check",
+        ],
+    )
+
+    assert deploy.exit_code == 0
+    load_calls = [
+        call.args[0]
+        for call in ssh.run_or_raise.call_args_list
+        if "/serve" in call.args[0]
+    ]
+    assert load_calls, "auto-serve should issue a /serve model-load command"
+    assert any("8081" in cmd for cmd in load_calls)
 
 
 def test_cosmos_status_reports_degraded_when_model_not_loaded(mocker) -> None:

--- a/npa/tests/cli/test_groot_cli.py
+++ b/npa/tests/cli/test_groot_cli.py
@@ -621,6 +621,7 @@ def test_groot_byovm_deploy_injects_s3_credentials_into_env(mocker) -> None:
             "nebius_secret_key=secret",
             "--skip-model-check",
             "--verify-env",
+            "--no-auto-serve",
         ],
     )
 
@@ -649,6 +650,97 @@ def test_groot_byovm_deploy_injects_s3_credentials_into_env(mocker) -> None:
     ):
         assert key in audited_keys
     assert "Warning: NGC credentials not configured" in result.output
+
+
+def test_groot_deploy_auto_serve_loads_model(mocker) -> None:
+    """A healthy deploy with auto-serve (default on) and a real embodiment issues a
+    /serve model load so the server is ready without a manual serve."""
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (0, "connected", "")
+    ssh.run_or_raise.return_value = (0, "GROOT_SERVE_READY\n", "")
+    mocker.patch("npa.cli.groot.SSHClient", return_value=ssh)
+    mocker.patch("npa.cli.groot.provisioner.init")
+    mocker.patch("npa.cli.groot.provisioner.apply")
+    mocker.patch("npa.cli.groot.resolve_environment", return_value=None)
+    mocker.patch(
+        "npa.cli.groot.resolve_credentials",
+        return_value=CredentialsConfig(tokens={"HF_TOKEN": "PLACEHOLDER_HF_TOKEN"}),
+    )
+    mocker.patch("npa.cli.groot.list_projects", return_value={})
+    mocker.patch("npa.cli.groot.write_config")
+    mocker.patch("npa.cli.groot.update_workbench_app_status")
+    mocker.patch("npa.cli.groot.health_check_auto", return_value=(True, ""))
+    mocker.patch("npa.cli.groot.write_manifest")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench", "groot", "-p", "proj", "-n", "groot", "deploy",
+            "--runtime", "byovm",
+            "--host", "203.0.113.10",
+            "--ssh-key", "~/.ssh/byovm",
+            "--region", "eu-north1",
+            "--server-port", "8081",
+            "--skip-model-check",
+            "--robot-embodiment", "REAL_G1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    load_calls = [
+        call.args[0]
+        for call in ssh.run_or_raise.call_args_list
+        if "-X POST" in call.args[0] and "/serve" in call.args[0]
+    ]
+    assert load_calls, "auto-serve should issue a /serve model-load command"
+    assert any("8081" in cmd for cmd in load_calls)
+    assert any("REAL_G1" in cmd for cmd in load_calls), (
+        "auto-serve should carry the supplied embodiment tag"
+    )
+
+
+def test_groot_deploy_auto_serve_skips_without_real_embodiment(mocker) -> None:
+    """Auto-serve is skipped (with guidance) when only the NEW_EMBODIMENT
+    fine-tuning tag is available, since the base model cannot load with it."""
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (0, "connected", "")
+    ssh.run_or_raise.return_value = (0, "GROOT_SERVE_READY\n", "")
+    mocker.patch("npa.cli.groot.SSHClient", return_value=ssh)
+    mocker.patch("npa.cli.groot.provisioner.init")
+    mocker.patch("npa.cli.groot.provisioner.apply")
+    mocker.patch("npa.cli.groot.resolve_environment", return_value=None)
+    mocker.patch(
+        "npa.cli.groot.resolve_credentials",
+        return_value=CredentialsConfig(tokens={"HF_TOKEN": "PLACEHOLDER_HF_TOKEN"}),
+    )
+    mocker.patch("npa.cli.groot.list_projects", return_value={})
+    mocker.patch("npa.cli.groot.write_config")
+    mocker.patch("npa.cli.groot.update_workbench_app_status")
+    mocker.patch("npa.cli.groot.health_check_auto", return_value=(True, ""))
+    mocker.patch("npa.cli.groot.write_manifest")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench", "groot", "-p", "proj", "-n", "groot", "deploy",
+            "--runtime", "byovm",
+            "--host", "203.0.113.10",
+            "--ssh-key", "~/.ssh/byovm",
+            "--region", "eu-north1",
+            "--server-port", "8081",
+            "--skip-model-check",
+        ],
+    )
+
+    assert result.exit_code == 0
+    load_calls = [
+        call.args[0]
+        for call in ssh.run_or_raise.call_args_list
+        if "-X POST" in call.args[0] and "/serve" in call.args[0]
+    ]
+    assert not load_calls, "auto-serve must not load the base model with NEW_EMBODIMENT"
+    assert "Skipping auto-serve" in result.output
+    assert "--robot-embodiment" in result.output
 
 
 def test_groot_byovm_deploy_injects_ngc_credentials_into_env(mocker) -> None:
@@ -701,6 +793,7 @@ def test_groot_byovm_deploy_injects_ngc_credentials_into_env(mocker) -> None:
             "eu-north1",
             "--skip-model-check",
             "--verify-env",
+            "--no-auto-serve",
         ],
     )
 

--- a/npa/tests/guardrails/test_confidentiality_scan.py
+++ b/npa/tests/guardrails/test_confidentiality_scan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 
@@ -11,6 +12,7 @@ from npa.guardrails.confidentiality import (
     main,
     scan_paths,
     scan_text,
+    should_skip_unconfigured_fork_pull_request,
     tracked_text_files,
 )
 
@@ -116,3 +118,51 @@ def test_confidentiality_scan_cli_fails_closed_when_source_missing(tmp_path) -> 
     missing_file = tmp_path / "missing.regex"
 
     assert main(["--repo-root", str(tmp_path), "--pattern-file", str(missing_file)]) == 2
+
+
+def test_should_skip_unconfigured_fork_pull_request(tmp_path) -> None:
+    event_file = tmp_path / "event.json"
+    event_file.write_text(
+        json.dumps(
+            {
+                "repository": {"full_name": "nebius/nebius-physical-ai"},
+                "pull_request": {
+                    "head": {"repo": {"full_name": "contributor/nebius-physical-ai"}},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert should_skip_unconfigured_fork_pull_request(
+        "CUSTOMER_DENYLIST",
+        environ={
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_EVENT_PATH": str(event_file),
+            "GITHUB_REPOSITORY": "nebius/nebius-physical-ai",
+        },
+    )
+
+
+def test_should_not_skip_same_repo_pull_request(tmp_path) -> None:
+    event_file = tmp_path / "event.json"
+    event_file.write_text(
+        json.dumps(
+            {
+                "repository": {"full_name": "nebius/nebius-physical-ai"},
+                "pull_request": {
+                    "head": {"repo": {"full_name": "nebius/nebius-physical-ai"}},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert not should_skip_unconfigured_fork_pull_request(
+        "CUSTOMER_DENYLIST",
+        environ={
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_EVENT_PATH": str(event_file),
+            "GITHUB_REPOSITORY": "nebius/nebius-physical-ai",
+        },
+    )


### PR DESCRIPTION
## Summary

Models now load automatically after `cosmos deploy` and `groot deploy`, so a fresh deploy reports `app_status: healthy` without a separate manual `serve`. Resolves the FIXME [M] item "Cosmos requires manual serve after deploy/restart
with no auto-load"; the same treatment is applied to GR00T for consistency.

## Changes

- **Cosmos / GR00T deploy:** add `--auto-serve/--no-auto-serve` (default on). After a healthy deploy the model is loaded; a load failure degrades to a warning pointing at the manual `serve` command.
- **GR00T embodiment handling:** the base checkpoint cannot load with the`NEW_EMBODIMENT` fine-tuning tag (as surfaced in the demo runbook), so add `--robot-embodiment` to groot deploy. Auto-serve loads with the supplied real embodiment; when only the default tag is present it skips the load and prints how to load it manually.
- **Docs:** 8-GPU H200 runbook threads `--robot-embodiment "$GROOT_EMBODIMENT"` into the GR00T deploy step and adds a note on the auto-serve feature.

## Tests

- GR00T: auto-serve loads with a real embodiment; auto-serve skips on the default tag.
- Cosmos: deploy auto-serve issues the model load; `serve` also pre-warms the model on the vm runtime.