### PR TITLE
feat(workbench): native Nebius Token Factory tool, workflows, and live tests

### DIFF
--- a/.agents/skills/platform/testing-conventions/SKILL.md
+++ b/.agents/skills/platform/testing-conventions/SKILL.md
@@ -31,6 +31,7 @@ npa/.venv/bin/python -m ruff check <files>
 - Known pre-existing failure: `tests/smoke/test_cosmos_serverless_smoke.py` has 5 tests gated by `NPA_COSMOS_SERVERLESS_SMOKE=1`; they fail with `Unable to list Nebius VPC networks for project project-smoke: unsupported`.
 - E2E tests are gated by `NPA_INTEGRATION_E2E=1` and excluded from standard runs with `--ignore=npa/tests/e2e`.
 - Pipeline E2E tests use the `e2e_pipeline` pytest marker.
+- Live Nebius Token Factory tests use the `token_factory_e2e` marker (in `npa/tests/e2e/test_token_factory_e2e.py`). They self-skip without a real `NEBIUS_API_KEY`; the marker is in conftest `_LIVE_MARKERS` so the key is not scrubbed. Run with `NEBIUS_API_KEY=... pytest npa/tests/e2e/test_token_factory_e2e.py`.
 
 Expected baseline: 1242+ passed, 21 skipped, 1 xpassed, 0 failures.
 

--- a/.agents/skills/workbench/compose-cloud-tokenfactory/SKILL.md
+++ b/.agents/skills/workbench/compose-cloud-tokenfactory/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: compose-cloud-tokenfactory
+description: Use when composing NPA workbench pipelines that pair Nebius AI Cloud compute (serverless GPU, Kubernetes, or VM) with hosted Nebius Token Factory inference, or when a user asks how to get the AI Cloud + Token Factory tokens and chain a GPU stage into a hosted text/vision/reasoning stage.
+---
+
+# Composing Nebius cloud + Token Factory pipelines
+
+Combo pipelines pair **real Nebius compute** (GPU/sim work) with **hosted Token
+Factory inference** (zero-GPU). Full guide for users:
+`docs/workbench/composing-cloud-and-token-factory.md`. This skill is the agent
+fast-path.
+
+## The one contract
+
+```
+[ Nebius compute stage ] --writes--> [ S3 ] --reads--> [ Token Factory stage ]
+```
+
+Compute stage (GPU/VM/k8s) uploads artifacts to an `s3://` `--output-path`; the
+Token Factory stage (`caption`/`generate`/`reason`/`vlm-eval --backend api`)
+reads that URI and calls the hosted API. Glue = S3 URIs + two credentials.
+
+## Two tokens (they are different keys)
+
+- **AI Cloud** (compute + storage): `nebius profile create` →
+  `nebius iam get-access-token`; S3 keys under `storage:` in
+  `~/.npa/credentials.yaml`; project ID passed as `--project-id` (never
+  hardcoded). Verify: `nebius iam get-access-token >/dev/null`.
+- **Token Factory** (hosted inference): mint at <https://tokenfactory.nebius.com/>,
+  set `NEBIUS_API_KEY` (via `npa configure`, env, or `tokens:` in credentials).
+  Verify: `npa workbench token-factory verify`. Registration detail:
+  `docs/workbench/token-factory.md`.
+
+## Two composition styles
+
+1. **Python runner** (fan-out / branching / local glue): shell out to `npa` for
+   the GPU stage, call Token Factory tool functions in-process. Keep pure logic
+   in `npa/src/npa/workflows/token_factory_combos.py` (unit-tested) and I/O in
+   the runner. Always add `--render-only` (no infra) and a cheap no-GPU mode.
+   Examples: `run_tokenfactory_train_triage.py`, `run_tokenfactory_sim_sweep.py`.
+2. **SkyPilot serial YAML** (clean hand-off): `execution: serial`, one doc per
+   stage; GPU stage requests `accelerators`, hosted stage omits them. Pass `s3://`
+   URIs via `envs`; fail fast if `NEBIUS_API_KEY` is unset; launch with
+   `--secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID --secret AWS_SECRET_ACCESS_KEY`.
+   Examples: `tokenfactory-rollout-judge.yaml`,
+   `tokenfactory-scene-to-rollout-judge.yaml`.
+
+## Reusable pure helpers (token_factory_combos.py)
+
+`summarize_run_artifacts` (bounded, binary-skipping digest), prompt builders
+(`build_triage_prompt`, `build_ranking_prompt`, `build_sweep_design_prompt`),
+`join_uri` / `sweep_variant_output_uri`, ID/job-name derivation (`utc_stamp`,
+`triage_job_name`, `sweep_variants`). Add new pure logic here, not in the runner.
+
+## Rules
+
+- No hardcoded project/registry/bucket IDs — flags, `--var`, or `--secret` only.
+- Token Factory stages are CPU-only: no `accelerators`, no vLLM serving.
+- Unit tests stay infra-free; mock S3/Nebius/GPU and never call the live API.
+  Live checks go in `npa/tests/e2e/` behind a key, or via the runner's
+  `--render-only` / no-GPU modes.

--- a/.agents/skills/workbench/token-factory/SKILL.md
+++ b/.agents/skills/workbench/token-factory/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: token-factory
+description: Use when working on Nebius Token Factory native workflows in NPA — the OpenAI-compatible hosted-inference client, the token-factory workbench tool (caption/generate), the vlm-eval api backend, or the zero-GPU Token Factory SkyPilot workflows.
+---
+
+# Nebius Token Factory
+
+Nebius Token Factory is an OpenAI-compatible hosted-inference API for open text
+and vision models. Because inference is hosted, Token Factory workflows are
+**zero-GPU**: they run on CPU and call the API. Base URL defaults to
+`https://api.tokenfactory.nebius.com/v1/`; auth is the `NEBIUS_API_KEY`
+environment variable.
+
+## Single Source Of Truth
+
+All endpoint, auth, and request logic lives in
+`npa/src/npa/clients/token_factory.py` (`TokenFactoryClient`, `resolve_config`).
+Do not re-derive the base URL or read `NEBIUS_API_KEY` elsewhere; call the
+client. Base URL overrides: `NEBIUS_TOKEN_FACTORY_BASE_URL` or
+`NEBIUS_BASE_URL`.
+
+`NEBIUS_API_KEY` is a first-class credential: `npa configure` prompts for it,
+or put it under `tokens:` in `~/.npa/credentials.yaml`. It is injected into every
+workbench/workflow run via `shared_credential_env`. `npa workbench token-factory
+verify` does a live authenticated `list_models` call (exits non-zero on
+auth/connectivity failure); `status` reports the resolved key/base URL with no
+network call. User-facing setup guide: `docs/workbench/token-factory.md`.
+
+## token-factory Workbench Tool
+
+`npa workbench token-factory ...`, behavior in
+`npa/src/npa/workbench/token_factory/__init__.py`. Like every tool it uses
+`--input-path` / `--output-path` S3 URIs.
+
+- `caption`: caption images / rollout frames with a hosted vision model →
+  `captions.json`.
+- `generate`: batch text generation from a JSONL/text prompt file →
+  `generations.jsonl` (synthetic task instructions, Cosmos scene prompts, sim
+  variation).
+- `reason`: physical-AI scene reasoning with `nvidia/Cosmos3-Super-Reasoner`
+  (default) → `scene_reasoning.json`. Scene images + a task in, scene
+  understanding + plan of action out. Backs the physical-common-sense challenge.
+- `models`: list models available to the key. `verify`: live authenticated
+  models call (exits non-zero on failure). `status` / `list`: observability.
+
+Mocked tests inject a `TokenFactoryClient` built on `httpx.MockTransport`; never
+hit the live API. CLI tests monkeypatch `token_factory._default_client`.
+
+## Live Testing (first-class)
+
+Live tests live in `npa/tests/e2e/test_token_factory_e2e.py`, marked
+`token_factory_e2e`, and self-skip without a key. The marker is in
+`_LIVE_MARKERS` so the conftest credential scrub does not strip `NEBIUS_API_KEY`
+for them. Run with `NEBIUS_API_KEY=... pytest npa/tests/e2e/test_token_factory_e2e.py`.
+Cosmos model availability is key-dependent; confirm with
+`npa workbench token-factory models`.
+
+## vlm-eval Over Token Factory
+
+The vlm-eval `api` backend defaults its base URL to Token Factory and accepts
+`NEBIUS_API_KEY` (falling back to `OPENAI_API_KEY`). This gives zero-GPU rollout
+scoring with no vLLM serving stage.
+
+## Workflows
+
+In `npa/workflows/workbench/skypilot/` (all CPU-only, `cloud: kubernetes`, no
+`accelerators`):
+
+- `token-factory-caption.yaml`
+- `token-factory-generate.yaml`
+- `vlm-eval-token-factory.yaml`
+
+Pass the key as a SkyPilot secret at launch:
+`sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID --secret AWS_SECRET_ACCESS_KEY <yaml>`.
+Each `run` block fails fast if `NEBIUS_API_KEY` is unset.

--- a/.agents/skills/workbench/token-factory/SKILL.md
+++ b/.agents/skills/workbench/token-factory/SKILL.md
@@ -88,11 +88,24 @@ network/storage calls live in the runner and existing tool modules.
   unless the workbench config supplies a project and
   `storage.checkpoint_bucket`. `--render-only` previews with no infra;
   `--from-output-path` triages an existing prefix without launching a GPU Job.
+- `npa/scripts/run_tokenfactory_sim_sweep.py` (**serverless fan-out**): a text
+  model designs the sweep, a deterministic `--steps` grid launches one LeRobot
+  serverless GPU train per variant, then a text model ranks the completed runs.
+  `--render-only` previews; `--rank-existing a,b` ranks existing prefixes with no
+  GPU spend. `lerobot train` has no `--seed`, so the grid varies `--steps`.
 - `npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml`
   (**kubernetes**): stage 1 renders a `lerobot-eval` rollout on a k8s GPU and
   uploads videos to S3; stage 2 is CPU `vlm-eval --backend api` judging via a
   hosted VLM. Two serial docs, two images (lerobot GPU, then token-factory CPU).
+- `npa/workflows/workbench/skypilot/tokenfactory-scene-to-rollout-judge.yaml`
+  (**kubernetes**): three serial stages — `token-factory reason` over scene
+  images (CPU) → `lerobot-eval` rollout (k8s GPU) → `vlm-eval --backend api`
+  judging the rollout against the reasoner's plan (CPU). The hackathon
+  physical-common-sense loop end to end.
 
-Guide: `docs/workbench/cookbooks/tokenfactory-compute-combos.md`. Both are
-smoke-sized to stay cheap. The runner exports `~/.npa/credentials.yaml` into the
-environment itself because it is launched as a plain script, not via the CLI.
+Guide: `docs/workbench/cookbooks/tokenfactory-compute-combos.md`. To compose new
+combos (the contract, both tokens, the two styles), see
+`docs/workbench/composing-cloud-and-token-factory.md` and the
+`compose-cloud-tokenfactory` skill. All combos are smoke-sized to stay cheap.
+The runners export `~/.npa/credentials.yaml` into the environment themselves
+because they are launched as plain scripts, not via the CLI.

--- a/.agents/skills/workbench/token-factory/SKILL.md
+++ b/.agents/skills/workbench/token-factory/SKILL.md
@@ -63,13 +63,36 @@ scoring with no vLLM serving stage.
 
 ## Workflows
 
-In `npa/workflows/workbench/skypilot/` (all CPU-only, `cloud: kubernetes`, no
-`accelerators`):
+Zero-GPU workflows in `npa/workflows/workbench/skypilot/` (CPU-only,
+`cloud: kubernetes`, no `accelerators`):
 
 - `token-factory-caption.yaml`
 - `token-factory-generate.yaml`
+- `token-factory-cosmos-reason.yaml`
 - `vlm-eval-token-factory.yaml`
 
 Pass the key as a SkyPilot secret at launch:
 `sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID --secret AWS_SECRET_ACCESS_KEY <yaml>`.
 Each `run` block fails fast if `NEBIUS_API_KEY` is unset.
+
+## Compute Combos (Nebius GPU + Token Factory)
+
+Two workflows deliberately pair **real Nebius GPU compute** with the hosted
+Token Factory stage, so the pipeline exercises both. Pure logic lives in
+`npa/src/npa/workflows/token_factory_combos.py` (infra-free, unit-tested);
+network/storage calls live in the runner and existing tool modules.
+
+- `npa/scripts/run_tokenfactory_train_triage.py` (**serverless**): a LeRobot
+  serverless GPU Job writes run artifacts to S3, then `token-factory generate`
+  has a text model write a triage report. Needs `--project-id` + `--output-path`
+  unless the workbench config supplies a project and
+  `storage.checkpoint_bucket`. `--render-only` previews with no infra;
+  `--from-output-path` triages an existing prefix without launching a GPU Job.
+- `npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml`
+  (**kubernetes**): stage 1 renders a `lerobot-eval` rollout on a k8s GPU and
+  uploads videos to S3; stage 2 is CPU `vlm-eval --backend api` judging via a
+  hosted VLM. Two serial docs, two images (lerobot GPU, then token-factory CPU).
+
+Guide: `docs/workbench/cookbooks/tokenfactory-compute-combos.md`. Both are
+smoke-sized to stay cheap. The runner exports `~/.npa/credentials.yaml` into the
+environment itself because it is launched as a plain script, not via the CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Nebius Physical AI provides containerized workbench tools and SkyPilot workflows
 - `.agents/skills/workbench/fiftyone/SKILL.md`: FiftyOne curation, visualization, public access, and app behavior.
 - `.agents/skills/workbench/vlm-eval/SKILL.md`: VLM-eval scoring, stub/self-hosted/api backends, benchmark sweeps, the sim-to-real loop, and the zero-credential first run.
 - `.agents/skills/workbench/token-factory/SKILL.md`: Nebius Token Factory native workflows — the OpenAI-compatible hosted-inference client, the token-factory tool (caption/generate), the vlm-eval api backend, and the zero-GPU Token Factory SkyPilot workflows.
+- `.agents/skills/workbench/compose-cloud-tokenfactory/SKILL.md`: composing pipelines that pair Nebius AI Cloud compute (serverless/k8s/VM GPU) with hosted Token Factory inference — getting both tokens, the S3 contract, and the runner-script vs serial-YAML composition styles.
 - `.agents/skills/workbench/genesis/SKILL.md`: Genesis simulation, RL teacher training, and EGL/DRI rendering limits.
 - `.agents/skills/workbench/isaac-lab/SKILL.md`: Isaac Lab RT-core routing, headless training, workflows, and custom forks.
 - `.agents/skills/workbench/cosmos/SKILL.md`: Cosmos world-model serving, backend selection, downloads, and rendering limits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Nebius Physical AI provides containerized workbench tools and SkyPilot workflows
 - `.agents/skills/workbench/lerobot/SKILL.md`: LeRobot policy training, serving, inference, datasets, and validation.
 - `.agents/skills/workbench/fiftyone/SKILL.md`: FiftyOne curation, visualization, public access, and app behavior.
 - `.agents/skills/workbench/vlm-eval/SKILL.md`: VLM-eval scoring, stub/self-hosted/api backends, benchmark sweeps, the sim-to-real loop, and the zero-credential first run.
+- `.agents/skills/workbench/token-factory/SKILL.md`: Nebius Token Factory native workflows — the OpenAI-compatible hosted-inference client, the token-factory tool (caption/generate), the vlm-eval api backend, and the zero-GPU Token Factory SkyPilot workflows.
 - `.agents/skills/workbench/genesis/SKILL.md`: Genesis simulation, RL teacher training, and EGL/DRI rendering limits.
 - `.agents/skills/workbench/isaac-lab/SKILL.md`: Isaac Lab RT-core routing, headless training, workflows, and custom forks.
 - `.agents/skills/workbench/cosmos/SKILL.md`: Cosmos world-model serving, backend selection, downloads, and rendering limits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Claude Code should treat this file as an index. Load the relevant skill before m
 - `.claude/skills/workbench/mjlab/SKILL.md`: load for MJLab locomotion evaluation and SONIC checkpoint scoring.
 - `.claude/skills/workbench/retargeting/SKILL.md`: load for motion retargeting in SONIC locomotion workflows.
 - `.agents/skills/workbench/sim-to-real/SKILL.md`: load for generic sim-to-real data import, Cosmos autoscale, VLM evaluation, and controller-loop workflow planning.
+- `.agents/skills/workbench/token-factory/SKILL.md`: load for native Nebius Token Factory workflows — the hosted-inference client, the token-factory tool (caption/generate), the vlm-eval api backend, and the zero-GPU Token Factory SkyPilot workflows.
 
 ### Partner Capability Roadmap
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,32 @@ flagship walkthrough in
 
 ---
 
+## 🪙 Zero-GPU hosted inference: Nebius Token Factory
+
+[Nebius Token Factory](https://tokenfactory.nebius.com/) is an OpenAI-compatible
+hosted-inference API for open text and vision models. NPA uses it natively so
+several workbench tools run with **no GPU and no server to manage** — you only
+need a `NEBIUS_API_KEY`. This includes physical-AI scene reasoning with
+`nvidia/Cosmos3-Super-Reasoner` (image/video → scene understanding + plan).
+
+```bash
+# 1. Get a key at https://tokenfactory.nebius.com/ -> API keys, then:
+npa configure                       # stores NEBIUS_API_KEY in ~/.npa/credentials.yaml
+npa workbench token-factory verify  # confirms auth + lists served models
+
+# 2. Use it (zero GPU):
+npa workbench token-factory reason   --input-path ./scene  --output-path /tmp/plan      # Cosmos reasoner
+npa workbench token-factory caption  --input-path ./frames --output-path /tmp/captions  # vision
+npa workbench token-factory generate --input-path ./prompts.jsonl --output-path /tmp/gen # text
+npa workbench vlm-eval run --backend api --api-key-env NEBIUS_API_KEY \
+  --input-path ./rollout --output-path /tmp/eval                                        # score rollouts
+```
+
+Full register-and-use walkthrough, SkyPilot workflows, and a physical-reasoning
+hackathon challenge: [docs/workbench/token-factory.md](docs/workbench/token-factory.md).
+
+---
+
 ## ☁️ Running on Nebius
 
 To go from the local loop to real GPUs, authenticate with the Nebius CLI and

--- a/docs/credentials.yaml.example
+++ b/docs/credentials.yaml.example
@@ -1,5 +1,8 @@
 tokens:
   HF_TOKEN: <your-hugging-face-token>
+  # Nebius Token Factory API key (OpenAI-compatible hosted inference).
+  # Get one at https://tokenfactory.nebius.com/ -> API keys.
+  NEBIUS_API_KEY: <your-nebius-token-factory-api-key>
 
 ngc:
   api_key: <your-ngc-api-key>

--- a/docs/workbench/composing-cloud-and-token-factory.md
+++ b/docs/workbench/composing-cloud-and-token-factory.md
@@ -1,0 +1,216 @@
+# Composing Nebius cloud + Token Factory pipelines
+
+This guide shows how to **compose** NPA workbench tools into pipelines that use
+both **Nebius AI Cloud compute** (serverless GPU Jobs, Managed Kubernetes, or a
+VM) **and** **Nebius Token Factory** hosted inference (zero-GPU text / vision /
+reasoning). It covers getting both tokens, the one composition contract, the
+reusable building blocks, and two copy-paste recipes. The four shipped combo
+workflows are worked examples of exactly this pattern.
+
+## The mental model
+
+Every combo is the same shape:
+
+```
+[ Nebius compute stage ]  --writes-->  [ S3 ]  --reads-->  [ Token Factory stage ]
+   GPU / VM / k8s                       artifacts             hosted, CPU-only
+   (lerobot, genesis, ...)          (videos, logs,        (caption / generate /
+                                     checkpoints,          reason / vlm-eval)
+                                     scene images)
+```
+
+- The **compute stage** does the expensive GPU/sim work and uploads artifacts to
+  S3. Use any workbench tool that runs on Nebius (`lerobot train`,
+  `lerobot eval`, `genesis`, `isaac-lab`, ...).
+- The **Token Factory stage** is **zero-GPU**: it reads those artifacts from S3
+  and calls the hosted API (`token-factory caption|generate|reason`, or
+  `vlm-eval --backend api`). No GPU server, no vLLM.
+- The **glue** is S3 URIs and two credentials. That is the entire contract — get
+  those right and any two stages compose.
+
+## Step 1 — get your two tokens
+
+You need **two independent credentials**. They are not the same key.
+
+### A. Nebius AI Cloud token (for compute + storage)
+
+This authorizes serverless Jobs, Kubernetes, VMs, and S3. NPA reads it through
+the standard Nebius CLI profile plus object-storage keys in
+`~/.npa/credentials.yaml`.
+
+```bash
+# 1. Create / refresh a Nebius CLI profile (opens browser SSO the first time).
+nebius profile create
+nebius iam get-access-token >/dev/null   # proves the profile works
+
+# 2. Bootstrap NPA's config + credentials interactively.
+npa configure
+```
+
+`npa configure` writes machine config to `~/.npa/config.yaml` and secrets to
+`~/.npa/credentials.yaml`. For compute + storage you need, in
+`~/.npa/credentials.yaml`:
+
+```yaml
+storage:
+  AWS_ACCESS_KEY_ID: <nebius-s3-access-key>
+  AWS_SECRET_ACCESS_KEY: <nebius-s3-secret-key>
+  AWS_ENDPOINT_URL: https://storage.eu-north1.nebius.cloud
+```
+
+Your **project ID** (`project-...`) comes from the Nebius console / your profile;
+pass it to serverless runs with `--project-id` (never hardcode it in a committed
+file). S3 access keys are minted in the Nebius console under your storage
+service account.
+
+> Tip: the runner scripts below export these into the environment for you via
+> `apply_shared_credential_env`. SkyPilot YAMLs receive them as `--secret`s at
+> launch.
+
+### B. Token Factory token (for hosted inference)
+
+This is a separate console and a separate key (`NEBIUS_API_KEY`). Full
+walkthrough: [token-factory.md](./token-factory.md). The 2-minute version:
+
+1. Sign in at <https://tokenfactory.nebius.com/> and make sure the project has
+   credit.
+2. **API keys → Create API key**, copy it once.
+3. Give it to NPA (any one):
+
+```bash
+npa configure                       # answer the NEBIUS_API_KEY prompt, or
+export NEBIUS_API_KEY=nebius_xxx     # env var for CI / one-off shells, or
+# put it under tokens: in ~/.npa/credentials.yaml
+```
+
+4. Verify it authenticates and see the served catalog:
+
+```bash
+npa workbench token-factory verify
+npa workbench token-factory models   # confirms e.g. nvidia/Cosmos3-Super-Reasoner
+```
+
+### Both tokens, one check
+
+```bash
+nebius iam get-access-token >/dev/null && echo "AI Cloud: ok"
+npa workbench token-factory verify
+```
+
+If both pass, you can run any combo below.
+
+## Step 2 — the building blocks
+
+**Nebius compute stages** (each writes artifacts to an `--output-path`/S3 URI):
+
+| Tool | What it produces |
+| --- | --- |
+| `npa workbench lerobot train --runtime serverless` | checkpoints + train logs/config |
+| `lerobot-eval` (in a GPU SkyPilot stage) | rollout videos + `eval_info.json` |
+| `npa workbench genesis ...` / `isaac-lab ...` | sim rollouts / synthetic data |
+
+**Token Factory stages** (each reads an `--input-path`/S3 URI, calls the hosted API):
+
+| Tool | What it does |
+| --- | --- |
+| `npa workbench token-factory caption` | caption images / frames → `captions.json` |
+| `npa workbench token-factory generate` | batch text gen (triage, ranking, synthetic prompts) → `generations.jsonl` |
+| `npa workbench token-factory reason` | scene understanding + plan with Cosmos3-Super-Reasoner → `scene_reasoning.json` |
+| `npa workbench vlm-eval run --backend api` | score a rollout with a hosted VLM → eval JSON |
+
+**Pure glue helpers** — `npa/src/npa/workflows/token_factory_combos.py` holds
+infra-free logic you can reuse so your runner stays unit-testable: bounded
+artifact digesting (`summarize_run_artifacts`), prompt builders
+(`build_triage_prompt`, `build_ranking_prompt`, `build_sweep_design_prompt`),
+URI joining (`join_uri`, `sweep_variant_output_uri`), and Nebius-safe ID/job-name
+derivation (`utc_stamp`, `triage_job_name`, `sweep_variants`).
+
+## Step 3 — pick a composition style
+
+There are two idiomatic ways to wire stages together. Use whichever fits.
+
+### Style 1 — Python runner script (best for fan-out, branching, local glue)
+
+A plain script that shells out to `npa` for the GPU stage(s) and calls the
+Token Factory tool functions in-process. Good when you need loops (a sweep),
+conditional logic, or to download + reshape artifacts between stages. Keep all
+*pure* logic in `token_factory_combos.py` and all *I/O* in the runner so the
+logic stays testable. Always give the runner a `--render-only` mode that prints
+the plan with **no** infrastructure, and a cheap "skip the GPU stage" mode
+(e.g. `--from-output-path` / `--rank-existing`) for fast iteration.
+
+Skeleton:
+
+```python
+from npa.workflows.token_factory_combos import join_uri, summarize_run_artifacts
+from npa.workbench.token_factory import generate_text
+
+# 1. GPU stage on Nebius (serverless) via the CLI.
+subprocess.run([sys.executable, "-c", "from npa.cli.main import app_entry; app_entry()",
+                "workbench", "lerobot", "train", "--runtime", "serverless",
+                "--output-path", out_uri, "--output", "json"], check=True)
+
+# 2. Token Factory stage in-process (zero-GPU).
+digest = summarize_run_artifacts(local_artifacts)     # bounded, safe
+generate_text(input_path=prompts_jsonl, output_path=join_uri(out_uri, "triage"))
+```
+
+Worked examples: `npa/scripts/run_tokenfactory_train_triage.py` (train→triage)
+and `npa/scripts/run_tokenfactory_sim_sweep.py` (design→sweep→rank).
+
+### Style 2 — SkyPilot serial YAML (best for a clean, hand-off pipeline on Nebius)
+
+A multi-document YAML with `execution: serial`: one document per stage, each
+with its own image and resources. The GPU stage requests `accelerators`; the
+Token Factory stage omits them (CPU-only) and uses a small image. Pass `s3://`
+URIs through `envs` so each stage reads exactly what the previous one wrote, and
+fail fast if `NEBIUS_API_KEY` is unset.
+
+```yaml
+name: my-combo
+execution: serial
+---
+name: gpu-stage
+resources: { cloud: kubernetes, accelerators: H100:1 }
+envs: { OUT_URI: "s3://<your-bucket-name>/<run-id>/artifacts/" }
+run: |
+  ... GPU work ...; aws/boto3 upload to ${OUT_URI}
+---
+name: tokenfactory-stage
+resources: { cloud: kubernetes, cpus: 4 }   # no accelerators -> zero-GPU
+envs: { OUT_URI: "s3://<your-bucket-name>/<run-id>/artifacts/" }
+run: |
+  [[ -z "${NEBIUS_API_KEY:-}" ]] && { echo "NEBIUS_API_KEY required"; exit 1; }
+  npa workbench vlm-eval run --input-path "${OUT_URI}" --backend api ...
+```
+
+Launch with both credential sets as secrets:
+
+```bash
+sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID \
+  --secret AWS_SECRET_ACCESS_KEY npa/workflows/workbench/skypilot/<your>.yaml
+```
+
+Worked examples: `tokenfactory-rollout-judge.yaml` (GPU rollout → VLM judge) and
+`tokenfactory-scene-to-rollout-judge.yaml` (reason → GPU rollout → VLM judge).
+
+## Step 4 — the four shipped combos (study these)
+
+| Workflow | Style | Compute (AI Cloud) | Token Factory | Entry point |
+| --- | --- | --- | --- | --- |
+| train-triage | runner | serverless GPU LeRobot train | text triage report | `run_tokenfactory_train_triage.py` |
+| sim-sweep | runner | N serverless GPU trains (fan-out) | text design + ranking | `run_tokenfactory_sim_sweep.py` |
+| rollout-judge | YAML | k8s GPU rollout | VLM judge | `tokenfactory-rollout-judge.yaml` |
+| scene-to-rollout-judge | YAML | k8s GPU rollout | reason → VLM judge | `tokenfactory-scene-to-rollout-judge.yaml` |
+
+How to run each: [cookbooks/tokenfactory-compute-combos.md](./cookbooks/tokenfactory-compute-combos.md).
+
+## Checklist for your own combo
+
+- [ ] Both tokens verified (`nebius iam get-access-token`, `token-factory verify`).
+- [ ] Compute stage writes to an `s3://` `--output-path` you control.
+- [ ] Token Factory stage reads that same URI; no GPU/vLLM in that stage.
+- [ ] No hardcoded project/registry/bucket IDs — pass via flag, `--var`, or `--secret`.
+- [ ] Pure logic in `token_factory_combos.py` (unit-tested); I/O in the runner/YAML.
+- [ ] Runner has `--render-only` and a cheap no-GPU iteration mode.
+- [ ] `NEBIUS_API_KEY` checked at the start of every hosted stage.

--- a/docs/workbench/cookbooks/README.md
+++ b/docs/workbench/cookbooks/README.md
@@ -14,6 +14,10 @@ workflows with Nebius Physical AI Workbench.
   behind the one-command H100 quickstart.
 - [VLM-Eval Loop Runbook](vlm-eval-loop-runbook.md): serve a VLM with vLLM,
   score rollout directories with `vlm-eval`, and write a task-success report.
+- [Token Factory + Nebius compute combos](tokenfactory-compute-combos.md): two
+  workflows that pair real Nebius GPU compute with hosted Token Factory
+  inference — a serverless GPU train run triaged by a text model, and a
+  Kubernetes GPU rollout judged by a hosted VLM.
 - [LeRobot GPU Benchmarks](lerobot-gpu-benchmarks.md): reproduce the May 2026
   LeRobot GPU benchmark research across L40S, H200, B300, and RTX PRO 6000.
 - [LeRobot GPU Benchmarks Runbook](lerobot-gpu-benchmarks-runbook.md): exact

--- a/docs/workbench/cookbooks/physical-reasoning-challenge.md
+++ b/docs/workbench/cookbooks/physical-reasoning-challenge.md
@@ -1,0 +1,82 @@
+# Physical Reasoning Challenge (Token Factory + Cosmos3-Super-Reasoner)
+
+A zero-GPU hackathon challenge built on Nebius Token Factory's hosted
+`nvidia/Cosmos3-Super-Reasoner`. Teams walk a robot (or just a phone camera) to
+different scenes around campus, capture images, and use the reasoner to extract
+**scene understanding** and a **plan of action** for a task at that scene.
+
+No GPUs, no servers to manage: inference is hosted, so a team needs only a
+`NEBIUS_API_KEY` and the `npa` CLI.
+
+## Why this works
+
+`nvidia/Cosmos3-Super-Reasoner` is a vision-language model post-trained for
+physical-AI common sense and embodied reasoning. Given scene images plus a task,
+it reasons over objects, spatial layout, motion, and physical interactions and
+returns a concrete, ordered plan — exactly the "what do I see, what should I do"
+loop this challenge needs.
+
+## Setup (once per team)
+
+```bash
+npa configure                         # enter the Token Factory API key when prompted
+npa workbench token-factory verify    # confirm auth + that the model is available
+npa workbench token-factory models | grep -i cosmos
+```
+
+If `nvidia/Cosmos3-Super-Reasoner` is not listed for your key, ask an organizer
+to enable it (or use whatever Cosmos reasoner id `models` reports via `--model`).
+
+## Run the loop (local)
+
+1. Walk to a scene and capture one or more images into a folder, e.g. `./scene/`.
+2. Ask the reasoner what to do:
+
+```bash
+npa workbench token-factory reason \
+  --input-path ./scene \
+  --output-path ./out \
+  --task "What is in this scene and what steps should the robot take to <YOUR TASK>?" \
+  --output json
+```
+
+3. Read `./out/scene_reasoning.json` — it contains the model, the task, the
+   image list, and the `analysis` (scene understanding + plan of action).
+
+## Run at scale (SkyPilot, S3 in/out)
+
+Push scenes to S3 and launch the CPU-only workflow; the key rides in as a secret:
+
+```bash
+sky jobs launch \
+  --secret NEBIUS_API_KEY \
+  --secret AWS_ACCESS_KEY_ID \
+  --secret AWS_SECRET_ACCESS_KEY \
+  npa/workflows/workbench/skypilot/token-factory-cosmos-reason.yaml
+```
+
+Set `INPUT_URI`, `OUTPUT_URI`, and `TASK` in the YAML's `envs:` (or override at
+launch).
+
+## Suggested scoring rubric
+
+- **Scene understanding** — did it correctly identify objects, layout, hazards?
+- **Plan quality** — are the steps ordered, executable, and safe?
+- **Grounding** — does the plan reference what is actually visible?
+- **Robustness** — try the same task across 3+ scenes (indoor, outdoor, cluttered).
+
+Teams can compare models with `--model`, tune the framing with `--task` /
+`--system-prompt`, and send multiple angles of a scene with `--max-images`.
+
+## Is one reasoner enough for a challenge?
+
+Yes for a focused, fun challenge: a single hosted reasoner removes all infra
+friction and still exercises real physical common sense. Caveats to set
+expectations with teams:
+
+- **Model availability and rate limits** are key-dependent — verify early and
+  share one organizer key budget or per-team keys.
+- **Stills vs. video**: this cookbook sends images. Multi-image (several angles)
+  improves spatial grounding; capture 2–4 frames per scene.
+- **It plans, it does not act** — pair it with a teleoperated or scripted robot;
+  the reasoner is the "brain", not the controller.

--- a/docs/workbench/cookbooks/tokenfactory-compute-combos.md
+++ b/docs/workbench/cookbooks/tokenfactory-compute-combos.md
@@ -10,9 +10,14 @@ not just on its own.
 | Workflow | Nebius compute | Token Factory stage | Entry point |
 | --- | --- | --- | --- |
 | **train-triage** | Serverless GPU Job (LeRobot train) | Text model writes a triage report from the run's artifacts | [`run_tokenfactory_train_triage.py`](../../../npa/scripts/run_tokenfactory_train_triage.py) |
+| **sim-sweep** | N serverless GPU Jobs (LeRobot train fan-out) | Text model designs the sweep, then ranks the runs | [`run_tokenfactory_sim_sweep.py`](../../../npa/scripts/run_tokenfactory_sim_sweep.py) |
 | **rollout-judge** | Managed Kubernetes GPU (LeRobot eval rollout) | Hosted VLM scores the rollout (`vlm-eval --backend api`) | [`tokenfactory-rollout-judge.yaml`](../../../npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml) |
+| **scene-to-rollout-judge** | Managed Kubernetes GPU (LeRobot eval rollout) | Reasoner extracts a plan, then a VLM judges the rollout against it | [`tokenfactory-scene-to-rollout-judge.yaml`](../../../npa/workflows/workbench/skypilot/tokenfactory-scene-to-rollout-judge.yaml) |
 
-Both are intentionally **smoke-sized** so they are cheap to run end-to-end.
+All are intentionally **smoke-sized** so they are cheap to run end-to-end. New to
+composing these? Read
+[composing-cloud-and-token-factory.md](../composing-cloud-and-token-factory.md)
+first — it explains the contract, both tokens, and the two composition styles.
 
 ## Prerequisites
 
@@ -88,11 +93,67 @@ Output: a `vlm-eval` task-success report under `JUDGE_URI` with per-rollout
 `lerobot/diffusion_pusht` checkpoint on the `pusht` environment, so it runs out
 of the box; swap `CHECKPOINT`/`ENV_TYPE` for your own policy.
 
+## 3. sim-sweep (Token Factory design → N serverless GPUs → Token Factory rank)
+
+A fan-out sweep that uses Token Factory **twice** around a batch of Nebius GPU
+jobs. A hosted text model writes a per-variant hypothesis; a deterministic grid
+launches one LeRobot serverless GPU smoke train per variant (varying `--steps`,
+the real comparable knob — `lerobot train` has no `--seed`); a hosted text model
+then ranks the completed runs from their real artifacts and names a winner.
+
+```bash
+# No-infrastructure preview of design prompt + grid + per-variant commands.
+python npa/scripts/run_tokenfactory_sim_sweep.py --render-only --num-variants 2
+
+# Full live run: design -> N serverless GPU trains -> ranking.
+NEBIUS_API_KEY=... python npa/scripts/run_tokenfactory_sim_sweep.py \
+  --project-id project-xxxxxxxx \
+  --bucket s3://your-bucket/tf-sim-sweep \
+  --num-variants 2
+
+# Cheap iteration: rank existing run prefixes (skips design + GPU stages).
+NEBIUS_API_KEY=... python npa/scripts/run_tokenfactory_sim_sweep.py \
+  --rank-existing s3://your-bucket/runA/,s3://your-bucket/runB/
+```
+
+Output: a `generations.jsonl` ranking report under `<sweep-root>/ranking/`, plus
+the design notes under `<sweep-root>/design/` and per-variant artifacts under
+`<sweep-root>/variants/<id>/`.
+
+## 4. scene-to-rollout-judge (Token Factory reason → k8s GPU → Token Factory VLM)
+
+The hackathon physical-common-sense loop as one serial SkyPilot pipeline. Stage
+1 (zero-GPU) runs `token-factory reason` over scene images with
+`nvidia/Cosmos3-Super-Reasoner` and writes a plan of action. Stage 2 rolls out a
+policy on a Nebius **Managed Kubernetes GPU**. Stage 3 (zero-GPU) folds the
+Stage 1 plan into the `vlm-eval` task and has a hosted VLM judge whether the
+rollout accomplished the plan.
+
+```bash
+npa skypilot bootstrap
+
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/tokenfactory-scene-to-rollout-judge.yaml \
+  --run-id scene-judge \
+  --var NPA_LEROBOT_IMAGE=cr.eu-north1.nebius.cloud/<registry>/npa-lerobot:0.5.1 \
+  --var NPA_TOKEN_FACTORY_IMAGE=cr.eu-north1.nebius.cloud/<registry>/npa-cosmos:1.0.9 \
+  --var SCENE_URI=s3://your-bucket/tokenfactory/<run-id>/scene/ \
+  --var PLAN_URI=s3://your-bucket/tokenfactory/<run-id>/plan/ \
+  --var ROLLOUTS_URI=s3://your-bucket/tokenfactory/<run-id>/rollouts/ \
+  --var JUDGE_URI=s3://your-bucket/tokenfactory/<run-id>/vlm-judge/
+```
+
+Put a few scene images (jpg/png) under `SCENE_URI` first. Output: a
+`scene_reasoning.json` plan under `PLAN_URI` and a per-rollout
+`{passed, score, rationale}` report under `JUDGE_URI`.
+
 ## Why these are "combo" workflows
 
 The other Token Factory workflows (`token-factory-caption`,
 `token-factory-generate`, `token-factory-cosmos-reason`,
-`vlm-eval-token-factory`) are CPU-only and only call the hosted API. These two
-deliberately put a real Nebius GPU stage in front of the hosted stage so the
+`vlm-eval-token-factory`) are CPU-only and only call the hosted API. These four
+deliberately put a real Nebius GPU stage alongside the hosted stage(s) so the
 pipeline exercises **both** Nebius cloud compute and Token Factory in one run.
+See [composing-cloud-and-token-factory.md](../composing-cloud-and-token-factory.md)
+to build your own.
 ```

--- a/docs/workbench/cookbooks/tokenfactory-compute-combos.md
+++ b/docs/workbench/cookbooks/tokenfactory-compute-combos.md
@@ -1,0 +1,98 @@
+# Token Factory + Nebius compute combos
+
+Most Token Factory workflows are **zero-GPU** — they only call the hosted API.
+These two **combo** workflows are different: each pairs *real Nebius cloud
+compute* (a GPU job) with *hosted Token Factory inference*. The GPU stage
+produces artifacts; the hosted, zero-GPU stage reasons over them. They were
+built for the hackathon to show Token Factory working alongside Nebius compute,
+not just on its own.
+
+| Workflow | Nebius compute | Token Factory stage | Entry point |
+| --- | --- | --- | --- |
+| **train-triage** | Serverless GPU Job (LeRobot train) | Text model writes a triage report from the run's artifacts | [`run_tokenfactory_train_triage.py`](../../../npa/scripts/run_tokenfactory_train_triage.py) |
+| **rollout-judge** | Managed Kubernetes GPU (LeRobot eval rollout) | Hosted VLM scores the rollout (`vlm-eval --backend api`) | [`tokenfactory-rollout-judge.yaml`](../../../npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml) |
+
+Both are intentionally **smoke-sized** so they are cheap to run end-to-end.
+
+## Prerequisites
+
+- A Token Factory API key in `NEBIUS_API_KEY` (see
+  [token-factory.md](../token-factory.md) to register and mint one).
+- Nebius cloud credentials for compute + storage. The serverless path needs a
+  Nebius **project ID** and an S3 **bucket** you can write to; the Kubernetes
+  path needs SkyPilot bootstrapped (`npa skypilot bootstrap`).
+- Object-storage credentials in `~/.npa/credentials.yaml` (the runner exports
+  them for you; SkyPilot reads them as `--secret`s).
+
+Never hardcode project, registry, or bucket IDs in committed files — pass them
+at launch via flags, `--var`, or SkyPilot secrets.
+
+## 1. train-triage (serverless GPU → Token Factory report)
+
+A LeRobot **serverless GPU Job** trains a policy (smoke settings by default) and
+uploads its run artifacts (configs, logs, metrics) to S3. A Token Factory text
+model then reads those artifacts and writes a triage + next-steps report next to
+the run.
+
+```bash
+# No-infrastructure preview of exactly what will run.
+python npa/scripts/run_tokenfactory_train_triage.py --render-only
+
+# Full live run: serverless GPU smoke train, then Token Factory triage.
+# --project-id and --output-path are required unless your workbench config
+# already provides a project and storage.checkpoint_bucket.
+NEBIUS_API_KEY=... python npa/scripts/run_tokenfactory_train_triage.py \
+  --project-id project-xxxxxxxx \
+  --output-path s3://your-bucket/tf-triage/<run-id>/ \
+  --gpu-type h200
+
+# Cheap iteration: skip the GPU stage and only triage an existing run prefix.
+NEBIUS_API_KEY=... python npa/scripts/run_tokenfactory_train_triage.py \
+  --from-output-path s3://your-bucket/lerobot-serverless-test/<ts>/
+```
+
+Output: a `generations.jsonl` triage report under `<artifacts>/triage/` (or
+`--triage-root`). Choose the triage model with `--model` (default
+`meta-llama/Llama-3.3-70B-Instruct`; `nvidia/Cosmos3-Super-Reasoner` also works).
+
+## 2. rollout-judge (Kubernetes GPU → Token Factory VLM judge)
+
+A two-stage serial SkyPilot pipeline. Stage 1 runs `lerobot-eval` on a Nebius
+**Managed Kubernetes GPU**, renders rollout videos, and uploads them to S3.
+Stage 2 is zero-GPU: `vlm-eval --backend api` scores the rollout with a hosted
+Token Factory VLM — no local vLLM serving stage.
+
+```bash
+npa skypilot bootstrap
+export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+
+npa workbench workflow submit \
+  npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml \
+  --run-id rollout-judge \
+  --var NPA_LEROBOT_IMAGE=cr.eu-north1.nebius.cloud/<registry>/npa-lerobot:0.5.1 \
+  --var NPA_TOKEN_FACTORY_IMAGE=cr.eu-north1.nebius.cloud/<registry>/npa-cosmos:1.0.9 \
+  --var ROLLOUTS_URI=s3://your-bucket/tokenfactory/<run-id>/rollouts/ \
+  --var JUDGE_URI=s3://your-bucket/tokenfactory/<run-id>/vlm-judge/
+```
+
+Pass the key and storage creds as secrets when launching the YAML directly:
+
+```bash
+sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID \
+  --secret AWS_SECRET_ACCESS_KEY \
+  npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml
+```
+
+Output: a `vlm-eval` task-success report under `JUDGE_URI` with per-rollout
+`{passed, score, rationale}`. The default rollout uses the public
+`lerobot/diffusion_pusht` checkpoint on the `pusht` environment, so it runs out
+of the box; swap `CHECKPOINT`/`ENV_TYPE` for your own policy.
+
+## Why these are "combo" workflows
+
+The other Token Factory workflows (`token-factory-caption`,
+`token-factory-generate`, `token-factory-cosmos-reason`,
+`vlm-eval-token-factory`) are CPU-only and only call the hosted API. These two
+deliberately put a real Nebius GPU stage in front of the hosted stage so the
+pipeline exercises **both** Nebius cloud compute and Token Factory in one run.
+```

--- a/docs/workbench/token-factory.md
+++ b/docs/workbench/token-factory.md
@@ -71,7 +71,7 @@ Caption a folder of images (local or S3):
 npa workbench token-factory caption \
   --input-path ./frames \
   --output-path /tmp/captions \
-  --model Qwen/Qwen2-VL-7B-Instruct \
+  --model Qwen/Qwen2.5-VL-72B-Instruct \
   --output json
 ```
 

--- a/docs/workbench/token-factory.md
+++ b/docs/workbench/token-factory.md
@@ -1,0 +1,171 @@
+# Nebius Token Factory Integration Guide
+
+Nebius Token Factory is an OpenAI-compatible hosted-inference API for open text
+and vision models. NPA uses it natively for zero-GPU workflows: captioning,
+batch text generation, and VLM-based rollout scoring all call the hosted API
+instead of starting a GPU server.
+
+Authentication is a single API key sent as an `Authorization: Bearer <key>`
+header. NPA reads it from the `NEBIUS_API_KEY` environment variable (or
+`~/.npa/credentials.yaml`). The default endpoint is
+`https://api.tokenfactory.nebius.com/v1/`.
+
+## 1. Get an API key
+
+1. Sign in at <https://tokenfactory.nebius.com/>.
+2. Open **API keys** → **Create API key**.
+3. Copy the key now — it cannot be shown again.
+
+## 2. Give the key to NPA
+
+Pick one (NPA checks them in this order: explicit arg → env var → credentials file).
+
+**A. Interactive setup (recommended)**
+
+```bash
+npa configure
+# ... answer the "Nebius Token Factory API key (NEBIUS_API_KEY)" prompt
+```
+
+**B. Credentials file by hand** — `~/.npa/credentials.yaml`:
+
+```yaml
+tokens:
+  NEBIUS_API_KEY: nebius_xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+```bash
+chmod 600 ~/.npa/credentials.yaml
+```
+
+**C. Environment variable** (good for CI / one-off shells):
+
+```bash
+export NEBIUS_API_KEY=nebius_xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## 3. Verify authentication
+
+```bash
+npa workbench token-factory verify
+```
+
+Expected output confirms the key authenticated and lists a few available models:
+
+```
+  authenticated: True
+  base_url: https://api.tokenfactory.nebius.com/v1/
+  model_count: 42
+  sample_models: ['meta-llama/Llama-3.3-70B-Instruct', ...]
+```
+
+`npa workbench token-factory status` shows the resolved base URL and whether a
+key is configured **without** making a network call.
+`npa workbench token-factory models` lists the full model catalog.
+
+## 4. Run something
+
+Caption a folder of images (local or S3):
+
+```bash
+npa workbench token-factory caption \
+  --input-path ./frames \
+  --output-path /tmp/captions \
+  --model Qwen/Qwen2-VL-7B-Instruct \
+  --output json
+```
+
+Batch text generation from a JSONL prompt file (`{"id": ..., "prompt": ...}`
+per line) or a `.txt` file (one prompt per line):
+
+```bash
+npa workbench token-factory generate \
+  --input-path ./prompts.jsonl \
+  --output-path /tmp/generations \
+  --model meta-llama/Llama-3.3-70B-Instruct \
+  --output json
+```
+
+Reason over a scene with NVIDIA Cosmos3-Super-Reasoner — point it at scene
+images and ask what a robot should do (scene understanding + plan of action):
+
+```bash
+npa workbench token-factory reason \
+  --input-path ./scene \
+  --output-path /tmp/scene-reasoning \
+  --task "What is in this scene and how should a robot pick up the red box?" \
+  --model nvidia/Cosmos3-Super-Reasoner \
+  --output json
+```
+
+Score a rollout with a hosted VLM (no GPU, no vLLM):
+
+```bash
+npa workbench vlm-eval run \
+  --input-path ./rollouts/episode-000 \
+  --output-path /tmp/vlm-eval \
+  --backend api \
+  --api-key-env NEBIUS_API_KEY \
+  --output json
+```
+
+## 5. Run on Nebius (SkyPilot)
+
+The checked-in CPU-only workflows pass the key as a SkyPilot secret:
+
+```bash
+sky jobs launch \
+  --secret NEBIUS_API_KEY \
+  --secret AWS_ACCESS_KEY_ID \
+  --secret AWS_SECRET_ACCESS_KEY \
+  npa/workflows/workbench/skypilot/token-factory-caption.yaml
+```
+
+Other workflows: `token-factory-generate.yaml`,
+`token-factory-cosmos-reason.yaml`, `vlm-eval-token-factory.yaml`.
+
+## Live testing (first-class)
+
+The mocked unit tests never touch the network. The *live* tests that actually
+authenticate against Token Factory are in `npa/tests/e2e/test_token_factory_e2e.py`
+and are marked `token_factory_e2e`. They self-skip when no key is configured, so
+the only thing you need to run them is a real key:
+
+```bash
+NEBIUS_API_KEY=nebius_xxx npa/.venv/bin/python -m pytest \
+  npa/tests/e2e/test_token_factory_e2e.py -v
+```
+
+They cover: `list_models` authenticates, a text chat completion returns text,
+and `nvidia/Cosmos3-Super-Reasoner` produces a scene plan (that last one skips if
+the model is not available for your key). For a quick manual check use
+`npa workbench token-factory verify`.
+
+## Use it in Python
+
+NPA's client is a thin OpenAI-compatible wrapper, so you can call it directly:
+
+```python
+from npa.clients.token_factory import TokenFactoryClient
+
+client = TokenFactoryClient()  # reads NEBIUS_API_KEY
+text = client.chat_completion_text(
+    model="meta-llama/Llama-3.3-70B-Instruct",
+    messages=[{"role": "user", "content": "Give me one robot task instruction."}],
+)
+print(text)
+```
+
+Override the endpoint with `NEBIUS_TOKEN_FACTORY_BASE_URL` (or `NEBIUS_BASE_URL`)
+if you are pointed at a non-default deployment.
+
+## Troubleshooting
+
+- **`NEBIUS_API_KEY is not set`** — provide the key via step 2; confirm with
+  `npa workbench token-factory status`.
+- **`Token Factory request failed (401)`** — the key is invalid or revoked;
+  create a new one.
+- **`Token Factory request failed (404)` on a model** — the model id is wrong or
+  retired; check `npa workbench token-factory models`.
+- **Workflow exits with "NEBIUS_API_KEY is required"** — you did not pass
+  `--secret NEBIUS_API_KEY` to `sky jobs launch`.

--- a/docs/workbench/token-factory.md
+++ b/docs/workbench/token-factory.md
@@ -10,11 +10,38 @@ header. NPA reads it from the `NEBIUS_API_KEY` environment variable (or
 `~/.npa/credentials.yaml`). The default endpoint is
 `https://api.tokenfactory.nebius.com/v1/`.
 
-## 1. Get an API key
+## 1. Register and get an API key
 
-1. Sign in at <https://tokenfactory.nebius.com/>.
-2. Open **API keys** → **Create API key**.
-3. Copy the key now — it cannot be shown again.
+Token Factory has its own console, separate from the main Nebius cloud console.
+Registering and minting a key takes about two minutes:
+
+1. **Create an account / sign in.** Go to <https://tokenfactory.nebius.com/> and
+   sign up (Google/GitHub/email all work) or sign in. New accounts land in a
+   default organization and project.
+2. **Make sure the project has credit.** Token Factory is pay-per-token. New
+   accounts usually get trial credit; otherwise open **Billing** and add a
+   payment method or redeem credits. A project with no balance returns
+   `402`/`403` on inference calls. If your team already has a Token Factory
+   project, just confirm you're switched into it (top-left project switcher).
+3. **Create the API key.** In the left nav open **API keys** → **Create API
+   key**, give it a name (e.g. `npa-hackathon`), and click **Create**.
+4. **Copy it now.** The key is shown **once** and cannot be reopened later. It's
+   a long opaque Bearer token. Store it somewhere safe (a password manager) —
+   you'll paste it into NPA in step 2.
+
+> Tip: each Token Factory project also has an **AI project ID** (looks like
+> `aiproject-...`, visible in the project switcher / settings). You don't need
+> it for normal use — the API key already scopes requests to its project — but
+> it's handy when filtering models by project in the console.
+
+Optional 10-second self-test from your own terminal (proves the key works and
+shows the served catalog, including whether `nvidia/Cosmos3-Super-Reasoner` is
+enabled for you):
+
+```bash
+curl -s https://api.tokenfactory.nebius.com/v1/models \
+  -H "Authorization: Bearer <PASTE_KEY>" | head
+```
 
 ## 2. Give the key to NPA
 

--- a/npa/pyproject.toml
+++ b/npa/pyproject.toml
@@ -118,4 +118,5 @@ markers = [
     "ngc_e2e: GR00T NGC credential e2e tests that require NPA_TEST_GROOT_NGC_E2E=1 and a live GR00T workbench.",
     "byovm_live: BYOVM tests that require opt-in live target environment variables.",
     "gpu: tests that provision a live GPU through SkyPilot when credentials are available.",
+    "token_factory_e2e: live Nebius Token Factory API tests that require a real NEBIUS_API_KEY.",
 ]

--- a/npa/scripts/run_tokenfactory_sim_sweep.py
+++ b/npa/scripts/run_tokenfactory_sim_sweep.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Design a sweep with Token Factory, run it on Nebius GPUs, then rank it.
+
+This is a *combo* workflow that exercises all three layers in one run:
+
+  1. **Token Factory (hosted, zero-GPU)** designs the sweep: a text model writes
+     a per-variant hypothesis for the experiment grid.
+  2. **Nebius AI Cloud (serverless GPU)** runs the sweep: one LeRobot serverless
+     GPU Job per variant (``--smoke`` by default), each writing artifacts to S3.
+  3. **Token Factory (hosted, zero-GPU)** ranks the sweep: a text model reads the
+     completed runs' real artifacts and produces a best-to-worst ranking with a
+     promoted winner.
+
+The actual hyper-parameters launched on GPUs come from a deterministic grid
+(:func:`npa.workflows.token_factory_combos.sweep_variants`), so the GPU stage
+never depends on parsing free-form model output. The model contributes the
+experiment *rationale* (stage 1) and the *judgement* (stage 3).
+
+Examples:
+  # No-infrastructure preview of the full plan (design prompt + grid + commands).
+  python npa/scripts/run_tokenfactory_sim_sweep.py --render-only --num-variants 2
+
+  # Full live run: design -> N serverless GPU smoke trains -> ranking.
+  NEBIUS_API_KEY=... python npa/scripts/run_tokenfactory_sim_sweep.py \
+      --project-id project-xxxxxxxx \
+      --bucket s3://your-bucket/tf-sim-sweep \
+      --num-variants 2
+
+  # Cheap iteration: skip the GPU stage and only rank existing run prefixes.
+  NEBIUS_API_KEY=... python npa/scripts/run_tokenfactory_sim_sweep.py \
+      --rank-existing s3://your-bucket/runA/,s3://your-bucket/runB/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from npa.clients.token_factory import DEFAULT_TEXT_MODEL
+from npa.workflows.token_factory_combos import (
+    DEFAULT_SWEEP_DESIGN_SYSTEM_PROMPT,
+    DEFAULT_SWEEP_RANKING_SYSTEM_PROMPT,
+    build_ranking_prompt,
+    build_sweep_design_prompt,
+    default_sweep_run_id,
+    join_uri,
+    render_triage_prompts_jsonl,
+    summarize_run_artifacts,
+    sweep_variant_output_uri,
+    sweep_variants,
+    triage_job_name,
+)
+
+
+class SweepRunError(RuntimeError):
+    """Raised when a serverless or Token Factory stage fails."""
+
+
+# ``npa.cli.main`` has no ``__main__`` guard; invoke the Typer app entrypoint
+# directly so this runner uses the same npa package it was imported from.
+_NPA_CLI_BOOTSTRAP = "from npa.cli.main import app_entry; app_entry()"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    plan = build_plan(args)
+    if args.render_only:
+        print(json.dumps({"plan": plan}, indent=2, sort_keys=True))
+        return 0
+    try:
+        return _run(args, plan)
+    except SweepRunError as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, indent=2, sort_keys=True))
+        return 1
+
+
+def build_plan(args: argparse.Namespace) -> dict[str, Any]:
+    """Resolve the sweep plan without touching infrastructure (render-only safe)."""
+
+    run_id = args.run_id or default_sweep_run_id()
+    plan: dict[str, Any] = {
+        "run_id": run_id,
+        "compute": "nebius-serverless-gpu",
+        "hosted_inference": "nebius-token-factory",
+        "design_model": args.model or DEFAULT_TEXT_MODEL,
+        "ranking_model": args.model or DEFAULT_TEXT_MODEL,
+    }
+    if args.rank_existing:
+        plan["mode"] = "rank-existing"
+        plan["variant_uris"] = _split_csv(args.rank_existing)
+        return plan
+
+    plan["mode"] = "full-sweep"
+    sweep_root = join_uri(args.bucket, run_id) if args.bucket else f"<bucket>/{run_id}"
+    variants = sweep_variants(args.num_variants)
+    plan["sweep_root"] = sweep_root
+    plan["variants"] = [
+        {
+            **variant,
+            "output_uri": sweep_variant_output_uri(sweep_root, variant["id"]),
+            "train_command": _train_command(args, variant, sweep_root),
+        }
+        for variant in variants
+    ]
+    plan["design_prompt"] = build_sweep_design_prompt(
+        objective=args.objective,
+        dataset=args.dataset,
+        policy_type=args.policy_type,
+        variants=variants,
+    )
+    return plan
+
+
+def _train_command(
+    args: argparse.Namespace, variant: dict[str, Any], sweep_root: str
+) -> list[str]:
+    job_name = triage_job_name(f"{args.run_id or 'tf-sweep'}-{variant['id']}")
+    cmd = [
+        "workbench",
+        "lerobot",
+        "train",
+        "--runtime",
+        "serverless",
+        "--policy-type",
+        args.policy_type,
+        "--dataset",
+        args.dataset,
+        "--job-name",
+        job_name,
+        "--gpu-type",
+        args.gpu_type,
+        "--steps",
+        str(variant["steps"]),
+        "--output-path",
+        sweep_variant_output_uri(sweep_root, variant["id"]) + "/",
+        "--wait-timeout",
+        str(args.wait_timeout),
+        "--poll-interval",
+        str(args.poll_interval),
+        "--output",
+        "json",
+    ]
+    if args.smoke:
+        cmd.append("--smoke")
+    if args.project_id:
+        cmd += ["--project-id", args.project_id]
+    if args.image:
+        cmd += ["--image", args.image]
+    return cmd
+
+
+def _run(args: argparse.Namespace, plan: dict[str, Any]) -> int:
+    _hydrate_credentials()
+    summary: dict[str, Any] = {"status": "running", "plan_mode": plan["mode"], "run_id": plan["run_id"]}
+
+    if plan["mode"] == "rank-existing":
+        completed = _label_existing_runs(plan["variant_uris"])
+    else:
+        summary["design"] = _design_sweep(plan, model=plan["design_model"], max_tokens=args.max_tokens)
+        completed = _launch_variants(plan["variants"])
+        summary["variants"] = completed
+
+    ranking = _rank_runs(
+        objective=args.objective,
+        runs=completed,
+        rank_root=args.rank_root or join_uri(plan.get("sweep_root", plan["variant_uris"][0]), "ranking"),
+        model=plan["ranking_model"],
+        max_tokens=args.max_tokens,
+    )
+    summary["ranking"] = ranking
+    summary["status"] = "completed"
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+def _design_sweep(plan: dict[str, Any], *, model: str, max_tokens: int) -> dict[str, Any]:
+    from npa.workbench.token_factory import generate_text
+
+    with tempfile.TemporaryDirectory(prefix="npa-tf-sweep-design-") as tmp:
+        prompts_file = Path(tmp) / "prompts.jsonl"
+        prompts_file.write_text(
+            render_triage_prompts_jsonl([{"id": "sweep-design", "prompt": plan["design_prompt"]}]),
+            encoding="utf-8",
+        )
+        result = generate_text(
+            input_path=str(prompts_file),
+            output_path=join_uri(plan["sweep_root"], "design"),
+            model=model,
+            system_prompt=DEFAULT_SWEEP_DESIGN_SYSTEM_PROMPT,
+            max_tokens=max_tokens,
+        )
+    text = result.generations[0].completion if result.generations else ""
+    return {"status": result.status, "model": result.model, "design_preview": text[:600]}
+
+
+def _launch_variants(variants: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    completed: list[dict[str, Any]] = []
+    for variant in variants:
+        train_result = _submit_serverless_train(variant["train_command"])
+        if train_result.get("status") not in {"succeeded", "success"}:
+            raise SweepRunError(f"variant {variant['id']} train failed: {train_result}")
+        completed.append(
+            {
+                "id": variant["id"],
+                "steps": variant["steps"],
+                "uri": train_result.get("output_path") or variant["output_uri"],
+                "status": train_result.get("status"),
+            }
+        )
+    return completed
+
+
+def _rank_runs(
+    *,
+    objective: str,
+    runs: list[dict[str, Any]],
+    rank_root: str,
+    model: str,
+    max_tokens: int,
+) -> dict[str, Any]:
+    from npa.workbench.token_factory import generate_text
+
+    with tempfile.TemporaryDirectory(prefix="npa-tf-sweep-rank-") as tmp:
+        tmp_path = Path(tmp)
+        digested: list[dict[str, str]] = []
+        for run in runs:
+            local = _materialize(run["uri"], tmp_path / run["id"])
+            digested.append({"id": run["id"], "uri": run["uri"], "digest": summarize_run_artifacts(local)})
+        prompt = build_ranking_prompt(objective=objective, runs=digested)
+        prompts_file = tmp_path / "prompts.jsonl"
+        prompts_file.write_text(
+            render_triage_prompts_jsonl([{"id": "sweep-ranking", "prompt": prompt}]),
+            encoding="utf-8",
+        )
+        result = generate_text(
+            input_path=str(prompts_file),
+            output_path=rank_root,
+            model=model,
+            system_prompt=DEFAULT_SWEEP_RANKING_SYSTEM_PROMPT,
+            max_tokens=max_tokens,
+        )
+    text = result.generations[0].completion if result.generations else ""
+    return {
+        "status": result.status,
+        "model": result.model,
+        "report_uri": result.result_uri,
+        "ranked_variants": [run["id"] for run in runs],
+        "report_preview": text[:800],
+    }
+
+
+def _submit_serverless_train(train_command: list[str]) -> dict[str, Any]:
+    cmd = [sys.executable, "-c", _NPA_CLI_BOOTSTRAP, *train_command]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise SweepRunError(
+            "serverless lerobot train failed "
+            f"(exit {proc.returncode}): {proc.stderr.strip()[-800:] or proc.stdout.strip()[-800:]}"
+        )
+    return _parse_last_json(proc.stdout) or {"status": "succeeded", "raw_stdout": proc.stdout[-400:]}
+
+
+def _materialize(uri: str, dest: Path) -> Path:
+    if not uri.startswith("s3://"):
+        return Path(uri)
+    from npa.clients.storage import StorageClient
+
+    dest.mkdir(parents=True, exist_ok=True)
+    local = StorageClient.from_environment().download_path(uri, str(dest))
+    return Path(local)
+
+
+def _hydrate_credentials() -> None:
+    """Export ~/.npa/credentials.yaml into the environment for S3 + subprocess.
+
+    The CLI does this on startup, but this runner is invoked as a plain script,
+    so the serverless subprocess and StorageClient need the credentials exported
+    here. Existing environment values win.
+    """
+
+    try:
+        import os
+
+        from npa.clients.credentials import apply_shared_credential_env, load_credentials
+
+        apply_shared_credential_env(os.environ, load_credentials())
+    except Exception:  # noqa: BLE001 - best-effort; live calls surface real errors.
+        pass
+
+
+def _parse_last_json(text: str) -> dict[str, Any] | None:
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                continue
+    start = text.find("{")
+    if start >= 0:
+        try:
+            return json.loads(text[start:])
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _split_csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _uri_label(uri: str) -> str:
+    return uri.rstrip("/").rsplit("/", 1)[-1] or uri
+
+
+def _label_existing_runs(uris: list[str]) -> list[dict[str, str]]:
+    """Assign a unique, human-readable id to each existing run prefix.
+
+    Last path segments often collide (e.g. ``.../pretrained_model``), so any
+    label shared by more than one prefix is suffixed with a positional index.
+    """
+
+    labels = [_uri_label(uri) for uri in uris]
+    runs: list[dict[str, str]] = []
+    for index, (uri, label) in enumerate(zip(uris, labels)):
+        unique = label if labels.count(label) == 1 else f"{label}-{index}"
+        runs.append({"id": unique, "uri": uri})
+    return runs
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--run-id", default="", help="Run ID; defaults to a timestamped value.")
+    parser.add_argument("--objective", default="Maximize PushT success while keeping training stable.", help="Sweep objective fed to the design + ranking models.")
+    parser.add_argument("--num-variants", type=int, default=2, help="Number of GPU variants to launch (clamped to the seed grid).")
+    parser.add_argument("--policy-type", default="act", help="LeRobot policy type for each GPU train Job.")
+    parser.add_argument("--dataset", default="lerobot/pusht", help="Public HF dataset repo ID for the train Jobs.")
+    parser.add_argument("--gpu-type", default="h200", help="Serverless GPU type (h200, b300, l40s, ...).")
+    parser.add_argument("--smoke", action="store_true", default=True, help="Use smoke training settings (default).")
+    parser.add_argument("--no-smoke", dest="smoke", action="store_false", help="Disable smoke settings (real run).")
+    parser.add_argument("--project-id", default="", help="Nebius project ID override (auto-resolved if omitted).")
+    parser.add_argument("--image", default="", help="Container image override for the serverless Jobs.")
+    parser.add_argument("--bucket", default="", help="S3 prefix for sweep artifacts, e.g. s3://bucket/tf-sim-sweep.")
+    parser.add_argument("--rank-root", default="", help="S3 URI for the ranking report (default: <sweep-root>/ranking/).")
+    parser.add_argument("--model", default="", help=f"Token Factory text model for design + ranking (default {DEFAULT_TEXT_MODEL}).")
+    parser.add_argument("--max-tokens", type=int, default=1024, help="Max tokens for design + ranking generations.")
+    parser.add_argument(
+        "--rank-existing",
+        default="",
+        help="Comma-separated existing artifact prefixes to rank (skips design + GPU stages).",
+    )
+    parser.add_argument("--wait-timeout", type=int, default=3600, help="Max seconds to wait for each Job.")
+    parser.add_argument("--poll-interval", type=float, default=30.0, help="Seconds between Job status checks.")
+    parser.add_argument("--render-only", action="store_true", help="Print the plan and exit (no infrastructure).")
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/npa/scripts/run_tokenfactory_train_triage.py
+++ b/npa/scripts/run_tokenfactory_train_triage.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Train on a Nebius serverless GPU, then triage the run with Token Factory.
+
+This is a *combo* workflow: it uses **real Nebius cloud compute** (a LeRobot
+serverless GPU Job via ``npa workbench lerobot train --runtime serverless``) and
+**hosted Token Factory inference** (a text model reads the run's artifacts and
+writes a triage + next-steps report). The GPU half produces the artifacts; the
+zero-GPU hosted half explains them.
+
+Stages:
+  1. Submit a LeRobot serverless GPU Job (``--smoke`` by default) and wait for it
+     to finish. The Job uploads its run artifacts (configs, logs, metrics) to S3.
+  2. Download those textual artifacts, build a triage prompt, and call Token
+     Factory ``generate`` to write a human-readable report next to the run.
+
+Examples:
+  # No-infrastructure preview of what would run.
+  python npa/scripts/run_tokenfactory_train_triage.py --render-only
+
+  # Full live run: serverless GPU smoke train + Token Factory triage.
+  NEBIUS_API_KEY=... python npa/scripts/run_tokenfactory_train_triage.py
+
+  # Skip the GPU stage and only triage an existing run prefix (cheap iteration).
+  NEBIUS_API_KEY=... python npa/scripts/run_tokenfactory_train_triage.py \
+      --from-output-path s3://my-bucket/lerobot-serverless-test/<ts>/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from npa.clients.token_factory import DEFAULT_TEXT_MODEL
+from npa.workflows.token_factory_combos import (
+    DEFAULT_TRIAGE_SYSTEM_PROMPT,
+    build_triage_prompt,
+    default_triage_run_id,
+    join_uri,
+    render_triage_prompts_jsonl,
+    summarize_run_artifacts,
+    triage_job_name,
+    triage_report_uri,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    plan = build_plan(args)
+    if args.render_only:
+        print(json.dumps({"plan": plan}, indent=2, sort_keys=True))
+        return 0
+    try:
+        return _run(args, plan)
+    except TriageRunError as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, indent=2, sort_keys=True))
+        return 1
+
+
+class TriageRunError(RuntimeError):
+    """Raised when the serverless or Token Factory stage fails."""
+
+
+def build_plan(args: argparse.Namespace) -> dict[str, Any]:
+    """Resolve the run plan without touching infrastructure (render-only safe)."""
+
+    run_id = args.run_id or default_triage_run_id()
+    job_name = args.job_name or triage_job_name(run_id)
+    plan: dict[str, Any] = {
+        "run_id": run_id,
+        "compute": "nebius-serverless-gpu",
+        "hosted_inference": "nebius-token-factory",
+        "triage_model": args.model or DEFAULT_TEXT_MODEL,
+        "skip_train": bool(args.from_output_path),
+    }
+    if args.from_output_path:
+        plan["artifacts_uri"] = args.from_output_path
+        plan["triage_root"] = args.triage_root or join_uri(args.from_output_path, "triage")
+    else:
+        plan["train_command"] = _train_command(args, job_name)
+        plan["job_name"] = job_name
+        plan["triage_root_template"] = "<run output-path>/triage/ (resolved after the Job completes)"
+        if args.triage_root:
+            plan["triage_root"] = args.triage_root
+    return plan
+
+
+def _train_command(args: argparse.Namespace, job_name: str) -> list[str]:
+    cmd = [
+        "workbench",
+        "lerobot",
+        "train",
+        "--runtime",
+        "serverless",
+        "--policy-type",
+        args.policy_type,
+        "--dataset",
+        args.dataset,
+        "--job-name",
+        job_name,
+        "--gpu-type",
+        args.gpu_type,
+        "--wait-timeout",
+        str(args.wait_timeout),
+        "--poll-interval",
+        str(args.poll_interval),
+        "--output",
+        "json",
+    ]
+    if args.smoke:
+        cmd.append("--smoke")
+    if args.steps:
+        cmd += ["--steps", str(args.steps)]
+    if args.project_id:
+        cmd += ["--project-id", args.project_id]
+    if args.image:
+        cmd += ["--image", args.image]
+    if args.output_path:
+        cmd += ["--output-path", args.output_path]
+    return cmd
+
+
+def _hydrate_credentials() -> None:
+    """Export ~/.npa/credentials.yaml into the environment for S3 + subprocess.
+
+    The CLI does this on startup, but this runner is invoked as a plain script,
+    so the serverless subprocess and StorageClient need the credentials exported
+    here. Existing environment values win.
+    """
+
+    try:
+        import os
+
+        from npa.clients.credentials import apply_shared_credential_env, load_credentials
+
+        apply_shared_credential_env(os.environ, load_credentials())
+    except Exception:  # noqa: BLE001 - best-effort; live calls surface real errors.
+        pass
+
+
+def _run(args: argparse.Namespace, plan: dict[str, Any]) -> int:
+    _hydrate_credentials()
+    summary: dict[str, Any] = {"status": "running", "plan": plan}
+
+    if args.from_output_path:
+        artifacts_uri = args.from_output_path
+        triage_root = plan["triage_root"]
+    else:
+        train_result = _submit_serverless_train(plan["train_command"])
+        summary["train"] = train_result
+        if train_result.get("status") not in {"succeeded", "success"}:
+            summary["status"] = "failed"
+            print(json.dumps(summary, indent=2, sort_keys=True))
+            return 1
+        artifacts_uri = train_result.get("output_path") or ""
+        if not artifacts_uri:
+            raise TriageRunError("serverless train did not report an output_path to triage")
+        triage_root = args.triage_root or join_uri(artifacts_uri, "triage")
+
+    summary["artifacts_uri"] = artifacts_uri
+    summary["triage_root"] = triage_root
+
+    triage = _triage_artifacts(
+        artifacts_uri=artifacts_uri,
+        triage_root=triage_root,
+        job_name=plan.get("job_name", plan["run_id"]),
+        model=plan["triage_model"],
+        max_tokens=args.max_tokens,
+        extra_context=args.notes,
+    )
+    summary["triage"] = triage
+    summary["status"] = "completed"
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+# ``npa.cli.main`` has no ``__main__`` guard; invoke the Typer app entrypoint
+# directly so this runner uses the same npa package it was imported from.
+_NPA_CLI_BOOTSTRAP = "from npa.cli.main import app_entry; app_entry()"
+
+
+def _submit_serverless_train(train_command: list[str]) -> dict[str, Any]:
+    cmd = [sys.executable, "-c", _NPA_CLI_BOOTSTRAP, *train_command]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise TriageRunError(
+            "serverless lerobot train failed "
+            f"(exit {proc.returncode}): {proc.stderr.strip()[-800:] or proc.stdout.strip()[-800:]}"
+        )
+    return _parse_last_json(proc.stdout) or {"status": "succeeded", "raw_stdout": proc.stdout[-400:]}
+
+
+def _triage_artifacts(
+    *,
+    artifacts_uri: str,
+    triage_root: str,
+    job_name: str,
+    model: str,
+    max_tokens: int,
+    extra_context: str,
+) -> dict[str, Any]:
+    from npa.workbench.token_factory import generate_text
+
+    with tempfile.TemporaryDirectory(prefix="npa-tf-triage-") as tmp:
+        tmp_path = Path(tmp)
+        local_artifacts = _materialize(artifacts_uri, tmp_path / "artifacts")
+        digest = summarize_run_artifacts(local_artifacts)
+        prompt = build_triage_prompt(
+            job_name=job_name,
+            output_uri=artifacts_uri,
+            artifact_digest=digest,
+            extra_context=extra_context,
+        )
+        prompts_file = tmp_path / "prompts.jsonl"
+        prompts_file.write_text(
+            render_triage_prompts_jsonl([{"id": f"triage-{triage_job_name(job_name)}", "prompt": prompt}]),
+            encoding="utf-8",
+        )
+        result = generate_text(
+            input_path=str(prompts_file),
+            output_path=triage_root,
+            model=model,
+            system_prompt=DEFAULT_TRIAGE_SYSTEM_PROMPT,
+            max_tokens=max_tokens,
+        )
+        report_text = result.generations[0].completion if result.generations else ""
+
+    return {
+        "status": result.status,
+        "model": result.model,
+        "report_uri": triage_report_uri(triage_root)
+        if not triage_root.endswith((".json", ".jsonl"))
+        else result.result_uri,
+        "report_preview": report_text[:600],
+    }
+
+
+def _materialize(uri: str, dest: Path) -> Path:
+    if not uri.startswith("s3://"):
+        return Path(uri)
+    from npa.clients.storage import StorageClient
+
+    dest.mkdir(parents=True, exist_ok=True)
+    local = StorageClient.from_environment().download_path(uri, str(dest))
+    return Path(local)
+
+
+def _parse_last_json(text: str) -> dict[str, Any] | None:
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                continue
+    start = text.find("{")
+    if start >= 0:
+        try:
+            return json.loads(text[start:])
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--run-id", default="", help="Run ID; defaults to a timestamped value.")
+    parser.add_argument("--policy-type", default="act", help="LeRobot policy type for the GPU train Job.")
+    parser.add_argument("--dataset", default="lerobot/pusht", help="Public HF dataset repo ID for the train Job.")
+    parser.add_argument("--job-name", default="", help="Serverless Job name; derived from --run-id if omitted.")
+    parser.add_argument("--gpu-type", default="h200", help="Serverless GPU type (h200, b300, l40s, ...).")
+    parser.add_argument("--project-id", default="", help="Nebius project ID override (auto-resolved if omitted).")
+    parser.add_argument("--image", default="", help="Container image override for the serverless Job.")
+    parser.add_argument("--output-path", default="", help="S3 URI for train artifacts (auto-derived if omitted).")
+    parser.add_argument("--steps", type=int, default=0, help="Training steps (0 = tool default; --smoke overrides).")
+    parser.add_argument("--smoke", action="store_true", default=True, help="Use smoke training settings (default).")
+    parser.add_argument("--no-smoke", dest="smoke", action="store_false", help="Disable smoke settings (real run).")
+    parser.add_argument("--model", default="", help=f"Token Factory triage model (default {DEFAULT_TEXT_MODEL}).")
+    parser.add_argument("--max-tokens", type=int, default=1024, help="Max tokens for the triage report.")
+    parser.add_argument("--notes", default="", help="Optional operator context added to the triage prompt.")
+    parser.add_argument("--triage-root", default="", help="S3 URI for the triage report (default: <artifacts>/triage/).")
+    parser.add_argument(
+        "--from-output-path",
+        default="",
+        help="Skip the GPU Job and triage an existing artifacts S3 prefix instead.",
+    )
+    parser.add_argument("--wait-timeout", type=int, default=3600, help="Max seconds to wait for the Job.")
+    parser.add_argument("--poll-interval", type=float, default=30.0, help="Seconds between Job status checks.")
+    parser.add_argument("--render-only", action="store_true", help="Print the plan and exit (no infrastructure).")
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -67,6 +67,9 @@ BYOVM SSH defaults:
 
 tokens:
   HF_TOKEN: hf_REPLACE_ME
+  # Nebius Token Factory API key (OpenAI-compatible hosted inference).
+  # Get one at https://tokenfactory.nebius.com/ -> API keys.
+  NEBIUS_API_KEY: nebius_REPLACE_ME
 ngc:
   api_key: nvapi_REPLACE_ME
   # org: optional-ngc-org
@@ -190,6 +193,7 @@ def _run_interactive_configure() -> None:
         ).strip()
 
     hf_token = ask("Hugging Face token (HF_TOKEN)", secret=True)
+    nebius_api_key = ask("Nebius Token Factory API key (NEBIUS_API_KEY)", secret=True)
     s3_access_key = ask("S3 access key id (AWS_ACCESS_KEY_ID)", secret=True)
     s3_secret_key = ask("S3 secret access key (AWS_SECRET_ACCESS_KEY)", secret=True)
     s3_endpoint = ask("S3 endpoint URL", default=DEFAULT_STORAGE_ENDPOINT)
@@ -201,7 +205,7 @@ def _run_interactive_configure() -> None:
 
     credentials_path = write_credentials_file(
         {
-            "tokens": {"HF_TOKEN": hf_token},
+            "tokens": {"HF_TOKEN": hf_token, "NEBIUS_API_KEY": nebius_api_key},
             "storage": {
                 "aws_access_key_id": s3_access_key,
                 "aws_secret_access_key": s3_secret_key,

--- a/npa/src/npa/cli/workbench/__init__.py
+++ b/npa/src/npa/cli/workbench/__init__.py
@@ -21,6 +21,7 @@ from npa.cli.workbench.sim2real import app as sim2real_app
 from npa.cli.workbench.sim2real_envgen import app as sim2real_envgen_app
 from npa.cli.workbench.lancedb import app as lancedb_app
 from npa.cli.workbench.detection_training import app as detection_training_app
+from npa.cli.workbench.token_factory import app as token_factory_app
 from npa.cli.workbench.vlm_eval import app as vlm_eval_app
 from npa.cli.workbench.workflow import app as workflow_app
 from npa.cli.workbench.trigger import app as trigger_app
@@ -58,5 +59,6 @@ app.add_typer(retargeting_app, name="retargeting")
 app.add_typer(lancedb_app, name="lancedb")
 app.add_typer(detection_training_app, name="detection-training")
 app.add_typer(vlm_eval_app, name="vlm-eval")
+app.add_typer(token_factory_app, name="token-factory")
 app.add_typer(workflow_app, name="workflow")
 app.add_typer(trigger_app, name="trigger")

--- a/npa/src/npa/cli/workbench/token_factory.py
+++ b/npa/src/npa/cli/workbench/token_factory.py
@@ -1,0 +1,294 @@
+"""npa workbench token-factory - Nebius Token Factory hosted-inference commands."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+
+from npa.clients.token_factory import (
+    DEFAULT_BASE_URL,
+    DEFAULT_REASONER_MODEL,
+    DEFAULT_TEXT_MODEL,
+    DEFAULT_VISION_MODEL,
+    TokenFactoryError,
+    resolve_config,
+)
+from npa.workbench.token_factory import (
+    DEFAULT_CAPTION_INSTRUCTION,
+    DEFAULT_GENERATE_SYSTEM_PROMPT,
+    DEFAULT_MAX_IMAGES,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_REASON_MAX_IMAGES,
+    DEFAULT_REASON_MAX_TOKENS,
+    DEFAULT_REASON_SYSTEM_PROMPT,
+    DEFAULT_REASON_TASK,
+    TokenFactoryToolError,
+    caption_images,
+    generate_text,
+    list_models,
+    reason_scene,
+    write_captions,
+    write_generations,
+    write_reason,
+)
+
+app = typer.Typer(
+    name="token-factory",
+    help="Nebius Token Factory hosted inference (zero-GPU, OpenAI-compatible).",
+    no_args_is_help=True,
+)
+console = Console(stderr=True)
+
+CAPTION_WORKFLOW_PATH = Path("npa/workflows/workbench/skypilot/token-factory-caption.yaml")
+GENERATE_WORKFLOW_PATH = Path("npa/workflows/workbench/skypilot/token-factory-generate.yaml")
+REASON_WORKFLOW_PATH = Path("npa/workflows/workbench/skypilot/token-factory-cosmos-reason.yaml")
+VLM_EVAL_WORKFLOW_PATH = Path("npa/workflows/workbench/skypilot/vlm-eval-token-factory.yaml")
+
+
+class OutputFormat(str, Enum):
+    text = "text"
+    json = "json"
+
+
+@app.command("caption")
+def caption_cmd(
+    input_path: str = typer.Option(..., "--input-path", help="S3 or local path to images."),
+    output_path: str = typer.Option(..., "--output-path", help="S3 or local path for captions JSON."),
+    model: str = typer.Option(DEFAULT_VISION_MODEL, "--model", help="Token Factory vision model."),
+    instruction: str = typer.Option(
+        DEFAULT_CAPTION_INSTRUCTION, "--instruction", help="Captioning instruction prompt."
+    ),
+    max_images: int = typer.Option(DEFAULT_MAX_IMAGES, "--max-images", help="Maximum images to caption."),
+    max_tokens: int = typer.Option(DEFAULT_MAX_TOKENS, "--max-tokens", help="Max tokens per caption."),
+    temperature: float = typer.Option(0.2, "--temperature", help="Sampling temperature."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Do not write the result artifact."),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Caption a folder of images with a hosted Token Factory vision model."""
+
+    try:
+        result = caption_images(
+            input_path=input_path,
+            output_path=output_path,
+            model=model,
+            instruction=instruction,
+            max_images=max_images,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        payload = asdict(result)
+        payload["dry_run"] = dry_run
+        if not dry_run:
+            payload["written_uri"] = write_captions(payload, result_uri=result.result_uri)
+    except (TokenFactoryToolError, TokenFactoryError) as exc:
+        _fail(str(exc))
+        return
+    _emit(payload, output)
+
+
+@app.command("generate")
+def generate_cmd(
+    input_path: str = typer.Option(..., "--input-path", help="S3 or local JSONL/text prompt file."),
+    output_path: str = typer.Option(..., "--output-path", help="S3 or local path for generations JSONL."),
+    model: str = typer.Option(DEFAULT_TEXT_MODEL, "--model", help="Token Factory text model."),
+    system_prompt: str = typer.Option(
+        DEFAULT_GENERATE_SYSTEM_PROMPT, "--system-prompt", help="System prompt applied to every request."
+    ),
+    max_prompts: int = typer.Option(0, "--max-prompts", help="Limit prompts processed (0 = all)."),
+    max_tokens: int = typer.Option(DEFAULT_MAX_TOKENS, "--max-tokens", help="Max tokens per completion."),
+    temperature: float = typer.Option(0.7, "--temperature", help="Sampling temperature."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Do not write the result artifact."),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Generate completions for each prompt in a JSONL/text file."""
+
+    try:
+        result = generate_text(
+            input_path=input_path,
+            output_path=output_path,
+            model=model,
+            system_prompt=system_prompt,
+            max_prompts=max_prompts,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        payload = asdict(result)
+        payload["dry_run"] = dry_run
+        if not dry_run:
+            rows = [asdict(item) for item in result.generations]
+            payload["written_uri"] = write_generations(rows, result_uri=result.result_uri)
+    except (TokenFactoryToolError, TokenFactoryError) as exc:
+        _fail(str(exc))
+        return
+    _emit(payload, output)
+
+
+@app.command("reason")
+def reason_cmd(
+    input_path: str = typer.Option(..., "--input-path", help="S3 or local path to scene images."),
+    output_path: str = typer.Option(..., "--output-path", help="S3 or local path for the reasoning JSON."),
+    task: str = typer.Option(DEFAULT_REASON_TASK, "--task", help="Task / question for the reasoner."),
+    model: str = typer.Option(DEFAULT_REASONER_MODEL, "--model", help="Token Factory reasoning model."),
+    system_prompt: str = typer.Option(
+        DEFAULT_REASON_SYSTEM_PROMPT, "--system-prompt", help="System prompt for the reasoner."
+    ),
+    max_images: int = typer.Option(
+        DEFAULT_REASON_MAX_IMAGES, "--max-images", help="Max scene images sent in one request."
+    ),
+    max_tokens: int = typer.Option(DEFAULT_REASON_MAX_TOKENS, "--max-tokens", help="Max tokens in the answer."),
+    temperature: float = typer.Option(0.2, "--temperature", help="Sampling temperature."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Do not write the result artifact."),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Reason over scene images for physical understanding and a plan of action.
+
+    Defaults to nvidia/Cosmos3-Super-Reasoner: point it at images of a scene and
+    ask what a robot should do there.
+    """
+
+    try:
+        result = reason_scene(
+            input_path=input_path,
+            output_path=output_path,
+            task=task,
+            model=model,
+            system_prompt=system_prompt,
+            max_images=max_images,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        payload = asdict(result)
+        payload["dry_run"] = dry_run
+        if not dry_run:
+            payload["written_uri"] = write_reason(payload, result_uri=result.result_uri)
+    except (TokenFactoryToolError, TokenFactoryError) as exc:
+        _fail(str(exc))
+        return
+    _emit(payload, output)
+
+
+@app.command("models")
+def models_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """List models available to the configured Token Factory API key."""
+
+    try:
+        models = list_models()
+    except (TokenFactoryToolError, TokenFactoryError) as exc:
+        _fail(str(exc))
+        return
+    _emit({"count": len(models), "models": models}, output)
+
+
+@app.command("verify")
+def verify_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Verify Token Factory authentication with a live models call.
+
+    Confirms NEBIUS_API_KEY is resolvable and the key authenticates against the
+    configured base URL. Exits non-zero on any auth or connectivity failure.
+    """
+
+    config = resolve_config(require_api_key=False)
+    if not config.api_key:
+        _fail(
+            "NEBIUS_API_KEY is not set. Add it under tokens: in "
+            "~/.npa/credentials.yaml (run `npa configure`) or export NEBIUS_API_KEY."
+        )
+        return
+    try:
+        models = list_models()
+    except (TokenFactoryToolError, TokenFactoryError) as exc:
+        _fail(str(exc))
+        return
+    _emit(
+        {
+            "authenticated": True,
+            "base_url": config.base_url,
+            "model_count": len(models),
+            "sample_models": models[:5],
+        },
+        output,
+    )
+
+
+@app.command("status")
+def status_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Show Token Factory connection status (no network call)."""
+
+    config = resolve_config(require_api_key=False)
+    _emit(
+        {
+            "provider": "nebius-token-factory",
+            "base_url": config.base_url,
+            "api_key_configured": bool(config.api_key),
+            "default_text_model": DEFAULT_TEXT_MODEL,
+            "default_vision_model": DEFAULT_VISION_MODEL,
+            "default_reasoner_model": DEFAULT_REASONER_MODEL,
+            "caption_workflow": str(CAPTION_WORKFLOW_PATH),
+            "generate_workflow": str(GENERATE_WORKFLOW_PATH),
+            "reason_workflow": str(REASON_WORKFLOW_PATH),
+            "vlm_eval_workflow": str(VLM_EVAL_WORKFLOW_PATH),
+        },
+        output,
+    )
+
+
+@app.command("list")
+def list_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """List Token Factory tool capabilities."""
+
+    _emit(
+        {
+            "default_base_url": DEFAULT_BASE_URL,
+            "capabilities": [
+                {"name": "caption", "kind": "vision", "default_model": DEFAULT_VISION_MODEL},
+                {"name": "generate", "kind": "text", "default_model": DEFAULT_TEXT_MODEL},
+                {"name": "reason", "kind": "physical-reasoning", "default_model": DEFAULT_REASONER_MODEL},
+                {"name": "models", "kind": "discovery"},
+            ],
+        },
+        output,
+    )
+
+
+@app.command("workflow")
+def workflow_cmd(
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Show the checked-in Token Factory SkyPilot workflow templates."""
+
+    _emit(
+        {
+            "caption_workflow": str(CAPTION_WORKFLOW_PATH),
+            "generate_workflow": str(GENERATE_WORKFLOW_PATH),
+            "reason_workflow": str(REASON_WORKFLOW_PATH),
+            "vlm_eval_workflow": str(VLM_EVAL_WORKFLOW_PATH),
+        },
+        output,
+    )
+
+
+def _emit(payload: dict[str, Any], output: OutputFormat) -> None:
+    if output == OutputFormat.json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    for key, value in payload.items():
+        typer.echo(f"  {key}: {value}")
+
+
+def _fail(message: str) -> None:
+    console.print(f"[red]Error:[/red] {message}")
+    raise typer.Exit(1)

--- a/npa/src/npa/clients/credentials.py
+++ b/npa/src/npa/clients/credentials.py
@@ -13,7 +13,8 @@ import yaml
 
 CREDENTIALS_PATH = Path.home() / ".npa" / "credentials.yaml"
 NGC_ENV_KEYS = ("NGC_API_KEY", "NGC_ORG", "NGC_TEAM")
-KNOWN_TOKEN_KEYS = ("HF_TOKEN", *NGC_ENV_KEYS)
+TOKEN_FACTORY_ENV_KEY = "NEBIUS_API_KEY"
+KNOWN_TOKEN_KEYS = ("HF_TOKEN", TOKEN_FACTORY_ENV_KEY, *NGC_ENV_KEYS)
 HF_TOKEN_MISSING_WARNING = (
     "Warning: HF_TOKEN not found in ~/.npa/credentials.yaml. "
     "Gated model downloads will fail."
@@ -47,6 +48,10 @@ class CredentialsConfig:
     @property
     def hf_token(self) -> str:
         return self.tokens.get("HF_TOKEN", "")
+
+    @property
+    def nebius_api_key(self) -> str:
+        return self.tokens.get(TOKEN_FACTORY_ENV_KEY, "")
 
     @property
     def ngc_api_key(self) -> str:
@@ -334,7 +339,7 @@ def shared_credential_env(credentials: CredentialsConfig) -> dict[str, str]:
         env["HF_TOKEN"] = hf_token
         env["HUGGING_FACE_HUB_TOKEN"] = hf_token
     tokens = getattr(credentials, "tokens", {}) or {}
-    for key in NGC_ENV_KEYS:
+    for key in (TOKEN_FACTORY_ENV_KEY, *NGC_ENV_KEYS):
         value = tokens.get(key, "")
         if value:
             env[key] = value

--- a/npa/src/npa/clients/token_factory.py
+++ b/npa/src/npa/clients/token_factory.py
@@ -24,7 +24,7 @@ DEFAULT_BASE_URL = "https://api.tokenfactory.nebius.com/v1/"
 DEFAULT_API_KEY_ENV = "NEBIUS_API_KEY"
 DEFAULT_TIMEOUT_S = 120.0
 DEFAULT_TEXT_MODEL = "meta-llama/Llama-3.3-70B-Instruct"
-DEFAULT_VISION_MODEL = "Qwen/Qwen2-VL-7B-Instruct"
+DEFAULT_VISION_MODEL = "Qwen/Qwen2.5-VL-72B-Instruct"
 # NVIDIA Cosmos3 Super-Reasoner: hosted vision-language physical-AI reasoner.
 # Confirm availability for your key with `npa workbench token-factory models`.
 DEFAULT_REASONER_MODEL = "nvidia/Cosmos3-Super-Reasoner"

--- a/npa/src/npa/clients/token_factory.py
+++ b/npa/src/npa/clients/token_factory.py
@@ -1,0 +1,218 @@
+"""Native Nebius Token Factory client.
+
+Nebius Token Factory is an OpenAI-compatible inference API for hosted open
+models (text and vision). This module is the single source of truth for
+resolving the base URL and API key and for issuing chat-completion and
+model-listing requests. Workbench tools and workflows call into here instead of
+duplicating endpoint, auth, or request-shaping logic.
+
+The default base URL is ``https://api.tokenfactory.nebius.com/v1/`` and the
+default credential is the ``NEBIUS_API_KEY`` environment variable, matching the
+upstream Token Factory documentation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import httpx
+
+DEFAULT_BASE_URL = "https://api.tokenfactory.nebius.com/v1/"
+DEFAULT_API_KEY_ENV = "NEBIUS_API_KEY"
+DEFAULT_TIMEOUT_S = 120.0
+DEFAULT_TEXT_MODEL = "meta-llama/Llama-3.3-70B-Instruct"
+DEFAULT_VISION_MODEL = "Qwen/Qwen2-VL-7B-Instruct"
+# NVIDIA Cosmos3 Super-Reasoner: hosted vision-language physical-AI reasoner.
+# Confirm availability for your key with `npa workbench token-factory models`.
+DEFAULT_REASONER_MODEL = "nvidia/Cosmos3-Super-Reasoner"
+
+BASE_URL_ENV_KEYS = (
+    "NEBIUS_TOKEN_FACTORY_BASE_URL",
+    "NEBIUS_BASE_URL",
+)
+API_KEY_ENV_KEYS = (
+    DEFAULT_API_KEY_ENV,
+    "NEBIUS_TOKEN_FACTORY_API_KEY",
+)
+
+
+class TokenFactoryError(RuntimeError):
+    """Raised when a Token Factory request is misconfigured or fails."""
+
+
+@dataclass(frozen=True)
+class TokenFactoryConfig:
+    """Resolved connection settings for Nebius Token Factory."""
+
+    base_url: str
+    api_key: str
+    timeout_s: float = DEFAULT_TIMEOUT_S
+
+    @property
+    def chat_completions_url(self) -> str:
+        return _join_path(self.base_url, "chat/completions")
+
+    @property
+    def models_url(self) -> str:
+        return _join_path(self.base_url, "models")
+
+
+def resolve_config(
+    *,
+    base_url: str = "",
+    api_key: str = "",
+    api_key_env: str = DEFAULT_API_KEY_ENV,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    environ: dict[str, str] | None = None,
+    require_api_key: bool = True,
+) -> TokenFactoryConfig:
+    """Resolve Token Factory connection settings.
+
+    Precedence is explicit argument, then environment override, then the
+    documented default. The API key is read from ``api_key`` if supplied,
+    otherwise from ``api_key_env`` and the standard Token Factory env keys.
+    """
+
+    env = environ if environ is not None else os.environ
+    resolved_base = base_url.strip() or _first_env(env, BASE_URL_ENV_KEYS) or DEFAULT_BASE_URL
+    resolved_key = api_key.strip()
+    if not resolved_key:
+        key_candidates = (api_key_env, *API_KEY_ENV_KEYS) if api_key_env else API_KEY_ENV_KEYS
+        resolved_key = _first_env(env, key_candidates)
+    if require_api_key and not resolved_key:
+        raise TokenFactoryError(
+            "Nebius Token Factory API key not found. Set NEBIUS_API_KEY in your "
+            "environment or ~/.npa/credentials.yaml (tokens.NEBIUS_API_KEY)."
+        )
+    if timeout_s <= 0:
+        raise TokenFactoryError("timeout_s must be positive")
+    return TokenFactoryConfig(base_url=resolved_base, api_key=resolved_key, timeout_s=timeout_s)
+
+
+class TokenFactoryClient:
+    """Thin OpenAI-compatible client for Nebius Token Factory."""
+
+    def __init__(
+        self,
+        config: TokenFactoryConfig | None = None,
+        *,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self._config = config or resolve_config()
+        self._http_client = http_client
+
+    @property
+    def config(self) -> TokenFactoryConfig:
+        return self._config
+
+    def chat_completion(
+        self,
+        *,
+        model: str,
+        messages: Sequence[dict[str, Any]],
+        temperature: float = 0.0,
+        max_tokens: int | None = None,
+        response_format: dict[str, Any] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue a chat-completion request and return the parsed JSON payload."""
+
+        if not model:
+            raise TokenFactoryError("model is required")
+        if not messages:
+            raise TokenFactoryError("messages must be a non-empty sequence")
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": list(messages),
+            "temperature": temperature,
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if response_format is not None:
+            payload["response_format"] = response_format
+        if extra:
+            payload.update(extra)
+
+        data = self._post_json(self._config.chat_completions_url, payload)
+        if not isinstance(data, dict):
+            raise TokenFactoryError("Token Factory returned a non-object response")
+        return data
+
+    def chat_completion_text(self, **kwargs: Any) -> str:
+        """Return the assistant message text from a chat completion."""
+
+        data = self.chat_completion(**kwargs)
+        try:
+            return str(data["choices"][0]["message"]["content"])
+        except (KeyError, IndexError, TypeError) as exc:
+            raise TokenFactoryError(
+                "Token Factory response missing choices[0].message.content"
+            ) from exc
+
+    def list_models(self) -> list[str]:
+        """Return the list of model IDs available to this API key."""
+
+        data = self._get_json(self._config.models_url)
+        items = data.get("data") if isinstance(data, dict) else None
+        if not isinstance(items, list):
+            raise TokenFactoryError("Token Factory models response missing data list")
+        return [str(item["id"]) for item in items if isinstance(item, dict) and item.get("id")]
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._config.api_key:
+            headers["Authorization"] = f"Bearer {self._config.api_key}"
+        return headers
+
+    def _post_json(self, url: str, payload: dict[str, Any]) -> Any:
+        return self._request("POST", url, json_body=payload)
+
+    def _get_json(self, url: str) -> Any:
+        return self._request("GET", url)
+
+    def _request(self, method: str, url: str, *, json_body: dict[str, Any] | None = None) -> Any:
+        owns_client = self._http_client is None
+        client = self._http_client or httpx.Client(timeout=self._config.timeout_s)
+        try:
+            response = client.request(method, url, headers=self._headers(), json=json_body)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            raise TokenFactoryError(
+                f"Token Factory request failed ({exc.response.status_code}): "
+                f"{_truncate(exc.response.text)}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise TokenFactoryError(f"Token Factory request failed: {exc}") from exc
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise TokenFactoryError("Token Factory returned non-JSON response") from exc
+        finally:
+            if owns_client:
+                client.close()
+
+
+def _first_env(env: dict[str, str], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = env.get(key)
+        if value:
+            return value.strip()
+    return ""
+
+
+def _join_path(base_url: str, suffix: str) -> str:
+    base = base_url.rstrip("/")
+    suffix = suffix.strip("/")
+    if base.endswith(f"/{suffix}"):
+        return base
+    if base.endswith("/v1"):
+        return f"{base}/{suffix}"
+    return f"{base}/v1/{suffix}"
+
+
+def _truncate(text: str, *, limit: int = 500) -> str:
+    text = text.strip()
+    return text if len(text) <= limit else text[:limit] + "..."

--- a/npa/src/npa/sdk/workbench/__init__.py
+++ b/npa/src/npa/sdk/workbench/__init__.py
@@ -15,6 +15,7 @@ from . import (
     sim2real,
     sim2real_envgen,
     sonic,
+    token_factory,
     trigger,
     vlm_eval,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "sim2real",
     "sim2real_envgen",
     "sonic",
+    "token_factory",
     "trigger",
     "vlm_eval",
 ]

--- a/npa/src/npa/sdk/workbench/token_factory.py
+++ b/npa/src/npa/sdk/workbench/token_factory.py
@@ -1,0 +1,25 @@
+"""SDK wrappers for the Workbench Nebius Token Factory CLI."""
+
+from __future__ import annotations
+
+from npa._sdk import make_cli_wrapper
+
+caption = make_cli_wrapper("npa.cli.workbench.token_factory", "caption_cmd", "Caption images with Token Factory.")
+generate = make_cli_wrapper("npa.cli.workbench.token_factory", "generate_cmd", "Generate text with Token Factory.")
+reason = make_cli_wrapper("npa.cli.workbench.token_factory", "reason_cmd", "Reason over scene images with Token Factory.")
+models = make_cli_wrapper("npa.cli.workbench.token_factory", "models_cmd", "List Token Factory models.")
+verify = make_cli_wrapper("npa.cli.workbench.token_factory", "verify_cmd", "Verify Token Factory auth.")
+status = make_cli_wrapper("npa.cli.workbench.token_factory", "status_cmd", "Show Token Factory status.")
+list = make_cli_wrapper("npa.cli.workbench.token_factory", "list_cmd", "List Token Factory capabilities.")
+workflow = make_cli_wrapper("npa.cli.workbench.token_factory", "workflow_cmd", "Show Token Factory workflows.")
+
+__all__ = [
+    "caption",
+    "generate",
+    "list",
+    "models",
+    "reason",
+    "status",
+    "verify",
+    "workflow",
+]

--- a/npa/src/npa/workbench/token_factory/__init__.py
+++ b/npa/src/npa/workbench/token_factory/__init__.py
@@ -1,0 +1,549 @@
+"""Nebius Token Factory workbench tool.
+
+Hackathon-ready building blocks that call Nebius Token Factory (an
+OpenAI-compatible hosted-inference API) natively, with the same
+``--input-path`` / ``--output-path`` S3 contract as every other workbench tool.
+
+Two capabilities, both zero-GPU because inference is hosted:
+
+- ``caption_images``: caption / annotate a folder of images (or rollout frames)
+  with a hosted vision model and write a JSON manifest.
+- ``generate_text``: batch text generation / transformation from a JSONL of
+  prompts (for example synthetic task or scene-prompt generation for Cosmos and
+  sim variation) and write a JSONL of completions.
+
+All Token Factory request, auth, and endpoint logic lives in
+``npa.clients.token_factory``; this module only shapes inputs and outputs.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+import tempfile
+from typing import TYPE_CHECKING, Any, Iterator, Sequence
+
+from PIL import Image
+
+from npa.clients.token_factory import (
+    DEFAULT_REASONER_MODEL,
+    DEFAULT_TEXT_MODEL,
+    DEFAULT_VISION_MODEL,
+    TokenFactoryClient,
+    TokenFactoryError,
+)
+
+if TYPE_CHECKING:
+    from npa.clients.storage import StorageClient
+
+DEFAULT_CAPTION_INSTRUCTION = (
+    "Describe this image in one or two sentences. Focus on the objects, the "
+    "scene, and any action taking place. Be concrete and factual."
+)
+DEFAULT_GENERATE_SYSTEM_PROMPT = (
+    "You are a helpful assistant generating concise, high-quality text for a "
+    "physical-AI dataset. Respond with the requested content only."
+)
+DEFAULT_REASON_SYSTEM_PROMPT = (
+    "You are a physical-AI reasoning assistant for a mobile robot. Analyze the "
+    "scene images carefully and reason about objects, spatial layout, motion, "
+    "and physical interactions. Then produce a concrete, ordered plan of action "
+    "the robot can execute to complete the requested task, calling out "
+    "preconditions, hazards, and failure cases."
+)
+DEFAULT_REASON_TASK = (
+    "Describe this scene and give a step-by-step plan of action a robot should "
+    "follow to operate safely and usefully here."
+)
+DEFAULT_MAX_IMAGES = 50
+DEFAULT_MAX_TOKENS = 512
+DEFAULT_REASON_MAX_IMAGES = 8
+DEFAULT_REASON_MAX_TOKENS = 1024
+CAPTION_RESULT_FILENAME = "captions.json"
+GENERATE_RESULT_FILENAME = "generations.jsonl"
+REASON_RESULT_FILENAME = "scene_reasoning.json"
+IMAGE_SUFFIXES = {".bmp", ".jpeg", ".jpg", ".png", ".ppm", ".webp"}
+
+
+class TokenFactoryToolError(ValueError):
+    """Raised when a Token Factory tool request is invalid."""
+
+
+@dataclass(frozen=True)
+class CaptionItem:
+    image: str
+    caption: str
+
+
+@dataclass(frozen=True)
+class CaptionResult:
+    status: str
+    input_path: str
+    output_path: str
+    result_uri: str
+    model: str
+    instruction: str
+    image_count: int
+    generated_at: str
+    captions: list[CaptionItem] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class GenerationItem:
+    id: str
+    prompt: str
+    completion: str
+
+
+@dataclass(frozen=True)
+class GenerateResult:
+    status: str
+    input_path: str
+    output_path: str
+    result_uri: str
+    model: str
+    prompt_count: int
+    generated_at: str
+    generations: list[GenerationItem] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ReasonResult:
+    status: str
+    input_path: str
+    output_path: str
+    result_uri: str
+    model: str
+    task: str
+    image_count: int
+    images: list[str]
+    analysis: str
+    generated_at: str
+
+
+__all__ = [
+    "CaptionItem",
+    "CaptionResult",
+    "GenerateResult",
+    "GenerationItem",
+    "ReasonResult",
+    "TokenFactoryToolError",
+    "caption_images",
+    "caption_result_uri_for",
+    "generate_result_uri_for",
+    "generate_text",
+    "list_models",
+    "reason_result_uri_for",
+    "reason_scene",
+    "write_captions",
+    "write_generations",
+    "write_reason",
+]
+
+
+def list_models(*, client: TokenFactoryClient | None = None) -> list[str]:
+    """Return the model IDs available to the configured Token Factory key."""
+
+    active = client or _default_client()
+    try:
+        return active.list_models()
+    except TokenFactoryError as exc:
+        raise TokenFactoryToolError(str(exc)) from exc
+
+
+def caption_images(
+    *,
+    input_path: str,
+    output_path: str,
+    model: str = DEFAULT_VISION_MODEL,
+    instruction: str = DEFAULT_CAPTION_INSTRUCTION,
+    max_images: int = DEFAULT_MAX_IMAGES,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    temperature: float = 0.2,
+    client: TokenFactoryClient | None = None,
+) -> CaptionResult:
+    """Caption every image under ``input_path`` with a hosted vision model."""
+
+    _require(input_path, "input_path")
+    _require(output_path, "output_path")
+    if max_images <= 0:
+        raise TokenFactoryToolError("--max-images must be positive")
+    effective_model = model or DEFAULT_VISION_MODEL
+    effective_instruction = (instruction or DEFAULT_CAPTION_INSTRUCTION).strip()
+    active = client or _default_client()
+
+    with _materialized_input(input_path) as local_input:
+        image_paths = _discover_image_paths(local_input)[:max_images]
+        if not image_paths:
+            raise TokenFactoryToolError(
+                f"No images found in {input_path}. Expected files with suffixes: "
+                f"{', '.join(sorted(IMAGE_SUFFIXES))}."
+            )
+        captions: list[CaptionItem] = []
+        for image_path in image_paths:
+            label = _relative_label(image_path, local_input)
+            data_url = _image_to_data_url(image_path)
+            try:
+                text = active.chat_completion_text(
+                    model=effective_model,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": effective_instruction},
+                                {"type": "image_url", "image_url": {"url": data_url}},
+                            ],
+                        }
+                    ],
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            except TokenFactoryError as exc:
+                raise TokenFactoryToolError(f"captioning {label} failed: {exc}") from exc
+            captions.append(CaptionItem(image=label, caption=text.strip()))
+
+    return CaptionResult(
+        status="completed",
+        input_path=input_path,
+        output_path=output_path,
+        result_uri=caption_result_uri_for(output_path),
+        model=effective_model,
+        instruction=effective_instruction,
+        image_count=len(captions),
+        generated_at=_now(),
+        captions=captions,
+    )
+
+
+def generate_text(
+    *,
+    input_path: str,
+    output_path: str,
+    model: str = DEFAULT_TEXT_MODEL,
+    system_prompt: str = DEFAULT_GENERATE_SYSTEM_PROMPT,
+    max_prompts: int = 0,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    temperature: float = 0.7,
+    client: TokenFactoryClient | None = None,
+) -> GenerateResult:
+    """Generate a completion for each prompt in a JSONL/text input file."""
+
+    _require(input_path, "input_path")
+    _require(output_path, "output_path")
+    effective_model = model or DEFAULT_TEXT_MODEL
+    effective_system = (system_prompt or DEFAULT_GENERATE_SYSTEM_PROMPT).strip()
+    active = client or _default_client()
+
+    with _materialized_input(input_path) as local_input:
+        prompts = _load_prompts(local_input)
+    if not prompts:
+        raise TokenFactoryToolError(
+            f"No prompts found in {input_path}. Expected a .jsonl file with "
+            '{"id": ..., "prompt": ...} objects or a .txt file with one prompt per line.'
+        )
+    if max_prompts and max_prompts > 0:
+        prompts = prompts[:max_prompts]
+
+    generations: list[GenerationItem] = []
+    for item_id, prompt in prompts:
+        messages: list[dict[str, Any]] = []
+        if effective_system:
+            messages.append({"role": "system", "content": effective_system})
+        messages.append({"role": "user", "content": prompt})
+        try:
+            text = active.chat_completion_text(
+                model=effective_model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except TokenFactoryError as exc:
+            raise TokenFactoryToolError(f"generation for {item_id!r} failed: {exc}") from exc
+        generations.append(GenerationItem(id=item_id, prompt=prompt, completion=text.strip()))
+
+    return GenerateResult(
+        status="completed",
+        input_path=input_path,
+        output_path=output_path,
+        result_uri=generate_result_uri_for(output_path),
+        model=effective_model,
+        prompt_count=len(generations),
+        generated_at=_now(),
+        generations=generations,
+    )
+
+
+def reason_scene(
+    *,
+    input_path: str,
+    output_path: str,
+    task: str = DEFAULT_REASON_TASK,
+    model: str = DEFAULT_REASONER_MODEL,
+    system_prompt: str = DEFAULT_REASON_SYSTEM_PROMPT,
+    max_images: int = DEFAULT_REASON_MAX_IMAGES,
+    max_tokens: int = DEFAULT_REASON_MAX_TOKENS,
+    temperature: float = 0.2,
+    client: TokenFactoryClient | None = None,
+) -> ReasonResult:
+    """Reason over scene images with a hosted physical-AI reasoner.
+
+    Sends the scene images plus the task to the reasoning model (default
+    ``nvidia/Cosmos3-Super-Reasoner``) in a single request and returns the
+    model's scene understanding and plan of action. Built for the "walk the
+    robot to a scene, ask what to do" physical-common-sense loop.
+    """
+
+    _require(input_path, "input_path")
+    _require(output_path, "output_path")
+    if max_images <= 0:
+        raise TokenFactoryToolError("--max-images must be positive")
+    effective_model = model or DEFAULT_REASONER_MODEL
+    effective_task = (task or DEFAULT_REASON_TASK).strip()
+    effective_system = (system_prompt or DEFAULT_REASON_SYSTEM_PROMPT).strip()
+    active = client or _default_client()
+
+    with _materialized_input(input_path) as local_input:
+        image_paths = _discover_image_paths(local_input)[:max_images]
+        if not image_paths:
+            raise TokenFactoryToolError(
+                f"No scene images found in {input_path}. Expected files with suffixes: "
+                f"{', '.join(sorted(IMAGE_SUFFIXES))}."
+            )
+        labels = [_relative_label(path, local_input) for path in image_paths]
+        content: list[dict[str, Any]] = [{"type": "text", "text": effective_task}]
+        for image_path in image_paths:
+            content.append(
+                {"type": "image_url", "image_url": {"url": _image_to_data_url(image_path)}}
+            )
+        messages: list[dict[str, Any]] = []
+        if effective_system:
+            messages.append({"role": "system", "content": effective_system})
+        messages.append({"role": "user", "content": content})
+        try:
+            analysis = active.chat_completion_text(
+                model=effective_model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except TokenFactoryError as exc:
+            raise TokenFactoryToolError(f"scene reasoning failed: {exc}") from exc
+
+    return ReasonResult(
+        status="completed",
+        input_path=input_path,
+        output_path=output_path,
+        result_uri=reason_result_uri_for(output_path),
+        model=effective_model,
+        task=effective_task,
+        image_count=len(labels),
+        images=labels,
+        analysis=analysis.strip(),
+        generated_at=_now(),
+    )
+
+
+def caption_result_uri_for(output_path: str) -> str:
+    if output_path.endswith(".json"):
+        return output_path
+    return output_path.rstrip("/") + f"/{CAPTION_RESULT_FILENAME}"
+
+
+def generate_result_uri_for(output_path: str) -> str:
+    if output_path.endswith((".jsonl", ".json")):
+        return output_path
+    return output_path.rstrip("/") + f"/{GENERATE_RESULT_FILENAME}"
+
+
+def reason_result_uri_for(output_path: str) -> str:
+    if output_path.endswith(".json"):
+        return output_path
+    return output_path.rstrip("/") + f"/{REASON_RESULT_FILENAME}"
+
+
+def write_captions(
+    payload: dict[str, Any],
+    *,
+    result_uri: str,
+    storage_client: "StorageClient | None" = None,
+) -> str:
+    body = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    return _write_text(body, result_uri=result_uri, filename=CAPTION_RESULT_FILENAME, storage_client=storage_client)
+
+
+def write_generations(
+    generations: Sequence[dict[str, Any]],
+    *,
+    result_uri: str,
+    storage_client: "StorageClient | None" = None,
+) -> str:
+    body = "".join(json.dumps(row, sort_keys=True) + "\n" for row in generations)
+    return _write_text(body, result_uri=result_uri, filename=GENERATE_RESULT_FILENAME, storage_client=storage_client)
+
+
+def write_reason(
+    payload: dict[str, Any],
+    *,
+    result_uri: str,
+    storage_client: "StorageClient | None" = None,
+) -> str:
+    body = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    return _write_text(body, result_uri=result_uri, filename=REASON_RESULT_FILENAME, storage_client=storage_client)
+
+
+def _write_text(
+    body: str,
+    *,
+    result_uri: str,
+    filename: str,
+    storage_client: "StorageClient | None",
+) -> str:
+    if result_uri.startswith("s3://"):
+        from npa.clients.storage import StorageClient
+
+        client = storage_client or StorageClient.from_environment()
+        with tempfile.TemporaryDirectory(prefix="npa-token-factory-") as tmp:
+            local_path = Path(tmp) / filename
+            local_path.write_text(body, encoding="utf-8")
+            return client.upload_file(str(local_path), result_uri)
+
+    path = Path(result_uri)
+    if path.suffix not in {".json", ".jsonl"}:
+        path = path / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+def _default_client() -> TokenFactoryClient:
+    try:
+        return TokenFactoryClient()
+    except TokenFactoryError as exc:
+        raise TokenFactoryToolError(str(exc)) from exc
+
+
+@contextmanager
+def _materialized_input(input_path: str) -> Iterator[Path]:
+    if not input_path.startswith("s3://"):
+        yield Path(input_path)
+        return
+
+    from npa.clients.storage import StorageClient
+
+    with tempfile.TemporaryDirectory(prefix="npa-token-factory-input-") as tmp:
+        local = StorageClient.from_environment().download_path(input_path, tmp)
+        yield Path(local)
+
+
+def _discover_image_paths(path: Path) -> list[Path]:
+    if path.is_file() and path.suffix.lower() in IMAGE_SUFFIXES:
+        return [path]
+    if not path.is_dir():
+        return []
+    return sorted(
+        file
+        for file in path.rglob("*")
+        if file.is_file()
+        and file.suffix.lower() in IMAGE_SUFFIXES
+        and not any(part.startswith(".") for part in file.relative_to(path).parts)
+    )
+
+
+def _relative_label(image_path: Path, base: Path) -> str:
+    try:
+        return str(image_path.relative_to(base))
+    except ValueError:
+        return image_path.name
+
+
+def _image_to_data_url(path: Path) -> str:
+    with Image.open(path) as image:
+        image = image.convert("RGB")
+        image.thumbnail((768, 768))
+        buffer = BytesIO()
+        image.save(buffer, format="PNG", optimize=True)
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def _load_prompts(local_input: Path) -> list[tuple[str, str]]:
+    path = _resolve_prompt_file(local_input)
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".jsonl":
+        return _parse_jsonl_prompts(text)
+    if path.suffix.lower() == ".json":
+        return _parse_json_prompts(text)
+    return [
+        (f"line-{index:04d}", line.strip())
+        for index, line in enumerate(text.splitlines(), start=1)
+        if line.strip()
+    ]
+
+
+def _resolve_prompt_file(local_input: Path) -> Path:
+    if local_input.is_file():
+        return local_input
+    if local_input.is_dir():
+        for name in ("prompts.jsonl", "prompts.json", "prompts.txt"):
+            candidate = local_input / name
+            if candidate.is_file():
+                return candidate
+        for suffix in (".jsonl", ".json", ".txt"):
+            matches = sorted(local_input.glob(f"*{suffix}"))
+            if matches:
+                return matches[0]
+    raise TokenFactoryToolError(
+        f"No prompt file found at {local_input}. Expected a .jsonl, .json, or .txt file."
+    )
+
+
+def _parse_jsonl_prompts(text: str) -> list[tuple[str, str]]:
+    prompts: list[tuple[str, str]] = []
+    for index, line in enumerate(text.splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise TokenFactoryToolError(f"prompt file line {index} is not valid JSON") from exc
+        prompts.append(_prompt_from_object(payload, index))
+    return prompts
+
+
+def _parse_json_prompts(text: str) -> list[tuple[str, str]]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise TokenFactoryToolError("prompt file is not valid JSON") from exc
+    if isinstance(payload, dict):
+        payload = payload.get("prompts") or payload.get("items") or []
+    if not isinstance(payload, list):
+        raise TokenFactoryToolError("prompt JSON must be a list or have a 'prompts' list")
+    return [_prompt_from_object(item, index) for index, item in enumerate(payload, start=1)]
+
+
+def _prompt_from_object(payload: Any, index: int) -> tuple[str, str]:
+    if isinstance(payload, str):
+        return (f"item-{index:04d}", payload.strip())
+    if not isinstance(payload, dict):
+        raise TokenFactoryToolError(f"prompt item {index} must be a string or object")
+    prompt = payload.get("prompt") or payload.get("text") or payload.get("instruction")
+    if not prompt:
+        raise TokenFactoryToolError(f"prompt item {index} must include a 'prompt' field")
+    item_id = str(payload.get("id") or payload.get("name") or f"item-{index:04d}").strip()
+    return (item_id or f"item-{index:04d}", str(prompt).strip())
+
+
+def _require(value: str, name: str) -> None:
+    if not value:
+        raise TokenFactoryToolError(f"{name} is required")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/npa/src/npa/workbench/vlm_eval/__init__.py
+++ b/npa/src/npa/workbench/vlm_eval/__init__.py
@@ -1102,10 +1102,20 @@ def _resolve_endpoint_url(*, backend: str, endpoint_url: str) -> str:
     if endpoint_url:
         return endpoint_url
     if backend == "api":
+        from npa.clients.token_factory import (
+            BASE_URL_ENV_KEYS,
+            DEFAULT_BASE_URL as TOKEN_FACTORY_BASE_URL,
+        )
+
+        token_factory_base = next(
+            (os.environ[key] for key in BASE_URL_ENV_KEYS if os.environ.get(key)),
+            "",
+        )
         return (
             os.environ.get("VLM_EVAL_API_BASE_URL")
             or os.environ.get("OPENAI_BASE_URL")
-            or DEFAULT_ENDPOINT_URL
+            or token_factory_base
+            or TOKEN_FACTORY_BASE_URL
         )
     return (
         os.environ.get("VLM_EVAL_ENDPOINT_URL")
@@ -1117,10 +1127,15 @@ def _resolve_endpoint_url(*, backend: str, endpoint_url: str) -> str:
 def _resolve_api_key(*, backend: str, api_key_env: str) -> str:
     key = os.environ.get(api_key_env or DEFAULT_API_KEY_ENV, "")
     if backend == "api":
-        key = key or os.environ.get("OPENAI_API_KEY", "")
+        key = (
+            key
+            or os.environ.get("NEBIUS_API_KEY", "")
+            or os.environ.get("OPENAI_API_KEY", "")
+        )
         if not key:
             raise VlmEvalError(
-                f"--backend api requires an API key in {api_key_env or DEFAULT_API_KEY_ENV} or OPENAI_API_KEY"
+                f"--backend api requires an API key in {api_key_env or DEFAULT_API_KEY_ENV}, "
+                "NEBIUS_API_KEY, or OPENAI_API_KEY"
             )
     return key
 

--- a/npa/src/npa/workflows/token_factory_combos.py
+++ b/npa/src/npa/workflows/token_factory_combos.py
@@ -1,0 +1,211 @@
+"""Infra-free helpers for the Token Factory + Nebius-compute combo workflows.
+
+Two hackathon workflows compose *real Nebius GPU compute* with *hosted Token
+Factory inference* (zero-GPU on the client side):
+
+1. **train-triage (serverless).** A LeRobot **serverless GPU Job** trains/evals a
+   policy and writes its run artifacts (configs, logs, metrics) to S3. A Token
+   Factory text model then reads those real artifacts and writes a human-readable
+   triage + next-steps report. Runner: ``npa/scripts/run_tokenfactory_train_triage.py``.
+2. **rollout-judge (kubernetes).** A LeRobot eval rollout renders videos on a
+   Nebius **Managed Kubernetes GPU**; ``vlm-eval --backend api`` then scores the
+   rollout with a hosted VLM, with no local VLM serving stage. Workflow:
+   ``npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml``.
+
+This module holds only pure logic (digesting artifacts, building the triage
+prompt, deriving run IDs / job names / URIs) so it is unit-testable without SSH,
+S3, Nebius, or GPUs. All network, storage, and Token Factory calls live in the
+runner script and the existing client/tool modules.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_TRIAGE_SYSTEM_PROMPT = (
+    "You are a senior robot-learning engineer triaging a training run for a "
+    "physical-AI team. You are given the run's configuration and log artifacts. "
+    "Write a concise, technical report with these sections: (1) Summary — what "
+    "was trained and whether it looks healthy; (2) Signals — concrete numbers or "
+    "facts you can cite from the artifacts (losses, steps, durations, config "
+    "choices); (3) Risks — anything that looks misconfigured, unstable, or "
+    "missing; (4) Next steps — a short, ordered list of what to try next. Only "
+    "use facts present in the artifacts; if something is unknown, say so rather "
+    "than inventing numbers."
+)
+
+# Textual artifact suffixes worth feeding to a text model. Binary weights
+# (.safetensors, .pt, .ckpt) and media are intentionally excluded.
+_TEXT_ARTIFACT_SUFFIXES = {
+    ".json",
+    ".jsonl",
+    ".log",
+    ".md",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+# Cap how much artifact text we forward so a noisy run cannot blow the context
+# window or the request cost.
+DEFAULT_MAX_FILES = 24
+DEFAULT_MAX_FILE_BYTES = 4_000
+DEFAULT_MAX_TOTAL_BYTES = 24_000
+
+
+def utc_stamp(now: datetime | None = None) -> str:
+    """Return a compact UTC timestamp suitable for run IDs and job names."""
+
+    moment = now or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def default_triage_run_id(now: datetime | None = None) -> str:
+    return f"tf-train-triage-{utc_stamp(now)}"
+
+
+def triage_job_name(run_id: str) -> str:
+    """Derive a Nebius-safe serverless Job name from a run ID.
+
+    Job names must be lowercase alphanumeric plus hyphens; collapse anything
+    else and trim to a conservative length.
+    """
+
+    cleaned = "".join(ch.lower() if ch.isalnum() else "-" for ch in run_id.strip())
+    cleaned = "-".join(part for part in cleaned.split("-") if part)
+    if not cleaned:
+        cleaned = f"tf-triage-{utc_stamp()}"
+    return cleaned[:48].rstrip("-")
+
+
+def join_uri(base: str, *parts: str) -> str:
+    """Join an ``s3://`` (or local) prefix with path parts, normalizing slashes."""
+
+    root = base.rstrip("/")
+    tail = "/".join(part.strip("/") for part in parts if part.strip("/"))
+    return f"{root}/{tail}" if tail else root + "/"
+
+
+def triage_prompts_uri(triage_root: str) -> str:
+    return join_uri(triage_root, "prompts.jsonl")
+
+
+def triage_report_uri(triage_root: str) -> str:
+    return join_uri(triage_root, "generations.jsonl")
+
+
+def _is_textual(path: Path) -> bool:
+    return path.suffix.lower() in _TEXT_ARTIFACT_SUFFIXES
+
+
+def _iter_textual_files(local_dir: Path) -> Iterable[Path]:
+    if local_dir.is_file():
+        if _is_textual(local_dir):
+            yield local_dir
+        return
+    yield from sorted(
+        path
+        for path in local_dir.rglob("*")
+        if path.is_file()
+        and _is_textual(path)
+        and not any(part.startswith(".") for part in path.relative_to(local_dir).parts)
+    )
+
+
+def summarize_run_artifacts(
+    local_dir: str | Path,
+    *,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+) -> str:
+    """Build a bounded, labelled digest of the textual artifacts under a dir.
+
+    Reads ``.json/.log/.txt/.yaml/...`` files, truncates each to
+    ``max_file_bytes``, and stops once ``max_total_bytes`` is reached so the
+    prompt stays within a sane size regardless of how chatty the run was.
+    """
+
+    base = Path(local_dir)
+    if not base.exists():
+        raise FileNotFoundError(f"artifact path does not exist: {base}")
+
+    sections: list[str] = []
+    total = 0
+    file_count = 0
+    for path in _iter_textual_files(base):
+        if file_count >= max_files or total >= max_total_bytes:
+            break
+        label = str(path.relative_to(base)) if base.is_dir() else path.name
+        try:
+            raw = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        snippet = raw.strip()
+        if len(snippet.encode("utf-8")) > max_file_bytes:
+            snippet = snippet.encode("utf-8")[:max_file_bytes].decode("utf-8", errors="ignore")
+            snippet = snippet.rstrip() + "\n... [truncated]"
+        if not snippet:
+            continue
+        block = f"### {label}\n{snippet}"
+        total += len(block.encode("utf-8"))
+        file_count += 1
+        sections.append(block)
+
+    if not sections:
+        return "(no textual artifacts found in the run output)"
+    return "\n\n".join(sections)
+
+
+def build_triage_prompt(
+    *,
+    job_name: str,
+    output_uri: str,
+    artifact_digest: str,
+    extra_context: str = "",
+) -> str:
+    """Compose the user prompt that asks the text model to triage one run."""
+
+    header = (
+        f"Triage this robot-policy training run.\n"
+        f"- Job name: {job_name}\n"
+        f"- Artifacts location: {output_uri}\n"
+    )
+    if extra_context.strip():
+        header += f"- Operator notes: {extra_context.strip()}\n"
+    return (
+        f"{header}\n"
+        "Run artifacts (configs and logs) follow. Base your report only on these.\n\n"
+        f"{artifact_digest}\n"
+    )
+
+
+def triage_prompt_record(
+    *,
+    job_name: str,
+    output_uri: str,
+    artifact_digest: str,
+    extra_context: str = "",
+) -> dict[str, str]:
+    """Return one ``{"id", "prompt"}`` record for the token-factory generate tool."""
+
+    return {
+        "id": f"triage-{triage_job_name(job_name)}",
+        "prompt": build_triage_prompt(
+            job_name=job_name,
+            output_uri=output_uri,
+            artifact_digest=artifact_digest,
+            extra_context=extra_context,
+        ),
+    }
+
+
+def render_triage_prompts_jsonl(records: Iterable[dict[str, str]]) -> str:
+    """Serialize prompt records to JSONL text for the generate tool."""
+
+    return "".join(json.dumps(record, sort_keys=True) + "\n" for record in records)

--- a/npa/src/npa/workflows/token_factory_combos.py
+++ b/npa/src/npa/workflows/token_factory_combos.py
@@ -11,11 +11,19 @@ Factory inference* (zero-GPU on the client side):
    Nebius **Managed Kubernetes GPU**; ``vlm-eval --backend api`` then scores the
    rollout with a hosted VLM, with no local VLM serving stage. Workflow:
    ``npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml``.
+3. **sim-sweep (serverless fan-out).** A hosted text model designs an experiment
+   sweep, a deterministic grid launches one LeRobot **serverless GPU Job** per
+   variant, and a hosted text model ranks the completed runs from their real
+   artifacts. Runner: ``npa/scripts/run_tokenfactory_sim_sweep.py``.
+4. **scene-to-rollout-judge (kubernetes).** A hosted reasoner extracts a plan
+   from scene images, a Nebius **Managed Kubernetes GPU** rolls out a policy, and
+   a hosted VLM judges the rollout against that plan. Workflow:
+   ``npa/workflows/workbench/skypilot/tokenfactory-scene-to-rollout-judge.yaml``.
 
-This module holds only pure logic (digesting artifacts, building the triage
-prompt, deriving run IDs / job names / URIs) so it is unit-testable without SSH,
-S3, Nebius, or GPUs. All network, storage, and Token Factory calls live in the
-runner script and the existing client/tool modules.
+This module holds only pure logic (digesting artifacts, building prompts,
+deriving run IDs / job names / URIs / variant grids) so it is unit-testable
+without SSH, S3, Nebius, or GPUs. All network, storage, and Token Factory calls
+live in the runner scripts and the existing client/tool modules.
 """
 
 from __future__ import annotations
@@ -23,7 +31,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 DEFAULT_TRIAGE_SYSTEM_PROMPT = (
     "You are a senior robot-learning engineer triaging a training run for a "
@@ -209,3 +217,122 @@ def render_triage_prompts_jsonl(records: Iterable[dict[str, str]]) -> str:
     """Serialize prompt records to JSONL text for the generate tool."""
 
     return "".join(json.dumps(record, sort_keys=True) + "\n" for record in records)
+
+
+# ---------------------------------------------------------------------------
+# sim-sweep combo: Token Factory design -> N serverless GPU trains -> ranking.
+#
+# Pure logic for the "experiment sweep" composition: a hosted text model
+# proposes an experiment rationale, a deterministic grid defines the actual
+# hyper-parameters launched on Nebius GPUs (so the GPU stage never depends on
+# parsing free-form model output), and a hosted text model finally ranks the
+# completed runs from their real artifacts. All network/storage/GPU work lives
+# in ``npa/scripts/run_tokenfactory_sim_sweep.py``.
+# ---------------------------------------------------------------------------
+
+DEFAULT_SWEEP_DESIGN_SYSTEM_PROMPT = (
+    "You are a robot-learning research lead designing a small training sweep for "
+    "a physical-AI team. You are given an objective and the concrete variant grid "
+    "that will actually run on GPUs. For each variant, write one or two sentences "
+    "stating the hypothesis it tests and what signal would confirm or refute it. "
+    "Be specific and grounded in the given hyper-parameters; do not invent "
+    "variants that are not in the grid."
+)
+
+DEFAULT_SWEEP_RANKING_SYSTEM_PROMPT = (
+    "You are a senior robot-learning engineer reviewing the results of a training "
+    "sweep. You are given the sweep objective and, for each completed variant, its "
+    "configuration and log artifacts. Produce a report with: (1) Ranking — order "
+    "the variants best-to-worst with a one-line justification each, citing concrete "
+    "numbers from the artifacts; (2) Winner — the variant you would promote and why; "
+    "(3) Caveats — what the artifacts do not tell you. Only use facts present in the "
+    "artifacts; if a metric is missing, say so rather than inventing it."
+)
+
+# Training-step counts used as the deterministic sweep knob. ``lerobot train``
+# exposes ``--steps`` (but no ``--seed``), so steps give a real, comparable axis.
+DEFAULT_SWEEP_STEPS = (50, 100, 150, 200)
+
+
+def default_sweep_run_id(now: datetime | None = None) -> str:
+    return f"tf-sim-sweep-{utc_stamp(now)}"
+
+
+def sweep_variants(
+    num_variants: int,
+    *,
+    steps_grid: Iterable[int] = DEFAULT_SWEEP_STEPS,
+) -> list[dict[str, Any]]:
+    """Return a deterministic variant grid (one dict per GPU train Job).
+
+    The grid varies ``--steps`` so the GPU stage is fully defined by code, never
+    by model output. ``num_variants`` is clamped to ``[1, len(steps_grid)]``.
+    """
+
+    grid = [int(value) for value in steps_grid]
+    if not grid:
+        raise ValueError("steps_grid must be non-empty")
+    count = max(1, min(int(num_variants), len(grid)))
+    return [
+        {"index": index, "id": f"v{index}-steps{grid[index]}", "steps": grid[index]}
+        for index in range(count)
+    ]
+
+
+def sweep_variant_output_uri(sweep_root: str, variant_id: str) -> str:
+    return join_uri(sweep_root, "variants", variant_id)
+
+
+def build_sweep_design_prompt(
+    *,
+    objective: str,
+    dataset: str,
+    policy_type: str,
+    variants: Iterable[dict[str, Any]],
+) -> str:
+    """Compose the prompt asking the text model to design the sweep rationale."""
+
+    lines = [
+        "Design the rationale for this robot-policy training sweep.",
+        f"- Objective: {objective.strip() or '(none given)'}",
+        f"- Dataset: {dataset}",
+        f"- Policy type: {policy_type}",
+        "- Variant grid (these exact runs will launch on Nebius GPUs):",
+    ]
+    for variant in variants:
+        extras = ", ".join(
+            f"{key}={value}" for key, value in variant.items() if key not in {"index", "id"}
+        )
+        lines.append(f"  - {variant['id']}: {extras}" if extras else f"  - {variant['id']}")
+    lines.append("")
+    lines.append("Write the per-variant hypotheses described in your instructions.")
+    return "\n".join(lines) + "\n"
+
+
+def build_ranking_prompt(
+    *,
+    objective: str,
+    runs: Iterable[dict[str, str]],
+) -> str:
+    """Compose the prompt that ranks completed sweep runs from their artifacts.
+
+    Each run is ``{"id", "uri", "digest"}`` where ``digest`` is the bounded
+    textual artifact digest produced by :func:`summarize_run_artifacts`.
+    """
+
+    header = [
+        "Rank the completed training-sweep variants below.",
+        f"- Objective: {objective.strip() or '(none given)'}",
+        "",
+        "Each variant's artifacts (configs and logs) follow. Base your report only",
+        "on these.",
+        "",
+    ]
+    blocks: list[str] = []
+    for run in runs:
+        blocks.append(
+            f"## Variant {run['id']}\n- Artifacts location: {run.get('uri', '')}\n\n{run.get('digest', '')}"
+        )
+    if not blocks:
+        blocks.append("(no completed variants were provided)")
+    return "\n".join(header) + "\n\n".join(blocks) + "\n"

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -102,6 +102,7 @@ def test_configure_interactive_writes_credentials_and_config(monkeypatch, tmp_pa
     answers = "\n".join(
         [
             "hf_secret_token",   # HF token
+            "nebius_secret_key", # Nebius Token Factory API key
             "AKIAEXAMPLE",       # S3 access key id
             "s3secretvalue",     # S3 secret access key
             "",                  # S3 endpoint (default)
@@ -118,6 +119,7 @@ def test_configure_interactive_writes_credentials_and_config(monkeypatch, tmp_pa
     assert result.exit_code == 0, result.output
     creds = yaml.safe_load(creds_path.read_text())
     assert creds["tokens"]["HF_TOKEN"] == "hf_secret_token"
+    assert creds["tokens"]["NEBIUS_API_KEY"] == "nebius_secret_key"
     assert creds["storage"]["aws_access_key_id"] == "AKIAEXAMPLE"
     assert creds["storage"]["aws_secret_access_key"] == "s3secretvalue"
     assert creds["storage"]["endpoint_url"] == "https://storage.eu-north1.nebius.cloud"
@@ -146,7 +148,7 @@ def test_configure_interactive_skips_config_without_project(monkeypatch, tmp_pat
     monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
 
     # Skip every field; only the defaulted endpoint/registry/region remain.
-    answers = "\n".join([""] * 9) + "\n"
+    answers = "\n".join([""] * 10) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
     assert result.exit_code == 0, result.output

--- a/npa/tests/cli/test_workbench_token_factory_cli.py
+++ b/npa/tests/cli/test_workbench_token_factory_cli.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+from PIL import Image
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.clients.token_factory import TokenFactoryClient, resolve_config
+import npa.workbench.token_factory as tool
+
+runner = CliRunner()
+
+
+def _install_fake_client(monkeypatch, reply: str) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": [{"message": {"content": reply}}]})
+
+    config = resolve_config(api_key="test-key", environ={})
+    client = TokenFactoryClient(config, http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+    monkeypatch.setattr(tool, "_default_client", lambda: client)
+
+
+def test_token_factory_help() -> None:
+    result = runner.invoke(app, ["workbench", "token-factory", "--help"])
+    assert result.exit_code == 0
+    assert "Token Factory" in result.output
+
+
+def test_token_factory_status_reports_base_url() -> None:
+    result = runner.invoke(app, ["workbench", "token-factory", "status", "--output", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["provider"] == "nebius-token-factory"
+    assert payload["base_url"].startswith("https://api.tokenfactory.nebius.com")
+
+
+def test_token_factory_list_capabilities() -> None:
+    result = runner.invoke(app, ["workbench", "token-factory", "list", "--output", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    names = {cap["name"] for cap in payload["capabilities"]}
+    assert {"caption", "generate"} <= names
+
+
+def test_token_factory_verify_without_key_fails(monkeypatch) -> None:
+    monkeypatch.delenv("NEBIUS_API_KEY", raising=False)
+    result = runner.invoke(app, ["workbench", "token-factory", "verify"])
+    assert result.exit_code == 1
+    assert "NEBIUS_API_KEY is not set" in result.output
+
+
+def test_token_factory_verify_with_key_reports_authenticated(monkeypatch) -> None:
+    monkeypatch.setenv("NEBIUS_API_KEY", "test-key")
+
+    class _FakeClient:
+        def list_models(self):
+            return ["model-a", "model-b"]
+
+    monkeypatch.setattr(tool, "_default_client", lambda: _FakeClient())
+
+    result = runner.invoke(app, ["workbench", "token-factory", "verify", "--output", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["authenticated"] is True
+    assert payload["model_count"] == 2
+    assert payload["base_url"].startswith("https://api.tokenfactory.nebius.com")
+
+
+def test_token_factory_caption_writes_local_json(monkeypatch, tmp_path: Path) -> None:
+    _install_fake_client(monkeypatch, "a caption")
+    images = tmp_path / "images"
+    images.mkdir()
+    Image.new("RGB", (16, 16), (1, 2, 3)).save(images / "frame.png")
+    output = tmp_path / "out"
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "token-factory",
+            "caption",
+            "--input-path",
+            str(images),
+            "--output-path",
+            str(output),
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["image_count"] == 1
+    written = output / "captions.json"
+    assert written.exists()
+    assert json.loads(written.read_text(encoding="utf-8"))["captions"][0]["caption"] == "a caption"
+
+
+def test_token_factory_reason_writes_scene_json(monkeypatch, tmp_path: Path) -> None:
+    _install_fake_client(monkeypatch, "1. approach the box\n2. grasp it")
+    scene = tmp_path / "scene"
+    scene.mkdir()
+    Image.new("RGB", (16, 16), (200, 40, 40)).save(scene / "frame.png")
+    output = tmp_path / "out"
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "token-factory",
+            "reason",
+            "--input-path",
+            str(scene),
+            "--output-path",
+            str(output),
+            "--task",
+            "How does the robot pick up the red box?",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["model"] == "nvidia/Cosmos3-Super-Reasoner"
+    assert payload["image_count"] == 1
+    written = output / "scene_reasoning.json"
+    assert written.exists()
+    assert "grasp" in json.loads(written.read_text(encoding="utf-8"))["analysis"]
+
+
+def test_token_factory_generate_writes_jsonl(monkeypatch, tmp_path: Path) -> None:
+    _install_fake_client(monkeypatch, "generated")
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text(json.dumps({"id": "p1", "prompt": "hi"}), encoding="utf-8")
+    output = tmp_path / "gen"
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "token-factory",
+            "generate",
+            "--input-path",
+            str(prompts),
+            "--output-path",
+            str(output),
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    written = output / "generations.jsonl"
+    assert written.exists()
+    row = json.loads(written.read_text(encoding="utf-8").splitlines()[0])
+    assert row == {"id": "p1", "prompt": "hi", "completion": "generated"}

--- a/npa/tests/clients/test_token_factory.py
+++ b/npa/tests/clients/test_token_factory.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from npa.clients.token_factory import (
+    DEFAULT_BASE_URL,
+    TokenFactoryClient,
+    TokenFactoryError,
+    resolve_config,
+)
+
+
+def _client(handler) -> TokenFactoryClient:
+    config = resolve_config(api_key="test-key", environ={})
+    return TokenFactoryClient(config, http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+
+
+def test_resolve_config_defaults_to_token_factory_base_url() -> None:
+    config = resolve_config(api_key="abc", environ={})
+    assert config.base_url == DEFAULT_BASE_URL
+    assert config.chat_completions_url == "https://api.tokenfactory.nebius.com/v1/chat/completions"
+    assert config.models_url == "https://api.tokenfactory.nebius.com/v1/models"
+
+
+def test_resolve_config_reads_nebius_api_key_from_env() -> None:
+    config = resolve_config(environ={"NEBIUS_API_KEY": "env-key"})
+    assert config.api_key == "env-key"
+
+
+def test_resolve_config_base_url_override() -> None:
+    config = resolve_config(
+        api_key="abc",
+        environ={"NEBIUS_TOKEN_FACTORY_BASE_URL": "https://example.com/v1"},
+    )
+    assert config.base_url == "https://example.com/v1"
+    assert config.chat_completions_url == "https://example.com/v1/chat/completions"
+
+
+def test_resolve_config_requires_api_key() -> None:
+    with pytest.raises(TokenFactoryError):
+        resolve_config(environ={})
+
+
+def test_resolve_config_allows_missing_key_when_not_required() -> None:
+    config = resolve_config(environ={}, require_api_key=False)
+    assert config.api_key == ""
+
+
+def test_chat_completion_text_sends_bearer_and_parses_content() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("Authorization")
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "a caption"}}]},
+        )
+
+    client = _client(handler)
+    text = client.chat_completion_text(
+        model="some-model",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=128,
+    )
+
+    assert text == "a caption"
+    assert seen["auth"] == "Bearer test-key"
+    assert seen["url"] == "https://api.tokenfactory.nebius.com/v1/chat/completions"
+    assert seen["body"]["model"] == "some-model"
+    assert seen["body"]["max_tokens"] == 128
+
+
+def test_chat_completion_missing_content_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": []})
+
+    client = _client(handler)
+    with pytest.raises(TokenFactoryError):
+        client.chat_completion_text(model="m", messages=[{"role": "user", "content": "x"}])
+
+
+def test_chat_completion_http_error_wrapped() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, text="rate limited")
+
+    client = _client(handler)
+    with pytest.raises(TokenFactoryError) as exc:
+        client.chat_completion(model="m", messages=[{"role": "user", "content": "x"}])
+    assert "429" in str(exc.value)
+
+
+def test_list_models_returns_ids() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://api.tokenfactory.nebius.com/v1/models"
+        return httpx.Response(
+            200,
+            json={"object": "list", "data": [{"id": "model-a"}, {"id": "model-b"}, {}]},
+        )
+
+    client = _client(handler)
+    assert client.list_models() == ["model-a", "model-b"]
+
+
+def test_chat_completion_requires_model_and_messages() -> None:
+    client = _client(lambda request: httpx.Response(200, json={}))
+    with pytest.raises(TokenFactoryError):
+        client.chat_completion(model="", messages=[{"role": "user", "content": "x"}])
+    with pytest.raises(TokenFactoryError):
+        client.chat_completion(model="m", messages=[])

--- a/npa/tests/conftest.py
+++ b/npa/tests/conftest.py
@@ -22,6 +22,7 @@ _LIVE_MARKERS = frozenset(
         "gpu",
         "multi_gpu",
         "ngc_e2e",
+        "token_factory_e2e",
     }
 )
 
@@ -47,6 +48,10 @@ _AMBIENT_CREDENTIAL_ENV_VARS = (
     "NPA_REGISTRY_ID",
     "HF_TOKEN",
     "HUGGING_FACE_HUB_TOKEN",
+    "NEBIUS_API_KEY",
+    "NEBIUS_TOKEN_FACTORY_API_KEY",
+    "NEBIUS_TOKEN_FACTORY_BASE_URL",
+    "NEBIUS_BASE_URL",
     "NGC_API_KEY",
     "NGC_ORG",
     "NGC_TEAM",
@@ -88,6 +93,7 @@ def block_live_huggingface_http(monkeypatch, request):
         "gpu",
         "multi_gpu",
         "ngc_e2e",
+        "token_factory_e2e",
     }
     if any(request.node.get_closest_marker(marker) for marker in live_markers):
         return

--- a/npa/tests/e2e/test_token_factory_e2e.py
+++ b/npa/tests/e2e/test_token_factory_e2e.py
@@ -1,0 +1,103 @@
+"""Live Nebius Token Factory API tests.
+
+These are first-class live tests: they hit the real Token Factory endpoint and
+require a real ``NEBIUS_API_KEY``. They self-skip when no key is configured, so
+they are safe to leave in the suite. Run explicitly with:
+
+    NEBIUS_API_KEY=... npa/.venv/bin/python -m pytest \
+        npa/tests/e2e/test_token_factory_e2e.py -v
+
+They live under ``tests/e2e`` (excluded from the default unit run via
+``--ignore=tests/e2e``) and are marked ``token_factory_e2e``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image, ImageDraw
+
+from npa.clients.token_factory import (
+    DEFAULT_REASONER_MODEL,
+    DEFAULT_TEXT_MODEL,
+    TokenFactoryClient,
+    resolve_config,
+)
+from npa.workbench.token_factory import reason_scene
+
+pytestmark = pytest.mark.token_factory_e2e
+
+
+def _require_key() -> str:
+    config = resolve_config(require_api_key=False)
+    if not config.api_key:
+        pytest.skip(
+            "Live Token Factory test requires NEBIUS_API_KEY in the environment "
+            "or ~/.npa/credentials.yaml (tokens.NEBIUS_API_KEY)."
+        )
+    return config.api_key
+
+
+def _has_model(client: TokenFactoryClient, model_id: str) -> bool:
+    try:
+        models = client.list_models()
+    except Exception:  # pragma: no cover - network dependent
+        return False
+    return model_id in models
+
+
+def _write_scene_image(path: Path) -> Path:
+    image = Image.new("RGB", (640, 480), (200, 200, 200))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle([0, 360, 640, 480], fill=(120, 90, 60))  # floor
+    draw.rectangle([260, 250, 380, 360], fill=(180, 40, 40))  # a box on the floor
+    draw.rectangle([60, 120, 160, 360], fill=(60, 60, 180))  # a wall/shelf
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image.save(path)
+    return path
+
+
+def test_live_list_models_authenticates() -> None:
+    _require_key()
+    models = TokenFactoryClient().list_models()
+    assert isinstance(models, list)
+    assert models, "Token Factory returned no models for this key"
+
+
+def test_live_text_chat_completion() -> None:
+    _require_key()
+    client = TokenFactoryClient()
+    model = DEFAULT_TEXT_MODEL if _has_model(client, DEFAULT_TEXT_MODEL) else client.list_models()[0]
+    text = client.chat_completion_text(
+        model=model,
+        messages=[{"role": "user", "content": "Reply with the single word: ready"}],
+        max_tokens=16,
+    )
+    assert isinstance(text, str)
+    assert text.strip()
+
+
+def test_live_cosmos_super_reasoner_scene_plan(tmp_path: Path) -> None:
+    _require_key()
+    client = TokenFactoryClient()
+    if not _has_model(client, DEFAULT_REASONER_MODEL):
+        pytest.skip(
+            f"{DEFAULT_REASONER_MODEL} is not available for this key; "
+            "check `npa workbench token-factory models`."
+        )
+    scene = tmp_path / "scene"
+    _write_scene_image(scene / "frame.png")
+
+    result = reason_scene(
+        input_path=str(scene),
+        output_path=str(tmp_path / "out"),
+        task="What objects are in this scene and what steps should a robot take to pick up the red box?",
+        model=DEFAULT_REASONER_MODEL,
+        max_tokens=512,
+    )
+
+    assert result.status == "completed"
+    assert result.model == DEFAULT_REASONER_MODEL
+    assert result.image_count == 1
+    assert result.analysis.strip(), "reasoner returned an empty analysis"

--- a/npa/tests/guardrails/test_three_tier_contract.py
+++ b/npa/tests/guardrails/test_three_tier_contract.py
@@ -223,6 +223,7 @@ def test_new_workbench_tools_require_contract_or_explicit_seam() -> None:
         "retargeting",
         "sim2real",
         "sim2real-envgen",
+        "token-factory",
         "workflow",
     }
     discovered = registered_workbench_tools()

--- a/npa/tests/test_credentials.py
+++ b/npa/tests/test_credentials.py
@@ -89,6 +89,30 @@ def test_load_credentials_reads_ngc_section_and_env_overrides(tmp_path: Path) ->
     assert shared_credential_env(resolved)["NGC_TEAM"] == "team-env"
 
 
+def test_load_credentials_reads_nebius_token_factory_key(tmp_path: Path) -> None:
+    credentials_path = tmp_path / "credentials.yaml"
+    credentials_path.write_text(
+        yaml.safe_dump({"tokens": {"NEBIUS_API_KEY": "tf-file"}})
+    )
+
+    resolved = load_credentials(path=credentials_path, environ={})
+
+    assert resolved.nebius_api_key == "tf-file"
+    assert resolved.tokens["NEBIUS_API_KEY"] == "tf-file"
+    assert shared_credential_env(resolved)["NEBIUS_API_KEY"] == "tf-file"
+
+
+def test_nebius_api_key_env_overrides_file(tmp_path: Path) -> None:
+    credentials_path = tmp_path / "credentials.yaml"
+    credentials_path.write_text(
+        yaml.safe_dump({"tokens": {"NEBIUS_API_KEY": "tf-file"}})
+    )
+
+    resolved = load_credentials(path=credentials_path, environ={"NEBIUS_API_KEY": "tf-env"})
+
+    assert resolved.nebius_api_key == "tf-env"
+
+
 def test_load_credentials_reads_byovm_ssh_config(tmp_path: Path) -> None:
     credentials_path = tmp_path / "credentials.yaml"
     credentials_path.write_text(

--- a/npa/tests/workbench/test_token_factory_tool.py
+++ b/npa/tests/workbench/test_token_factory_tool.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from PIL import Image
+
+from npa.clients.token_factory import (
+    DEFAULT_REASONER_MODEL,
+    TokenFactoryClient,
+    resolve_config,
+)
+from npa.workbench.token_factory import (
+    TokenFactoryToolError,
+    caption_images,
+    generate_text,
+    reason_scene,
+)
+
+
+def _client(reply: str) -> TokenFactoryClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": [{"message": {"content": reply}}]})
+
+    config = resolve_config(api_key="test-key", environ={})
+    return TokenFactoryClient(config, http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+
+
+def _capturing_client(reply: str, captured: dict) -> TokenFactoryClient:
+    import json as _json
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = _json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, json={"choices": [{"message": {"content": reply}}]})
+
+    config = resolve_config(api_key="test-key", environ={})
+    return TokenFactoryClient(config, http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+
+
+def _write_image(path: Path, color: tuple[int, int, int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (32, 32), color).save(path)
+
+
+def test_caption_images_writes_manifest(tmp_path: Path) -> None:
+    images = tmp_path / "images"
+    _write_image(images / "a.png", (10, 20, 30))
+    _write_image(images / "b.jpg", (200, 100, 50))
+    output = tmp_path / "out"
+
+    result = caption_images(
+        input_path=str(images),
+        output_path=str(output),
+        client=_client("a clear caption"),
+    )
+
+    assert result.status == "completed"
+    assert result.image_count == 2
+    assert {item.image for item in result.captions} == {"a.png", "b.jpg"}
+    assert all(item.caption == "a clear caption" for item in result.captions)
+    assert result.result_uri.endswith("/captions.json")
+
+
+def test_caption_images_respects_max_images(tmp_path: Path) -> None:
+    images = tmp_path / "images"
+    for index in range(5):
+        _write_image(images / f"frame-{index}.png", (index * 10, 0, 0))
+
+    result = caption_images(
+        input_path=str(images),
+        output_path=str(tmp_path / "out"),
+        max_images=2,
+        client=_client("cap"),
+    )
+
+    assert result.image_count == 2
+
+
+def test_caption_images_no_images_raises(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(TokenFactoryToolError):
+        caption_images(input_path=str(empty), output_path=str(tmp_path / "out"), client=_client("x"))
+
+
+def test_generate_text_from_jsonl(tmp_path: Path) -> None:
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text(
+        "\n".join(
+            [
+                json.dumps({"id": "p1", "prompt": "Write a task instruction"}),
+                json.dumps({"prompt": "Another prompt"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "gen"
+
+    result = generate_text(
+        input_path=str(prompts),
+        output_path=str(output),
+        client=_client("generated text"),
+    )
+
+    assert result.prompt_count == 2
+    assert result.generations[0].id == "p1"
+    assert result.generations[1].id == "item-0002"
+    assert all(item.completion == "generated text" for item in result.generations)
+    assert result.result_uri.endswith("/generations.jsonl")
+
+
+def test_generate_text_from_txt_lines(tmp_path: Path) -> None:
+    prompts = tmp_path / "prompts.txt"
+    prompts.write_text("first prompt\n\nsecond prompt\n", encoding="utf-8")
+
+    result = generate_text(
+        input_path=str(prompts),
+        output_path=str(tmp_path / "gen"),
+        client=_client("ok"),
+    )
+
+    assert result.prompt_count == 2
+    assert [item.prompt for item in result.generations] == ["first prompt", "second prompt"]
+
+
+def test_generate_text_missing_prompt_field_raises(tmp_path: Path) -> None:
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text(json.dumps({"id": "p1"}), encoding="utf-8")
+    with pytest.raises(TokenFactoryToolError):
+        generate_text(input_path=str(prompts), output_path=str(tmp_path / "gen"), client=_client("x"))
+
+
+def test_reason_scene_sends_images_and_returns_plan(tmp_path: Path) -> None:
+    scene = tmp_path / "scene"
+    _write_image(scene / "a.png", (10, 20, 30))
+    _write_image(scene / "b.png", (40, 50, 60))
+    captured: dict = {}
+
+    result = reason_scene(
+        input_path=str(scene),
+        output_path=str(tmp_path / "out"),
+        task="What should the robot do here?",
+        client=_capturing_client("1. approach 2. grasp", captured),
+    )
+
+    assert result.status == "completed"
+    assert result.model == DEFAULT_REASONER_MODEL
+    assert result.image_count == 2
+    assert result.images == ["a.png", "b.png"]
+    assert result.analysis == "1. approach 2. grasp"
+    assert result.result_uri.endswith("/scene_reasoning.json")
+    # One request carries the task text plus both images.
+    content = captured["body"]["messages"][-1]["content"]
+    assert content[0] == {"type": "text", "text": "What should the robot do here?"}
+    image_parts = [part for part in content if part["type"] == "image_url"]
+    assert len(image_parts) == 2
+
+
+def test_reason_scene_respects_max_images(tmp_path: Path) -> None:
+    scene = tmp_path / "scene"
+    for index in range(5):
+        _write_image(scene / f"f-{index}.png", (index * 10, 0, 0))
+
+    result = reason_scene(
+        input_path=str(scene),
+        output_path=str(tmp_path / "out"),
+        max_images=3,
+        client=_client("plan"),
+    )
+
+    assert result.image_count == 3
+
+
+def test_reason_scene_no_images_raises(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(TokenFactoryToolError):
+        reason_scene(input_path=str(empty), output_path=str(tmp_path / "out"), client=_client("x"))

--- a/npa/tests/workbench/test_vlm_eval_token_factory.py
+++ b/npa/tests/workbench/test_vlm_eval_token_factory.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from npa.workbench.vlm_eval import VlmEvalError, _resolve_api_key, _resolve_endpoint_url
+
+
+def test_api_backend_defaults_to_token_factory_base_url(monkeypatch) -> None:
+    for key in ("VLM_EVAL_API_BASE_URL", "OPENAI_BASE_URL", "NEBIUS_TOKEN_FACTORY_BASE_URL", "NEBIUS_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
+    url = _resolve_endpoint_url(backend="api", endpoint_url="")
+    assert url == "https://api.tokenfactory.nebius.com/v1/"
+
+
+def test_api_backend_honors_explicit_endpoint(monkeypatch) -> None:
+    url = _resolve_endpoint_url(backend="api", endpoint_url="http://localhost:9000/v1")
+    assert url == "http://localhost:9000/v1"
+
+
+def test_api_backend_accepts_nebius_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("VLM_EVAL_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("NEBIUS_API_KEY", "tf-key")
+    assert _resolve_api_key(backend="api", api_key_env="VLM_EVAL_API_KEY") == "tf-key"
+
+
+def test_api_backend_requires_a_key(monkeypatch) -> None:
+    for key in ("VLM_EVAL_API_KEY", "NEBIUS_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    with pytest.raises(VlmEvalError):
+        _resolve_api_key(backend="api", api_key_env="VLM_EVAL_API_KEY")

--- a/npa/tests/workflows/test_token_factory_combos.py
+++ b/npa/tests/workflows/test_token_factory_combos.py
@@ -9,12 +9,20 @@ import pytest
 import yaml
 
 from npa.workflows.token_factory_combos import (
+    DEFAULT_SWEEP_DESIGN_SYSTEM_PROMPT,
+    DEFAULT_SWEEP_RANKING_SYSTEM_PROMPT,
+    DEFAULT_SWEEP_STEPS,
     DEFAULT_TRIAGE_SYSTEM_PROMPT,
+    build_ranking_prompt,
+    build_sweep_design_prompt,
     build_triage_prompt,
+    default_sweep_run_id,
     default_triage_run_id,
     join_uri,
     render_triage_prompts_jsonl,
     summarize_run_artifacts,
+    sweep_variant_output_uri,
+    sweep_variants,
     triage_job_name,
     triage_prompt_record,
     triage_report_uri,
@@ -22,16 +30,27 @@ from npa.workflows.token_factory_combos import (
 )
 
 ROOT = Path(__file__).resolve().parents[3]
-ROLLOUT_JUDGE_YAML = ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "tokenfactory-rollout-judge.yaml"
+SKYPILOT = ROOT / "npa" / "workflows" / "workbench" / "skypilot"
+ROLLOUT_JUDGE_YAML = SKYPILOT / "tokenfactory-rollout-judge.yaml"
+SCENE_JUDGE_YAML = SKYPILOT / "tokenfactory-scene-to-rollout-judge.yaml"
 TRIAGE_RUNNER = ROOT / "npa" / "scripts" / "run_tokenfactory_train_triage.py"
+SWEEP_RUNNER = ROOT / "npa" / "scripts" / "run_tokenfactory_sim_sweep.py"
 
 
-def _load_runner():
-    spec = importlib.util.spec_from_file_location("run_tokenfactory_train_triage", TRIAGE_RUNNER)
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _load_runner():
+    return _load_module("run_tokenfactory_train_triage", TRIAGE_RUNNER)
+
+
+def _load_sweep_runner():
+    return _load_module("run_tokenfactory_sim_sweep", SWEEP_RUNNER)
 
 
 def _docs(path: Path) -> list[dict]:
@@ -190,5 +209,145 @@ def test_rollout_judge_is_two_stage_gpu_then_hosted_judge() -> None:
 
 def test_rollout_judge_has_no_hardcoded_infra_ids() -> None:
     text = ROLLOUT_JUDGE_YAML.read_text(encoding="utf-8")
+    assert "<your-registry-id>" in text
+    assert "<your-bucket-name>" in text
+
+
+# --- sim-sweep pure helpers ----------------------------------------------
+
+
+def test_sweep_run_id_and_variants_are_deterministic() -> None:
+    moment = datetime(2026, 6, 11, 18, 30, 5, tzinfo=timezone.utc)
+    assert default_sweep_run_id(moment) == "tf-sim-sweep-20260611T183005Z"
+
+    variants = sweep_variants(2)
+    assert [v["id"] for v in variants] == ["v0-steps50", "v1-steps100"]
+    assert [v["steps"] for v in variants] == [50, 100]
+
+
+def test_sweep_variants_clamps_to_grid_bounds() -> None:
+    assert len(sweep_variants(0)) == 1  # clamps up to at least one
+    assert len(sweep_variants(99)) == len(DEFAULT_SWEEP_STEPS)  # clamps down to grid
+    with pytest.raises(ValueError):
+        sweep_variants(2, steps_grid=[])
+
+
+def test_sweep_variant_output_uri_nests_under_variants() -> None:
+    uri = sweep_variant_output_uri("s3://b/sweep", "v0-steps50")
+    assert uri == "s3://b/sweep/variants/v0-steps50"
+
+
+def test_build_sweep_design_prompt_lists_only_grid_variants() -> None:
+    variants = sweep_variants(2)
+    prompt = build_sweep_design_prompt(
+        objective="maximize success",
+        dataset="lerobot/pusht",
+        policy_type="act",
+        variants=variants,
+    )
+    assert "maximize success" in prompt
+    assert "v0-steps50" in prompt and "steps=50" in prompt
+    assert "v1-steps100" in prompt
+    assert "v2-" not in prompt  # only the two requested variants
+
+
+def test_build_ranking_prompt_includes_each_run_digest() -> None:
+    prompt = build_ranking_prompt(
+        objective="best policy",
+        runs=[
+            {"id": "v0", "uri": "s3://b/v0/", "digest": "### train.log\nloss 0.3"},
+            {"id": "v1", "uri": "s3://b/v1/", "digest": "### train.log\nloss 0.9"},
+        ],
+    )
+    assert "best policy" in prompt
+    assert "Variant v0" in prompt and "Variant v1" in prompt
+    assert "loss 0.3" in prompt and "loss 0.9" in prompt
+
+
+def test_build_ranking_prompt_handles_no_runs() -> None:
+    assert "no completed variants" in build_ranking_prompt(objective="x", runs=[])
+
+
+def test_sweep_system_prompts_are_grounded() -> None:
+    assert "only use facts" in DEFAULT_SWEEP_RANKING_SYSTEM_PROMPT.lower()
+    assert "do not invent" in DEFAULT_SWEEP_DESIGN_SYSTEM_PROMPT.lower()
+
+
+# --- sim-sweep runner (render-only, no infrastructure) --------------------
+
+
+def test_sweep_runner_render_only_full_sweep() -> None:
+    module = _load_sweep_runner()
+    args = module._parse_args(
+        ["--run-id", "demo", "--num-variants", "2", "--bucket", "s3://b/tf-sim-sweep"]
+    )
+    plan = module.build_plan(args)
+    assert plan["mode"] == "full-sweep"
+    assert plan["compute"] == "nebius-serverless-gpu"
+    assert plan["hosted_inference"] == "nebius-token-factory"
+    assert len(plan["variants"]) == 2
+    cmd = plan["variants"][0]["train_command"]
+    assert cmd[:3] == ["workbench", "lerobot", "train"]
+    assert "--runtime" in cmd and "serverless" in cmd
+    assert "--steps" in cmd
+    assert "--seed" not in cmd  # lerobot train has no --seed flag
+    assert plan["variants"][0]["output_uri"].endswith("variants/v0-steps50")
+    assert "Design the rationale" in plan["design_prompt"]
+
+
+def test_sweep_runner_rank_existing_skips_design_and_gpu() -> None:
+    module = _load_sweep_runner()
+    args = module._parse_args(["--rank-existing", "s3://b/runA/, s3://b/runB/"])
+    plan = module.build_plan(args)
+    assert plan["mode"] == "rank-existing"
+    assert plan["variant_uris"] == ["s3://b/runA/", "s3://b/runB/"]
+    assert "variants" not in plan
+    assert "design_prompt" not in plan
+
+
+def test_sweep_runner_disambiguates_colliding_run_labels() -> None:
+    module = _load_sweep_runner()
+    # Distinct last segments keep their names...
+    runs = module._label_existing_runs(["s3://b/runA/", "s3://b/runB/"])
+    assert [r["id"] for r in runs] == ["runA", "runB"]
+    # ...colliding last segments are suffixed by position.
+    collide = module._label_existing_runs(
+        ["s3://b/r1/checkpoints/pretrained_model/", "s3://b/r2/checkpoints/pretrained_model/"]
+    )
+    assert [r["id"] for r in collide] == ["pretrained_model-0", "pretrained_model-1"]
+    assert len({r["id"] for r in collide}) == 2
+
+
+# --- scene-to-rollout-judge SkyPilot YAML (reason -> k8s GPU -> VLM judge) -
+
+
+def test_scene_judge_is_three_stage_reason_gpu_judge() -> None:
+    docs = _docs(SCENE_JUDGE_YAML)
+    assert docs[0] == {"name": "tokenfactory-scene-to-rollout-judge", "execution": "serial"}
+    reason_stage, gpu_stage, judge_stage = docs[1], docs[2], docs[3]
+
+    # Stage 1: hosted reasoner, zero-GPU.
+    assert reason_stage["name"] == "scene-reason"
+    assert "accelerators" not in reason_stage["resources"]
+    assert "npa workbench token-factory reason" in reason_stage["run"]
+    assert reason_stage["envs"]["PLAN_URI"].startswith("s3://")
+
+    # Stage 2: genuine Nebius k8s GPU rollout.
+    assert gpu_stage["name"] == "rollout-gpu"
+    assert gpu_stage["resources"]["cloud"] == "kubernetes"
+    assert "accelerators" in gpu_stage["resources"]
+    assert "lerobot-eval" in gpu_stage["run"]
+
+    # Stage 3: hosted VLM judge that consumes the plan and the rollout.
+    assert judge_stage["name"] == "scene-judge"
+    assert "accelerators" not in judge_stage["resources"]
+    assert "npa workbench vlm-eval run" in judge_stage["run"]
+    assert "--backend api" in judge_stage["run"]
+    assert judge_stage["envs"]["PLAN_URI"] == reason_stage["envs"]["PLAN_URI"]
+    assert judge_stage["envs"]["ROLLOUTS_URI"] == gpu_stage["envs"]["ROLLOUTS_URI"]
+
+
+def test_scene_judge_has_no_hardcoded_infra_ids() -> None:
+    text = SCENE_JUDGE_YAML.read_text(encoding="utf-8")
     assert "<your-registry-id>" in text
     assert "<your-bucket-name>" in text

--- a/npa/tests/workflows/test_token_factory_combos.py
+++ b/npa/tests/workflows/test_token_factory_combos.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+from npa.workflows.token_factory_combos import (
+    DEFAULT_TRIAGE_SYSTEM_PROMPT,
+    build_triage_prompt,
+    default_triage_run_id,
+    join_uri,
+    render_triage_prompts_jsonl,
+    summarize_run_artifacts,
+    triage_job_name,
+    triage_prompt_record,
+    triage_report_uri,
+    utc_stamp,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+ROLLOUT_JUDGE_YAML = ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "tokenfactory-rollout-judge.yaml"
+TRIAGE_RUNNER = ROOT / "npa" / "scripts" / "run_tokenfactory_train_triage.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("run_tokenfactory_train_triage", TRIAGE_RUNNER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _docs(path: Path) -> list[dict]:
+    return [doc for doc in yaml.safe_load_all(path.read_text(encoding="utf-8")) if doc is not None]
+
+
+# --- pure helpers ---------------------------------------------------------
+
+
+def test_utc_stamp_and_run_id_are_deterministic_and_safe() -> None:
+    moment = datetime(2026, 6, 11, 18, 30, 5, tzinfo=timezone.utc)
+    assert utc_stamp(moment) == "20260611T183005Z"
+    assert default_triage_run_id(moment) == "tf-train-triage-20260611T183005Z"
+
+
+def test_triage_job_name_sanitizes_to_nebius_safe() -> None:
+    name = triage_job_name("TF Train/Triage_2026!!")
+    assert name == "tf-train-triage-2026"
+    assert name == name.lower()
+    assert all(ch.isalnum() or ch == "-" for ch in name)
+    assert not name.startswith("-") and not name.endswith("-")
+    assert len(triage_job_name("x" * 200)) <= 48
+
+
+def test_join_and_report_uris() -> None:
+    assert join_uri("s3://b/run/", "triage") == "s3://b/run/triage"
+    assert join_uri("s3://b/run", "a", "b") == "s3://b/run/a/b"
+    assert join_uri("s3://b/run/", "") == "s3://b/run/"
+    assert triage_report_uri("s3://b/run/triage") == "s3://b/run/triage/generations.jsonl"
+
+
+def test_summarize_run_artifacts_reads_text_skips_binary_and_truncates(tmp_path: Path) -> None:
+    (tmp_path / "train_config.json").write_text(json.dumps({"steps": 50, "policy": "act"}), encoding="utf-8")
+    (tmp_path / "train.log").write_text("step 0 loss 1.2\nstep 50 loss 0.3\n", encoding="utf-8")
+    (tmp_path / "model.safetensors").write_bytes(b"\x00\x01\x02binaryweights")
+    nested = tmp_path / "checkpoints" / "last"
+    nested.mkdir(parents=True)
+    (nested / "config.yaml").write_text("device: cuda\n", encoding="utf-8")
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / ".hidden" / "secret.json").write_text("{}", encoding="utf-8")
+
+    digest = summarize_run_artifacts(tmp_path)
+    assert "train_config.json" in digest
+    assert "train.log" in digest
+    assert "checkpoints/last/config.yaml" in digest
+    assert "safetensors" not in digest  # binary weights excluded
+    assert "secret.json" not in digest  # dotfiles excluded
+
+
+def test_summarize_truncates_large_files(tmp_path: Path) -> None:
+    (tmp_path / "big.log").write_text("x" * 50_000, encoding="utf-8")
+    digest = summarize_run_artifacts(tmp_path, max_file_bytes=1000, max_total_bytes=5000)
+    assert "[truncated]" in digest
+    assert len(digest.encode("utf-8")) < 8000
+
+
+def test_summarize_missing_path_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        summarize_run_artifacts(tmp_path / "nope")
+
+
+def test_summarize_empty_dir_is_explicit(tmp_path: Path) -> None:
+    assert "no textual artifacts" in summarize_run_artifacts(tmp_path)
+
+
+def test_build_triage_prompt_includes_context_and_digest() -> None:
+    prompt = build_triage_prompt(
+        job_name="job-1",
+        output_uri="s3://b/run/",
+        artifact_digest="### train_config.json\n{...}",
+        extra_context="ran on H200",
+    )
+    assert "job-1" in prompt
+    assert "s3://b/run/" in prompt
+    assert "ran on H200" in prompt
+    assert "### train_config.json" in prompt
+
+
+def test_triage_prompt_record_and_jsonl_roundtrip() -> None:
+    record = triage_prompt_record(job_name="My Job", output_uri="s3://b/run/", artifact_digest="d")
+    assert record["id"] == "triage-my-job"
+    jsonl = render_triage_prompts_jsonl([record])
+    parsed = json.loads(jsonl.strip())
+    assert parsed["id"] == "triage-my-job"
+    assert "prompt" in parsed
+    assert jsonl.endswith("\n")
+
+
+def test_default_triage_system_prompt_is_grounded() -> None:
+    assert "only use facts" in DEFAULT_TRIAGE_SYSTEM_PROMPT.lower()
+
+
+# --- runner (render-only, no infrastructure) ------------------------------
+
+
+def test_runner_render_only_plan_serverless() -> None:
+    module = _load_runner()
+    args = module._parse_args(["--run-id", "demo", "--gpu-type", "h200"])
+    plan = module.build_plan(args)
+    assert plan["compute"] == "nebius-serverless-gpu"
+    assert plan["hosted_inference"] == "nebius-token-factory"
+    assert plan["job_name"] == "demo"
+    assert plan["skip_train"] is False
+    cmd = plan["train_command"]
+    assert cmd[:3] == ["workbench", "lerobot", "train"]
+    assert "--runtime" in cmd and "serverless" in cmd
+    assert "--smoke" in cmd
+    assert "--gpu-type" in cmd
+    assert "--output" in cmd and "json" in cmd
+
+
+def test_runner_from_output_path_skips_train() -> None:
+    module = _load_runner()
+    args = module._parse_args(["--from-output-path", "s3://b/run/"])
+    plan = module.build_plan(args)
+    assert plan["skip_train"] is True
+    assert plan["artifacts_uri"] == "s3://b/run/"
+    assert plan["triage_root"] == "s3://b/run/triage"
+    assert "train_command" not in plan
+
+
+def test_runner_no_smoke_flag() -> None:
+    module = _load_runner()
+    args = module._parse_args(["--no-smoke", "--steps", "200"])
+    plan = module.build_plan(args)
+    assert "--smoke" not in plan["train_command"]
+    assert "--steps" in plan["train_command"]
+
+
+# --- rollout-judge SkyPilot YAML (k8s GPU + Token Factory) ----------------
+
+
+def test_rollout_judge_is_two_stage_gpu_then_hosted_judge() -> None:
+    docs = _docs(ROLLOUT_JUDGE_YAML)
+    assert docs[0] == {"name": "tokenfactory-rollout-judge", "execution": "serial"}
+    gpu_stage, judge_stage = docs[1], docs[2]
+
+    # Stage 1 genuinely uses a Nebius k8s GPU.
+    assert gpu_stage["name"] == "rollout-gpu"
+    assert gpu_stage["resources"]["cloud"] == "kubernetes"
+    assert "accelerators" in gpu_stage["resources"]
+    assert "lerobot-eval" in gpu_stage["run"]
+    assert gpu_stage["envs"]["ROLLOUTS_URI"].startswith("s3://")
+
+    # Stage 2 is zero-GPU hosted Token Factory judging.
+    assert judge_stage["name"] == "tokenfactory-judge"
+    assert judge_stage["resources"]["cloud"] == "kubernetes"
+    assert "accelerators" not in judge_stage["resources"]
+    assert "python3 -m vllm" not in judge_stage["run"]
+    assert "npa workbench vlm-eval run" in judge_stage["run"]
+    assert "--backend api" in judge_stage["run"]
+    assert "--api-key-env NEBIUS_API_KEY" in judge_stage["run"]
+    # The judge reads exactly what the GPU stage wrote.
+    assert judge_stage["envs"]["ROLLOUTS_URI"] == gpu_stage["envs"]["ROLLOUTS_URI"]
+
+
+def test_rollout_judge_has_no_hardcoded_infra_ids() -> None:
+    text = ROLLOUT_JUDGE_YAML.read_text(encoding="utf-8")
+    assert "<your-registry-id>" in text
+    assert "<your-bucket-name>" in text

--- a/npa/tests/workflows/test_token_factory_workflow.py
+++ b/npa/tests/workflows/test_token_factory_workflow.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+SKYPILOT = ROOT / "npa" / "workflows" / "workbench" / "skypilot"
+CAPTION_YAML = SKYPILOT / "token-factory-caption.yaml"
+GENERATE_YAML = SKYPILOT / "token-factory-generate.yaml"
+REASON_YAML = SKYPILOT / "token-factory-cosmos-reason.yaml"
+VLM_EVAL_YAML = SKYPILOT / "vlm-eval-token-factory.yaml"
+
+
+def _docs(path: Path) -> list[dict]:
+    return [doc for doc in yaml.safe_load_all(path.read_text(encoding="utf-8")) if doc is not None]
+
+
+def test_caption_workflow_is_cpu_only_and_runs_cli() -> None:
+    docs = _docs(CAPTION_YAML)
+    assert docs[0] == {"name": "token-factory-caption", "execution": "serial"}
+    task = docs[1]
+    assert task["resources"]["cloud"] == "kubernetes"
+    assert "accelerators" not in task["resources"]
+    assert "npa workbench token-factory caption" in task["run"]
+    assert "NEBIUS_API_KEY" in task["run"]
+    for flag in ("--input-path", "--output-path", "--model", "--instruction", "--max-images"):
+        assert flag in task["run"]
+
+
+def test_generate_workflow_is_cpu_only_and_runs_cli() -> None:
+    docs = _docs(GENERATE_YAML)
+    assert docs[0] == {"name": "token-factory-generate", "execution": "serial"}
+    task = docs[1]
+    assert task["resources"]["cloud"] == "kubernetes"
+    assert "accelerators" not in task["resources"]
+    assert "npa workbench token-factory generate" in task["run"]
+    for flag in ("--input-path", "--output-path", "--model", "--system-prompt", "--max-prompts"):
+        assert flag in task["run"]
+
+
+def test_cosmos_reason_workflow_is_cpu_only_and_runs_cli() -> None:
+    docs = _docs(REASON_YAML)
+    assert docs[0] == {"name": "token-factory-cosmos-reason", "execution": "serial"}
+    task = docs[1]
+    assert task["resources"]["cloud"] == "kubernetes"
+    assert "accelerators" not in task["resources"]
+    assert task["envs"]["MODEL"] == "nvidia/Cosmos3-Super-Reasoner"
+    assert "python3 -m vllm" not in task["run"]
+    assert "npa workbench token-factory reason" in task["run"]
+    assert "NEBIUS_API_KEY" in task["run"]
+    for flag in ("--input-path", "--output-path", "--model", "--task", "--max-images"):
+        assert flag in task["run"]
+
+
+def test_vlm_eval_token_factory_workflow_uses_api_backend_no_gpu() -> None:
+    docs = _docs(VLM_EVAL_YAML)
+    assert docs[0] == {"name": "vlm-eval-token-factory", "execution": "serial"}
+    task = docs[1]
+    assert task["resources"]["cloud"] == "kubernetes"
+    assert "accelerators" not in task["resources"]
+    assert task["envs"]["VLM_BACKEND"] == "api"
+    assert "python3 -m vllm" not in task["run"]
+    assert "npa workbench vlm-eval run" in task["run"]
+    assert "--api-key-env NEBIUS_API_KEY" in task["run"]

--- a/npa/workflows/workbench/skypilot/README.md
+++ b/npa/workflows/workbench/skypilot/README.md
@@ -42,8 +42,13 @@ truth; the top-level `README.md` shows only a few common entry points.)
 | Stage the Cosmos3 framework + checkpoints | [`cosmos3-ea-fetch.yaml`](./cosmos3-ea-fetch.yaml) | `npa workbench cosmos` | CPU | [cosmos3-setup SKILL](../../../../.agents/skills/cosmos3-setup/SKILL.md) |
 | Run Cosmos3 Reason inference | [`cosmos3-reason.yaml`](./cosmos3-reason.yaml) | `npa workbench cosmos` | RTX PRO 6000 | [inference SKILL](../../../../.agents/skills/inference/SKILL.md) |
 | Run a Cosmos2 transfer (video-to-world) stage | [`cosmos2-transfer.yaml`](./cosmos2-transfer.yaml) | `npa workbench cosmos` | RTX PRO 6000 | [cosmos SKILL](../../../../.agents/skills/workbench/cosmos/SKILL.md) |
-| **Roll out on a k8s GPU, then judge it with hosted Token Factory** | [`tokenfactory-rollout-judge.yaml`](./tokenfactory-rollout-judge.yaml) | `npa workbench workflow submit` | L40S (judge stage CPU) | [tokenfactory-compute-combos.md](../../../../docs/workbench/cookbooks/tokenfactory-compute-combos.md) |
+| **Roll out on a k8s GPU, then judge it with hosted Token Factory** | [`tokenfactory-rollout-judge.yaml`](./tokenfactory-rollout-judge.yaml) | `npa workbench workflow submit` | H100 (judge stage CPU) | [tokenfactory-compute-combos.md](../../../../docs/workbench/cookbooks/tokenfactory-compute-combos.md) |
+| **Reason over a scene, roll out on a k8s GPU, then judge vs. the plan** | [`tokenfactory-scene-to-rollout-judge.yaml`](./tokenfactory-scene-to-rollout-judge.yaml) | `npa workbench workflow submit` | H100 (reason + judge stages CPU) | [tokenfactory-compute-combos.md](../../../../docs/workbench/cookbooks/tokenfactory-compute-combos.md) |
 | Train on a serverless GPU, then triage the run with Token Factory | _(runner script)_ | [`run_tokenfactory_train_triage.py`](../../../scripts/run_tokenfactory_train_triage.py) | serverless GPU (triage CPU) | [tokenfactory-compute-combos.md](../../../../docs/workbench/cookbooks/tokenfactory-compute-combos.md) |
+| Design a sweep, run N serverless GPU trains, then rank them with Token Factory | _(runner script)_ | [`run_tokenfactory_sim_sweep.py`](../../../scripts/run_tokenfactory_sim_sweep.py) | serverless GPU ×N (design + rank CPU) | [tokenfactory-compute-combos.md](../../../../docs/workbench/cookbooks/tokenfactory-compute-combos.md) |
+
+To compose your own combo, read
+[composing-cloud-and-token-factory.md](../../../../docs/workbench/composing-cloud-and-token-factory.md).
 
 The Cosmos guides are agent skills under `.agents/skills/`; everything else
 links to a human-facing guide under `docs/`.

--- a/npa/workflows/workbench/skypilot/README.md
+++ b/npa/workflows/workbench/skypilot/README.md
@@ -42,6 +42,8 @@ truth; the top-level `README.md` shows only a few common entry points.)
 | Stage the Cosmos3 framework + checkpoints | [`cosmos3-ea-fetch.yaml`](./cosmos3-ea-fetch.yaml) | `npa workbench cosmos` | CPU | [cosmos3-setup SKILL](../../../../.agents/skills/cosmos3-setup/SKILL.md) |
 | Run Cosmos3 Reason inference | [`cosmos3-reason.yaml`](./cosmos3-reason.yaml) | `npa workbench cosmos` | RTX PRO 6000 | [inference SKILL](../../../../.agents/skills/inference/SKILL.md) |
 | Run a Cosmos2 transfer (video-to-world) stage | [`cosmos2-transfer.yaml`](./cosmos2-transfer.yaml) | `npa workbench cosmos` | RTX PRO 6000 | [cosmos SKILL](../../../../.agents/skills/workbench/cosmos/SKILL.md) |
+| **Roll out on a k8s GPU, then judge it with hosted Token Factory** | [`tokenfactory-rollout-judge.yaml`](./tokenfactory-rollout-judge.yaml) | `npa workbench workflow submit` | L40S (judge stage CPU) | [tokenfactory-compute-combos.md](../../../../docs/workbench/cookbooks/tokenfactory-compute-combos.md) |
+| Train on a serverless GPU, then triage the run with Token Factory | _(runner script)_ | [`run_tokenfactory_train_triage.py`](../../../scripts/run_tokenfactory_train_triage.py) | serverless GPU (triage CPU) | [tokenfactory-compute-combos.md](../../../../docs/workbench/cookbooks/tokenfactory-compute-combos.md) |
 
 The Cosmos guides are agent skills under `.agents/skills/`; everything else
 links to a human-facing guide under `docs/`.

--- a/npa/workflows/workbench/skypilot/token-factory-caption.yaml
+++ b/npa/workflows/workbench/skypilot/token-factory-caption.yaml
@@ -22,7 +22,7 @@ envs:
   NPA_TOKEN_FACTORY_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
   INPUT_URI: "s3://<your-bucket-name>/token-factory/<run-id>/images/"
   OUTPUT_URI: "s3://<your-bucket-name>/token-factory/<run-id>/captions/"
-  MODEL: "Qwen/Qwen2-VL-7B-Instruct"
+  MODEL: "Qwen/Qwen2.5-VL-72B-Instruct"
   INSTRUCTION: "Describe this image in one or two sentences. Focus on the objects, the scene, and any action taking place. Be concrete and factual."
   MAX_IMAGES: "50"
   MAX_TOKENS: "512"

--- a/npa/workflows/workbench/skypilot/token-factory-caption.yaml
+++ b/npa/workflows/workbench/skypilot/token-factory-caption.yaml
@@ -1,0 +1,50 @@
+# What:   Caption a folder of images with Nebius Token Factory (zero-GPU).
+# Guide:  docs/workbench/token-factory.md
+# Runner: npa workbench token-factory caption
+# Index:  npa/workflows/workbench/skypilot/README.md
+#
+# Inference is hosted by Token Factory over its OpenAI-compatible API, so this
+# job runs on CPU only. Provide the API key as a SkyPilot secret at launch:
+#   sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID \
+#     --secret AWS_SECRET_ACCESS_KEY token-factory-caption.yaml
+name: token-factory-caption
+execution: serial
+---
+name: token-factory-caption
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  # NPA_TOKEN_FACTORY_IMAGE just needs npa + httpx + pillow; the default is the
+  # first-party Workbench image with npa baked at /opt/nebius-physical-ai/npa.
+  image_id: "docker:${NPA_TOKEN_FACTORY_IMAGE}"
+envs:
+  NPA_TOKEN_FACTORY_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
+  INPUT_URI: "s3://<your-bucket-name>/token-factory/<run-id>/images/"
+  OUTPUT_URI: "s3://<your-bucket-name>/token-factory/<run-id>/captions/"
+  MODEL: "Qwen/Qwen2-VL-7B-Instruct"
+  INSTRUCTION: "Describe this image in one or two sentences. Focus on the objects, the scene, and any action taking place. Be concrete and factual."
+  MAX_IMAGES: "50"
+  MAX_TOKENS: "512"
+  # Optional override; defaults to https://api.tokenfactory.nebius.com/v1/.
+  NEBIUS_TOKEN_FACTORY_BASE_URL: ""
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  if [[ -z "${NEBIUS_API_KEY:-}" ]]; then
+    echo "NEBIUS_API_KEY is required. Pass it with: sky jobs launch --secret NEBIUS_API_KEY ..." >&2
+    exit 1
+  fi
+  npa workbench token-factory caption \
+    --input-path "${INPUT_URI}" \
+    --output-path "${OUTPUT_URI}" \
+    --model "${MODEL}" \
+    --instruction "${INSTRUCTION}" \
+    --max-images "${MAX_IMAGES}" \
+    --max-tokens "${MAX_TOKENS}" \
+    --output json

--- a/npa/workflows/workbench/skypilot/token-factory-cosmos-reason.yaml
+++ b/npa/workflows/workbench/skypilot/token-factory-cosmos-reason.yaml
@@ -1,0 +1,50 @@
+# Physical-AI scene reasoning with Nebius Token Factory (zero-GPU).
+#
+# Points nvidia/Cosmos3-Super-Reasoner (hosted by Token Factory) at scene images
+# and asks for scene understanding plus a robot plan of action. Inference is
+# hosted, so this runs on CPU only. Designed for the "walk the robot to a scene,
+# ask what to do" physical-common-sense loop. Provide the API key as a SkyPilot
+# secret at launch:
+#   sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID \
+#     --secret AWS_SECRET_ACCESS_KEY token-factory-cosmos-reason.yaml
+name: token-factory-cosmos-reason
+execution: serial
+---
+name: token-factory-cosmos-reason
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  image_id: "docker:${NPA_TOKEN_FACTORY_IMAGE}"
+envs:
+  NPA_TOKEN_FACTORY_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
+  INPUT_URI: "s3://<your-bucket-name>/token-factory/<run-id>/scene/"
+  OUTPUT_URI: "s3://<your-bucket-name>/token-factory/<run-id>/scene-reasoning/"
+  MODEL: "nvidia/Cosmos3-Super-Reasoner"
+  TASK: "Describe this scene and give a step-by-step plan of action a robot should follow to operate safely and usefully here."
+  MAX_IMAGES: "8"
+  MAX_TOKENS: "1024"
+  TEMPERATURE: "0.2"
+  # Optional override; defaults to https://api.tokenfactory.nebius.com/v1/.
+  NEBIUS_TOKEN_FACTORY_BASE_URL: ""
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  if [[ -z "${NEBIUS_API_KEY:-}" ]]; then
+    echo "NEBIUS_API_KEY is required. Pass it with: sky jobs launch --secret NEBIUS_API_KEY ..." >&2
+    exit 1
+  fi
+  npa workbench token-factory reason \
+    --input-path "${INPUT_URI}" \
+    --output-path "${OUTPUT_URI}" \
+    --model "${MODEL}" \
+    --task "${TASK}" \
+    --max-images "${MAX_IMAGES}" \
+    --max-tokens "${MAX_TOKENS}" \
+    --temperature "${TEMPERATURE}" \
+    --output json

--- a/npa/workflows/workbench/skypilot/token-factory-generate.yaml
+++ b/npa/workflows/workbench/skypilot/token-factory-generate.yaml
@@ -1,0 +1,51 @@
+# What:   Batch text generation with Nebius Token Factory (zero-GPU).
+# Guide:  docs/workbench/token-factory.md
+# Runner: npa workbench token-factory generate
+# Index:  npa/workflows/workbench/skypilot/README.md
+#
+# Reads a JSONL/text prompt file and writes one completion per prompt. Useful
+# for synthetic task instructions, scene-prompt generation for Cosmos, or sim
+# variation. Inference is hosted, so this runs on CPU only. Provide the API key
+# as a SkyPilot secret at launch:
+#   sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID \
+#     --secret AWS_SECRET_ACCESS_KEY token-factory-generate.yaml
+name: token-factory-generate
+execution: serial
+---
+name: token-factory-generate
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  image_id: "docker:${NPA_TOKEN_FACTORY_IMAGE}"
+envs:
+  NPA_TOKEN_FACTORY_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
+  INPUT_URI: "s3://<your-bucket-name>/token-factory/<run-id>/prompts.jsonl"
+  OUTPUT_URI: "s3://<your-bucket-name>/token-factory/<run-id>/generations/"
+  MODEL: "meta-llama/Llama-3.3-70B-Instruct"
+  SYSTEM_PROMPT: "You are a helpful assistant generating concise, high-quality text for a physical-AI dataset. Respond with the requested content only."
+  MAX_PROMPTS: "0"
+  MAX_TOKENS: "512"
+  TEMPERATURE: "0.7"
+  NEBIUS_TOKEN_FACTORY_BASE_URL: ""
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  if [[ -z "${NEBIUS_API_KEY:-}" ]]; then
+    echo "NEBIUS_API_KEY is required. Pass it with: sky jobs launch --secret NEBIUS_API_KEY ..." >&2
+    exit 1
+  fi
+  npa workbench token-factory generate \
+    --input-path "${INPUT_URI}" \
+    --output-path "${OUTPUT_URI}" \
+    --model "${MODEL}" \
+    --system-prompt "${SYSTEM_PROMPT}" \
+    --max-prompts "${MAX_PROMPTS}" \
+    --max-tokens "${MAX_TOKENS}" \
+    --temperature "${TEMPERATURE}" \
+    --output json

--- a/npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml
+++ b/npa/workflows/workbench/skypilot/tokenfactory-rollout-judge.yaml
@@ -1,0 +1,129 @@
+# What:   Roll out a policy on a Nebius k8s GPU, then judge it with Token Factory.
+# Guide:  docs/workbench/cookbooks/tokenfactory-compute-combos.md
+# Runner: npa workbench workflow submit (two-stage serial pipeline)
+# Index:  npa/workflows/workbench/skypilot/README.md
+#
+# A "combo" workflow: real Nebius cloud compute + hosted Token Factory inference.
+#   Stage 1 (Nebius Managed Kubernetes GPU): lerobot-eval rolls out a policy and
+#           renders rollout videos, then uploads them to S3.
+#   Stage 2 (CPU, zero-GPU): vlm-eval --backend api scores the rollout with a
+#           hosted Token Factory VLM. No local VLM serving stage is needed.
+# Provide the API key (and S3 creds) as SkyPilot secrets at launch:
+#   sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID \
+#     --secret AWS_SECRET_ACCESS_KEY tokenfactory-rollout-judge.yaml
+name: tokenfactory-rollout-judge
+execution: serial
+---
+# Stage 1: render a rollout on a Nebius Managed Kubernetes GPU.
+name: rollout-gpu
+resources:
+  cloud: kubernetes
+  accelerators: H100:1
+  cpus: 8
+  memory: 32
+  # GPU defaults to H100:1. Change resources.accelerators to L40S:1 or H200:1 to
+  # match your cluster's capacity before launch. NPA_LEROBOT_IMAGE is
+  # BYO-overridable.
+  image_id: "docker:${NPA_LEROBOT_IMAGE}"
+envs:
+  NPA_LEROBOT_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lerobot:0.5.1"
+  # Public LeRobot checkpoint + environment for an out-of-the-box smoke rollout.
+  CHECKPOINT: "lerobot/diffusion_pusht"
+  ENV_TYPE: "pusht"
+  ENV_TASK: ""
+  EPISODES: "2"
+  # Where the rendered rollout videos are written and read by the judge stage.
+  ROLLOUTS_URI: "s3://<your-bucket-name>/tokenfactory/<run-id>/rollouts/"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+setup: |
+  set -e
+run: |
+  set -euo pipefail
+  if [[ "${ROLLOUTS_URI}" != s3://* ]]; then
+    echo "ROLLOUTS_URI must be an s3:// URI" >&2
+    exit 1
+  fi
+  source /opt/lerobot/venv/bin/activate
+  if [ -f /opt/lerobot/.env ]; then set -a && source /opt/lerobot/.env && set +a; fi
+
+  rollout_dir="/tmp/npa-rollout"
+  rm -rf "${rollout_dir}"
+  env_task_arg=""
+  if [[ -n "${ENV_TASK}" ]]; then env_task_arg="--env.task=${ENV_TASK}"; fi
+
+  lerobot-eval \
+    --policy.path="${CHECKPOINT}" \
+    --env.type="${ENV_TYPE}" \
+    ${env_task_arg} \
+    --eval.n_episodes="${EPISODES}" \
+    --eval.batch_size=1 \
+    --output_dir="${rollout_dir}"
+
+  # Upload the rendered rollout (videos + eval_info.json) to S3 for the judge.
+  python3 - "${rollout_dir}" "${ROLLOUTS_URI}" <<'PY'
+  import os
+  import pathlib
+  import sys
+  from urllib.parse import urlparse
+
+  import boto3
+
+  local = pathlib.Path(sys.argv[1])
+  parsed = urlparse(sys.argv[2])
+  prefix = parsed.path.strip("/")
+  prefix = (prefix + "/") if prefix else ""
+  s3 = boto3.client(
+      "s3",
+      endpoint_url=os.environ.get("AWS_ENDPOINT_URL") or os.environ.get("NEBIUS_S3_ENDPOINT") or None,
+  )
+  uploaded = 0
+  for path in local.rglob("*"):
+      if path.is_file():
+          s3.upload_file(str(path), parsed.netloc, prefix + str(path.relative_to(local)))
+          uploaded += 1
+  print(f"NPA_ROLLOUT_UPLOADED {uploaded} files -> {sys.argv[2]}", flush=True)
+  PY
+---
+# Stage 2: judge the rollout with a hosted Token Factory VLM (zero-GPU).
+name: tokenfactory-judge
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  image_id: "docker:${NPA_TOKEN_FACTORY_IMAGE}"
+envs:
+  NPA_TOKEN_FACTORY_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
+  ROLLOUTS_URI: "s3://<your-bucket-name>/tokenfactory/<run-id>/rollouts/"
+  JUDGE_URI: "s3://<your-bucket-name>/tokenfactory/<run-id>/vlm-judge/"
+  VLM_EVAL_TASK: "sim-to-real"
+  VLM_MODEL: "Qwen/Qwen2.5-VL-72B-Instruct"
+  VLM_FRAME_SELECTION: "keyframes"
+  VLM_MAX_FRAMES: "4"
+  VLM_SUCCESS_THRESHOLD: "0.8"
+  VLM_REQUEST_TIMEOUT_S: "240"
+  # Optional override; defaults to https://api.tokenfactory.nebius.com/v1/.
+  NEBIUS_TOKEN_FACTORY_BASE_URL: ""
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  if [[ -z "${NEBIUS_API_KEY:-}" ]]; then
+    echo "NEBIUS_API_KEY is required. Pass it with: sky jobs launch --secret NEBIUS_API_KEY ..." >&2
+    exit 1
+  fi
+  npa workbench vlm-eval run \
+    --input-path "${ROLLOUTS_URI}" \
+    --output-path "${JUDGE_URI}" \
+    --task "${VLM_EVAL_TASK}" \
+    --backend api \
+    --model "${VLM_MODEL}" \
+    --api-key-env NEBIUS_API_KEY \
+    --frame-selection "${VLM_FRAME_SELECTION}" \
+    --max-frames "${VLM_MAX_FRAMES}" \
+    --success-threshold "${VLM_SUCCESS_THRESHOLD}" \
+    --timeout-s "${VLM_REQUEST_TIMEOUT_S}" \
+    --output json

--- a/npa/workflows/workbench/skypilot/tokenfactory-scene-to-rollout-judge.yaml
+++ b/npa/workflows/workbench/skypilot/tokenfactory-scene-to-rollout-judge.yaml
@@ -1,0 +1,186 @@
+# What:   Reason over a scene, roll out a policy on a Nebius k8s GPU, then judge
+#         the rollout against the reasoner's plan with Token Factory.
+# Guide:  docs/workbench/cookbooks/tokenfactory-compute-combos.md
+# Runner: npa workbench workflow submit (three-stage serial pipeline)
+# Index:  npa/workflows/workbench/skypilot/README.md
+#
+# A "combo" workflow that exercises all three layers in one pipeline:
+#   Stage 1 (CPU, zero-GPU): token-factory `reason` extracts a plan of action
+#           from scene images with nvidia/Cosmos3-Super-Reasoner.
+#   Stage 2 (Nebius Managed Kubernetes GPU): lerobot-eval rolls out a policy and
+#           uploads rollout videos to S3.
+#   Stage 3 (CPU, zero-GPU): vlm-eval --backend api judges the rollout against
+#           the Stage 1 plan with a hosted Token Factory VLM.
+# This is the hackathon "physical common-sense" loop: walk a robot to a scene,
+# ask the reasoner what to do, execute, and have a VLM grade the attempt.
+# Provide the API key (and S3 creds) as SkyPilot secrets at launch:
+#   sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID \
+#     --secret AWS_SECRET_ACCESS_KEY tokenfactory-scene-to-rollout-judge.yaml
+name: tokenfactory-scene-to-rollout-judge
+execution: serial
+---
+# Stage 1: reason over the scene images (zero-GPU, hosted Token Factory).
+name: scene-reason
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  image_id: "docker:${NPA_TOKEN_FACTORY_IMAGE}"
+envs:
+  NPA_TOKEN_FACTORY_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
+  # S3 prefix holding the scene images (jpg/png) to reason over.
+  SCENE_URI: "s3://<your-bucket-name>/tokenfactory/<run-id>/scene/"
+  # Where the reasoner's plan of action is written and read by the judge stage.
+  PLAN_URI: "s3://<your-bucket-name>/tokenfactory/<run-id>/plan/"
+  REASON_TASK: "Describe this scene and give a step-by-step plan a tabletop robot arm should follow to complete the most useful manipulation task here."
+  REASON_MODEL: "nvidia/Cosmos3-Super-Reasoner"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  if [[ -z "${NEBIUS_API_KEY:-}" ]]; then
+    echo "NEBIUS_API_KEY is required. Pass it with: sky jobs launch --secret NEBIUS_API_KEY ..." >&2
+    exit 1
+  fi
+  if [[ "${SCENE_URI}" != s3://* || "${PLAN_URI}" != s3://* ]]; then
+    echo "SCENE_URI and PLAN_URI must be s3:// URIs" >&2
+    exit 1
+  fi
+  npa workbench token-factory reason \
+    --input-path "${SCENE_URI}" \
+    --output-path "${PLAN_URI}" \
+    --task "${REASON_TASK}" \
+    --model "${REASON_MODEL}" \
+    --output json
+---
+# Stage 2: render a rollout on a Nebius Managed Kubernetes GPU.
+name: rollout-gpu
+resources:
+  cloud: kubernetes
+  accelerators: H100:1
+  cpus: 8
+  memory: 32
+  # GPU defaults to H100:1. Change resources.accelerators to L40S:1 or H200:1 to
+  # match your cluster's capacity before launch.
+  image_id: "docker:${NPA_LEROBOT_IMAGE}"
+envs:
+  NPA_LEROBOT_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lerobot:0.5.1"
+  CHECKPOINT: "lerobot/diffusion_pusht"
+  ENV_TYPE: "pusht"
+  ENV_TASK: ""
+  EPISODES: "2"
+  ROLLOUTS_URI: "s3://<your-bucket-name>/tokenfactory/<run-id>/rollouts/"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+setup: |
+  set -e
+run: |
+  set -euo pipefail
+  if [[ "${ROLLOUTS_URI}" != s3://* ]]; then
+    echo "ROLLOUTS_URI must be an s3:// URI" >&2
+    exit 1
+  fi
+  source /opt/lerobot/venv/bin/activate
+  if [ -f /opt/lerobot/.env ]; then set -a && source /opt/lerobot/.env && set +a; fi
+
+  rollout_dir="/tmp/npa-rollout"
+  rm -rf "${rollout_dir}"
+  env_task_arg=""
+  if [[ -n "${ENV_TASK}" ]]; then env_task_arg="--env.task=${ENV_TASK}"; fi
+
+  lerobot-eval \
+    --policy.path="${CHECKPOINT}" \
+    --env.type="${ENV_TYPE}" \
+    ${env_task_arg} \
+    --eval.n_episodes="${EPISODES}" \
+    --eval.batch_size=1 \
+    --output_dir="${rollout_dir}"
+
+  python3 - "${rollout_dir}" "${ROLLOUTS_URI}" <<'PY'
+  import os
+  import pathlib
+  import sys
+  from urllib.parse import urlparse
+
+  import boto3
+
+  local = pathlib.Path(sys.argv[1])
+  parsed = urlparse(sys.argv[2])
+  prefix = parsed.path.strip("/")
+  prefix = (prefix + "/") if prefix else ""
+  s3 = boto3.client(
+      "s3",
+      endpoint_url=os.environ.get("AWS_ENDPOINT_URL") or os.environ.get("NEBIUS_S3_ENDPOINT") or None,
+  )
+  uploaded = 0
+  for path in local.rglob("*"):
+      if path.is_file():
+          s3.upload_file(str(path), parsed.netloc, prefix + str(path.relative_to(local)))
+          uploaded += 1
+  print(f"NPA_ROLLOUT_UPLOADED {uploaded} files -> {sys.argv[2]}", flush=True)
+  PY
+---
+# Stage 3: judge the rollout against the Stage 1 plan (zero-GPU, hosted VLM).
+name: scene-judge
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  image_id: "docker:${NPA_TOKEN_FACTORY_IMAGE}"
+envs:
+  NPA_TOKEN_FACTORY_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
+  PLAN_URI: "s3://<your-bucket-name>/tokenfactory/<run-id>/plan/"
+  ROLLOUTS_URI: "s3://<your-bucket-name>/tokenfactory/<run-id>/rollouts/"
+  JUDGE_URI: "s3://<your-bucket-name>/tokenfactory/<run-id>/vlm-judge/"
+  VLM_MODEL: "Qwen/Qwen2.5-VL-72B-Instruct"
+  VLM_FRAME_SELECTION: "keyframes"
+  VLM_MAX_FRAMES: "4"
+  VLM_SUCCESS_THRESHOLD: "0.6"
+  VLM_REQUEST_TIMEOUT_S: "600"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  if [[ -z "${NEBIUS_API_KEY:-}" ]]; then
+    echo "NEBIUS_API_KEY is required. Pass it with: sky jobs launch --secret NEBIUS_API_KEY ..." >&2
+    exit 1
+  fi
+  # Pull the Stage 1 plan and fold it into the judge task so the VLM grades the
+  # rollout against what the reasoner actually planned.
+  plan_task="$(python3 - "${PLAN_URI%/}/scene_reasoning.json" <<'PY'
+  import json
+  import os
+  import sys
+  from urllib.parse import urlparse
+
+  import boto3
+
+  parsed = urlparse(sys.argv[1])
+  s3 = boto3.client(
+      "s3",
+      endpoint_url=os.environ.get("AWS_ENDPOINT_URL") or os.environ.get("NEBIUS_S3_ENDPOINT") or None,
+  )
+  obj = s3.get_object(Bucket=parsed.netloc, Key=parsed.path.lstrip("/"))
+  analysis = json.loads(obj["Body"].read())["analysis"].strip().replace("\n", " ")
+  print(f"Judge whether the robot rollout accomplishes this planned task. Plan: {analysis[:900]}")
+  PY
+  )"
+  npa workbench vlm-eval run \
+    --input-path "${ROLLOUTS_URI}" \
+    --output-path "${JUDGE_URI}" \
+    --task "${plan_task}" \
+    --backend api \
+    --model "${VLM_MODEL}" \
+    --api-key-env NEBIUS_API_KEY \
+    --frame-selection "${VLM_FRAME_SELECTION}" \
+    --max-frames "${VLM_MAX_FRAMES}" \
+    --success-threshold "${VLM_SUCCESS_THRESHOLD}" \
+    --timeout-s "${VLM_REQUEST_TIMEOUT_S}" \
+    --output json

--- a/npa/workflows/workbench/skypilot/vlm-eval-token-factory.yaml
+++ b/npa/workflows/workbench/skypilot/vlm-eval-token-factory.yaml
@@ -1,0 +1,58 @@
+# What:   Score a rollout with vlm-eval against Nebius Token Factory (zero-GPU).
+# Guide:  docs/workbench/token-factory.md
+# Runner: npa workbench vlm-eval run --backend api
+# Index:  npa/workflows/workbench/skypilot/README.md
+#
+# Uses the vlm-eval `api` backend, which natively defaults to Token Factory
+# (https://api.tokenfactory.nebius.com/v1/) and reads NEBIUS_API_KEY. No GPU and
+# no vLLM serving stage are needed because inference is hosted. Provide the API
+# key as a SkyPilot secret at launch:
+#   sky jobs launch --secret NEBIUS_API_KEY --secret AWS_ACCESS_KEY_ID \
+#     --secret AWS_SECRET_ACCESS_KEY vlm-eval-token-factory.yaml
+name: vlm-eval-token-factory
+execution: serial
+---
+name: vlm-eval-token-factory
+resources:
+  cloud: kubernetes
+  cpus: 4
+  memory: 16
+  image_id: "docker:${NPA_TOKEN_FACTORY_IMAGE}"
+envs:
+  NPA_TOKEN_FACTORY_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
+  EVAL_INPUT_URI: "s3://<your-bucket-name>/sim-to-real/<run-id>/rollouts/episode-000/"
+  VLM_EVAL_OUTPUT_URI: "s3://<your-bucket-name>/sim-to-real/<run-id>/vlm-eval-token-factory/"
+  VLM_EVAL_TASK: "sim-to-real"
+  VLM_BACKEND: "api"
+  VLM_MODEL: "Qwen/Qwen2-VL-7B-Instruct"
+  VLM_FRAME_SELECTION: "keyframes"
+  VLM_MAX_FRAMES: "4"
+  VLM_SUCCESS_THRESHOLD: "0.8"
+  VLM_REQUEST_TIMEOUT_S: "240"
+  # Optional override; defaults to https://api.tokenfactory.nebius.com/v1/.
+  NEBIUS_TOKEN_FACTORY_BASE_URL: ""
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
+  NPA_DRY_RUN: "0"
+setup: |
+  set -e
+  if ! command -v npa >/dev/null 2>&1 && [ -d /opt/nebius-physical-ai/npa ]; then
+    python3 -m pip install -e /opt/nebius-physical-ai/npa
+  fi
+run: |
+  set -euo pipefail
+  if [[ -z "${NEBIUS_API_KEY:-}" ]]; then
+    echo "NEBIUS_API_KEY is required. Pass it with: sky jobs launch --secret NEBIUS_API_KEY ..." >&2
+    exit 1
+  fi
+  npa workbench vlm-eval run \
+    --input-path "${EVAL_INPUT_URI}" \
+    --output-path "${VLM_EVAL_OUTPUT_URI}" \
+    --task "${VLM_EVAL_TASK}" \
+    --backend "${VLM_BACKEND}" \
+    --model "${VLM_MODEL}" \
+    --api-key-env NEBIUS_API_KEY \
+    --frame-selection "${VLM_FRAME_SELECTION}" \
+    --max-frames "${VLM_MAX_FRAMES}" \
+    --success-threshold "${VLM_SUCCESS_THRESHOLD}" \
+    --timeout-s "${VLM_REQUEST_TIMEOUT_S}" \
+    --output json

--- a/npa/workflows/workbench/skypilot/vlm-eval-token-factory.yaml
+++ b/npa/workflows/workbench/skypilot/vlm-eval-token-factory.yaml
@@ -24,7 +24,7 @@ envs:
   VLM_EVAL_OUTPUT_URI: "s3://<your-bucket-name>/sim-to-real/<run-id>/vlm-eval-token-factory/"
   VLM_EVAL_TASK: "sim-to-real"
   VLM_BACKEND: "api"
-  VLM_MODEL: "Qwen/Qwen2-VL-7B-Instruct"
+  VLM_MODEL: "Qwen/Qwen2.5-VL-72B-Instruct"
   VLM_FRAME_SELECTION: "keyframes"
   VLM_MAX_FRAMES: "4"
   VLM_SUCCESS_THRESHOLD: "0.8"


### PR DESCRIPTION
## Summary
Isolated branch for the **Nebius Token Factory** work, split out of the shared chat working tree so it doesn't conflict with the other in-flight changes. This branch contains **only** Token Factory changes.

Native, zero-GPU integration with Nebius Token Factory (OpenAI-compatible hosted inference):

- **Client** (`npa/clients/token_factory.py`): single source of truth for base URL / `NEBIUS_API_KEY` resolution, chat completions, model listing.
- **Tool** `npa workbench token-factory`: `caption` (vision), `generate` (text), `reason` (`nvidia/Cosmos3-Super-Reasoner` scene → plan), plus `models`/`verify`/`status`/`list`/`workflow`. CLI + SDK + shared impl using the standard `--input-path`/`--output-path` S3 contract.
- **vlm-eval** `api` backend now defaults to Token Factory and accepts `NEBIUS_API_KEY` (zero-GPU rollout scoring).
- **Credentials**: `NEBIUS_API_KEY` is first-class (`npa configure` prompt, `shared_credential_env`, `credentials.yaml.example`).
- **Workflows** (CPU-only): `token-factory-caption`, `token-factory-generate`, `token-factory-cosmos-reason`, `vlm-eval-token-factory`.
- **Docs/skill**: README section, Token Factory guide (register-and-use walkthrough), physical-reasoning-challenge cookbook, agent skill.

Base is `docs/workflow-navigation` because some changes (e.g. interactive `npa configure`) depend on commits on that branch, not yet on `main`.

## Test plan
- [x] `ruff check` clean on all changed source
- [x] Token-factory + cross-cutting suite: **83 passed, 3 skipped** (live e2e self-skip without a key)
- [x] **Live validation against a real Nebius Token Factory instance** (see PR comments): `verify` authenticated (34 models), `nvidia/Cosmos3-Super-Reasoner` available, `tests/e2e/test_token_factory_e2e.py` **3 passed**, and all four workflows (`reason`/`caption`/`generate`/`vlm-eval --backend api`) returned real responses. Surfaced + fixed a default-vision-model gap (`Qwen/Qwen2-VL-7B-Instruct` not served → `Qwen/Qwen2.5-VL-72B-Instruct`).
