### PR TITLE
docs: workflow catalog + Workbench-first navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # Nebius Physical AI
 
-Partners integrate independently. Teams assemble from open blueprints. Nebius
-owns the infrastructure layer and compute substrate.
+**One command surface for robotics, simulation, perception, and synthetic-data
+workloads — running on Nebius GPUs.**
+
+`npa` is the CLI and SDK for physical-AI workloads on Nebius. **Workbench is the
+primary solution**: data curation, simulation, synthetic data, policy training,
+evaluation, export, and observability, all driven by `npa workbench` commands
+and reproducible SkyPilot workflows on the Nebius substrate (object storage,
+managed Kubernetes, vLLM serving, and GPU clusters).
 
 ![Nebius Physical AI Workbench](docs/assets/workbench-architecture.png)
 
-`npa` is the CLI and SDK for physical-AI workloads on Nebius. Workbench is the
-primary solution: it gives developers one command surface for data curation,
-simulation, synthetic data, policy training, evaluation, export, observability,
-and SkyPilot workflows running on the Nebius substrate of object storage,
-orchestration, vLLM serving, managed Kubernetes, and GPU clusters.
+---
 
-## Quick Start
+## ⚡ Try it in 60 seconds — no cloud, no GPU, no credentials
 
-Install the `npa` package into a fresh virtual environment. The venv can live
-anywhere; activating it puts `npa` on your `PATH` (Python 3.10+ required):
+Install `npa` into a fresh virtual environment (Python 3.10+), then score a
+shipped sample rollout set with the offline `stub` backend:
 
 ```bash
 git clone https://github.com/nebius/nebius-physical-ai.git
@@ -25,13 +27,6 @@ source .venv/bin/activate
 pip install --upgrade pip
 pip install -e npa
 
-npa --version
-```
-
-Run your first real result with **no cloud, GPU, or credentials** — score a
-shipped sample rollout set with the offline stub backend:
-
-```bash
 npa workbench vlm-eval benchmark \
   --dataset npa/src/npa/workbench/vlm_eval/fixtures/sample_benchmark/benchmark.json \
   --output /tmp/vlm-eval-benchmark.json \
@@ -43,22 +38,77 @@ npa workbench vlm-eval benchmark \
 ```
 
 You should see a ranked report with `accuracy: 1.0` over four labeled rollouts.
-That is the full local loop; the same command swaps `--backend stub` for a real
+That is the full local loop — the same command swaps `--backend stub` for a real
 `self-hosted` or `api` VLM backend once you add credentials.
 
-Next, authenticate with the Nebius CLI and print the credential schema (see
-[docs/quickstart.md](docs/quickstart.md) for the full walkthrough):
+---
 
-```bash
-nebius profile create
-nebius iam get-access-token >/dev/null
-npa configure
-```
+## 🧭 Find your workflow
 
-The flagship GPU workload is **NVIDIA Cosmos** (world-foundation model for
-synthetic data and world generation). It runs across multiple NVIDIA GPU
-platforms via a single `--gpu-type` flag (`gpu-h100-sxm`, `gpu-h200-sxm`,
-`gpu-b300-sxm`, `gpu-l40s`) with no RT-core lock-in:
+**The fastest way to navigate this repo is the workflow catalog:**
+
+### → [Workflow Catalog](npa/workflows/workbench/skypilot/README.md)
+
+It has a single "I want to…" table that maps every goal to the workflow YAML,
+the command to run it, the GPU it needs, and its guide. A few common entry
+points:
+
+| I want to… | Run | Guide |
+| --- | --- | --- |
+| Score robot rollouts with a VLM | `npa workbench vlm-eval` | [vlm-eval loop](docs/workbench/cookbooks/vlm-eval-loop-runbook.md) |
+| Generate synthetic frames with Cosmos | `npa workbench cosmos` | [quickstart](docs/quickstart.md#7-flagship-gpu-workload-nvidia-cosmos) |
+| Curate + train an AV perception model | [`run_bdd100k_pipeline.py`](npa/scripts/run_bdd100k_pipeline.py) | [BDD100K pipeline](docs/workbench/cookbooks/bdd100k-pipeline.md) |
+| Run a sim-to-real train → eval loop | [`run_sim_to_real_pipeline.py`](npa/scripts/run_sim_to_real_pipeline.py) | [sim-to-real](docs/workbench/cookbooks/sim-to-real-pipeline.md) |
+| Train / fine-tune a robot policy | `npa workbench sonic`, `lerobot`, `groot` | [cookbooks](docs/workbench/cookbooks/README.md) |
+| Train an Isaac Lab RL policy | [`run_isaac_lab_rl.py`](npa/scripts/run_isaac_lab_rl.py) | [Isaac Lab BYOF](docs/workbench/cookbooks/byof-isaac-lab/README.md) |
+
+Every workflow YAML lives in
+[`npa/workflows/workbench/skypilot/`](npa/workflows/workbench/skypilot/); the
+catalog maps each one to the command that runs it and its guide.
+
+---
+
+## 🗺️ Where do I go? (by audience)
+
+| You are a… | Start here |
+| --- | --- |
+| **Salesperson / evaluator** | [Try it in 60 seconds](#-try-it-in-60-seconds--no-cloud-no-gpu-no-credentials), then the [Workflow Catalog](npa/workflows/workbench/skypilot/README.md) to see what the platform does |
+| **Customer running a first workload** | [docs/workbench/getting-started.md](docs/workbench/getting-started.md) |
+| **Developer building pipelines** | [Workflow Catalog](npa/workflows/workbench/skypilot/README.md) + [docs/workbench-yaml-guide.md](docs/workbench-yaml-guide.md) |
+| **SDK integrator or agent author** | [docs/workbench/cli-sdk-yaml-walkthrough.md](docs/workbench/cli-sdk-yaml-walkthrough.md), [docs/sdk/errors.md](docs/sdk/errors.md) |
+| **Contributor to `npa` itself** | [CONTRIBUTING.md](CONTRIBUTING.md) |
+
+---
+
+## 🛠️ Workbench tool surface
+
+Workbench tools are mounted directly under `npa workbench` (there is no
+`solutions` CLI namespace). Tools share the same lifecycle verbs — `deploy`,
+`status`, `list`, `run`, `train`, `eval`, `serve`, `infer`, `export`,
+`system-info` — and hand off data through S3-style `--input-path` /
+`--output-path` values.
+
+| Category | Workbench commands |
+| --- | --- |
+| **Data curation** | `npa workbench data sync/status/list`; `fiftyone curate/eval/load-dataset`; `lancedb deploy/import-bdd100k/create-mv/query`; `detection-training train/eval` |
+| **Synthetic data** | `npa workbench cosmos infer/train/serve`; `genesis generate-demos` |
+| **Simulation** | `npa workbench isaac-lab train/eval/export-lerobot`; `genesis train-teacher/eval-student`; `retargeting run` |
+| **Eval** | `npa workbench vlm-eval run/benchmark`; `mjlab eval`; `sonic eval`; `fiftyone eval`; `isaac-lab eval` |
+| **Robot policy** | `npa workbench lerobot train/eval/serve/infer`; `groot finetune/serve/infer`; `sonic train/serve/export/eval` |
+| **World models** | `npa workbench cosmos deploy/serve/infer/train/status` |
+| **Observability** | Tool-level `status`/`list`/`system-info`; `workflow status/logs`; `rerun host/share`; `cluster status` |
+| **Workflows** | `npa workbench workflow submit/run/status/logs/teardown` over the YAMLs in the [catalog](npa/workflows/workbench/skypilot/README.md) |
+
+The generated CLI reference is in [docs/cli/README.md](docs/cli/README.md).
+
+---
+
+## 🚀 Flagship GPU workload: NVIDIA Cosmos
+
+Cosmos is the world-foundation model for synthetic data and world generation. It
+runs across multiple NVIDIA GPU platforms via a single `--gpu-type` flag
+(`gpu-h100-sxm`, `gpu-h200-sxm`, `gpu-b300-sxm`, `gpu-l40s`) with no RT-core
+lock-in:
 
 ```bash
 npa workbench cosmos -p <your-project-alias> -n cosmos deploy \
@@ -69,177 +119,72 @@ npa workbench cosmos -p <your-project-alias> -n cosmos infer \
 ```
 
 Cosmos needs Nebius credentials, an `HF_TOKEN`, and GPU capacity; see the
-flagship walkthrough in [docs/quickstart.md](docs/quickstart.md#7-flagship-gpu-workload-nvidia-cosmos).
+flagship walkthrough in
+[docs/quickstart.md](docs/quickstart.md#7-flagship-gpu-workload-nvidia-cosmos).
 
-To work on `npa` itself (tests, lint), install the dev extra and run the fast
-suite — see [CONTRIBUTING.md](CONTRIBUTING.md):
+---
+
+## ☁️ Running on Nebius
+
+To go from the local loop to real GPUs, authenticate with the Nebius CLI and
+configure `npa` (full walkthrough in [docs/quickstart.md](docs/quickstart.md)):
+
+```bash
+nebius profile create
+nebius iam get-access-token >/dev/null
+npa configure
+```
+
+Workbench runs on Nebius infrastructure rather than hiding it:
+
+- **Object storage** is the data layer for datasets, checkpoints, rollouts, eval
+  JSON, exported models, and Rerun recordings.
+- **SkyPilot** orchestrates multi-stage jobs and managed-Kubernetes workflows.
+- **vLLM-compatible endpoints** back shared model-serving and Eval paths.
+- **Managed Kubernetes, VM, BYOVM, container, and serverless** runtimes cover
+  H100, H200, L40S, B300, and RTX6000 GPU targets as each tool is validated.
+- **Nebius CLI auth + IAM**, with user secrets in `~/.npa/credentials.yaml` kept
+  separate from machine-managed config in `~/.npa/config.yaml`.
+
+---
+
+## 🧩 Solutions framework
+
+Workbench is the current primary solution, implemented as the top-level SDK
+namespace `npa.workbench` and the CLI namespace `npa workbench`. The repository
+supports multiple top-level solution namespaces, and future solutions (a
+datalake or simfarm, say) are **additive**: they sit beside Workbench as another
+top-level `npa` namespace and must not rename Workbench, move it under a
+`solutions` namespace, or change existing `npa workbench` commands. See
+[docs/architecture/solutions-model.md](docs/architecture/solutions-model.md).
+
+---
+
+## 🤝 Contributing
+
+To work on `npa` itself, install the dev extra and run the fast suite:
 
 ```bash
 pip install -e "npa[dev]"
 make test
 ```
 
-For full cloud setup, continue with [docs/quickstart.md](docs/quickstart.md)
-and [docs/workbench/getting-started.md](docs/workbench/getting-started.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md). Repo validation uses
+`npa/.venv/bin/python`, never bare `python`.
 
-## Workbench
+---
 
-Workbench is the main product surface in this repository. Current Workbench
-tools are mounted directly under `npa workbench`; there is no `solutions` CLI
-namespace.
+## 📚 Docs
 
-| Category | Workbench commands |
-| --- | --- |
-| Data curation | `npa workbench data sync`, `npa workbench data status`, `npa workbench data list`; `npa workbench fiftyone curate`, `eval`, `load-dataset`, `datasets list`; `npa workbench lancedb deploy`, `create-table`, `import-lerobot`, `import-bdd100k`, `backfill`, `create-mv`, `refresh-mv`, `query-table`, `query`; `npa workbench detection-training train`, `eval`, `status`, `list` |
-| Synthetic data | `npa workbench cosmos infer`, `train`, `serve`, `status`; `npa workbench genesis generate-demos`; SkyPilot templates such as `npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml` and `npa/workflows/workbench/templates/curate-augment-train.yaml` |
-| Simulation | `npa workbench isaac-lab train`, `eval`, `export-lerobot`; `npa workbench genesis train-teacher`, `generate-demos`, `eval-teacher`, `eval-student`, `diagnose`, `tune`; `npa workbench retargeting run` |
-| Eval | `npa workbench vlm-eval run`, `benchmark`, `workflow`, `status`, `list`; `npa workbench mjlab eval`; `npa workbench sonic eval`; `npa workbench fiftyone eval`; `npa workbench isaac-lab eval`; `npa workbench genesis eval-student` |
-| Observability | Tool-level `status`, `list`, and `system-info` commands; `npa workbench workflow status`, `logs`; `npa rerun host`, `share`, `list-shares`, `revoke`; `npa cluster status`, `list` |
-| Robot policy | `npa workbench lerobot train`, `eval`, `serve`, `infer`, `list-checkpoints`, `benchmark`, `profile-train`, `train-student`; `npa workbench groot download`, `finetune`, `eval`, `serve`, `infer`, `convert`; `npa workbench sonic train`, `serve`, `export`, `eval`, `status`, `list` |
-| World models | `npa workbench cosmos deploy`, `serve`, `infer`, `train`, `status`, `system-info` |
-| Blueprints | `npa workbench workflow submit`, `run`, `status`, `logs`, `teardown`, `distill`; checked-in YAML under `npa/workflows/workbench/skypilot/` for Isaac Lab, VLM eval, SONIC export, SONIC eval, SONIC locomotion fine-tuning, retargeting, MJLab eval, sim-to-real, and BDD100K pipelines |
-
-### Eval: VLM Backend
-
-`vlm-eval` is a first-class Eval capability. It scores rollout artifacts with
-self-hosted, API, or stub backends and has a checked-in SkyPilot template at
-`npa/workflows/workbench/skypilot/vlm-eval.yaml`. The benchmark command sweeps a
-labeled rollout set across thresholds, rubrics, and models, then writes a ranked
-accuracy report with the best config.
-
-```bash
-npa workbench vlm-eval list
-npa workbench vlm-eval status
-npa workbench vlm-eval workflow
-npa workbench vlm-eval run \
-  --input-path ./rollout.json \
-  --output-path ./eval.json \
-  --backend stub \
-  --score 0.9 \
-  --dry-run
-npa workbench vlm-eval benchmark \
-  --dataset npa/src/npa/workbench/vlm_eval/fixtures/sample_benchmark/benchmark.json \
-  --output /tmp/vlm-eval-benchmark.json \
-  --backend stub \
-  --thresholds 0.5,0.8,0.9 \
-  --rubrics default,strict \
-  --models Qwen/Qwen2-VL-7B-Instruct
-```
-
-The self-hosted workflow starts an OpenAI-compatible vLLM server and then calls
-`npa workbench vlm-eval run`; the benchmark workflow does the same for
-`npa workbench vlm-eval benchmark`.
-
-### Robot Policy: GR00T, LeRobot, and SONIC
-
-Robot policy work is split across policy training/serving, humanoid foundation
-model operations, whole-body control, and export:
-
-```bash
-npa workbench lerobot train --help
-npa workbench lerobot serve --help
-npa workbench groot finetune --help
-npa workbench groot serve --help
-npa workbench sonic train --help
-npa workbench sonic export --help
-npa workbench sonic eval --help
-```
-
-`sonic export` is a first-class Robot Policy model-export capability. It
-converts a trained SONIC locomotion checkpoint to a deterministic-action ONNX
-graph:
-
-```bash
-npa workbench sonic export \
-  --checkpoint sonic_release/last.pt \
-  --output exported/sonic_policy.onnx
-```
-
-The matching workflow template is
-`npa/workflows/workbench/skypilot/sonic-export.yaml`.
-`npa workbench sonic eval` consumes the exported ONNX and sidecar metadata and
-can run the built-in reference backend or a configured eval container. The
-checked-in SkyPilot template is
-`npa/workflows/workbench/skypilot/sonic-eval.yaml`.
-
-### Workflows And Routing
-
-Workbench workflow orchestration lives under the Workbench solution:
-
-```bash
-npa workbench workflow submit npa/workflows/workbench/skypilot/vlm-eval.yaml --run-id vlm-eval
-npa workbench workflow submit npa/workflows/workbench/skypilot/sonic-export.yaml --run-id sonic-export
-npa workbench workflow submit npa/workflows/workbench/skypilot/sonic-eval.yaml --run-id sonic-eval
-npa workbench workflow run distill --local
-npa workbench workflow status run-1
-npa workbench workflow logs run-1 train_student
-```
-
-`submit` sends SkyPilot YAML through the NPA controller convention and supports
-`--controller-backend kubernetes`, `--controller-backend nebius`, `--run-id`,
-and repeated `--var KEY=VALUE` substitutions.
-
-SONIC image routing is manifest-driven:
-
-- `npa workbench sonic train` resolves the first-party image from
-  `npa/src/npa/deploy/sonic_image_manifest.json` using `--gpu-type`, with
-  `--image` and `--image-variant` available as explicit overrides.
-- L40S VM targets use the baked `npa-sonic:0.1.2` image. RTX PRO 6000
-  Blackwell Kubernetes targets use the host-mounted `npa-sonic:0.1.2-k8s-runtime`
-  image. See `docs/workbench/sonic-image-catalog.md`.
-
-### Solution Patterns
-
-Workbench tools share the same platform patterns:
-
-- Object-storage handoff through S3-style `--input-path` and `--output-path`
-  values, with `~/.npa/credentials.yaml` as the user-authored credential file.
-- SkyPilot workflows checked into `npa/workflows/workbench/` and submitted with
-  `npa workbench workflow submit`.
-- vLLM-compatible self-hosted serving for VLM eval and model-serving paths where
-  the runtime exposes an OpenAI-compatible endpoint.
-- Lifecycle commands that keep deploy, status, list, run, train, eval, serve,
-  infer, export, and system-info behavior predictable across tools.
-
-## Solutions Framework
-
-The repository supports multiple top-level solution namespaces. Workbench is the
-current primary solution and is implemented as the top-level SDK namespace
-`npa.workbench` and the CLI namespace `npa workbench`.
-
-Future solutions are additive: a datalake or simfarm solution would sit beside
-Workbench as another top-level `npa` namespace. Future solutions should not
-rename Workbench, move Workbench under a `solutions` namespace, or require users
-to change existing `npa workbench` commands.
-
-## Nebius Cloud Substrate
-
-Workbench runs on Nebius infrastructure rather than hiding it:
-
-- Object storage is the data layer for datasets, checkpoints, rollouts, eval
-  JSON, exported models, and Rerun recordings.
-- SkyPilot provides orchestration patterns for multi-stage jobs and managed
-  Kubernetes backed workflows.
-- vLLM-compatible endpoints support shared model-serving and Eval backends.
-- Managed Kubernetes, VM, BYOVM, container, and serverless runtimes cover GPU
-  targets including H100, H200, L40S, B300, and RTX6000 profiles as each tool is
-  validated.
-- Nebius CLI authentication, IAM, local `~/.npa/credentials.yaml`, and
-  machine-managed `~/.npa/config.yaml` keep user secrets separate from project,
-  workbench, endpoint, SSH, storage, and Terraform state metadata.
-
-## Docs And Contributing
-
-- [docs/quickstart.md](docs/quickstart.md): install, Nebius auth, and
-  credential setup.
+- [Workflow Catalog](npa/workflows/workbench/skypilot/README.md): find any
+  SkyPilot workflow by what you want to do.
+- [docs/quickstart.md](docs/quickstart.md): install, Nebius auth, credentials.
 - [docs/workbench/getting-started.md](docs/workbench/getting-started.md):
-  Workbench setup and first workload path.
-- [docs/workbench/](docs/workbench/): Workbench guides, cookbooks, and
-  troubleshooting.
+  Workbench setup and first workload.
+- [docs/workbench/cookbooks/README.md](docs/workbench/cookbooks/README.md):
+  end-to-end cookbooks (BDD100K, sim-to-real, VLM-eval loop, SONIC, Isaac Lab).
+- [docs/workbench/cli-sdk-yaml-walkthrough.md](docs/workbench/cli-sdk-yaml-walkthrough.md):
+  call any tool through the CLI, SDK, and YAML.
 - [docs/cli/README.md](docs/cli/README.md): generated CLI reference.
-- [docs/architecture/solutions-model.md](docs/architecture/solutions-model.md):
-  solution namespace model.
-- [docs/architecture/cli-namespaces.md](docs/architecture/cli-namespaces.md):
-  CLI namespace conventions.
-- [CONTRIBUTING.md](CONTRIBUTING.md): contribution guidelines.
+- [docs/README.md](docs/README.md): full documentation index.
 - [LICENSE](LICENSE): Apache License 2.0.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Nebius Physical AI.
 | Path | Purpose |
 | --- | --- |
 | [workbench/](workbench/) | Workbench solution docs, including getting started, cookbooks, and troubleshooting |
+| [../npa/workflows/workbench/skypilot/README.md](../npa/workflows/workbench/skypilot/README.md) | **Workflow catalog** — find the right SkyPilot YAML by what you want to do |
 | [architecture/solutions-model.md](architecture/solutions-model.md) | Platform model for adding and maintaining solutions |
 | [architecture/cli-namespaces.md](architecture/cli-namespaces.md) | CLI namespace conventions |
 | [quickstart.md](quickstart.md) | Full `npa` CLI quickstart |
@@ -21,6 +22,7 @@ Nebius Physical AI.
 
 | Reader | Start with |
 | --- | --- |
+| Salesperson or evaluator | [Workflow catalog](../npa/workflows/workbench/skypilot/README.md) to see what the platform runs |
 | Customer running a first Workbench workload | [workbench/getting-started.md](workbench/getting-started.md) |
 | Developer adding a solution | [architecture/solutions-model.md](architecture/solutions-model.md) |
 | SDK integrator or agent author | [sdk/errors.md](sdk/errors.md) |

--- a/docs/workbench/README.md
+++ b/docs/workbench/README.md
@@ -8,6 +8,7 @@ workflows, and operational runbooks.
 | Path | Purpose |
 | --- | --- |
 | [getting-started.md](getting-started.md) | Fresh-clone onboarding path for install, credentials, and first Workbench runs |
+| [../../npa/workflows/workbench/skypilot/README.md](../../npa/workflows/workbench/skypilot/README.md) | **Workflow catalog** — find the right SkyPilot YAML by what you want to do |
 | [cli-sdk-yaml-walkthrough.md](cli-sdk-yaml-walkthrough.md) | How to call any Workbench tool through the CLI, SDK, and SkyPilot YAML against the same service |
 | [sim-to-real-quickstart.md](sim-to-real-quickstart.md) | One-command H100 sim-to-real proof run with checkpoint, metric, S3 artifacts, and teardown |
 | [../quickstart.md](../quickstart.md) | Full `npa` CLI quickstart |
@@ -26,6 +27,7 @@ workflows, and operational runbooks.
 
 | Reader | Start with |
 | --- | --- |
+| Salesperson or evaluator | [Workflow catalog](../../npa/workflows/workbench/skypilot/README.md) to see what the platform runs |
 | Customer running their first Workbench workload | [getting-started.md](getting-started.md) |
 | Anyone choosing between CLI, SDK, and YAML | [cli-sdk-yaml-walkthrough.md](cli-sdk-yaml-walkthrough.md) |
 | Customer running the first H100 sim-to-real proof | [sim-to-real-quickstart.md](sim-to-real-quickstart.md) |

--- a/docs/workbench/cookbooks/README.md
+++ b/docs/workbench/cookbooks/README.md
@@ -3,6 +3,10 @@
 Technical recipes for reproducing benchmark, demo, and customer evaluation
 workflows with Nebius Physical AI Workbench.
 
+> Looking for the SkyPilot YAML behind a cookbook? The
+> [workflow catalog](../../../npa/workflows/workbench/skypilot/README.md) maps
+> every workflow YAML to its command and guide.
+
 ## Available Cookbooks
 
 - [Sim-To-Real Pipeline](sim-to-real-pipeline.md): CLI, SDK, raw SkyPilot, BYO

--- a/npa/workflows/workbench/README.md
+++ b/npa/workflows/workbench/README.md
@@ -4,9 +4,22 @@ This directory contains Workbench reference workflows for robotics,
 simulation, perception, eval, and synthetic-data workloads. SkyPilot is the
 workflow orchestrator for these templates.
 
+## ➡️ Start here: the workflow catalog
+
+**[`skypilot/README.md`](skypilot/README.md)** is the catalog of every runnable
+workflow. It has a "Find your workflow" table that maps *what you want to do* →
+the YAML → the command to run it → its guide. Start there to pick a pipeline.
+
+As a companion convention, each YAML should open with a short header comment
+carrying the same pointers (`What`, `Guide`, `Runner`, `Index`) so you can jump
+from any file to its guide and back to the catalog.
+
 ## Layout
 
-- `skypilot/`: runnable SkyPilot YAMLs for reference pipelines.
+- `skypilot/`: runnable SkyPilot YAMLs for reference pipelines, plus the
+  [workflow catalog](skypilot/README.md) that maps each YAML to its guide in
+  `docs/` and its submission wrapper in `npa/scripts/`.
+- `sim2real/`: the self-contained Sim2Real runbook (guide + YAML colocated).
 - `schemas/`: conventions for parameters, artifacts, naming, and runtime
   constraints.
 - `steps/` and `templates/`: legacy placeholders kept for compatibility with

--- a/npa/workflows/workbench/skypilot/README.md
+++ b/npa/workflows/workbench/skypilot/README.md
@@ -1,0 +1,161 @@
+# Workbench SkyPilot Workflow Catalog
+
+**This is the index of every runnable Workbench workflow YAML.** Each YAML is a
+SkyPilot pipeline you can submit with `npa workbench workflow submit`. The
+narrative walkthroughs (prerequisites, run, verify) live in `docs/`, and thin
+submission wrappers live in `npa/scripts/`.
+
+Use the catalog below to find a workflow by what you want to do. As a companion
+convention, each YAML should open with a short header comment carrying the same
+four pointers, so you can navigate from a file back to its guide and this index:
+
+```text
+# What:   one-line description of the pipeline
+# Guide:  docs/... walkthrough
+# Runner: how to submit it (CLI command or npa/scripts/ wrapper)
+# Index:  npa/workflows/workbench/skypilot/README.md  (this file)
+```
+
+## Find your workflow
+
+Pick the row that matches what you want to do. (This catalog is the source of
+truth; the top-level `README.md` shows only a few common entry points.)
+
+| I want to… | Workflow YAML | Run it with | GPU | Guide |
+| --- | --- | --- | --- | --- |
+| **Score robot rollouts with a VLM, no GPU/credentials** | [`vlm-eval.yaml`](./vlm-eval.yaml) | `npa workbench vlm-eval` | H100 (or `stub` locally) | [vlm-eval-loop-runbook.md](../../../../docs/workbench/cookbooks/vlm-eval-loop-runbook.md) |
+| Sweep eval thresholds / rubrics / models and rank them | [`vlm-eval-benchmark.yaml`](./vlm-eval-benchmark.yaml) | `npa workbench vlm-eval benchmark` | H100 | [vlm-eval-loop-runbook.md](../../../../docs/workbench/cookbooks/vlm-eval-loop-runbook.md) |
+| Run the full sim-to-real train → eval pipeline | [`sim-to-real-pipeline.yaml`](./sim-to-real-pipeline.yaml) | [`run_sim_to_real_pipeline.py`](../../../scripts/run_sim_to_real_pipeline.py) | H100 | [sim-to-real-pipeline.md](../../../../docs/workbench/cookbooks/sim-to-real-pipeline.md) |
+| Run the sim-to-real VLM-eval feedback loop | [`sim-to-real-loop.yaml`](./sim-to-real-loop.yaml) | [`run_sim_to_real_pipeline.py`](../../../scripts/run_sim_to_real_pipeline.py) | H100 | [vlm-eval-loop-runbook.md](../../../../docs/workbench/cookbooks/vlm-eval-loop-runbook.md) |
+| Re-trigger sim-to-real when new data lands in S3 | [`sim-to-real-trigger.yaml`](./sim-to-real-trigger.yaml) | [`run_sim_to_real_pipeline.py`](../../../scripts/run_sim_to_real_pipeline.py) | CPU | [sim-to-real-pipeline.md](../../../../docs/workbench/cookbooks/sim-to-real-pipeline.md) |
+| Curate + train an AV perception model (BDD100K) | [`bdd100k-pipeline.yaml`](./bdd100k-pipeline.yaml) | [`run_bdd100k_pipeline.py`](../../../scripts/run_bdd100k_pipeline.py) | H100 | [bdd100k-pipeline.md](../../../../docs/workbench/cookbooks/bdd100k-pipeline.md) |
+| Train one Isaac Lab RL policy | [`isaac-lab-rl-train.yaml`](./isaac-lab-rl-train.yaml) | [`run_isaac_lab_rl.py`](../../../scripts/run_isaac_lab_rl.py) | L40S | [byof-isaac-lab/README.md](../../../../docs/workbench/cookbooks/byof-isaac-lab/README.md) |
+| Sweep many Isaac Lab RL configs in parallel | [`isaac-lab-rl-sweep.yaml`](./isaac-lab-rl-sweep.yaml) | [`run_isaac_lab_rl.py`](../../../scripts/run_isaac_lab_rl.py) | L40S | [workbench-yaml-guide.md](../../../../docs/workbench-yaml-guide.md#isaac-lab-rl-training) |
+| Fine-tune a SONIC G1 locomotion policy + MuJoCo eval | [`sonic-locomotion-finetuning.yaml`](./sonic-locomotion-finetuning.yaml) | `npa workbench sonic` | H100 / L40S | [sonic-locomotion-finetuning.md](../../../../docs/workbench/cookbooks/sonic-locomotion-finetuning.md) |
+| Run a SONIC training smoke job | [`sonic-train-standalone.yaml`](./sonic-train-standalone.yaml) | `npa workbench sonic train` | L40S | [sonic-train-runbook.md](../../../../docs/workbench/cookbooks/sonic-train-runbook.md) |
+| Export a trained SONIC checkpoint to ONNX | [`sonic-export.yaml`](./sonic-export.yaml) | `npa workbench sonic export` | L40S | [sonic-eval-runbook.md](../../../../docs/workbench/cookbooks/sonic-eval-runbook.md) |
+| Export then evaluate a SONIC policy in one run | [`sonic-export-eval.yaml`](./sonic-export-eval.yaml) | `npa workbench sonic` | L40S | [sonic-eval-runbook.md](../../../../docs/workbench/cookbooks/sonic-eval-runbook.md) |
+| Evaluate an exported SONIC ONNX policy | [`sonic-eval.yaml`](./sonic-eval.yaml) | `npa workbench sonic eval` | L40S | [sonic-eval-runbook.md](../../../../docs/workbench/cookbooks/sonic-eval-runbook.md) |
+| Score a SONIC checkpoint with MJLab metrics | [`mjlab-eval.yaml`](./mjlab-eval.yaml) | `npa workbench mjlab eval` | H100 | [sonic-locomotion-finetuning.md](../../../../docs/workbench/cookbooks/sonic-locomotion-finetuning.md) |
+| Retarget source motion to the SONIC embodiment | [`retargeting.yaml`](./retargeting.yaml) | `npa workbench retargeting run` | CPU | [sonic-locomotion-finetuning.md](../../../../docs/workbench/cookbooks/sonic-locomotion-finetuning.md) |
+| Generate synthetic frames with Cosmos3 (text → image) | [`cosmos3-text-to-image-inference.yaml`](./cosmos3-text-to-image-inference.yaml) | `npa workbench cosmos` | H100 | [inference SKILL](../../../../.agents/skills/inference/SKILL.md) |
+| Stage the Cosmos3 framework + checkpoints | [`cosmos3-ea-fetch.yaml`](./cosmos3-ea-fetch.yaml) | `npa workbench cosmos` | CPU | [cosmos3-setup SKILL](../../../../.agents/skills/cosmos3-setup/SKILL.md) |
+| Run Cosmos3 Reason inference | [`cosmos3-reason.yaml`](./cosmos3-reason.yaml) | `npa workbench cosmos` | RTX PRO 6000 | [inference SKILL](../../../../.agents/skills/inference/SKILL.md) |
+| Run a Cosmos2 transfer (video-to-world) stage | [`cosmos2-transfer.yaml`](./cosmos2-transfer.yaml) | `npa workbench cosmos` | RTX PRO 6000 | [cosmos SKILL](../../../../.agents/skills/workbench/cosmos/SKILL.md) |
+
+The Cosmos guides are agent skills under `.agents/skills/`; everything else
+links to a human-facing guide under `docs/`.
+
+[`sim2real-actions.yaml`](./sim2real-actions.yaml) and
+[`sim2real-envgen-split.yaml`](./sim2real-envgen-split.yaml) are step components
+of the self-contained Sim2Real runbook at
+[`../sim2real/README.md`](../sim2real/README.md) — the one workflow that keeps
+its guide and YAML colocated because it is a single CLI/SDK-driven chain rather
+than a docs-site cookbook.
+
+## How to submit a workflow
+
+```bash
+# 1. Bootstrap SkyPilot once.
+npa skypilot bootstrap
+export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+
+# 2a. Submit a YAML directly.
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/vlm-eval.yaml --run-id vlm-eval
+
+# 2b. Or use a thin wrapper when a workflow needs run-scoped S3 paths,
+#     secret-env injection, GPU validation, or cleanup.
+npa/.venv/bin/python npa/scripts/run_sim_to_real_pipeline.py --help
+npa/.venv/bin/python npa/scripts/run_isaac_lab_rl.py --help
+npa/.venv/bin/python npa/scripts/run_bdd100k_pipeline.py --help
+
+# 3. Track and tear down.
+npa workbench workflow status <run-id>
+npa workbench workflow logs <run-id> <task-name>
+npa workbench workflow teardown <run-id>
+```
+
+`submit` supports `--controller-backend kubernetes`, `--controller-backend
+nebius`, `--run-id`, and repeated `--var KEY=VALUE` substitutions.
+
+## Gated Hugging Face models
+
+Several workflows pass an `HF_TOKEN` so a runtime can download model weights or
+datasets from Hugging Face. A token alone is **not** enough for *gated* repos:
+you must also visit the model page once while signed in with the same account
+and accept its license/usage terms, or the download returns `403 Gated`.
+
+<details>
+<summary>Per-workflow gated-repo table (operators)</summary>
+
+"None" means the workflow either uses no Hugging Face repo or only public ones
+(a token is optional and only helps avoid anonymous rate limits). Gated repos
+are marked **(gated — accept license)**.
+
+| Workflow YAML | Hugging Face repos to accept | Notes |
+| --- | --- | --- |
+| `sonic-train-standalone.yaml` | `nvidia/GEAR-SONIC` **(gated — accept license)** | Default `SONIC_CHECKPOINT=nvidia/GEAR-SONIC:sonic_release/last.pt`. |
+| `sonic-locomotion-finetuning.yaml` | `nvidia/GEAR-SONIC` **(gated — accept license)** | Fine-tune stage downloads the released SONIC checkpoint; the MuJoCo-eval stage consumes the S3 checkpoint and needs no HF access. |
+| `cosmos3-ea-fetch.yaml` | `nvidia/Cosmos3-Nano` **(gated — early-access, accept license)** | `NPA_COSMOS3_MODEL_ID` default; override for a BYO checkpoint. |
+| `cosmos3-text-to-image-inference.yaml` | `nvidia/Cosmos3-Nano` **(gated — early-access, accept license)** | Same `NPA_COSMOS3_MODEL_ID` default; also needs `GITHUB_TOKEN` for the source repo. |
+| `cosmos3-reason.yaml` | `nvidia/Cosmos-Reason1-7B` **(gated — accept license)** | `COSMOS3_REASON_MODEL` default. |
+| `cosmos2-transfer.yaml` | NVIDIA Cosmos diffusion weights baked into `COSMOS2_TRANSFER_IMAGE` **(gated — accept license)** | The repo depends on the chosen image; the `npa workbench cosmos` default is `nvidia/Cosmos-1.0-Diffusion-7B-Text2World`. |
+| `vlm-eval.yaml` | `Qwen/Qwen2-VL-7B-Instruct` (public) | `VLM_MODEL` default. Token optional; not gated. |
+| `vlm-eval-benchmark.yaml` | `Qwen/Qwen2-VL-7B-Instruct` (public) | `VLM_MODELS` default. Token optional; not gated. |
+| `sim-to-real-loop.yaml` | `Qwen/Qwen2-VL-7B-Instruct` (public) | Self-hosted vLLM default `MODEL`. Token optional; not gated. |
+| `sim-to-real-pipeline.yaml` | `lerobot/pusht` (public dataset) | Default `LEROBOT_DATASET_REPO_ID`; the default `VLM_EVAL_BACKEND=stub` pulls no VLM. Token optional. |
+| `sim-to-real-trigger.yaml` | `lerobot/pusht` (public dataset) | Watches/retriggers `sim-to-real-pipeline.yaml`; same public dataset. |
+| `../sim2real/runbook.yaml` | `nvidia/Cosmos-Reason1-7B` **(gated — accept license)**; `lerobot/pusht` (public dataset) | Default `--vlm-model nvidia/Cosmos-Reason1-7B` and `--trigger-dataset-id lerobot/pusht`. |
+| `bdd100k-pipeline.yaml` | None | CLIP embeddings run inside the first-party LanceDB image; no gated HF repo. |
+| `isaac-lab-rl-train.yaml`, `isaac-lab-rl-sweep.yaml` | None | Isaac Lab RSL-RL training pulls no HF weights. |
+| `sonic-export.yaml`, `sonic-export-eval.yaml`, `sonic-eval.yaml` | None | Operate on already-trained checkpoints staged in S3. |
+| `mjlab-eval.yaml`, `retargeting.yaml` | None | Consume S3 artifacts; no HF download. |
+| `sim2real-actions.yaml`, `sim2real-envgen-split.yaml` | None | Env generation / action conditioning use BYO container images, not HF repos. |
+| `../templates/curate-augment-train.yaml` | None | Placeholder Argo steps; no HF download. |
+
+### Workbench tools driven by the CLI (not YAML)
+
+These are launched through `npa workbench ...` rather than a SkyPilot YAML, but
+they also require accepting gated repos before they can download weights:
+
+- GR00T (`npa workbench groot ...`): `nvidia/GR00T-N1.7-3B` and
+  `nvidia/Cosmos-Reason2-2B` — both **gated — accept license**.
+- Cosmos (`npa workbench cosmos ...`): the configured model, default
+  `nvidia/Cosmos-1.0-Diffusion-7B-Text2World` — **gated — accept license**.
+
+</details>
+
+### How to accept a gated repo
+
+1. Sign in to Hugging Face with the account whose token you set as `HF_TOKEN`.
+2. Open the model page (for example `https://huggingface.co/nvidia/GEAR-SONIC`)
+   and accept the license / "Agree and access repository" prompt. NVIDIA repos
+   may also require completing a request form.
+3. Confirm the token can reach the repo before launching a long run.
+   `npa workbench cosmos check` and `npa workbench groot` validate gated-model
+   access for those tools; for other workflows a quick
+   `huggingface-cli download <repo> --revision main` smoke check works.
+
+## Why the guides live in `docs/` and not next to each YAML
+
+The guide-to-YAML relationship is many-to-many, so guides are not colocated 1:1:
+
+- One guide often drives several YAMLs (the SONIC locomotion cookbook uses
+  `sonic-locomotion-finetuning.yaml`, `retargeting.yaml`, and `mjlab-eval.yaml`).
+- One YAML is often referenced by several guides (`bdd100k-pipeline.yaml` is used
+  by its cookbook, the demo writeup, and `docs/workbench-yaml-guide.md`).
+- Guides are customer-facing product documentation that cross-link to the
+  quickstart, getting-started, architecture, and CLI references. They belong in
+  the navigable `docs/` tree rooted at `docs/README.md`.
+
+The header comment on each YAML and the catalog above keep both directions easy
+to traverse. **Update both ends when you add or rename a workflow.**
+
+## Conventions
+
+- Shared parameter, artifact, naming, GPU, and safety rules:
+  [`../schemas/workflow-conventions.md`](../schemas/workflow-conventions.md).
+- General YAML structure (label maps, env vars, endpoints, S3 paths):
+  [`../../../../docs/workbench-yaml-guide.md`](../../../../docs/workbench-yaml-guide.md).
+- Submission, SkyPilot runtime, and cleanup pattern: [`../README.md`](../README.md).


### PR DESCRIPTION
## Summary

Make the repo easy to navigate for **users, developers, agents, and salespeople**, with the **Workbench** solution front and center and the SkyPilot workflow YAMLs easy to find.

- **Top-level `README.md` rewrite** — a 60-second, zero-credential first result; a prominent **"Find your workflow"** path; and a **"Where do I go?"** audience map that explicitly includes salespeople/evaluators.
- **New canonical [Workflow Catalog](../blob/docs/workflow-navigation/npa/workflows/workbench/skypilot/README.md)** (`npa/workflows/workbench/skypilot/README.md`) — a single *"I want to…"* table mapping every committed workflow YAML to the command that runs it, its GPU, and its guide. YAML filenames link straight to the file; the heavy gated-Hugging-Face table is collapsed under `<details>` so non-operators can skim.
- **Wired the catalog into the docs tree** — `docs/README.md`, `docs/workbench/README.md`, `docs/workbench/cookbooks/README.md`, and `npa/workflows/workbench/README.md` all point at it.

## Scope / base

This is **docs-only** and **stacks on `sonic/train-configurability`** (the active branch), not `main`. The navigation docs reference doc infrastructure (the CLI/SDK/YAML walkthrough, beginner guides, modified READMEs) that lives in the in-flight commits and is not yet on `main`, so basing on `main` would ship broken links and a divergent 11-commit diff. Targeting the feature branch keeps the diff to exactly this one docs commit.

The per-YAML `What`/`Guide`/`Runner`/`Index` header comment is described as a **companion convention** and lands in a separate change; this PR does not modify any YAML.

## Review

Incorporates a DevRel / docs-lead persona review:
- Dropped links to not-yet-committed files (Token Factory doc + YAMLs, workflow-authoring skill) so every link resolves to a tracked file.
- Softened the "every YAML carries a header" claim to a convention (headers are not in this PR).
- Added the sales/evaluator audience row to the doc indexes.
- Collapsed the operator-heavy gated-HF table.

## Test plan

- [x] Every relative link in the changed docs resolves to a **git-tracked** file.
- [x] All 21 committed SkyPilot YAMLs are represented in the catalog.
- [x] Diff is limited to the 6 documentation files (no code/YAML/test changes).
- [ ] Reviewer skim: can a salesperson reach the right workflow YAML from the README in under a minute?

Made with [Cursor](https://cursor.com)