### PR TITLE
chore: document safe remote branch cleanup candidates

### DIFF
--- a/docs/safe-branch-cleanup.md
+++ b/docs/safe-branch-cleanup.md
@@ -1,0 +1,21 @@
+# Safe Branch Cleanup Candidates
+
+Date: 2026-06-14
+
+Scope: remote branches already fully merged into `origin/main`.
+
+## Safe-to-delete candidates (pending maintainer approval)
+
+- `origin/dev-refactor-move-npa-workbench-npa`
+- `origin/dev-refactor-move-npa-workbench-npa-c226`
+
+## Safety checks used
+
+- Included only branches reported by:
+  - `git for-each-ref --format='%(refname:short)' refs/remotes/origin --merged origin/main`
+- Excluded protected/default refs:
+  - `origin/main`, `origin/HEAD`
+
+## Important
+
+No remote branches were deleted as part of this change. Deletion should happen only after PR review and explicit approval.


### PR DESCRIPTION
## Summary
- add a short note documenting remote dev branches that are fully merged into `origin/main`
- keep cleanup safe: no remote branch deletions are performed in this PR
- include clear criteria used to identify candidates

## Remote branches to review before any deletion
- `origin/dev-refactor-move-npa-workbench-npa`
- `origin/dev-refactor-move-npa-workbench-npa-c226`

## Test plan
- [x] verify candidates were derived from `git for-each-ref ... --merged origin/main`
- [x] verify protected refs (`origin/main`, `origin/HEAD`) are excluded
- [x] confirm this PR performs documentation-only changes

Made with [Cursor](https://cursor.com)