### PR TITLE
feat(sim2real): end-to-end VLM→RL workflow — genuine signal, BYO assets, Isaac/Genesis backends, Rerun, RBAC

### DIFF
--- a/.agents/skills/workbench/isaac-lab/SKILL.md
+++ b/.agents/skills/workbench/isaac-lab/SKILL.md
@@ -53,6 +53,40 @@ The runner exposes `--image` directly. It does not expose a `--run-cmd` flag, so
 custom entrypoints should use a customer-owned YAML variant that preserves the
 runtime contract, checkpoint discovery, manifest creation, and S3 upload block.
 
+## Sim2Real Held-Out Backend
+
+Isaac Lab is also the default sim engine for the Sim2Real loop's non-VLM
+held-out rollout eval. The held-out eval is backend-pluggable:
+
+- `sim_backend=isaac` (default): the held-out rollout runs headless Isaac Sim
+  inside the Isaac Lab image as the eval component Job. It uses the Isaac Lab
+  manipulation task (`Isaac-Lift-Cube-Franka-v0` by default) for a Franka
+  pick/lift rollout.
+- `sim_backend=genesis`: the existing Genesis `FrankaPickPlaceEnv` path, kept
+  fully intact.
+
+Select with `--sim-backend`, env `NPA_SIM2REAL_SIM_BACKEND`, or the runbook
+YAML. Both backends emit the identical `npa.sim2real.heldout_eval.v1` per-env
+schema (`env_id`/`score`/`success`/`details`), so `report.json` and the
+outer-loop gate are backend-agnostic. The VLM eval (Cosmos-Reason) is unchanged.
+
+Asset handling mirrors the Genesis no-fallback provenance discipline:
+
+- Stock: the built-in Isaac lift-cube manipuland, recorded as
+  `asset_source=isaac_stock` (no sha256).
+- BYO mesh: a customer mesh/URDF imported to USD via Isaac Lab's offline
+  converters (`isaaclab.sim.converters.MeshConverter` / `UrdfConverter`),
+  recorded as `asset_source=byo_mesh` with a sha256. A mesh that fails to
+  import or load raises; there is no silent fallback to the stock asset.
+
+The Isaac Lab image bakes no `npa` code, and Isaac Sim is only importable via
+its bundled interpreter `/isaac-sim/python.sh`. The eval component injects
+branch `npa` code into that interpreter at start from an S3 source tarball
+(`NPA_SIM2REAL_SOURCE_TARBALL_URI`) or, when the repo is reachable, a git clone
+(`NPA_SOURCE_REPO`/`NPA_SOURCE_REF`), and ensures `boto3` for the S3 client.
+
+Architecture + licensing rationale: `docs/architecture/sim-backend-selection.md`.
+
 ## Operational Safety
 
 Managed VM `deploy` defaults to in-place updates for existing aliases. Terraform

--- a/docs/architecture/sim-backend-selection.md
+++ b/docs/architecture/sim-backend-selection.md
@@ -60,6 +60,49 @@ task scene. Every object records `{asset_source, sha256, loaded}`, and a
 requested mesh that fails to import or load raises rather than substituting the
 stock asset. This proves the customer asset was actually exercised.
 
+## Robot embodiment (BYO arm, not just BYO object)
+
+The robot is described by a simulator-agnostic `RobotSpec`
+(`npa.genesis.robot_assets`), a sibling of `SceneSpec`. It selects a
+`robot_source`:
+
+| `robot_source`    | Meaning                                              |
+| ----------------- | ---------------------------------------------------- |
+| `stock_franka`    | Default. Genesis built-in Franka Panda MJCF.         |
+| `byo_urdf`        | Customer arm as a URDF (+ meshes), downloaded + hashed. |
+| `byo_mjcf`        | Customer arm as MuJoCo MJCF (Genesis only).          |
+| `byo_usd`         | Customer arm as USD (Isaac only).                    |
+| `genesis_builtin` | An articulated robot shipped in the Genesis assets tree. |
+
+Selection points (all alongside the object SceneSpec):
+
+- CLI: `--robot-preset {franka|ur5e|ur10e|flexiv}`, `--robot-spec-uri <RobotSpec JSON>`,
+  or `--robot-source <source>`
+- env: `ROBOT_PRESET` / `ROBOT_SPEC_URI` / `ROBOT_SOURCE`
+  (threaded into the component as `NPA_SIM2REAL_ROBOT_*`)
+
+Presets ship for Franka (the current values, byte-for-byte), Universal
+Robots UR5e/UR10e (6-DOF, `tool0` end-effector, no integrated gripper), and
+Flexiv Rizon (7-DOF, `flange` end-effector). A customer can pick a preset or
+supply a full URDF plus a minimal `RobotSpec` JSON (end-effector link name,
+DOF count, gains, force ranges, home pose). The env's cached links, PD gains,
+force ranges, home pose, and the IK end-effector link all come from the
+`RobotSpec`; the no-spec / `stock_franka` path reproduces today's Franka
+behavior exactly.
+
+**The robot must be an articulated description (URDF / MJCF / USD).** UR and
+Flexiv publish these. A plain visual mesh (`.obj` / `.glb` / `.stl` / `.ply`)
+is only valid for a manipulated *object*, never the robot — supplying one as
+the robot raises a clear error. A BYO robot that fails to download, validate,
+or load raises rather than silently falling back to Franka, and the robot
+provenance (`{robot_source, robot_uri, sha256, loaded, robot_fallback_used}`)
+is written into `report.json` so a run can prove the customer arm was loaded.
+
+Gripper control for the UR/Flexiv presets is a follow-up: their published
+URDFs ship without an integrated gripper, so those presets run gripperless
+(the gripper action channel is ignored) until a customer attaches and
+configures one.
+
 ## Code injection into the Isaac image
 
 The Isaac Lab image ships Isaac Sim + Isaac Lab only under its bundled

--- a/docs/architecture/sim-backend-selection.md
+++ b/docs/architecture/sim-backend-selection.md
@@ -1,0 +1,84 @@
+# Sim2Real Held-Out Eval: Pluggable Sim Backend (genesis | isaac)
+
+The Sim2Real loop's non-VLM held-out evaluation runs a robot manipulation
+rollout to produce deterministic per-environment metrics that gate the outer
+loop. That rollout engine is pluggable behind a single backend selector so the
+same loop can run on either of two simulators without changing the report
+schema or the gate.
+
+## Backends
+
+- **`genesis`** — the Genesis `FrankaPickPlaceEnv` pick-and-place rollout. This
+  is the original, fully-supported path and remains unchanged.
+- **`isaac`** (default) — a headless Isaac Sim / Isaac Lab rollout using a
+  Franka manipulation task (lift-cube by default). Requires RT-core GPUs
+  (L40S / RTX Pro class); it will not run correctly on datacenter GPUs without
+  RT cores.
+
+Selection points (all map to the same config field):
+
+- CLI flag `--sim-backend genesis|isaac`
+- env `NPA_SIM2REAL_SIM_BACKEND`
+- runbook YAML `NPA_SIM2REAL_SIM_BACKEND`
+
+## Why a selector instead of replacing Genesis
+
+The two simulators have different strengths and different licensing profiles
+(below). Teams that want NVIDIA's manipulation/USD ecosystem run `isaac`; teams
+that want an unrestricted, lightweight default run `genesis`. Keeping both
+behind one selector means the rest of the loop — VLM eval (Cosmos-Reason),
+signal conversion, training, the threshold gate, and `report.json` — is
+backend-agnostic.
+
+## Schema parity (the contract)
+
+Both backends emit the identical `npa.sim2real.heldout_eval.v1` report:
+
+```
+per_env: [ { env_id, score, success, details{ final_target_distance,
+             max_reward, steps, ... } }, ... ]
+```
+
+Plus a `sim_backend` field and the shared asset-provenance block. The
+outer-loop threshold gate consumes only this schema, so swapping backends never
+changes downstream behavior. Only the rollout engine differs; the VLM eval is
+untouched.
+
+## Assets and provenance (no silent fallback)
+
+Both backends reuse the same simulator-agnostic `SceneSpec` and the same
+no-fallback provenance discipline:
+
+| Path        | Genesis `asset_source`          | Isaac `asset_source` |
+| ----------- | ------------------------------- | -------------------- |
+| Stock       | `primitive` / `genesis_builtin` | `isaac_stock`        |
+| Custom mesh | `byo_mesh` (+ sha256)           | `byo_mesh` (+ sha256)|
+
+For the Isaac backend, a custom mesh/URDF is imported to USD offline with Isaac
+Lab's converters (`MeshConverter` / `UrdfConverter`) and then loaded into the
+task scene. Every object records `{asset_source, sha256, loaded}`, and a
+requested mesh that fails to import or load raises rather than substituting the
+stock asset. This proves the customer asset was actually exercised.
+
+## Code injection into the Isaac image
+
+The Isaac Lab image ships Isaac Sim + Isaac Lab only under its bundled
+interpreter and bakes no workbench code. The held-out eval component therefore
+injects the branch's workbench code into that interpreter at container start —
+from an object-storage source tarball (using the pod's mounted storage
+credentials) or, when the source repo is reachable, a shallow git clone — and
+ensures the storage client dependency is present. This keeps the simulator
+image generic and lets any branch run without rebuilding it.
+
+## Licensing reality
+
+- **Isaac Sim / Isaac Lab** are free for internal R&D and for customers running
+  their own training and simulation. The NVIDIA AI Enterprise license is
+  triggered by *delivering Isaac Sim as a hosted service / redistributing it*,
+  **not** by importing custom assets or running customer simulations. Bringing
+  your own meshes is a normal, unrestricted use.
+- **Genesis** is Apache-2.0 with no service restriction, which is why it is the
+  unrestricted default option for teams that do not need the NVIDIA ecosystem.
+
+When packaging either backend for customers, the line to watch is hosted-service
+redistribution of Isaac Sim, not asset or workload content.

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -1,0 +1,254 @@
+# Sim-to-Real VLM→RL Workflow — Step-by-Step User Guide
+
+This is the hands-on guide for the sim-to-real workflow: a closed loop that
+generates simulation rollouts, scores them with a vision-language model (VLM),
+turns the critique into a reinforcement-learning signal, updates a policy,
+evaluates on held-out environments, and emits Rerun observability — all on
+Nebius GPUs via one SkyPilot workflow.
+
+It is written so you can (1) run it in minutes, (2) edit it safely with an AI
+agent, and (3) plug in your own LeRobot-based training container.
+
+- Workflow file: `npa/workflows/workbench/sim2real/runbook.yaml`
+- Reference: `npa/workflows/workbench/sim2real/README.md`
+- CLI: `npa workbench sim2real run`
+
+---
+
+## 0. What you need (only three credentials)
+
+This workflow needs **exactly three** credential sources — nothing else:
+
+| Credential | Where it goes | Used for |
+| --- | --- | --- |
+| **Hugging Face token** (`HF_TOKEN`) | `~/.npa/credentials.yaml` → `tokens.HF_TOKEN` | dataset + gated model pulls |
+| **NGC API key** | `~/.npa/credentials.yaml` → `ngc.api_key` | NVIDIA container/base pulls |
+| **Nebius credentials** | Nebius CLI profile + `~/.npa/credentials.yaml` → `storage.*` (S3 keys) | cluster + S3 |
+
+Non-secret machine config (project/region/registry/bucket) lives in
+`~/.npa/config.yaml`. You do **not** need a Token Factory `NEBIUS_API_KEY` for
+this workflow — the VLM step runs the genuine Cosmos-Reason image on the
+cluster, not a hosted API.
+
+```bash
+nebius profile create
+npa configure        # interactive; writes ~/.npa/credentials.yaml
+```
+
+---
+
+## 1. Prove it locally (no cloud, no GPU)
+
+Before spending GPU, validate the pipeline shape offline:
+
+```bash
+npa/.venv/bin/python -m npa.workflows.sim2real_loop full-loop \
+  --run-id local-smoke --output-dir /tmp/s2r-smoke \
+  --inner-iterations 1 --rollout-count 2 --heldout-env-count 2
+```
+
+This runs the loop's CPU stages and writes artifacts under `/tmp/s2r-smoke`
+without touching the cluster. Inspect `reports/` and `inner_loop/.../evidence.json`.
+
+---
+
+## 2. Preflight the cluster
+
+The preflight catches the recurring blockers (S3, image pull, tokens, kube
+context, GPU count) up front:
+
+```bash
+npa workbench health sim2real \
+  --s3-bucket <your-bucket> \
+  --s3-endpoint <your-s3-endpoint> \
+  --k8s-context <your-cluster-context> \
+  --k8s-kubeconfig ~/.npa/clusters/<your-cluster>/kubeconfig
+```
+
+All checks should report PASS (an optional `config` WARN for unset
+`assets_uri`/`scene_spec_uri` is fine — those default to a documented stub).
+
+---
+
+## 3. Run the workflow
+
+```bash
+npa workbench sim2real run \
+  --run-id pusht-demo \
+  --s3-bucket <your-bucket> \
+  --s3-prefix sim2real \
+  --s3-endpoint <your-s3-endpoint> \
+  --trigger-dataset-id lerobot/pusht \
+  --sim-backend genesis \
+  --inner-iterations 2 --outer-iterations 1 \
+  --rollout-count 3 --steps-per-rollout 4 --heldout-env-count 8 \
+  --upload-artifacts
+```
+
+What you get back: a task-success / held-out report, an RL-signal diversity
+block, image-digest provenance proving the genuine VLM/eval images ran, and a
+Rerun recording (see §6). Outputs land under `s3://<your-bucket>/sim2real/<run-id>/`.
+
+> **Trigger on new data instead of running manually:** drop a LeRobot dataset at
+> a watched S3 prefix and let the trigger launch the run:
+> `npa workbench trigger watch --s3-bucket <your-bucket> --s3-prefix <trigger-prefix> ...`
+
+---
+
+## 4. Specify a custom LeRobot container
+
+The trainer step is a swappable seam. You can bring a container that builds on
+LeRobot in **two ways**, both pure flags — no change to NPA:
+
+### Option A — swap the trainer *image* (runs as a sibling K8s job)
+
+```bash
+npa workbench sim2real run ... \
+  --trainer-image <your-registry>/<your-lerobot-trainer>:<tag>
+```
+
+### Option B — swap the trainer *command* (runs in-process in your base image)
+
+```bash
+npa workbench sim2real run ... \
+  --byo-trainer-command "python -m your_pkg.train_from_vlm_signal"
+```
+
+**The contract your container/command must honor** (this is all it needs to do):
+
+1. Read the VLM→RL signal batch from the path in `NPA_SIM2REAL_SIGNAL_JSON`
+   (schema `npa.sim2real.rl_signal.v1`: per-step `reward`, `advantage`, and an
+   action-delta `target`).
+2. Run one training update on your LeRobot policy. The documented integration
+   point is right after the policy forward pass and before `optimizer.step()`:
+   `loss = imitation_loss + signal_loss_weight·corrective_mse − advantage·policy_logit_proxy`.
+3. Write the result JSON to the path in `NPA_SIM2REAL_OUTPUT_JSON` with at least:
+   `reward_head_after` (float), `policy_output_after` (list of floats),
+   `policy_delta_l2` (float); optional `loss_before` / `loss_after`.
+
+If your command fails or writes a non-conforming/empty result, the run **fails
+loudly** — it never silently falls back to the reference trainer, so a green run
+means your container actually ran. The run records `trainer_source=byo_command`
+(or `byo_image`) in the evidence so you can prove it.
+
+> Minimal example of a BYO trainer command:
+> ```bash
+> --byo-trainer-command 'python - <<PY
+> import json, os
+> sig = json.load(open(os.environ["NPA_SIM2REAL_SIGNAL_JSON"]))
+> # ... your LeRobot update here, using sig["signals"] ...
+> json.dump({"reward_head_after": 0.51, "policy_output_after": [0.01, 0.0, 0.0],
+>            "policy_delta_l2": 0.004}, open(os.environ["NPA_SIM2REAL_OUTPUT_JSON"], "w"))
+> PY'
+> ```
+
+You can swap the **signal converter** the same way with `--byo-signal-converter`
+(reads `NPA_SIM2REAL_EVALUATION_JSON`, writes an `rl_signal.v1` JSON).
+
+---
+
+## 5. Edit the workflow with an AI agent
+
+The workflow is plain YAML (`runbook.yaml`) plus one shared Python implementation
+(`sim2real_loop.py`), which makes it agent-editable. To change it safely with a
+Cursor/Claude agent:
+
+1. **Point the agent at the right files and skill.** Ask it to load the
+   `workflow-authoring` and `sim-to-real` skills, then edit
+   `npa/workflows/workbench/sim2real/runbook.yaml` (knobs/envs) and/or
+   `npa/src/npa/workflows/sim2real_loop.py` (behavior).
+2. **Describe the change as config when possible.** Most adjustments are env
+   values in the runbook `envs:` block — scale (`INNER_ITERATIONS`,
+   `ROLLOUT_COUNT`, `HELDOUT_ENV_COUNT`), images (`VLM_IMAGE`, `EVAL_IMAGE`,
+   `TRAINER_IMAGE`), backend (`--sim-backend genesis|isaac`), thresholds
+   (`SUCCESS_THRESHOLD`), and the BYO seams (`BYO_TRAINER_COMMAND`,
+   `BYO_SIGNAL_CONVERTER`, `BYO_RERUN_COMMAND`). Editing a value rarely needs
+   code changes.
+3. **Tell the agent the guardrails** (so it doesn't break the run):
+   - SkyPilot 0.12.2 does **not** interpolate `${VAR}` inside the YAML `envs:`
+     block — materialize literals or expand in the `run:` block.
+   - Keep credentials out of the YAML; never hardcode project/registry/bucket
+     IDs (they are configuration).
+   - Reach GPUs via the direct-Kubernetes route, not `sky jobs launch`.
+4. **Have the agent validate before you run:**
+   ```bash
+   npa/.venv/bin/python -m pytest npa/tests/workflows/test_sim2real_loop.py -q
+   npa workbench health sim2real --checks config,coherence   # infra-free
+   ```
+   Then a `--mock`/local smoke (§1), then a small cluster run.
+
+A good prompt: *"Load the sim-to-real and workflow-authoring skills. In
+`runbook.yaml`, add a second outer iteration and raise held-out envs to 16, keep
+all images and credentials as config, then run the unit tests and the infra-free
+preflight and show me the diff."*
+
+---
+
+## 6. Rerun observability
+
+The loop emits a Rerun recording after the run:
+
+```text
+s3://<your-bucket>/sim2real/<run-id>/reports/sim2real.rrd
+```
+
+It logs rollout camera frames, per-rollout VLM critique + score overlays, the
+per-step reward/advantage timeseries, and held-out per-env scores. View it:
+
+```bash
+pip install rerun-sdk
+rerun /path/to/sim2real.rrd
+```
+
+Toggle with `--rerun/--no-rerun` (default on) or `NPA_SIM2REAL_RERUN=0`; swap the
+emitter with `--byo-rerun-command`.
+
+---
+
+## 7. Custom simulation assets and robots
+
+- **Objects** (e.g. parts to sort): upload a mesh (`.obj`, `.stl`, `.glb`,
+  `.ply`, `.usd`) and point `--assets-uri` / a SceneSpec at it. The mesh loads
+  into the sim with content-hash provenance and no silent fallback.
+- **Robot embodiment**: use the built-in Franka, or bring your own arm
+  (Universal Robots / Flexiv) as an **articulated** description (URDF / MJCF /
+  USD — a plain CAD/OBJ mesh has no joints and is only valid for *objects*, not
+  the robot). Presets exist for Franka, UR, and Flexiv.
+- **Engines**: `--sim-backend genesis` (default, no extra licensing) or
+  `--sim-backend isaac` (Isaac Sim/Lab; runs on RT-core GPUs such as RTX PRO
+  6000). Both support stock and custom assets.
+
+---
+
+## 8. Anticipated questions
+
+**Do I need a Token Factory `NEBIUS_API_KEY`?** No. This workflow needs only HF,
+NGC, and Nebius credentials. The VLM step runs the genuine Cosmos-Reason image on
+the cluster.
+
+**Genesis or Isaac?** Genesis is the default and has no service-delivery
+licensing concern. Use Isaac (`--sim-backend isaac`) if you need Isaac Sim
+parity; it requires RT-core GPUs (L40S / RTX PRO 6000), not H100/H200.
+
+**My held-out scores come back low / 0 — is it broken?** Expected for an
+untrained or reference policy on novel geometry. The workflow proves the
+*signal* is genuine (diverse, coherent, non-degenerate) and the assets/images
+actually loaded — not that an out-of-the-box policy succeeds. Train more
+iterations or plug in your own trainer (§4).
+
+**How do I confirm the genuine images really ran?** Check
+`component_invocation.image_digests` (resolved pod image digest) and
+`signal_diversity.coherent=true` in the run artifacts. Empty digests or a
+degenerate signal fail the anti-hollow gate.
+
+**Small metal parts (e.g. nails) — will the sim be accurate?** Thin-body
+contact is physically hard in any simulator; provide real dimensions, units, and
+mass/material for best fidelity. This is the limiting factor, not asset format.
+
+**My custom trainer ran but the run failed — why?** Your command must write a
+conforming JSON to `NPA_SIM2REAL_OUTPUT_JSON` (§4). A missing/empty/invalid
+result fails the run on purpose (no silent fallback).
+
+**`sky check` shows 403 / "anonymous" / missing context.** Pin the kube context:
+`export KUBECONFIG=~/.npa/clusters/<cluster>/kubeconfig` and pass
+`--k8s-context <cluster>`; refresh Nebius credentials if the token expired.

--- a/npa/src/npa/__init__.py
+++ b/npa/src/npa/__init__.py
@@ -7,7 +7,7 @@ the public API reaches v1 stability.
 
 from __future__ import annotations
 
-from npa import convert, demo, errors, network, rerun, workflow, workbench
+import os as _os
 
 __all__ = [
     "convert",
@@ -18,3 +18,15 @@ __all__ = [
     "workflow",
     "workbench",
 ]
+
+# Opt-in light import for minimal interpreters (e.g. the Isaac Lab held-out
+# eval image, which lacks the full npa dependency set such as pyarrow / lancedb
+# / fiftyone). When NPA_SKIP_EAGER_IMPORTS is set, the SDK convenience
+# submodules are not eagerly imported; ``import npa.<submodule>`` still works on
+# demand. Default behavior (flag unset) eagerly imports the SDK surface.
+if _os.environ.get("NPA_SKIP_EAGER_IMPORTS", "").strip().lower() not in (
+    "1",
+    "true",
+    "yes",
+):
+    from npa import convert, demo, errors, network, rerun, workflow, workbench

--- a/npa/src/npa/cli/cluster/terraform_lifecycle.py
+++ b/npa/src/npa/cli/cluster/terraform_lifecycle.py
@@ -190,10 +190,25 @@ def _require_bin(binary: str) -> str:
 
 def _terraform_env(nebius_bin: str) -> dict[str, str]:
     env = os.environ.copy()
-    if not env.get("TF_VAR_iam_token"):
-        token = _run_capture([nebius_bin, "iam", "get-access-token"], env=env).stdout.strip()
-        env["TF_VAR_iam_token"] = token
-        env["NEBIUS_IAM_TOKEN"] = token
+    # A stale ambient IAM token (e.g. a cloud-env token) silently shadows the
+    # intended Nebius profile and mints kubeconfig/registry credentials for the
+    # wrong principal -- the cause of Forbidden jobs/pods/nodes and 401 image
+    # pulls. Mint a fresh token by default after clearing any stale token; opt
+    # back into reuse only when NPA_REUSE_IAM_TOKEN is explicitly set (e.g. CI
+    # that injects a short-lived token intentionally).
+    reuse = env.get("NPA_REUSE_IAM_TOKEN", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if reuse and env.get("TF_VAR_iam_token"):
+        return env
+    env.pop("TF_VAR_iam_token", None)
+    env.pop("NEBIUS_IAM_TOKEN", None)
+    token = _run_capture([nebius_bin, "iam", "get-access-token"], env=env).stdout.strip()
+    env["TF_VAR_iam_token"] = token
+    env["NEBIUS_IAM_TOKEN"] = token
     return env
 
 

--- a/npa/src/npa/cli/skypilot/__init__.py
+++ b/npa/src/npa/cli/skypilot/__init__.py
@@ -139,6 +139,23 @@ def verify_cmd(
         "--path",
         help=f"SkyPilot venv path. Defaults to {VENV_PATH_ENV} or ~/.npa/skypilot-venv.",
     ),
+    kubeconfig: Path | None = typer.Option(
+        None,
+        "--kubeconfig",
+        help=(
+            "Kubeconfig to verify against. Sets KUBECONFIG for `sky check` so "
+            "verify does not silently run against an ambient/empty context and "
+            "report a misleading 403 anonymous 'missing context'."
+        ),
+    ),
+    cluster: str | None = typer.Option(
+        None,
+        "--cluster",
+        help=(
+            "NPA cluster name. Resolves ~/.npa/clusters/<name>/kubeconfig when "
+            "--kubeconfig is not given."
+        ),
+    ),
 ) -> None:
     """Run `sky check` against the isolated SkyPilot runtime."""
 
@@ -148,12 +165,40 @@ def verify_cmd(
         _fail(f"SkyPilot {SKYPILOT_VERSION} is not ready in {state.path}: {detail}. Run `npa skypilot bootstrap`.")
         return
 
-    result = _run_no_raise([str(state.sky_bin), "check"])
+    check_env = _verify_kube_env(kubeconfig=kubeconfig, cluster=cluster)
+    result = _run_no_raise([str(state.sky_bin), "check"], env=check_env)
     if result.stdout:
         typer.echo(result.stdout.rstrip())
     if result.stderr:
         console.print(result.stderr.rstrip())
     raise typer.Exit(result.returncode)
+
+
+def _verify_kube_env(
+    *, kubeconfig: Path | None, cluster: str | None
+) -> dict[str, str] | None:
+    """Build the env for `sky check`, pinning KUBECONFIG when known.
+
+    Without an explicit kubeconfig/cluster the behavior is unchanged (inherits
+    the ambient environment).
+    """
+
+    resolved = kubeconfig
+    if resolved is None and cluster:
+        from npa.cluster.state import kubeconfig_file
+
+        resolved = kubeconfig_file(cluster)
+    if resolved is None:
+        return None
+    resolved = resolved.expanduser()
+    if not resolved.exists():
+        _fail(
+            f"Kubeconfig not found: {resolved}. Run `npa cluster up`/`deploy` first "
+            "or pass an explicit --kubeconfig."
+        )
+    env = os.environ.copy()
+    env["KUBECONFIG"] = str(resolved)
+    return env
 
 
 def bootstrap_skypilot(
@@ -340,9 +385,13 @@ def _sky_importable(python_bin: Path) -> bool:
     return result.returncode == 0
 
 
-def _run_no_raise(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+def _run_no_raise(
+    cmd: list[str], *, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=False, env=env
+        )
     except FileNotFoundError as exc:
         return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
     except OSError as exc:

--- a/npa/src/npa/cli/workbench/sim2real.py
+++ b/npa/src/npa/cli/workbench/sim2real.py
@@ -79,6 +79,19 @@ def run_command(
     ),
     vlm_image: str = typer.Option("", "--vlm-image", help="BYO VLM image."),
     eval_image: str = typer.Option("", "--eval-image", help="BYO held-out eval image."),
+    isaac_image: str = typer.Option(
+        "", "--isaac-image", help="Isaac Lab held-out rollout image (Isaac Sim headless)."
+    ),
+    sim_backend: str = typer.Option(
+        "isaac",
+        "--sim-backend",
+        help="Held-out sim backend: 'isaac' (default) or 'genesis'.",
+    ),
+    isaac_task: str = typer.Option(
+        "Isaac-Lift-Cube-Franka-v0",
+        "--isaac-task",
+        help="Isaac Lab manipulation task id for the stock held-out rollout.",
+    ),
     vlm_model: str = typer.Option(
         "nvidia/Cosmos-Reason1-7B", "--vlm-model", help="VLM model id/name."
     ),
@@ -188,6 +201,9 @@ def run_command(
         trainer_image=trainer_image,
         vlm_image=vlm_image,
         eval_image=eval_image,
+        isaac_image=isaac_image,
+        sim_backend=sim_backend,
+        isaac_task=isaac_task,
         vlm_model=vlm_model,
         threshold=threshold,
         inner_iterations=inner_iterations,

--- a/npa/src/npa/cli/workbench/sim2real.py
+++ b/npa/src/npa/cli/workbench/sim2real.py
@@ -70,6 +70,19 @@ def run_command(
     scene_spec_uri: str = typer.Option(
         "", "--scene-spec-uri", help="BYO SceneSpec URI."
     ),
+    robot_spec_uri: str = typer.Option(
+        "", "--robot-spec-uri", help="BYO RobotSpec JSON URI (robot embodiment)."
+    ),
+    robot_source: str = typer.Option(
+        "",
+        "--robot-source",
+        help="BYO robot source: stock_franka/byo_urdf/byo_mjcf/byo_usd/genesis_builtin.",
+    ),
+    robot_preset: str = typer.Option(
+        "",
+        "--robot-preset",
+        help="Built-in robot preset: franka/ur5e/ur10e/flexiv.",
+    ),
     augment_image: str = typer.Option(
         "", "--augment-image", help="BYO augmentation image."
     ),
@@ -196,6 +209,9 @@ def run_command(
         heldout_envs_uri=heldout_envs_uri,
         assets_uri=assets_uri,
         scene_spec_uri=scene_spec_uri,
+        robot_spec_uri=robot_spec_uri,
+        robot_source=robot_source,
+        robot_preset=robot_preset,
         augment_image=augment_image,
         policy_image=policy_image,
         trainer_image=trainer_image,

--- a/npa/src/npa/genesis/env_pick_place.py
+++ b/npa/src/npa/genesis/env_pick_place.py
@@ -348,19 +348,24 @@ class FrankaPickPlaceEnv:
             return entity
 
         source = spec.robot_source
+        # Preserve the configured end-effector + finger links even when they are
+        # attached by a fixed joint (the UR `tool0` / Flexiv `flange` convention).
+        # Genesis merges fixed-joint links into their parent by default, which
+        # would hide the IK/ee link; ``links_to_keep`` keeps them resolvable.
+        links_to_keep = [name for name in (spec.ee_link, *spec.finger_links) if name]
         if source in (ROBOT_SOURCE_BYO_URDF, ROBOT_SOURCE_GENESIS_BUILTIN):
             if not spec.local_path:
                 raise RobotSpecError(
                     f"robot {spec.name!r} ({source}) has no resolved local_path; "
                     "the robot asset must be downloaded/resolved before building"
                 )
-            morph = gs.morphs.URDF(file=spec.local_path, fixed=True)
+            morph = self._urdf_morph(gs, spec.local_path, links_to_keep)
         elif source == ROBOT_SOURCE_BYO_MJCF:
             if not spec.local_path:
                 raise RobotSpecError(
                     f"robot {spec.name!r} ({source}) has no resolved local_path"
                 )
-            morph = gs.morphs.MJCF(file=spec.local_path)
+            morph = self._mjcf_morph(gs, spec.local_path, links_to_keep)
         elif source == ROBOT_SOURCE_BYO_USD:
             # Genesis loads robots from URDF/MJCF, not USD. USD robots are an
             # Isaac-backend capability; fail loudly rather than silently using
@@ -383,6 +388,27 @@ class FrankaPickPlaceEnv:
         spec.loaded = True
         self.robot_provenance = spec.provenance()
         return entity
+
+    @staticmethod
+    def _urdf_morph(gs: Any, file: str, links_to_keep: list[str]) -> Any:
+        """Build a URDF morph, keeping named fixed links when supported.
+
+        ``links_to_keep`` is a Genesis convenience for preserving fixed-joint
+        links (e.g. a tool flange) so they stay resolvable for IK/contacts.
+        Falls back gracefully on Genesis builds that lack the kwarg.
+        """
+
+        try:
+            return gs.morphs.URDF(file=file, fixed=True, links_to_keep=links_to_keep)
+        except TypeError:
+            return gs.morphs.URDF(file=file, fixed=True)
+
+    @staticmethod
+    def _mjcf_morph(gs: Any, file: str, links_to_keep: list[str]) -> Any:
+        try:
+            return gs.morphs.MJCF(file=file, links_to_keep=links_to_keep)
+        except TypeError:
+            return gs.morphs.MJCF(file=file)
 
     def _build_scene_objects(self, gs: Any, spec: SceneSpec) -> Any:
         """Add every SceneSpec object; return the manipuland entity.

--- a/npa/src/npa/genesis/env_pick_place.py
+++ b/npa/src/npa/genesis/env_pick_place.py
@@ -19,6 +19,16 @@ from typing import Any
 import numpy as np
 import torch
 
+from npa.genesis.scene_assets import (
+    PRIMITIVE_BOX,
+    PRIMITIVE_CYLINDER,
+    PRIMITIVE_SPHERE,
+    ROLE_MANIPULAND,
+    ObjectSpec,
+    SceneSpec,
+    SceneSpecError,
+)
+
 
 @dataclass
 class EnvConfig:
@@ -48,6 +58,10 @@ class EnvConfig:
     # Target zone
     target_pos: tuple[float, float, float] = (0.5, 0.3, 0.04)
     target_threshold: float = 0.05
+    # BYO scene: when set, the manipulated object(s) are built from this parsed
+    # SceneSpec (mesh / primitive) instead of the hardcoded red Box. When None,
+    # the default Franka + red-Box scene is reproduced exactly.
+    scene_spec: SceneSpec | None = None
     # Domain randomization ranges
     cube_pos_noise: float = 0.1
     friction_range: tuple[float, float] = (0.3, 1.2)
@@ -69,6 +83,22 @@ class EnvConfig:
 
 # Franka Panda home joint configuration (ready pose)
 FRANKA_HOME = [0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785, 0.04, 0.04]
+
+
+def _euler_deg_to_quat_wxyz(
+    euler_deg: tuple[float, float, float],
+) -> tuple[float, float, float, float]:
+    """Convert extrinsic x-y-z Euler degrees to a (w, x, y, z) quaternion."""
+
+    rx, ry, rz = (np.deg2rad(float(a)) for a in euler_deg)
+    cx, sx = np.cos(rx / 2.0), np.sin(rx / 2.0)
+    cy, sy = np.cos(ry / 2.0), np.sin(ry / 2.0)
+    cz, sz = np.cos(rz / 2.0), np.sin(rz / 2.0)
+    w = cx * cy * cz + sx * sy * sz
+    x = sx * cy * cz - cx * sy * sz
+    y = cx * sy * cz + sx * cy * sz
+    z = cx * cy * sz - sx * sy * cz
+    return (float(w), float(x), float(y), float(z))
 
 
 class FrankaPickPlaceEnv:
@@ -107,6 +137,14 @@ class FrankaPickPlaceEnv:
         else:
             self._n_actions = 8  # delta joints (7) + gripper (1)
 
+        # When a BYO SceneSpec is supplied, derive the manipuland init pose,
+        # primitive cube size, and target zone from it so the existing reset /
+        # reward / success logic operates on the spec's manipulated object.
+        self._manip_quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+        self.scene_provenance: dict[str, Any] | None = None
+        if self.cfg.scene_spec is not None:
+            self._apply_scene_spec(self.cfg.scene_spec)
+
         self._step_count: torch.Tensor | None = None
         self._scene = None
         self._robot = None
@@ -129,8 +167,20 @@ class FrankaPickPlaceEnv:
                 3, device=self.device, dtype=torch.float32,
             ).unsqueeze(0)  # (1, 3, 3) — broadcasts over n_envs
 
+    def _apply_scene_spec(self, spec: SceneSpec) -> None:
+        """Derive cube/target config from a BYO SceneSpec before building."""
+
+        manip = spec.manipuland()
+        self.cfg.cube_init_pos = tuple(manip.pos)
+        self._manip_quat = _euler_deg_to_quat_wxyz(manip.euler)
+        if manip.asset_source == "primitive" and manip.primitive == PRIMITIVE_BOX:
+            # Keep the scalar cube_size contract in sync for the primitive path.
+            self.cfg.cube_size = float(manip.size[0])
+        self.cfg.target_pos = tuple(spec.goal_pos)
+        self.cfg.target_threshold = float(spec.goal_threshold)
+
     def _build_scene(self) -> None:
-        """Construct the Genesis scene with robot, cube, cameras."""
+        """Construct the Genesis scene with robot, manipulated object, cameras."""
         import genesis as gs
 
         if not gs._initialized:
@@ -166,14 +216,24 @@ class FrankaPickPlaceEnv:
             ),
         )
 
-        # Cube to pick and place
-        self._cube = self._scene.add_entity(
-            gs.morphs.Box(
-                size=(self.cfg.cube_size, self.cfg.cube_size, self.cfg.cube_size),
-                pos=self.cfg.cube_init_pos,
-            ),
-            surface=gs.surfaces.Rough(color=(1.0, 0.0, 0.0)),
-        )
+        if self.cfg.scene_spec is not None:
+            # BYO scene: build each object from the parsed SceneSpec. The
+            # manipuland entity replaces self._cube so all downstream reset /
+            # reward / contact / success logic operates on it unchanged.
+            self._cube = self._build_scene_objects(gs, self.cfg.scene_spec)
+        else:
+            # Default scene (unchanged): a 4cm red Box primitive.
+            self._cube = self._scene.add_entity(
+                gs.morphs.Box(
+                    size=(
+                        self.cfg.cube_size,
+                        self.cfg.cube_size,
+                        self.cfg.cube_size,
+                    ),
+                    pos=self.cfg.cube_init_pos,
+                ),
+                surface=gs.surfaces.Rough(color=(1.0, 0.0, 0.0)),
+            )
 
         # Cameras (only if needed — rendering slows simulation significantly)
         if self.cfg.enable_cameras:
@@ -220,6 +280,74 @@ class FrankaPickPlaceEnv:
             FRANKA_HOME, device=self.device, dtype=torch.float32,
         )
 
+    def _build_scene_objects(self, gs: Any, spec: SceneSpec) -> Any:
+        """Add every SceneSpec object; return the manipuland entity.
+
+        Records per-object provenance (loaded=true once add_entity succeeds)
+        and a scene-level asset_fallback_used flag. A requested mesh that fails
+        to load raises SceneSpecError — there is NO silent primitive fallback.
+        """
+
+        manipuland_entity = None
+        for obj in spec.objects:
+            entity = self._add_object_entity(gs, obj)
+            if obj.role == ROLE_MANIPULAND and manipuland_entity is None:
+                manipuland_entity = entity
+        if manipuland_entity is None:
+            raise SceneSpecError("SceneSpec produced no manipuland entity")
+        self.scene_provenance = spec.provenance_block()
+        return manipuland_entity
+
+    def _add_object_entity(self, gs: Any, obj: ObjectSpec) -> Any:
+        """Build one Genesis entity from an ObjectSpec, honoring source/pose."""
+
+        if obj.is_mesh():
+            if not obj.local_path:
+                raise SceneSpecError(
+                    f"object {obj.name!r} ({obj.asset_source}) has no resolved "
+                    "local_path; assets must be downloaded before building"
+                )
+            morph = gs.morphs.Mesh(
+                file=obj.local_path,
+                scale=obj.scale,
+                pos=tuple(obj.pos),
+                euler=tuple(obj.euler),
+                fixed=obj.fixed,
+            )
+        elif obj.primitive == PRIMITIVE_BOX:
+            morph = gs.morphs.Box(
+                size=tuple(obj.size),
+                pos=tuple(obj.pos),
+                euler=tuple(obj.euler),
+                fixed=obj.fixed,
+            )
+        elif obj.primitive == PRIMITIVE_SPHERE:
+            morph = gs.morphs.Sphere(
+                radius=obj.radius,
+                pos=tuple(obj.pos),
+                fixed=obj.fixed,
+            )
+        elif obj.primitive == PRIMITIVE_CYLINDER:
+            morph = gs.morphs.Cylinder(
+                radius=obj.radius,
+                height=obj.height,
+                pos=tuple(obj.pos),
+                euler=tuple(obj.euler),
+                fixed=obj.fixed,
+            )
+        else:  # pragma: no cover - parser restricts primitive values
+            raise SceneSpecError(f"unsupported primitive {obj.primitive!r}")
+
+        kwargs: dict[str, Any] = {"surface": gs.surfaces.Rough(color=tuple(obj.color))}
+        if obj.friction is not None:
+            try:
+                kwargs["material"] = gs.materials.Rigid(friction=float(obj.friction))
+            except Exception:  # noqa: BLE001 - material is best-effort physics
+                pass
+        entity = self._scene.add_entity(morph, **kwargs)
+        obj.loaded = True
+        return entity
+
     def reset(self, env_ids: torch.Tensor | None = None) -> dict[str, torch.Tensor]:
         """Reset environments and return initial observations.
 
@@ -255,7 +383,7 @@ class FrankaPickPlaceEnv:
             cube_pos += noise
 
         cube_quat = torch.tensor(
-            [1.0, 0.0, 0.0, 0.0], device=self.device, dtype=torch.float32,
+            list(self._manip_quat), device=self.device, dtype=torch.float32,
         ).unsqueeze(0).expand(n, -1)
         self._cube.set_pos(cube_pos, envs_idx=env_ids)
         self._cube.set_quat(cube_quat, envs_idx=env_ids)

--- a/npa/src/npa/genesis/env_pick_place.py
+++ b/npa/src/npa/genesis/env_pick_place.py
@@ -19,6 +19,16 @@ from typing import Any
 import numpy as np
 import torch
 
+from npa.genesis.robot_assets import (
+    ROBOT_SOURCE_BYO_MJCF,
+    ROBOT_SOURCE_BYO_URDF,
+    ROBOT_SOURCE_BYO_USD,
+    ROBOT_SOURCE_GENESIS_BUILTIN,
+    ROBOT_SOURCE_STOCK_FRANKA,
+    STOCK_FRANKA_MJCF,
+    RobotSpec,
+    RobotSpecError,
+)
 from npa.genesis.scene_assets import (
     PRIMITIVE_BOX,
     PRIMITIVE_CYLINDER,
@@ -62,6 +72,11 @@ class EnvConfig:
     # SceneSpec (mesh / primitive) instead of the hardcoded red Box. When None,
     # the default Franka + red-Box scene is reproduced exactly.
     scene_spec: SceneSpec | None = None
+    # BYO robot: when set, the robot embodiment (URDF/MJCF/USD/preset) is built
+    # from this parsed RobotSpec instead of the hardcoded Franka Panda, and the
+    # cached links, gains, force ranges, home pose, and IK end-effector link are
+    # taken from it. When None, the default Franka Panda is reproduced exactly.
+    robot_spec: RobotSpec | None = None
     # Domain randomization ranges
     cube_pos_noise: float = 0.1
     friction_range: tuple[float, float] = (0.3, 1.2)
@@ -126,6 +141,20 @@ class FrankaPickPlaceEnv:
         self.n_envs = self.cfg.n_envs
         self.device: str = "cuda"
 
+        # Robot embodiment. When no RobotSpec is supplied the env reproduces the
+        # hardcoded Franka Panda exactly (class-level N_* constants stay 7/2/9).
+        # When a RobotSpec is supplied, the DOF counts, gripper width, end-
+        # effector link, gains, force ranges, and home pose come from it.
+        self._robot_spec: RobotSpec | None = self.cfg.robot_spec
+        self.robot_provenance: dict[str, Any] | None = None
+        if self._robot_spec is not None:
+            self._robot_spec.validate()
+            self.N_JOINTS = self._robot_spec.n_arm_joints
+            self.N_GRIPPER = self._robot_spec.n_gripper_joints
+            self.N_DOFS = self._robot_spec.dof_count
+            self.N_PRIV_OBS = self.N_DOFS + 13  # joints + gripper(1)+pose(7)+contacts(2)+goal(3)
+            self.N_STATE = self.N_DOFS + 1
+
         if self.cfg.action_space not in ("joint", "cartesian"):
             raise ValueError(
                 f"action_space must be 'joint' or 'cartesian', "
@@ -135,7 +164,7 @@ class FrankaPickPlaceEnv:
         if self.cfg.action_space == "cartesian":
             self._n_actions = 4  # delta xyz (3) + gripper (1)
         else:
-            self._n_actions = 8  # delta joints (7) + gripper (1)
+            self._n_actions = self.N_JOINTS + 1  # delta joints + gripper (1)
 
         # When a BYO SceneSpec is supplied, derive the manipuland init pose,
         # primitive cube size, and target zone from it so the existing reset /
@@ -154,7 +183,8 @@ class FrankaPickPlaceEnv:
         self._wrist_cam = None
 
         # Link references (populated after build)
-        self._hand_link = None
+        self._ee_link = None
+        self._finger_links: list[Any] = []
         self._left_finger_link = None
         self._right_finger_link = None
 
@@ -209,12 +239,9 @@ class FrankaPickPlaceEnv:
         # Ground plane
         self._scene.add_entity(gs.morphs.Plane())
 
-        # Franka Panda robot (MJCF from Genesis built-in assets)
-        self._robot = self._scene.add_entity(
-            gs.morphs.MJCF(
-                file="xml/franka_emika_panda/panda.xml",
-            ),
-        )
+        # Robot embodiment. The default (no RobotSpec) path is the Franka Panda
+        # MJCF from Genesis built-in assets, byte-for-byte identical to before.
+        self._robot = self._add_robot_entity(gs)
 
         if self.cfg.scene_spec is not None:
             # BYO scene: build each object from the parsed SceneSpec. The
@@ -254,19 +281,39 @@ class FrankaPickPlaceEnv:
         # Build scene with parallel environments
         self._scene.build(n_envs=self.n_envs)
 
-        # Cache link references (must be after build)
-        self._hand_link = self._robot.get_link("hand")
-        self._left_finger_link = self._robot.get_link("left_finger")
-        self._right_finger_link = self._robot.get_link("right_finger")
+        # Cache link references (must be after build). The end-effector link and
+        # the optional gripper finger links come from the RobotSpec; the default
+        # path keeps the Franka "hand"/"left_finger"/"right_finger" lookups.
+        spec = self._robot_spec
+        ee_name = spec.ee_link if spec is not None else "hand"
+        finger_names = (
+            spec.finger_links if spec is not None else ("left_finger", "right_finger")
+        )
+        self._ee_link = self._robot.get_link(ee_name)
+        self._finger_links = [self._robot.get_link(name) for name in finger_names]
+        # Preserve the historical left/right finger handles for the default path.
+        self._left_finger_link = self._finger_links[0] if self._finger_links else None
+        self._right_finger_link = (
+            self._finger_links[1]
+            if len(self._finger_links) > 1
+            else (self._finger_links[0] if self._finger_links else None)
+        )
 
         # Set PD gains (must be after build, per Genesis docs)
-        self._robot.set_dofs_kp(list(self.cfg.kp))
-        self._robot.set_dofs_kv(list(self.cfg.kv))
-
-        # Set force limits for Franka
-        lower = [-87, -87, -87, -87, -12, -12, -12, -100, -100]
-        upper = [87, 87, 87, 87, 12, 12, 12, 100, 100]
-        self._robot.set_dofs_force_range(lower, upper)
+        if spec is not None:
+            kp, kv = list(spec.kp), list(spec.kv)
+            force_lower = list(spec.force_lower)
+            force_upper = list(spec.force_upper)
+            home_qpos = list(spec.home_qpos)
+        else:
+            kp, kv = list(self.cfg.kp), list(self.cfg.kv)
+            # Default Franka force limits (unchanged).
+            force_lower = [-87, -87, -87, -87, -12, -12, -12, -100, -100]
+            force_upper = [87, 87, 87, 87, 12, 12, 12, 100, 100]
+            home_qpos = FRANKA_HOME
+        self._robot.set_dofs_kp(kp)
+        self._robot.set_dofs_kv(kv)
+        self._robot.set_dofs_force_range(force_lower, force_upper)
 
         # Target positions per env (may be randomized)
         self._target_pos = torch.tensor(
@@ -277,8 +324,65 @@ class FrankaPickPlaceEnv:
 
         # Precompute home position tensor
         self._home_qpos = torch.tensor(
-            FRANKA_HOME, device=self.device, dtype=torch.float32,
+            home_qpos, device=self.device, dtype=torch.float32,
         )
+
+    def _add_robot_entity(self, gs: Any) -> Any:
+        """Add the robot embodiment from the RobotSpec (default: Franka MJCF).
+
+        Dispatches on ``robot_source``. The default / ``stock_franka`` path adds
+        the Genesis built-in Franka Panda MJCF unchanged. BYO robots load the
+        downloaded articulated description via ``gs.morphs.URDF`` / ``MJCF``; a
+        BYO robot that fails to load raises ``RobotSpecError`` (no fallback to
+        Franka). Records robot provenance with ``loaded=True`` on success.
+        """
+
+        spec = self._robot_spec
+        if spec is None or spec.robot_source == ROBOT_SOURCE_STOCK_FRANKA:
+            entity = self._scene.add_entity(
+                gs.morphs.MJCF(file=STOCK_FRANKA_MJCF),
+            )
+            if spec is not None:
+                spec.loaded = True
+                self.robot_provenance = spec.provenance()
+            return entity
+
+        source = spec.robot_source
+        if source in (ROBOT_SOURCE_BYO_URDF, ROBOT_SOURCE_GENESIS_BUILTIN):
+            if not spec.local_path:
+                raise RobotSpecError(
+                    f"robot {spec.name!r} ({source}) has no resolved local_path; "
+                    "the robot asset must be downloaded/resolved before building"
+                )
+            morph = gs.morphs.URDF(file=spec.local_path, fixed=True)
+        elif source == ROBOT_SOURCE_BYO_MJCF:
+            if not spec.local_path:
+                raise RobotSpecError(
+                    f"robot {spec.name!r} ({source}) has no resolved local_path"
+                )
+            morph = gs.morphs.MJCF(file=spec.local_path)
+        elif source == ROBOT_SOURCE_BYO_USD:
+            # Genesis loads robots from URDF/MJCF, not USD. USD robots are an
+            # Isaac-backend capability; fail loudly rather than silently using
+            # Franka so the operator routes the run to the Isaac backend.
+            raise RobotSpecError(
+                "robot_source=byo_usd is not supported by the Genesis backend; "
+                "use the Isaac backend for USD robots, or supply a URDF/MJCF "
+                "for Genesis (no silent fallback to Franka)."
+            )
+        else:  # pragma: no cover - validate() restricts robot_source
+            raise RobotSpecError(f"unsupported robot_source {source!r}")
+
+        try:
+            entity = self._scene.add_entity(morph)
+        except Exception as exc:  # noqa: BLE001 - surface loader failures loudly
+            raise RobotSpecError(
+                f"failed to load BYO robot {spec.name!r} from {spec.local_path!r} "
+                f"({source}): {exc}"
+            ) from exc
+        spec.loaded = True
+        self.robot_provenance = spec.provenance()
+        return entity
 
     def _build_scene_objects(self, gs: Any, spec: SceneSpec) -> Any:
         """Add every SceneSpec object; return the manipuland entity.
@@ -437,16 +541,25 @@ class FrankaPickPlaceEnv:
         current_pos = self._robot.get_dofs_position()  # (n_envs, 9)
         joint_targets = current_pos[:, :self.N_JOINTS] + joint_deltas
 
-        # Gripper: cmd > 0 → open (0.04), cmd <= 0 → close (0.0)
-        gripper_val = torch.where(
-            gripper_cmd > 0,
-            torch.full_like(gripper_cmd, 0.04),
-            torch.zeros_like(gripper_cmd),
-        )
-        gripper_targets = gripper_val.expand(-1, self.N_GRIPPER)
+        if self.N_GRIPPER > 0:
+            # Gripper: cmd > 0 → open, cmd <= 0 → close. Open/close widths come
+            # from the RobotSpec (Franka default 0.04 / 0.0).
+            spec = self._robot_spec
+            open_val = spec.gripper_open if spec is not None else 0.04
+            close_val = spec.gripper_close if spec is not None else 0.0
+            gripper_val = torch.where(
+                gripper_cmd > 0,
+                torch.full_like(gripper_cmd, open_val),
+                torch.full_like(gripper_cmd, close_val),
+            )
+            gripper_targets = gripper_val.expand(-1, self.N_GRIPPER)
+            targets = torch.cat([joint_targets, gripper_targets], dim=-1)
+        else:
+            # Gripperless arm (e.g. UR/Flexiv base URDF): the gripper command
+            # channel is ignored and only arm joints are position-controlled.
+            targets = joint_targets
 
         # Apply PD position control
-        targets = torch.cat([joint_targets, gripper_targets], dim=-1)
         self._robot.control_dofs_position(targets)
 
         # Step physics
@@ -484,8 +597,8 @@ class FrankaPickPlaceEnv:
                 (ee_pos is NOT included in flat to preserve the 22-dim
                 policy interface and checkpoint compatibility)
         """
-        joint_pos = self._robot.get_dofs_position()  # (n_envs, 9)
-        gripper_state = joint_pos[:, self.N_JOINTS:].mean(dim=-1, keepdim=True)
+        joint_pos = self._robot.get_dofs_position()  # (n_envs, n_dofs)
+        gripper_state = self._gripper_state(joint_pos)
 
         cube_pos = self._cube.get_pos()  # (n_envs, 3)
         cube_quat = self._cube.get_quat()  # (n_envs, 4) — (w,x,y,z)
@@ -494,7 +607,7 @@ class FrankaPickPlaceEnv:
         # Contact detection between gripper fingers and cube
         contact_flags = self._get_contact_flags()  # (n_envs, 2)
 
-        ee_pos = self._hand_link.get_pos()  # (n_envs, 3)
+        ee_pos = self._ee_link.get_pos()  # (n_envs, 3)
 
         obs = {
             "joint_pos": joint_pos,
@@ -541,7 +654,7 @@ class FrankaPickPlaceEnv:
             wr_list.append(np.asarray(wr_rgb))
 
         joint_pos = self._robot.get_dofs_position()
-        gripper_state = joint_pos[:, self.N_JOINTS:].mean(dim=-1, keepdim=True)
+        gripper_state = self._gripper_state(joint_pos)
 
         return {
             "workspace": np.stack(ws_list),
@@ -572,15 +685,17 @@ class FrankaPickPlaceEnv:
             envs_idx=env_ids,
         )
 
-        # Randomize friction on robot fingers
-        finger_friction = lo + torch.rand(n, 2, device=self.device) * (hi - lo)
-        left_idx = self._left_finger_link.idx_local
-        right_idx = self._right_finger_link.idx_local
-        self._robot.set_friction_ratio(
-            finger_friction,
-            links_idx_local=[left_idx, right_idx],
-            envs_idx=env_ids,
-        )
+        # Randomize friction on robot fingers (skipped for gripperless arms).
+        if self._finger_links:
+            finger_idx = [link.idx_local for link in self._finger_links]
+            finger_friction = lo + torch.rand(
+                n, len(finger_idx), device=self.device
+            ) * (hi - lo)
+            self._robot.set_friction_ratio(
+                finger_friction,
+                links_idx_local=finger_idx,
+                envs_idx=env_ids,
+            )
 
     def _compute_reward(self, obs: dict[str, torch.Tensor]) -> torch.Tensor:
         """Pick-and-place reward function.
@@ -591,7 +706,7 @@ class FrankaPickPlaceEnv:
             3. Place: negative distance from cube to target
             4. Success: large bonus when cube is at target and stable
         """
-        ee_pos = self._hand_link.get_pos()  # (n_envs, 3)
+        ee_pos = self._ee_link.get_pos()  # (n_envs, 3)
         cube_pos = self._cube.get_pos()  # (n_envs, 3)
 
         # 1. Approach reward
@@ -643,14 +758,24 @@ class FrankaPickPlaceEnv:
 
         return at_target & stable
 
+    def _gripper_state(self, joint_pos: torch.Tensor) -> torch.Tensor:
+        """Mean gripper opening as (n_envs, 1); zeros for gripperless arms."""
+
+        if self.N_GRIPPER > 0:
+            return joint_pos[:, self.N_JOINTS:].mean(dim=-1, keepdim=True)
+        return torch.zeros(joint_pos.shape[0], 1, device=joint_pos.device, dtype=joint_pos.dtype)
+
     def _get_contact_flags(self) -> torch.Tensor:
         """Detect contact between gripper fingers and the cube.
 
         Uses net contact force magnitude on finger links as a proxy for
-        binary contact detection.
-
-        Returns (n_envs, 2) tensor with left/right finger contact floats.
+        binary contact detection. Returns a (n_envs, 2) tensor with left/right
+        finger contact floats. Gripperless arms (no finger links) report zeros
+        so the observation schema stays fixed across embodiments.
         """
+        if not self._finger_links:
+            return torch.zeros(self.n_envs, 2, device=self.device)
+
         # Get net contact force on all robot links: (n_envs, n_links, 3)
         net_forces = self._robot.get_links_net_contact_force()
 
@@ -681,9 +806,9 @@ class FrankaPickPlaceEnv:
         Returns:
             (n_envs, 7) joint position deltas in radians.
         """
-        # Get full Jacobian for the hand link: (n_envs, 6, n_dofs)
+        # Get full Jacobian for the end-effector link: (n_envs, 6, n_dofs)
         # Rows 0-2 are the position Jacobian, rows 3-5 are orientation.
-        J_full = self._robot.get_jacobian(link=self._hand_link)
+        J_full = self._robot.get_jacobian(link=self._ee_link)
         J_pos = J_full[:, :3, :self.N_JOINTS]  # (n_envs, 3, 7)
 
         # Damped least-squares: J^T (J J^T + λ²I)^{-1} Δx

--- a/npa/src/npa/genesis/robot_assets.py
+++ b/npa/src/npa/genesis/robot_assets.py
@@ -1,0 +1,516 @@
+"""RobotSpec schema, presets, asset download, and provenance for BYO robots.
+
+This module describes the *robot embodiment* of a pick-and-place scene
+independently of the simulator, mirroring the object-side ``scene_assets``
+module. It is deliberately free of ``torch`` / ``genesis`` / ``isaaclab``
+imports at module level so it can be unit-tested without a GPU.
+
+A RobotSpec selects a ``robot_source``:
+
+- ``stock_franka`` (default): the Franka Emika Panda MJCF shipped inside the
+  Genesis package (``xml/franka_emika_panda/panda.xml``). No download. This
+  reproduces today's hardcoded robot byte-for-byte.
+- ``byo_urdf`` / ``byo_mjcf`` / ``byo_usd``: a customer arm fetched from an
+  S3/URI as an *articulated* description (URDF + meshes, MJCF, or USD). The
+  file is downloaded, hashed, and loaded; provenance records
+  ``{robot_source, robot_uri, local_path, sha256, loaded}``. A BYO robot that
+  fails to load raises ``RobotSpecError`` — there is **no silent fallback to
+  Franka**.
+- ``genesis_builtin``: an articulated robot description shipped inside the
+  Genesis ``assets`` tree (e.g. a built-in UR/xarm URDF), resolved by path.
+
+The robot must be an articulated description (URDF/MJCF/USD). A plain visual
+mesh (``.obj`` / ``.glb`` / ``.stl`` / ``.ply``) is only valid for the
+manipulated *object*, never the robot; supplying one as the robot raises a
+clear ``RobotSpecError``.
+
+Control/morphology config (``ee_link``, ``finger_links``, ``dof_count``,
+``kp`` / ``kv`` gains, force ranges, ``home_qpos``) lets the env operate on a
+configured embodiment instead of Franka constants. Presets are provided for
+Franka and for UR/Flexiv-class arms so a customer can pick a preset or supply
+a full URDF plus minimal config.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from npa.genesis.scene_assets import download_asset, sha256_file
+
+ROBOT_SPEC_SCHEMA = "npa.sim2real.robot_spec.v1"
+
+ROBOT_SOURCE_STOCK_FRANKA = "stock_franka"
+ROBOT_SOURCE_BYO_URDF = "byo_urdf"
+ROBOT_SOURCE_BYO_MJCF = "byo_mjcf"
+ROBOT_SOURCE_BYO_USD = "byo_usd"
+ROBOT_SOURCE_GENESIS_BUILTIN = "genesis_builtin"
+ROBOT_SOURCES = (
+    ROBOT_SOURCE_STOCK_FRANKA,
+    ROBOT_SOURCE_BYO_URDF,
+    ROBOT_SOURCE_BYO_MJCF,
+    ROBOT_SOURCE_BYO_USD,
+    ROBOT_SOURCE_GENESIS_BUILTIN,
+)
+
+# BYO sources that require a downloadable, articulated robot description.
+ROBOT_SOURCES_BYO = (
+    ROBOT_SOURCE_BYO_URDF,
+    ROBOT_SOURCE_BYO_MJCF,
+    ROBOT_SOURCE_BYO_USD,
+)
+
+# Articulated description suffixes accepted per source. A robot MUST be one of
+# these — a plain visual mesh (.obj/.glb/.stl/.ply/.dae) is rejected loudly.
+URDF_SUFFIXES = (".urdf",)
+MJCF_SUFFIXES = (".xml", ".mjcf")
+USD_SUFFIXES = (".usd", ".usda", ".usdc")
+ARTICULATED_SUFFIXES = URDF_SUFFIXES + MJCF_SUFFIXES + USD_SUFFIXES
+# Visual-mesh suffixes that are valid for OBJECTS but never for the ROBOT.
+VISUAL_MESH_SUFFIXES = (".obj", ".glb", ".gltf", ".ply", ".stl", ".dae")
+
+_SOURCE_SUFFIXES = {
+    ROBOT_SOURCE_BYO_URDF: URDF_SUFFIXES,
+    ROBOT_SOURCE_BYO_MJCF: MJCF_SUFFIXES,
+    ROBOT_SOURCE_BYO_USD: USD_SUFFIXES,
+}
+
+# Stock Franka MJCF shipped with Genesis (the path the env hardcodes today).
+STOCK_FRANKA_MJCF = "xml/franka_emika_panda/panda.xml"
+
+# Franka Panda home joint configuration (ready pose) — matches FRANKA_HOME in
+# env_pick_place.py so the default path is byte-for-byte identical.
+FRANKA_HOME = (0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785, 0.04, 0.04)
+
+
+class RobotSpecError(RuntimeError):
+    """Raised when a RobotSpec is malformed or a robot asset cannot load."""
+
+
+@dataclass
+class RobotSpec:
+    """A parsed, simulator-agnostic robot embodiment description."""
+
+    robot_source: str = ROBOT_SOURCE_STOCK_FRANKA
+    name: str = "franka_panda"
+    # Source references
+    robot_uri: str = ""  # byo_* source (s3:// or local path)
+    builtin_path: str = ""  # genesis_builtin path relative to <genesis>/assets
+    # Morphology / control
+    ee_link: str = "hand"  # end-effector link name (IK + ee_pos)
+    finger_links: tuple[str, ...] = ("left_finger", "right_finger")
+    n_arm_joints: int = 7
+    n_gripper_joints: int = 2
+    joint_names: tuple[str, ...] = ()
+    kp: tuple[float, ...] = (4500, 4500, 3500, 3500, 2000, 2000, 2000, 100, 100)
+    kv: tuple[float, ...] = (450, 450, 350, 350, 200, 200, 200, 10, 10)
+    force_lower: tuple[float, ...] = (-87, -87, -87, -87, -12, -12, -12, -100, -100)
+    force_upper: tuple[float, ...] = (87, 87, 87, 87, 12, 12, 12, 100, 100)
+    home_qpos: tuple[float, ...] = FRANKA_HOME
+    gripper_open: float = 0.04
+    gripper_close: float = 0.0
+    # Isaac-side hint: the task whose robot this preset corresponds to, used to
+    # pick a sane default action/observation contract. Optional metadata only.
+    isaac_robot_hint: str = ""
+    # Resolved fields (populated by resolve_robot_asset)
+    local_path: str = ""
+    sha256: str = ""
+    loaded: bool = False
+
+    @property
+    def dof_count(self) -> int:
+        return self.n_arm_joints + self.n_gripper_joints
+
+    @property
+    def has_gripper(self) -> bool:
+        return self.n_gripper_joints > 0 and bool(self.finger_links)
+
+    def is_stock_franka(self) -> bool:
+        return self.robot_source == ROBOT_SOURCE_STOCK_FRANKA
+
+    def is_byo(self) -> bool:
+        return self.robot_source in ROBOT_SOURCES_BYO
+
+    def requires_download(self) -> bool:
+        return self.robot_source in ROBOT_SOURCES_BYO
+
+    def provenance(self) -> dict[str, Any]:
+        """Robot provenance record (mirrors the object asset provenance)."""
+
+        return {
+            "schema": "npa.sim2real.robot_provenance.v1",
+            "name": self.name,
+            "robot_source": self.robot_source,
+            "robot_uri": self.robot_uri,
+            "builtin_path": self.builtin_path,
+            "local_path": self.local_path,
+            "sha256": self.sha256,
+            "loaded": bool(self.loaded),
+            "ee_link": self.ee_link,
+            "dof_count": self.dof_count,
+            "n_arm_joints": self.n_arm_joints,
+            "n_gripper_joints": self.n_gripper_joints,
+            # No silent fallback to Franka is ever permitted for a BYO robot.
+            "robot_fallback_used": False,
+        }
+
+    def validate(self) -> None:
+        """Validate source/articulation invariants. Raises RobotSpecError."""
+
+        if self.robot_source not in ROBOT_SOURCES:
+            raise RobotSpecError(
+                f"robot_source must be one of {ROBOT_SOURCES}, "
+                f"got {self.robot_source!r}"
+            )
+        if self.n_arm_joints <= 0:
+            raise RobotSpecError("n_arm_joints must be positive")
+        if self.n_gripper_joints < 0:
+            raise RobotSpecError("n_gripper_joints must be non-negative")
+        for gain, label in ((self.kp, "kp"), (self.kv, "kv")):
+            if len(gain) != self.dof_count:
+                raise RobotSpecError(
+                    f"{label} must have dof_count ({self.dof_count}) entries, "
+                    f"got {len(gain)}"
+                )
+        if len(self.force_lower) != self.dof_count or len(self.force_upper) != self.dof_count:
+            raise RobotSpecError(
+                f"force_lower/force_upper must have dof_count ({self.dof_count}) "
+                "entries"
+            )
+        if len(self.home_qpos) != self.dof_count:
+            raise RobotSpecError(
+                f"home_qpos must have dof_count ({self.dof_count}) entries, "
+                f"got {len(self.home_qpos)}"
+            )
+        if not self.ee_link:
+            raise RobotSpecError("ee_link must be a non-empty link name")
+        if self.is_byo():
+            if not self.robot_uri:
+                raise RobotSpecError(
+                    f"robot_source={self.robot_source} requires a non-empty robot_uri"
+                )
+            _validate_articulated_uri(self.robot_uri, self.robot_source)
+        elif self.robot_source == ROBOT_SOURCE_GENESIS_BUILTIN and not self.builtin_path:
+            raise RobotSpecError("genesis_builtin robot requires builtin_path")
+
+
+def _suffix_of(uri: str) -> str:
+    return Path(str(uri).split("?", 1)[0].rstrip("/")).suffix.lower()
+
+
+def _validate_articulated_uri(uri: str, robot_source: str) -> None:
+    """Reject a non-articulated file given as the robot (clear error)."""
+
+    suffix = _suffix_of(uri)
+    if suffix in VISUAL_MESH_SUFFIXES:
+        raise RobotSpecError(
+            f"robot asset {uri!r} is a visual mesh ({suffix}); the ROBOT requires "
+            "an articulated URDF/MJCF/USD description (UR/Flexiv publish these). "
+            "A plain mesh/OBJ is only valid for a manipulated OBJECT, not the robot."
+        )
+    expected = _SOURCE_SUFFIXES.get(robot_source, ARTICULATED_SUFFIXES)
+    if suffix and suffix not in expected:
+        raise RobotSpecError(
+            f"robot_source={robot_source} expects one of {expected} for robot_uri, "
+            f"got {suffix!r} ({uri!r})"
+        )
+    if not suffix:
+        raise RobotSpecError(
+            f"robot_uri {uri!r} has no file extension; the robot must be an "
+            f"articulated description ({ARTICULATED_SUFFIXES})"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Presets
+# --------------------------------------------------------------------------- #
+
+# Franka Panda — the current default. Values mirror env_pick_place.py exactly.
+_FRANKA_PRESET = RobotSpec(
+    robot_source=ROBOT_SOURCE_STOCK_FRANKA,
+    name="franka_panda",
+    ee_link="hand",
+    finger_links=("left_finger", "right_finger"),
+    n_arm_joints=7,
+    n_gripper_joints=2,
+    kp=(4500, 4500, 3500, 3500, 2000, 2000, 2000, 100, 100),
+    kv=(450, 450, 350, 350, 200, 200, 200, 10, 10),
+    force_lower=(-87, -87, -87, -87, -12, -12, -12, -100, -100),
+    force_upper=(87, 87, 87, 87, 12, 12, 12, 100, 100),
+    home_qpos=FRANKA_HOME,
+    gripper_open=0.04,
+    gripper_close=0.0,
+    isaac_robot_hint="franka",
+)
+
+# Universal Robots UR5e — 6-DOF arm, flange end-effector link ``tool0``. UR
+# arms ship without a gripper in the base ur_description URDF, so there are no
+# finger links by default (gripper control is a BYO follow-up). Gains are
+# conservative position-control defaults sized to the 6 arm joints.
+_UR5E_PRESET = RobotSpec(
+    robot_source=ROBOT_SOURCE_BYO_URDF,
+    name="ur5e",
+    ee_link="tool0",
+    finger_links=(),
+    n_arm_joints=6,
+    n_gripper_joints=0,
+    joint_names=(
+        "shoulder_pan_joint",
+        "shoulder_lift_joint",
+        "elbow_joint",
+        "wrist_1_joint",
+        "wrist_2_joint",
+        "wrist_3_joint",
+    ),
+    kp=(3000, 3000, 2000, 1500, 1000, 1000),
+    kv=(300, 300, 200, 150, 100, 100),
+    force_lower=(-150, -150, -150, -28, -28, -28),
+    force_upper=(150, 150, 150, 28, 28, 28),
+    home_qpos=(0.0, -1.5708, 1.5708, -1.5708, -1.5708, 0.0),
+    isaac_robot_hint="ur",
+)
+
+# Universal Robots UR10e — 6-DOF, larger payload/torques than the UR5e.
+_UR10E_PRESET = replace(
+    _UR5E_PRESET,
+    name="ur10e",
+    kp=(4500, 4500, 3000, 2000, 1500, 1500),
+    kv=(450, 450, 300, 200, 150, 150),
+    force_lower=(-330, -330, -150, -56, -56, -56),
+    force_upper=(330, 330, 150, 56, 56, 56),
+)
+
+# Flexiv Rizon — 7-DOF serial arm, tool flange link ``flange``. Like the UR
+# arms, the published URDF has no integrated gripper, so finger control is a
+# BYO follow-up. Gains sized to the 7 arm joints.
+_FLEXIV_RIZON_PRESET = RobotSpec(
+    robot_source=ROBOT_SOURCE_BYO_URDF,
+    name="flexiv_rizon",
+    ee_link="flange",
+    finger_links=(),
+    n_arm_joints=7,
+    n_gripper_joints=0,
+    joint_names=(
+        "joint1",
+        "joint2",
+        "joint3",
+        "joint4",
+        "joint5",
+        "joint6",
+        "joint7",
+    ),
+    kp=(3000, 3000, 2500, 2500, 1500, 1500, 1000),
+    kv=(300, 300, 250, 250, 150, 150, 100),
+    force_lower=(-123, -123, -64, -64, -39, -39, -39),
+    force_upper=(123, 123, 64, 64, 39, 39, 39),
+    home_qpos=(0.0, -0.698, 0.0, 1.571, 0.0, 0.698, 0.0),
+    isaac_robot_hint="flexiv",
+)
+
+ROBOT_PRESETS: dict[str, RobotSpec] = {
+    "franka": _FRANKA_PRESET,
+    "stock_franka": _FRANKA_PRESET,
+    "ur5e": _UR5E_PRESET,
+    "ur10e": _UR10E_PRESET,
+    "flexiv": _FLEXIV_RIZON_PRESET,
+    "flexiv_rizon": _FLEXIV_RIZON_PRESET,
+    "rizon": _FLEXIV_RIZON_PRESET,
+}
+
+
+def default_franka_robot_spec() -> RobotSpec:
+    """Return the stock Franka RobotSpec (today's hardcoded embodiment)."""
+
+    return replace(_FRANKA_PRESET)
+
+
+def robot_spec_from_preset(name: str) -> RobotSpec:
+    """Return a copy of a named preset (franka/ur5e/ur10e/flexiv)."""
+
+    key = str(name or "").strip().lower()
+    if key not in ROBOT_PRESETS:
+        raise RobotSpecError(
+            f"unknown robot preset {name!r}; known presets: "
+            f"{sorted(set(ROBOT_PRESETS))}"
+        )
+    return replace(ROBOT_PRESETS[key])
+
+
+def _coerce_float_tuple(value: Any, label: str) -> tuple[float, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise RobotSpecError(f"{label} must be a list of numbers, got {value!r}")
+    try:
+        return tuple(float(v) for v in value)
+    except (TypeError, ValueError) as exc:
+        raise RobotSpecError(f"{label} must be numeric: {value!r}") from exc
+
+
+def _coerce_str_tuple(value: Any, label: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if not isinstance(value, (list, tuple)):
+        raise RobotSpecError(f"{label} must be a list of strings, got {value!r}")
+    return tuple(str(v) for v in value)
+
+
+def parse_robot_spec(doc: dict[str, Any]) -> RobotSpec:
+    """Parse and validate a RobotSpec JSON document into a RobotSpec.
+
+    A ``preset`` key (franka/ur5e/ur10e/flexiv) seeds the defaults; any other
+    keys override the preset, so a customer can supply only a URDF uri plus a
+    couple of overrides on top of, say, the ``ur5e`` preset.
+    """
+
+    if not isinstance(doc, dict):
+        raise RobotSpecError(f"RobotSpec must be a JSON object, got {type(doc)!r}")
+
+    preset_name = str(doc.get("preset") or "").strip().lower()
+    spec = robot_spec_from_preset(preset_name) if preset_name else RobotSpec()
+
+    if doc.get("robot_source") is not None:
+        spec.robot_source = str(doc["robot_source"]).strip()
+    if doc.get("name"):
+        spec.name = str(doc["name"]).strip()
+    if doc.get("robot_uri") is not None:
+        spec.robot_uri = str(doc["robot_uri"]).strip()
+    if doc.get("builtin_path") is not None:
+        spec.builtin_path = str(doc["builtin_path"]).strip()
+    if doc.get("ee_link"):
+        spec.ee_link = str(doc["ee_link"]).strip()
+    if "finger_links" in doc:
+        spec.finger_links = _coerce_str_tuple(doc["finger_links"], "finger_links")
+    if doc.get("joint_names") is not None:
+        spec.joint_names = _coerce_str_tuple(doc["joint_names"], "joint_names")
+    if doc.get("n_arm_joints") is not None:
+        spec.n_arm_joints = int(doc["n_arm_joints"])
+    if doc.get("n_gripper_joints") is not None:
+        spec.n_gripper_joints = int(doc["n_gripper_joints"])
+    if doc.get("kp") is not None:
+        spec.kp = _coerce_float_tuple(doc["kp"], "kp")
+    if doc.get("kv") is not None:
+        spec.kv = _coerce_float_tuple(doc["kv"], "kv")
+    if doc.get("force_lower") is not None:
+        spec.force_lower = _coerce_float_tuple(doc["force_lower"], "force_lower")
+    if doc.get("force_upper") is not None:
+        spec.force_upper = _coerce_float_tuple(doc["force_upper"], "force_upper")
+    if doc.get("home_qpos") is not None:
+        spec.home_qpos = _coerce_float_tuple(doc["home_qpos"], "home_qpos")
+    if doc.get("gripper_open") is not None:
+        spec.gripper_open = float(doc["gripper_open"])
+    if doc.get("gripper_close") is not None:
+        spec.gripper_close = float(doc["gripper_close"])
+    if doc.get("isaac_robot_hint"):
+        spec.isaac_robot_hint = str(doc["isaac_robot_hint"]).strip()
+
+    spec.validate()
+    return spec
+
+
+def robot_spec_from_inputs(
+    *,
+    robot_spec_uri: str = "",
+    robot_source: str = "",
+    robot_preset: str = "",
+) -> RobotSpec | None:
+    """Build a RobotSpec from loose CLI/env inputs (no download).
+
+    Resolution order:
+    - ``robot_spec_uri``: handled by the caller (downloads + parses JSON).
+    - ``robot_preset``: a named preset (ur5e/ur10e/flexiv/franka).
+    - ``robot_source``: a bare source (e.g. byo_urdf) — caller must also supply
+      a uri via the spec; used mainly for the stock_franka default.
+
+    Returns ``None`` when nothing robot-related is requested (default Franka).
+    """
+
+    preset = str(robot_preset or "").strip().lower()
+    source = str(robot_source or "").strip().lower()
+    if preset:
+        return robot_spec_from_preset(preset)
+    if source and source != ROBOT_SOURCE_STOCK_FRANKA:
+        spec = RobotSpec(robot_source=source)
+        return spec
+    if source == ROBOT_SOURCE_STOCK_FRANKA:
+        return default_franka_robot_spec()
+    return None
+
+
+def resolve_robot_asset(
+    spec: RobotSpec,
+    *,
+    dest_dir: str | Path,
+    client: Any = None,
+    endpoint_url: str = "",
+    downloader: Any = None,
+    builtin_resolver: Any = None,
+) -> RobotSpec:
+    """Download/resolve the robot description, computing local_path + sha256.
+
+    Mutates and returns ``spec``. BYO robots are downloaded and hashed;
+    genesis_builtin robots are resolved under the Genesis assets tree;
+    stock_franka resolves to the built-in MJCF path with no download. A robot
+    that cannot be resolved raises ``RobotSpecError`` — there is no silent
+    fallback to Franka.
+    """
+
+    spec.validate()
+    downloader = downloader or download_asset
+    dest_dir = Path(dest_dir)
+
+    if spec.robot_source == ROBOT_SOURCE_STOCK_FRANKA:
+        # Resolved lazily inside the GPU image (built-in MJCF). Record the
+        # built-in path as provenance; no download / sha256.
+        spec.local_path = ""
+        spec.builtin_path = spec.builtin_path or STOCK_FRANKA_MJCF
+        return spec
+
+    if spec.is_byo():
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        local = downloader(
+            spec.robot_uri,
+            dest_dir / _safe_name(spec.name),
+            client=client,
+            endpoint_url=endpoint_url,
+        )
+        # Re-validate the *downloaded* file is articulated (defense in depth).
+        _validate_articulated_uri(str(local), spec.robot_source)
+        spec.local_path = str(local)
+        spec.sha256 = sha256_file(local)
+        return spec
+
+    # genesis_builtin
+    builtin_resolver = builtin_resolver or _resolve_genesis_builtin_robot
+    local = builtin_resolver(spec.builtin_path)
+    local_path = Path(local)
+    if not local_path.is_file() or local_path.stat().st_size == 0:
+        raise RobotSpecError(
+            f"genesis_builtin robot not resolved to a file: {spec.builtin_path}"
+        )
+    spec.local_path = str(local_path)
+    spec.sha256 = sha256_file(local_path)
+    return spec
+
+
+def _resolve_genesis_builtin_robot(builtin_path: str) -> Path:
+    """Resolve a builtin robot path relative to the installed Genesis package."""
+
+    builtin_path = str(builtin_path or "").strip().lstrip("/")
+    if not builtin_path:
+        raise RobotSpecError("genesis_builtin robot requires a builtin_path")
+    import genesis as gs  # noqa: PLC0415 - lazy, GPU image only
+
+    assets_root = Path(gs.__file__).resolve().parent / "assets"
+    candidate = assets_root / builtin_path
+    if not candidate.is_file():
+        raise RobotSpecError(
+            f"genesis_builtin robot not found under {assets_root}: {builtin_path}"
+        )
+    return candidate
+
+
+def _safe_name(value: str) -> str:
+    chars = [c if c.isalnum() or c in ("-", "_", ".") else "-" for c in str(value)]
+    return "".join(chars) or "robot"

--- a/npa/src/npa/genesis/scene_assets.py
+++ b/npa/src/npa/genesis/scene_assets.py
@@ -34,10 +34,15 @@ SCENE_SPEC_SCHEMA = "npa.sim2real.manip_scene_spec.v1"
 ASSET_SOURCE_BYO_MESH = "byo_mesh"
 ASSET_SOURCE_GENESIS_BUILTIN = "genesis_builtin"
 ASSET_SOURCE_PRIMITIVE = "primitive"
+# Isaac Lab / Isaac Sim stock asset (built-in lift-cube manipuland). No
+# download: it is materialized inside the Isaac image at rollout time. Recorded
+# in provenance as ``asset_source=isaac_stock`` (no sha256, no fallback).
+ASSET_SOURCE_ISAAC_STOCK = "isaac_stock"
 ASSET_SOURCES = (
     ASSET_SOURCE_BYO_MESH,
     ASSET_SOURCE_GENESIS_BUILTIN,
     ASSET_SOURCE_PRIMITIVE,
+    ASSET_SOURCE_ISAAC_STOCK,
 )
 
 ROLE_MANIPULAND = "manipuland"
@@ -227,6 +232,10 @@ def _object_from_dict(raw: dict[str, Any], index: int) -> ObjectSpec:
                 f"object[{index}] genesis_builtin requires builtin_path"
             )
         obj.builtin_path = builtin
+    elif asset_source == ASSET_SOURCE_ISAAC_STOCK:
+        # Optional reference to the stock Isaac asset (e.g. a task id or a
+        # built-in USD key); no download, materialized inside the Isaac image.
+        obj.builtin_path = str(raw.get("builtin_path") or raw.get("stock_asset") or "").strip()
     else:  # primitive
         primitive = str(raw.get("primitive") or PRIMITIVE_BOX).strip()
         if primitive not in PRIMITIVES:
@@ -344,6 +353,31 @@ def synthesize_scene_spec(
         goal_pos=goal_pos,
         goal_threshold=goal_threshold,
         source_uri=mesh_uri,
+    )
+
+
+def default_isaac_stock_scene_spec(*, stock_asset: str = "lift_cube") -> SceneSpec:
+    """Return the stock Isaac Lab scene (built-in lift-cube manipuland).
+
+    Used by the Isaac held-out rollout when no BYO mesh/SceneSpec is supplied.
+    Records ``asset_source=isaac_stock`` provenance (no sha256, no fallback).
+    """
+
+    return SceneSpec(
+        objects=[
+            ObjectSpec(
+                name="isaac_stock_cube",
+                asset_source=ASSET_SOURCE_ISAAC_STOCK,
+                role=ROLE_MANIPULAND,
+                builtin_path=stock_asset,
+                size=(DEFAULT_CUBE_SIZE, DEFAULT_CUBE_SIZE, DEFAULT_CUBE_SIZE),
+                pos=DEFAULT_CUBE_POS,
+                color=DEFAULT_COLOR,
+            )
+        ],
+        goal_pos=DEFAULT_TARGET_POS,
+        goal_threshold=DEFAULT_TARGET_THRESHOLD,
+        source_uri="isaac://stock/lift_cube",
     )
 
 

--- a/npa/src/npa/genesis/scene_assets.py
+++ b/npa/src/npa/genesis/scene_assets.py
@@ -1,0 +1,468 @@
+"""SceneSpec schema, parser, asset download, and provenance for BYO sim assets.
+
+This module describes the manipulated object(s) of a Genesis pick-and-place
+scene independently of the simulator. It is deliberately free of ``torch`` /
+``genesis`` imports at module level so it can be unit-tested without a GPU.
+
+A SceneSpec is a JSON document (downloaded from ``scene_spec_uri`` or
+synthesized from ``assets_uri`` / ``byo_mesh_uri``) describing one or more
+objects. Each object has an ``asset_source``:
+
+- ``byo_mesh``: a customer mesh fetched from an S3/URI (.obj/.glb/.urdf/.ply…),
+  loaded with ``gs.morphs.Mesh(file=<local_path>)``.
+- ``genesis_builtin``: a mesh shipped inside the Genesis package
+  (a path relative to ``<genesis>/assets``), also loaded via ``gs.morphs.Mesh``.
+- ``primitive``: a box/sphere/cylinder built from primitive morphs. The current
+  default red ``gs.morphs.Box`` cube is the primitive fallback.
+
+Provenance: every object records ``{uri, local_path, sha256, asset_source,
+loaded}`` and the scene records a single ``asset_fallback_used`` flag, so a run
+can prove the requested mesh actually loaded and that nothing silently fell
+back to a primitive. If a requested mesh cannot be resolved, resolution and the
+build raise ``SceneSpecError`` rather than substituting a primitive.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCENE_SPEC_SCHEMA = "npa.sim2real.manip_scene_spec.v1"
+
+ASSET_SOURCE_BYO_MESH = "byo_mesh"
+ASSET_SOURCE_GENESIS_BUILTIN = "genesis_builtin"
+ASSET_SOURCE_PRIMITIVE = "primitive"
+ASSET_SOURCES = (
+    ASSET_SOURCE_BYO_MESH,
+    ASSET_SOURCE_GENESIS_BUILTIN,
+    ASSET_SOURCE_PRIMITIVE,
+)
+
+ROLE_MANIPULAND = "manipuland"
+ROLE_TARGET = "target"
+ROLE_STATIC = "static"
+ROLES = (ROLE_MANIPULAND, ROLE_TARGET, ROLE_STATIC)
+
+PRIMITIVE_BOX = "box"
+PRIMITIVE_SPHERE = "sphere"
+PRIMITIVE_CYLINDER = "cylinder"
+PRIMITIVES = (PRIMITIVE_BOX, PRIMITIVE_SPHERE, PRIMITIVE_CYLINDER)
+
+MESH_SUFFIXES = (".obj", ".glb", ".gltf", ".ply", ".stl", ".urdf", ".xml", ".dae")
+
+# The exact default object that today's hardcoded scene builds: a 4cm red cube.
+DEFAULT_CUBE_SIZE = 0.04
+DEFAULT_CUBE_POS = (0.5, 0.0, 0.04)
+DEFAULT_TARGET_POS = (0.5, 0.3, 0.04)
+DEFAULT_TARGET_THRESHOLD = 0.05
+DEFAULT_COLOR = (1.0, 0.0, 0.0)
+
+
+class SceneSpecError(RuntimeError):
+    """Raised when a SceneSpec is malformed or an asset cannot be resolved."""
+
+
+@dataclass
+class ObjectSpec:
+    """One physical object in the scene (manipuland, target, or static)."""
+
+    name: str
+    asset_source: str
+    role: str = ROLE_MANIPULAND
+    # Source references
+    uri: str = ""  # byo_mesh source (s3:// or local path)
+    builtin_path: str = ""  # genesis_builtin path relative to <genesis>/assets
+    primitive: str = PRIMITIVE_BOX
+    # Geometry
+    scale: float | tuple[float, float, float] = 1.0  # mesh scale
+    size: tuple[float, float, float] = (
+        DEFAULT_CUBE_SIZE,
+        DEFAULT_CUBE_SIZE,
+        DEFAULT_CUBE_SIZE,
+    )  # box
+    radius: float = 0.02  # sphere/cylinder
+    height: float = 0.04  # cylinder
+    # Pose
+    pos: tuple[float, float, float] = DEFAULT_CUBE_POS
+    euler: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    # Appearance / physics
+    color: tuple[float, float, float] = DEFAULT_COLOR
+    mass: float | None = None
+    friction: float | None = None
+    fixed: bool = False
+    # Resolved fields (populated by resolve_scene_assets)
+    local_path: str = ""
+    sha256: str = ""
+    loaded: bool = False
+
+    def is_mesh(self) -> bool:
+        return self.asset_source in (
+            ASSET_SOURCE_BYO_MESH,
+            ASSET_SOURCE_GENESIS_BUILTIN,
+        )
+
+    def provenance(self) -> dict[str, Any]:
+        """Per-object provenance record (mirrors #84's image_digests pattern)."""
+
+        return {
+            "name": self.name,
+            "role": self.role,
+            "asset_source": self.asset_source,
+            "uri": self.uri,
+            "builtin_path": self.builtin_path,
+            "local_path": self.local_path,
+            "sha256": self.sha256,
+            "loaded": bool(self.loaded),
+        }
+
+
+@dataclass
+class SceneSpec:
+    """A parsed, simulator-agnostic scene description for the pick-place env."""
+
+    objects: list[ObjectSpec] = field(default_factory=list)
+    schema: str = SCENE_SPEC_SCHEMA
+    goal_pos: tuple[float, float, float] = DEFAULT_TARGET_POS
+    goal_threshold: float = DEFAULT_TARGET_THRESHOLD
+    source_uri: str = ""
+    asset_fallback_used: bool = False
+
+    def manipuland(self) -> ObjectSpec:
+        for obj in self.objects:
+            if obj.role == ROLE_MANIPULAND:
+                return obj
+        if self.objects:
+            return self.objects[0]
+        raise SceneSpecError("SceneSpec has no objects")
+
+    def provenance_block(self) -> dict[str, Any]:
+        """Scene-level provenance written into report.json / consumed spec."""
+
+        objects = [obj.provenance() for obj in self.objects]
+        return {
+            "schema": "npa.sim2real.asset_provenance.v1",
+            "scene_spec_schema": self.schema,
+            "source_uri": self.source_uri,
+            "asset_fallback_used": bool(self.asset_fallback_used),
+            "goal_pos": list(self.goal_pos),
+            "goal_threshold": self.goal_threshold,
+            "objects": objects,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "goal_pos": list(self.goal_pos),
+            "goal_threshold": self.goal_threshold,
+            "source_uri": self.source_uri,
+            "objects": [_object_to_dict(obj) for obj in self.objects],
+        }
+
+
+def default_scene_spec() -> SceneSpec:
+    """Return the SceneSpec that reproduces today's red-Box primitive cube."""
+
+    return SceneSpec(
+        objects=[
+            ObjectSpec(
+                name="cube",
+                asset_source=ASSET_SOURCE_PRIMITIVE,
+                role=ROLE_MANIPULAND,
+                primitive=PRIMITIVE_BOX,
+                size=(DEFAULT_CUBE_SIZE, DEFAULT_CUBE_SIZE, DEFAULT_CUBE_SIZE),
+                pos=DEFAULT_CUBE_POS,
+                color=DEFAULT_COLOR,
+            )
+        ],
+        goal_pos=DEFAULT_TARGET_POS,
+        goal_threshold=DEFAULT_TARGET_THRESHOLD,
+    )
+
+
+def _coerce_triple(value: Any, name: str) -> tuple[float, float, float]:
+    if not isinstance(value, (list, tuple)) or len(value) != 3:
+        raise SceneSpecError(f"{name} must be a 3-element list, got {value!r}")
+    try:
+        return (float(value[0]), float(value[1]), float(value[2]))
+    except (TypeError, ValueError) as exc:
+        raise SceneSpecError(f"{name} must be numeric: {value!r}") from exc
+
+
+def _coerce_scale(value: Any) -> float | tuple[float, float, float]:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, (list, tuple)) and len(value) == 3:
+        return _coerce_triple(value, "scale")
+    raise SceneSpecError(f"scale must be a number or 3-element list, got {value!r}")
+
+
+def _object_from_dict(raw: dict[str, Any], index: int) -> ObjectSpec:
+    if not isinstance(raw, dict):
+        raise SceneSpecError(f"object[{index}] must be a JSON object, got {raw!r}")
+    asset_source = str(raw.get("asset_source") or "").strip()
+    if asset_source not in ASSET_SOURCES:
+        raise SceneSpecError(
+            f"object[{index}] asset_source must be one of {ASSET_SOURCES}, "
+            f"got {asset_source!r}"
+        )
+    role = str(raw.get("role") or ROLE_MANIPULAND).strip()
+    if role not in ROLES:
+        raise SceneSpecError(
+            f"object[{index}] role must be one of {ROLES}, got {role!r}"
+        )
+    name = str(raw.get("name") or f"object-{index:02d}").strip()
+    obj = ObjectSpec(name=name, asset_source=asset_source, role=role)
+
+    if asset_source == ASSET_SOURCE_BYO_MESH:
+        uri = str(raw.get("uri") or "").strip()
+        if not uri:
+            raise SceneSpecError(f"object[{index}] byo_mesh requires a non-empty uri")
+        obj.uri = uri
+    elif asset_source == ASSET_SOURCE_GENESIS_BUILTIN:
+        builtin = str(raw.get("builtin_path") or raw.get("file") or "").strip()
+        if not builtin:
+            raise SceneSpecError(
+                f"object[{index}] genesis_builtin requires builtin_path"
+            )
+        obj.builtin_path = builtin
+    else:  # primitive
+        primitive = str(raw.get("primitive") or PRIMITIVE_BOX).strip()
+        if primitive not in PRIMITIVES:
+            raise SceneSpecError(
+                f"object[{index}] primitive must be one of {PRIMITIVES}, "
+                f"got {primitive!r}"
+            )
+        obj.primitive = primitive
+
+    if "scale" in raw:
+        obj.scale = _coerce_scale(raw["scale"])
+    if "size" in raw:
+        obj.size = _coerce_triple(raw["size"], "size")
+    if "radius" in raw:
+        obj.radius = float(raw["radius"])
+    if "height" in raw:
+        obj.height = float(raw["height"])
+    if "pos" in raw:
+        obj.pos = _coerce_triple(raw["pos"], "pos")
+    if "euler" in raw:
+        obj.euler = _coerce_triple(raw["euler"], "euler")
+    if "color" in raw:
+        obj.color = _coerce_triple(raw["color"], "color")
+    if raw.get("mass") is not None:
+        obj.mass = float(raw["mass"])
+    if raw.get("friction") is not None:
+        obj.friction = float(raw["friction"])
+    obj.fixed = bool(raw.get("fixed", role == ROLE_STATIC))
+    return obj
+
+
+def _object_to_dict(obj: ObjectSpec) -> dict[str, Any]:
+    scale = list(obj.scale) if isinstance(obj.scale, tuple) else obj.scale
+    return {
+        "name": obj.name,
+        "asset_source": obj.asset_source,
+        "role": obj.role,
+        "uri": obj.uri,
+        "builtin_path": obj.builtin_path,
+        "primitive": obj.primitive,
+        "scale": scale,
+        "size": list(obj.size),
+        "radius": obj.radius,
+        "height": obj.height,
+        "pos": list(obj.pos),
+        "euler": list(obj.euler),
+        "color": list(obj.color),
+        "mass": obj.mass,
+        "friction": obj.friction,
+        "fixed": obj.fixed,
+    }
+
+
+def parse_scene_spec(doc: dict[str, Any], *, source_uri: str = "") -> SceneSpec:
+    """Parse and validate a SceneSpec JSON document into a SceneSpec."""
+
+    if not isinstance(doc, dict):
+        raise SceneSpecError(f"SceneSpec must be a JSON object, got {type(doc)!r}")
+    raw_objects = doc.get("objects")
+    if not isinstance(raw_objects, list) or not raw_objects:
+        raise SceneSpecError("SceneSpec must include a non-empty 'objects' list")
+    objects = [_object_from_dict(raw, index) for index, raw in enumerate(raw_objects)]
+    manipulands = [obj for obj in objects if obj.role == ROLE_MANIPULAND]
+    if not manipulands:
+        raise SceneSpecError("SceneSpec must include at least one manipuland object")
+    goal_pos = (
+        _coerce_triple(doc["goal_pos"], "goal_pos")
+        if doc.get("goal_pos") is not None
+        else DEFAULT_TARGET_POS
+    )
+    goal_threshold = float(doc.get("goal_threshold", DEFAULT_TARGET_THRESHOLD))
+    if goal_threshold <= 0:
+        raise SceneSpecError("goal_threshold must be positive")
+    return SceneSpec(
+        objects=objects,
+        schema=str(doc.get("schema") or SCENE_SPEC_SCHEMA),
+        goal_pos=goal_pos,
+        goal_threshold=goal_threshold,
+        source_uri=source_uri or str(doc.get("source_uri") or ""),
+    )
+
+
+def synthesize_scene_spec(
+    *,
+    assets_uri: str = "",
+    byo_mesh_uri: str = "",
+    scale: float | tuple[float, float, float] = 1.0,
+    pos: tuple[float, float, float] = DEFAULT_CUBE_POS,
+    goal_pos: tuple[float, float, float] = DEFAULT_TARGET_POS,
+    goal_threshold: float = DEFAULT_TARGET_THRESHOLD,
+) -> SceneSpec:
+    """Build a single-manipuland SceneSpec from a bare mesh URI.
+
+    Used when only ``assets_uri`` / ``byo_mesh_uri`` is provided (no full
+    SceneSpec JSON). Keeps the Franka robot and the documented target zone.
+    """
+
+    mesh_uri = (byo_mesh_uri or assets_uri or "").strip()
+    if not mesh_uri:
+        raise SceneSpecError(
+            "synthesize_scene_spec requires byo_mesh_uri or assets_uri"
+        )
+    return SceneSpec(
+        objects=[
+            ObjectSpec(
+                name="byo_object",
+                asset_source=ASSET_SOURCE_BYO_MESH,
+                role=ROLE_MANIPULAND,
+                uri=mesh_uri,
+                scale=scale,
+                pos=pos,
+                color=DEFAULT_COLOR,
+            )
+        ],
+        goal_pos=goal_pos,
+        goal_threshold=goal_threshold,
+        source_uri=mesh_uri,
+    )
+
+
+def sha256_file(path: str | Path) -> str:
+    """Return the hex SHA-256 of a file (streamed)."""
+
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_local_asset(path: Path, *, what: str) -> None:
+    if not path.is_file():
+        raise SceneSpecError(f"{what} did not produce a file at {path}")
+    if path.stat().st_size == 0:
+        raise SceneSpecError(f"{what} produced an empty file at {path}")
+
+
+def download_asset(
+    uri: str,
+    dest_dir: str | Path,
+    *,
+    client: Any = None,
+    endpoint_url: str = "",
+) -> Path:
+    """Fetch a mesh asset (s3:// or local path) to ``dest_dir``; validate it.
+
+    Returns the local path. Raises ``SceneSpecError`` if the asset is missing
+    or empty. The S3 client follows the repo's ``StorageClient`` patterns.
+    """
+
+    uri = str(uri or "").strip()
+    if not uri:
+        raise SceneSpecError("download_asset requires a non-empty uri")
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    filename = Path(uri.split("?", 1)[0].rstrip("/")).name or "asset.bin"
+    dest = dest_dir / filename
+
+    if uri.startswith("s3://"):
+        if client is None:
+            from npa.clients.storage import StorageClient
+
+            client = StorageClient.from_environment(endpoint_url=endpoint_url)
+        client.download_path(uri, str(dest))
+    elif uri.startswith("file://"):
+        src = Path(uri[len("file://") :])
+        _validate_local_asset(src, what=f"asset source {uri}")
+        dest.write_bytes(src.read_bytes())
+    else:
+        src = Path(uri)
+        _validate_local_asset(src, what=f"asset source {uri}")
+        if src.resolve() != dest.resolve():
+            dest.write_bytes(src.read_bytes())
+
+    _validate_local_asset(dest, what=f"download of {uri}")
+    return dest
+
+
+def resolve_genesis_builtin_path(builtin_path: str) -> Path:
+    """Resolve a builtin asset path relative to the installed Genesis package.
+
+    Imported lazily so this module stays importable without genesis-world.
+    """
+
+    builtin_path = str(builtin_path or "").strip().lstrip("/")
+    if not builtin_path:
+        raise SceneSpecError("genesis_builtin requires a builtin_path")
+    import genesis as gs  # noqa: PLC0415 - lazy, GPU image only
+
+    assets_root = Path(gs.__file__).resolve().parent / "assets"
+    candidate = assets_root / builtin_path
+    if not candidate.is_file():
+        raise SceneSpecError(
+            f"genesis_builtin asset not found under {assets_root}: {builtin_path}"
+        )
+    return candidate
+
+
+def resolve_scene_assets(
+    spec: SceneSpec,
+    *,
+    dest_dir: str | Path,
+    client: Any = None,
+    endpoint_url: str = "",
+    downloader: Any = None,
+    builtin_resolver: Any = None,
+) -> SceneSpec:
+    """Download/resolve every object's asset, computing local_path + sha256.
+
+    Mutates ``spec`` objects in place (sets ``local_path`` / ``sha256``) and
+    returns it. Mesh assets that fail to resolve raise ``SceneSpecError`` —
+    there is no silent primitive fallback.
+    """
+
+    downloader = downloader or download_asset
+    builtin_resolver = builtin_resolver or resolve_genesis_builtin_path
+    dest_dir = Path(dest_dir)
+    for obj in spec.objects:
+        if obj.asset_source == ASSET_SOURCE_BYO_MESH:
+            local = downloader(
+                obj.uri,
+                dest_dir / _safe_name(obj.name),
+                client=client,
+                endpoint_url=endpoint_url,
+            )
+            obj.local_path = str(local)
+            obj.sha256 = sha256_file(local)
+        elif obj.asset_source == ASSET_SOURCE_GENESIS_BUILTIN:
+            local = builtin_resolver(obj.builtin_path)
+            _validate_local_asset(Path(local), what=f"genesis_builtin {obj.builtin_path}")
+            obj.local_path = str(local)
+            obj.sha256 = sha256_file(local)
+        # primitives: nothing to download; local_path/sha256 stay empty.
+    return spec
+
+
+def _safe_name(value: str) -> str:
+    chars = [c if c.isalnum() or c in ("-", "_", ".") else "-" for c in str(value)]
+    return "".join(chars) or "object"

--- a/npa/src/npa/workbench/lerobot/policy_container.py
+++ b/npa/src/npa/workbench/lerobot/policy_container.py
@@ -115,6 +115,60 @@ class VlmSignalUpdateResult:
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> VlmSignalUpdateResult:
+        """Parse a BYO trainer-command JSON result into a structured update.
+
+        Required fields (a BYO trainer-command MUST emit these): ``reward_head_after``,
+        ``policy_output_after`` (non-empty list), and ``policy_delta_l2``. Every other
+        field falls back to a safe default so a minimal customer trainer hook still
+        produces a usable, attributable update record.
+        """
+
+        if not isinstance(payload, dict):
+            raise PolicyContainerError(
+                "VlmSignalUpdateResult.from_dict requires a JSON object payload"
+            )
+        for required in ("reward_head_after", "policy_output_after", "policy_delta_l2"):
+            if required not in payload:
+                raise PolicyContainerError(
+                    f"trainer update payload missing required field: {required}"
+                )
+        policy_output_after = payload["policy_output_after"]
+        if not isinstance(policy_output_after, list) or not policy_output_after:
+            raise PolicyContainerError(
+                "trainer update policy_output_after must be a non-empty list"
+            )
+        policy_output_after = [float(item) for item in policy_output_after]
+        raw_before = payload.get("policy_output_before")
+        if isinstance(raw_before, list) and raw_before:
+            policy_output_before = [float(item) for item in raw_before]
+        else:
+            policy_output_before = [0.0 for _ in policy_output_after]
+        loss_before = float(payload.get("loss_before", 0.0))
+        loss_after = float(payload.get("loss_after", loss_before))
+        return cls(
+            status=str(payload.get("status", "updated")),
+            backend=str(payload.get("backend", "byo_command")),
+            steps=int(payload.get("steps", 1)),
+            loss_before=loss_before,
+            loss_after=loss_after,
+            reward_head_before=float(payload.get("reward_head_before", 0.0)),
+            reward_head_after=float(payload["reward_head_after"]),
+            policy_output_before=policy_output_before,
+            policy_output_after=policy_output_after,
+            policy_delta_l2=float(payload["policy_delta_l2"]),
+            mean_reward=float(payload.get("mean_reward", 0.0)),
+            mean_advantage=float(payload.get("mean_advantage", 0.0)),
+            checkpoint_path=str(payload.get("checkpoint_path", "")),
+            signal_count=int(payload.get("signal_count", 0)),
+            control=bool(payload.get("control", False)),
+            loss_integration_point=str(
+                payload.get("loss_integration_point", "byo_trainer_command")
+            ),
+            duration_ms=float(payload.get("duration_ms", 0.0)),
+        )
+
 
 @dataclass(frozen=True)
 class LeRobotImportResult:

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -21,10 +21,21 @@ from urllib.parse import urlparse
 
 from npa.clients.storage import StorageClient
 from npa.deploy.images import container_image_for_tool
-from npa.workbench.lerobot.policy_container import (
-    parse_vlm_signal_batch,
-    run_vlm_signal_training_step,
-)
+
+# npa.workbench.lerobot.policy_container is imported lazily inside the inner
+# loop (see _signal_training_imports). Importing it at module load pulls the
+# full npa.workbench tool tree (lancedb/fiftyone/etc.), which is intentionally
+# absent from the Isaac Lab held-out image; the Isaac rollout path never needs
+# it. Keeping the import lazy lets sim2real_loop run on a minimal interpreter.
+
+
+def _signal_training_imports():
+    from npa.workbench.lerobot.policy_container import (
+        parse_vlm_signal_batch,
+        run_vlm_signal_training_step,
+    )
+
+    return parse_vlm_signal_batch, run_vlm_signal_training_step
 
 
 DEFAULT_S3_ENDPOINT = ""
@@ -962,6 +973,7 @@ def run_inner_loop(
         _write_json_artifact(
             signal_batch_path, {"schema": SCHEMA_RL_SIGNAL, "signals": signals}
         )
+        parse_vlm_signal_batch, run_vlm_signal_training_step = _signal_training_imports()
         parsed_signals = parse_vlm_signal_batch({"signals": signals})
         update = run_vlm_signal_training_step(
             parsed_signals,
@@ -1485,6 +1497,7 @@ def _component_job_script(component: str, *, sim_backend: str = DEFAULT_SIM_BACK
     # boto3 is installed to a writable target dir for the S3 client.
     if component == "heldout_eval" and sim_backend == SIM_BACKEND_ISAAC:
         return f"""set -euo pipefail
+export NPA_SKIP_EAGER_IMPORTS=1
 PYBIN=/isaac-sim/python.sh
 if [ ! -x "$PYBIN" ]; then PYBIN=python; fi
 DEPS=/tmp/npa-pydeps

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -838,6 +838,7 @@ def run_inner_loop(
     iteration_records: list[dict[str, Any]] = []
     reward_trend: list[float] = []
     policy_deltas: list[float] = []
+    all_signals: list[dict[str, Any]] = []
     quality = float(initial_quality)
     reward_head = 0.0
     action_bias = 0.0
@@ -882,6 +883,7 @@ def run_inner_loop(
             _write_json_artifact(signal_dir / f"{signal['rollout_id']}.json", signal)
             evals.append(evaluation)
             signals.append(signal)
+            all_signals.append(signal)
         signal_batch_path = (
             local_dir
             / "inner_loop"
@@ -949,11 +951,25 @@ def run_inner_loop(
             }
         )
 
+    signal_diversity = _signal_diversity_report(all_signals)
+    if signal_diversity["degenerate"] and _bool_value(
+        os.environ.get("NPA_SIM2REAL_REQUIRE_SIGNAL_DIVERSITY", "0")
+    ):
+        raise Sim2RealLoopError(
+            "VLM->RL signal is degenerate: "
+            f"{signal_diversity['distinct_scores']} distinct score(s) and "
+            f"{signal_diversity['distinct_mean_rewards']} distinct mean-reward(s) "
+            f"across {signal_diversity['total_rollouts']} rollout(s) "
+            f"(scores={signal_diversity['score_values']}). "
+            "Unset NPA_SIM2REAL_REQUIRE_SIGNAL_DIVERSITY to downgrade this gate to a "
+            "diagnostic."
+        )
     evidence = {
         "schema": "npa.sim2real.inner_loop_evidence.v1",
         "outer_iteration": outer_iteration,
         "status": "closed",
         "reward_trend": reward_trend,
+        "signal_diversity": signal_diversity,
         "policy_delta_vs_no_signal_control": policy_deltas,
         "attribution": (
             "The reference update and no-signal control share initial adapter state. "
@@ -1257,6 +1273,7 @@ def _run_kubernetes_image_component(
         "mode": "kubernetes_job",
         "component": component,
         "image": image,
+        "image_digests": pod_info.get("image_digests", []),
         "namespace": namespace,
         "job_name": job_name,
         "pod": pod_info,
@@ -1303,7 +1320,7 @@ def _component_job_manifest(
             {
                 "name": "component",
                 "image": image,
-                "imagePullPolicy": "IfNotPresent",
+                "imagePullPolicy": _image_pull_policy(image),
                 "command": ["bash", "-lc"],
                 "args": [_component_job_script(component)],
                 "env": [
@@ -1475,20 +1492,27 @@ def _component_pod_info(
     container = (pod.get("spec", {}).get("containers") or [{}])[0]
     resources = container.get("resources", {})
     statuses = pod.get("status", {}).get("containerStatuses") or []
+    container_statuses = [
+        {
+            "name": item.get("name", ""),
+            "ready": item.get("ready", False),
+            "restart_count": item.get("restartCount", 0),
+            "image": item.get("image", ""),
+            "image_id": item.get("imageID", ""),
+            "state": item.get("state", {}),
+        }
+        for item in statuses
+    ]
+    image_digests = [
+        status["image_id"] for status in container_statuses if status["image_id"]
+    ]
     return {
         "name": pod.get("metadata", {}).get("name", ""),
         "node_name": pod.get("spec", {}).get("nodeName", ""),
         "phase": pod.get("status", {}).get("phase", ""),
         "resources": resources,
-        "container_statuses": [
-            {
-                "name": item.get("name", ""),
-                "ready": item.get("ready", False),
-                "restart_count": item.get("restartCount", 0),
-                "state": item.get("state", {}),
-            }
-            for item in statuses
-        ],
+        "container_statuses": container_statuses,
+        "image_digests": image_digests,
     }
 
 
@@ -2318,11 +2342,16 @@ def _parse_cosmos_reason_output(
             or model_text
         ).strip()
         tags = payload.get("error_tags") or _tags_from_text(critique)
+        # The model returned no per-step breakdown, so the single summary critique
+        # is broadcast across every action step. Mark it as such so a degenerate
+        # (all-identical) per-step signal is visible rather than masquerading as
+        # genuine per-step granularity.
         raw_steps = [
             {
                 "step": int(action.get("step", index)),
                 "critique_text": critique,
                 "error_tags": tags,
+                "critique_source": "summary_broadcast",
                 "camera_observation": f"camera-{int(action.get('step', index)):03d}.ppm",
             }
             for index, action in enumerate(actions)
@@ -2502,7 +2531,9 @@ def _run_genesis_heldout_rollouts(
             env_success = bool(success[index].detach().item())
             distance_score = max(0.0, min(1.0, 1.0 - dist / 0.5))
             reward_score = max(0.0, min(1.0, reward_value / 10.0))
-            score = 1.0 if env_success else round(0.7 * distance_score + 0.3 * reward_score, 6)
+            score = _heldout_env_score(
+                distance_score, reward_score, env_success=env_success
+            )
             per_env.append(
                 {
                     "env_id": str(env_record.get("env_id") or f"heldout-{start + index:04d}"),
@@ -2987,6 +3018,68 @@ def _merge_targets(tags: list[str]) -> dict[str, Any]:
 def _signal_mean_reward(signal: dict[str, Any]) -> float:
     steps = signal.get("per_step") or []
     return sum(float(step["reward"]) for step in steps) / float(len(steps))
+
+
+def _heldout_env_score(
+    distance_score: float, reward_score: float, *, env_success: bool
+) -> float:
+    """Map per-env distance/reward to a continuous held-out score.
+
+    Successful and failed envs occupy separate bands, but the score stays
+    continuous in the env's own distance/reward so the held-out report keeps a
+    gradient instead of collapsing to a flat ``1.0`` across every env (which
+    produced an uninformative, incoherent signal).
+    """
+
+    quality = max(0.0, min(1.0, 0.7 * distance_score + 0.3 * reward_score))
+    if env_success:
+        return round(0.75 + 0.25 * quality, 6)
+    return round(0.6 * quality, 6)
+
+
+def _signal_diversity_report(signals: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize cross-rollout diversity of the VLM->RL signal.
+
+    A genuine signal varies across rollouts; a single distinct score/reward
+    across every rollout is the degenerate ("hollow") pattern. These metrics
+    (``distinct_scores``, ``coherent``) are emitted into loop evidence so a run
+    is self-describing instead of requiring an external validator to infer them.
+    """
+
+    scores = [round(float(signal.get("score") or 0.0), 4) for signal in signals]
+    mean_rewards = [round(_signal_mean_reward(signal), 4) for signal in signals]
+    distinct_scores = sorted({score for score in scores})
+    distinct_rewards = sorted({reward for reward in mean_rewards})
+    total = len(signals)
+    coherent = total > 1 and len(distinct_scores) > 1 and len(distinct_rewards) > 1
+    return {
+        "total_rollouts": total,
+        "distinct_scores": len(distinct_scores),
+        "distinct_mean_rewards": len(distinct_rewards),
+        "score_values": distinct_scores,
+        "mean_reward_values": distinct_rewards,
+        "coherent": coherent,
+        "degenerate": not coherent,
+    }
+
+
+def _image_pull_policy(image: str) -> str:
+    """Choose the imagePullPolicy for a sibling component image.
+
+    Provenance-sensitive ``-genuine-`` builds are pulled fresh so a stale image
+    cached under the same tag cannot silently masquerade as the genuine build.
+    A digest-pinned reference (``@sha256:``) is already immutable.
+    """
+
+    override = os.environ.get("NPA_SIM2REAL_IMAGE_PULL_POLICY", "").strip()
+    if override:
+        return override
+    if "@sha256:" in image:
+        return "IfNotPresent"
+    tag = image.rsplit(":", 1)[-1] if ":" in image.rsplit("/", 1)[-1] else ""
+    if "genuine" in tag:
+        return "Always"
+    return "IfNotPresent"
 
 
 def _write_ppm(path: Path, *, red: int, green: int, blue: int) -> None:

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -35,6 +35,15 @@ DEFAULT_ENVGEN_TAG = "0.1.1"
 DEFAULT_REFERENCE_POLICY_TAG = "0.1.1"
 DEFAULT_TRAINER_TAG = "0.1.0"
 DEFAULT_EVAL_TAG = "0.1.1-genuine-sm120"
+DEFAULT_ISAAC_TAG = "2.3.2.post1"
+# Pluggable held-out sim backend. Genesis remains fully supported; Isaac Lab
+# (Isaac Sim headless) is the default and requires RT-core GPUs (L40S / RTX Pro).
+SIM_BACKEND_GENESIS = "genesis"
+SIM_BACKEND_ISAAC = "isaac"
+SIM_BACKENDS = (SIM_BACKEND_GENESIS, SIM_BACKEND_ISAAC)
+DEFAULT_SIM_BACKEND = SIM_BACKEND_ISAAC
+# Default headless Isaac Lab manipulation task for the stock held-out rollout.
+DEFAULT_ISAAC_TASK = "Isaac-Lift-Cube-Franka-v0"
 DEFAULT_THRESHOLD = 0.75
 DEFAULT_INNER_ITERATIONS = 2
 DEFAULT_OUTER_ITERATIONS = 1
@@ -125,6 +134,9 @@ class Sim2RealLoopConfig:
     trainer_image: str = f"npa-lerobot-vlm-rl:{DEFAULT_TRAINER_TAG}"
     vlm_image: str = f"npa-cosmos3-reason:{DEFAULT_VLM_IMAGE_TAG}"
     eval_image: str = f"npa-sim2real-eval:{DEFAULT_EVAL_TAG}"
+    isaac_image: str = f"npa-isaac-lab:{DEFAULT_ISAAC_TAG}"
+    sim_backend: str = DEFAULT_SIM_BACKEND
+    isaac_task: str = DEFAULT_ISAAC_TASK
     vlm_model: str = DEFAULT_REFERENCE_VLM_MODEL
     threshold: float = DEFAULT_THRESHOLD
     inner_iterations: int = DEFAULT_INNER_ITERATIONS
@@ -182,6 +194,21 @@ class Sim2RealLoopConfig:
             raise Sim2RealLoopError("k8s_job_timeout_s must be positive")
         if self.heldout_eval_limit < 0:
             raise Sim2RealLoopError("heldout_eval_limit must be non-negative")
+        if self.sim_backend not in SIM_BACKENDS:
+            raise Sim2RealLoopError(
+                f"sim_backend must be one of {SIM_BACKENDS}, got {self.sim_backend!r}"
+            )
+
+    def heldout_backend_image(self) -> str:
+        """Return the container image that runs the held-out rollout backend.
+
+        Genesis runs inside the reference eval image; Isaac runs inside the
+        Isaac Lab image (Isaac Sim headless, RT cores required).
+        """
+
+        if self.sim_backend == SIM_BACKEND_ISAAC:
+            return self.isaac_image
+        return self.eval_image
 
 
 def new_run_id(prefix: str = "sim2real-b") -> str:
@@ -229,6 +256,14 @@ def default_eval_image(*, registry: str | None = None) -> str:
     if registry or os.environ.get("NPA_REGISTRY"):
         return container_image_for_tool("sim2real-eval", registry=registry)
     return f"npa-sim2real-eval:{DEFAULT_EVAL_TAG}"
+
+
+def default_isaac_image(*, registry: str | None = None) -> str:
+    """Return the Isaac Lab held-out rollout image (Isaac Sim headless)."""
+
+    if registry or os.environ.get("NPA_REGISTRY"):
+        return container_image_for_tool("isaac-lab", registry=registry)
+    return f"npa-isaac-lab:{DEFAULT_ISAAC_TAG}"
 
 
 def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
@@ -320,6 +355,21 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
             overrides.get("eval_image")
             or os.environ.get("EVAL_IMAGE")
             or default_eval_image(registry=registry or None)
+        ),
+        isaac_image=str(
+            overrides.get("isaac_image")
+            or os.environ.get("ISAAC_IMAGE")
+            or default_isaac_image(registry=registry or None)
+        ),
+        sim_backend=str(
+            overrides.get("sim_backend")
+            or os.environ.get("NPA_SIM2REAL_SIM_BACKEND")
+            or DEFAULT_SIM_BACKEND
+        ).strip().lower(),
+        isaac_task=str(
+            overrides.get("isaac_task")
+            or os.environ.get("NPA_SIM2REAL_ISAAC_TASK")
+            or DEFAULT_ISAAC_TASK
         ),
         vlm_model=str(
             overrides.get("vlm_model")
@@ -514,6 +564,9 @@ def byo_seams(config: Sim2RealLoopConfig) -> dict[str, Any]:
         "trainer_image": config.trainer_image,
         "vlm_image": config.vlm_image,
         "eval_image": config.eval_image,
+        "isaac_image": config.isaac_image,
+        "sim_backend": config.sim_backend,
+        "isaac_task": config.isaac_task,
         "threshold": config.threshold,
         "inner_iterations": config.inner_iterations,
         "outer_iterations": config.outer_iterations,
@@ -1338,7 +1391,7 @@ def _component_job_manifest(
                 "image": image,
                 "imagePullPolicy": _image_pull_policy(image),
                 "command": ["bash", "-lc"],
-                "args": [_component_job_script(component)],
+                "args": [_component_job_script(component, sim_backend=config.sim_backend)],
                 "env": [
                     {"name": key, "value": value}
                     for key, value in sorted(env_values.items())
@@ -1399,7 +1452,7 @@ def _component_job_manifest(
     }
 
 
-def _component_job_script(component: str) -> str:
+def _component_job_script(component: str, *, sim_backend: str = DEFAULT_SIM_BACKEND) -> str:
     if component == "vlm_eval":
         subcommand = (
             "component-vlm-eval "
@@ -1417,11 +1470,44 @@ def _component_job_script(component: str) -> str:
             "--output-uri \"${NPA_SIM2REAL_OUTPUT_URI}\" "
             "--threshold \"${NPA_SIM2REAL_THRESHOLD}\" "
             "--limit \"${NPA_SIM2REAL_HELDOUT_EVAL_LIMIT:-0}\" "
+            "--sim-backend \"${NPA_SIM2REAL_SIM_BACKEND:-genesis}\" "
+            "--isaac-task \"${NPA_SIM2REAL_ISAAC_TASK:-}\" "
             "--scene-spec-uri \"${NPA_SIM2REAL_SCENE_SPEC_URI:-}\" "
             "--assets-uri \"${NPA_SIM2REAL_ASSETS_URI:-}\""
         )
     else:
         raise Sim2RealLoopError(f"unsupported image component: {component}")
+    # The Isaac Lab image ships Isaac Sim + isaaclab only under its bundled
+    # interpreter (/isaac-sim/python.sh) and bakes no npa code. Branch npa code
+    # is injected at start either from an S3 source tarball
+    # (NPA_SIM2REAL_SOURCE_TARBALL_URI, using the pod's mounted S3 creds) or via
+    # a git clone (NPA_SOURCE_REPO/NPA_SOURCE_REF when the repo is reachable).
+    # boto3 is installed to a writable target dir for the S3 client.
+    if component == "heldout_eval" and sim_backend == SIM_BACKEND_ISAAC:
+        return f"""set -euo pipefail
+PYBIN=/isaac-sim/python.sh
+if [ ! -x "$PYBIN" ]; then PYBIN=python; fi
+DEPS=/tmp/npa-pydeps
+"$PYBIN" -c "import boto3" 2>/dev/null || "$PYBIN" -m pip install --quiet --target "$DEPS" boto3 botocore
+export PYTHONPATH="$DEPS:${{PYTHONPATH:-}}"
+if [ -n "${{NPA_SIM2REAL_SOURCE_TARBALL_URI:-}}" ]; then
+  rm -rf /tmp/npa-source && mkdir -p /tmp/npa-source
+  "$PYBIN" - "${{NPA_SIM2REAL_SOURCE_TARBALL_URI}}" <<'PYB'
+import os, sys, tarfile, urllib.parse, boto3
+u = urllib.parse.urlparse(sys.argv[1])
+ep = os.environ.get("AWS_ENDPOINT_URL") or os.environ.get("S3_ENDPOINT_URL") or None
+boto3.client("s3", endpoint_url=ep).download_file(u.netloc, u.path.lstrip("/"), "/tmp/npa-src.tgz")
+with tarfile.open("/tmp/npa-src.tgz") as tar:
+    tar.extractall("/tmp/npa-source")
+PYB
+  export PYTHONPATH="/tmp/npa-source/npa/src:${{PYTHONPATH:-}}"
+elif [ -n "${{NPA_SOURCE_REPO:-}}" ] && [ -n "${{NPA_SOURCE_REF:-}}" ]; then
+  rm -rf /tmp/npa-source
+  git clone --quiet --depth 1 --branch "${{NPA_SOURCE_REF}}" "${{NPA_SOURCE_REPO}}" /tmp/npa-source
+  export PYTHONPATH="/tmp/npa-source/npa/src:${{PYTHONPATH:-}}"
+fi
+"$PYBIN" -m npa.workflows.sim2real_loop {subcommand}
+"""
     return f"""set -euo pipefail
 if [ -n "${{NPA_SOURCE_REPO:-}}" ] && [ -n "${{NPA_SOURCE_REF:-}}" ]; then
   rm -rf /tmp/npa-source
@@ -1841,6 +1927,9 @@ def run_heldout_eval(
             "NPA_SIM2REAL_INNER_EVIDENCE_JSON": str(inner_path),
             "NPA_SIM2REAL_THRESHOLD": str(config.threshold),
             "NPA_SIM2REAL_EVAL_IMAGE": config.eval_image,
+            "NPA_SIM2REAL_ISAAC_IMAGE": config.isaac_image,
+            "NPA_SIM2REAL_SIM_BACKEND": config.sim_backend,
+            "NPA_SIM2REAL_ISAAC_TASK": config.isaac_task,
             "NPA_SIM2REAL_SCENE_SPEC_URI": config.scene_spec_uri,
             "NPA_SIM2REAL_ASSETS_URI": config.assets_uri,
         },
@@ -1884,7 +1973,7 @@ def run_heldout_eval(
         env["NPA_SIM2REAL_OUTPUT_URI"] = output_uri
         env["NPA_SIM2REAL_HELDOUT_EVAL_LIMIT"] = str(config.heldout_eval_limit)
         invocation = _run_image_component(
-            config.eval_image,
+            config.heldout_backend_image(),
             component="heldout_eval",
             env=env,
             output_json=output_path,
@@ -2083,15 +2172,24 @@ def run_heldout_eval_component_from_s3(
     scene_spec_uri: str = "",
     assets_uri: str = "",
     byo_mesh_uri: str = "",
+    sim_backend: str = DEFAULT_SIM_BACKEND,
+    isaac_task: str = DEFAULT_ISAAC_TASK,
 ) -> dict[str, Any]:
     """Run the image-local held-out eval contract against env records in S3.
 
-    When ``scene_spec_uri`` (a SceneSpec JSON) or ``assets_uri`` /
-    ``byo_mesh_uri`` (a bare mesh URI) is provided, the scene's manipulated
-    object(s) are downloaded, validated, and loaded into the Genesis sim, and
-    per-object asset provenance is recorded into the report.
+    Dispatches on ``sim_backend`` (``genesis`` or ``isaac``). When
+    ``scene_spec_uri`` (a SceneSpec JSON) or ``assets_uri`` / ``byo_mesh_uri``
+    (a bare mesh URI) is provided, the scene's manipulated object(s) are
+    downloaded, validated, and loaded into the simulator, and per-object asset
+    provenance is recorded into the report. For the Isaac backend with no BYO
+    inputs the stock Isaac Lab scene is used (``asset_source=isaac_stock``).
     """
 
+    sim_backend = (sim_backend or DEFAULT_SIM_BACKEND).strip().lower()
+    if sim_backend not in SIM_BACKENDS:
+        raise Sim2RealLoopError(
+            f"sim_backend must be one of {SIM_BACKENDS}, got {sim_backend!r}"
+        )
     with tempfile.TemporaryDirectory(prefix="sim2real-heldout-component-") as tmp:
         root = Path(tmp)
         env_dir = root / "heldout"
@@ -2106,18 +2204,29 @@ def run_heldout_eval_component_from_s3(
             envs = envs[:limit]
         if not envs:
             raise Sim2RealLoopError("held-out component found no env records")
-        scene = _resolve_heldout_scene(
-            scene_spec_uri=scene_spec_uri,
-            assets_uri=assets_uri,
-            byo_mesh_uri=byo_mesh_uri,
-            dest_dir=root / "assets",
-            client=client,
-        )
+        if sim_backend == SIM_BACKEND_ISAAC:
+            scene = _resolve_isaac_scene(
+                scene_spec_uri=scene_spec_uri,
+                assets_uri=assets_uri,
+                byo_mesh_uri=byo_mesh_uri,
+                dest_dir=root / "assets",
+                client=client,
+            )
+        else:
+            scene = _resolve_heldout_scene(
+                scene_spec_uri=scene_spec_uri,
+                assets_uri=assets_uri,
+                byo_mesh_uri=byo_mesh_uri,
+                dest_dir=root / "assets",
+                client=client,
+            )
         payload = _component_heldout_payload(
             envs,
             inner_evidence=inner_evidence,
             threshold=threshold,
             scene=scene,
+            sim_backend=sim_backend,
+            isaac_task=isaac_task,
         )
         _write_json_artifact(output_path, payload)
         client.upload_file(str(output_path), output_uri)
@@ -2132,6 +2241,7 @@ def run_heldout_eval_component_from_s3(
             json.dumps(
                 {
                     "component": "heldout_eval",
+                    "sim_backend": sim_backend,
                     "env_count": len(payload["per_env"]),
                     "output_uri": output_uri,
                     "asset_fallback_used": payload.get("asset_fallback_used"),
@@ -2162,6 +2272,41 @@ def _resolve_heldout_scene(
     mesh_uri = (byo_mesh_uri or assets_uri or "").strip()
     if not scene_spec_uri and not mesh_uri:
         return None
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    if scene_spec_uri:
+        spec_local = dest_dir / "scene-spec.json"
+        client.download_path(scene_spec_uri, str(spec_local))
+        doc = json.loads(spec_local.read_text(encoding="utf-8"))
+        scene = scene_assets.parse_scene_spec(doc, source_uri=scene_spec_uri)
+    else:
+        scene = scene_assets.synthesize_scene_spec(byo_mesh_uri=mesh_uri)
+    scene_assets.resolve_scene_assets(scene, dest_dir=dest_dir, client=client)
+    return scene
+
+
+def _resolve_isaac_scene(
+    *,
+    scene_spec_uri: str,
+    assets_uri: str,
+    byo_mesh_uri: str,
+    dest_dir: Path,
+    client: Any,
+) -> Any:
+    """Resolve the Isaac held-out scene (stock or BYO mesh).
+
+    With no BYO URIs the stock Isaac Lab lift-cube scene is returned
+    (``asset_source=isaac_stock``). When a SceneSpec JSON or a bare mesh URI is
+    given, the manipuland is downloaded + hashed (``asset_source=byo_mesh``) so
+    the Isaac rollout can import it to USD and prove it loaded (no fallback).
+    """
+
+    from npa.genesis import scene_assets
+
+    scene_spec_uri = (scene_spec_uri or "").strip()
+    mesh_uri = (byo_mesh_uri or assets_uri or "").strip()
+    if not scene_spec_uri and not mesh_uri:
+        return scene_assets.default_isaac_stock_scene_spec()
 
     dest_dir.mkdir(parents=True, exist_ok=True)
     if scene_spec_uri:
@@ -2278,20 +2423,49 @@ def _component_heldout_payload(
     inner_evidence: dict[str, Any],
     threshold: float,
     scene: Any = None,
+    sim_backend: str = DEFAULT_SIM_BACKEND,
+    isaac_task: str = DEFAULT_ISAAC_TASK,
 ) -> dict[str, Any]:
-    per_env = _run_genesis_heldout_rollouts(
-        envs,
-        inner_evidence=inner_evidence,
-        threshold=threshold,
-        scene=scene,
-    )
-    payload = {
-        "schema": SCHEMA_HELDOUT_REPORT,
-        "per_env": per_env,
-        "component_source": "genesis_rollout",
-        "rollout_backend": "npa.genesis.env_pick_place.FrankaPickPlaceEnv",
-        "policy_source": "inner_evidence_adapter",
-    }
+    """Run the held-out rollout on the selected backend and shape report.json.
+
+    Both backends emit the identical ``npa.sim2real.heldout_eval.v1`` schema
+    (``per_env`` with ``env_id``/``score``/``success``/``details``) so the
+    outer-loop gate and report stay backend-agnostic. The Genesis path
+    (PR #92) is preserved unchanged for ``sim_backend=genesis``.
+    """
+
+    sim_backend = (sim_backend or DEFAULT_SIM_BACKEND).strip().lower()
+    if sim_backend == SIM_BACKEND_ISAAC:
+        per_env = _run_isaac_heldout_rollouts(
+            envs,
+            inner_evidence=inner_evidence,
+            threshold=threshold,
+            scene=scene,
+            isaac_task=isaac_task,
+        )
+        payload = {
+            "schema": SCHEMA_HELDOUT_REPORT,
+            "per_env": per_env,
+            "sim_backend": SIM_BACKEND_ISAAC,
+            "component_source": "isaac_rollout",
+            "rollout_backend": f"isaaclab:{isaac_task}",
+            "policy_source": "inner_evidence_adapter",
+        }
+    else:
+        per_env = _run_genesis_heldout_rollouts(
+            envs,
+            inner_evidence=inner_evidence,
+            threshold=threshold,
+            scene=scene,
+        )
+        payload = {
+            "schema": SCHEMA_HELDOUT_REPORT,
+            "per_env": per_env,
+            "sim_backend": SIM_BACKEND_GENESIS,
+            "component_source": "genesis_rollout",
+            "rollout_backend": "npa.genesis.env_pick_place.FrankaPickPlaceEnv",
+            "policy_source": "inner_evidence_adapter",
+        }
     if scene is not None:
         provenance = scene.provenance_block()
         manipuland = scene.manipuland()
@@ -2759,6 +2933,301 @@ def _run_genesis_heldout_rollouts(
     return per_env
 
 
+def _isaac_import_mesh_to_usd(local_path: str, *, work_dir: Path) -> str:
+    """Convert a BYO mesh/URDF to USD using Isaac Lab's offline converters.
+
+    Returns the resolved USD path. Raises ``Sim2RealLoopError`` if conversion
+    does not produce a USD file (no silent fallback to the stock asset).
+    """
+
+    src = Path(local_path)
+    if not src.is_file() or src.stat().st_size == 0:
+        raise Sim2RealLoopError(f"BYO asset missing/empty for Isaac import: {src}")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    suffix = src.suffix.lower()
+    try:
+        if suffix == ".urdf":
+            from isaaclab.sim.converters import UrdfConverter, UrdfConverterCfg
+
+            cfg = UrdfConverterCfg(
+                asset_path=str(src),
+                usd_dir=str(work_dir),
+                usd_file_name=f"{src.stem}.usd",
+                force_usd_conversion=True,
+            )
+            converter = UrdfConverter(cfg)
+        else:
+            from isaaclab.sim.converters import MeshConverter, MeshConverterCfg
+
+            cfg = MeshConverterCfg(
+                asset_path=str(src),
+                usd_dir=str(work_dir),
+                usd_file_name=f"{src.stem}.usd",
+                force_usd_conversion=True,
+            )
+            converter = MeshConverter(cfg)
+    except Exception as exc:  # noqa: BLE001 - surface converter import/runtime errors
+        raise Sim2RealLoopError(
+            f"Isaac mesh->USD conversion failed for {src.name}: {exc}"
+        ) from exc
+    usd_path = getattr(converter, "usd_path", "")
+    if not usd_path or not Path(usd_path).is_file():
+        raise Sim2RealLoopError(
+            f"Isaac mesh->USD conversion produced no USD for {src.name}"
+        )
+    return usd_path
+
+
+def _set_isaac_object_usd(env_cfg: Any, usd_path: str, *, scale: Any) -> None:
+    """Point the lift task's manipuland spawn at a converted BYO USD asset."""
+
+    import isaaclab.sim as sim_utils
+
+    if isinstance(scale, (int, float)):
+        usd_scale = (float(scale), float(scale), float(scale))
+    elif isinstance(scale, (list, tuple)) and len(scale) == 3:
+        usd_scale = tuple(float(v) for v in scale)
+    else:
+        usd_scale = (1.0, 1.0, 1.0)
+    obj_cfg = env_cfg.scene.object
+    obj_cfg.spawn = sim_utils.UsdFileCfg(
+        usd_path=usd_path,
+        scale=usd_scale,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            solver_position_iteration_count=16,
+            solver_velocity_iteration_count=1,
+            max_angular_velocity=1000.0,
+            max_linear_velocity=1000.0,
+            max_depenetration_velocity=5.0,
+            disable_gravity=False,
+        ),
+    )
+
+
+def _isaac_goal_distance(env_unwrapped: Any) -> Any:
+    """Return per-env object->goal world distance for the lift task.
+
+    Uses the command manager's desired object pose (robot-base frame) combined
+    with the robot root pose to get the world goal, then the object's world
+    position. Returns a 1-D CUDA tensor.
+    """
+
+    import torch
+
+    scene = env_unwrapped.scene
+    object_pos_w = scene["object"].data.root_pos_w[:, :3]
+    command = env_unwrapped.command_manager.get_command("object_pose")
+    robot = scene["robot"]
+    root_pos_w = robot.data.root_state_w[:, :3]
+    root_quat_w = robot.data.root_state_w[:, 3:7]
+    try:
+        from isaaclab.utils.math import combine_frame_transforms
+
+        des_pos_w, _ = combine_frame_transforms(
+            root_pos_w, root_quat_w, command[:, :3], command[:, 3:7]
+        )
+    except Exception:  # noqa: BLE001 - fall back to base-frame offset
+        des_pos_w = root_pos_w + command[:, :3]
+    return torch.norm(object_pos_w - des_pos_w, dim=-1)
+
+
+def _isaac_adapter_actions(action_dim: int, adapter: dict[str, Any], *, n_envs: int, step: int, device: str):
+    """Deterministic adapter-biased actions for the Isaac manipulation rollout.
+
+    The inner-loop adapter bias steers the arm action; a small seeded,
+    decaying exploration term keeps the rollout non-degenerate. The gripper
+    channel closes progressively, mirroring the Genesis adapter contract.
+    """
+
+    import torch
+
+    bias_values = adapter.get("action_bias") or [0.0, 0.0, 0.0]
+    bias = torch.zeros(action_dim, device=device, dtype=torch.float32)
+    for i in range(min(action_dim, len(bias_values))):
+        bias[i] = float(bias_values[i])
+    actions = bias.unsqueeze(0).repeat(n_envs, 1)
+    decay = 1.0 / (1.0 + 0.05 * step)
+    explore = 0.15 * decay * torch.sin(
+        torch.arange(action_dim, device=device, dtype=torch.float32) * (step + 1) * 0.37
+    )
+    actions = actions + explore.unsqueeze(0)
+    if action_dim >= 1:
+        # Last channel = gripper: open early, close as the episode progresses.
+        actions[:, -1] = 1.0 if step < 30 else -1.0
+    return torch.clamp(actions, -1.0, 1.0)
+
+
+def _run_isaac_heldout_rollouts(
+    envs: list[dict[str, Any]],
+    *,
+    inner_evidence: dict[str, Any],
+    threshold: float,
+    scene: Any = None,
+    isaac_task: str = DEFAULT_ISAAC_TASK,
+) -> list[dict[str, Any]]:
+    """Run the adapter policy through headless Isaac Lab held-out episodes.
+
+    Mirrors ``_run_genesis_heldout_rollouts``: it returns the identical
+    per-env metric schema (``env_id``/``score``/``success``/``details``) so
+    ``report.json`` stays backend-agnostic. Stock runs use the built-in Isaac
+    lift-cube manipuland (``asset_source=isaac_stock``); BYO runs import the
+    customer mesh/URDF to USD and load it into the task (``asset_source=
+    byo_mesh``). A BYO mesh that fails to import raises (no silent fallback).
+    """
+
+    from npa.genesis.scene_assets import ASSET_SOURCE_ISAAC_STOCK
+
+    try:
+        from isaaclab.app import AppLauncher
+    except Exception as exc:  # noqa: BLE001
+        raise Sim2RealLoopError(
+            f"Isaac rollout eval requires isaaclab/Isaac Sim in the image: {exc}"
+        ) from exc
+
+    simulation_app = AppLauncher(headless=True).app
+    try:
+        import torch
+        import gymnasium as gym  # noqa: PLC0415
+        import isaaclab_tasks  # noqa: F401, PLC0415
+        from isaaclab_tasks.utils import parse_env_cfg
+    except Exception as exc:  # noqa: BLE001
+        raise Sim2RealLoopError(
+            f"Isaac rollout eval requires gymnasium and isaaclab_tasks: {exc}"
+        ) from exc
+    if not torch.cuda.is_available():
+        raise Sim2RealLoopError("Isaac rollout eval requires a CUDA GPU")
+    device = "cuda:0"
+
+    usd_override = ""
+    manip_scale: Any = 1.0
+    if scene is not None:
+        manip = scene.manipuland()
+        manip_scale = manip.scale
+        if manip.asset_source == ASSET_SOURCE_ISAAC_STOCK:
+            manip.loaded = True
+            print(
+                json.dumps(
+                    {
+                        "component": "heldout_eval",
+                        "event": "isaac_scene_loading",
+                        "asset_source": manip.asset_source,
+                        "isaac_task": isaac_task,
+                        "stock_asset": manip.builtin_path,
+                    },
+                    sort_keys=True,
+                )
+            )
+        elif manip.is_mesh():
+            import tempfile as _tempfile
+
+            convert_dir = Path(_tempfile.mkdtemp(prefix="isaac-usd-"))
+            usd_override = _isaac_import_mesh_to_usd(
+                manip.local_path, work_dir=convert_dir
+            )
+            manip.loaded = True
+            print(
+                json.dumps(
+                    {
+                        "component": "heldout_eval",
+                        "event": "isaac_byo_mesh_imported",
+                        "asset_source": manip.asset_source,
+                        "manipuland": manip.name,
+                        "local_path": manip.local_path,
+                        "sha256": manip.sha256,
+                        "usd_path": usd_override,
+                    },
+                    sort_keys=True,
+                )
+            )
+
+    adapter = _policy_adapter_from_inner_evidence(inner_evidence)
+    batch_size = max(1, int(os.environ.get("NPA_SIM2REAL_ISAAC_BATCH_SIZE", "8")))
+    max_steps = max(1, int(os.environ.get("NPA_SIM2REAL_ISAAC_MAX_STEPS", "120")))
+    reward_norm = float(os.environ.get("NPA_SIM2REAL_ISAAC_REWARD_NORM", "20.0"))
+    success_dist = float(os.environ.get("NPA_SIM2REAL_ISAAC_SUCCESS_DIST", "0.05"))
+    per_env: list[dict[str, Any]] = []
+    try:
+        for start in range(0, len(envs), batch_size):
+            batch = envs[start : start + batch_size]
+            seed = int(batch[0].get("seed") or (42 + start))
+            torch.manual_seed(seed)
+            env_cfg = parse_env_cfg(isaac_task, device=device, num_envs=len(batch))
+            if usd_override:
+                _set_isaac_object_usd(env_cfg, usd_override, scale=manip_scale)
+            env = gym.make(isaac_task, cfg=env_cfg)
+            action_dim = int(env.action_space.shape[-1])
+            obs, _ = env.reset()
+            n = len(batch)
+            max_reward = torch.full((n,), -1.0e9, device=device)
+            final_distance = torch.full((n,), 1.0e9, device=device)
+            for step in range(max_steps):
+                actions = _isaac_adapter_actions(
+                    action_dim, adapter, n_envs=n, step=step, device=device
+                )
+                obs, reward, terminated, truncated, _ = env.step(actions)
+                reward_t = torch.as_tensor(reward, device=device, dtype=torch.float32).reshape(-1)
+                max_reward = torch.maximum(max_reward, reward_t)
+                final_distance = _isaac_goal_distance(env.unwrapped).reshape(-1).detach()
+                done = torch.as_tensor(terminated, device=device).reshape(-1) | torch.as_tensor(
+                    truncated, device=device
+                ).reshape(-1)
+                if bool(done.all()):
+                    break
+            success = final_distance < success_dist
+            batch_successes = int(success.sum().item())
+            print(
+                json.dumps(
+                    {
+                        "component": "heldout_eval",
+                        "event": "isaac_rollout_batch_complete",
+                        "batch_start": start,
+                        "env_count": n,
+                        "successes": batch_successes,
+                        "max_steps": max_steps,
+                        "isaac_task": isaac_task,
+                    },
+                    sort_keys=True,
+                )
+            )
+            for index, env_record in enumerate(batch):
+                dist = float(final_distance[index].detach().item())
+                reward_value = float(max_reward[index].detach().item())
+                env_success = bool(success[index].detach().item())
+                distance_score = max(0.0, min(1.0, 1.0 - dist / 0.5))
+                reward_score = max(0.0, min(1.0, reward_value / reward_norm))
+                score = _heldout_env_score(
+                    distance_score, reward_score, env_success=env_success
+                )
+                per_env.append(
+                    {
+                        "env_id": str(
+                            env_record.get("env_id") or f"heldout-{start + index:04d}"
+                        ),
+                        "score": score,
+                        "success": env_success,
+                        "details": {
+                            "source": "isaac_lift_env_goal_distance",
+                            "sim_backend": SIM_BACKEND_ISAAC,
+                            "isaac_task": isaac_task,
+                            "seed": env_record.get("seed"),
+                            "target_threshold": success_dist,
+                            "final_target_distance": round(dist, 6),
+                            "max_reward": round(reward_value, 6),
+                            "steps": max_steps,
+                            "policy_adapter": adapter,
+                            "threshold": threshold,
+                        },
+                    }
+                )
+            env.close()
+    finally:
+        try:
+            simulation_app.close()
+        except Exception:  # noqa: BLE001
+            pass
+    return per_env
+
+
 def _policy_adapter_from_inner_evidence(inner_evidence: dict[str, Any]) -> dict[str, Any]:
     iterations = inner_evidence.get("iterations") or []
     update = {}
@@ -2871,6 +3340,15 @@ def main(argv: list[str] | None = None) -> int:
     component_heldout.add_argument("--scene-spec-uri", default="")
     component_heldout.add_argument("--assets-uri", default="")
     component_heldout.add_argument("--byo-mesh-uri", default="")
+    component_heldout.add_argument(
+        "--sim-backend",
+        default=os.environ.get("NPA_SIM2REAL_SIM_BACKEND", DEFAULT_SIM_BACKEND),
+        choices=list(SIM_BACKENDS),
+    )
+    component_heldout.add_argument(
+        "--isaac-task",
+        default=os.environ.get("NPA_SIM2REAL_ISAAC_TASK", DEFAULT_ISAAC_TASK),
+    )
     args = parser.parse_args(argv)
 
     if args.command == "convert-signal":
@@ -2896,6 +3374,8 @@ def main(argv: list[str] | None = None) -> int:
             scene_spec_uri=args.scene_spec_uri,
             assets_uri=args.assets_uri,
             byo_mesh_uri=args.byo_mesh_uri,
+            sim_backend=args.sim_backend,
+            isaac_task=args.isaac_task,
         )
         return 0
 
@@ -2917,6 +3397,9 @@ def main(argv: list[str] | None = None) -> int:
         trainer_image=args.trainer_image,
         vlm_image=args.vlm_image,
         eval_image=args.eval_image,
+        isaac_image=args.isaac_image,
+        sim_backend=args.sim_backend,
+        isaac_task=args.isaac_task,
         vlm_model=args.vlm_model,
         threshold=args.threshold,
         inner_iterations=args.inner_iterations,
@@ -3005,6 +3488,16 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--trainer-image", default=os.environ.get("TRAINER_IMAGE", ""))
     parser.add_argument("--vlm-image", default=os.environ.get("VLM_IMAGE", ""))
     parser.add_argument("--eval-image", default=os.environ.get("EVAL_IMAGE", ""))
+    parser.add_argument("--isaac-image", default=os.environ.get("ISAAC_IMAGE", ""))
+    parser.add_argument(
+        "--sim-backend",
+        default=os.environ.get("NPA_SIM2REAL_SIM_BACKEND", DEFAULT_SIM_BACKEND),
+        choices=list(SIM_BACKENDS),
+    )
+    parser.add_argument(
+        "--isaac-task",
+        default=os.environ.get("NPA_SIM2REAL_ISAAC_TASK", DEFAULT_ISAAC_TASK),
+    )
     parser.add_argument(
         "--vlm-model", default=os.environ.get("VLM_MODEL", DEFAULT_REFERENCE_VLM_MODEL)
     )
@@ -3338,6 +3831,10 @@ __all__ = [
     "SCHEMA_THRESHOLD_DECISION",
     "SCHEMA_VLM_EVAL",
     "DEFAULT_LEROBOT_DATASET_ID",
+    "DEFAULT_ISAAC_TASK",
+    "SIM_BACKENDS",
+    "SIM_BACKEND_GENESIS",
+    "SIM_BACKEND_ISAAC",
     "Sim2RealLoopConfig",
     "Sim2RealLoopError",
     "artifact_uris",
@@ -3346,6 +3843,7 @@ __all__ = [
     "convert_vlm_eval_to_rl_signal",
     "default_envgen_image",
     "default_eval_image",
+    "default_isaac_image",
     "default_policy_image",
     "default_trainer_image",
     "default_vlm_image",

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -565,31 +565,47 @@ def run_full_loop(
         )
     )
 
-    stage_records.append(
-        _write_stage(
-            local_dir,
-            2,
-            "assets",
-            {
-                "schema": "npa.sim2real.external_stub.v1",
-                "stage": 2,
-                "name": "external real assets and SceneSpec",
-                "status": "documented_external_stub",
-                "assets_uri": config.assets_uri,
-                "scene_spec_uri": config.scene_spec_uri,
-                "next_action": "CONTINUE",
-            },
-            filename="external_stub.json",
+    if config.scene_spec_uri or config.assets_uri:
+        consumed = _consume_stage_assets(config, local_dir)
+        stage_records.append(consumed["stage_record"])
+        components.append(
+            ComponentRecord(
+                "stage_02_assets",
+                "WORKS",
+                (
+                    "Downloaded and validated the BYO mesh/SceneSpec and emitted a "
+                    "consumed scene spec with per-object provenance for the "
+                    "held-out Genesis rollout."
+                ),
+                {"local": consumed["consumed_spec_path"]},
+            )
         )
-    )
-    components.append(
-        ComponentRecord(
-            "stage_02_assets",
-            "SEAM",
-            "External assets and SceneSpec are documented BYO inputs for this reference run.",
-            {"local": str(local_dir / "stage_02_assets" / "external_stub.json")},
+    else:
+        stage_records.append(
+            _write_stage(
+                local_dir,
+                2,
+                "assets",
+                {
+                    "schema": "npa.sim2real.external_stub.v1",
+                    "stage": 2,
+                    "name": "external real assets and SceneSpec",
+                    "status": "documented_external_stub",
+                    "assets_uri": config.assets_uri,
+                    "scene_spec_uri": config.scene_spec_uri,
+                    "next_action": "CONTINUE",
+                },
+                filename="external_stub.json",
+            )
         )
-    )
+        components.append(
+            ComponentRecord(
+                "stage_02_assets",
+                "SEAM",
+                "External assets and SceneSpec are documented BYO inputs for this reference run.",
+                {"local": str(local_dir / "stage_02_assets" / "external_stub.json")},
+            )
+        )
 
     stage_records.append(
         _write_json_artifact(
@@ -1400,7 +1416,9 @@ def _component_job_script(component: str) -> str:
             "--inner-evidence-uri \"${NPA_SIM2REAL_INNER_EVIDENCE_URI}\" "
             "--output-uri \"${NPA_SIM2REAL_OUTPUT_URI}\" "
             "--threshold \"${NPA_SIM2REAL_THRESHOLD}\" "
-            "--limit \"${NPA_SIM2REAL_HELDOUT_EVAL_LIMIT:-0}\""
+            "--limit \"${NPA_SIM2REAL_HELDOUT_EVAL_LIMIT:-0}\" "
+            "--scene-spec-uri \"${NPA_SIM2REAL_SCENE_SPEC_URI:-}\" "
+            "--assets-uri \"${NPA_SIM2REAL_ASSETS_URI:-}\""
         )
     else:
         raise Sim2RealLoopError(f"unsupported image component: {component}")
@@ -1823,6 +1841,8 @@ def run_heldout_eval(
             "NPA_SIM2REAL_INNER_EVIDENCE_JSON": str(inner_path),
             "NPA_SIM2REAL_THRESHOLD": str(config.threshold),
             "NPA_SIM2REAL_EVAL_IMAGE": config.eval_image,
+            "NPA_SIM2REAL_SCENE_SPEC_URI": config.scene_spec_uri,
+            "NPA_SIM2REAL_ASSETS_URI": config.assets_uri,
         },
     )
     if config.byo_eval_command.strip():
@@ -1916,7 +1936,7 @@ def _normalize_heldout_report(
             }
         )
     success_rate = passed / float(len(per_env))
-    return {
+    report = {
         "schema": SCHEMA_HELDOUT_REPORT,
         "stage": 10,
         "outer_iteration": outer_iteration,
@@ -1930,6 +1950,15 @@ def _normalize_heldout_report(
         "component_invocation": _public_invocation(invocation),
         "generated_at": _utc_now(),
     }
+    if "asset_provenance" in payload:
+        report["asset_provenance"] = payload["asset_provenance"]
+        report["asset_fallback_used"] = bool(
+            payload.get(
+                "asset_fallback_used",
+                payload["asset_provenance"].get("asset_fallback_used", False),
+            )
+        )
+    return report
 
 
 def threshold_decision(
@@ -2051,8 +2080,17 @@ def run_heldout_eval_component_from_s3(
     output_uri: str,
     threshold: float = DEFAULT_THRESHOLD,
     limit: int = 0,
+    scene_spec_uri: str = "",
+    assets_uri: str = "",
+    byo_mesh_uri: str = "",
 ) -> dict[str, Any]:
-    """Run the image-local held-out eval contract against env records in S3."""
+    """Run the image-local held-out eval contract against env records in S3.
+
+    When ``scene_spec_uri`` (a SceneSpec JSON) or ``assets_uri`` /
+    ``byo_mesh_uri`` (a bare mesh URI) is provided, the scene's manipulated
+    object(s) are downloaded, validated, and loaded into the Genesis sim, and
+    per-object asset provenance is recorded into the report.
+    """
 
     with tempfile.TemporaryDirectory(prefix="sim2real-heldout-component-") as tmp:
         root = Path(tmp)
@@ -2068,24 +2106,138 @@ def run_heldout_eval_component_from_s3(
             envs = envs[:limit]
         if not envs:
             raise Sim2RealLoopError("held-out component found no env records")
+        scene = _resolve_heldout_scene(
+            scene_spec_uri=scene_spec_uri,
+            assets_uri=assets_uri,
+            byo_mesh_uri=byo_mesh_uri,
+            dest_dir=root / "assets",
+            client=client,
+        )
         payload = _component_heldout_payload(
             envs,
             inner_evidence=inner_evidence,
             threshold=threshold,
+            scene=scene,
         )
         _write_json_artifact(output_path, payload)
         client.upload_file(str(output_path), output_uri)
+        if scene is not None:
+            spec_path = root / "consumed-scene-spec.json"
+            _write_json_artifact(spec_path, scene.provenance_block())
+            client.upload_file(
+                str(spec_path),
+                _sibling_uri(output_uri, "consumed-scene-spec.json"),
+            )
         print(
             json.dumps(
                 {
                     "component": "heldout_eval",
                     "env_count": len(payload["per_env"]),
                     "output_uri": output_uri,
+                    "asset_fallback_used": payload.get("asset_fallback_used"),
                 },
                 sort_keys=True,
             )
         )
         return payload
+
+
+def _resolve_heldout_scene(
+    *,
+    scene_spec_uri: str,
+    assets_uri: str,
+    byo_mesh_uri: str,
+    dest_dir: Path,
+    client: Any,
+) -> Any:
+    """Download/synthesize and resolve a SceneSpec for the held-out rollout.
+
+    Returns a resolved ``SceneSpec`` (with local asset paths + sha256) or
+    ``None`` when no BYO scene/asset URIs are provided (documented-stub path).
+    """
+
+    from npa.genesis import scene_assets
+
+    scene_spec_uri = (scene_spec_uri or "").strip()
+    mesh_uri = (byo_mesh_uri or assets_uri or "").strip()
+    if not scene_spec_uri and not mesh_uri:
+        return None
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    if scene_spec_uri:
+        spec_local = dest_dir / "scene-spec.json"
+        client.download_path(scene_spec_uri, str(spec_local))
+        doc = json.loads(spec_local.read_text(encoding="utf-8"))
+        scene = scene_assets.parse_scene_spec(doc, source_uri=scene_spec_uri)
+    else:
+        scene = scene_assets.synthesize_scene_spec(byo_mesh_uri=mesh_uri)
+    scene_assets.resolve_scene_assets(scene, dest_dir=dest_dir, client=client)
+    return scene
+
+
+def _sibling_uri(uri: str, filename: str) -> str:
+    base = uri.rsplit("/", 1)[0] if "/" in uri else uri
+    return f"{base.rstrip('/')}/{filename}"
+
+
+def _consume_stage_assets(
+    config: Sim2RealLoopConfig, local_dir: Path
+) -> dict[str, Any]:
+    """Stage 2: download + validate BYO mesh/SceneSpec and write a consumed spec.
+
+    Unlike the documented stub, this actually fetches the asset(s) referenced by
+    ``scene_spec_uri`` / ``assets_uri`` and records per-object provenance
+    (sha256, asset_source, downloaded). byo_mesh objects are downloaded and
+    validated here; genesis_builtin objects are resolved at rollout time inside
+    the GPU image. A failed download raises (no silent fallback).
+    """
+
+    from npa.genesis import scene_assets
+
+    stage_dir = local_dir / "stage_02_assets"
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    client = _storage_client(config)
+    scene_spec_uri = (config.scene_spec_uri or "").strip()
+    mesh_uri = (config.assets_uri or "").strip()
+    if scene_spec_uri:
+        spec_local = stage_dir / "scene-spec.json"
+        client.download_path(scene_spec_uri, str(spec_local))
+        doc = json.loads(spec_local.read_text(encoding="utf-8"))
+        scene = scene_assets.parse_scene_spec(doc, source_uri=scene_spec_uri)
+    else:
+        scene = scene_assets.synthesize_scene_spec(byo_mesh_uri=mesh_uri)
+
+    assets_dir = stage_dir / "assets"
+    for obj in scene.objects:
+        if obj.asset_source == scene_assets.ASSET_SOURCE_BYO_MESH:
+            local = scene_assets.download_asset(
+                obj.uri,
+                assets_dir / obj.name,
+                client=client,
+                endpoint_url=config.s3_endpoint,
+            )
+            obj.local_path = str(local)
+            obj.sha256 = scene_assets.sha256_file(local)
+
+    consumed = {
+        "schema": "npa.sim2real.consumed_scene_spec.v1",
+        "stage": 2,
+        "name": "external real assets and SceneSpec",
+        "status": "consumed",
+        "assets_uri": config.assets_uri,
+        "scene_spec_uri": config.scene_spec_uri,
+        "scene_spec": scene.to_dict(),
+        "asset_provenance": scene.provenance_block(),
+        "next_action": "CONTINUE",
+    }
+    stage_record = _write_stage(
+        local_dir, 2, "assets", consumed, filename="consumed_scene_spec.json"
+    )
+    return {
+        "stage_record": stage_record,
+        "consumed_spec_path": str(stage_dir / "consumed_scene_spec.json"),
+        "scene": scene,
+    }
 
 
 def _component_vlm_payload(
@@ -2125,19 +2277,32 @@ def _component_heldout_payload(
     *,
     inner_evidence: dict[str, Any],
     threshold: float,
+    scene: Any = None,
 ) -> dict[str, Any]:
     per_env = _run_genesis_heldout_rollouts(
         envs,
         inner_evidence=inner_evidence,
         threshold=threshold,
+        scene=scene,
     )
-    return {
+    payload = {
         "schema": SCHEMA_HELDOUT_REPORT,
         "per_env": per_env,
         "component_source": "genesis_rollout",
         "rollout_backend": "npa.genesis.env_pick_place.FrankaPickPlaceEnv",
         "policy_source": "inner_evidence_adapter",
     }
+    if scene is not None:
+        provenance = scene.provenance_block()
+        manipuland = scene.manipuland()
+        if manipuland.is_mesh() and not manipuland.loaded:
+            raise Sim2RealLoopError(
+                "BYO scene manipuland mesh was not loaded into the simulator "
+                "(no silent fallback is permitted)"
+            )
+        payload["asset_provenance"] = provenance
+        payload["asset_fallback_used"] = provenance["asset_fallback_used"]
+    return payload
 
 
 def _rollout_image_paths(rollout_root: Path, observations: list[Any]) -> list[Path]:
@@ -2457,8 +2622,16 @@ def _run_genesis_heldout_rollouts(
     *,
     inner_evidence: dict[str, Any],
     threshold: float,
+    scene: Any = None,
 ) -> list[dict[str, Any]]:
-    """Run the trained adapter policy through real Genesis held-out episodes."""
+    """Run the trained adapter policy through real Genesis held-out episodes.
+
+    When ``scene`` (a parsed ``npa.genesis.scene_assets.SceneSpec`` with
+    resolved local asset paths) is provided, the manipulated object(s) are
+    built from it (mesh / primitive) instead of the default red Box. The
+    SceneSpec objects' ``loaded`` provenance flags are set as a side effect of
+    building the env, so the caller can prove the requested mesh loaded.
+    """
 
     try:
         import torch
@@ -2469,6 +2642,23 @@ def _run_genesis_heldout_rollouts(
         ) from exc
     if not torch.cuda.is_available():
         raise Sim2RealLoopError("Genesis rollout eval requires a CUDA GPU")
+
+    if scene is not None:
+        manip = scene.manipuland()
+        print(
+            json.dumps(
+                {
+                    "component": "heldout_eval",
+                    "event": "byo_scene_loading",
+                    "asset_source": manip.asset_source,
+                    "manipuland": manip.name,
+                    "local_path": manip.local_path,
+                    "sha256": manip.sha256,
+                    "object_count": len(scene.objects),
+                },
+                sort_keys=True,
+            )
+        )
 
     adapter = _policy_adapter_from_inner_evidence(inner_evidence)
     batch_size = max(1, int(os.environ.get("NPA_SIM2REAL_GENESIS_BATCH_SIZE", "16")))
@@ -2485,8 +2675,23 @@ def _run_genesis_heldout_rollouts(
             max_episode_steps=max_steps,
             action_space="cartesian",
             action_scale=float(os.environ.get("NPA_SIM2REAL_GENESIS_ACTION_SCALE", "0.045")),
+            scene_spec=scene,
         )
         env = FrankaPickPlaceEnv(cfg)
+        if scene is not None and start == 0:
+            print(
+                json.dumps(
+                    {
+                        "component": "heldout_eval",
+                        "event": "byo_scene_loaded",
+                        "asset_fallback_used": scene.asset_fallback_used,
+                        "loaded_objects": [
+                            obj.name for obj in scene.objects if obj.loaded
+                        ],
+                    },
+                    sort_keys=True,
+                )
+            )
         obs = env.reset()
         active = torch.ones(len(batch), device="cuda", dtype=torch.bool)
         success = torch.zeros(len(batch), device="cuda", dtype=torch.bool)
@@ -2663,6 +2868,9 @@ def main(argv: list[str] | None = None) -> int:
     component_heldout.add_argument("--output-uri", required=True)
     component_heldout.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
     component_heldout.add_argument("--limit", type=int, default=0)
+    component_heldout.add_argument("--scene-spec-uri", default="")
+    component_heldout.add_argument("--assets-uri", default="")
+    component_heldout.add_argument("--byo-mesh-uri", default="")
     args = parser.parse_args(argv)
 
     if args.command == "convert-signal":
@@ -2685,6 +2893,9 @@ def main(argv: list[str] | None = None) -> int:
             output_uri=args.output_uri,
             threshold=args.threshold,
             limit=args.limit,
+            scene_spec_uri=args.scene_spec_uri,
+            assets_uri=args.assets_uri,
+            byo_mesh_uri=args.byo_mesh_uri,
         )
         return 0
 

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -145,6 +145,13 @@ class Sim2RealLoopConfig:
     heldout_envs_uri: str = ""
     assets_uri: str = ""
     scene_spec_uri: str = ""
+    # BYO robot embodiment (alongside the object SceneSpec). ``robot_spec_uri``
+    # points at a RobotSpec JSON; ``robot_preset`` selects a built-in preset
+    # (franka/ur5e/ur10e/flexiv); ``robot_source`` selects a bare source. All
+    # empty => the default Franka Panda robot (no change to today's behavior).
+    robot_spec_uri: str = ""
+    robot_source: str = ""
+    robot_preset: str = ""
     augment_image: str = f"npa-sim2real-envgen:{DEFAULT_ENVGEN_TAG}"
     policy_image: str = f"npa-sim2real-reference-policy:{DEFAULT_REFERENCE_POLICY_TAG}"
     trainer_image: str = f"npa-lerobot-vlm-rl:{DEFAULT_TRAINER_TAG}"
@@ -347,6 +354,24 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
         scene_spec_uri=str(
             overrides.get("scene_spec_uri") or os.environ.get("SCENE_SPEC_URI") or ""
         ),
+        robot_spec_uri=str(
+            overrides.get("robot_spec_uri")
+            or os.environ.get("ROBOT_SPEC_URI")
+            or os.environ.get("NPA_SIM2REAL_ROBOT_SPEC_URI")
+            or ""
+        ),
+        robot_source=str(
+            overrides.get("robot_source")
+            or os.environ.get("ROBOT_SOURCE")
+            or os.environ.get("NPA_SIM2REAL_ROBOT_SOURCE")
+            or ""
+        ).strip().lower(),
+        robot_preset=str(
+            overrides.get("robot_preset")
+            or os.environ.get("ROBOT_PRESET")
+            or os.environ.get("NPA_SIM2REAL_ROBOT_PRESET")
+            or ""
+        ).strip().lower(),
         augment_image=str(
             overrides.get("augment_image")
             or os.environ.get("AUGMENT_IMAGE")
@@ -1490,7 +1515,10 @@ def _component_job_script(component: str, *, sim_backend: str = DEFAULT_SIM_BACK
             "--sim-backend \"${NPA_SIM2REAL_SIM_BACKEND:-genesis}\" "
             "--isaac-task \"${NPA_SIM2REAL_ISAAC_TASK:-}\" "
             "--scene-spec-uri \"${NPA_SIM2REAL_SCENE_SPEC_URI:-}\" "
-            "--assets-uri \"${NPA_SIM2REAL_ASSETS_URI:-}\""
+            "--assets-uri \"${NPA_SIM2REAL_ASSETS_URI:-}\" "
+            "--robot-spec-uri \"${NPA_SIM2REAL_ROBOT_SPEC_URI:-}\" "
+            "--robot-source \"${NPA_SIM2REAL_ROBOT_SOURCE:-}\" "
+            "--robot-preset \"${NPA_SIM2REAL_ROBOT_PRESET:-}\""
         )
     else:
         raise Sim2RealLoopError(f"unsupported image component: {component}")
@@ -1950,6 +1978,9 @@ def run_heldout_eval(
             "NPA_SIM2REAL_ISAAC_TASK": config.isaac_task,
             "NPA_SIM2REAL_SCENE_SPEC_URI": config.scene_spec_uri,
             "NPA_SIM2REAL_ASSETS_URI": config.assets_uri,
+            "NPA_SIM2REAL_ROBOT_SPEC_URI": config.robot_spec_uri,
+            "NPA_SIM2REAL_ROBOT_SOURCE": config.robot_source,
+            "NPA_SIM2REAL_ROBOT_PRESET": config.robot_preset,
         },
     )
     if config.byo_eval_command.strip():
@@ -2070,6 +2101,9 @@ def _normalize_heldout_report(
                 payload["asset_provenance"].get("asset_fallback_used", False),
             )
         )
+    if "robot_provenance" in payload:
+        report["robot_provenance"] = payload["robot_provenance"]
+        report["robot_fallback_used"] = bool(payload.get("robot_fallback_used", False))
     return report
 
 
@@ -2195,6 +2229,9 @@ def run_heldout_eval_component_from_s3(
     scene_spec_uri: str = "",
     assets_uri: str = "",
     byo_mesh_uri: str = "",
+    robot_spec_uri: str = "",
+    robot_source: str = "",
+    robot_preset: str = "",
     sim_backend: str = DEFAULT_SIM_BACKEND,
     isaac_task: str = DEFAULT_ISAAC_TASK,
 ) -> dict[str, Any]:
@@ -2243,11 +2280,19 @@ def run_heldout_eval_component_from_s3(
                 dest_dir=root / "assets",
                 client=client,
             )
+        robot = _resolve_heldout_robot(
+            robot_spec_uri=robot_spec_uri,
+            robot_source=robot_source,
+            robot_preset=robot_preset,
+            dest_dir=root / "robot",
+            client=client,
+        )
         payload = _component_heldout_payload(
             envs,
             inner_evidence=inner_evidence,
             threshold=threshold,
             scene=scene,
+            robot=robot,
             sim_backend=sim_backend,
             isaac_task=isaac_task,
         )
@@ -2260,6 +2305,13 @@ def run_heldout_eval_component_from_s3(
                 str(spec_path),
                 _sibling_uri(output_uri, "consumed-scene-spec.json"),
             )
+        if robot is not None:
+            robot_path = root / "consumed-robot-spec.json"
+            _write_json_artifact(robot_path, robot.provenance())
+            client.upload_file(
+                str(robot_path),
+                _sibling_uri(output_uri, "consumed-robot-spec.json"),
+            )
         print(
             json.dumps(
                 {
@@ -2268,6 +2320,9 @@ def run_heldout_eval_component_from_s3(
                     "env_count": len(payload["per_env"]),
                     "output_uri": output_uri,
                     "asset_fallback_used": payload.get("asset_fallback_used"),
+                    "robot_source": payload.get("robot_provenance", {}).get("robot_source")
+                    if payload.get("robot_provenance")
+                    else None,
                 },
                 sort_keys=True,
             )
@@ -2346,6 +2401,47 @@ def _resolve_isaac_scene(
         scene = scene_assets.synthesize_scene_spec(byo_mesh_uri=mesh_uri)
     scene_assets.resolve_scene_assets(scene, dest_dir=dest_dir, client=client)
     return scene
+
+
+def _resolve_heldout_robot(
+    *,
+    robot_spec_uri: str,
+    robot_source: str,
+    robot_preset: str,
+    dest_dir: Path,
+    client: Any,
+) -> Any:
+    """Download/synthesize and resolve a RobotSpec for the held-out rollout.
+
+    Returns a resolved ``RobotSpec`` (with local asset path + sha256 for BYO
+    robots) or ``None`` when no robot is requested (default Franka path). A BYO
+    robot that fails to download/validate raises — there is no silent fallback
+    to Franka.
+    """
+
+    from npa.genesis import robot_assets
+
+    robot_spec_uri = (robot_spec_uri or "").strip()
+    robot_source = (robot_source or "").strip().lower()
+    robot_preset = (robot_preset or "").strip().lower()
+    if not robot_spec_uri and not robot_source and not robot_preset:
+        return None
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    if robot_spec_uri:
+        spec_local = dest_dir / "robot-spec.json"
+        client.download_path(robot_spec_uri, str(spec_local))
+        doc = json.loads(spec_local.read_text(encoding="utf-8"))
+        spec = robot_assets.parse_robot_spec(doc)
+    else:
+        spec = robot_assets.robot_spec_from_inputs(
+            robot_source=robot_source,
+            robot_preset=robot_preset,
+        )
+        if spec is None:
+            return None
+    robot_assets.resolve_robot_asset(spec, dest_dir=dest_dir, client=client)
+    return spec
 
 
 def _sibling_uri(uri: str, filename: str) -> str:
@@ -2451,6 +2547,7 @@ def _component_heldout_payload(
     inner_evidence: dict[str, Any],
     threshold: float,
     scene: Any = None,
+    robot: Any = None,
     sim_backend: str = DEFAULT_SIM_BACKEND,
     isaac_task: str = DEFAULT_ISAAC_TASK,
 ) -> dict[str, Any]:
@@ -2469,6 +2566,7 @@ def _component_heldout_payload(
             inner_evidence=inner_evidence,
             threshold=threshold,
             scene=scene,
+            robot=robot,
             isaac_task=isaac_task,
         )
         payload = {
@@ -2485,6 +2583,7 @@ def _component_heldout_payload(
             inner_evidence=inner_evidence,
             threshold=threshold,
             scene=scene,
+            robot=robot,
         )
         payload = {
             "schema": SCHEMA_HELDOUT_REPORT,
@@ -2494,6 +2593,14 @@ def _component_heldout_payload(
             "rollout_backend": "npa.genesis.env_pick_place.FrankaPickPlaceEnv",
             "policy_source": "inner_evidence_adapter",
         }
+    if robot is not None:
+        if robot.is_byo() and not robot.loaded:
+            raise Sim2RealLoopError(
+                f"BYO robot {robot.name!r} ({robot.robot_source}) was not loaded "
+                "into the simulator (no silent fallback to Franka is permitted)"
+            )
+        payload["robot_provenance"] = robot.provenance()
+        payload["robot_fallback_used"] = False
     if scene is not None:
         provenance = scene.provenance_block()
         manipuland = scene.manipuland()
@@ -2825,6 +2932,7 @@ def _run_genesis_heldout_rollouts(
     inner_evidence: dict[str, Any],
     threshold: float,
     scene: Any = None,
+    robot: Any = None,
 ) -> list[dict[str, Any]]:
     """Run the trained adapter policy through real Genesis held-out episodes.
 
@@ -2833,6 +2941,10 @@ def _run_genesis_heldout_rollouts(
     built from it (mesh / primitive) instead of the default red Box. The
     SceneSpec objects' ``loaded`` provenance flags are set as a side effect of
     building the env, so the caller can prove the requested mesh loaded.
+
+    When ``robot`` (a resolved ``npa.genesis.robot_assets.RobotSpec``) is
+    provided, the env loads that embodiment (URDF/MJCF/preset) instead of the
+    hardcoded Franka Panda; its ``loaded`` flag is set when the env builds it.
     """
 
     try:
@@ -2861,6 +2973,22 @@ def _run_genesis_heldout_rollouts(
                 sort_keys=True,
             )
         )
+    if robot is not None:
+        print(
+            json.dumps(
+                {
+                    "component": "heldout_eval",
+                    "event": "byo_robot_loading",
+                    "robot_source": robot.robot_source,
+                    "robot_name": robot.name,
+                    "ee_link": robot.ee_link,
+                    "dof_count": robot.dof_count,
+                    "local_path": robot.local_path,
+                    "sha256": robot.sha256,
+                },
+                sort_keys=True,
+            )
+        )
 
     adapter = _policy_adapter_from_inner_evidence(inner_evidence)
     batch_size = max(1, int(os.environ.get("NPA_SIM2REAL_GENESIS_BATCH_SIZE", "16")))
@@ -2878,6 +3006,7 @@ def _run_genesis_heldout_rollouts(
             action_space="cartesian",
             action_scale=float(os.environ.get("NPA_SIM2REAL_GENESIS_ACTION_SCALE", "0.045")),
             scene_spec=scene,
+            robot_spec=robot,
         )
         env = FrankaPickPlaceEnv(cfg)
         if scene is not None and start == 0:
@@ -2890,6 +3019,20 @@ def _run_genesis_heldout_rollouts(
                         "loaded_objects": [
                             obj.name for obj in scene.objects if obj.loaded
                         ],
+                    },
+                    sort_keys=True,
+                )
+            )
+        if robot is not None and start == 0:
+            print(
+                json.dumps(
+                    {
+                        "component": "heldout_eval",
+                        "event": "byo_robot_loaded",
+                        "robot_source": robot.robot_source,
+                        "robot_name": robot.name,
+                        "loaded": bool(robot.loaded),
+                        "robot_fallback_used": False,
                     },
                     sort_keys=True,
                 )
@@ -3041,6 +3184,72 @@ def _set_isaac_object_usd(env_cfg: Any, usd_path: str, *, scale: Any) -> None:
     )
 
 
+def _isaac_robot_usd_override(robot: Any) -> str:
+    """Resolve a BYO robot to a USD path for the Isaac lift task, or "".
+
+    Default / ``stock_franka`` robots keep the task's built-in Franka (returns
+    ""). A BYO URDF (or genesis_builtin URDF) is imported to USD via Isaac's
+    URDF converter; an explicit USD is used as-is. Marks the robot ``loaded``
+    on success. A robot that cannot be imported raises ``Sim2RealLoopError``
+    (no silent fallback to Franka). Isaac cannot import MJCF, so that raises.
+    """
+
+    if robot is None:
+        return ""
+    from npa.genesis import robot_assets
+
+    if robot.robot_source == robot_assets.ROBOT_SOURCE_STOCK_FRANKA:
+        robot.loaded = True
+        return ""
+    if robot.robot_source == robot_assets.ROBOT_SOURCE_BYO_MJCF:
+        raise Sim2RealLoopError(
+            "robot_source=byo_mjcf is not importable by the Isaac backend; "
+            "supply a URDF/USD robot, or run the Genesis backend (no fallback)."
+        )
+    if not robot.local_path:
+        raise Sim2RealLoopError(
+            f"BYO robot {robot.name!r} has no resolved local_path for Isaac import"
+        )
+    if robot.robot_source == robot_assets.ROBOT_SOURCE_BYO_USD:
+        usd = robot.local_path
+        if not Path(usd).is_file():
+            raise Sim2RealLoopError(f"BYO robot USD missing: {usd}")
+        robot.loaded = True
+        return usd
+    import tempfile as _tempfile
+
+    convert_dir = Path(_tempfile.mkdtemp(prefix="isaac-robot-usd-"))
+    usd = _isaac_import_mesh_to_usd(robot.local_path, work_dir=convert_dir)
+    robot.loaded = True
+    return usd
+
+
+def _set_isaac_robot_usd(env_cfg: Any, usd_path: str, robot: Any) -> None:
+    """Point the lift task's articulation spawn at a converted BYO robot USD.
+
+    Overrides the robot articulation's spawn USD and best-effort widens the
+    actuator joint-name expressions so a non-Franka arm's joints are actuated.
+    Full joint/actuator remapping for an arbitrary arm is a follow-up; this
+    establishes the BYO-robot import seam and proves the asset loads.
+    """
+
+    import isaaclab.sim as sim_utils
+
+    robot_cfg = env_cfg.scene.robot
+    spawn = getattr(robot_cfg, "spawn", None)
+    new_spawn = sim_utils.UsdFileCfg(usd_path=usd_path)
+    # Preserve articulation/rigid props from the task's spawn when available.
+    for attr in ("articulation_props", "rigid_props", "activate_contact_sensors"):
+        if hasattr(spawn, attr) and hasattr(new_spawn, attr):
+            setattr(new_spawn, attr, getattr(spawn, attr))
+    robot_cfg.spawn = new_spawn
+    actuators = getattr(robot_cfg, "actuators", None)
+    if isinstance(actuators, dict):
+        for actuator in actuators.values():
+            if hasattr(actuator, "joint_names_expr"):
+                actuator.joint_names_expr = [".*"]
+
+
 def _isaac_goal_distance(env_unwrapped: Any) -> Any:
     """Return per-env object->goal world distance for the lift task.
 
@@ -3100,6 +3309,7 @@ def _run_isaac_heldout_rollouts(
     inner_evidence: dict[str, Any],
     threshold: float,
     scene: Any = None,
+    robot: Any = None,
     isaac_task: str = DEFAULT_ISAAC_TASK,
 ) -> list[dict[str, Any]]:
     """Run the adapter policy through headless Isaac Lab held-out episodes.
@@ -3182,6 +3392,25 @@ def _run_isaac_heldout_rollouts(
                 )
             )
 
+    robot_usd_override = _isaac_robot_usd_override(robot)
+    if robot_usd_override:
+        print(
+            json.dumps(
+                {
+                    "component": "heldout_eval",
+                    "event": "isaac_byo_robot_imported",
+                    "robot_source": robot.robot_source,
+                    "robot_name": robot.name,
+                    "ee_link": robot.ee_link,
+                    "dof_count": robot.dof_count,
+                    "local_path": robot.local_path,
+                    "sha256": robot.sha256,
+                    "usd_path": robot_usd_override,
+                },
+                sort_keys=True,
+            )
+        )
+
     adapter = _policy_adapter_from_inner_evidence(inner_evidence)
     batch_size = max(1, int(os.environ.get("NPA_SIM2REAL_ISAAC_BATCH_SIZE", "8")))
     max_steps = max(1, int(os.environ.get("NPA_SIM2REAL_ISAAC_MAX_STEPS", "120")))
@@ -3195,6 +3424,8 @@ def _run_isaac_heldout_rollouts(
         env_cfg = parse_env_cfg(isaac_task, device=device, num_envs=len(batch))
         if usd_override:
             _set_isaac_object_usd(env_cfg, usd_override, scale=manip_scale)
+        if robot_usd_override:
+            _set_isaac_robot_usd(env_cfg, robot_usd_override, robot)
         env = gym.make(isaac_task, cfg=env_cfg)
         action_dim = int(env.action_space.shape[-1])
         obs, _ = env.reset()
@@ -3393,6 +3624,9 @@ def main(argv: list[str] | None = None) -> int:
     component_heldout.add_argument("--scene-spec-uri", default="")
     component_heldout.add_argument("--assets-uri", default="")
     component_heldout.add_argument("--byo-mesh-uri", default="")
+    component_heldout.add_argument("--robot-spec-uri", default="")
+    component_heldout.add_argument("--robot-source", default="")
+    component_heldout.add_argument("--robot-preset", default="")
     component_heldout.add_argument(
         "--sim-backend",
         default=os.environ.get("NPA_SIM2REAL_SIM_BACKEND", DEFAULT_SIM_BACKEND),
@@ -3427,6 +3661,9 @@ def main(argv: list[str] | None = None) -> int:
             scene_spec_uri=args.scene_spec_uri,
             assets_uri=args.assets_uri,
             byo_mesh_uri=args.byo_mesh_uri,
+            robot_spec_uri=args.robot_spec_uri,
+            robot_source=args.robot_source,
+            robot_preset=args.robot_preset,
             sim_backend=args.sim_backend,
             isaac_task=args.isaac_task,
         )
@@ -3445,6 +3682,9 @@ def main(argv: list[str] | None = None) -> int:
         heldout_envs_uri=args.heldout_envs_uri,
         assets_uri=args.assets_uri,
         scene_spec_uri=args.scene_spec_uri,
+        robot_spec_uri=args.robot_spec_uri,
+        robot_source=args.robot_source,
+        robot_preset=args.robot_preset,
         augment_image=args.augment_image,
         policy_image=args.policy_image,
         trainer_image=args.trainer_image,
@@ -3536,6 +3776,11 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--scene-spec-uri", default=os.environ.get("SCENE_SPEC_URI", "")
     )
+    parser.add_argument(
+        "--robot-spec-uri", default=os.environ.get("ROBOT_SPEC_URI", "")
+    )
+    parser.add_argument("--robot-source", default=os.environ.get("ROBOT_SOURCE", ""))
+    parser.add_argument("--robot-preset", default=os.environ.get("ROBOT_PRESET", ""))
     parser.add_argument("--augment-image", default=os.environ.get("AUGMENT_IMAGE", ""))
     parser.add_argument("--policy-image", default=os.environ.get("POLICY_IMAGE", ""))
     parser.add_argument("--trainer-image", default=os.environ.get("TRAINER_IMAGE", ""))

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -2996,7 +2996,6 @@ def _isaac_import_mesh_to_usd(local_path: str, *, work_dir: Path) -> str:
                 usd_dir=str(work_dir),
                 usd_file_name=f"{src.stem}.usd",
                 force_usd_conversion=True,
-                collision_approximation="convexHull",
                 mass_props=sim_utils.MassPropertiesCfg(mass=0.1),
                 rigid_props=sim_utils.RigidBodyPropertiesCfg(),
                 collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=True),

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 from npa.clients.storage import StorageClient
 from npa.deploy.images import container_image_for_tool
 from npa.workbench.lerobot.policy_container import (
+    VlmSignalUpdateResult,
     parse_vlm_signal_batch,
     run_vlm_signal_training_step,
 )
@@ -143,6 +144,8 @@ class Sim2RealLoopConfig:
     byo_trainer_command: str = ""
     byo_vlm_command: str = ""
     byo_eval_command: str = ""
+    byo_rerun_command: str = ""
+    rerun_enabled: bool = True
     k8s_namespace: str = ""
     k8s_service_account: str = "agent-sa"
     k8s_image_pull_secrets: str = "agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry"
@@ -410,6 +413,14 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
             or os.environ.get("BYO_EVAL_COMMAND")
             or ""
         ),
+        byo_rerun_command=str(
+            overrides.get("byo_rerun_command")
+            or os.environ.get("BYO_RERUN_COMMAND")
+            or ""
+        ),
+        rerun_enabled=_bool_value(
+            overrides.get("rerun_enabled", os.environ.get("NPA_SIM2REAL_RERUN", "1"))
+        ),
         k8s_namespace=str(
             overrides.get("k8s_namespace")
             or os.environ.get("NPA_SIM2REAL_K8S_NAMESPACE")
@@ -531,6 +542,8 @@ def byo_seams(config: Sim2RealLoopConfig) -> dict[str, Any]:
         "byo_trainer_command": config.byo_trainer_command,
         "byo_vlm_command": config.byo_vlm_command,
         "byo_eval_command": config.byo_eval_command,
+        "byo_rerun_command": config.byo_rerun_command,
+        "rerun_enabled": config.rerun_enabled,
         "k8s_namespace": config.k8s_namespace,
         "k8s_service_account": config.k8s_service_account,
         "k8s_image_pull_secrets": _split_csv(config.k8s_image_pull_secrets),
@@ -761,6 +774,14 @@ def run_full_loop(
         )
     )
 
+    viz_component, viz_info = _run_sim2real_viz_stage(
+        config,
+        local_dir=local_dir,
+        inner_evidence=final_inner,
+        heldout_report=final_eval,
+    )
+    components.append(viz_component)
+
     components.extend(
         [
             ComponentRecord(
@@ -801,6 +822,7 @@ def run_full_loop(
             "latest_heldout_report": final_eval,
             "latest_decision": final_decision,
         },
+        "visualization": viz_info,
         "image_completeness": {
             "required": [
                 config.augment_image,
@@ -834,6 +856,126 @@ def run_full_loop(
         }
         _write_json_artifact(report_path, report)
     return report
+
+
+def _run_sim2real_viz_stage(
+    config: Sim2RealLoopConfig,
+    *,
+    local_dir: Path,
+    inner_evidence: dict[str, Any],
+    heldout_report: dict[str, Any] | None,
+) -> tuple[ComponentRecord, dict[str, Any]]:
+    """Produce ``reports/sim2real.rrd`` and a status ComponentRecord.
+
+    Degrades gracefully (WARN, not hard-fail) when ``rerun`` is unavailable or the
+    toggle is off, but produces a real ``.rrd`` whenever rerun is installed. If a
+    ``byo_rerun_command`` is set it runs that customer hook instead, reading the
+    run dir from ``NPA_SIM2REAL_RUN_DIR`` / report from ``NPA_SIM2REAL_REPORT_JSON``
+    and writing to ``NPA_SIM2REAL_OUTPUT_RRD``.
+    """
+
+    rrd_path = local_dir / "reports" / "sim2real.rrd"
+    if not config.rerun_enabled:
+        info = {"status": "disabled", "reason": "rerun_enabled is false"}
+        return (
+            ComponentRecord(
+                "stage_14_rerun_viz",
+                "SEAM",
+                "Rerun visualization disabled via toggle (NPA_SIM2REAL_RERUN=0 / --no-rerun).",
+                {},
+                next_action="CONTINUE",
+            ),
+            info,
+        )
+
+    if config.byo_rerun_command.strip():
+        return _run_byo_rerun_command(config, local_dir=local_dir, rrd_path=rrd_path)
+
+    try:
+        from npa.workflows.sim2real_viz import (
+            RerunUnavailableError,
+            emit_sim2real_rerun,
+        )
+
+        result = emit_sim2real_rerun(
+            local_dir=local_dir,
+            inner_evidence=inner_evidence,
+            heldout_report=heldout_report,
+            output_rrd=rrd_path,
+            write_mp4=_bool_value(os.environ.get("NPA_SIM2REAL_RERUN_MP4", "0")),
+        )
+    except RerunUnavailableError as exc:
+        info = {"status": "skipped", "reason": str(exc), "source": "reference"}
+        return (
+            ComponentRecord(
+                "stage_14_rerun_viz",
+                "WARN",
+                "rerun-sdk not installed locally; skipped .rrd emission (install rerun-sdk to enable).",
+                {},
+                next_action="CONTINUE",
+            ),
+            info,
+        )
+    info = {"source": "reference", **result.to_dict()}
+    return (
+        ComponentRecord(
+            "stage_14_rerun_viz",
+            "WORKS",
+            (
+                f"Wrote Rerun recording with {result.rollout_count} rollout(s), "
+                f"{result.frame_count} camera frame(s), and {result.heldout_env_count} "
+                "held-out env score(s); camera streams, VLM critiques, RL signal, and "
+                "held-out scores are logged."
+            ),
+            {"rrd": str(rrd_path)},
+        ),
+        info,
+    )
+
+
+def _run_byo_rerun_command(
+    config: Sim2RealLoopConfig,
+    *,
+    local_dir: Path,
+    rrd_path: Path,
+) -> tuple[ComponentRecord, dict[str, Any]]:
+    rrd_path.parent.mkdir(parents=True, exist_ok=True)
+    report_json = local_dir / "reports" / "sim2real-report.json"
+    env = _component_env(
+        config,
+        component="rerun_viz",
+        output_json=rrd_path,
+        extra={
+            "NPA_SIM2REAL_RUN_DIR": str(local_dir),
+            "NPA_SIM2REAL_REPORT_JSON": str(report_json),
+            "NPA_SIM2REAL_OUTPUT_RRD": str(rrd_path),
+        },
+    )
+    invocation = _run_component_command(
+        config.byo_rerun_command,
+        cwd=local_dir,
+        env=env,
+        component="rerun_viz",
+    )
+    if not rrd_path.exists() or rrd_path.stat().st_size == 0:
+        raise Sim2RealLoopError(
+            f"byo_rerun_command did not write a non-empty recording to {rrd_path}"
+        )
+    info = {
+        "source": "byo_command",
+        "status": "written",
+        "output_rrd_path": str(rrd_path),
+        "component_invocation": _public_invocation(invocation),
+    }
+    return (
+        ComponentRecord(
+            "stage_14_rerun_viz",
+            "WORKS",
+            "Customer byo_rerun_command produced the Rerun recording.",
+            {"rrd": str(rrd_path)},
+        ),
+        info,
+    )
 
 
 def run_inner_loop(
@@ -883,13 +1025,20 @@ def run_inner_loop(
         )
         evals: list[dict[str, Any]] = []
         signals: list[dict[str, Any]] = []
+        signal_converter_source = (
+            "byo_command" if config.byo_signal_converter.strip() else "reference"
+        )
         for rollout in rollouts:
             evaluation = evaluate_rollout_with_vlm(
                 rollout,
                 output_dir=eval_dir,
                 config=config,
             )
-            signal = convert_vlm_eval_to_rl_signal(evaluation)
+            signal = _convert_eval_to_signal(
+                evaluation,
+                config=config,
+                output_dir=signal_dir,
+            )
             _write_json_artifact(signal_dir / f"{signal['rollout_id']}.json", signal)
             evals.append(evaluation)
             signals.append(signal)
@@ -904,18 +1053,35 @@ def run_inner_loop(
             signal_batch_path, {"schema": SCHEMA_RL_SIGNAL, "signals": signals}
         )
         parsed_signals = parse_vlm_signal_batch({"signals": signals})
-        update = run_vlm_signal_training_step(
-            parsed_signals,
-            output_dir=local_dir
+        trainer_dir = (
+            local_dir
             / "inner_loop"
             / f"outer-{outer_iteration:02d}"
             / "trainer"
-            / f"iter-{iteration:02d}",
-            learning_rate=config.learning_rate,
-            signal_loss_weight=config.signal_loss_weight,
-            initial_reward_head=reward_head,
-            initial_action_bias=action_bias,
+            / f"iter-{iteration:02d}"
         )
+        if config.byo_trainer_command.strip():
+            update = _run_trainer_via_command(
+                signal_batch_path,
+                config=config,
+                output_dir=trainer_dir,
+                initial_reward_head=reward_head,
+                initial_action_bias=action_bias,
+            )
+            trainer_source = "byo_command"
+        else:
+            update = run_vlm_signal_training_step(
+                parsed_signals,
+                output_dir=trainer_dir,
+                learning_rate=config.learning_rate,
+                signal_loss_weight=config.signal_loss_weight,
+                initial_reward_head=reward_head,
+                initial_action_bias=action_bias,
+            )
+            trainer_source = "reference"
+        # The no-signal control always runs the in-process reference trainer so the
+        # policy-delta attribution baseline stays honest even when a BYO trainer
+        # produces the signal-driven update.
         control = run_vlm_signal_training_step(
             parsed_signals,
             output_dir=local_dir
@@ -952,6 +1118,8 @@ def run_inner_loop(
                 "signal_dir": str(signal_dir),
                 "signal_batch": str(signal_batch_path),
                 "mean_reward": mean_reward,
+                "trainer_source": trainer_source,
+                "signal_converter_source": signal_converter_source,
                 "update": update.to_dict(),
                 "no_signal_control": control.to_dict(),
                 "policy_delta_vs_control": round(delta_vs_control, 8),
@@ -978,6 +1146,12 @@ def run_inner_loop(
         "schema": "npa.sim2real.inner_loop_evidence.v1",
         "outer_iteration": outer_iteration,
         "status": "closed",
+        "trainer_source": (
+            "byo_command" if config.byo_trainer_command.strip() else "reference"
+        ),
+        "signal_converter_source": (
+            "byo_command" if config.byo_signal_converter.strip() else "reference"
+        ),
         "reward_trend": reward_trend,
         "signal_diversity": signal_diversity,
         "policy_delta_vs_no_signal_control": policy_deltas,
@@ -1807,6 +1981,136 @@ def signal_mapping_rules() -> dict[str, Any]:
         "nl_corrective_targets": CORRECTIVE_TARGETS,
         "error_severity": ERROR_SEVERITY,
     }
+
+
+def _convert_eval_to_signal(
+    evaluation: dict[str, Any],
+    *,
+    config: Sim2RealLoopConfig,
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Convert a VLM eval to an RL signal via the BYO command or the reference.
+
+    BYO signal-converter contract: the command reads the VLM evaluation JSON from
+    ``NPA_SIM2REAL_EVALUATION_JSON`` and writes an ``npa.sim2real.rl_signal.v1``
+    document to ``NPA_SIM2REAL_OUTPUT_JSON``. A missing, empty, non-conforming, or
+    failing command raises ``Sim2RealLoopError`` -- the loop never silently falls
+    back to the in-process reference converter.
+    """
+
+    if not config.byo_signal_converter.strip():
+        return convert_vlm_eval_to_rl_signal(evaluation)
+
+    rollout_id = str(evaluation.get("rollout_id") or "rollout")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    eval_path = output_dir / f"{rollout_id}.evaluation.json"
+    _write_json_artifact(eval_path, evaluation)
+    output_path = output_dir / f"{rollout_id}.byo-signal.json"
+    env = _component_env(
+        config,
+        component="signal_converter",
+        output_json=output_path,
+        extra={
+            "NPA_SIM2REAL_EVALUATION_JSON": str(eval_path),
+            "NPA_SIM2REAL_ROLLOUT_ID": rollout_id,
+            "NPA_SIM2REAL_RL_SIGNAL_SCHEMA": SCHEMA_RL_SIGNAL,
+        },
+    )
+    invocation = _run_component_command(
+        config.byo_signal_converter,
+        cwd=output_dir,
+        env=env,
+        component="signal_converter",
+    )
+    payload = _read_component_json(output_path, invocation)
+    return _normalize_byo_rl_signal(
+        payload,
+        rollout_id=rollout_id,
+        invocation=invocation,
+    )
+
+
+def _normalize_byo_rl_signal(
+    payload: dict[str, Any],
+    *,
+    rollout_id: str,
+    invocation: dict[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise Sim2RealLoopError("signal_converter output must be a JSON object")
+    if payload.get("schema") != SCHEMA_RL_SIGNAL:
+        raise Sim2RealLoopError(
+            "signal_converter output must use schema "
+            f"{SCHEMA_RL_SIGNAL}, got {payload.get('schema')!r}"
+        )
+    per_step = payload.get("per_step")
+    if not isinstance(per_step, list) or not per_step:
+        raise Sim2RealLoopError(
+            "signal_converter output must include non-empty per_step"
+        )
+    payload.setdefault("rollout_id", rollout_id)
+    payload.setdefault("source", "byo")
+    try:
+        parse_vlm_signal_batch(payload)
+    except Exception as exc:
+        raise Sim2RealLoopError(
+            f"signal_converter output is not a valid {SCHEMA_RL_SIGNAL}: {exc}"
+        ) from exc
+    payload["component_invocation"] = _public_invocation(invocation)
+    return payload
+
+
+def _run_trainer_via_command(
+    signal_batch_path: Path,
+    *,
+    config: Sim2RealLoopConfig,
+    output_dir: Path,
+    initial_reward_head: float,
+    initial_action_bias: float,
+) -> VlmSignalUpdateResult:
+    """Run the BYO trainer command and parse its update result.
+
+    BYO trainer contract: the command reads the parsed signal batch JSON from
+    ``NPA_SIM2REAL_SIGNAL_JSON`` and writes an update JSON to
+    ``NPA_SIM2REAL_OUTPUT_JSON`` containing at least ``reward_head_after``,
+    ``policy_output_after`` (list), and ``policy_delta_l2`` (optional
+    ``loss_before``/``loss_after``). A missing, empty, non-conforming, or failing
+    command raises ``Sim2RealLoopError`` -- the loop never silently falls back to
+    the in-process reference trainer.
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "byo-trainer-update.json"
+    env = _component_env(
+        config,
+        component="trainer",
+        output_json=output_path,
+        extra={
+            "NPA_SIM2REAL_SIGNAL_JSON": str(signal_batch_path),
+            "NPA_SIM2REAL_INITIAL_REWARD_HEAD": str(initial_reward_head),
+            "NPA_SIM2REAL_INITIAL_ACTION_BIAS": str(initial_action_bias),
+            "NPA_SIM2REAL_LEARNING_RATE": str(config.learning_rate),
+            "NPA_SIM2REAL_SIGNAL_LOSS_WEIGHT": str(config.signal_loss_weight),
+            "NPA_SIM2REAL_TRAINER_IMAGE": config.trainer_image,
+        },
+    )
+    invocation = _run_component_command(
+        config.byo_trainer_command,
+        cwd=output_dir,
+        env=env,
+        component="trainer",
+    )
+    payload = _read_component_json(output_path, invocation)
+    if not isinstance(payload, dict):
+        raise Sim2RealLoopError("trainer command output must be a JSON object")
+    try:
+        result = VlmSignalUpdateResult.from_dict(payload)
+    except Exception as exc:
+        raise Sim2RealLoopError(
+            f"trainer command output is not a valid update result: {exc}"
+        ) from exc
+    _write_json_artifact(output_path, result.to_dict())
+    return result
 
 
 def run_heldout_eval(
@@ -2733,6 +3037,8 @@ def main(argv: list[str] | None = None) -> int:
         byo_trainer_command=args.byo_trainer_command,
         byo_vlm_command=args.byo_vlm_command,
         byo_eval_command=args.byo_eval_command,
+        byo_rerun_command=args.byo_rerun_command,
+        rerun_enabled=args.rerun,
         k8s_namespace=args.k8s_namespace,
         k8s_service_account=args.k8s_service_account,
         k8s_image_pull_secrets=args.k8s_image_pull_secrets,
@@ -2835,6 +3141,20 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--byo-trainer-command", default="")
     parser.add_argument("--byo-vlm-command", default="")
     parser.add_argument("--byo-eval-command", default="")
+    parser.add_argument("--byo-rerun-command", default="")
+    parser.add_argument(
+        "--rerun",
+        dest="rerun",
+        action="store_true",
+        default=_bool_value(os.environ.get("NPA_SIM2REAL_RERUN", "1")),
+        help="Emit a Rerun .rrd visualization after the loop (default on).",
+    )
+    parser.add_argument(
+        "--no-rerun",
+        dest="rerun",
+        action="store_false",
+        help="Disable Rerun .rrd visualization emission.",
+    )
     parser.add_argument(
         "--k8s-namespace",
         default=os.environ.get("NPA_SIM2REAL_K8S_NAMESPACE", ""),

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -55,6 +55,11 @@ SIM_BACKENDS = (SIM_BACKEND_GENESIS, SIM_BACKEND_ISAAC)
 DEFAULT_SIM_BACKEND = SIM_BACKEND_ISAAC
 # Default headless Isaac Lab manipulation task for the stock held-out rollout.
 DEFAULT_ISAAC_TASK = "Isaac-Lift-Cube-Franka-v0"
+
+# Holds the live Isaac Sim app between the rollout and the report upload.
+# Isaac Sim's SimulationApp.close() hard-terminates the process, so it is closed
+# only after the held-out report.json has been uploaded. See _close_isaac_app.
+_ISAAC_SIMULATION_APP: Any = None
 DEFAULT_THRESHOLD = 0.75
 DEFAULT_INNER_ITERATIONS = 2
 DEFAULT_OUTER_ITERATIONS = 1
@@ -2267,6 +2272,11 @@ def run_heldout_eval_component_from_s3(
                 sort_keys=True,
             )
         )
+        sys.stdout.flush()
+        sys.stderr.flush()
+        # report.json is uploaded above; closing Isaac Sim hard-terminates the
+        # process, so it must come last (no-op for the Genesis backend).
+        _close_isaac_app()
         return payload
 
 
@@ -3103,6 +3113,11 @@ def _run_isaac_heldout_rollouts(
         ) from exc
 
     simulation_app = AppLauncher(headless=True).app
+    # Isaac Sim's SimulationApp.close() hard-terminates the process, so it must
+    # NOT be called here (the held-out report has to be uploaded first). The
+    # handle is stashed and closed by the component entrypoint after upload.
+    global _ISAAC_SIMULATION_APP
+    _ISAAC_SIMULATION_APP = simulation_app
     try:
         import torch
         import gymnasium as gym  # noqa: PLC0415
@@ -3164,7 +3179,7 @@ def _run_isaac_heldout_rollouts(
     reward_norm = float(os.environ.get("NPA_SIM2REAL_ISAAC_REWARD_NORM", "20.0"))
     success_dist = float(os.environ.get("NPA_SIM2REAL_ISAAC_SUCCESS_DIST", "0.05"))
     per_env: list[dict[str, Any]] = []
-    try:
+    if True:
         for start in range(0, len(envs), batch_size):
             batch = envs[start : start + batch_size]
             seed = int(batch[0].get("seed") or (42 + start))
@@ -3238,12 +3253,24 @@ def _run_isaac_heldout_rollouts(
                     }
                 )
             env.close()
-    finally:
+    return per_env
+
+
+def _close_isaac_app() -> None:
+    """Close the stashed Isaac Sim app, if any (hard-terminates the process).
+
+    Called by the component entrypoint only after the held-out report has been
+    written and uploaded. No-op for the Genesis backend.
+    """
+
+    global _ISAAC_SIMULATION_APP
+    app = _ISAAC_SIMULATION_APP
+    _ISAAC_SIMULATION_APP = None
+    if app is not None:
         try:
-            simulation_app.close()
+            app.close()
         except Exception:  # noqa: BLE001
             pass
-    return per_env
 
 
 def _policy_adapter_from_inner_evidence(inner_evidence: dict[str, Any]) -> dict[str, Any]:

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -16,7 +16,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from npa.clients.storage import StorageClient
@@ -27,6 +27,10 @@ from npa.deploy.images import container_image_for_tool
 # (lancedb/fiftyone/etc.), which is intentionally absent from the Isaac Lab
 # held-out image; the Isaac rollout path never needs it. Keeping the import lazy
 # lets sim2real_loop run on a minimal interpreter.
+
+
+if TYPE_CHECKING:
+    from npa.workbench.lerobot.policy_container import VlmSignalUpdateResult
 
 
 def _signal_training_imports():

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -848,6 +848,7 @@ def run_inner_loop(
     iteration_records: list[dict[str, Any]] = []
     reward_trend: list[float] = []
     policy_deltas: list[float] = []
+    all_signals: list[dict[str, Any]] = []
     quality = float(initial_quality)
     reward_head = 0.0
     action_bias = 0.0
@@ -892,6 +893,7 @@ def run_inner_loop(
             _write_json_artifact(signal_dir / f"{signal['rollout_id']}.json", signal)
             evals.append(evaluation)
             signals.append(signal)
+            all_signals.append(signal)
         signal_batch_path = (
             local_dir
             / "inner_loop"
@@ -959,11 +961,25 @@ def run_inner_loop(
             }
         )
 
+    signal_diversity = _signal_diversity_report(all_signals)
+    if signal_diversity["degenerate"] and _bool_value(
+        os.environ.get("NPA_SIM2REAL_REQUIRE_SIGNAL_DIVERSITY", "0")
+    ):
+        raise Sim2RealLoopError(
+            "VLM->RL signal is degenerate: "
+            f"{signal_diversity['distinct_scores']} distinct score(s) and "
+            f"{signal_diversity['distinct_mean_rewards']} distinct mean-reward(s) "
+            f"across {signal_diversity['total_rollouts']} rollout(s) "
+            f"(scores={signal_diversity['score_values']}). "
+            "Unset NPA_SIM2REAL_REQUIRE_SIGNAL_DIVERSITY to downgrade this gate to a "
+            "diagnostic."
+        )
     evidence = {
         "schema": "npa.sim2real.inner_loop_evidence.v1",
         "outer_iteration": outer_iteration,
         "status": "closed",
         "reward_trend": reward_trend,
+        "signal_diversity": signal_diversity,
         "policy_delta_vs_no_signal_control": policy_deltas,
         "attribution": (
             "The reference update and no-signal control share initial adapter state. "
@@ -1267,6 +1283,7 @@ def _run_kubernetes_image_component(
         "mode": "kubernetes_job",
         "component": component,
         "image": image,
+        "image_digests": pod_info.get("image_digests", []),
         "namespace": namespace,
         "job_name": job_name,
         "pod": pod_info,
@@ -1313,7 +1330,7 @@ def _component_job_manifest(
             {
                 "name": "component",
                 "image": image,
-                "imagePullPolicy": "IfNotPresent",
+                "imagePullPolicy": _image_pull_policy(image),
                 "command": ["bash", "-lc"],
                 "args": [_component_job_script(component)],
                 "env": [
@@ -1485,20 +1502,27 @@ def _component_pod_info(
     container = (pod.get("spec", {}).get("containers") or [{}])[0]
     resources = container.get("resources", {})
     statuses = pod.get("status", {}).get("containerStatuses") or []
+    container_statuses = [
+        {
+            "name": item.get("name", ""),
+            "ready": item.get("ready", False),
+            "restart_count": item.get("restartCount", 0),
+            "image": item.get("image", ""),
+            "image_id": item.get("imageID", ""),
+            "state": item.get("state", {}),
+        }
+        for item in statuses
+    ]
+    image_digests = [
+        status["image_id"] for status in container_statuses if status["image_id"]
+    ]
     return {
         "name": pod.get("metadata", {}).get("name", ""),
         "node_name": pod.get("spec", {}).get("nodeName", ""),
         "phase": pod.get("status", {}).get("phase", ""),
         "resources": resources,
-        "container_statuses": [
-            {
-                "name": item.get("name", ""),
-                "ready": item.get("ready", False),
-                "restart_count": item.get("restartCount", 0),
-                "state": item.get("state", {}),
-            }
-            for item in statuses
-        ],
+        "container_statuses": container_statuses,
+        "image_digests": image_digests,
     }
 
 
@@ -2328,11 +2352,16 @@ def _parse_cosmos_reason_output(
             or model_text
         ).strip()
         tags = payload.get("error_tags") or _tags_from_text(critique)
+        # The model returned no per-step breakdown, so the single summary critique
+        # is broadcast across every action step. Mark it as such so a degenerate
+        # (all-identical) per-step signal is visible rather than masquerading as
+        # genuine per-step granularity.
         raw_steps = [
             {
                 "step": int(action.get("step", index)),
                 "critique_text": critique,
                 "error_tags": tags,
+                "critique_source": "summary_broadcast",
                 "camera_observation": f"camera-{int(action.get('step', index)):03d}.ppm",
             }
             for index, action in enumerate(actions)
@@ -2512,7 +2541,9 @@ def _run_genesis_heldout_rollouts(
             env_success = bool(success[index].detach().item())
             distance_score = max(0.0, min(1.0, 1.0 - dist / 0.5))
             reward_score = max(0.0, min(1.0, reward_value / 10.0))
-            score = 1.0 if env_success else round(0.7 * distance_score + 0.3 * reward_score, 6)
+            score = _heldout_env_score(
+                distance_score, reward_score, env_success=env_success
+            )
             per_env.append(
                 {
                     "env_id": str(env_record.get("env_id") or f"heldout-{start + index:04d}"),
@@ -2997,6 +3028,68 @@ def _merge_targets(tags: list[str]) -> dict[str, Any]:
 def _signal_mean_reward(signal: dict[str, Any]) -> float:
     steps = signal.get("per_step") or []
     return sum(float(step["reward"]) for step in steps) / float(len(steps))
+
+
+def _heldout_env_score(
+    distance_score: float, reward_score: float, *, env_success: bool
+) -> float:
+    """Map per-env distance/reward to a continuous held-out score.
+
+    Successful and failed envs occupy separate bands, but the score stays
+    continuous in the env's own distance/reward so the held-out report keeps a
+    gradient instead of collapsing to a flat ``1.0`` across every env (which
+    produced an uninformative, incoherent signal).
+    """
+
+    quality = max(0.0, min(1.0, 0.7 * distance_score + 0.3 * reward_score))
+    if env_success:
+        return round(0.75 + 0.25 * quality, 6)
+    return round(0.6 * quality, 6)
+
+
+def _signal_diversity_report(signals: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize cross-rollout diversity of the VLM->RL signal.
+
+    A genuine signal varies across rollouts; a single distinct score/reward
+    across every rollout is the degenerate ("hollow") pattern. These metrics
+    (``distinct_scores``, ``coherent``) are emitted into loop evidence so a run
+    is self-describing instead of requiring an external validator to infer them.
+    """
+
+    scores = [round(float(signal.get("score") or 0.0), 4) for signal in signals]
+    mean_rewards = [round(_signal_mean_reward(signal), 4) for signal in signals]
+    distinct_scores = sorted({score for score in scores})
+    distinct_rewards = sorted({reward for reward in mean_rewards})
+    total = len(signals)
+    coherent = total > 1 and len(distinct_scores) > 1 and len(distinct_rewards) > 1
+    return {
+        "total_rollouts": total,
+        "distinct_scores": len(distinct_scores),
+        "distinct_mean_rewards": len(distinct_rewards),
+        "score_values": distinct_scores,
+        "mean_reward_values": distinct_rewards,
+        "coherent": coherent,
+        "degenerate": not coherent,
+    }
+
+
+def _image_pull_policy(image: str) -> str:
+    """Choose the imagePullPolicy for a sibling component image.
+
+    Provenance-sensitive ``-genuine-`` builds are pulled fresh so a stale image
+    cached under the same tag cannot silently masquerade as the genuine build.
+    A digest-pinned reference (``@sha256:``) is already immutable.
+    """
+
+    override = os.environ.get("NPA_SIM2REAL_IMAGE_PULL_POLICY", "").strip()
+    if override:
+        return override
+    if "@sha256:" in image:
+        return "IfNotPresent"
+    tag = image.rsplit(":", 1)[-1] if ":" in image.rsplit("/", 1)[-1] else ""
+    if "genuine" in tag:
+        return "Always"
+    return "IfNotPresent"
 
 
 def _write_ppm(path: Path, *, red: int, green: int, blue: int) -> None:

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -2034,11 +2034,16 @@ def _normalize_heldout_report(
         "threshold": config.threshold,
         "per_env": per_env,
         "eval_image": config.eval_image,
+        "sim_backend": str(payload.get("sim_backend") or config.sim_backend),
+        "heldout_backend_image": config.heldout_backend_image(),
         "byo_eval_command": _redact_command(config.byo_eval_command),
         "inner_evidence_uri": inner_evidence_uri,
         "component_invocation": _public_invocation(invocation),
         "generated_at": _utc_now(),
     }
+    for key in ("component_source", "rollout_backend"):
+        if payload.get(key):
+            report[key] = payload[key]
     if "asset_provenance" in payload:
         report["asset_provenance"] = payload["asset_provenance"]
         report["asset_fallback_used"] = bool(

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -2985,13 +2985,21 @@ def _isaac_import_mesh_to_usd(local_path: str, *, work_dir: Path) -> str:
             )
             converter = UrdfConverter(cfg)
         else:
+            import isaaclab.sim as sim_utils
             from isaaclab.sim.converters import MeshConverter, MeshConverterCfg
 
+            # Bake RigidBody/Collision/Mass APIs into the converted USD so the
+            # mesh spawns as a physics rigid body (Isaac Lab's RigidObject
+            # requires 'USD RigidBodyAPI' on the prim).
             cfg = MeshConverterCfg(
                 asset_path=str(src),
                 usd_dir=str(work_dir),
                 usd_file_name=f"{src.stem}.usd",
                 force_usd_conversion=True,
+                collision_approximation="convexHull",
+                mass_props=sim_utils.MassPropertiesCfg(mass=0.1),
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(),
+                collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=True),
             )
             converter = MeshConverter(cfg)
     except Exception as exc:  # noqa: BLE001 - surface converter import/runtime errors
@@ -3029,6 +3037,8 @@ def _set_isaac_object_usd(env_cfg: Any, usd_path: str, *, scale: Any) -> None:
             max_depenetration_velocity=5.0,
             disable_gravity=False,
         ),
+        mass_props=sim_utils.MassPropertiesCfg(mass=0.1),
+        collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=True),
     )
 
 
@@ -3179,80 +3189,79 @@ def _run_isaac_heldout_rollouts(
     reward_norm = float(os.environ.get("NPA_SIM2REAL_ISAAC_REWARD_NORM", "20.0"))
     success_dist = float(os.environ.get("NPA_SIM2REAL_ISAAC_SUCCESS_DIST", "0.05"))
     per_env: list[dict[str, Any]] = []
-    if True:
-        for start in range(0, len(envs), batch_size):
-            batch = envs[start : start + batch_size]
-            seed = int(batch[0].get("seed") or (42 + start))
-            torch.manual_seed(seed)
-            env_cfg = parse_env_cfg(isaac_task, device=device, num_envs=len(batch))
-            if usd_override:
-                _set_isaac_object_usd(env_cfg, usd_override, scale=manip_scale)
-            env = gym.make(isaac_task, cfg=env_cfg)
-            action_dim = int(env.action_space.shape[-1])
-            obs, _ = env.reset()
-            n = len(batch)
-            max_reward = torch.full((n,), -1.0e9, device=device)
-            final_distance = torch.full((n,), 1.0e9, device=device)
-            for step in range(max_steps):
-                actions = _isaac_adapter_actions(
-                    action_dim, adapter, n_envs=n, step=step, device=device
-                )
-                obs, reward, terminated, truncated, _ = env.step(actions)
-                reward_t = torch.as_tensor(reward, device=device, dtype=torch.float32).reshape(-1)
-                max_reward = torch.maximum(max_reward, reward_t)
-                final_distance = _isaac_goal_distance(env.unwrapped).reshape(-1).detach()
-                done = torch.as_tensor(terminated, device=device).reshape(-1) | torch.as_tensor(
-                    truncated, device=device
-                ).reshape(-1)
-                if bool(done.all()):
-                    break
-            success = final_distance < success_dist
-            batch_successes = int(success.sum().item())
-            print(
-                json.dumps(
-                    {
-                        "component": "heldout_eval",
-                        "event": "isaac_rollout_batch_complete",
-                        "batch_start": start,
-                        "env_count": n,
-                        "successes": batch_successes,
-                        "max_steps": max_steps,
-                        "isaac_task": isaac_task,
-                    },
-                    sort_keys=True,
-                )
+    for start in range(0, len(envs), batch_size):
+        batch = envs[start : start + batch_size]
+        seed = int(batch[0].get("seed") or (42 + start))
+        torch.manual_seed(seed)
+        env_cfg = parse_env_cfg(isaac_task, device=device, num_envs=len(batch))
+        if usd_override:
+            _set_isaac_object_usd(env_cfg, usd_override, scale=manip_scale)
+        env = gym.make(isaac_task, cfg=env_cfg)
+        action_dim = int(env.action_space.shape[-1])
+        obs, _ = env.reset()
+        n = len(batch)
+        max_reward = torch.full((n,), -1.0e9, device=device)
+        final_distance = torch.full((n,), 1.0e9, device=device)
+        for step in range(max_steps):
+            actions = _isaac_adapter_actions(
+                action_dim, adapter, n_envs=n, step=step, device=device
             )
-            for index, env_record in enumerate(batch):
-                dist = float(final_distance[index].detach().item())
-                reward_value = float(max_reward[index].detach().item())
-                env_success = bool(success[index].detach().item())
-                distance_score = max(0.0, min(1.0, 1.0 - dist / 0.5))
-                reward_score = max(0.0, min(1.0, reward_value / reward_norm))
-                score = _heldout_env_score(
-                    distance_score, reward_score, env_success=env_success
-                )
-                per_env.append(
-                    {
-                        "env_id": str(
-                            env_record.get("env_id") or f"heldout-{start + index:04d}"
-                        ),
-                        "score": score,
-                        "success": env_success,
-                        "details": {
-                            "source": "isaac_lift_env_goal_distance",
-                            "sim_backend": SIM_BACKEND_ISAAC,
-                            "isaac_task": isaac_task,
-                            "seed": env_record.get("seed"),
-                            "target_threshold": success_dist,
-                            "final_target_distance": round(dist, 6),
-                            "max_reward": round(reward_value, 6),
-                            "steps": max_steps,
-                            "policy_adapter": adapter,
-                            "threshold": threshold,
-                        },
-                    }
-                )
-            env.close()
+            obs, reward, terminated, truncated, _ = env.step(actions)
+            reward_t = torch.as_tensor(reward, device=device, dtype=torch.float32).reshape(-1)
+            max_reward = torch.maximum(max_reward, reward_t)
+            final_distance = _isaac_goal_distance(env.unwrapped).reshape(-1).detach()
+            done = torch.as_tensor(terminated, device=device).reshape(-1) | torch.as_tensor(
+                truncated, device=device
+            ).reshape(-1)
+            if bool(done.all()):
+                break
+        success = final_distance < success_dist
+        batch_successes = int(success.sum().item())
+        print(
+            json.dumps(
+                {
+                    "component": "heldout_eval",
+                    "event": "isaac_rollout_batch_complete",
+                    "batch_start": start,
+                    "env_count": n,
+                    "successes": batch_successes,
+                    "max_steps": max_steps,
+                    "isaac_task": isaac_task,
+                },
+                sort_keys=True,
+            )
+        )
+        for index, env_record in enumerate(batch):
+            dist = float(final_distance[index].detach().item())
+            reward_value = float(max_reward[index].detach().item())
+            env_success = bool(success[index].detach().item())
+            distance_score = max(0.0, min(1.0, 1.0 - dist / 0.5))
+            reward_score = max(0.0, min(1.0, reward_value / reward_norm))
+            score = _heldout_env_score(
+                distance_score, reward_score, env_success=env_success
+            )
+            per_env.append(
+                {
+                    "env_id": str(
+                        env_record.get("env_id") or f"heldout-{start + index:04d}"
+                    ),
+                    "score": score,
+                    "success": env_success,
+                    "details": {
+                        "source": "isaac_lift_env_goal_distance",
+                        "sim_backend": SIM_BACKEND_ISAAC,
+                        "isaac_task": isaac_task,
+                        "seed": env_record.get("seed"),
+                        "target_threshold": success_dist,
+                        "final_target_distance": round(dist, 6),
+                        "max_reward": round(reward_value, 6),
+                        "steps": max_steps,
+                        "policy_adapter": adapter,
+                        "threshold": threshold,
+                    },
+                }
+            )
+        env.close()
     return per_env
 
 

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -1555,7 +1555,18 @@ fi
 "$PYBIN" -m npa.workflows.sim2real_loop {subcommand}
 """
     return f"""set -euo pipefail
-if [ -n "${{NPA_SOURCE_REPO:-}}" ] && [ -n "${{NPA_SOURCE_REF:-}}" ]; then
+if [ -n "${{NPA_SIM2REAL_SOURCE_TARBALL_URI:-}}" ]; then
+  rm -rf /tmp/npa-source && mkdir -p /tmp/npa-source
+  python - "${{NPA_SIM2REAL_SOURCE_TARBALL_URI}}" <<'PYB'
+import os, sys, tarfile, urllib.parse, boto3
+u = urllib.parse.urlparse(sys.argv[1])
+ep = os.environ.get("AWS_ENDPOINT_URL") or os.environ.get("S3_ENDPOINT_URL") or None
+boto3.client("s3", endpoint_url=ep).download_file(u.netloc, u.path.lstrip("/"), "/tmp/npa-src.tgz")
+with tarfile.open("/tmp/npa-src.tgz") as tar:
+    tar.extractall("/tmp/npa-source")
+PYB
+  export PYTHONPATH="/tmp/npa-source/npa/src:${{PYTHONPATH:-}}"
+elif [ -n "${{NPA_SOURCE_REPO:-}}" ] && [ -n "${{NPA_SOURCE_REF:-}}" ]; then
   rm -rf /tmp/npa-source
   git clone --quiet --depth 1 --branch "${{NPA_SOURCE_REF}}" "${{NPA_SOURCE_REPO}}" /tmp/npa-source
   export PYTHONPATH="/tmp/npa-source/npa/src:${{PYTHONPATH:-}}"

--- a/npa/src/npa/workflows/sim2real_viz.py
+++ b/npa/src/npa/workflows/sim2real_viz.py
@@ -1,0 +1,401 @@
+"""Rerun visualization emitter for completed Sim2Real loop runs.
+
+This module turns a completed Sim2Real run's artifact tree into a single Rerun
+``.rrd`` recording (and, optionally, per-rollout MP4s) so the VLM->RL loop can be
+inspected visually: rollout camera frames as image streams, per-rollout VLM
+critique text and score overlays, the per-step reward/advantage signal as scalar
+timeseries, and the held-out per-env scores as a scalar/bar view.
+
+It reuses the repo's existing Rerun capability (the ``rerun-sdk`` recording API
+that ``npa.viz.adapters.lerobot_to_rerun`` and ``npa.viz.backends.rerun`` build
+on) rather than reinventing a logger. ``rerun`` is imported lazily so the loop
+degrades gracefully (WARN, not hard-fail) when the SDK is not installed locally,
+but it MUST produce a non-empty ``.rrd`` whenever the SDK is available.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+APPLICATION_ID = "npa_sim2real_loop"
+TIMELINE = "frame_time"
+ROLLOUT_FRAME_SECONDS = 0.5
+HELDOUT_STEP_SECONDS = 1.0
+CRITIQUE_COLOR = (255, 136, 0, 255)
+
+
+class Sim2RealVizError(Exception):
+    """Raised when the Sim2Real Rerun emitter cannot produce a recording."""
+
+
+class RerunUnavailableError(Sim2RealVizError):
+    """Raised when the ``rerun`` SDK is not importable (caller WARNs and skips)."""
+
+
+@dataclass(frozen=True)
+class Sim2RealVizResult:
+    """Result of emitting a Sim2Real Rerun recording."""
+
+    status: str
+    output_rrd_path: str
+    entity_counts: dict[str, int] = field(default_factory=dict)
+    rollout_count: int = 0
+    frame_count: int = 0
+    heldout_env_count: int = 0
+    mp4_paths: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "output_rrd_path": self.output_rrd_path,
+            "entity_counts": dict(self.entity_counts),
+            "rollout_count": self.rollout_count,
+            "frame_count": self.frame_count,
+            "heldout_env_count": self.heldout_env_count,
+            "mp4_paths": list(self.mp4_paths),
+        }
+
+
+def emit_sim2real_rerun(
+    *,
+    local_dir: Path,
+    inner_evidence: dict[str, Any],
+    heldout_report: dict[str, Any] | None,
+    output_rrd: Path | None = None,
+    write_mp4: bool = False,
+) -> Sim2RealVizResult:
+    """Write ``reports/sim2real.rrd`` for a completed run's artifacts.
+
+    Raises ``RerunUnavailableError`` when the ``rerun`` SDK is missing so the
+    caller can WARN and continue. Any other failure (rerun present but logging
+    failed) raises ``Sim2RealVizError`` so a broken recording is never silently
+    accepted.
+    """
+
+    rr, rrb = _import_rerun()
+    local_dir = Path(local_dir)
+    output_rrd = Path(output_rrd) if output_rrd is not None else local_dir / "reports" / "sim2real.rrd"
+    if output_rrd.suffix.lower() != ".rrd":
+        raise Sim2RealVizError(f"Rerun output path must end in .rrd, got: {output_rrd}")
+    output_rrd.parent.mkdir(parents=True, exist_ok=True)
+
+    blueprint = _build_blueprint(rrb)
+    recording = rr.RecordingStream(APPLICATION_ID)
+    rr.save(output_rrd, default_blueprint=blueprint, recording=recording)
+    _send_blueprint(rr, blueprint, recording)
+
+    counts: dict[str, int] = {}
+    seconds = 0.0
+    rollout_count = 0
+    frame_count = 0
+    mp4_paths: list[str] = []
+
+    iterations = inner_evidence.get("iterations") or []
+    for record in iterations:
+        iteration = int(record.get("iteration", len(mp4_paths) + 1))
+        actions_dir = _maybe_path(record.get("actions_dir"))
+        eval_dir = _maybe_path(record.get("vlm_eval_dir"))
+        signal_dir = _maybe_path(record.get("signal_dir"))
+        for rollout_dir in _rollout_dirs(actions_dir):
+            rollout_id = rollout_dir.name
+            iter_root = f"rollouts/iter_{iteration:02d}/{rollout_id}"
+            evaluation = _read_json(eval_dir / f"{rollout_id}.json") if eval_dir else {}
+            signal = _read_json(signal_dir / f"{rollout_id}.json") if signal_dir else {}
+            frames = _rollout_frames(rollout_dir)
+            seconds = _log_rollout(
+                rr,
+                recording,
+                root=iter_root,
+                frames=frames,
+                evaluation=evaluation,
+                signal=signal,
+                start_seconds=seconds,
+                counts=counts,
+            )
+            rollout_count += 1
+            frame_count += len(frames)
+            if write_mp4 and frames:
+                mp4_path = _maybe_write_mp4(rollout_dir, frames)
+                if mp4_path is not None:
+                    mp4_paths.append(str(mp4_path))
+
+    _log_reward_trend(rr, recording, inner_evidence.get("reward_trend") or [], counts)
+    heldout_env_count = _log_heldout(
+        rr,
+        recording,
+        (heldout_report or {}).get("per_env") or [],
+        counts,
+    )
+
+    _disconnect(rr, recording)
+
+    if not output_rrd.exists() or output_rrd.stat().st_size == 0:
+        raise Sim2RealVizError(f"Rerun recording was not written: {output_rrd}")
+    if frame_count == 0 and rollout_count == 0 and heldout_env_count == 0:
+        raise Sim2RealVizError(
+            "Sim2Real Rerun recording has no rollout frames, signal, or held-out content"
+        )
+
+    return Sim2RealVizResult(
+        status="written",
+        output_rrd_path=str(output_rrd),
+        entity_counts=counts,
+        rollout_count=rollout_count,
+        frame_count=frame_count,
+        heldout_env_count=heldout_env_count,
+        mp4_paths=mp4_paths,
+    )
+
+
+def _log_rollout(
+    rr: Any,
+    recording: Any,
+    *,
+    root: str,
+    frames: list[np.ndarray],
+    evaluation: dict[str, Any],
+    signal: dict[str, Any],
+    start_seconds: float,
+    counts: dict[str, int],
+) -> float:
+    seconds = start_seconds
+    per_step_eval = {int(item.get("step", index)): item for index, item in enumerate(evaluation.get("per_step") or [])}
+    per_step_signal = {int(item.get("step", index)): item for index, item in enumerate(signal.get("per_step") or [])}
+    score = evaluation.get("score")
+    summary = str(evaluation.get("summary") or "")
+
+    for step, frame in enumerate(frames):
+        _set_time(rr, recording, seconds)
+        rr.log(f"{root}/camera", rr.Image(frame), recording=recording)
+        _bump(counts, f"{root}/camera")
+
+        eval_step = per_step_eval.get(step, {})
+        critique = str(eval_step.get("critique_text") or summary or "")
+        tags = eval_step.get("error_tags") or []
+        if critique:
+            overlay = critique if not tags else f"{critique}\n\nerror_tags: {', '.join(str(tag) for tag in tags)}"
+            rr.log(
+                f"{root}/critique",
+                rr.TextDocument(overlay, media_type="text/markdown"),
+                recording=recording,
+            )
+            _bump(counts, f"{root}/critique")
+        if score is not None:
+            rr.log(f"{root}/score", _scalar(rr, float(score)), recording=recording)
+            _bump(counts, f"{root}/score")
+
+        signal_step = per_step_signal.get(step, {})
+        if "reward" in signal_step:
+            rr.log("signal/reward", _scalar(rr, float(signal_step["reward"])), recording=recording)
+            _bump(counts, "signal/reward")
+        if signal_step.get("advantage") is not None:
+            rr.log("signal/advantage", _scalar(rr, float(signal_step["advantage"])), recording=recording)
+            _bump(counts, "signal/advantage")
+        seconds += ROLLOUT_FRAME_SECONDS
+    return seconds
+
+
+def _log_reward_trend(rr: Any, recording: Any, reward_trend: list[Any], counts: dict[str, int]) -> None:
+    for index, value in enumerate(reward_trend):
+        _set_time(rr, recording, float(index))
+        rr.log("signal/reward_trend", _scalar(rr, float(value)), recording=recording)
+        _bump(counts, "signal/reward_trend")
+
+
+def _log_heldout(rr: Any, recording: Any, per_env: list[dict[str, Any]], counts: dict[str, int]) -> int:
+    seconds = 0.0
+    logged = 0
+    for index, item in enumerate(per_env):
+        if not isinstance(item, dict):
+            continue
+        env_id = str(item.get("env_id") or f"heldout-{index:04d}")
+        score = float(item.get("score", 0.0))
+        _set_time(rr, recording, seconds)
+        rr.log("heldout/scores", _scalar(rr, score), recording=recording)
+        rr.log(f"heldout/per_env/{env_id}", _scalar(rr, score), recording=recording)
+        _bump(counts, "heldout/scores")
+        _bump(counts, f"heldout/per_env/{env_id}")
+        seconds += HELDOUT_STEP_SECONDS
+        logged += 1
+    return logged
+
+
+def _build_blueprint(rrb: Any) -> Any:
+    return rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.Spatial2DView(origin="rollouts", contents="rollouts/**", name="Rollout cameras"),
+            rrb.TextDocumentView(origin="rollouts", contents="rollouts/**/critique", name="VLM critiques"),
+            rrb.Vertical(
+                rrb.TimeSeriesView(origin="signal", contents="signal/**", name="VLM->RL signal"),
+                rrb.TimeSeriesView(origin="heldout", contents="heldout/**", name="Held-out scores"),
+            ),
+            column_shares=[2.0, 1.5, 1.5],
+        ),
+        rrb.TimePanel(state=rrb.PanelState.Expanded, timeline=TIMELINE),
+        auto_layout=False,
+    )
+
+
+def _rollout_dirs(actions_dir: Path | None) -> list[Path]:
+    if actions_dir is None or not actions_dir.exists():
+        return []
+    return sorted(path for path in actions_dir.iterdir() if path.is_dir() and path.name.startswith("rollout-"))
+
+
+def _rollout_frames(rollout_dir: Path) -> list[np.ndarray]:
+    frames: list[np.ndarray] = []
+    for frame_path in sorted(rollout_dir.glob("camera-*.ppm")):
+        frame = _read_ppm(frame_path)
+        if frame is not None:
+            frames.append(frame)
+    return frames
+
+
+def _read_ppm(path: Path) -> np.ndarray | None:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    if not data.startswith(b"P6"):
+        return None
+    fields: list[bytes] = []
+    index = 2
+    while len(fields) < 3 and index < len(data):
+        while index < len(data) and data[index] in b" \t\r\n":
+            index += 1
+        if index < len(data) and data[index:index + 1] == b"#":
+            while index < len(data) and data[index] not in b"\r\n":
+                index += 1
+            continue
+        start = index
+        while index < len(data) and data[index] not in b" \t\r\n":
+            index += 1
+        fields.append(data[start:index])
+    if len(fields) < 3:
+        return None
+    width, height, _maxval = (int(field) for field in fields)
+    index += 1  # single whitespace separator after maxval
+    pixels = data[index:index + width * height * 3]
+    if len(pixels) < width * height * 3:
+        return None
+    return np.frombuffer(pixels, dtype=np.uint8).reshape(height, width, 3).copy()
+
+
+def _maybe_write_mp4(rollout_dir: Path, frames: list[np.ndarray]) -> Path | None:
+    """Best-effort per-rollout MP4 via ffmpeg; returns None if ffmpeg is missing."""
+
+    import shutil
+    import subprocess
+    import tempfile
+
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return None
+    output_path = rollout_dir / "rollout.mp4"
+    with tempfile.TemporaryDirectory(prefix="npa-sim2real-mp4-") as tmp:
+        tmp_dir = Path(tmp)
+        for index, frame in enumerate(frames):
+            _write_png(tmp_dir / f"frame_{index:06d}.png", frame)
+        command = [
+            ffmpeg,
+            "-y",
+            "-loglevel",
+            "error",
+            "-framerate",
+            "2",
+            "-i",
+            str(tmp_dir / "frame_%06d.png"),
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(output_path),
+        ]
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0 or not output_path.exists():
+        return None
+    return output_path
+
+
+def _write_png(path: Path, frame: np.ndarray) -> None:
+    import struct
+    import zlib
+
+    height, width = int(frame.shape[0]), int(frame.shape[1])
+    raw = bytearray()
+    for row in range(height):
+        raw.append(0)
+        raw.extend(frame[row].tobytes())
+
+    def _chunk(tag: bytes, payload: bytes) -> bytes:
+        return struct.pack("!I", len(payload)) + tag + payload + struct.pack("!I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+
+    header = struct.pack("!IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", header)
+    png += _chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+    png += _chunk(b"IEND", b"")
+    path.write_bytes(png)
+
+
+def _scalar(rr: Any, value: float) -> Any:
+    if hasattr(rr, "Scalars"):
+        return rr.Scalars(value)
+    return rr.Scalar(value)
+
+
+def _set_time(rr: Any, recording: Any, seconds: float) -> None:
+    if hasattr(rr, "set_time_seconds"):
+        rr.set_time_seconds(TIMELINE, seconds, recording=recording)
+    else:
+        rr.set_time(TIMELINE, duration=seconds, recording=recording)
+
+
+def _send_blueprint(rr: Any, blueprint: Any, recording: Any) -> None:
+    sender = getattr(rr, "send_blueprint", None)
+    if callable(sender):
+        sender(blueprint, recording=recording)
+
+
+def _disconnect(rr: Any, recording: Any) -> None:
+    disconnect = getattr(rr, "disconnect", None)
+    if callable(disconnect):
+        try:
+            disconnect(recording=recording)
+        except Exception:
+            pass
+
+
+def _bump(counts: dict[str, int], entity: str) -> None:
+    normalized = "/" + entity.strip("/")
+    counts[normalized] = counts.get(normalized, 0) + 1
+
+
+def _maybe_path(value: Any) -> Path | None:
+    if not value:
+        return None
+    return Path(str(value))
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _import_rerun() -> tuple[Any, Any]:
+    try:
+        import rerun as rr
+        import rerun.blueprint as rrb
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch in tests
+        raise RerunUnavailableError(
+            "rerun-sdk is not installed; skipping Sim2Real Rerun visualization"
+        ) from exc
+    return rr, rrb

--- a/npa/tests/cli/test_skypilot_bootstrap.py
+++ b/npa/tests/cli/test_skypilot_bootstrap.py
@@ -161,3 +161,80 @@ def test_skypilot_bootstrap_can_install_local_tiny_package(tmp_path: Path) -> No
     assert result.reused is False
     assert result.sky_bin.is_file()
     assert '"extras": [\n    "test"\n  ]' in result.marker_path.read_text(encoding="utf-8")
+
+
+def _intercept_sky_check(monkeypatch: pytest.MonkeyPatch, captured: dict[str, object]):
+    """Capture only the `sky check` invocation; delegate other calls.
+
+    ``_run_no_raise`` is also used by ``inspect_venv`` for version/import probes,
+    so a blanket stub would make the venv look uninstalled.
+    """
+
+    original = skypilot_cli._run_no_raise
+
+    def fake_run(cmd, *, env=None):  # noqa: ANN001 - test stub
+        if cmd[-1] == "check":
+            captured["cmd"] = cmd
+            captured["env"] = env
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="checks passed", stderr=""
+            )
+        return original(cmd, env=env)
+
+    monkeypatch.setattr(skypilot_cli, "_run_no_raise", fake_run)
+
+
+def test_verify_pins_kubeconfig_from_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    kubeconfig = tmp_path / "kube.yaml"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+    _intercept_sky_check(monkeypatch, captured)
+
+    result = runner.invoke(
+        app,
+        ["skypilot", "verify", "--path", str(venv), "--kubeconfig", str(kubeconfig)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["cmd"][-1] == "check"
+    assert captured["env"]["KUBECONFIG"] == str(kubeconfig)
+
+
+def test_verify_without_kubeconfig_inherits_ambient_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    captured: dict[str, object] = {}
+    _intercept_sky_check(monkeypatch, captured)
+
+    result = runner.invoke(app, ["skypilot", "verify", "--path", str(venv)])
+
+    assert result.exit_code == 0, result.output
+    assert captured["env"] is None
+
+
+def test_verify_fails_clearly_on_missing_kubeconfig(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    missing = tmp_path / "absent" / "kube.yaml"
+
+    original = skypilot_cli._run_no_raise
+
+    def fake_run(cmd, *, env=None):  # noqa: ANN001 - test stub
+        if cmd[-1] == "check":
+            raise AssertionError("sky check must not run when kubeconfig is missing")
+        return original(cmd, env=env)
+
+    monkeypatch.setattr(skypilot_cli, "_run_no_raise", fake_run)
+
+    result = runner.invoke(
+        app,
+        ["skypilot", "verify", "--path", str(venv), "--kubeconfig", str(missing)],
+    )
+
+    assert result.exit_code == 1
+    assert "Kubeconfig not found" in result.output

--- a/npa/tests/test_robot_assets.py
+++ b/npa/tests/test_robot_assets.py
@@ -1,0 +1,343 @@
+"""Unit tests for BYO RobotSpec parsing, presets, download, and env dispatch.
+
+These tests never import torch or genesis at module level. The env robot build
+dispatch is exercised against a fake ``gs`` module and a fake torch installed
+into ``sys.modules`` (mirroring tests/test_scene_assets.py).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from npa.genesis import robot_assets as ra
+
+
+# --------------------------------------------------------------------------- #
+# RobotSpec presets / parse / validate
+# --------------------------------------------------------------------------- #
+
+
+def test_default_franka_robot_spec_matches_hardcoded_franka() -> None:
+    spec = ra.default_franka_robot_spec()
+    assert spec.robot_source == ra.ROBOT_SOURCE_STOCK_FRANKA
+    assert spec.ee_link == "hand"
+    assert spec.finger_links == ("left_finger", "right_finger")
+    assert spec.n_arm_joints == 7
+    assert spec.n_gripper_joints == 2
+    assert spec.dof_count == 9
+    assert spec.kp == (4500, 4500, 3500, 3500, 2000, 2000, 2000, 100, 100)
+    assert spec.kv == (450, 450, 350, 350, 200, 200, 200, 10, 10)
+    assert spec.home_qpos == ra.FRANKA_HOME
+    spec.validate()
+
+
+def test_preset_ur5e_six_dof_tool0_no_gripper() -> None:
+    spec = ra.robot_spec_from_preset("ur5e")
+    assert spec.name == "ur5e"
+    assert spec.robot_source == ra.ROBOT_SOURCE_BYO_URDF
+    assert spec.ee_link == "tool0"
+    assert spec.n_arm_joints == 6
+    assert spec.n_gripper_joints == 0
+    assert spec.dof_count == 6
+    assert spec.has_gripper is False
+    assert len(spec.kp) == 6
+    assert len(spec.force_lower) == 6
+    assert len(spec.home_qpos) == 6
+
+
+def test_preset_ur10e_distinct_from_ur5e() -> None:
+    ur5e = ra.robot_spec_from_preset("ur5e")
+    ur10e = ra.robot_spec_from_preset("ur10e")
+    assert ur10e.ee_link == "tool0"
+    assert ur10e.n_arm_joints == 6
+    assert ur10e.force_upper != ur5e.force_upper  # larger payload torques
+
+
+def test_preset_flexiv_rizon_seven_dof_flange() -> None:
+    spec = ra.robot_spec_from_preset("flexiv")
+    assert spec.name == "flexiv_rizon"
+    assert spec.ee_link == "flange"
+    assert spec.n_arm_joints == 7
+    assert spec.n_gripper_joints == 0
+    assert spec.dof_count == 7
+    assert len(spec.kp) == 7
+    assert ra.robot_spec_from_preset("rizon").name == "flexiv_rizon"
+
+
+def test_unknown_preset_raises() -> None:
+    with pytest.raises(ra.RobotSpecError):
+        ra.robot_spec_from_preset("kuka_iiwa")
+
+
+def test_parse_robot_spec_byo_urdf_full() -> None:
+    doc = {
+        "schema": ra.ROBOT_SPEC_SCHEMA,
+        "robot_source": "byo_urdf",
+        "name": "customer_arm",
+        "robot_uri": "s3://bucket/robots/arm.urdf",
+        "ee_link": "tool0",
+        "n_arm_joints": 6,
+        "n_gripper_joints": 0,
+        "kp": [1, 2, 3, 4, 5, 6],
+        "kv": [1, 2, 3, 4, 5, 6],
+        "force_lower": [-1, -1, -1, -1, -1, -1],
+        "force_upper": [1, 1, 1, 1, 1, 1],
+        "home_qpos": [0, 0, 0, 0, 0, 0],
+    }
+    spec = ra.parse_robot_spec(doc)
+    assert spec.robot_source == ra.ROBOT_SOURCE_BYO_URDF
+    assert spec.robot_uri.endswith("arm.urdf")
+    assert spec.ee_link == "tool0"
+    assert spec.dof_count == 6
+
+
+def test_parse_robot_spec_preset_with_uri_override() -> None:
+    # A customer supplies just a preset + their URDF uri on top.
+    doc = {"preset": "ur5e", "robot_uri": "s3://bucket/robots/ur5e.urdf"}
+    spec = ra.parse_robot_spec(doc)
+    assert spec.ee_link == "tool0"
+    assert spec.n_arm_joints == 6
+    assert spec.robot_uri.endswith("ur5e.urdf")
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        {"robot_source": "bogus"},
+        {"robot_source": "byo_urdf"},  # missing robot_uri
+        {"robot_source": "genesis_builtin"},  # missing builtin_path
+        {"preset": "ur5e", "kp": [1, 2, 3]},  # gains wrong length
+        {"robot_source": "byo_urdf", "robot_uri": "s3://b/arm.obj"},  # non-articulated
+    ],
+)
+def test_parse_robot_spec_rejects_malformed(doc: dict) -> None:
+    with pytest.raises(ra.RobotSpecError):
+        ra.parse_robot_spec(doc)
+
+
+def test_non_articulated_robot_file_gives_clear_error() -> None:
+    spec = ra.RobotSpec(
+        robot_source=ra.ROBOT_SOURCE_BYO_URDF,
+        robot_uri="s3://bucket/robots/arm.obj",
+        ee_link="tool0",
+        n_arm_joints=6,
+        n_gripper_joints=0,
+        kp=(1,) * 6,
+        kv=(1,) * 6,
+        force_lower=(-1,) * 6,
+        force_upper=(1,) * 6,
+        home_qpos=(0,) * 6,
+    )
+    with pytest.raises(ra.RobotSpecError) as exc:
+        spec.validate()
+    assert "visual mesh" in str(exc.value).lower()
+
+
+def test_robot_spec_from_inputs_preset_and_default() -> None:
+    assert ra.robot_spec_from_inputs(robot_preset="ur5e").name == "ur5e"
+    assert (
+        ra.robot_spec_from_inputs(robot_source="stock_franka").robot_source
+        == ra.ROBOT_SOURCE_STOCK_FRANKA
+    )
+    assert ra.robot_spec_from_inputs() is None
+
+
+# --------------------------------------------------------------------------- #
+# Download / resolve + provenance
+# --------------------------------------------------------------------------- #
+
+
+class _FakeStorageClient:
+    def __init__(self, *, payload: bytes = b"<robot/>") -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.payload = payload
+
+    def download_path(self, uri: str, local_path: str) -> str:
+        self.calls.append((uri, local_path))
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(local_path).write_bytes(self.payload)
+        return local_path
+
+
+def test_resolve_robot_asset_byo_urdf_records_sha_and_no_fallback(tmp_path: Path) -> None:
+    client = _FakeStorageClient(payload=b"<robot>urdf</robot>")
+    spec = ra.RobotSpec(
+        robot_source=ra.ROBOT_SOURCE_BYO_URDF,
+        name="ur5e",
+        robot_uri="s3://bucket/robots/ur5e.urdf",
+        ee_link="tool0",
+        n_arm_joints=6,
+        n_gripper_joints=0,
+        kp=(1,) * 6,
+        kv=(1,) * 6,
+        force_lower=(-1,) * 6,
+        force_upper=(1,) * 6,
+        home_qpos=(0,) * 6,
+    )
+    ra.resolve_robot_asset(spec, dest_dir=tmp_path, client=client)
+    assert spec.local_path
+    assert spec.sha256 == ra.sha256_file(spec.local_path)
+    prov = spec.provenance()
+    assert prov["robot_source"] == "byo_urdf"
+    assert prov["robot_fallback_used"] is False
+    assert prov["loaded"] is False  # not loaded into sim until env builds it
+
+
+def test_resolve_robot_asset_stock_franka_no_download(tmp_path: Path) -> None:
+    spec = ra.default_franka_robot_spec()
+    ra.resolve_robot_asset(spec, dest_dir=tmp_path, client=None)
+    assert spec.local_path == ""
+    assert spec.builtin_path == ra.STOCK_FRANKA_MJCF
+
+
+def test_resolve_robot_asset_raises_when_download_fails(tmp_path: Path) -> None:
+    def boom(*args, **kwargs):
+        raise ra.RobotSpecError("download exploded")
+
+    spec = ra.robot_spec_from_preset("ur5e")
+    spec.robot_uri = "s3://bucket/robots/ur5e.urdf"
+    with pytest.raises(ra.RobotSpecError):
+        ra.resolve_robot_asset(spec, dest_dir=tmp_path, downloader=boom)
+
+
+# --------------------------------------------------------------------------- #
+# Env robot build dispatch (fake gs + fake torch)
+# --------------------------------------------------------------------------- #
+
+
+class _RecordingMorph:
+    def __init__(self, kind: str, **kwargs) -> None:
+        self.kind = kind
+        self.kwargs = kwargs
+
+
+class _FakeEntity:
+    def __init__(self, morph, **kwargs) -> None:
+        self.morph = morph
+        self.kwargs = kwargs
+
+
+class _FakeScene:
+    def __init__(self) -> None:
+        self.added: list[_FakeEntity] = []
+
+    def add_entity(self, morph, **kwargs) -> _FakeEntity:
+        entity = _FakeEntity(morph, **kwargs)
+        self.added.append(entity)
+        return entity
+
+
+def _fake_gs() -> types.SimpleNamespace:
+    morphs = types.SimpleNamespace(
+        MJCF=lambda **kw: _RecordingMorph("MJCF", **kw),
+        URDF=lambda **kw: _RecordingMorph("URDF", **kw),
+        Mesh=lambda **kw: _RecordingMorph("Mesh", **kw),
+    )
+    return types.SimpleNamespace(morphs=morphs)
+
+
+@pytest.fixture()
+def env_module(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", types.ModuleType("torch"))
+    sys.modules.pop("npa.genesis.env_pick_place", None)
+    module = importlib.import_module("npa.genesis.env_pick_place")
+    yield module
+    sys.modules.pop("npa.genesis.env_pick_place", None)
+
+
+def _bare_env(env_module, robot_spec=None):
+    env = env_module.FrankaPickPlaceEnv.__new__(env_module.FrankaPickPlaceEnv)
+    env._scene = _FakeScene()
+    env._robot_spec = robot_spec
+    env.robot_provenance = None
+    return env
+
+
+def test_default_robot_build_is_stock_franka_mjcf(env_module) -> None:
+    env = _bare_env(env_module, robot_spec=None)
+    entity = env._add_robot_entity(_fake_gs())
+    assert entity.morph.kind == "MJCF"
+    assert entity.morph.kwargs["file"] == "xml/franka_emika_panda/panda.xml"
+    # No RobotSpec => no robot provenance recorded (default path unchanged).
+    assert env.robot_provenance is None
+
+
+def test_stock_franka_spec_build_records_provenance(env_module) -> None:
+    spec = ra.default_franka_robot_spec()
+    env = _bare_env(env_module, robot_spec=spec)
+    entity = env._add_robot_entity(_fake_gs())
+    assert entity.morph.kind == "MJCF"
+    assert entity.morph.kwargs["file"] == "xml/franka_emika_panda/panda.xml"
+    assert spec.loaded is True
+    assert env.robot_provenance["robot_source"] == "stock_franka"
+    assert env.robot_provenance["loaded"] is True
+
+
+def test_byo_urdf_build_calls_urdf_with_local_path(env_module) -> None:
+    spec = ra.robot_spec_from_preset("ur5e")
+    spec.robot_uri = "s3://bucket/robots/ur5e.urdf"
+    spec.local_path = "/tmp/resolved/ur5e.urdf"
+    spec.sha256 = "deadbeef"
+    env = _bare_env(env_module, robot_spec=spec)
+    entity = env._add_robot_entity(_fake_gs())
+    assert entity.morph.kind == "URDF"
+    assert entity.morph.kwargs["file"] == "/tmp/resolved/ur5e.urdf"
+    assert spec.loaded is True
+    assert env.robot_provenance["robot_source"] == "byo_urdf"
+    assert env.robot_provenance["ee_link"] == "tool0"
+    assert env.robot_provenance["sha256"] == "deadbeef"
+
+
+def test_byo_mjcf_build_calls_mjcf_with_local_path(env_module) -> None:
+    spec = ra.RobotSpec(
+        robot_source=ra.ROBOT_SOURCE_BYO_MJCF,
+        name="byo_mjcf_arm",
+        robot_uri="s3://bucket/robots/arm.xml",
+        local_path="/tmp/resolved/arm.xml",
+        ee_link="ee",
+        n_arm_joints=6,
+        n_gripper_joints=0,
+        kp=(1,) * 6,
+        kv=(1,) * 6,
+        force_lower=(-1,) * 6,
+        force_upper=(1,) * 6,
+        home_qpos=(0,) * 6,
+    )
+    env = _bare_env(env_module, robot_spec=spec)
+    entity = env._add_robot_entity(_fake_gs())
+    assert entity.morph.kind == "MJCF"
+    assert entity.morph.kwargs["file"] == "/tmp/resolved/arm.xml"
+
+
+def test_byo_urdf_without_local_path_raises(env_module) -> None:
+    spec = ra.robot_spec_from_preset("ur5e")
+    spec.robot_uri = "s3://bucket/robots/ur5e.urdf"
+    spec.local_path = ""  # not resolved -> must fail loudly (no fallback)
+    env = _bare_env(env_module, robot_spec=spec)
+    with pytest.raises(ra.RobotSpecError):
+        env._add_robot_entity(_fake_gs())
+
+
+def test_byo_usd_robot_unsupported_on_genesis_raises(env_module) -> None:
+    spec = ra.RobotSpec(
+        robot_source=ra.ROBOT_SOURCE_BYO_USD,
+        name="usd_arm",
+        robot_uri="s3://bucket/robots/arm.usd",
+        local_path="/tmp/resolved/arm.usd",
+        ee_link="ee",
+        n_arm_joints=6,
+        n_gripper_joints=0,
+        kp=(1,) * 6,
+        kv=(1,) * 6,
+        force_lower=(-1,) * 6,
+        force_upper=(1,) * 6,
+        home_qpos=(0,) * 6,
+    )
+    env = _bare_env(env_module, robot_spec=spec)
+    with pytest.raises(ra.RobotSpecError):
+        env._add_robot_entity(_fake_gs())

--- a/npa/tests/test_scene_assets.py
+++ b/npa/tests/test_scene_assets.py
@@ -1,0 +1,405 @@
+"""Unit tests for BYO SceneSpec parsing, asset download, and env build dispatch.
+
+These tests never import torch or genesis at module level. The env build
+dispatch is exercised against a fake ``gs`` module and a fake torch installed
+into ``sys.modules`` (mirroring tests/test_genesis.py).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from npa.genesis import scene_assets as sa
+
+
+# --------------------------------------------------------------------------- #
+# SceneSpec parse / validate
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_scene_spec_byo_mesh_object() -> None:
+    doc = {
+        "schema": sa.SCENE_SPEC_SCHEMA,
+        "goal_pos": [0.5, 0.3, 0.04],
+        "goal_threshold": 0.05,
+        "objects": [
+            {
+                "name": "widget",
+                "asset_source": "byo_mesh",
+                "role": "manipuland",
+                "uri": "s3://bucket/sim2real-assets/run/object.obj",
+                "scale": 1.5,
+                "pos": [0.5, 0.0, 0.05],
+                "color": [0.1, 0.8, 0.2],
+                "mass": 0.3,
+                "friction": 0.9,
+            }
+        ],
+    }
+    spec = sa.parse_scene_spec(doc, source_uri="s3://bucket/spec.json")
+
+    assert len(spec.objects) == 1
+    obj = spec.manipuland()
+    assert obj.asset_source == sa.ASSET_SOURCE_BYO_MESH
+    assert obj.uri.endswith("object.obj")
+    assert obj.scale == 1.5
+    assert obj.pos == (0.5, 0.0, 0.05)
+    assert obj.mass == 0.3
+    assert obj.friction == 0.9
+    assert spec.goal_pos == (0.5, 0.3, 0.04)
+    assert spec.source_uri == "s3://bucket/spec.json"
+
+
+def test_parse_scene_spec_supports_multiple_objects_and_target() -> None:
+    doc = {
+        "objects": [
+            {"name": "cube", "asset_source": "primitive", "primitive": "box"},
+            {
+                "name": "table",
+                "asset_source": "genesis_builtin",
+                "role": "static",
+                "builtin_path": "meshes/table.obj",
+            },
+        ],
+        "goal_pos": [0.4, 0.2, 0.04],
+    }
+    spec = sa.parse_scene_spec(doc)
+
+    assert [o.name for o in spec.objects] == ["cube", "table"]
+    table = spec.objects[1]
+    assert table.asset_source == sa.ASSET_SOURCE_GENESIS_BUILTIN
+    assert table.role == sa.ROLE_STATIC
+    assert table.fixed is True  # static defaults to fixed
+    assert spec.manipuland().name == "cube"
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        {},  # no objects
+        {"objects": []},  # empty objects
+        {"objects": [{"name": "x", "asset_source": "bogus"}]},  # bad source
+        {"objects": [{"name": "x", "asset_source": "byo_mesh"}]},  # missing uri
+        {"objects": [{"name": "x", "asset_source": "genesis_builtin"}]},  # missing path
+        {"objects": [{"name": "x", "asset_source": "primitive", "primitive": "cone"}]},
+        {
+            "objects": [
+                {"name": "t", "asset_source": "primitive", "role": "target"}
+            ]
+        },  # no manipuland
+        {
+            "objects": [{"name": "x", "asset_source": "primitive"}],
+            "goal_pos": [0.1, 0.2],
+        },  # bad goal_pos
+    ],
+)
+def test_parse_scene_spec_rejects_malformed(doc: dict) -> None:
+    with pytest.raises(sa.SceneSpecError):
+        sa.parse_scene_spec(doc)
+
+
+def test_synthesize_scene_spec_from_mesh_uri() -> None:
+    spec = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    obj = spec.manipuland()
+    assert obj.asset_source == sa.ASSET_SOURCE_BYO_MESH
+    assert obj.uri == "s3://bucket/run/object.obj"
+    assert spec.source_uri == "s3://bucket/run/object.obj"
+
+
+def test_synthesize_scene_spec_requires_uri() -> None:
+    with pytest.raises(sa.SceneSpecError):
+        sa.synthesize_scene_spec()
+
+
+def test_default_scene_spec_matches_red_box_primitive() -> None:
+    spec = sa.default_scene_spec()
+    obj = spec.manipuland()
+    assert obj.asset_source == sa.ASSET_SOURCE_PRIMITIVE
+    assert obj.primitive == sa.PRIMITIVE_BOX
+    assert obj.size == (0.04, 0.04, 0.04)
+    assert obj.pos == (0.5, 0.0, 0.04)
+    assert obj.color == (1.0, 0.0, 0.0)
+    assert spec.goal_pos == (0.5, 0.3, 0.04)
+
+
+# --------------------------------------------------------------------------- #
+# Asset download + resolve + provenance
+# --------------------------------------------------------------------------- #
+
+
+class _FakeStorageClient:
+    """Records download_path calls and writes a fake mesh file."""
+
+    def __init__(self, *, payload: bytes = b"OBJ-DATA") -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.payload = payload
+
+    def download_path(self, uri: str, local_path: str) -> str:
+        self.calls.append((uri, local_path))
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(local_path).write_bytes(self.payload)
+        return local_path
+
+
+def test_download_asset_s3_uses_client_and_validates(tmp_path: Path) -> None:
+    client = _FakeStorageClient()
+    dest = sa.download_asset(
+        "s3://bucket/run/object.obj", tmp_path / "obj", client=client
+    )
+    assert dest.is_file()
+    assert dest.name == "object.obj"
+    assert dest.read_bytes() == b"OBJ-DATA"
+    assert client.calls[0][0] == "s3://bucket/run/object.obj"
+
+
+def test_download_asset_local_path(tmp_path: Path) -> None:
+    src = tmp_path / "src.obj"
+    src.write_bytes(b"v 0 0 0\n")
+    dest = sa.download_asset(str(src), tmp_path / "out")
+    assert dest.read_bytes() == b"v 0 0 0\n"
+
+
+def test_download_asset_rejects_empty_file(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.obj"
+    empty.write_bytes(b"")
+    with pytest.raises(sa.SceneSpecError):
+        sa.download_asset(str(empty), tmp_path / "out")
+
+
+def test_resolve_scene_assets_byo_records_sha_source_and_no_fallback(
+    tmp_path: Path,
+) -> None:
+    client = _FakeStorageClient(payload=b"MESH-BYTES")
+    spec = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    sa.resolve_scene_assets(spec, dest_dir=tmp_path, client=client)
+
+    obj = spec.manipuland()
+    assert obj.local_path
+    assert obj.sha256 == sa.sha256_file(obj.local_path)
+    block = spec.provenance_block()
+    assert block["asset_fallback_used"] is False
+    assert block["objects"][0]["asset_source"] == "byo_mesh"
+    assert block["objects"][0]["sha256"] == obj.sha256
+    # Not yet loaded into the sim until the env builds it.
+    assert block["objects"][0]["loaded"] is False
+
+
+def test_resolve_scene_assets_genesis_builtin_uses_resolver(tmp_path: Path) -> None:
+    builtin_file = tmp_path / "builtin" / "duck.obj"
+    builtin_file.parent.mkdir(parents=True)
+    builtin_file.write_bytes(b"BUILTIN-MESH")
+
+    doc = {
+        "objects": [
+            {
+                "name": "duck",
+                "asset_source": "genesis_builtin",
+                "builtin_path": "meshes/duck.obj",
+            }
+        ]
+    }
+    spec = sa.parse_scene_spec(doc)
+    sa.resolve_scene_assets(
+        spec,
+        dest_dir=tmp_path,
+        builtin_resolver=lambda path: builtin_file,
+    )
+    obj = spec.manipuland()
+    assert obj.asset_source == "genesis_builtin"
+    assert obj.local_path == str(builtin_file)
+    assert obj.sha256 == sa.sha256_file(builtin_file)
+
+
+def test_resolve_scene_assets_raises_when_download_fails(tmp_path: Path) -> None:
+    def boom(*args, **kwargs):
+        raise sa.SceneSpecError("download exploded")
+
+    spec = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    with pytest.raises(sa.SceneSpecError):
+        sa.resolve_scene_assets(spec, dest_dir=tmp_path, downloader=boom)
+
+
+# --------------------------------------------------------------------------- #
+# Env build dispatch (fake gs + fake torch)
+# --------------------------------------------------------------------------- #
+
+
+class _RecordingMorph:
+    def __init__(self, kind: str, **kwargs) -> None:
+        self.kind = kind
+        self.kwargs = kwargs
+
+
+class _FakeEntity:
+    def __init__(self, morph, **kwargs) -> None:
+        self.morph = morph
+        self.kwargs = kwargs
+
+
+class _FakeScene:
+    def __init__(self) -> None:
+        self.added: list[_FakeEntity] = []
+
+    def add_entity(self, morph, **kwargs) -> _FakeEntity:
+        entity = _FakeEntity(morph, **kwargs)
+        self.added.append(entity)
+        return entity
+
+
+def _fake_gs() -> types.SimpleNamespace:
+    morphs = types.SimpleNamespace(
+        Mesh=lambda **kw: _RecordingMorph("Mesh", **kw),
+        Box=lambda **kw: _RecordingMorph("Box", **kw),
+        Sphere=lambda **kw: _RecordingMorph("Sphere", **kw),
+        Cylinder=lambda **kw: _RecordingMorph("Cylinder", **kw),
+    )
+    surfaces = types.SimpleNamespace(Rough=lambda **kw: ("Rough", kw))
+    materials = types.SimpleNamespace(Rigid=lambda **kw: ("Rigid", kw))
+    return types.SimpleNamespace(morphs=morphs, surfaces=surfaces, materials=materials)
+
+
+@pytest.fixture()
+def env_module(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", types.ModuleType("torch"))
+    sys.modules.pop("npa.genesis.env_pick_place", None)
+    module = importlib.import_module("npa.genesis.env_pick_place")
+    yield module
+    sys.modules.pop("npa.genesis.env_pick_place", None)
+
+
+def _bare_env(env_module):
+    env = env_module.FrankaPickPlaceEnv.__new__(env_module.FrankaPickPlaceEnv)
+    env._scene = _FakeScene()
+    env.scene_provenance = None
+    return env
+
+
+def test_build_dispatch_byo_mesh_calls_mesh_with_local_path(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="widget",
+        asset_source=sa.ASSET_SOURCE_BYO_MESH,
+        uri="s3://bucket/object.obj",
+        local_path="/tmp/resolved/object.obj",
+        scale=2.0,
+        pos=(0.5, 0.0, 0.05),
+    )
+    entity = env._add_object_entity(_fake_gs(), obj)
+
+    assert entity.morph.kind == "Mesh"
+    assert entity.morph.kwargs["file"] == "/tmp/resolved/object.obj"
+    assert entity.morph.kwargs["scale"] == 2.0
+    assert obj.loaded is True
+
+
+def test_build_dispatch_genesis_builtin_calls_mesh(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="duck",
+        asset_source=sa.ASSET_SOURCE_GENESIS_BUILTIN,
+        builtin_path="meshes/duck.obj",
+        local_path="/opt/genesis/assets/meshes/duck.obj",
+    )
+    entity = env._add_object_entity(_fake_gs(), obj)
+    assert entity.morph.kind == "Mesh"
+    assert entity.morph.kwargs["file"].endswith("duck.obj")
+    assert obj.loaded is True
+
+
+def test_build_dispatch_primitive_box_calls_box(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="cube",
+        asset_source=sa.ASSET_SOURCE_PRIMITIVE,
+        primitive=sa.PRIMITIVE_BOX,
+        size=(0.04, 0.04, 0.04),
+        pos=(0.5, 0.0, 0.04),
+    )
+    entity = env._add_object_entity(_fake_gs(), obj)
+    assert entity.morph.kind == "Box"
+    assert entity.morph.kwargs["size"] == (0.04, 0.04, 0.04)
+    assert obj.loaded is True
+
+
+def test_build_dispatch_primitive_sphere_calls_sphere(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="ball",
+        asset_source=sa.ASSET_SOURCE_PRIMITIVE,
+        primitive=sa.PRIMITIVE_SPHERE,
+        radius=0.03,
+    )
+    entity = env._add_object_entity(_fake_gs(), obj)
+    assert entity.morph.kind == "Sphere"
+    assert entity.morph.kwargs["radius"] == 0.03
+
+
+def test_build_dispatch_mesh_without_local_path_raises(env_module) -> None:
+    env = _bare_env(env_module)
+    obj = sa.ObjectSpec(
+        name="widget",
+        asset_source=sa.ASSET_SOURCE_BYO_MESH,
+        uri="s3://bucket/object.obj",
+        local_path="",  # not resolved -> must fail loudly
+    )
+    with pytest.raises(sa.SceneSpecError):
+        env._add_object_entity(_fake_gs(), obj)
+
+
+def test_build_scene_objects_records_provenance_and_manipuland(env_module) -> None:
+    env = _bare_env(env_module)
+    spec = sa.SceneSpec(
+        objects=[
+            sa.ObjectSpec(
+                name="widget",
+                asset_source=sa.ASSET_SOURCE_BYO_MESH,
+                role=sa.ROLE_MANIPULAND,
+                uri="s3://bucket/object.obj",
+                local_path="/tmp/object.obj",
+                sha256="abc123",
+            ),
+            sa.ObjectSpec(
+                name="table",
+                asset_source=sa.ASSET_SOURCE_PRIMITIVE,
+                role=sa.ROLE_STATIC,
+                primitive=sa.PRIMITIVE_BOX,
+            ),
+        ]
+    )
+    manip = env._build_scene_objects(_fake_gs(), spec)
+
+    assert manip.morph.kind == "Mesh"
+    assert env.scene_provenance["asset_fallback_used"] is False
+    objs = {o["name"]: o for o in env.scene_provenance["objects"]}
+    assert objs["widget"]["loaded"] is True
+    assert objs["widget"]["sha256"] == "abc123"
+    assert objs["table"]["loaded"] is True
+
+
+def test_apply_scene_spec_overrides_cube_and_target(env_module) -> None:
+    env = env_module.FrankaPickPlaceEnv.__new__(env_module.FrankaPickPlaceEnv)
+    env.cfg = env_module.EnvConfig()
+    env._manip_quat = (1.0, 0.0, 0.0, 0.0)
+    spec = sa.SceneSpec(
+        objects=[
+            sa.ObjectSpec(
+                name="cube",
+                asset_source=sa.ASSET_SOURCE_PRIMITIVE,
+                primitive=sa.PRIMITIVE_BOX,
+                size=(0.06, 0.06, 0.06),
+                pos=(0.55, 0.01, 0.06),
+            )
+        ],
+        goal_pos=(0.4, 0.25, 0.04),
+        goal_threshold=0.07,
+    )
+    env._apply_scene_spec(spec)
+    assert env.cfg.cube_init_pos == (0.55, 0.01, 0.06)
+    assert env.cfg.cube_size == 0.06
+    assert env.cfg.target_pos == (0.4, 0.25, 0.04)
+    assert env.cfg.target_threshold == 0.07

--- a/npa/tests/test_scene_assets.py
+++ b/npa/tests/test_scene_assets.py
@@ -22,6 +22,43 @@ from npa.genesis import scene_assets as sa
 # --------------------------------------------------------------------------- #
 
 
+def test_default_isaac_stock_scene_spec() -> None:
+    scene = sa.default_isaac_stock_scene_spec()
+    manip = scene.manipuland()
+    assert manip.asset_source == sa.ASSET_SOURCE_ISAAC_STOCK
+    assert sa.ASSET_SOURCE_ISAAC_STOCK in sa.ASSET_SOURCES
+    assert manip.is_mesh() is False  # stock asset, not a downloadable mesh
+    prov = scene.provenance_block()
+    assert prov["objects"][0]["asset_source"] == "isaac_stock"
+    assert prov["objects"][0]["sha256"] == ""
+    assert prov["asset_fallback_used"] is False
+
+
+def test_parse_scene_spec_isaac_stock_object() -> None:
+    doc = {
+        "objects": [
+            {
+                "name": "stock_cube",
+                "asset_source": "isaac_stock",
+                "role": "manipuland",
+                "builtin_path": "lift_cube",
+            }
+        ]
+    }
+    spec = sa.parse_scene_spec(doc)
+    manip = spec.manipuland()
+    assert manip.asset_source == sa.ASSET_SOURCE_ISAAC_STOCK
+    assert manip.builtin_path == "lift_cube"
+
+
+def test_resolve_scene_assets_skips_isaac_stock(tmp_path: Path) -> None:
+    scene = sa.default_isaac_stock_scene_spec()
+    sa.resolve_scene_assets(scene, dest_dir=tmp_path, client=None)
+    # No download attempted; stock object has no local_path / sha256.
+    assert scene.manipuland().local_path == ""
+    assert scene.manipuland().sha256 == ""
+
+
 def test_parse_scene_spec_byo_mesh_object() -> None:
     doc = {
         "schema": sa.SCENE_SPEC_SCHEMA,

--- a/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
+++ b/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
@@ -316,3 +316,54 @@ def test_down_runs_terraform_destroy(monkeypatch, tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert ["terraform", "init"] in stream_calls
     assert ["terraform", "destroy", "-auto-approve"] in stream_calls
+
+
+def test_terraform_env_refreshes_stale_token_by_default(monkeypatch) -> None:
+    # A stale ambient token must NOT shadow the freshly minted profile token.
+    monkeypatch.setenv("TF_VAR_iam_token", "stale-cloud-env-token")
+    monkeypatch.setenv("NEBIUS_IAM_TOKEN", "stale-cloud-env-token")
+    monkeypatch.delenv("NPA_REUSE_IAM_TOKEN", raising=False)
+
+    captured_env: dict[str, str] = {}
+
+    def fake_capture(args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return _completed("fresh-token\n")
+
+    monkeypatch.setattr(tf_mod, "_run_capture", fake_capture)
+
+    env = tf_mod._terraform_env("nebius")
+
+    assert env["TF_VAR_iam_token"] == "fresh-token"
+    assert env["NEBIUS_IAM_TOKEN"] == "fresh-token"
+    # The stale token is cleared before minting so it cannot leak into the mint call.
+    assert captured_env.get("TF_VAR_iam_token") in (None, "")
+    assert captured_env.get("NEBIUS_IAM_TOKEN") in (None, "")
+
+
+def test_terraform_env_reuses_token_when_opted_in(monkeypatch) -> None:
+    monkeypatch.setenv("TF_VAR_iam_token", "intentional-ci-token")
+    monkeypatch.setenv("NPA_REUSE_IAM_TOKEN", "1")
+
+    def fail_capture(args, **kwargs):
+        raise AssertionError("must not mint a new token when reuse is opted in")
+
+    monkeypatch.setattr(tf_mod, "_run_capture", fail_capture)
+
+    env = tf_mod._terraform_env("nebius")
+
+    assert env["TF_VAR_iam_token"] == "intentional-ci-token"
+
+
+def test_terraform_env_mints_when_no_token_present(monkeypatch) -> None:
+    monkeypatch.delenv("TF_VAR_iam_token", raising=False)
+    monkeypatch.delenv("NEBIUS_IAM_TOKEN", raising=False)
+    monkeypatch.setenv("NPA_REUSE_IAM_TOKEN", "1")
+
+    monkeypatch.setattr(
+        tf_mod, "_run_capture", lambda *a, **k: _completed("minted-token\n")
+    )
+
+    env = tf_mod._terraform_env("nebius")
+
+    assert env["TF_VAR_iam_token"] == "minted-token"

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -511,7 +511,7 @@ def test_component_heldout_payload_uses_genesis_rollout_backend(monkeypatch) -> 
     ]
     captured = {}
 
-    def fake_genesis_rollouts(env_payload, *, inner_evidence, threshold, scene=None):
+    def fake_genesis_rollouts(env_payload, *, inner_evidence, threshold, scene=None, robot=None):
         captured["envs"] = env_payload
         captured["scene"] = scene
         captured["inner_evidence"] = inner_evidence
@@ -635,7 +635,7 @@ def test_component_heldout_payload_with_scene_attaches_provenance(
     scene = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
     sa.resolve_scene_assets(scene, dest_dir=tmp_path, client=client)
 
-    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None):
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None, robot=None):
         # Simulate the env building the mesh and marking it loaded.
         if scene is not None:
             for obj in scene.objects:
@@ -666,7 +666,7 @@ def test_component_heldout_payload_raises_when_mesh_not_loaded(
     scene = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
     sa.resolve_scene_assets(scene, dest_dir=tmp_path, client=client)
 
-    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None):
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None, robot=None):
         return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
 
     monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_rollouts)
@@ -678,6 +678,117 @@ def test_component_heldout_payload_raises_when_mesh_not_loaded(
             scene=scene,
             sim_backend="genesis",
         )
+
+
+def test_resolve_heldout_robot_none_without_inputs(tmp_path: Path) -> None:
+    robot = loop_module._resolve_heldout_robot(
+        robot_spec_uri="",
+        robot_source="",
+        robot_preset="",
+        dest_dir=tmp_path,
+        client=_FakeMeshClient(),
+    )
+    assert robot is None
+
+
+def test_resolve_heldout_robot_byo_urdf_records_provenance(tmp_path: Path) -> None:
+    from npa.genesis import robot_assets as ra
+
+    doc = {
+        "preset": "ur5e",
+        "robot_source": "byo_urdf",
+        "robot_uri": "s3://bucket/robots/ur5e.urdf",
+    }
+    client = _FakeMeshClient(spec_doc=doc, mesh=b"<robot>urdf</robot>")
+    robot = loop_module._resolve_heldout_robot(
+        robot_spec_uri="s3://bucket/robots/robot-spec.json",
+        robot_source="",
+        robot_preset="",
+        dest_dir=tmp_path,
+        client=client,
+    )
+    assert robot is not None
+    assert robot.robot_source == ra.ROBOT_SOURCE_BYO_URDF
+    assert robot.ee_link == "tool0"
+    assert robot.sha256 == ra.sha256_file(robot.local_path)
+    assert robot.provenance()["robot_fallback_used"] is False
+
+
+def test_component_heldout_payload_with_robot_attaches_provenance(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from npa.genesis import robot_assets as ra
+
+    client = _FakeMeshClient(mesh=b"<robot>urdf</robot>")
+    robot = ra.robot_spec_from_preset("ur5e")
+    robot.robot_uri = "s3://bucket/robots/ur5e.urdf"
+    ra.resolve_robot_asset(robot, dest_dir=tmp_path, client=client)
+
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None, robot=None):
+        if robot is not None:
+            robot.loaded = True  # env builds it
+        return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
+
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_rollouts)
+    payload = loop_module._component_heldout_payload(
+        [{"env_id": "heldout-0000", "seed": 1}],
+        inner_evidence={"reward_trend": [0.2, 0.6]},
+        threshold=0.75,
+        robot=robot,
+        sim_backend="genesis",
+    )
+    assert payload["robot_fallback_used"] is False
+    prov = payload["robot_provenance"]
+    assert prov["robot_source"] == "byo_urdf"
+    assert prov["loaded"] is True
+    assert prov["ee_link"] == "tool0"
+
+
+def test_component_heldout_payload_raises_when_byo_robot_not_loaded(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from npa.genesis import robot_assets as ra
+
+    client = _FakeMeshClient(mesh=b"<robot>urdf</robot>")
+    robot = ra.robot_spec_from_preset("ur5e")
+    robot.robot_uri = "s3://bucket/robots/ur5e.urdf"
+    ra.resolve_robot_asset(robot, dest_dir=tmp_path, client=client)
+
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None, robot=None):
+        return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
+
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_rollouts)
+    with pytest.raises(loop_module.Sim2RealLoopError):
+        loop_module._component_heldout_payload(
+            [{"env_id": "heldout-0000", "seed": 1}],
+            inner_evidence={},
+            threshold=0.75,
+            robot=robot,
+            sim_backend="genesis",
+        )
+
+
+def test_normalize_heldout_report_propagates_robot_provenance() -> None:
+    payload = {
+        "per_env": [{"env_id": "h-0", "score": 0.9, "success": True}],
+        "robot_provenance": {
+            "schema": "npa.sim2real.robot_provenance.v1",
+            "robot_source": "byo_urdf",
+            "loaded": True,
+            "robot_fallback_used": False,
+        },
+        "robot_fallback_used": False,
+    }
+    config = Sim2RealLoopConfig(run_id="r", threshold=0.5)
+    report = loop_module._normalize_heldout_report(
+        payload,
+        config=config,
+        outer_iteration=1,
+        inner_evidence_uri="inner.json",
+        invocation={"component": "heldout_eval"},
+    )
+    assert report["robot_provenance"]["robot_source"] == "byo_urdf"
+    assert report["robot_fallback_used"] is False
 
 
 def test_normalize_heldout_report_propagates_provenance() -> None:
@@ -727,7 +838,7 @@ def test_run_heldout_eval_component_from_s3_writes_provenance(
 
     monkeypatch.setattr(client, "download_path", download_path)
 
-    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None):
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None, robot=None):
         if scene is not None:
             for obj in scene.objects:
                 obj.loaded = True
@@ -833,7 +944,7 @@ def test_component_heldout_payload_dispatches_isaac_backend(monkeypatch) -> None
     envs = [{"env_id": "heldout-0000", "seed": 1}]
     captured = {}
 
-    def fake_isaac(env_payload, *, inner_evidence, threshold, scene=None, isaac_task):
+    def fake_isaac(env_payload, *, inner_evidence, threshold, scene=None, robot=None, isaac_task):
         captured["isaac_called"] = True
         captured["isaac_task"] = isaac_task
         return [{"env_id": "heldout-0000", "score": 0.7, "success": False, "details": {}}]
@@ -860,7 +971,7 @@ def test_component_heldout_payload_dispatches_isaac_backend(monkeypatch) -> None
 
 
 def test_component_heldout_payload_genesis_backend_unchanged(monkeypatch) -> None:
-    def fake_genesis(env_payload, *, inner_evidence, threshold, scene=None):
+    def fake_genesis(env_payload, *, inner_evidence, threshold, scene=None, robot=None):
         return [{"env_id": "heldout-0000", "score": 0.8, "success": True, "details": {}}]
 
     def fake_isaac(*args, **kwargs):
@@ -940,7 +1051,7 @@ def test_isaac_payload_stock_scene_provenance(monkeypatch) -> None:
 
     scene = sa.default_isaac_stock_scene_spec()
 
-    def fake_isaac(envs, *, inner_evidence, threshold, scene=None, isaac_task):
+    def fake_isaac(envs, *, inner_evidence, threshold, scene=None, robot=None, isaac_task):
         # Stock manipuland is materialized by the task env (marks loaded).
         if scene is not None:
             scene.manipuland().loaded = True

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -538,6 +538,7 @@ def test_component_heldout_payload_uses_genesis_rollout_backend(monkeypatch) -> 
         envs,
         inner_evidence=inner_evidence,
         threshold=0.75,
+        sim_backend="genesis",
     )
 
     assert captured["envs"] == envs
@@ -647,6 +648,7 @@ def test_component_heldout_payload_with_scene_attaches_provenance(
         inner_evidence={"reward_trend": [0.2, 0.6]},
         threshold=0.75,
         scene=scene,
+        sim_backend="genesis",
     )
     assert payload["asset_fallback_used"] is False
     prov = payload["asset_provenance"]
@@ -674,6 +676,7 @@ def test_component_heldout_payload_raises_when_mesh_not_loaded(
             inner_evidence={},
             threshold=0.75,
             scene=scene,
+            sim_backend="genesis",
         )
 
 
@@ -738,6 +741,7 @@ def test_run_heldout_eval_component_from_s3_writes_provenance(
         output_uri="s3://bucket/run/output/report.json",
         threshold=0.75,
         assets_uri="s3://bucket/run/object.obj",
+        sim_backend="genesis",
     )
     assert payload["asset_fallback_used"] is False
     assert payload["asset_provenance"]["objects"][0]["asset_source"] == "byo_mesh"
@@ -802,6 +806,298 @@ def test_raw_runbook_invokes_full_loop_and_exposes_byo_envs() -> None:
     assert "--k8s-service-account" in task["run"]
     assert "--heldout-eval-limit" in task["run"]
     assert "nebius.cloud" not in RUNBOOK.read_text(encoding="utf-8")
+
+
+def test_sim_backend_defaults_to_isaac_and_validates() -> None:
+    config = Sim2RealLoopConfig(run_id="backend-default")
+    assert config.sim_backend == "isaac"
+    assert config.heldout_backend_image() == config.isaac_image
+    config.validate()
+
+    genesis_config = Sim2RealLoopConfig(run_id="backend-genesis", sim_backend="genesis")
+    assert genesis_config.heldout_backend_image() == genesis_config.eval_image
+
+    with pytest.raises(loop_module.Sim2RealLoopError):
+        Sim2RealLoopConfig(run_id="backend-bad", sim_backend="mujoco").validate()
+
+
+def test_build_config_from_env_reads_sim_backend(monkeypatch) -> None:
+    monkeypatch.setenv("NPA_SIM2REAL_SIM_BACKEND", "GENESIS")
+    config = loop_module.build_config_from_env(run_id="env-backend")
+    assert config.sim_backend == "genesis"
+    override = loop_module.build_config_from_env(run_id="ov", sim_backend="isaac")
+    assert override.sim_backend == "isaac"
+
+
+def test_component_heldout_payload_dispatches_isaac_backend(monkeypatch) -> None:
+    envs = [{"env_id": "heldout-0000", "seed": 1}]
+    captured = {}
+
+    def fake_isaac(env_payload, *, inner_evidence, threshold, scene=None, isaac_task):
+        captured["isaac_called"] = True
+        captured["isaac_task"] = isaac_task
+        return [{"env_id": "heldout-0000", "score": 0.7, "success": False, "details": {}}]
+
+    def fake_genesis(*args, **kwargs):
+        raise AssertionError("genesis rollout must not run for sim_backend=isaac")
+
+    monkeypatch.setattr(loop_module, "_run_isaac_heldout_rollouts", fake_isaac)
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_genesis)
+
+    payload = loop_module._component_heldout_payload(
+        envs,
+        inner_evidence={"reward_trend": [0.2, 0.5]},
+        threshold=0.75,
+        sim_backend="isaac",
+        isaac_task="Isaac-Lift-Cube-Franka-v0",
+    )
+    assert captured["isaac_called"] is True
+    assert captured["isaac_task"] == "Isaac-Lift-Cube-Franka-v0"
+    assert payload["sim_backend"] == "isaac"
+    assert payload["component_source"] == "isaac_rollout"
+    assert payload["rollout_backend"] == "isaaclab:Isaac-Lift-Cube-Franka-v0"
+    assert payload["schema"] == SCHEMA_HELDOUT_REPORT
+
+
+def test_component_heldout_payload_genesis_backend_unchanged(monkeypatch) -> None:
+    def fake_genesis(env_payload, *, inner_evidence, threshold, scene=None):
+        return [{"env_id": "heldout-0000", "score": 0.8, "success": True, "details": {}}]
+
+    def fake_isaac(*args, **kwargs):
+        raise AssertionError("isaac rollout must not run for sim_backend=genesis")
+
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_genesis)
+    monkeypatch.setattr(loop_module, "_run_isaac_heldout_rollouts", fake_isaac)
+
+    payload = loop_module._component_heldout_payload(
+        [{"env_id": "heldout-0000", "seed": 1}],
+        inner_evidence={"reward_trend": [0.2, 0.6]},
+        threshold=0.75,
+        sim_backend="genesis",
+    )
+    assert payload["sim_backend"] == "genesis"
+    assert payload["component_source"] == "genesis_rollout"
+    assert payload["rollout_backend"] == "npa.genesis.env_pick_place.FrankaPickPlaceEnv"
+
+
+def test_backends_emit_schema_compatible_reports(monkeypatch) -> None:
+    """Both backends must produce the identical per-env report schema."""
+
+    rows = [{"env_id": "heldout-0000", "score": 0.8, "success": True, "details": {"x": 1}}]
+    monkeypatch.setattr(
+        loop_module, "_run_genesis_heldout_rollouts", lambda *a, **k: rows
+    )
+    monkeypatch.setattr(
+        loop_module, "_run_isaac_heldout_rollouts", lambda *a, **k: rows
+    )
+    common = dict(inner_evidence={"reward_trend": [0.2]}, threshold=0.75)
+    genesis = loop_module._component_heldout_payload(rows, sim_backend="genesis", **common)
+    isaac = loop_module._component_heldout_payload(rows, sim_backend="isaac", **common)
+
+    assert genesis["schema"] == isaac["schema"] == SCHEMA_HELDOUT_REPORT
+    for payload in (genesis, isaac):
+        assert set(payload["per_env"][0]) >= {"env_id", "score", "success", "details"}
+        assert payload["policy_source"] == "inner_evidence_adapter"
+        assert "sim_backend" in payload
+    assert genesis["per_env"] == isaac["per_env"]
+
+
+def test_resolve_isaac_scene_stock_without_uris(tmp_path: Path) -> None:
+    from npa.genesis import scene_assets as sa
+
+    scene = loop_module._resolve_isaac_scene(
+        scene_spec_uri="",
+        assets_uri="",
+        byo_mesh_uri="",
+        dest_dir=tmp_path,
+        client=_FakeMeshClient(),
+    )
+    assert scene is not None
+    manip = scene.manipuland()
+    assert manip.asset_source == sa.ASSET_SOURCE_ISAAC_STOCK
+    assert manip.sha256 == ""
+    assert scene.provenance_block()["asset_fallback_used"] is False
+
+
+def test_resolve_isaac_scene_byo_mesh_records_provenance(tmp_path: Path) -> None:
+    from npa.genesis import scene_assets as sa
+
+    client = _FakeMeshClient(mesh=b"NAIL-MESH-BYTES")
+    scene = loop_module._resolve_isaac_scene(
+        scene_spec_uri="",
+        assets_uri="s3://bucket/run/nail.obj",
+        byo_mesh_uri="",
+        dest_dir=tmp_path,
+        client=client,
+    )
+    manip = scene.manipuland()
+    assert manip.asset_source == sa.ASSET_SOURCE_BYO_MESH
+    assert manip.sha256 == sa.sha256_file(manip.local_path)
+
+
+def test_isaac_payload_stock_scene_provenance(monkeypatch) -> None:
+    from npa.genesis import scene_assets as sa
+
+    scene = sa.default_isaac_stock_scene_spec()
+
+    def fake_isaac(envs, *, inner_evidence, threshold, scene=None, isaac_task):
+        # Stock manipuland is materialized by the task env (marks loaded).
+        if scene is not None:
+            scene.manipuland().loaded = True
+        return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
+
+    monkeypatch.setattr(loop_module, "_run_isaac_heldout_rollouts", fake_isaac)
+    payload = loop_module._component_heldout_payload(
+        [{"env_id": "heldout-0000", "seed": 1}],
+        inner_evidence={"reward_trend": [0.2, 0.6]},
+        threshold=0.75,
+        scene=scene,
+        sim_backend="isaac",
+    )
+    prov = payload["asset_provenance"]
+    assert prov["objects"][0]["asset_source"] == "isaac_stock"
+    assert payload["asset_fallback_used"] is False
+
+
+def test_isaac_payload_byo_mesh_not_loaded_raises(monkeypatch, tmp_path: Path) -> None:
+    from npa.genesis import scene_assets as sa
+
+    client = _FakeMeshClient(mesh=b"NAIL-MESH")
+    scene = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/nail.obj")
+    sa.resolve_scene_assets(scene, dest_dir=tmp_path, client=client)
+
+    # Isaac rollout that "forgets" to import the mesh must trip the no-fallback gate.
+    monkeypatch.setattr(
+        loop_module,
+        "_run_isaac_heldout_rollouts",
+        lambda *a, **k: [{"env_id": "heldout-0000", "score": 0.9, "success": True}],
+    )
+    with pytest.raises(loop_module.Sim2RealLoopError):
+        loop_module._component_heldout_payload(
+            [{"env_id": "heldout-0000", "seed": 1}],
+            inner_evidence={},
+            threshold=0.75,
+            scene=scene,
+            sim_backend="isaac",
+        )
+
+
+class _FakeMeshConverter:
+    """Fake Isaac Lab converter: writes a USD next to a tracked usd_path."""
+
+    instances: list[str] = []
+
+    def __init__(self, cfg) -> None:
+        out = Path(cfg.usd_dir) / cfg.usd_file_name
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text("#usda 1.0\n")
+        self.usd_path = str(out)
+        type(self).instances.append(cfg.asset_path)
+
+
+def _install_fake_isaac_converters(monkeypatch, *, kind: dict) -> None:
+    import types
+
+    mod = types.ModuleType("isaaclab.sim.converters")
+
+    class MeshConverterCfg:
+        def __init__(self, *, asset_path, usd_dir, usd_file_name, force_usd_conversion=True):
+            self.asset_path = asset_path
+            self.usd_dir = usd_dir
+            self.usd_file_name = usd_file_name
+
+    class UrdfConverterCfg(MeshConverterCfg):
+        pass
+
+    class MeshConverter(_FakeMeshConverter):
+        pass
+
+    class UrdfConverter(_FakeMeshConverter):
+        def __init__(self, cfg) -> None:
+            super().__init__(cfg)
+            kind["urdf"] = True
+
+    mod.MeshConverter = MeshConverter
+    mod.MeshConverterCfg = MeshConverterCfg
+    mod.UrdfConverter = UrdfConverter
+    mod.UrdfConverterCfg = UrdfConverterCfg
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.converters", mod)
+
+
+def test_isaac_import_mesh_to_usd_dispatches_mesh_converter(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _FakeMeshConverter.instances = []
+    kind: dict = {}
+    _install_fake_isaac_converters(monkeypatch, kind=kind)
+    src = tmp_path / "nail.obj"
+    src.write_text("v 0 0 0\n")
+    usd = loop_module._isaac_import_mesh_to_usd(str(src), work_dir=tmp_path / "usd")
+    assert usd.endswith("nail.usd")
+    assert Path(usd).is_file()
+    assert _FakeMeshConverter.instances == [str(src)]
+    assert "urdf" not in kind
+
+
+def test_isaac_import_urdf_to_usd_dispatches_urdf_converter(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _FakeMeshConverter.instances = []
+    kind: dict = {}
+    _install_fake_isaac_converters(monkeypatch, kind=kind)
+    src = tmp_path / "robot.urdf"
+    src.write_text("<robot/>\n")
+    usd = loop_module._isaac_import_mesh_to_usd(str(src), work_dir=tmp_path / "usd")
+    assert usd.endswith("robot.usd")
+    assert kind.get("urdf") is True
+
+
+def test_isaac_import_mesh_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(loop_module.Sim2RealLoopError):
+        loop_module._isaac_import_mesh_to_usd(
+            str(tmp_path / "absent.obj"), work_dir=tmp_path / "usd"
+        )
+
+
+def test_isaac_heldout_eval_launches_isaac_image_job(monkeypatch, tmp_path: Path) -> None:
+    output_payload = {
+        "schema": SCHEMA_HELDOUT_REPORT,
+        "sim_backend": "isaac",
+        "per_env": [
+            {"env_id": "env-a", "score": 0.81, "success": True, "details": {}},
+        ],
+    }
+    storage = _FakeComponentStorage({"heldout_eval": output_payload})
+    _patch_component_storage(monkeypatch, storage)
+    calls = _patch_kubectl(monkeypatch)
+    config = Sim2RealLoopConfig(
+        run_id="isaac-image-job",
+        s3_bucket="bucket",
+        s3_prefix="neutral-prefix",
+        s3_endpoint="https://storage.example",
+        heldout_envs_uri="s3://bucket/neutral-prefix/run/envs/heldout/",
+        threshold=0.75,
+        k8s_namespace="default",
+        sim_backend="isaac",
+        isaac_image="npa-isaac-lab:2.3.2.post1",
+        source_ref="dev-branch",
+        source_repo="https://example.invalid/repo.git",
+    )
+    run_heldout_eval(
+        config,
+        local_dir=tmp_path,
+        inner_evidence={"schema": "npa.sim2real.inner_loop_evidence.v1", "reward_trend": [0.1]},
+        outer_iteration=1,
+    )
+    apply_call = next(call for call in calls if "apply" in call["cmd"])
+    manifest = json.loads(apply_call["input"])
+    container = manifest["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == "npa-isaac-lab:2.3.2.post1"
+    script = container["args"][0]
+    assert "/isaac-sim/python.sh" in script
+    assert "--sim-backend" in script
+    env_names = {item["name"] for item in container["env"]}
+    assert "NPA_SIM2REAL_SIM_BACKEND" in env_names
 
 
 def test_cosmos_split_sdk_and_raw_yaml_contracts() -> None:

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -31,6 +31,12 @@ from npa.workflows.sim2real_loop import (
 
 ROOT = Path(__file__).resolve().parents[3]
 RUNBOOK = ROOT / "npa" / "workflows" / "workbench" / "sim2real" / "runbook.yaml"
+SIM2REAL_ACTIONS = (
+    ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "sim2real-actions.yaml"
+)
+SIM2REAL_ENVGEN_SPLIT = (
+    ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "sim2real-envgen-split.yaml"
+)
 COSMOS2_TRANSFER = (
     ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "cosmos2-transfer.yaml"
 )
@@ -610,6 +616,8 @@ def test_raw_runbook_invokes_full_loop_and_exposes_byo_envs() -> None:
     assert len(docs) == 1
     task = docs[0]
     assert task["name"] == "sim2real-full-loop"
+    assert task["resources"]["cloud"] == "kubernetes"
+    assert task["resources"]["accelerators"] == "RTX6000:1"
 
     # SkyPilot 0.12.2 does not interpolate ${VAR} inside `envs` or `image_id`.
     # The raw runbook must therefore carry materialized literals and expand env
@@ -634,8 +642,26 @@ def test_raw_runbook_invokes_full_loop_and_exposes_byo_envs() -> None:
     assert "--trigger-dataset-uri" in task["run"]
     assert "--byo-signal-converter" in task["run"]
     assert "--k8s-service-account" in task["run"]
+    assert "--k8s-gpu-product" in task["run"]
+    assert "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition" in task["run"]
     assert "--heldout-eval-limit" in task["run"]
     assert "nebius.cloud" not in RUNBOOK.read_text(encoding="utf-8")
+
+
+def test_sim2real_component_workflows_target_rtx_pro_6000() -> None:
+    actions = [
+        doc
+        for doc in yaml.safe_load_all(SIM2REAL_ACTIONS.read_text(encoding="utf-8"))
+        if doc is not None
+    ]
+    envgen = [
+        doc
+        for doc in yaml.safe_load_all(SIM2REAL_ENVGEN_SPLIT.read_text(encoding="utf-8"))
+        if doc is not None
+    ]
+
+    assert actions[0]["resources"]["accelerators"] == "RTXPRO6000:1"
+    assert envgen[0]["resources"]["accelerators"] == "RTXPRO6000:1"
 
 
 def test_cosmos_split_sdk_and_raw_yaml_contracts() -> None:

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -998,13 +998,30 @@ class _FakeMeshConverter:
 def _install_fake_isaac_converters(monkeypatch, *, kind: dict) -> None:
     import types
 
+    # Fake isaaclab.sim providing the spawn/property cfg classes the mesh
+    # converter path references (real module needs the Isaac Sim runtime / pxr).
+    root_mod = types.ModuleType("isaaclab")
+    monkeypatch.setitem(sys.modules, "isaaclab", root_mod)
+    sim_mod = types.ModuleType("isaaclab.sim")
+
+    class _Cfg:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    sim_mod.MassPropertiesCfg = _Cfg
+    sim_mod.RigidBodyPropertiesCfg = _Cfg
+    sim_mod.CollisionPropertiesCfg = _Cfg
+    sim_mod.UsdFileCfg = _Cfg
+    monkeypatch.setitem(sys.modules, "isaaclab.sim", sim_mod)
+
     mod = types.ModuleType("isaaclab.sim.converters")
 
     class MeshConverterCfg:
-        def __init__(self, *, asset_path, usd_dir, usd_file_name, force_usd_conversion=True):
+        def __init__(self, *, asset_path, usd_dir, usd_file_name, force_usd_conversion=True, **kwargs):
             self.asset_path = asset_path
             self.usd_dir = usd_dir
             self.usd_file_name = usd_file_name
+            self.__dict__.update(kwargs)
 
     class UrdfConverterCfg(MeshConverterCfg):
         pass

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -7,9 +7,13 @@ from pathlib import Path
 
 import yaml
 
+import pytest
+
 import npa.workflows.sim2real_loop as loop_module
 from npa.sdk.workbench import cosmos2, cosmos3, sim2real
 from npa.workbench.lerobot.policy_container import (
+    PolicyContainerError,
+    VlmSignalUpdateResult,
     parse_vlm_signal_batch,
     run_vlm_signal_training_step,
 )
@@ -18,6 +22,7 @@ from npa.workflows.sim2real_loop import (
     SCHEMA_RL_SIGNAL,
     SCHEMA_VLM_EVAL,
     Sim2RealLoopConfig,
+    Sim2RealLoopError,
     artifact_uris,
     build_config_from_env,
     convert_vlm_eval_to_rl_signal,
@@ -26,6 +31,7 @@ from npa.workflows.sim2real_loop import (
     generate_action_rollouts,
     run_full_loop,
     run_heldout_eval,
+    run_inner_loop,
 )
 
 
@@ -636,6 +642,324 @@ def test_raw_runbook_invokes_full_loop_and_exposes_byo_envs() -> None:
     assert "--k8s-service-account" in task["run"]
     assert "--heldout-eval-limit" in task["run"]
     assert "nebius.cloud" not in RUNBOOK.read_text(encoding="utf-8")
+
+
+def _signal_converter_command(tmp_path: Path, *, valid: bool = True) -> str:
+    script = tmp_path / "byo_signal_converter.py"
+    body = (
+        '''
+import json, os
+from pathlib import Path
+
+ev = json.loads(Path(os.environ["NPA_SIM2REAL_EVALUATION_JSON"]).read_text())
+out = Path(os.environ["NPA_SIM2REAL_OUTPUT_JSON"])
+out.parent.mkdir(parents=True, exist_ok=True)
+marker = Path(os.environ["NPA_SIM2REAL_SWAP_MARKER"])
+with marker.open("a", encoding="utf-8") as handle:
+    handle.write("signal_converter\\n")
+'''
+    )
+    if valid:
+        body += (
+            '''
+per_step = [
+    {
+        "step": int(s["step"]),
+        "reward": 0.5,
+        "advantage": 0.1,
+        "target": {"nl_correction": "byo correction", "action_delta": [0.0, 0.0, 0.0]},
+        "error_tags": s.get("error_tags", ["ok"]),
+    }
+    for s in ev["per_step"]
+]
+out.write_text(json.dumps({
+    "schema": os.environ["NPA_SIM2REAL_RL_SIGNAL_SCHEMA"],
+    "rollout_id": ev["rollout_id"],
+    "source": "byo-test",
+    "per_step": per_step,
+}))
+'''
+        )
+    else:
+        body += '\nout.write_text(json.dumps({"schema": "wrong.schema", "per_step": []}))\n'
+    script.write_text(body, encoding="utf-8")
+    return f"{sys.executable} {script}"
+
+
+def _trainer_command(tmp_path: Path, *, valid: bool = True) -> str:
+    script = tmp_path / "byo_trainer.py"
+    body = (
+        '''
+import json, os
+from pathlib import Path
+
+batch = json.loads(Path(os.environ["NPA_SIM2REAL_SIGNAL_JSON"]).read_text())
+out = Path(os.environ["NPA_SIM2REAL_OUTPUT_JSON"])
+out.parent.mkdir(parents=True, exist_ok=True)
+marker = Path(os.environ["NPA_SIM2REAL_SWAP_MARKER"])
+with marker.open("a", encoding="utf-8") as handle:
+    handle.write("trainer\\n")
+n = len(batch.get("signals", []))
+'''
+    )
+    if valid:
+        body += (
+            '''
+out.write_text(json.dumps({
+    "reward_head_after": 0.25 + 0.01 * n,
+    "policy_output_after": [0.06, 0.0, -0.03],
+    "policy_delta_l2": 0.42,
+    "loss_before": 1.0,
+    "loss_after": 0.4,
+    "backend": "byo-test",
+}))
+'''
+        )
+    else:
+        body += '\nout.write_text(json.dumps({"reward_head_after": 0.1}))\n'
+    script.write_text(body, encoding="utf-8")
+    return f"{sys.executable} {script}"
+
+
+def test_byo_signal_converter_swap_invoked_and_recorded(tmp_path: Path) -> None:
+    marker = tmp_path / "swap-marker.log"
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-signal-swap",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=(
+            f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {_component_command(tmp_path)}"
+        ),
+        byo_signal_converter=(
+            f"NPA_SIM2REAL_SWAP_MARKER={marker} {_signal_converter_command(tmp_path)}"
+        ),
+    )
+
+    evidence = run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+    assert evidence["signal_converter_source"] == "byo_command"
+    assert evidence["trainer_source"] == "reference"
+    assert evidence["iterations"][0]["signal_converter_source"] == "byo_command"
+    assert "signal_converter" in marker.read_text(encoding="utf-8")
+    sample_signal = evidence["iterations"][0]["sample_signal"]
+    assert sample_signal["schema"] == SCHEMA_RL_SIGNAL
+    assert sample_signal["source"] == "byo-test"
+    # The BYO signal must remain parseable by the downstream trainer contract.
+    parse_vlm_signal_batch(sample_signal)
+
+
+def test_byo_signal_converter_malformed_raises_no_fallback(tmp_path: Path) -> None:
+    marker = tmp_path / "swap-marker.log"
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-signal-bad",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=(
+            f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {_component_command(tmp_path)}"
+        ),
+        byo_signal_converter=(
+            f"NPA_SIM2REAL_SWAP_MARKER={marker} "
+            f"{_signal_converter_command(tmp_path, valid=False)}"
+        ),
+    )
+
+    with pytest.raises(Sim2RealLoopError, match="rl_signal"):
+        run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+
+def test_byo_trainer_command_swap_invoked_and_recorded(tmp_path: Path) -> None:
+    marker = tmp_path / "swap-marker.log"
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-trainer-swap",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=(
+            f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {_component_command(tmp_path)}"
+        ),
+        byo_trainer_command=(
+            f"NPA_SIM2REAL_SWAP_MARKER={marker} {_trainer_command(tmp_path)}"
+        ),
+    )
+
+    evidence = run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+    assert evidence["trainer_source"] == "byo_command"
+    assert evidence["signal_converter_source"] == "reference"
+    iteration = evidence["iterations"][0]
+    assert iteration["trainer_source"] == "byo_command"
+    update = iteration["update"]
+    assert update["reward_head_after"] == pytest.approx(0.26)
+    assert update["policy_output_after"] == [0.06, 0.0, -0.03]
+    assert update["policy_delta_l2"] == pytest.approx(0.42)
+    assert update["backend"] == "byo-test"
+    # The no-signal control still runs the in-process reference trainer.
+    assert iteration["no_signal_control"]["backend"] != "byo-test"
+    assert "trainer" in marker.read_text(encoding="utf-8")
+
+
+def test_byo_trainer_command_missing_fields_raises_no_fallback(tmp_path: Path) -> None:
+    marker = tmp_path / "swap-marker.log"
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-trainer-bad",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=(
+            f"NPA_SIM2REAL_COMPONENT_MARKER={marker} {_component_command(tmp_path)}"
+        ),
+        byo_trainer_command=(
+            f"NPA_SIM2REAL_SWAP_MARKER={marker} "
+            f"{_trainer_command(tmp_path, valid=False)}"
+        ),
+    )
+
+    with pytest.raises(Sim2RealLoopError, match="policy_output_after"):
+        run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+
+def test_default_inner_loop_provenance_is_reference(tmp_path: Path) -> None:
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-default-prov",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        byo_vlm_command=_component_command(tmp_path),
+    )
+
+    evidence = run_inner_loop(config, local_dir=tmp_path, initial_quality=0.4)
+
+    assert evidence["trainer_source"] == "reference"
+    assert evidence["signal_converter_source"] == "reference"
+
+
+def test_full_loop_writes_rerun_recording_by_default(tmp_path: Path) -> None:
+    command = _component_command(tmp_path)
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-rerun-default",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        outer_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        heldout_env_count=2,
+        byo_vlm_command=command,
+        byo_eval_command=command,
+    )
+
+    report = run_full_loop(config)
+
+    viz = report["visualization"]
+    assert viz["status"] == "written"
+    assert viz["source"] == "reference"
+    rrd = tmp_path / "reports" / "sim2real.rrd"
+    assert rrd.exists() and rrd.stat().st_size > 0
+    components = {c["name"]: c for c in report["components"]}
+    assert components["stage_14_rerun_viz"]["tier"] == "WORKS"
+
+
+def test_full_loop_rerun_disabled_toggle(tmp_path: Path) -> None:
+    command = _component_command(tmp_path)
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-rerun-off",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        outer_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        heldout_env_count=2,
+        byo_vlm_command=command,
+        byo_eval_command=command,
+        rerun_enabled=False,
+    )
+
+    report = run_full_loop(config)
+
+    assert report["visualization"]["status"] == "disabled"
+    assert not (tmp_path / "reports" / "sim2real.rrd").exists()
+    components = {c["name"]: c for c in report["components"]}
+    assert components["stage_14_rerun_viz"]["tier"] == "SEAM"
+
+
+def test_full_loop_rerun_warns_when_sdk_missing(monkeypatch, tmp_path: Path) -> None:
+    import npa.workflows.sim2real_viz as viz_module
+
+    def _raise(**_kwargs):
+        raise viz_module.RerunUnavailableError("rerun-sdk is not installed")
+
+    monkeypatch.setattr(viz_module, "emit_sim2real_rerun", _raise)
+    command = _component_command(tmp_path)
+    config = Sim2RealLoopConfig(
+        run_id="sim2real-rerun-warn",
+        output_dir=tmp_path,
+        threshold=0.4,
+        inner_iterations=1,
+        outer_iterations=1,
+        rollout_count=1,
+        steps_per_rollout=2,
+        heldout_env_count=2,
+        byo_vlm_command=command,
+        byo_eval_command=command,
+    )
+
+    report = run_full_loop(config)
+
+    assert report["visualization"]["status"] == "skipped"
+    components = {c["name"]: c for c in report["components"]}
+    assert components["stage_14_rerun_viz"]["tier"] == "WARN"
+
+
+def test_vlm_signal_update_result_from_dict_defaults_and_required() -> None:
+    result = VlmSignalUpdateResult.from_dict(
+        {
+            "reward_head_after": 0.3,
+            "policy_output_after": [0.1, -0.2],
+            "policy_delta_l2": 0.5,
+        }
+    )
+
+    assert result.reward_head_after == 0.3
+    assert result.policy_output_after == [0.1, -0.2]
+    assert result.policy_delta_l2 == 0.5
+    # Safe defaults fill the rest.
+    assert result.policy_output_before == [0.0, 0.0]
+    assert result.backend == "byo_command"
+    assert result.status == "updated"
+    assert result.loss_integration_point == "byo_trainer_command"
+    assert result.to_dict()["policy_delta_l2"] == 0.5
+
+    for missing in ("reward_head_after", "policy_output_after", "policy_delta_l2"):
+        payload = {
+            "reward_head_after": 0.3,
+            "policy_output_after": [0.1],
+            "policy_delta_l2": 0.5,
+        }
+        del payload[missing]
+        with pytest.raises(PolicyContainerError):
+            VlmSignalUpdateResult.from_dict(payload)
+
+    with pytest.raises(PolicyContainerError):
+        VlmSignalUpdateResult.from_dict(
+            {
+                "reward_head_after": 0.3,
+                "policy_output_after": [],
+                "policy_delta_l2": 0.5,
+            }
+        )
 
 
 def test_cosmos_split_sdk_and_raw_yaml_contracts() -> None:

--- a/npa/tests/workflows/test_sim2real_loop.py
+++ b/npa/tests/workflows/test_sim2real_loop.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 import npa.workflows.sim2real_loop as loop_module
@@ -510,8 +511,9 @@ def test_component_heldout_payload_uses_genesis_rollout_backend(monkeypatch) -> 
     ]
     captured = {}
 
-    def fake_genesis_rollouts(env_payload, *, inner_evidence, threshold):
+    def fake_genesis_rollouts(env_payload, *, inner_evidence, threshold, scene=None):
         captured["envs"] = env_payload
+        captured["scene"] = scene
         captured["inner_evidence"] = inner_evidence
         captured["threshold"] = threshold
         return [
@@ -545,6 +547,203 @@ def test_component_heldout_payload_uses_genesis_rollout_backend(monkeypatch) -> 
     assert payload["rollout_backend"] == "npa.genesis.env_pick_place.FrankaPickPlaceEnv"
     assert payload["policy_source"] == "inner_evidence_adapter"
     assert "synthetic_signature" not in payload
+
+
+class _FakeMeshClient:
+    """Fake StorageClient that writes JSON/mesh bytes for download_path."""
+
+    def __init__(self, *, spec_doc: dict | None = None, mesh: bytes = b"MESH") -> None:
+        self.spec_doc = spec_doc
+        self.mesh = mesh
+        self.downloads: list[tuple[str, str]] = []
+        self.uploads: list[tuple[str, str]] = []
+
+    def download_path(self, uri: str, local_path: str) -> str:
+        self.downloads.append((uri, local_path))
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        if uri.endswith(".json"):
+            Path(local_path).write_text(json.dumps(self.spec_doc or {}))
+        else:
+            Path(local_path).write_bytes(self.mesh)
+        return local_path
+
+    def upload_file(self, local_file: str, bucket_uri: str) -> str:
+        self.uploads.append((local_file, bucket_uri))
+        return bucket_uri
+
+
+def test_resolve_heldout_scene_byo_mesh_records_provenance(tmp_path: Path) -> None:
+    from npa.genesis import scene_assets as sa
+
+    client = _FakeMeshClient(mesh=b"OBJ-BYTES")
+    scene = loop_module._resolve_heldout_scene(
+        scene_spec_uri="",
+        assets_uri="s3://bucket/run/object.obj",
+        byo_mesh_uri="",
+        dest_dir=tmp_path,
+        client=client,
+    )
+    assert scene is not None
+    obj = scene.manipuland()
+    assert obj.asset_source == sa.ASSET_SOURCE_BYO_MESH
+    assert obj.sha256 == sa.sha256_file(obj.local_path)
+    assert scene.provenance_block()["asset_fallback_used"] is False
+
+
+def test_resolve_heldout_scene_none_without_uris(tmp_path: Path) -> None:
+    scene = loop_module._resolve_heldout_scene(
+        scene_spec_uri="",
+        assets_uri="",
+        byo_mesh_uri="",
+        dest_dir=tmp_path,
+        client=_FakeMeshClient(),
+    )
+    assert scene is None
+
+
+def test_resolve_heldout_scene_from_scene_spec_json(tmp_path: Path) -> None:
+    doc = {
+        "objects": [
+            {
+                "name": "widget",
+                "asset_source": "byo_mesh",
+                "uri": "s3://bucket/run/widget.glb",
+            }
+        ],
+        "goal_pos": [0.5, 0.3, 0.04],
+    }
+    client = _FakeMeshClient(spec_doc=doc)
+    scene = loop_module._resolve_heldout_scene(
+        scene_spec_uri="s3://bucket/run/scene-spec.json",
+        assets_uri="",
+        byo_mesh_uri="",
+        dest_dir=tmp_path,
+        client=client,
+    )
+    assert scene is not None
+    assert scene.manipuland().uri.endswith("widget.glb")
+    assert scene.manipuland().sha256
+
+
+def test_component_heldout_payload_with_scene_attaches_provenance(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from npa.genesis import scene_assets as sa
+
+    client = _FakeMeshClient(mesh=b"OBJ-BYTES")
+    scene = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    sa.resolve_scene_assets(scene, dest_dir=tmp_path, client=client)
+
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None):
+        # Simulate the env building the mesh and marking it loaded.
+        if scene is not None:
+            for obj in scene.objects:
+                obj.loaded = True
+        return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
+
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_rollouts)
+    payload = loop_module._component_heldout_payload(
+        [{"env_id": "heldout-0000", "seed": 1}],
+        inner_evidence={"reward_trend": [0.2, 0.6]},
+        threshold=0.75,
+        scene=scene,
+    )
+    assert payload["asset_fallback_used"] is False
+    prov = payload["asset_provenance"]
+    assert prov["objects"][0]["asset_source"] == "byo_mesh"
+    assert prov["objects"][0]["loaded"] is True
+    assert prov["objects"][0]["sha256"] == scene.manipuland().sha256
+
+
+def test_component_heldout_payload_raises_when_mesh_not_loaded(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from npa.genesis import scene_assets as sa
+
+    client = _FakeMeshClient(mesh=b"OBJ-BYTES")
+    scene = sa.synthesize_scene_spec(byo_mesh_uri="s3://bucket/run/object.obj")
+    sa.resolve_scene_assets(scene, dest_dir=tmp_path, client=client)
+
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None):
+        return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
+
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_rollouts)
+    with pytest.raises(loop_module.Sim2RealLoopError):
+        loop_module._component_heldout_payload(
+            [{"env_id": "heldout-0000", "seed": 1}],
+            inner_evidence={},
+            threshold=0.75,
+            scene=scene,
+        )
+
+
+def test_normalize_heldout_report_propagates_provenance() -> None:
+    payload = {
+        "per_env": [{"env_id": "h-0", "score": 0.9, "success": True}],
+        "asset_provenance": {
+            "schema": "npa.sim2real.asset_provenance.v1",
+            "asset_fallback_used": False,
+            "objects": [{"name": "widget", "asset_source": "byo_mesh", "loaded": True}],
+        },
+        "asset_fallback_used": False,
+    }
+    config = Sim2RealLoopConfig(run_id="r", threshold=0.5)
+    report = loop_module._normalize_heldout_report(
+        payload,
+        config=config,
+        outer_iteration=1,
+        inner_evidence_uri="inner.json",
+        invocation={"component": "heldout_eval"},
+    )
+    assert report["asset_fallback_used"] is False
+    assert report["asset_provenance"]["objects"][0]["asset_source"] == "byo_mesh"
+
+
+def test_run_heldout_eval_component_from_s3_writes_provenance(
+    monkeypatch, tmp_path: Path
+) -> None:
+    client = _FakeMeshClient(mesh=b"OBJ-BYTES")
+    monkeypatch.setattr(
+        loop_module.StorageClient, "from_environment", staticmethod(lambda **kw: client)
+    )
+
+    # Seed the env records the component downloads.
+    def download_path(uri, local_path):
+        client.downloads.append((uri, local_path))
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        if uri.endswith("heldout/"):
+            Path(local_path).mkdir(parents=True, exist_ok=True)
+            (Path(local_path) / "envs.jsonl").write_text(
+                json.dumps({"env_id": "heldout-0000", "seed": 7}) + "\n"
+            )
+        elif uri.endswith(".json"):
+            Path(local_path).write_text(json.dumps({"reward_trend": [0.2, 0.6]}))
+        else:
+            Path(local_path).write_bytes(b"OBJ-BYTES")
+        return local_path
+
+    monkeypatch.setattr(client, "download_path", download_path)
+
+    def fake_rollouts(envs, *, inner_evidence, threshold, scene=None):
+        if scene is not None:
+            for obj in scene.objects:
+                obj.loaded = True
+        return [{"env_id": "heldout-0000", "score": 0.9, "success": True}]
+
+    monkeypatch.setattr(loop_module, "_run_genesis_heldout_rollouts", fake_rollouts)
+
+    payload = loop_module.run_heldout_eval_component_from_s3(
+        heldout_envs_uri="s3://bucket/run/heldout/",
+        inner_evidence_uri="s3://bucket/run/inner-evidence.json",
+        output_uri="s3://bucket/run/output/report.json",
+        threshold=0.75,
+        assets_uri="s3://bucket/run/object.obj",
+    )
+    assert payload["asset_fallback_used"] is False
+    assert payload["asset_provenance"]["objects"][0]["asset_source"] == "byo_mesh"
+    # A consumed scene spec is uploaded alongside the report.
+    uploaded = [u[1] for u in client.uploads]
+    assert any(u.endswith("consumed-scene-spec.json") for u in uploaded)
 
 
 def test_sdk_exposes_sim2real_run(tmp_path: Path) -> None:

--- a/npa/tests/workflows/test_sim2real_signal_rca.py
+++ b/npa/tests/workflows/test_sim2real_signal_rca.py
@@ -1,0 +1,132 @@
+"""Regression tests for the sim2real genuine-signal RCA fixes.
+
+Covers the degenerate-signal root causes:
+- held-out scores collapsing to a flat ``1.0`` (no gradient),
+- cross-rollout diversity diagnostics / anti-hollow gate,
+- ``-genuine-`` image pull policy, and
+- image-digest provenance captured from the running pod.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+import npa.workflows.sim2real_loop as loop_module
+from npa.workflows.sim2real_loop import (
+    Sim2RealLoopConfig,
+    _heldout_env_score,
+    _image_pull_policy,
+    _signal_diversity_report,
+)
+
+
+def _signal(score: float, reward: float) -> dict[str, object]:
+    return {
+        "schema": loop_module.SCHEMA_RL_SIGNAL,
+        "score": score,
+        "per_step": [{"reward": reward}],
+    }
+
+
+def test_heldout_env_score_success_band_is_continuous_not_flat_one() -> None:
+    # Two successful envs with different distance/reward must NOT both be 1.0.
+    high = _heldout_env_score(1.0, 1.0, env_success=True)
+    low = _heldout_env_score(0.2, 0.0, env_success=True)
+
+    assert high == 1.0
+    assert low < high
+    assert 0.75 <= low <= 1.0
+
+
+def test_heldout_env_score_success_outranks_failure() -> None:
+    success = _heldout_env_score(0.5, 0.5, env_success=True)
+    failure = _heldout_env_score(0.5, 0.5, env_success=False)
+
+    assert success > failure
+    assert 0.0 <= failure <= 0.6
+
+
+def test_signal_diversity_report_flags_degenerate_batch() -> None:
+    degenerate = [_signal(1.0, 0.5) for _ in range(6)]
+
+    report = _signal_diversity_report(degenerate)
+
+    assert report["total_rollouts"] == 6
+    assert report["distinct_scores"] == 1
+    assert report["coherent"] is False
+    assert report["degenerate"] is True
+
+
+def test_signal_diversity_report_accepts_varied_batch() -> None:
+    varied = [_signal(0.2, -0.3), _signal(0.6, 0.1), _signal(0.9, 0.7)]
+
+    report = _signal_diversity_report(varied)
+
+    assert report["distinct_scores"] == 3
+    assert report["distinct_mean_rewards"] == 3
+    assert report["coherent"] is True
+    assert report["degenerate"] is False
+
+
+@pytest.mark.parametrize(
+    ("image", "expected"),
+    [
+        ("npa-cosmos3-reason:3.0.1-genuine-sm120", "Always"),
+        ("npa-sim2real-eval:0.1.1-genuine-sm120", "Always"),
+        ("npa-sim2real-eval:0.1.1", "IfNotPresent"),
+        ("registry.example/team/npa-sim2real-eval:0.1.1", "IfNotPresent"),
+        ("npa-sim2real-eval@sha256:" + "a" * 64, "IfNotPresent"),
+    ],
+)
+def test_image_pull_policy(image: str, expected: str) -> None:
+    assert _image_pull_policy(image) == expected
+
+
+def test_image_pull_policy_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NPA_SIM2REAL_IMAGE_PULL_POLICY", "Never")
+    assert _image_pull_policy("npa-cosmos3-reason:3.0.1-genuine-sm120") == "Never"
+
+
+def test_component_pod_info_captures_image_digests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    digest = "registry.example/npa-cosmos3-reason@sha256:" + "b" * 64
+    pod_payload = {
+        "items": [
+            {
+                "metadata": {"name": "pod-1"},
+                "spec": {"nodeName": "node-1", "containers": [{"resources": {}}]},
+                "status": {
+                    "phase": "Succeeded",
+                    "containerStatuses": [
+                        {
+                            "name": "component",
+                            "ready": False,
+                            "restartCount": 0,
+                            "image": "npa-cosmos3-reason:3.0.1-genuine-sm120",
+                            "imageID": digest,
+                            "state": {"terminated": {"exitCode": 0}},
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+    def fake_kubectl(config, args, **kwargs):  # noqa: ANN001 - test stub
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=json.dumps(pod_payload), stderr=""
+        )
+
+    monkeypatch.setattr(loop_module, "_kubectl", fake_kubectl)
+    config = Sim2RealLoopConfig(run_id="rca-test")
+
+    info = loop_module._component_pod_info(
+        config, namespace="default", job_name="job-1"
+    )
+
+    assert info["image_digests"] == [digest]
+    assert info["container_statuses"][0]["image_id"] == digest

--- a/npa/tests/workflows/test_sim2real_viz.py
+++ b/npa/tests/workflows/test_sim2real_viz.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import npa.workflows.sim2real_viz as viz_module
+from npa.workflows.sim2real_loop import generate_action_rollouts
+from npa.workflows.sim2real_viz import (
+    RerunUnavailableError,
+    Sim2RealVizError,
+    emit_sim2real_rerun,
+)
+
+
+class _FakeRecording:
+    pass
+
+
+class _FakeRerun:
+    """In-memory Rerun sink that records every logged entity for assertions."""
+
+    def __init__(self) -> None:
+        self.logged: list[tuple[str, str]] = []
+        self.times: list[float] = []
+        self.saved_path: Path | None = None
+        self.disconnected = False
+
+    # Archetype factories ---------------------------------------------------
+    def Scalars(self, value: float) -> dict[str, Any]:
+        return {"kind": "scalar", "value": float(value)}
+
+    def Image(self, array: Any) -> dict[str, Any]:
+        return {"kind": "image", "shape": getattr(array, "shape", None)}
+
+    def TextDocument(self, text: str, media_type: str = "") -> dict[str, Any]:
+        return {"kind": "text", "text": text}
+
+    # Recording lifecycle ---------------------------------------------------
+    def RecordingStream(self, application_id: str) -> _FakeRecording:
+        self.application_id = application_id
+        return _FakeRecording()
+
+    def save(self, path: Any, default_blueprint: Any = None, recording: Any = None) -> None:
+        self.saved_path = Path(path)
+        Path(path).write_bytes(b"FAKE_RRD_CONTENT")
+
+    def send_blueprint(self, blueprint: Any, recording: Any = None) -> None:
+        return None
+
+    def set_time_seconds(self, timeline: str, seconds: float, recording: Any = None) -> None:
+        self.times.append(float(seconds))
+
+    def log(self, entity_path: str, archetype: dict[str, Any], recording: Any = None) -> None:
+        self.logged.append((entity_path, archetype.get("kind", "?")))
+
+    def disconnect(self, recording: Any = None) -> None:
+        self.disconnected = True
+
+
+def _build_run_tree(tmp_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    actions_dir = tmp_path / "actions" / "train" / "outer-01" / "iter-01"
+    rollouts = generate_action_rollouts(
+        actions_dir, count=2, steps_per_rollout=3, seed=11, quality=0.4
+    )
+    eval_dir = tmp_path / "vlm_eval" / "train" / "outer-01" / "iter-01"
+    signal_dir = tmp_path / "training_signal" / "train" / "outer-01" / "iter-01"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    signal_dir.mkdir(parents=True, exist_ok=True)
+    for rollout in rollouts:
+        rollout_id = rollout.name
+        per_step = [
+            {
+                "step": step,
+                "critique_text": f"{rollout_id} step {step} drifted",
+                "error_tags": ["minor_alignment"],
+            }
+            for step in range(3)
+        ]
+        (eval_dir / f"{rollout_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema": "npa.sim2real.vlm_eval.v1",
+                    "rollout_id": rollout_id,
+                    "success": False,
+                    "score": 0.6,
+                    "per_step": per_step,
+                    "summary": "summary",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (signal_dir / f"{rollout_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema": "npa.sim2real.rl_signal.v1",
+                    "rollout_id": rollout_id,
+                    "per_step": [
+                        {"step": step, "reward": 0.1 * step, "advantage": 0.05 * step}
+                        for step in range(3)
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+    inner_evidence = {
+        "schema": "npa.sim2real.inner_loop_evidence.v1",
+        "reward_trend": [0.2, 0.45],
+        "iterations": [
+            {
+                "iteration": 1,
+                "actions_dir": str(actions_dir),
+                "vlm_eval_dir": str(eval_dir),
+                "signal_dir": str(signal_dir),
+            }
+        ],
+    }
+    heldout_report = {
+        "schema": "npa.sim2real.heldout_eval.v1",
+        "per_env": [
+            {"env_id": "heldout-0000", "score": 0.7, "success": True},
+            {"env_id": "heldout-0001", "score": 0.5, "success": False},
+        ],
+    }
+    return inner_evidence, heldout_report
+
+
+def test_emit_logs_frames_critiques_signal_and_heldout(monkeypatch, tmp_path: Path) -> None:
+    inner_evidence, heldout_report = _build_run_tree(tmp_path)
+    fake = _FakeRerun()
+    monkeypatch.setattr(viz_module, "_import_rerun", lambda: (fake, MagicMock()))
+
+    rrd_path = tmp_path / "reports" / "sim2real.rrd"
+    result = emit_sim2real_rerun(
+        local_dir=tmp_path,
+        inner_evidence=inner_evidence,
+        heldout_report=heldout_report,
+        output_rrd=rrd_path,
+    )
+
+    assert result.status == "written"
+    assert rrd_path.exists() and rrd_path.stat().st_size > 0
+    assert result.rollout_count == 2
+    assert result.frame_count == 6
+    assert result.heldout_env_count == 2
+    assert fake.disconnected is True
+
+    entities = [entity for entity, _kind in fake.logged]
+    kinds = {entity: kind for entity, kind in fake.logged}
+    # Rollout camera frames as image streams.
+    assert any(e.endswith("/camera") and kinds[e] == "image" for e in entities)
+    # VLM critique overlays.
+    assert any(e.endswith("/critique") and kinds[e] == "text" for e in entities)
+    # RL signal scalar timeseries.
+    assert "signal/reward" in entities
+    assert "signal/advantage" in entities
+    assert "signal/reward_trend" in entities
+    # Held-out scores.
+    assert "heldout/scores" in entities
+    assert any(e.startswith("heldout/per_env/") for e in entities)
+
+    counts = result.entity_counts
+    assert counts["/signal/reward"] == 6
+    assert counts["/heldout/scores"] == 2
+
+
+def test_emit_raises_when_rerun_unavailable(monkeypatch, tmp_path: Path) -> None:
+    inner_evidence, heldout_report = _build_run_tree(tmp_path)
+
+    def _raise() -> Any:
+        raise RerunUnavailableError("rerun-sdk is not installed")
+
+    monkeypatch.setattr(viz_module, "_import_rerun", _raise)
+
+    with pytest.raises(RerunUnavailableError):
+        emit_sim2real_rerun(
+            local_dir=tmp_path,
+            inner_evidence=inner_evidence,
+            heldout_report=heldout_report,
+            output_rrd=tmp_path / "reports" / "sim2real.rrd",
+        )
+
+
+def test_emit_raises_when_no_content(monkeypatch, tmp_path: Path) -> None:
+    fake = _FakeRerun()
+    monkeypatch.setattr(viz_module, "_import_rerun", lambda: (fake, MagicMock()))
+
+    with pytest.raises(Sim2RealVizError):
+        emit_sim2real_rerun(
+            local_dir=tmp_path,
+            inner_evidence={"iterations": [], "reward_trend": []},
+            heldout_report={"per_env": []},
+            output_rrd=tmp_path / "reports" / "sim2real.rrd",
+        )

--- a/npa/workflows/workbench/sim2real/README.md
+++ b/npa/workflows/workbench/sim2real/README.md
@@ -90,6 +90,7 @@ eval/heldout/
 outer_loop/decision.json
 stage_13_retrigger/retrigger.json
 reports/sim2real-report.json
+reports/sim2real.rrd
 ```
 
 ## Prerequisites
@@ -156,6 +157,37 @@ config field. Set what you need; the rest fall back to reference defaults.
 | Rollout count | `--rollout-count` | `rollout_count=` | `ROLLOUT_COUNT` |
 | Steps per rollout | `--steps-per-rollout` | `steps_per_rollout=` | `STEPS_PER_ROLLOUT` |
 | Held-out env count | `--heldout-env-count` | `heldout_env_count=` | `HELDOUT_ENV_COUNT` |
+| VLM command swap | `--byo-vlm-command` | `byo_vlm_command=` | `BYO_VLM_COMMAND` |
+| Signal-converter swap | `--byo-signal-converter` | `byo_signal_converter=` | `BYO_SIGNAL_CONVERTER` |
+| Trainer command swap | `--byo-trainer-command` | `byo_trainer_command=` | `BYO_TRAINER_COMMAND` |
+| Held-out eval swap | `--byo-eval-command` | `byo_eval_command=` | `BYO_EVAL_COMMAND` |
+| Rerun viz toggle | `--rerun` / `--no-rerun` | `rerun_enabled=` | `NPA_SIM2REAL_RERUN` |
+| Rerun command swap | `--byo-rerun-command` | `byo_rerun_command=` | `BYO_RERUN_COMMAND` |
+
+### Command-Swap I/O Contracts
+
+Each `byo_*_command` is a shell command the loop runs at the matching seam. They
+all share the same convention: inputs arrive as JSON file paths in environment
+variables, and the command writes its result JSON to `NPA_SIM2REAL_OUTPUT_JSON`.
+A command that exits non-zero, writes nothing, or emits a non-conforming /empty
+document fails the run loudly — the loop never silently falls back to the
+reference implementation. Each run records which path executed
+(`trainer_source` / `signal_converter_source` = `byo_command` | `reference`) in
+the inner-loop evidence so a run can prove the customer hook actually ran.
+
+| Seam | Reads | Writes (`NPA_SIM2REAL_OUTPUT_JSON`) |
+| --- | --- | --- |
+| `byo_vlm_command` | `NPA_SIM2REAL_ROLLOUT_DIR`, `NPA_SIM2REAL_ROLLOUT_MANIFEST` | `npa.sim2real.vlm_eval.v1` (score + per_step critiques) |
+| `byo_signal_converter` | `NPA_SIM2REAL_EVALUATION_JSON` | `npa.sim2real.rl_signal.v1` (non-empty `per_step` of `{step, reward, advantage?, target?, error_tags?}`) |
+| `byo_trainer_command` | `NPA_SIM2REAL_SIGNAL_JSON` (+ `NPA_SIM2REAL_INITIAL_REWARD_HEAD`, `NPA_SIM2REAL_INITIAL_ACTION_BIAS`, `NPA_SIM2REAL_LEARNING_RATE`, `NPA_SIM2REAL_SIGNAL_LOSS_WEIGHT`) | trainer update with at least `reward_head_after`, `policy_output_after` (list), `policy_delta_l2` (optional `loss_before`/`loss_after`) |
+| `byo_eval_command` | `NPA_SIM2REAL_HELDOUT_ENVS_DIR`, `NPA_SIM2REAL_INNER_EVIDENCE_JSON` | `npa.sim2real.heldout_eval.v1` (non-empty `per_env`) |
+| `byo_rerun_command` | `NPA_SIM2REAL_RUN_DIR`, `NPA_SIM2REAL_REPORT_JSON` | non-empty `.rrd` at `NPA_SIM2REAL_OUTPUT_RRD` |
+
+When a `byo_trainer_command` is set, the per-iteration no-signal **control** still
+runs the in-process reference trainer. This keeps the policy-delta attribution
+honest: the BYO trainer produces the signal-driven update, and the reference
+control provides the shared-initial-state, no-signal baseline that the delta is
+measured against.
 
 ## Run All Three Tiers
 
@@ -262,6 +294,32 @@ npa workbench sim2real inner-loop \
     `stage_12_external_validation/external_stub.json`.
 13. Retrigger: writes `stage_13_retrigger/retrigger.json`, targeting Stage 1
     when a new real-world LeRobot dataset lands in the trigger path.
+14. Rerun visualization: writes `reports/sim2real.rrd` (a single Rerun recording)
+    from the completed run's artifacts. Default on (`NPA_SIM2REAL_RERUN=1` /
+    `--rerun`); set `NPA_SIM2REAL_RERUN=0` / `--no-rerun` to skip. Degrades to a
+    WARN (not a hard failure) when `rerun-sdk` is not installed locally, but
+    always produces the `.rrd` when it is available.
+
+### Rerun Visualization
+
+The `.rrd` reuses the repo's existing Rerun capability (the same `rerun-sdk`
+recording API the LeRobot/GR00T adapters build on) and logs, on a shared
+`frame_time` timeline:
+
+- `rollouts/iter_NN/<rollout_id>/camera` — rollout camera frames as image streams.
+- `rollouts/iter_NN/<rollout_id>/critique` — per-step VLM critique text + error
+  tags as a text document overlay.
+- `rollouts/iter_NN/<rollout_id>/score` — the VLM success score.
+- `signal/reward` and `signal/advantage` — the per-step VLM->RL signal as scalar
+  timeseries, plus `signal/reward_trend` across iterations.
+- `heldout/scores` and `heldout/per_env/<env_id>` — held-out per-env scores as a
+  scalar/bar view.
+
+Open it with `rerun reports/sim2real.rrd`, or load it headlessly with
+`rerun.recording.load_recording(...)` to inspect entity counts. Set
+`NPA_SIM2REAL_RERUN_MP4=1` to also emit best-effort per-rollout `rollout.mp4`
+files (skipped when `ffmpeg` is not on PATH). When `--upload-artifacts` is set,
+the `.rrd` uploads with the rest of the run tree.
 
 ## Loops
 
@@ -341,6 +399,7 @@ options:
 - `byo_signal_converter`
 - `trainer_image`, `byo_trainer_command`
 - `eval_image`, `byo_eval_command`
+- `rerun_enabled`, `byo_rerun_command`
 - `threshold`
 - `inner_iterations`, `outer_iterations`, `loop_of_loops_iterations`
 - `rollout_count`, `steps_per_rollout`, `heldout_env_count`

--- a/npa/workflows/workbench/sim2real/runbook.yaml
+++ b/npa/workflows/workbench/sim2real/runbook.yaml
@@ -62,10 +62,31 @@ envs:
   SIGNAL_LOSS_WEIGHT: "1.0"
   LEARNING_RATE: "0.05"
   NO_GUARDRAILS: "0"
+  # BYO_SIGNAL_CONVERTER: shell command run once per rollout instead of the
+  # in-process critique->reward converter. Contract: it reads the VLM evaluation
+  # JSON from $NPA_SIM2REAL_EVALUATION_JSON and writes an
+  # npa.sim2real.rl_signal.v1 document to $NPA_SIM2REAL_OUTPUT_JSON (object with a
+  # non-empty per_step list of {step, reward, advantage?, target?, error_tags?}).
+  # A failing/empty/non-conforming command fails the run; it never falls back.
   BYO_SIGNAL_CONVERTER: ""
+  # BYO_TRAINER_COMMAND: shell command run once per inner iteration instead of the
+  # in-process reference trainer. Contract: it reads the parsed signal batch from
+  # $NPA_SIM2REAL_SIGNAL_JSON and writes an update JSON to
+  # $NPA_SIM2REAL_OUTPUT_JSON containing at least reward_head_after,
+  # policy_output_after (list), and policy_delta_l2 (optional loss_before/after).
+  # The no-signal control always uses the in-process reference trainer so policy-
+  # delta attribution stays honest. A failing/empty/non-conforming command fails
+  # the run; it never falls back.
   BYO_TRAINER_COMMAND: ""
   BYO_VLM_COMMAND: ""
   BYO_EVAL_COMMAND: ""
+  # BYO_RERUN_COMMAND: optional shell command run instead of the in-process Rerun
+  # emitter. Contract: reads the run dir from $NPA_SIM2REAL_RUN_DIR and report from
+  # $NPA_SIM2REAL_REPORT_JSON, writes a non-empty .rrd to $NPA_SIM2REAL_OUTPUT_RRD.
+  BYO_RERUN_COMMAND: ""
+  # NPA_SIM2REAL_RERUN: "1" (default) emits reports/sim2real.rrd after the loop;
+  # "0" disables it. Degrades to a WARN if rerun-sdk is not installed locally.
+  NPA_SIM2REAL_RERUN: "1"
   NPA_SIM2REAL_K8S_NAMESPACE: "default"
   NPA_SIM2REAL_K8S_SERVICE_ACCOUNT: "agent-sa"
   NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS: "agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry"
@@ -145,6 +166,7 @@ run: |
     --byo-trainer-command "${BYO_TRAINER_COMMAND:-}" \
     --byo-vlm-command "${BYO_VLM_COMMAND:-}" \
     --byo-eval-command "${BYO_EVAL_COMMAND:-}" \
+    --byo-rerun-command "${BYO_RERUN_COMMAND:-}" \
     --k8s-namespace "${NPA_SIM2REAL_K8S_NAMESPACE:-default}" \
     --k8s-service-account "${NPA_SIM2REAL_K8S_SERVICE_ACCOUNT:-agent-sa}" \
     --k8s-image-pull-secrets "${NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS:-agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry}" \

--- a/npa/workflows/workbench/sim2real/runbook.yaml
+++ b/npa/workflows/workbench/sim2real/runbook.yaml
@@ -51,6 +51,9 @@ envs:
   TRAINER_IMAGE: ""
   VLM_IMAGE: ""
   EVAL_IMAGE: ""
+  ISAAC_IMAGE: ""
+  NPA_SIM2REAL_SIM_BACKEND: "isaac"
+  NPA_SIM2REAL_ISAAC_TASK: "Isaac-Lift-Cube-Franka-v0"
   VLM_MODEL: "nvidia/Cosmos-Reason1-7B"
   SUCCESS_THRESHOLD: "0.75"
   INNER_ITERATIONS: "2"
@@ -131,6 +134,9 @@ run: |
     --trainer-image "${TRAINER_IMAGE:-npa-lerobot-vlm-rl:0.1.0}" \
     --vlm-image "${VLM_IMAGE:-npa-cosmos3-reason:3.0.1-genuine-sm120}" \
     --eval-image "${EVAL_IMAGE:-npa-sim2real-eval:0.1.1-genuine-sm120}" \
+    --isaac-image "${ISAAC_IMAGE:-npa-isaac-lab:2.3.2.post1}" \
+    --sim-backend "${NPA_SIM2REAL_SIM_BACKEND:-isaac}" \
+    --isaac-task "${NPA_SIM2REAL_ISAAC_TASK:-Isaac-Lift-Cube-Franka-v0}" \
     --vlm-model "${VLM_MODEL:-nvidia/Cosmos-Reason1-7B}" \
     --threshold "${SUCCESS_THRESHOLD:-0.75}" \
     --inner-iterations "${INNER_ITERATIONS:-2}" \


### PR DESCRIPTION
## Summary

Consolidates the full sim2real VLM→RL workflow into one branch off fresh `main`. This is the union of five prior PRs (#84, #92, #93, #97, #99) merged in dependency order with conflicts resolved to keep **all** features (no capability dropped).

### Consolidated features
- **Genuine VLM→RL signal (#84):** held-out scorer is a continuous blend over each env's own distance/reward (never hardcoded 1.0), critique de-dup, image-digest provenance, `_image_pull_policy` (digest-pinned → `IfNotPresent`), and pinned-SA / fresh-IAM-token credentials + RBAC (`skypilot verify --kubeconfig/--cluster`).
- **BYO scene assets (#92):** real mesh/`SceneSpec` loading into the held-out Genesis env (`npa/genesis/scene_assets.py`, `env_pick_place.py` mesh dispatch), asset provenance, strict no-fallback.
- **Loop swaps + Rerun (#93):** `byo_signal_converter` / `byo_trainer_command` execution swaps with no silent fallback, `signal_diversity` degeneracy report, and Rerun visualization (`npa/workflows/sim2real_viz.py` → `reports/sim2real.rrd`) wired into `run_full_loop`.
- **RTX PRO 6000 routing (#97):** validation that sim2real component workflows target `RTXPRO6000:1`.
- **Pluggable Isaac/Genesis backend (#99):** `sim_backend = genesis | isaac` dispatch for held-out eval (stock + BYO mesh on Isaac Sim headless), schema-compatible normalized reports, module stays importable on the minimal Isaac image (lazy `policy_container` imports).

### Conflict resolutions (all unions)
- `npa/src/npa/workflows/sim2real_loop.py` — import region: kept #99's lazy `policy_container` import (minimal Isaac image) **and** #93's BYO signal-converter/trainer helpers; the BYO helpers now use lazy runtime imports, and the trainer return annotation resolves via a `TYPE_CHECKING` import. The merged held-out path keeps continuous score (#84) + asset provenance (#92) + backend dispatch (#99); `run_inner_loop` keeps BYO execution + signal_diversity + Rerun emit (#93).
- `npa/tests/workflows/test_sim2real_loop.py` — kept the full Isaac-backend + BYO/Rerun test suites and appended #97's RTX routing test (no name collisions); removed a duplicate `import pytest`.

### Credential surface — **HF + NGC + Nebius only**
No `NEBIUS_API_KEY` or token-factory requirement anywhere in the sim2real path. The runbook env secrets are:

```
NPA_SIM2REAL_K8S_ENV_SECRET_NAMES: "hf-ngc-tokens,npa-storage-credentials"
```

The sim2real VLM eval runs the genuine Cosmos-Reason image (`npa-cosmos3-reason`, `nvidia/Cosmos-Reason1-7B`) in-container, **not** the token-factory api backend.

### Rerun observability
`rerun` 0.31.4 imports cleanly; `sim2real_viz.py` is present and wired into `run_full_loop` (`_run_sim2real_viz_stage`), emitting `reports/sim2real.rrd`. Gracefully no-ops with a status record when the SDK is absent.

## Test plan
- `ruff check npa/src npa/tests` → all checks passed.
- `pytest` over `test_sim2real_loop.py`, `test_sim2real_viz.py`, `test_sim2real_signal_rca.py`, `test_scene_assets.py`, `test_skypilot_bootstrap.py` → **96 passed**.

## Supersedes
Replaces #84, #92, #93, #97, #99 (closed as superseded; branches retained).

Made with [Cursor](https://cursor.com)