### PR TITLE
docs: beginner-friendly Workbench guides (Franka, Reachy 2, G1, quadrupeds) + data creds fix

### DIFF
--- a/.agents/skills/platform/context-efficiency/SKILL.md
+++ b/.agents/skills/platform/context-efficiency/SKILL.md
@@ -1,24 +1,38 @@
 ---
 name: context-efficiency
-description: Apply on every turn to minimize context ingestion, keep multi-turn chat memory lean, avoid full-workspace scans, and route work to the right model. Use when deciding how much to read, how to track state, how to structure code for small reads, and which model tier to use.
+description: Single source of truth for behavioral constraints. Apply on every turn to protect prompt-cache prefix stability, minimize context ingestion, keep multi-turn chat memory lean, avoid full-workspace scans, and route work to the right model. Use when deciding how much to read, how to track state, how to structure code for small reads, and which model tier to use.
 ---
 
 # Context & Token Efficiency
 
-Highest priority: minimize context ingestion, avoid full-workspace scans, and
-keep multi-turn chat memory lean. Apply these rules on every turn.
+Highest priority: protect the cached prompt prefix, minimize context ingestion,
+avoid full-workspace scans, and keep multi-turn chat memory lean. Apply these
+rules on every turn.
+
+## 0. Prompt Caching & Prefix Stability
+
+- Treat this file, the system instructions, and the repo index files
+  (`AGENTS.md`, `CLAUDE.md`) as a permanent, static prefix. Do not restate,
+  paraphrase, or re-emit them — doing so invalidates the prompt cache and taxes
+  every subsequent turn.
+- Never emit repetitive explanations, long greetings, restated task summaries,
+  or structural boilerplate that shifts prompt layout between turns. Stable
+  layout keeps the cache warm.
+- Keep responses compact and direct. Lead with the action or answer; omit
+  preamble and filler. Brevity preserves context-window longevity.
 
 ## 1. Context Minimization & Boundaries
 
 - NEVER read unrequested files or entire directories. Read only what the current
   task requires. Cross-module changes are the only justification for widening
   scope, and even then read the specific touched symbols, not whole trees.
-- Prefer targeted symbol matching (a named class, type, function, or constant)
-  over reading full files. Use grep/symbol search to jump to the relevant lines,
-  then read a tight range around them.
-- If a file exceeds 500 lines, do NOT ingest it whole. Ask for the specific
-  snippet, function, or module breakdown you need, or use a search to locate the
-  exact region.
+- Enforce targeted symbol isolation. Prefer a named class, type, function, or
+  constant over reading full files; request specific file lines or exact symbol
+  names via `@`-references (e.g. `@path/to/file.py` then a symbol/line range).
+  Use grep/symbol search to jump to the relevant lines, then read a tight range.
+- If a file exceeds 500 lines, refuse to read it whole. Request the specific
+  snippet, symbol, function, or module chunk you need, or use a search to locate
+  the exact region first.
 - Do not re-read a file you already have in context. Reuse what you've seen
   unless it changed.
 - Avoid speculative exploration. If you're unsure a file is relevant, ask before

--- a/.agents/skills/platform/context-efficiency/SKILL.md
+++ b/.agents/skills/platform/context-efficiency/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: context-efficiency
+description: Apply on every turn to minimize context ingestion, keep multi-turn chat memory lean, avoid full-workspace scans, and route work to the right model. Use when deciding how much to read, how to track state, how to structure code for small reads, and which model tier to use.
+---
+
+# Context & Token Efficiency
+
+Highest priority: minimize context ingestion, avoid full-workspace scans, and
+keep multi-turn chat memory lean. Apply these rules on every turn.
+
+## 1. Context Minimization & Boundaries
+
+- NEVER read unrequested files or entire directories. Read only what the current
+  task requires. Cross-module changes are the only justification for widening
+  scope, and even then read the specific touched symbols, not whole trees.
+- Prefer targeted symbol matching (a named class, type, function, or constant)
+  over reading full files. Use grep/symbol search to jump to the relevant lines,
+  then read a tight range around them.
+- If a file exceeds 500 lines, do NOT ingest it whole. Ask for the specific
+  snippet, function, or module breakdown you need, or use a search to locate the
+  exact region.
+- Do not re-read a file you already have in context. Reuse what you've seen
+  unless it changed.
+- Avoid speculative exploration. If you're unsure a file is relevant, ask before
+  reading it.
+
+## 2. State & Memory Management
+
+- Maintain an ultra-lean structural log (e.g. `todo.md` or `agents.md`) that
+  tracks ONLY: active architectural state, current task blocks, and breaking
+  changes.
+- The memory file must stay high-level. Strictly forbidden: code dumps, raw
+  logs, full stack traces, command output, or copied file contents. Summarize in
+  one line instead (e.g. "auth flow refactored to use middleware; token refresh
+  pending").
+- When a localized sub-task is completed, advise clearing the chat history or
+  opening a fresh thread before starting the next unrelated task. A clean thread
+  is cheaper and more accurate than a long one.
+
+## 3. DRY / Modular Code Principles
+
+- Enforce high modularity and strong separation of concerns. One responsibility
+  per file/module.
+- Keep files small and single-purpose. Smaller, isolated files keep automatic
+  context ingestion small and make targeted reads possible.
+- Favor shallow nesting and flat, predictable structure over deep hierarchies.
+- Eliminate duplication: extract shared logic into reusable functions/modules
+  rather than copy-pasting.
+
+## 4. Tool & Model Routing
+
+Use a fast/medium model for:
+
+- Minor syntax fixes and formatting
+- Boilerplate generation and scaffolding
+- Basic unit tests and simple, single-file edits
+
+Escalate to a deep-reasoning model for:
+
+- Complex orchestration or control-flow logic
+- Heavy multi-file debugging and refactors
+- Architectural decisions and cross-module design
+
+When in doubt, start with the cheaper model and escalate only if the task proves
+to need deeper reasoning.

--- a/.claude/skills/platform/context-efficiency/SKILL.md
+++ b/.claude/skills/platform/context-efficiency/SKILL.md
@@ -1,24 +1,38 @@
 ---
 name: context-efficiency
-description: Apply on every turn to minimize context ingestion, keep multi-turn chat memory lean, avoid full-workspace scans, and route work to the right model. Use when deciding how much to read, how to track state, how to structure code for small reads, and which model tier to use.
+description: Single source of truth for behavioral constraints. Apply on every turn to protect prompt-cache prefix stability, minimize context ingestion, keep multi-turn chat memory lean, avoid full-workspace scans, and route work to the right model. Use when deciding how much to read, how to track state, how to structure code for small reads, and which model tier to use.
 ---
 
 # Context & Token Efficiency
 
-Highest priority: minimize context ingestion, avoid full-workspace scans, and
-keep multi-turn chat memory lean. Apply these rules on every turn.
+Highest priority: protect the cached prompt prefix, minimize context ingestion,
+avoid full-workspace scans, and keep multi-turn chat memory lean. Apply these
+rules on every turn.
+
+## 0. Prompt Caching & Prefix Stability
+
+- Treat this file, the system instructions, and the repo index files
+  (`AGENTS.md`, `CLAUDE.md`) as a permanent, static prefix. Do not restate,
+  paraphrase, or re-emit them — doing so invalidates the prompt cache and taxes
+  every subsequent turn.
+- Never emit repetitive explanations, long greetings, restated task summaries,
+  or structural boilerplate that shifts prompt layout between turns. Stable
+  layout keeps the cache warm.
+- Keep responses compact and direct. Lead with the action or answer; omit
+  preamble and filler. Brevity preserves context-window longevity.
 
 ## 1. Context Minimization & Boundaries
 
 - NEVER read unrequested files or entire directories. Read only what the current
   task requires. Cross-module changes are the only justification for widening
   scope, and even then read the specific touched symbols, not whole trees.
-- Prefer targeted symbol matching (a named class, type, function, or constant)
-  over reading full files. Use grep/symbol search to jump to the relevant lines,
-  then read a tight range around them.
-- If a file exceeds 500 lines, do NOT ingest it whole. Ask for the specific
-  snippet, function, or module breakdown you need, or use a search to locate the
-  exact region.
+- Enforce targeted symbol isolation. Prefer a named class, type, function, or
+  constant over reading full files; request specific file lines or exact symbol
+  names via `@`-references (e.g. `@path/to/file.py` then a symbol/line range).
+  Use grep/symbol search to jump to the relevant lines, then read a tight range.
+- If a file exceeds 500 lines, refuse to read it whole. Request the specific
+  snippet, symbol, function, or module chunk you need, or use a search to locate
+  the exact region first.
 - Do not re-read a file you already have in context. Reuse what you've seen
   unless it changed.
 - Avoid speculative exploration. If you're unsure a file is relevant, ask before

--- a/.claude/skills/platform/context-efficiency/SKILL.md
+++ b/.claude/skills/platform/context-efficiency/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: context-efficiency
+description: Apply on every turn to minimize context ingestion, keep multi-turn chat memory lean, avoid full-workspace scans, and route work to the right model. Use when deciding how much to read, how to track state, how to structure code for small reads, and which model tier to use.
+---
+
+# Context & Token Efficiency
+
+Highest priority: minimize context ingestion, avoid full-workspace scans, and
+keep multi-turn chat memory lean. Apply these rules on every turn.
+
+## 1. Context Minimization & Boundaries
+
+- NEVER read unrequested files or entire directories. Read only what the current
+  task requires. Cross-module changes are the only justification for widening
+  scope, and even then read the specific touched symbols, not whole trees.
+- Prefer targeted symbol matching (a named class, type, function, or constant)
+  over reading full files. Use grep/symbol search to jump to the relevant lines,
+  then read a tight range around them.
+- If a file exceeds 500 lines, do NOT ingest it whole. Ask for the specific
+  snippet, function, or module breakdown you need, or use a search to locate the
+  exact region.
+- Do not re-read a file you already have in context. Reuse what you've seen
+  unless it changed.
+- Avoid speculative exploration. If you're unsure a file is relevant, ask before
+  reading it.
+
+## 2. State & Memory Management
+
+- Maintain an ultra-lean structural log (e.g. `todo.md` or `agents.md`) that
+  tracks ONLY: active architectural state, current task blocks, and breaking
+  changes.
+- The memory file must stay high-level. Strictly forbidden: code dumps, raw
+  logs, full stack traces, command output, or copied file contents. Summarize in
+  one line instead (e.g. "auth flow refactored to use middleware; token refresh
+  pending").
+- When a localized sub-task is completed, advise clearing the chat history or
+  opening a fresh thread before starting the next unrelated task. A clean thread
+  is cheaper and more accurate than a long one.
+
+## 3. DRY / Modular Code Principles
+
+- Enforce high modularity and strong separation of concerns. One responsibility
+  per file/module.
+- Keep files small and single-purpose. Smaller, isolated files keep automatic
+  context ingestion small and make targeted reads possible.
+- Favor shallow nesting and flat, predictable structure over deep hierarchies.
+- Eliminate duplication: extract shared logic into reusable functions/modules
+  rather than copy-pasting.
+
+## 4. Tool & Model Routing
+
+Use a fast/medium model for:
+
+- Minor syntax fixes and formatting
+- Boilerplate generation and scaffolding
+- Basic unit tests and simple, single-file edits
+
+Escalate to a deep-reasoning model for:
+
+- Complex orchestration or control-flow logic
+- Heavy multi-file debugging and refactors
+- Architectural decisions and cross-module design
+
+When in doubt, start with the cheaper model and escalate only if the task proves
+to need deeper reasoning.

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,74 @@
+# .cursorignore — keep large/generated/binary paths out of agent context and indexing.
+# Mirrors the high-volume entries in .gitignore plus a few Cursor-specific bleeders.
+# Goal: minimize token ingestion and avoid full-workspace scans.
+
+# Virtualenvs and installed dependencies (npa/.venv alone is ~1.5G)
+.venv/
+**/.venv/
+venv/
+**/venv/
+node_modules/
+**/node_modules/
+
+# Python build/test/type caches
+__pycache__/
+**/__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+.eggs/
+*.egg-info/
+dist/
+build/
+
+# Model checkpoints, weights, and generated arrays/datasets
+*.safetensors
+*.pt
+*.pth
+*.ckpt
+*.npy
+*.npz
+checkpoints/
+cosmos3-cache/
+npa-cosmos3-cache/
+
+# Large binary demo/media assets (docs/demos/assets is ~24M)
+docs/demos/assets/
+*.mp4
+*.webm
+*.png
+*.jpg
+*.jpeg
+*.gif
+
+# Lockfiles (large, low-signal for reasoning)
+uv.lock
+**/uv.lock
+poetry.lock
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# Run output, logs, and scratch
+results/
+runs/
+logs/
+*.log
+*.log*
+tmp/
+*.tmp
+*.temp
+
+# Terraform state and provider dirs
+.terraform/
+*.tfstate
+*.tfstate.*
+tfplan
+*.tfplan
+
+# Security scan reports
+kingfisher-result*.json
+semgrep-*.json

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,8 +1,8 @@
 # .cursorignore — keep large/generated/binary paths out of agent context and indexing.
 # Mirrors the high-volume entries in .gitignore plus a few Cursor-specific bleeders.
-# Goal: minimize token ingestion and avoid full-workspace scans.
+# Goal: minimize token ingestion, protect prompt-cache stability, avoid full scans.
 
-# Virtualenvs and installed dependencies (npa/.venv alone is ~1.5G)
+# --- Dependency directories ---
 .venv/
 **/.venv/
 venv/
@@ -10,7 +10,16 @@ venv/
 node_modules/
 **/node_modules/
 
-# Python build/test/type caches
+# --- Build targets, distribution binaries, temp caches ---
+dist/
+build/
+.eggs/
+*.egg-info/
+.turbo/
+.cache/
+**/.cache/
+.next/
+.parcel-cache/
 __pycache__/
 **/__pycache__/
 *.py[cod]
@@ -19,12 +28,19 @@ __pycache__/
 .ruff_cache/
 .coverage
 htmlcov/
-.eggs/
-*.egg-info/
-dist/
-build/
+tmp/
+*.tmp
+*.temp
 
-# Model checkpoints, weights, and generated arrays/datasets
+# --- Heavy lockfiles (large, low-signal for reasoning) ---
+uv.lock
+**/uv.lock
+poetry.lock
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# --- Model checkpoints, weights, and generated arrays ---
 *.safetensors
 *.pt
 *.pth
@@ -35,7 +51,27 @@ checkpoints/
 cosmos3-cache/
 npa-cosmos3-cache/
 
-# Large binary demo/media assets (docs/demos/assets is ~24M)
+# --- Massive data arrays / synthetic data / simulation logs (root-anchored to
+#     avoid hiding source packages like npa/src/npa/workbench/data/) ---
+/data/
+/datasets/
+/synthetic/
+/synthetic_data/
+/sim_logs/
+/rollouts/
+/outputs/
+/artifacts/
+wandb/
+**/wandb/
+
+# --- Run output, logs, scratch ---
+results/
+runs/
+logs/
+*.log
+*.log*
+
+# --- Large binary demo/media assets (docs/demos/assets is ~24M) ---
 docs/demos/assets/
 *.mp4
 *.webm
@@ -44,31 +80,13 @@ docs/demos/assets/
 *.jpeg
 *.gif
 
-# Lockfiles (large, low-signal for reasoning)
-uv.lock
-**/uv.lock
-poetry.lock
-package-lock.json
-pnpm-lock.yaml
-yarn.lock
-
-# Run output, logs, and scratch
-results/
-runs/
-logs/
-*.log
-*.log*
-tmp/
-*.tmp
-*.temp
-
-# Terraform state and provider dirs
+# --- Terraform state and provider dirs ---
 .terraform/
 *.tfstate
 *.tfstate.*
 tfplan
 *.tfplan
 
-# Security scan reports
+# --- Security scan reports ---
 kingfisher-result*.json
 semgrep-*.json

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+Before processing any user prompt, always read and strictly adhere to the operational constraints, context caching rules, and module boundaries defined in `.agents/skills`. Keep responses compact and direct to preserve context window longevity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Nebius Physical AI provides containerized workbench tools and SkyPilot workflows
 
 ## Codex Skills
 
+- `.agents/skills/platform/context-efficiency/SKILL.md`: apply on every turn to minimize context ingestion, keep chat memory lean, avoid full-workspace scans, and route work to the right model tier.
 - `.agents/skills/platform/quickstart/SKILL.md`: first-time setup, zero-credential first run, install, Nebius auth, and the contributor dev/test loop.
 - `.agents/skills/workbench/cookbooks/SKILL.md`: working end-to-end cookbooks mapped to their validated entrypoints (BDD100K, sim-to-real, VLM-eval loop, LeRobot benchmarks, Isaac Lab BYOF).
 - `.agents/skills/workbench/workbench-tool/SKILL.md`: workbench API/CLI/SDK/container pattern and S3 data flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Claude Code should treat this file as an index. Load the relevant skill before m
 - `.claude/skills/workbench/mjlab/SKILL.md`: load for MJLab locomotion evaluation and SONIC checkpoint scoring.
 - `.claude/skills/workbench/retargeting/SKILL.md`: load for motion retargeting in SONIC locomotion workflows.
 - `.agents/skills/workbench/sim-to-real/SKILL.md`: load for generic sim-to-real data import, Cosmos autoscale, VLM evaluation, and controller-loop workflow planning.
-- `.agents/skills/platform/context-efficiency/SKILL.md`: apply on every turn to minimize context ingestion, keep chat memory lean, avoid full-workspace scans, and route work to the right model tier.
+- `.claude/skills/platform/context-efficiency/SKILL.md`: apply on every turn to minimize context ingestion, keep chat memory lean, avoid full-workspace scans, and route work to the right model tier.
 
 ### Partner Capability Roadmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Claude Code should treat this file as an index. Load the relevant skill before m
 - `.claude/skills/workbench/mjlab/SKILL.md`: load for MJLab locomotion evaluation and SONIC checkpoint scoring.
 - `.claude/skills/workbench/retargeting/SKILL.md`: load for motion retargeting in SONIC locomotion workflows.
 - `.agents/skills/workbench/sim-to-real/SKILL.md`: load for generic sim-to-real data import, Cosmos autoscale, VLM evaluation, and controller-loop workflow planning.
+- `.agents/skills/platform/context-efficiency/SKILL.md`: apply on every turn to minimize context ingestion, keep chat memory lean, avoid full-workspace scans, and route work to the right model tier.
 
 ### Partner Capability Roadmap
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ make test
 For full cloud setup, continue with [docs/quickstart.md](docs/quickstart.md)
 and [docs/workbench/getting-started.md](docs/workbench/getting-started.md).
 
+## Easy Guides
+
+Short, fun, copy-paste walkthroughs that pair a **robot**, a **simulation
+environment**, and a **cool public dataset**. Start with the no-GPU one, then
+pick a robot — see [docs/workbench/guides/README.md](docs/workbench/guides/README.md).
+
+| Guide | Robot | Sim / engine | Public dataset |
+| --- | --- | --- | --- |
+| [Score a robot in 60 seconds (no GPU)](docs/workbench/guides/score-a-robot-no-gpu.md) | any | offline | shipped sample rollouts |
+| [Pick-and-place with a Franka arm](docs/workbench/guides/franka-pick-and-place-genesis.md) | Franka Emika Panda | Genesis | DROID (Franka) |
+| [Teach a robot to push a T](docs/workbench/guides/pusht-sim-to-real.md) | sim pusher | sim-to-real loop | `lerobot/pusht` |
+| [Train a Reachy 2 humanoid policy](docs/workbench/guides/reachy2-lerobot-policy.md) | Reachy 2 | LeRobot | Pollen Robotics / LeRobot Hub |
+| [Make a Unitree G1 walk](docs/workbench/guides/g1-humanoid-walk-sonic.md) | Unitree G1 | MuJoCo | NVIDIA GEAR-SONIC |
+| [Train a quadruped to run](docs/workbench/guides/quadruped-isaac-lab.md) | ANYmal / quadruped | Isaac Lab | Isaac Lab built-in tasks |
+
 ## Workbench
 
 Workbench is the main product surface in this repository. Current Workbench
@@ -234,6 +249,9 @@ Workbench runs on Nebius infrastructure rather than hiding it:
   credential setup.
 - [docs/workbench/getting-started.md](docs/workbench/getting-started.md):
   Workbench setup and first workload path.
+- [docs/workbench/guides/README.md](docs/workbench/guides/README.md): easy,
+  beginner-friendly guides built around Franka, Reachy 2, Unitree G1, and
+  quadrupeds in simulation with public datasets.
 - [docs/workbench/](docs/workbench/): Workbench guides, cookbooks, and
   troubleshooting.
 - [docs/workbench/cookbooks/README.md](docs/workbench/cookbooks/README.md):

--- a/docs/workbench/guides/README.md
+++ b/docs/workbench/guides/README.md
@@ -59,7 +59,14 @@ These guides were exercised against live Nebius (via `npa`), not just read:
 | `lerobot train --runtime serverless --smoke` | Nebius AI Job (H200) | works — produced a real ACT checkpoint (`model.safetensors`) in S3 |
 | `genesis train-teacher --runtime serverless` | Nebius AI Job (H100) | works, but is a **smoke** (import check + placeholder checkpoint); real Genesis training is local/VM |
 | `sim_to_real.local_smoke` | local, no cluster | runs the spine; reports `blocked` unless `lerobot` is installed locally |
-| `isaac-lab train --runtime serverless` | Nebius AI Job (L40S) | **fails today** (`W9-isaac-lab-e2e-fix`); prefer the RT-core VM / BYOF path |
+| `isaac-lab train --runtime serverless` | Nebius AI Job (`gpu-l40s-a`) | **capacity-blocked** — `NotEnoughResources` / VM schedule timeout |
+| `isaac-lab train --runtime serverless` | Nebius AI Job (`gpu-l40s-d`) | job schedules and completes; minimal run produced no artifact yet (small step budget / `W9-isaac-lab-e2e-fix`) |
+
+Isaac Lab needs RT cores, and serverless RT-core capacity varies by SKU: the
+default `gpu-l40s-a` pool failed to schedule, while `gpu-l40s-d` had capacity and
+ran to completion. `gpu-rtx6000` is **not** a serverless platform (use the
+managed-Kubernetes path). For real Isaac Lab training prefer an RT-core VM /
+managed-K8s + BYOF; for a serverless capacity retry use `--gpu-type gpu-l40s-d`.
 
 SONIC G1 (MuJoCo) is documented from its cookbook and not yet re-run here.
 

--- a/docs/workbench/guides/README.md
+++ b/docs/workbench/guides/README.md
@@ -1,0 +1,63 @@
+# Easy Guides
+
+Short, friendly, copy-paste guides for getting a robot doing something
+interesting on Nebius Physical AI. Each one picks a **robot**, a **simulation
+environment**, and a **cool public dataset**, then walks you from zero to a
+result.
+
+New here? Start with the no-GPU guide — it runs on your laptop with no cloud,
+no GPU, and no credentials. Then pick a robot and have fun.
+
+| Guide | Robot | Sim / engine | Public dataset | Needs a GPU? |
+| --- | --- | --- | --- | --- |
+| [Score a robot in 60 seconds](score-a-robot-no-gpu.md) | any | offline | shipped sample rollouts | No |
+| [Pick-and-place with a Franka arm](franka-pick-and-place-genesis.md) | Franka Emika Panda | Genesis | DROID (Franka) | Yes (L40S+) |
+| [Teach a robot to push a T](pusht-sim-to-real.md) | sim pusher | sim-to-real loop | `lerobot/pusht` | Yes (H100) — local smoke is free |
+| [Train a Reachy 2 humanoid policy](reachy2-lerobot-policy.md) | Reachy 2 | LeRobot | Pollen Robotics / LeRobot Hub | Yes |
+| [Make a Unitree G1 walk](g1-humanoid-walk-sonic.md) | Unitree G1 | MuJoCo | NVIDIA GEAR-SONIC checkpoint | Yes (H100) |
+| [Train a quadruped to run](quadruped-isaac-lab.md) | ANYmal / quadruped | Isaac Lab | Isaac Lab built-in tasks | Yes (RT-core: L40S / RTX PRO 6000) |
+
+## How these guides work
+
+Every guide follows the same shape so you always know where you are:
+
+- **The hook** — what you'll build and why it's fun.
+- **Ingredients** — robot, sim, dataset, and what you need installed.
+- **Fast path** — the shortest command that produces a result.
+- **Go bigger** — turn the toy run into a real GPU run.
+- **Look at it** — visualize the result (Rerun, FiftyOne, reports).
+- **Dig deeper** — links to the full cookbook and the skill behind it.
+
+## Before you start
+
+Install `npa` once (Python 3.10+). The virtual environment can live anywhere:
+
+```bash
+git clone https://github.com/nebius/nebius-physical-ai.git
+cd nebius-physical-ai
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e npa
+
+npa --version
+```
+
+The no-GPU guide needs nothing else. The GPU guides assume you have completed
+[../../quickstart.md](../../quickstart.md) and
+[../getting-started.md](../getting-started.md) (Nebius auth, an S3 bucket, and
+`npa configure`). Each guide calls out exactly when credentials are required.
+
+## Bring your own everything
+
+These guides use public datasets and the shipped robots so you can reproduce
+them, but the workbench is built to be swapped:
+
+- **Bring your own dataset** — point any guide at an S3 `LeRobotDataset` URI.
+- **Bring your own policy image** — swap the container, keep the contract.
+- **Bring your own robot** — Franka, Reachy 2, Unitree G1, quadrupeds, and more
+  are all just configs over the same train / eval / serve / infer commands.
+
+When you're ready for the production recipes, head to the
+[cookbooks](../cookbooks/README.md).

--- a/docs/workbench/guides/README.md
+++ b/docs/workbench/guides/README.md
@@ -49,6 +49,20 @@ The no-GPU guide needs nothing else. The GPU guides assume you have completed
 [../getting-started.md](../getting-started.md) (Nebius auth, an S3 bucket, and
 `npa configure`). Each guide calls out exactly when credentials are required.
 
+## What's been validated on real backends
+
+These guides were exercised against live Nebius (via `npa`), not just read:
+
+| Path | Backend | Result |
+| --- | --- | --- |
+| `vlm-eval benchmark/run` (stub) | local, offline | works (`accuracy: 1.0`) |
+| `lerobot train --runtime serverless --smoke` | Nebius AI Job (H200) | works — produced a real ACT checkpoint (`model.safetensors`) in S3 |
+| `genesis train-teacher --runtime serverless` | Nebius AI Job (H100) | works, but is a **smoke** (import check + placeholder checkpoint); real Genesis training is local/VM |
+| `sim_to_real.local_smoke` | local, no cluster | runs the spine; reports `blocked` unless `lerobot` is installed locally |
+| `isaac-lab train --runtime serverless` | Nebius AI Job (L40S) | **fails today** (`W9-isaac-lab-e2e-fix`); prefer the RT-core VM / BYOF path |
+
+SONIC G1 (MuJoCo) is documented from its cookbook and not yet re-run here.
+
 ## Bring your own everything
 
 These guides use public datasets and the shipped robots so you can reproduce

--- a/docs/workbench/guides/franka-pick-and-place-genesis.md
+++ b/docs/workbench/guides/franka-pick-and-place-genesis.md
@@ -79,12 +79,18 @@ npa workbench genesis eval-teacher --checkpoint ./checkpoints/teacher/model.pt
 
 ## Go bigger
 
-- **Run it serverless on Nebius** instead of locally — `train-teacher` takes
-  `--runtime serverless --project-id <your-project-id> --gpu-type l40s
-  --output-path s3://<bucket>/...` and submits a Nebius AI Job for you.
-  (Serverless needs `--project-id`, or a project configured in
-  `~/.npa/config.yaml`.) Inspect the artifacts it writes with
-  `npa workbench data list --input-path s3://<bucket>/.../`.
+- **Full training runs locally or on a workbench VM.** `train-teacher` (and
+  `generate-demos` / `eval-teacher`) run on your GPU box, or on a Workbench VM
+  when you pass `-p <project> -n <workbench>` (forwarded over SSH). This is where
+  real Franka PPO training happens.
+- **Validate serverless first.** `train-teacher --runtime serverless --project-id
+  <your-project-id> --gpu-type l40s --output-path s3://<bucket>/...` submits a
+  Nebius AI Job, but the serverless Genesis path is a **smoke** (it checks the
+  Genesis import and writes a placeholder checkpoint, verified end to end). Use
+  it to prove credentials, image pull, and S3 output before committing GPU time;
+  inspect what it wrote with
+  `npa workbench data list --input-path s3://<bucket>/.../`. (Serverless needs
+  `--project-id`, or a project configured in `~/.npa/config.yaml`.)
 - **Scale up:** the defaults are `--n-envs 4096 --max-iterations 500`. More envs
   and iterations give a stronger teacher.
 - **Tune rewards** without editing code via repeatable overrides, e.g.

--- a/docs/workbench/guides/franka-pick-and-place-genesis.md
+++ b/docs/workbench/guides/franka-pick-and-place-genesis.md
@@ -80,8 +80,11 @@ npa workbench genesis eval-teacher --checkpoint ./checkpoints/teacher/model.pt
 ## Go bigger
 
 - **Run it serverless on Nebius** instead of locally — `train-teacher` takes
-  `--runtime serverless --gpu-type l40s --output-path s3://<bucket>/...` and
-  submits a Nebius AI Job for you.
+  `--runtime serverless --project-id <your-project-id> --gpu-type l40s
+  --output-path s3://<bucket>/...` and submits a Nebius AI Job for you.
+  (Serverless needs `--project-id`, or a project configured in
+  `~/.npa/config.yaml`.) Inspect the artifacts it writes with
+  `npa workbench data list --input-path s3://<bucket>/.../`.
 - **Scale up:** the defaults are `--n-envs 4096 --max-iterations 500`. More envs
   and iterations give a stronger teacher.
 - **Tune rewards** without editing code via repeatable overrides, e.g.

--- a/docs/workbench/guides/franka-pick-and-place-genesis.md
+++ b/docs/workbench/guides/franka-pick-and-place-genesis.md
@@ -1,0 +1,115 @@
+# Pick-and-Place with a Franka Arm in Genesis
+
+**The hook:** spin up thousands of Franka Emika Panda arms in parallel inside
+the Genesis physics engine, train one of them to pick up a cube and drop it in a
+target zone, then record demonstrations you can turn into a LeRobot dataset —
+the same format the famous DROID Franka dataset uses.
+
+This is the classic "hello robot" of manipulation, done at GPU scale.
+
+## Ingredients
+
+- **Robot:** Franka Emika Panda (7-DOF arm + gripper). It's the arm in
+  `npa/src/npa/genesis/env_pick_place.py`.
+- **Sim / engine:** [Genesis](https://genesis-world.readthedocs.io/) —
+  GPU-accelerated parallel physics. Thousands of envs at once.
+- **Public dataset:**
+  [DROID](https://huggingface.co/docs/lerobot/main/en/porting_datasets_v3) —
+  76,000+ real Franka Panda manipulation trajectories. We use it as the
+  real-world counterpart to our synthetic demos (a 2 GB `droid_100` sample
+  exists for testing).
+- **You need:** a GPU with RT/CUDA support — **L40S or better**. Genesis trains
+  headless on Nebius. Finish [getting-started](../getting-started.md) first.
+
+## The shape of the workflow
+
+```text
+Genesis (Franka cube pick) ──train-teacher──▶ RL teacher (PPO)
+        │                                          │
+        └──────────── generate-demos ──────────────┘
+                              │
+                              ▼
+                    LeRobotDataset on S3 ──▶ train a student policy
+```
+
+A privileged **teacher** learns fast in sim with full state. It then **records
+demonstrations** (optionally with domain randomization), which become a standard
+`LeRobotDataset` you can train a camera-based **student** on.
+
+## Fast path
+
+**1. See the tool and your GPU.**
+
+```bash
+npa workbench genesis list
+npa workbench genesis system-info
+```
+
+**2. Train the RL teacher** to pick and place the cube (start small to prove the
+loop, then scale `--n-envs` / `--max-iterations`):
+
+```bash
+npa workbench genesis train-teacher \
+  --n-envs 1024 \
+  --max-iterations 50 \
+  --action-space cartesian \
+  --output ./checkpoints/teacher/
+```
+
+`--action-space cartesian` gives the policy a 4-D action (delta xyz + gripper)
+resolved with inverse kinematics — the most intuitive starting point. Switch to
+`joint` for raw 8-D joint control.
+
+**3. Record demonstrations** from the trained teacher, with domain randomization
+on so the data is varied:
+
+```bash
+npa workbench genesis generate-demos \
+  --checkpoint ./checkpoints/teacher/model.pt \
+  --n-envs 512 \
+  --domain-randomize \
+  --output-path ./demos/franka-pick/
+```
+
+**4. Check how good the policy is:**
+
+```bash
+npa workbench genesis eval-teacher --checkpoint ./checkpoints/teacher/model.pt
+```
+
+## Go bigger
+
+- **Run it serverless on Nebius** instead of locally — `train-teacher` takes
+  `--runtime serverless --gpu-type l40s --output-path s3://<bucket>/...` and
+  submits a Nebius AI Job for you.
+- **Scale up:** the defaults are `--n-envs 4096 --max-iterations 500`. More envs
+  and iterations give a stronger teacher.
+- **Tune rewards** without editing code via repeatable overrides, e.g.
+  `--env-override approach_scale=2.0 --env-override domain_randomize=true`.
+- **Train a student policy** on the recorded demos with
+  [LeRobot](reachy2-lerobot-policy.md) — the demos are already in LeRobot format.
+
+## Use the real Franka data too
+
+Your synthetic demos share the `LeRobotDataset` format with **DROID**, the
+large-scale real-world Franka dataset. That means you can mix or compare sim and
+real:
+
+- Grab the 2 GB `droid_100` sample to experiment, or port the full set to
+  LeRobot v3.0 (see the
+  [LeRobot porting guide](https://huggingface.co/docs/lerobot/main/en/porting_datasets_v3)).
+- Point any LeRobot training run at the resulting S3 URI exactly like you would
+  your Genesis demos.
+
+## Heads up
+
+- Genesis **training** works headless on Nebius. **Visual demo rendering at
+  scale** is currently limited by EGL/DRI device access in containers; 480x640
+  targeted renders work via the Mesa fallback. See
+  `.agents/skills/workbench/genesis/SKILL.md` for the current state.
+
+## Dig deeper
+
+- Env source: `npa/src/npa/genesis/env_pick_place.py`
+- Commands: `npa workbench genesis train-teacher | generate-demos | eval-teacher | eval-student | diagnose | tune`
+- Skill: `.agents/skills/workbench/genesis/SKILL.md`

--- a/docs/workbench/guides/g1-humanoid-walk-sonic.md
+++ b/docs/workbench/guides/g1-humanoid-walk-sonic.md
@@ -38,7 +38,7 @@ Meet the tool and check routing first:
 
 ```bash
 npa workbench sonic list
-npa workbench sonic system-info
+npa workbench sonic status
 ```
 
 Submit the fine-tune + MuJoCo-eval workflow on H100 spot (docker-payload mode):

--- a/docs/workbench/guides/g1-humanoid-walk-sonic.md
+++ b/docs/workbench/guides/g1-humanoid-walk-sonic.md
@@ -1,0 +1,116 @@
+# Make a Unitree G1 Humanoid Walk (SONIC + MuJoCo)
+
+**The hook:** take NVIDIA's released **GEAR-SONIC** locomotion checkpoint, warm-
+start a fine-tune for the **Unitree G1** humanoid, then watch it walk in a
+headless **MuJoCo** rollout — all as one SkyPilot workflow on an H100. This is
+whole-body humanoid control, and you don't have to train from scratch.
+
+## Ingredients
+
+- **Robot:** [Unitree G1](https://www.unitree.com/g1) humanoid (legs + whole
+  body).
+- **Sim / engine:** [MuJoCo](https://mujoco.org/) for the headless eval rollout;
+  SONIC's training stack for fine-tuning.
+- **Public checkpoint:** NVIDIA
+  [`nvidia/GEAR-SONIC`](https://huggingface.co/nvidia/GEAR-SONIC) —
+  `sonic_release/last.pt` is the warm-start.
+- **You need:** Nebius creds, a container registry, an S3 bucket, and **H100**
+  capacity (`eu-north1`). SONIC training is state-based and headless, so no RT
+  cores are required for this path.
+
+## The shape of the workflow
+
+```text
+GEAR-SONIC checkpoint ──finetune (G1, headless)──▶ trained checkpoint
+                                                          │
+                                                  MuJoCo rollout eval
+                                                          │
+                                              mujoco_eval_metrics.json
+```
+
+One SkyPilot YAML runs both stages: `sonic-g1-finetune` then
+`sonic-mujoco-eval`. The fine-tune uses tiny proof defaults so you can prove the
+path before scaling iterations.
+
+## Fast path
+
+Meet the tool and check routing first:
+
+```bash
+npa workbench sonic list
+npa workbench sonic system-info
+```
+
+Submit the fine-tune + MuJoCo-eval workflow on H100 spot (docker-payload mode):
+
+```bash
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml \
+  --tool sonic \
+  --run-id sonic-g1-$(date -u +%Y%m%dT%H%M%SZ) \
+  --registry cr.eu-north1.nebius.cloud/<registry-id> \
+  --gpu-target h100 \
+  --region eu-north1 \
+  --use-spot \
+  --require-controller-up \
+  --s3-endpoint https://storage.eu-north1.nebius.cloud \
+  --s3-bucket <bucket> \
+  --s3-prefix sonic-g1/<run-id> \
+  --var SONIC_PAYLOAD_MODE=docker \
+  --var SONIC_MAX_ITERATIONS=1 \
+  --var SONIC_MUJOCO_STEPS=64 \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY
+```
+
+When it finishes you'll have `mujoco_eval_metrics.json`, `gpu_device.json`, and
+`image_pull_proof.json` in S3 — proof the G1 checkpoint ran a real MuJoCo
+rollout.
+
+Prefer Python? The SDK runs the same materialize/submit path:
+
+```python
+from pathlib import Path
+from npa.sdk.workbench import sonic
+
+plan = sonic.materialize_workflow(
+    Path("npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml"),
+    run_id="sonic-g1-proof",
+    registry="cr.eu-north1.nebius.cloud/<registry-id>",
+    gpu_target="h100",
+    region="eu-north1",
+    use_spot=True,
+    s3_endpoint="https://storage.eu-north1.nebius.cloud",
+    s3_bucket="<bucket>",
+    s3_prefix="sonic-g1/sonic-g1-proof",
+    env_overrides={
+        "SONIC_PAYLOAD_MODE": "docker",
+        "SONIC_MAX_ITERATIONS": "1",
+        "SONIC_MUJOCO_STEPS": "64",
+    },
+)
+```
+
+## Go bigger
+
+- **Train longer:** raise `SONIC_MAX_ITERATIONS` and `SONIC_MUJOCO_STEPS` once
+  the proof run is green.
+- **Export to ONNX and re-evaluate:** `npa workbench sonic export` produces a
+  deterministic-action ONNX graph, and `npa workbench sonic eval` scores it. See
+  the [SONIC Export and Eval Runbook](../cookbooks/sonic-eval-runbook.md).
+- **Score with MJLab:** the
+  [SONIC Locomotion Fine-Tuning cookbook](../cookbooks/sonic-locomotion-finetuning.md)
+  adds motion retargeting and MJLab evaluation.
+
+## Heads up
+
+- Use `--gpu-target h200` only as a capacity fallback for the same headless
+  workload. `me-west1` is rejected; use `eu-north1`.
+- SONIC **render** validation (the Isaac render path) needs RT cores; the walk-
+  in-MuJoCo path in this guide does not.
+
+## Dig deeper
+
+- Cookbook: [SONIC G1 Fine-Tune to MuJoCo MVP](../cookbooks/sonic-mvp-g1-mujoco.md)
+- Workflow YAML: `npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml`
+- Skill: `.agents/skills/workbench/sonic/SKILL.md`

--- a/docs/workbench/guides/pusht-sim-to-real.md
+++ b/docs/workbench/guides/pusht-sim-to-real.md
@@ -47,7 +47,15 @@ print(report.status)
 ```
 
 This validates the data split, the eval backend, the feedback object, and the
-Rerun recording wiring without provisioning anything.
+Rerun recording wiring without provisioning anything. It downloads and inspects
+the public `lerobot/pusht` metadata (≈206 episodes, ≈25k frames) on the fly.
+
+The report is **tiered**, so read `report.status` and the per-component tiers
+literally. In a plain `pip install -e npa` environment the `LeRobotDataset`
+import isn't present, so the dataset component reports `PARTIAL`/`BLOCKED` and
+`report.status` is `blocked` — that's expected. Install the LeRobot extra (so
+`import lerobot` works) for a fully green local smoke; the live H100 run below
+uses the policy image and doesn't need LeRobot on your laptop.
 
 ## The one-command live run
 

--- a/docs/workbench/guides/pusht-sim-to-real.md
+++ b/docs/workbench/guides/pusht-sim-to-real.md
@@ -1,0 +1,108 @@
+# Teach a Robot to Push a T (PushT, Sim-to-Real)
+
+**The hook:** PushT is the beloved toy benchmark of robot learning — shove a
+T-shaped block onto a target. In this guide you run the **whole sim-to-real
+loop** end to end with one command: stage a public dataset, train a policy,
+evaluate it, collect feedback, and record a Rerun visualization you can scrub
+frame by frame.
+
+The best part: you can dry-run the entire spine locally before spending a
+single GPU-minute.
+
+## Ingredients
+
+- **Robot:** a simulated planar pusher (the PushT task).
+- **Sim / engine:** the workbench **sim-to-real loop** — imitation training plus
+  a pluggable evaluator and feedback source.
+- **Public dataset:**
+  [`lerobot/pusht`](https://huggingface.co/lerobot/pusht) — MIT-licensed, with
+  vision, state, action, episode, and timestamp fields. Pinned revision
+  `7628202a2180972f291ba1bc6723834921e72c19`.
+- **You need:** `npa` installed for the local smoke; Nebius creds + an H100 for
+  the live run.
+
+## Fast path (local smoke, no cluster)
+
+Run the same structural spine the live pipeline uses, entirely on your machine,
+with typed return objects:
+
+```python
+from npa.sdk.workbench import sim_to_real
+
+report = sim_to_real.local_smoke(
+    run_id="pusht-hello",
+    s3_bucket="your-bucket-name",
+    s3_endpoint="https://storage.eu-north1.nebius.cloud",
+    s3_prefix="sim-to-real/pusht-hello",
+    input_data_uri="s3://your-bucket-name/datasets/lerobot-pusht/",
+    policy_image="npa-lerobot-policy:0.1.0",
+    gpu="H100:1",
+    eval_backend="state-success",
+    feedback_source="sim-env",
+    feedback_type="scalar",
+    vlm_eval_backend="stub",
+    attempt_s3_roundtrip=False,
+)
+print(report.status)
+```
+
+This validates the data split, the eval backend, the feedback object, and the
+Rerun recording wiring without provisioning anything.
+
+## The one-command live run
+
+When you're ready to do it for real on an H100:
+
+```bash
+npa/.venv/bin/python npa/scripts/run_sim_to_real_quickstart.py
+```
+
+That wrapper renders `sim-to-real-pipeline.yaml`, submits it on `H100:1`, runs
+the real training/eval loop, prints the **task-success score** plus the
+checkpoint / report / Rerun S3 URIs, and tears down the run-scoped cluster.
+Warm runs target about 5-6 minutes for the small proof config.
+
+## What's happening under the hood
+
+```text
+lerobot/pusht ─▶ split (train / heldout) ─▶ imitation train ─▶ eval ─▶ feedback
+                                                   │                      │
+                                                   └──── checkpoint ◀──────┘
+                                                          + Rerun .rrd
+```
+
+Both the **evaluator** and the **feedback source** are swappable:
+
+- `--eval-backend`: `state-success` (pose predicate), `vlm-frames` (VLM judges
+  rendered frames), or `heldout-metrics`.
+- `--feedback-source`: `none`, `sim-env`, `vlm`, or `byo-container`.
+
+That's the same `vlm-eval` judge from the
+[no-GPU guide](score-a-robot-no-gpu.md), now grading a live policy.
+
+## Look at it
+
+Download the Rerun recording and scrub through demonstrations, the policy
+rollout, and per-episode feedback:
+
+```bash
+rerun /tmp/npa-sim-to-real-<run-id>/<run-id>.rrd
+```
+
+## Bring your own dataset
+
+Point the loop at any `LeRobotDataset` in S3 and keep the same visualization:
+
+```bash
+--input-data-uri "s3://your-bucket-name/datasets/my-lerobot-dataset/"
+```
+
+This is exactly how you'd plug in the [Franka demos](franka-pick-and-place-genesis.md)
+you recorded in Genesis, or a [Reachy 2](reachy2-lerobot-policy.md) dataset.
+
+## Dig deeper
+
+- Cookbook: [Sim-To-Real Pipeline Runbook](../cookbooks/sim-to-real-pipeline.md)
+- Quickstart: [../sim-to-real-quickstart.md](../sim-to-real-quickstart.md)
+- Workflow YAML: `npa/workflows/workbench/skypilot/sim-to-real-pipeline.yaml`
+- Skill: `.agents/skills/workbench/sim-to-real/SKILL.md`

--- a/docs/workbench/guides/quadruped-isaac-lab.md
+++ b/docs/workbench/guides/quadruped-isaac-lab.md
@@ -1,0 +1,91 @@
+# Train a Quadruped to Run in Isaac Lab
+
+**The hook:** drop a four-legged robot into NVIDIA **Isaac Lab**, run massively
+parallel reinforcement learning, and watch it learn to trot across flat and
+rough terrain. Isaac Lab ships dozens of ready-made tasks, so you get a real
+locomotion policy without writing an environment from scratch.
+
+## Ingredients
+
+- **Robot:** a quadruped — ANYmal-C is the built-in favorite (swap the task to
+  pick another).
+- **Sim / engine:** [Isaac Lab](https://isaac-sim.github.io/IsaacLab/) on Isaac
+  Sim — GPU RL with thousands of parallel envs.
+- **Public tasks / data:** Isaac Lab's built-in task registry, e.g.
+  `Isaac-Velocity-Flat-Anymal-C-v0` and `Isaac-Velocity-Rough-Anymal-C-v0`.
+- **You need:** Nebius creds + an **RT-core GPU — L40S or RTX PRO 6000**. Isaac
+  Lab will **not** run correctly on H100/H200 (no RT cores). Training must run
+  headless. See [getting-started](../getting-started.md).
+
+## The shape of the workflow
+
+```text
+Isaac Lab task (quadruped) ──train (headless RL)──▶ policy checkpoint
+                                                          │
+                                                    isaac-lab eval
+```
+
+## Fast path
+
+**1. Meet the tool and confirm your GPU is RT-capable:**
+
+```bash
+npa workbench isaac-lab list
+npa workbench isaac-lab system-info
+```
+
+**2. Train a quadruped velocity policy** (start with a small env count / step
+budget to prove the loop):
+
+```bash
+npa workbench isaac-lab train \
+  --task Isaac-Velocity-Flat-Anymal-C-v0 \
+  --num-envs 1024 \
+  --steps 200 \
+  --output-path s3://your-bucket-name/isaac-lab/anymal-flat/
+```
+
+**3. Make it harder** — swap to rough terrain once flat-ground walking works:
+
+```bash
+npa workbench isaac-lab train \
+  --task Isaac-Velocity-Rough-Anymal-C-v0 \
+  --num-envs 2048 \
+  --steps 500 \
+  --output-path s3://your-bucket-name/isaac-lab/anymal-rough/
+```
+
+**4. Evaluate the trained policy:**
+
+```bash
+npa workbench isaac-lab eval \
+  --task Isaac-Velocity-Flat-Anymal-C-v0 \
+  --help
+```
+
+## Go bigger
+
+- **Run serverless on Nebius:** add `--runtime serverless --gpu-type l40s` and
+  `train` submits a Nebius AI Job. (Keep it on an RT-core GPU type.)
+- **Try other robots:** the same `--task` flag covers arms (e.g.
+  `Isaac-Reach-Franka-v0`), humanoids, and more — Isaac Lab's whole task
+  registry is available.
+- **Bring your own fork:** layer a custom Isaac Lab image over the digest-pinned
+  base with `--image`. See the
+  [Isaac Lab BYOF cookbook](../cookbooks/byof-isaac-lab/README.md).
+- **Export to LeRobot:** roll out a humanoid/G1 task to a `LeRobotDataset` with
+  `npa workbench isaac-lab export-lerobot`, then train a policy with the
+  [LeRobot guide](reachy2-lerobot-policy.md).
+
+## Heads up
+
+- **RT cores are mandatory.** L40S or RTX PRO 6000 only. H100/H200 lack RT cores
+  and won't render/simulate Isaac Lab correctly.
+- Training must invoke **headless** mode — these commands do.
+
+## Dig deeper
+
+- Cookbook: [Isaac Lab BYOF](../cookbooks/byof-isaac-lab/README.md)
+- Workflows: `npa/workflows/workbench/skypilot/isaac-lab-rl-train.yaml`,
+  `isaac-lab-rl-sweep.yaml`; runner `npa/scripts/run_isaac_lab_rl.py`
+- Skill: `.agents/skills/workbench/isaac-lab/SKILL.md`

--- a/docs/workbench/guides/quadruped-isaac-lab.md
+++ b/docs/workbench/guides/quadruped-isaac-lab.md
@@ -65,12 +65,16 @@ npa workbench isaac-lab eval \
 
 ## Go bigger
 
-- **Serverless is not the validated path yet.** `--runtime serverless
-  --project-id <your-project-id> --gpu-type l40s` does submit a Nebius AI Job,
-  but Isaac Lab end-to-end serverless training is currently failing (tracked by
-  `W9-isaac-lab-e2e-fix`) and RT-core (L40S) serverless capacity is scarce, so
-  jobs often queue and then fail without artifacts. Prefer the VM / managed-
-  Kubernetes RT-core path and the BYOF flow below until that lands.
+- **Serverless works, but mind RT-core capacity.** `--runtime serverless
+  --project-id <your-project-id> --gpu-type l40s` submits a Nebius AI Job.
+  Isaac Lab needs RT cores, and capacity is SKU-specific: the default
+  `gpu-l40s-a` pool can fail to schedule (`NotEnoughResources` / VM schedule
+  timeout). If that happens, retry on the other L40S SKU with
+  `--gpu-type gpu-l40s-d`, which scheduled and ran to completion in our testing.
+  Note `gpu-rtx6000` is **not** a serverless platform (it's the managed-
+  Kubernetes path). End-to-end checkpoint production over serverless is still
+  being hardened (`W9-isaac-lab-e2e-fix`), so for real training prefer the
+  RT-core VM / managed-Kubernetes + BYOF flow below.
 - **Try other robots:** the same `--task` flag covers arms (e.g.
   `Isaac-Reach-Franka-v0`), humanoids, and more — Isaac Lab's whole task
   registry is available.

--- a/docs/workbench/guides/quadruped-isaac-lab.md
+++ b/docs/workbench/guides/quadruped-isaac-lab.md
@@ -65,10 +65,12 @@ npa workbench isaac-lab eval \
 
 ## Go bigger
 
-- **Run serverless on Nebius:** add `--runtime serverless --project-id
-  <your-project-id> --gpu-type l40s` and `train` submits a Nebius AI Job. (Keep
-  it on an RT-core GPU type. Serverless needs `--project-id`, or a project
-  configured in `~/.npa/config.yaml`.)
+- **Serverless is not the validated path yet.** `--runtime serverless
+  --project-id <your-project-id> --gpu-type l40s` does submit a Nebius AI Job,
+  but Isaac Lab end-to-end serverless training is currently failing (tracked by
+  `W9-isaac-lab-e2e-fix`) and RT-core (L40S) serverless capacity is scarce, so
+  jobs often queue and then fail without artifacts. Prefer the VM / managed-
+  Kubernetes RT-core path and the BYOF flow below until that lands.
 - **Try other robots:** the same `--task` flag covers arms (e.g.
   `Isaac-Reach-Franka-v0`), humanoids, and more — Isaac Lab's whole task
   registry is available.

--- a/docs/workbench/guides/quadruped-isaac-lab.md
+++ b/docs/workbench/guides/quadruped-isaac-lab.md
@@ -65,8 +65,10 @@ npa workbench isaac-lab eval \
 
 ## Go bigger
 
-- **Run serverless on Nebius:** add `--runtime serverless --gpu-type l40s` and
-  `train` submits a Nebius AI Job. (Keep it on an RT-core GPU type.)
+- **Run serverless on Nebius:** add `--runtime serverless --project-id
+  <your-project-id> --gpu-type l40s` and `train` submits a Nebius AI Job. (Keep
+  it on an RT-core GPU type. Serverless needs `--project-id`, or a project
+  configured in `~/.npa/config.yaml`.)
 - **Try other robots:** the same `--task` flag covers arms (e.g.
   `Isaac-Reach-Franka-v0`), humanoids, and more — Isaac Lab's whole task
   registry is available.

--- a/docs/workbench/guides/reachy2-lerobot-policy.md
+++ b/docs/workbench/guides/reachy2-lerobot-policy.md
@@ -1,0 +1,104 @@
+# Train a Reachy 2 Humanoid Policy from a Public Dataset
+
+**The hook:** Reachy 2 is the open-source humanoid from Pollen Robotics (now
+part of Hugging Face) — a friendly upper-body robot with two arms, a head, and
+a mobile base. In this guide you take a **public Reachy dataset off the Hugging
+Face Hub** and train an imitation policy on it with LeRobot, no robot hardware
+required.
+
+It's the fastest way to feel what teaching a humanoid to manipulate is like.
+
+## Ingredients
+
+- **Robot:** [Reachy 2](https://huggingface.co/docs/lerobot/main/en/reachy2)
+  (Pollen Robotics). Fully supported by LeRobot for teleop, training, and eval.
+- **Sim / engine:** LeRobot training + evaluation; pair it with the
+  [sim-to-real loop](pusht-sim-to-real.md) for closed-loop rollouts.
+- **Public dataset:** Reachy datasets published on the Hub under
+  [`pollen-robotics`](https://huggingface.co/pollen-robotics) and
+  [`lerobot`](https://huggingface.co/lerobot). Any `LeRobotDataset` works — the
+  examples below show the swap.
+- **You need:** Nebius creds + a GPU (see [getting-started](../getting-started.md)).
+
+## The shape of the workflow
+
+```text
+public Reachy dataset (HF Hub or S3) ──▶ npa workbench lerobot train
+                                                  │
+                                          policy checkpoint on S3
+                                                  │
+                              ┌───────────────────┼───────────────────┐
+                              ▼                    ▼                   ▼
+                        lerobot eval         lerobot serve       lerobot infer
+```
+
+LeRobot is the default policy framework and the data standard. It ships ACT,
+Diffusion Policy, and SmolVLA — start with `act` for a quick single-task
+baseline.
+
+## Fast path
+
+**1. See the tool:**
+
+```bash
+npa workbench lerobot list
+```
+
+**2. Train an ACT policy** straight from a Hub dataset. Swap `--dataset` for the
+Reachy dataset you want (a Pollen Robotics / LeRobot Hub repo ID):
+
+```bash
+npa workbench lerobot train \
+  --policy-type act \
+  --dataset pollen-robotics/<reachy-dataset> \
+  --job-name reachy-act-hello \
+  --steps 2000 \
+  --batch-size 8 \
+  --output-path s3://your-bucket-name/checkpoints/reachy-act/
+```
+
+Prefer to stage data in your own bucket first? Use `--input-path` with an S3
+`LeRobotDataset` URI instead of `--dataset` (it takes priority):
+
+```bash
+npa workbench lerobot train \
+  --policy-type act \
+  --input-path s3://your-bucket-name/datasets/reachy2-grasp/ \
+  --job-name reachy-act-byo \
+  --output-path s3://your-bucket-name/checkpoints/reachy-act/
+```
+
+**3. Evaluate and serve the trained checkpoint:**
+
+```bash
+npa workbench lerobot eval --help
+npa workbench lerobot serve --help
+npa workbench lerobot infer --help
+npa workbench lerobot list-checkpoints
+```
+
+## Go bigger
+
+- **Run serverless on Nebius:** add `--runtime serverless --gpu-type h200`
+  (or `b300` / `l40s`) and `train` submits a Nebius AI Job.
+- **Try a stronger policy:** `--policy-type smolvla` for a language-conditioned
+  VLA baseline, or `diffusion` for smooth continuous actions.
+- **Close the loop:** feed your checkpoint into the
+  [sim-to-real loop](pusht-sim-to-real.md) to evaluate rollouts and collect
+  feedback, then visualize with Rerun.
+- **Benchmark the GPUs:** see the
+  [LeRobot GPU benchmarks](../cookbooks/lerobot-gpu-benchmarks.md) across L40S,
+  H200, B300, and RTX PRO 6000.
+
+## Record your own Reachy data
+
+Got a real Reachy 2? LeRobot records directly to the same format with
+`lerobot-record --robot.type=reachy2 ...`, then you push to the Hub or stage to
+S3 and train with the exact commands above. The workbench never cares whether
+the data came from a real robot, a teleop session, or a simulator.
+
+## Dig deeper
+
+- LeRobot CLI: `npa workbench lerobot train | eval | serve | infer | list-checkpoints | benchmark`
+- Reachy 2 in LeRobot: https://huggingface.co/docs/lerobot/main/en/reachy2
+- Skill: `.agents/skills/workbench/lerobot/SKILL.md`

--- a/docs/workbench/guides/reachy2-lerobot-policy.md
+++ b/docs/workbench/guides/reachy2-lerobot-policy.md
@@ -79,8 +79,10 @@ npa workbench lerobot list-checkpoints
 
 ## Go bigger
 
-- **Run serverless on Nebius:** add `--runtime serverless --gpu-type h200`
-  (or `b300` / `l40s`) and `train` submits a Nebius AI Job.
+- **Run serverless on Nebius:** add `--runtime serverless --project-id
+  <your-project-id> --gpu-type h200` (or `b300` / `l40s`) and `train` submits a
+  Nebius AI Job. (Serverless needs `--project-id`, or a project configured in
+  `~/.npa/config.yaml`.)
 - **Try a stronger policy:** `--policy-type smolvla` for a language-conditioned
   VLA baseline, or `diffusion` for smooth continuous actions.
 - **Close the loop:** feed your checkpoint into the

--- a/docs/workbench/guides/score-a-robot-no-gpu.md
+++ b/docs/workbench/guides/score-a-robot-no-gpu.md
@@ -1,0 +1,77 @@
+# Score a Robot in 60 Seconds (No GPU, No Cloud)
+
+**The hook:** before you spin up a single GPU, prove the whole evaluation loop
+on your laptop. You'll grade a set of robot rollouts with a vision-language
+model "judge" and get a ranked report — using only the sample data that ships
+with `npa`. No cloud. No GPU. No credentials.
+
+This is the friendliest possible first taste of the workbench, and it's the same
+command you'll later point at a real VLM backend.
+
+## Ingredients
+
+- **Robot:** any — we score rollout clips, not a specific arm.
+- **Sim / engine:** none. The `stub` backend runs fully offline.
+- **Dataset:** a shipped, labeled benchmark of four robot rollouts.
+- **You need:** just `npa` installed (see
+  [the guides intro](README.md#before-you-start)).
+
+## Fast path
+
+Run the benchmark against the shipped sample set with the offline `stub`
+backend:
+
+```bash
+npa workbench vlm-eval benchmark \
+  --dataset npa/src/npa/workbench/vlm_eval/fixtures/sample_benchmark/benchmark.json \
+  --output /tmp/vlm-eval-benchmark.json \
+  --backend stub \
+  --thresholds 0.5,0.8,0.9 \
+  --rubrics default,strict \
+  --models Qwen/Qwen2-VL-7B-Instruct \
+  --format json
+```
+
+You should see a ranked report with `accuracy: 1.0` over four labeled rollouts.
+That's the entire local loop: a VLM judge scores each rollout, the sweep tries
+every threshold/rubric/model combination, and the best config wins.
+
+Want a single-rollout taste instead of a sweep? Try a dry run:
+
+```bash
+npa workbench vlm-eval run \
+  --input-path ./rollout.json \
+  --output-path ./eval.json \
+  --backend stub \
+  --score 0.9 \
+  --dry-run
+```
+
+## What just happened
+
+The `vlm-eval` tool is the workbench's evaluation backend. It takes robot
+rollout artifacts (frames + metadata), asks a vision-language model whether the
+task succeeded, and writes a task-success report. The `stub` backend returns
+deterministic scores so you can validate plumbing, CI, and report format with
+zero infrastructure.
+
+The exact same command swaps `--backend stub` for `--backend self-hosted`
+(a vLLM server you launch) or `--backend api` (a hosted endpoint) once you add
+credentials — the report shape never changes.
+
+## Go bigger
+
+- **Real judge, self-hosted:** serve a VLM with vLLM and score real rollout
+  directories — see the
+  [VLM-Eval Loop Runbook](../cookbooks/vlm-eval-loop-runbook.md).
+- **Real judge, hosted API:** use Nebius Token Factory as the backend with no
+  GPU of your own — see [../token-factory.md](../token-factory.md).
+- **In a pipeline:** `vlm-eval` is the scorer inside the
+  [sim-to-real loop](pusht-sim-to-real.md), where it grades a freshly trained
+  policy.
+
+## Dig deeper
+
+- Cookbook: [VLM-Eval Loop Runbook](../cookbooks/vlm-eval-loop-runbook.md)
+- Workflow YAML: `npa/workflows/workbench/skypilot/vlm-eval.yaml`
+- Skill: `.agents/skills/workbench/vlm-eval/SKILL.md`

--- a/docs/workbench/guides/score-a-robot-no-gpu.md
+++ b/docs/workbench/guides/score-a-robot-no-gpu.md
@@ -64,8 +64,9 @@ credentials — the report shape never changes.
 - **Real judge, self-hosted:** serve a VLM with vLLM and score real rollout
   directories — see the
   [VLM-Eval Loop Runbook](../cookbooks/vlm-eval-loop-runbook.md).
-- **Real judge, hosted API:** use Nebius Token Factory as the backend with no
-  GPU of your own — see [../token-factory.md](../token-factory.md).
+- **Real judge, hosted API:** point the `api` backend at a hosted, OpenAI-
+  compatible VLM (such as Nebius Token Factory) to score with no GPU of your own
+  — see the [VLM-Eval Loop Runbook](../cookbooks/vlm-eval-loop-runbook.md).
 - **In a pipeline:** `vlm-eval` is the scorer inside the
   [sim-to-real loop](pusht-sim-to-real.md), where it grades a freshly trained
   policy.

--- a/npa/src/npa/clients/project_credentials.py
+++ b/npa/src/npa/clients/project_credentials.py
@@ -9,6 +9,7 @@ import boto3
 from botocore.config import Config as BotoConfig
 
 from npa.clients.config import StorageConfig, list_projects, resolve_project_storage
+from npa.clients.credentials import load_credentials
 from npa.clients.storage import StorageClient
 from npa.errors import ScopedCredentialError
 
@@ -68,6 +69,24 @@ def resolve_credentials(
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
         )
+
+    # Fall back to the user credential file (~/.npa/credentials.yaml) that the
+    # rest of npa uses for S3 access. These are host-level credentials, so use
+    # them for the default project or when the caller opts in with
+    # allow_host_creds.
+    if normalized is None or allow_host_creds:
+        user_creds = load_credentials()
+        host_endpoint = endpoint_url or user_creds.s3_endpoint
+        host_access = access_key or user_creds.s3_access_key_id
+        host_secret = secret_key or user_creds.s3_secret_access_key
+        if host_endpoint and host_access and host_secret:
+            return CredentialPair(
+                project=normalized,
+                endpoint_url=host_endpoint,
+                aws_access_key_id=host_access,
+                aws_secret_access_key=host_secret,
+                uses_host_credentials=True,
+            )
 
     if allow_host_creds and endpoint_url:
         return CredentialPair(

--- a/npa/tests/test_cross_project_credentials.py
+++ b/npa/tests/test_cross_project_credentials.py
@@ -9,6 +9,7 @@ import yaml
 from npa.cli.demo import stage_artifacts
 from npa.cli.main import app
 from npa.clients import config
+from npa.clients import credentials as credentials_mod
 from npa.clients.project_credentials import resolve_credentials
 from npa.errors import ScopedCredentialError
 from fakes import _access_denied, _fake_s3_factory, _manifest
@@ -72,6 +73,63 @@ def test_resolve_credentials_nonexistent_project_raises(
 ) -> None:
     with pytest.raises(ScopedCredentialError, match="missing-project"):
         resolve_credentials(project="missing-project")
+
+
+@pytest.fixture()
+def user_credentials_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Empty machine config plus a user ~/.npa/credentials.yaml with S3 keys."""
+    cfg = tmp_path / ".npa" / "config.yaml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("projects:\n  proj-x: {}\n")
+    monkeypatch.setattr(config, "CONFIG_PATH", cfg)
+
+    for var in (
+        "AWS_ENDPOINT_URL",
+        "NEBIUS_S3_ENDPOINT",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    creds_file = tmp_path / ".npa" / "credentials.yaml"
+    creds_file.write_text(
+        yaml.safe_dump(
+            {
+                "storage": {
+                    "endpoint_url": "https://host-storage.example",
+                    "aws_access_key_id": "host-key",
+                    "aws_secret_access_key": "host-secret",
+                    "bucket": "s3://host-bucket/",
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(credentials_mod, "CREDENTIALS_PATH", creds_file)
+    return creds_file
+
+
+def test_resolve_credentials_default_falls_back_to_user_credentials_file(
+    user_credentials_file: Path,
+) -> None:
+    resolved = resolve_credentials(project=None)
+
+    assert resolved.endpoint_url == "https://host-storage.example"
+    assert resolved.aws_access_key_id == "host-key"
+    assert resolved.aws_secret_access_key == "host-secret"
+    assert resolved.uses_host_credentials is True
+
+
+def test_resolve_credentials_named_project_requires_allow_host_creds(
+    user_credentials_file: Path,
+) -> None:
+    with pytest.raises(ScopedCredentialError, match="--allow-host-creds"):
+        resolve_credentials(project="proj-x")
+
+    resolved = resolve_credentials(project="proj-x", allow_host_creds=True)
+    assert resolved.aws_access_key_id == "host-key"
+    assert resolved.uses_host_credentials is True
 
 
 def test_demo_stage_cross_project_uses_source_and_target_credentials(


### PR DESCRIPTION
## Summary

Adds beginner-friendly Workbench guides plus the fixes/validation that came out of testing them on real Nebius backends, and lands the cache-friendly agent-context guardrails.

### 1. Easy Guides (`docs/workbench/guides/`)
Six task-first guides, each tied to a validated `npa` entrypoint, a public dataset, and a real robot/sim, linked from the root `README.md`:
- **score-a-robot-no-gpu** — zero-GPU / zero-credential VLM-eval first run
- **franka-pick-and-place-genesis** — Franka in Genesis
- **pusht-sim-to-real** — PushT sim-to-real loop
- **reachy2-lerobot-policy** — Reachy 2 policy from public LeRobot data
- **g1-humanoid-walk-sonic** — Unitree G1 walk via SONIC/MuJoCo
- **quadruped-isaac-lab** — quadruped RL in Isaac Lab

`guides/README.md` includes a "what's validated on real backends" matrix.

### 2. Bug fix (found while testing the guides on serverless)
- `npa workbench data` now resolves S3 creds from `~/.npa/credentials.yaml` for the default project / `--allow-host-creds`, instead of failing. Regression test added.

### 3. Guide corrections from live runs
- Genesis serverless documented as smoke-only; `sonic system-info` → `status`; `--project-id` required for serverless; Genesis checkpoint `last.pt` → `model.pt`; broken token-factory link fixed; Isaac Lab serverless failure root-caused as capacity (`gpu-l40s-a`) — `gpu-l40s-d` schedules; VM/K8s recommended for real training.

### 4. Agent-context guardrails (token-cost / prompt-cache)
- Removes the legacy 55-line `.cursorrules`; adds a 1-line `.cursorrules` that delegates to `.agents/skills` (low baseline token tax).
- New `context-efficiency` skill (mirrored in `.agents` + `.claude`, indexed in `AGENTS.md`/`CLAUDE.md`): prompt-cache prefix stability, anti-bleed boundaries, `@`-reference symbol isolation, 500-line read refusal, lean state-file rules.
- Adds `.cursorignore` blocking the big sinks (`npa/.venv` ~1.5G, caches, model weights, binary demo assets, lockfiles, root-anchored data/sim-log dirs).

## Test plan
- [x] CI green: `gitleaks`, `guardrails`, `scan`, `test` (x2)
- [x] Creds fix covered by `npa/tests/test_cross_project_credentials.py`
- [x] Guide workflows exercised on Nebius serverless (see `guides/README.md` matrix)
- [ ] Reviewer approval (only remaining merge blocker)

Docs-only + one isolated creds fix; no changes to runtime workflow behavior.