### PR TITLE
refactor(cli): workbench namespace — retargeting under sonic, workflow glue demoted

### DIFF
--- a/.claude/skills/workbench/retargeting/SKILL.md
+++ b/.claude/skills/workbench/retargeting/SKILL.md
@@ -13,10 +13,10 @@ real motion-lib PKL schema consumed by SONIC locomotion training.
 CLI:
 
 ```bash
-npa workbench retargeting run
-npa workbench retargeting workflow
-npa workbench retargeting status
-npa workbench retargeting list
+npa workbench sonic retargeting run
+npa workbench sonic retargeting workflow
+npa workbench sonic retargeting status
+npa workbench sonic retargeting list
 ```
 
 SkyPilot YAML:

--- a/FTUE-AUDIT.md
+++ b/FTUE-AUDIT.md
@@ -73,7 +73,7 @@ a "non-default S3-compatible endpoint."
   `CapabilityContract`). Promoting the seams to explicit keyword parameters would
   change the public SDK signature; deferred.
 - **`sim2real` name collision.** Two surfaces share the "sim2real" name: the
-  13-stage VLM-to-RL loop (`npa workbench sim2real run`) and the separate
+  13-stage VLM-to-RL loop (`npa workbench workflow submit` on the sim2real runbook) and the separate
   sim-to-real H100 quickstart/pipeline. A first-time user cannot tell which is
   canonical. Naming reconciliation is deferred.
 - **Deeper GPU gate.** The cluster check counts schedulable `nvidia.com/gpu`; it

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ namespace.
 
 | Category | Workbench commands |
 | --- | --- |
-| Data curation | `npa workbench data sync`, `npa workbench data status`, `npa workbench data list`; `npa workbench fiftyone curate`, `eval`, `load-dataset`, `datasets list`; `npa workbench lancedb deploy`, `create-table`, `import-lerobot`, `import-bdd100k`, `backfill`, `create-mv`, `refresh-mv`, `query-table`, `query`; `npa workbench detection-training train`, `eval`, `status`, `list` |
+| Data curation | `npa workbench fiftyone curate`, `eval`, `load-dataset`, `datasets list`; `npa workbench lancedb deploy`, `create-table`, `import-lerobot`, `import-bdd100k`, `backfill`, `create-mv`, `refresh-mv`, `query-table`, `query`; `npa workbench detection-training train`, `eval`, `status`, `list` |
 | Synthetic data | `npa workbench cosmos infer`, `train`, `serve`, `status`; `npa workbench genesis generate-demos`; SkyPilot templates such as `npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml` and `npa/workflows/workbench/templates/curate-augment-train.yaml` |
-| Simulation | `npa workbench isaac-lab train`, `eval`, `export-lerobot`; `npa workbench genesis train-teacher`, `generate-demos`, `eval-teacher`, `eval-student`, `diagnose`, `tune`; `npa workbench retargeting run` |
+| Simulation | `npa workbench isaac-lab train`, `eval`, `export-lerobot`; `npa workbench genesis train-teacher`, `generate-demos`, `eval-teacher`, `eval-student`, `diagnose`, `tune`; `npa workbench sonic retargeting run` |
 | Eval | `npa workbench vlm-eval run`, `benchmark`, `workflow`, `status`, `list`; `npa workbench mjlab eval`; `npa workbench sonic eval`; `npa workbench fiftyone eval`; `npa workbench isaac-lab eval`; `npa workbench genesis eval-student` |
 | Observability | Tool-level `status`, `list`, and `system-info` commands; `npa workbench workflow status`, `logs`; `npa rerun host`, `share`, `list-shares`, `revoke`; `npa cluster status`, `list` |
 | Robot policy | `npa workbench lerobot train`, `eval`, `serve`, `infer`, `list-checkpoints`, `benchmark`, `profile-train`, `train-student`; `npa workbench groot download`, `finetune`, `eval`, `serve`, `infer`, `convert`; `npa workbench sonic train`, `serve`, `export`, `eval`, `status`, `list` |
 | World models | `npa workbench cosmos deploy`, `serve`, `infer`, `train`, `status`, `system-info` |
-| Blueprints | `npa workbench workflow submit`, `run`, `status`, `logs`, `teardown`, `distill`; checked-in YAML under `npa/workflows/workbench/skypilot/` for Isaac Lab, VLM eval, SONIC export, SONIC eval, SONIC locomotion fine-tuning, retargeting, MJLab eval, sim-to-real, and BDD100K pipelines |
+| Blueprints | `npa workbench workflow submit`, `workflow trigger watch`, `status`, `logs`, `teardown`, `distill`; checked-in YAML under `npa/workflows/workbench/skypilot/` and `npa/workflows/workbench/sim2real/` for Isaac Lab, VLM eval, SONIC export, SONIC eval, SONIC locomotion fine-tuning, retargeting, MJLab eval, sim-to-real, and BDD100K pipelines |
 
 ### Eval: VLM Backend
 

--- a/docs/architecture/solutions-model.md
+++ b/docs/architecture/solutions-model.md
@@ -1,6 +1,6 @@
 # Solutions Model
 
-> Last updated: 2026-05-26
+> Last updated: 2026-06-11
 
 Nebius Physical AI is organized as a platform with one or more solutions. The
 platform owns the shared command model, repository conventions, architecture
@@ -18,7 +18,8 @@ The current solution is Workbench:
 - User model: containerized workbench tools that can be deployed, queried, and
   invoked from the CLI or SDK
 - Documentation: [docs/workbench/](../workbench/)
-- Reference commands: `npa workbench <tool> <verb>`
+- Reference commands: `npa workbench <tool> <verb>` for deployable tools;
+  `npa workbench workflow submit <yaml>` for multi-stage pipelines
 
 A solution is not just a directory or a label. It must define who it serves, the
 tools it exposes, the contracts those tools honor, how operators validate it,
@@ -152,6 +153,24 @@ Tools that pass data between stages should use object storage paths, not direct
 tool-to-tool data transfer. Workbench commands use S3-style `--input-path` and
 `--output-path` options for pipeline data flow so one tool's artifacts can
 become the next tool's inputs.
+
+## Workbench Namespace Layout
+
+Everything Workbench-related stays under `npa workbench`. Only platform
+infrastructure (`npa configure`, `npa cluster`, `npa skypilot`, …) sits
+directly on `npa`.
+
+| Surface | Examples | Purpose |
+| --- | --- | --- |
+| **Tools** (slot 3) | `lerobot`, `sonic`, `lancedb`, `vlm-eval` | Deployable capabilities with `deploy` / `run` / `status` |
+| **Tool subcommands** | `npa workbench sonic retargeting run` | Job-shaped steps scoped to a parent tool |
+| **Workflows** | `npa workbench workflow submit <yaml>` | Multi-stage SkyPilot pipelines (sim-to-real, BDD100K, SONIC finetuning) |
+| **Workflow helpers** | `npa workbench workflow trigger watch` | Long-running watchers that resubmit pipeline YAML |
+| **Hidden compat** | `npa workbench data` (hidden) | S3 bridge for scripts/SDK; not advertised in `--help` |
+
+Do not register pipeline orchestrators (`sim2real`, `sim2real-envgen`) or
+operator tooling as top-level workbench tools. Use workflow YAML + cookbooks
+instead.
 
 Tool docs should state:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -20,7 +20,7 @@ Generated from `npa --help`. Run `bash scripts/build_docs.sh` after CLI changes.
 - [npa workbench mjlab](mjlab.md)
 - [npa network](network.md)
 - [npa rerun](rerun.md)
-- [npa workbench retargeting](retargeting.md)
+- [npa workbench sonic retargeting](retargeting.md)
 - [npa skypilot](skypilot.md)
 - [npa workbench sonic](sonic.md)
 - [npa viz](viz.md)

--- a/docs/cli/retargeting.md
+++ b/docs/cli/retargeting.md
@@ -1,62 +1,32 @@
-# `npa workbench retargeting`
+# `npa workbench sonic retargeting`
+
+Motion retargeting for SONIC locomotion workflows. Registered under the SONIC
+tool namespace.
 
 ## Command Tree
 
 ```text
-Usage: npa workbench retargeting [OPTIONS] COMMAND [ARGS]...
+Usage: npa workbench sonic retargeting [OPTIONS] COMMAND [ARGS]...
 
 Motion retargeting for SONIC locomotion workflows.
 
 Options
 --help  Show this message and exit.
 Commands
-run  Retarget source motion artifacts into the SONIC embodiment schema.
-workflow  Show the SkyPilot YAML template for retargeting.
-status  Show retargeting tool status.
-list  List supported retargeting source formats.
+run      Retarget source motion artifacts into the SONIC embodiment schema.
+workflow Print the bundled SkyPilot workflow path and default image.
+status   Report retargeting tool status.
+list     List supported source formats and defaults.
 ```
-
-## Options
-
-| Option | Description |
-| --- | --- |
-| `--help` | Show this message and exit. |
-
-## Subcommands
-
-| Command | Description |
-| --- | --- |
-| `run` | Retarget source motion artifacts into the SONIC embodiment schema. |
-| `workflow` | Show the SkyPilot YAML template for retargeting. |
-| `status` | Show retargeting tool status. |
-| `list` | List supported retargeting source formats. |
 
 ## Examples
 
 ```bash
-npa workbench retargeting --help
-npa workbench retargeting run --help
+npa workbench sonic retargeting --help
+npa workbench sonic retargeting run --help
+npa workbench sonic retargeting run \
+  --input-path s3://<your-bucket>/motions/source/ \
+  --output-path s3://<your-bucket>/sonic-locomotion/<run-id>/retargeted/
 ```
-
-Convert retargeted Bones-SEED/G1 CSVs to a SONIC motion library:
-
-```bash
-npa workbench retargeting run \
-  --input-path s3://bucket/bones-seed/g1/csv/210531/ \
-  --output-path s3://bucket/sonic-locomotion/run-1/retargeted/ \
-  --source-format bones-seed-csv \
-  --frame-rate 30 \
-  --source-frame-rate 120 \
-  --individual \
-  --output json
-```
-
-The command writes real SONIC motion-lib `.pkl` artifacts plus
-`retargeting_result.json` metadata. It no longer writes a manifest-only shim.
-
-Supported robot motion-lib inputs are `auto`, `soma-csv`, `bones-seed-csv`,
-`deploy-pkl`, `teleop-pkl`, and `motion-lib`. `bvh` invokes upstream SONIC's
-SOMA skeleton extractor and writes SOMA skeleton PKLs; upstream SONIC does not
-bundle the raw BVH-to-G1 robot retargeter.
 
 Regenerate this page with `bash scripts/build_docs.sh` after changing `retargeting`.

--- a/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
+++ b/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
@@ -6,7 +6,7 @@ This cookbook describes the SkyPilot workflow at
 The workflow composes three Workbench stages:
 
 1. Retarget source motion artifacts into the SONIC embodiment schema with
-   `npa workbench retargeting run`.
+   `npa workbench sonic retargeting run`.
 2. Fine-tune or smoke-validate the SONIC locomotion checkpoint on L40S with the
    baked SONIC image variant.
 3. Evaluate the resulting checkpoint with MJLab metrics through
@@ -45,7 +45,7 @@ The individual tool templates are available when you want to validate stages
 separately:
 
 ```bash
-npa workbench retargeting workflow
+npa workbench sonic retargeting workflow
 npa workbench mjlab workflow
 ```
 
@@ -207,7 +207,7 @@ The tool CLIs support `NPA_DRY_RUN=1`, which validates inputs and returns the
 artifact schema without writing outputs:
 
 ```bash
-NPA_DRY_RUN=1 npa workbench retargeting run \
+NPA_DRY_RUN=1 npa workbench sonic retargeting run \
   --input-path s3://bucket/motions/source/ \
   --output-path s3://bucket/sonic-locomotion/run-1/retargeted/ \
   --source-format bones-seed-csv \

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -11,7 +11,8 @@ agent, and (3) plug in your own LeRobot-based training container.
 
 - Workflow file: `npa/workflows/workbench/sim2real/runbook.yaml`
 - Reference: `npa/workflows/workbench/sim2real/README.md`
-- CLI: `npa workbench sim2real run`
+- Submit: `npa workbench workflow submit npa/workflows/workbench/sim2real/runbook.yaml`
+- SDK/local debug: `npa.sdk.workbench.sim2real.run()` or `python -m npa.workflows.sim2real_loop full-loop`
 
 ---
 
@@ -72,18 +73,19 @@ All checks should report PASS (an optional `config` WARN for unset
 
 ## 3. Run the workflow
 
+Submit the runbook YAML (preferred):
+
 ```bash
-npa workbench sim2real run \
+npa workbench workflow submit \
+  npa/workflows/workbench/sim2real/runbook.yaml \
   --run-id pusht-demo \
-  --s3-bucket <your-bucket> \
-  --s3-prefix sim2real \
-  --s3-endpoint <your-s3-endpoint> \
-  --trigger-dataset-id lerobot/pusht \
-  --sim-backend genesis \
-  --inner-iterations 2 --outer-iterations 1 \
-  --rollout-count 3 --steps-per-rollout 4 --heldout-env-count 8 \
-  --upload-artifacts
+  --var NPA_SIM2REAL_RUN_ID=pusht-demo \
+  --var NPA_SIM2REAL_BUCKET=<your-bucket> \
+  --var NPA_SIM2REAL_TRIGGER_DATASET_ID=lerobot/pusht \
+  --var AWS_ENDPOINT_URL=<your-s3-endpoint>
 ```
+
+Or launch with raw SkyPilot (see `npa/workflows/workbench/sim2real/README.md`).
 
 What you get back: a task-success / held-out report, an RL-signal diversity
 block, image-digest provenance proving the genuine VLM/eval images ran, and a
@@ -91,7 +93,7 @@ Rerun recording (see §6). Outputs land under `s3://<your-bucket>/sim2real/<run-
 
 > **Trigger on new data instead of running manually:** drop a LeRobot dataset at
 > a watched S3 prefix and let the trigger launch the run:
-> `npa workbench trigger watch --s3-bucket <your-bucket> --s3-prefix <trigger-prefix> ...`
+> `npa workbench workflow trigger watch --s3-bucket <your-bucket> --s3-prefix <trigger-prefix> ...`
 
 ---
 
@@ -103,16 +105,14 @@ LeRobot in **two ways**, both pure flags — no change to NPA:
 ### Option A — swap the trainer *image* (runs as a sibling K8s job)
 
 ```bash
-npa workbench sim2real run ... \
-  --trainer-image <your-registry>/<your-lerobot-trainer>:<tag>
+# Set TRAINER_IMAGE in runbook env / --var when submitting workflow YAML.
+export TRAINER_IMAGE=<your-registry>/<your-lerobot-trainer>:<tag>
 ```
 
 ### Option B — swap the trainer *command* (runs in-process in your base image)
 
-```bash
-npa workbench sim2real run ... \
-  --byo-trainer-command "python -m your_pkg.train_from_vlm_signal"
-```
+Set `BYO_TRAINER_COMMAND` in the runbook env (or pass `--byo-trainer-command` via SDK
+for local `sim2real_loop` runs).
 
 **The contract your container/command must honor** (this is all it needs to do):
 

--- a/npa/src/npa/cli/workbench/__init__.py
+++ b/npa/src/npa/cli/workbench/__init__.py
@@ -10,20 +10,16 @@ from npa.cli.workbench.cosmos3 import app as cosmos3_app
 from npa.cli.workbench.data import app as data_app
 from npa.cli.workbench.lerobot import app as lerobot_app
 from npa.cli.workbench.mjlab import app as mjlab_app
-from npa.cli.workbench.retargeting import app as retargeting_app
 from npa.cli.cosmos import app as cosmos_app
 from npa.cli.fiftyone import app as fiftyone_app
 from npa.cli.genesis import app as genesis_app
 from npa.cli.groot import app as groot_app
 from npa.cli.isaac_lab import app as isaac_lab_app
 from npa.cli.workbench.sonic import app as sonic_app
-from npa.cli.workbench.sim2real import app as sim2real_app
-from npa.cli.workbench.sim2real_envgen import app as sim2real_envgen_app
 from npa.cli.workbench.lancedb import app as lancedb_app
 from npa.cli.workbench.detection_training import app as detection_training_app
 from npa.cli.workbench.vlm_eval import app as vlm_eval_app
 from npa.cli.workbench.workflow import app as workflow_app
-from npa.cli.workbench.trigger import app as trigger_app
 from npa.cli.workbench.health import app as health_app
 
 app = typer.Typer(
@@ -43,7 +39,6 @@ def main() -> None:
 
 
 app.add_typer(lerobot_app, name="lerobot")
-app.add_typer(data_app, name="data")
 app.add_typer(cosmos_app, name="cosmos")
 app.add_typer(cosmos2_app, name="cosmos2")
 app.add_typer(cosmos3_app, name="cosmos3")
@@ -52,13 +47,11 @@ app.add_typer(genesis_app, name="genesis")
 app.add_typer(groot_app, name="groot")
 app.add_typer(isaac_lab_app, name="isaac-lab")
 app.add_typer(sonic_app, name="sonic")
-app.add_typer(sim2real_app, name="sim2real")
-app.add_typer(sim2real_envgen_app, name="sim2real-envgen")
 app.add_typer(mjlab_app, name="mjlab")
-app.add_typer(retargeting_app, name="retargeting")
 app.add_typer(lancedb_app, name="lancedb")
 app.add_typer(detection_training_app, name="detection-training")
 app.add_typer(vlm_eval_app, name="vlm-eval")
 app.add_typer(workflow_app, name="workflow")
-app.add_typer(trigger_app, name="trigger")
 app.add_typer(health_app, name="health")
+# Backward-compatible S3 bridge; not advertised in workbench --help.
+app.add_typer(data_app, name="data", hidden=True)

--- a/npa/src/npa/cli/workbench/data.py
+++ b/npa/src/npa/cli/workbench/data.py
@@ -1,4 +1,4 @@
-"""npa workbench data - S3 data bridge commands."""
+"""npa workbench data - hidden S3 data bridge for pipeline scripts and SDK."""
 
 from __future__ import annotations
 

--- a/npa/src/npa/cli/workbench/retargeting.py
+++ b/npa/src/npa/cli/workbench/retargeting.py
@@ -1,4 +1,4 @@
-"""npa workbench retargeting - motion retargeting commands."""
+"""npa workbench sonic retargeting - motion retargeting commands."""
 
 from __future__ import annotations
 

--- a/npa/src/npa/cli/workbench/sonic/cli.py
+++ b/npa/src/npa/cli/workbench/sonic/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typer
 
+from npa.cli.workbench.retargeting import app as retargeting_app
 from npa.cli.workbench.sonic import (
     deploy,
     eval as eval_mod,
@@ -42,3 +43,4 @@ app.command("eval")(eval_mod.eval_cmd)
 app.command("serve")(serve.serve_cmd)
 app.command("status")(status.status_cmd)
 app.command("list")(list_mod.list_cmd)
+app.add_typer(retargeting_app, name="retargeting")

--- a/npa/src/npa/cli/workbench/trigger.py
+++ b/npa/src/npa/cli/workbench/trigger.py
@@ -1,4 +1,4 @@
-"""npa workbench trigger - S3 retriggers for Workbench pipelines."""
+"""npa workbench workflow trigger - S3 retriggers for Workbench pipelines."""
 
 from __future__ import annotations
 

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from npa.cli.workbench.trigger import app as trigger_app
+
 app = typer.Typer(
     name="workflow",
     help="Multi-stage training workflow orchestration.",
@@ -1198,3 +1200,6 @@ def distill_cmd(
             status = info.get("status", "unknown")
             tag = "[green]OK[/green]" if status == "success" else "[red]FAILED[/red]"
             console.print(f"  {stage}: {tag}")
+
+
+app.add_typer(trigger_app, name="trigger")

--- a/npa/src/npa/solutions/solutions.toml
+++ b/npa/src/npa/solutions/solutions.toml
@@ -12,7 +12,7 @@ cli_command = "npa workbench workflow submit npa/workflows/workbench/skypilot/si
 [[solutions]]
 name = "retargeting"
 description = "Motion retargeting Workbench tool for SONIC locomotion pipelines"
-cli_command = "npa workbench retargeting"
+cli_command = "npa workbench sonic retargeting"
 
 [[solutions]]
 name = "mjlab"

--- a/npa/tests/cli/test_retargeting_cli.py
+++ b/npa/tests/cli/test_retargeting_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 import joblib
 import numpy as np
@@ -12,16 +13,24 @@ from npa.cli.main import app
 runner = CliRunner()
 
 
-def test_retargeting_registered_under_workbench() -> None:
-    result = runner.invoke(app, ["workbench", "--help"])
+def test_retargeting_registered_under_sonic() -> None:
+    result = runner.invoke(app, ["workbench", "sonic", "--help"])
 
     assert result.exit_code == 0
     assert "retargeting" in result.output
 
 
+def test_removed_tools_not_advertised_in_workbench_help() -> None:
+    result = runner.invoke(app, ["workbench", "--help"])
+
+    assert result.exit_code == 0
+    for removed in ("sim2real", "retargeting", "trigger", "golden-eval", "sim2real-envgen", "data"):
+        assert not re.search(rf"│\s+{re.escape(removed)}\s+", result.output)
+
+
 def test_retargeting_command_help() -> None:
     for command in ("run", "workflow", "status", "list"):
-        result = runner.invoke(app, ["workbench", "retargeting", command, "--help"])
+        result = runner.invoke(app, ["workbench", "sonic", "retargeting", command, "--help"])
 
         assert result.exit_code == 0
         assert "Usage:" in result.output
@@ -49,6 +58,7 @@ def test_retargeting_run_writes_real_motion_lib_and_metadata(tmp_path) -> None:
         app,
         [
             "workbench",
+            "sonic",
             "retargeting",
             "run",
             "--input-path",
@@ -91,6 +101,7 @@ def test_retargeting_respects_env_dry_run(monkeypatch, tmp_path) -> None:
         app,
         [
             "workbench",
+            "sonic",
             "retargeting",
             "run",
             "--input-path",
@@ -114,6 +125,7 @@ def test_retargeting_rejects_negative_frame_limit() -> None:
         app,
         [
             "workbench",
+            "sonic",
             "retargeting",
             "run",
             "--input-path",
@@ -130,7 +142,7 @@ def test_retargeting_rejects_negative_frame_limit() -> None:
 
 
 def test_retargeting_workflow_path() -> None:
-    result = runner.invoke(app, ["workbench", "retargeting", "workflow", "--output", "json"])
+    result = runner.invoke(app, ["workbench", "sonic", "retargeting", "workflow", "--output", "json"])
 
     assert result.exit_code == 0
     payload = json.loads(result.output)

--- a/npa/tests/cli/test_workbench_trigger_cli.py
+++ b/npa/tests/cli/test_workbench_trigger_cli.py
@@ -12,7 +12,7 @@ runner = CliRunner()
 
 
 def test_workbench_trigger_help() -> None:
-    result = runner.invoke(app, ["workbench", "trigger", "--help"])
+    result = runner.invoke(app, ["workbench", "workflow", "trigger", "--help"])
 
     assert result.exit_code == 0
     assert "retrigger Workbench workflows" in result.output
@@ -44,6 +44,7 @@ def test_workbench_trigger_run_passes_byo_endpoint_and_paths(monkeypatch) -> Non
         app,
         [
             "workbench",
+            "workflow",
             "trigger",
             "run",
             "--s3-endpoint",

--- a/npa/tests/e2e/test_sim_to_real_sonic_tools_e2e.py
+++ b/npa/tests/e2e/test_sim_to_real_sonic_tools_e2e.py
@@ -258,7 +258,7 @@ def test_e2e_workflow_yamls_cover_sim_to_real_and_sonic_contracts(
     ]
     assert sonic_docs[1]["resources"]["cloud"] == "kubernetes"
     assert sonic_docs[1]["envs"]["AWS_PROFILE"] == "nebius"
-    assert "npa workbench retargeting run" in sonic_docs[1]["run"]
+    assert "npa workbench sonic retargeting run" in sonic_docs[1]["run"]
     assert sonic_docs[2]["resources"]["accelerators"] == "H100:1"
     assert sonic_docs[2]["resources"]["use_spot"] is True
     assert sonic_docs[2]["resources"]["region"] == "eu-north1"
@@ -270,7 +270,7 @@ def test_e2e_workflow_yamls_cover_sim_to_real_and_sonic_contracts(
     assert "mujoco-eval" in sonic_docs[3]["run"]
 
     assert retarget_docs[1]["name"] == "retarget-motion"
-    assert "npa workbench retargeting run" in retarget_docs[1]["run"]
+    assert "npa workbench sonic retargeting run" in retarget_docs[1]["run"]
     assert mjlab_docs[1]["name"] == "mjlab-locomotion-eval"
     assert "npa workbench mjlab eval" in mjlab_docs[1]["run"]
     assert mjlab_docs[1]["resources"]["accelerators"] == "H100:1"
@@ -298,9 +298,9 @@ def test_e2e_cli_smoke_surfaces_for_pipeline_tools() -> None:
         ["workbench", "data", "--help"],
         ["workbench", "vlm-eval", "status", "--output", "json"],
         ["workbench", "vlm-eval", "list", "--output", "json"],
-        ["workbench", "retargeting", "status", "--output", "json"],
-        ["workbench", "retargeting", "list", "--output", "json"],
-        ["workbench", "retargeting", "workflow", "--output", "json"],
+        ["workbench", "sonic", "retargeting", "status", "--output", "json"],
+        ["workbench", "sonic", "retargeting", "list", "--output", "json"],
+        ["workbench", "sonic", "retargeting", "workflow", "--output", "json"],
         ["workbench", "mjlab", "status", "--output", "json"],
         ["workbench", "mjlab", "list", "--output", "json"],
         ["workbench", "mjlab", "workflow", "--output", "json"],

--- a/npa/tests/guardrails/test_three_tier_contract.py
+++ b/npa/tests/guardrails/test_three_tier_contract.py
@@ -59,7 +59,7 @@ CONTRACTS: tuple[CapabilityContract, ...] = (
         ),
     ),
     CapabilityContract(
-        name="retargeting/run",
+        name="sonic/retargeting/run",
         cli_module="npa.cli.workbench.retargeting",
         cli_callback="run_cmd",
         sdk_module="npa.sdk.workbench.retargeting",
@@ -164,7 +164,7 @@ CONTRACTS: tuple[CapabilityContract, ...] = (
         ),
     ),
     CapabilityContract(
-        name="trigger/run",
+        name="workflow/trigger/run",
         cli_module="npa.cli.workbench.trigger",
         cli_callback="run_cmd",
         sdk_module="npa.sdk.workbench.trigger",
@@ -208,7 +208,7 @@ CONTRACTS: tuple[CapabilityContract, ...] = (
         ),
     ),
     CapabilityContract(
-        name="trigger/watch",
+        name="workflow/trigger/watch",
         cli_module="npa.cli.workbench.trigger",
         cli_callback="watch_cmd",
         sdk_module="npa.sdk.workbench.trigger",
@@ -256,8 +256,6 @@ def test_new_workbench_tools_require_contract_or_explicit_seam() -> None:
         "lancedb",
         "lerobot",
         "mjlab",
-        "sim2real",
-        "sim2real-envgen",
         "workflow",
     }
     discovered = registered_workbench_tools()

--- a/npa/tests/unit/solutions/test_registry.py
+++ b/npa/tests/unit/solutions/test_registry.py
@@ -25,7 +25,7 @@ CONFIGURED_SOLUTIONS = [
     {
         "name": "retargeting",
         "description": "Motion retargeting Workbench tool for SONIC locomotion pipelines",
-        "cli_command": "npa workbench retargeting",
+        "cli_command": "npa workbench sonic retargeting",
     },
     {
         "name": "mjlab",

--- a/npa/tests/workflows/test_sonic_locomotion_finetuning.py
+++ b/npa/tests/workflows/test_sonic_locomotion_finetuning.py
@@ -62,7 +62,7 @@ def test_sonic_locomotion_pipeline_yaml_is_serial_and_uses_expected_tools() -> N
         "sonic-g1-finetune",
         "sonic-mujoco-eval",
     ]
-    assert "npa workbench retargeting run" in tasks[0]["run"]
+    assert "npa workbench sonic retargeting run" in tasks[0]["run"]
     assert "/entrypoint.sh finetune" in tasks[1]["run"]
     assert "mujoco-eval" in tasks[2]["run"]
 
@@ -234,7 +234,7 @@ def test_tool_yamls_match_registered_cli_surfaces() -> None:
 
     assert retarget_docs[0] == {"name": "retargeting", "execution": "serial"}
     assert retarget_docs[1]["name"] == "retarget-motion"
-    assert "npa workbench retargeting run" in retarget_docs[1]["run"]
+    assert "npa workbench sonic retargeting run" in retarget_docs[1]["run"]
     assert "accelerators" not in retarget_docs[1]["resources"]
     assert retarget_docs[1]["resources"]["image_id"] == "docker:${NPA_RETARGETING_IMAGE}"
     assert retarget_docs[1]["envs"]["NPA_RETARGETING_IMAGE"] == EXPECTED_RETARGETING_IMAGE

--- a/npa/workflows/workbench/sim2real/README.md
+++ b/npa/workflows/workbench/sim2real/README.md
@@ -48,22 +48,23 @@ export ROLLOUT_COUNT=3
 export STEPS_PER_ROLLOUT=4
 export HELDOUT_ENV_COUNT=8
 
-npa workbench sim2real run \
+npa workbench workflow submit \
+  npa/workflows/workbench/sim2real/runbook.yaml \
   --run-id "${NPA_SIM2REAL_RUN_ID}" \
-  --s3-bucket "${NPA_SIM2REAL_BUCKET}" \
-  --s3-prefix "${NPA_SIM2REAL_PREFIX}" \
-  --s3-endpoint "${AWS_ENDPOINT_URL}" \
-  --trigger-dataset-uri "${NPA_SIM2REAL_TRIGGER_DATASET_URI}" \
-  --trigger-dataset-id "${NPA_SIM2REAL_TRIGGER_DATASET_ID}" \
-  --assets-uri "${ASSETS_URI}" \
-  --scene-spec-uri "${SCENE_SPEC_URI}" \
-  --inner-iterations "${INNER_ITERATIONS}" \
-  --outer-iterations "${OUTER_ITERATIONS}" \
-  --loop-of-loops-iterations "${LOOP_OF_LOOPS_ITERATIONS}" \
-  --rollout-count "${ROLLOUT_COUNT}" \
-  --steps-per-rollout "${STEPS_PER_ROLLOUT}" \
-  --heldout-env-count "${HELDOUT_ENV_COUNT}" \
-  --upload-artifacts
+  --var NPA_SIM2REAL_RUN_ID="${NPA_SIM2REAL_RUN_ID}" \
+  --var NPA_SIM2REAL_BUCKET="${NPA_SIM2REAL_BUCKET}" \
+  --var NPA_SIM2REAL_PREFIX="${NPA_SIM2REAL_PREFIX}" \
+  --var AWS_ENDPOINT_URL="${AWS_ENDPOINT_URL}" \
+  --var NPA_SIM2REAL_TRIGGER_DATASET_URI="${NPA_SIM2REAL_TRIGGER_DATASET_URI}" \
+  --var NPA_SIM2REAL_TRIGGER_DATASET_ID="${NPA_SIM2REAL_TRIGGER_DATASET_ID}" \
+  --var ASSETS_URI="${ASSETS_URI}" \
+  --var SCENE_SPEC_URI="${SCENE_SPEC_URI}" \
+  --var INNER_ITERATIONS="${INNER_ITERATIONS}" \
+  --var OUTER_ITERATIONS="${OUTER_ITERATIONS}" \
+  --var LOOP_OF_LOOPS_ITERATIONS="${LOOP_OF_LOOPS_ITERATIONS}" \
+  --var ROLLOUT_COUNT="${ROLLOUT_COUNT}" \
+  --var STEPS_PER_ROLLOUT="${STEPS_PER_ROLLOUT}" \
+  --var HELDOUT_ENV_COUNT="${HELDOUT_ENV_COUNT}"
 ```
 
 Canonical S3 layout for the quickstart:
@@ -246,26 +247,27 @@ report = sim2real.run(
 print(report["outer_loop"]["latest_decision"])
 ```
 
-CLI:
+Workflow submit:
 
 ```bash
-npa workbench sim2real run \
+npa workbench workflow submit \
+  npa/workflows/workbench/sim2real/runbook.yaml \
   --run-id pusht-cli-demo \
-  --s3-bucket <bucket> \
-  --s3-prefix pusht-cli-demo \
-  --trigger-dataset-uri s3://<bucket>/sim2real-triggers/pusht-cli-demo/lerobot-pusht/ \
-  --trigger-dataset-id lerobot/pusht \
-  --assets-uri s3://<bucket>/sim2real-assets/pusht/ \
-  --scene-spec-uri s3://<bucket>/sim2real-assets/pusht/scene-spec.json \
-  --inner-iterations 2 \
-  --outer-iterations 1 \
-  --upload-artifacts
+  --var NPA_SIM2REAL_RUN_ID=pusht-cli-demo \
+  --var NPA_SIM2REAL_BUCKET=<bucket> \
+  --var NPA_SIM2REAL_PREFIX=pusht-cli-demo \
+  --var NPA_SIM2REAL_TRIGGER_DATASET_URI=s3://<bucket>/sim2real-triggers/pusht-cli-demo/lerobot-pusht/ \
+  --var NPA_SIM2REAL_TRIGGER_DATASET_ID=lerobot/pusht \
+  --var ASSETS_URI=s3://<bucket>/sim2real-assets/pusht/ \
+  --var SCENE_SPEC_URI=s3://<bucket>/sim2real-assets/pusht/scene-spec.json \
+  --var INNER_ITERATIONS=2 \
+  --var OUTER_ITERATIONS=1
 ```
 
-Inner loop only:
+Inner loop only (local SDK / module — no top-level workbench CLI):
 
 ```bash
-npa workbench sim2real inner-loop \
+npa/.venv/bin/python -m npa.workflows.sim2real_loop inner-loop \
   --run-id sim2real-inner-example \
   --output-dir /tmp/sim2real-inner-example \
   --inner-iterations 2

--- a/npa/workflows/workbench/sim2real/runbook.yaml
+++ b/npa/workflows/workbench/sim2real/runbook.yaml
@@ -1,8 +1,8 @@
 # Standalone Sim2Real VLM-to-RL full-loop runbook.
 #
 # This is the raw-SkyPilot tier of the three-tier example set. It is meant to be
-# read and run without npa in the loop. The SDK (sim2real.run) and CLI
-# (npa workbench sim2real run) wrap the same workflow; they do not gate it.
+# read and run without npa in the loop. The SDK (sim2real.run) and
+# `npa workbench workflow submit` wrap the same workflow; they do not gate it.
 #
 # SkyPilot 0.12.2 does NOT interpolate ${VAR} inside the YAML `envs` block or in
 # `image_id` at submission time. So every value below is a materialized literal,

--- a/npa/workflows/workbench/skypilot/retargeting.yaml
+++ b/npa/workflows/workbench/skypilot/retargeting.yaml
@@ -35,7 +35,7 @@ run: |
   export AWS_PROFILE="${AWS_PROFILE:-nebius}"
   export AWS_ENDPOINT_URL="${AWS_ENDPOINT_URL:-${S3_ENDPOINT_URL:-https://storage.eu-north1.nebius.cloud}}"
   export NEBIUS_S3_ENDPOINT="${NEBIUS_S3_ENDPOINT:-${AWS_ENDPOINT_URL}}"
-  cmd=(npa workbench retargeting run \
+  cmd=(npa workbench sonic retargeting run \
     --input-path "${INPUT_MOTION_URI}" \
     --output-path "${RETARGETED_MOTION_URI}" \
     --source-format "${SOURCE_FORMAT}" \

--- a/npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml
@@ -39,7 +39,7 @@ run: |
   export AWS_PROFILE="${AWS_PROFILE:-nebius}"
   export AWS_ENDPOINT_URL="${AWS_ENDPOINT_URL:-${S3_ENDPOINT_URL:-https://storage.eu-north1.nebius.cloud}}"
   export NEBIUS_S3_ENDPOINT="${NEBIUS_S3_ENDPOINT:-${AWS_ENDPOINT_URL}}"
-  cmd=(npa workbench retargeting run \
+  cmd=(npa workbench sonic retargeting run \
     --input-path "${INPUT_MOTION_URI}" \
     --output-path "${RETARGETED_MOTION_URI}" \
     --source-format "${SOURCE_FORMAT}" \


### PR DESCRIPTION
## Summary

- **Retargeting** moves to `npa workbench sonic retargeting …` (SONIC locomotion seam).
- **Trigger** moves to `npa workbench workflow trigger run|watch`.
- **Sim2real / sim2real-envgen / golden-eval** drop from `npa workbench --help`; sim2real is submitted via `npa workbench workflow submit npa/workflows/workbench/sim2real/runbook.yaml`.
- **`data`** stays registered with `hidden=True` for backward-compatible S3 bridge access only.
- Docs, SkyPilot YAMLs, solutions registry, guardrails, and tests updated to match.

## Test plan

- [x] `pytest npa/tests/guardrails/test_three_tier_contract.py npa/tests/cli/test_retargeting_cli.py npa/tests/cli/test_workbench_trigger_cli.py npa/tests/workflows/test_sonic_locomotion_finetuning.py` (22 passed)
- [x] `npa workbench --help` — deployable tools only (no sim2real/retargeting/trigger/golden-eval/data commands)
- [x] `npa workbench sonic --help` — lists `retargeting`
- [x] `npa workbench workflow trigger --help` — lists `run` and `watch`


Made with [Cursor](https://cursor.com)