### PR TITLE
feat(sim2real): Isaac held-out Rerun capture with dual URL serve

### DIFF
--- a/npa/src/npa/cli/workbench/sim2real.py
+++ b/npa/src/npa/cli/workbench/sim2real.py
@@ -26,6 +26,15 @@ from npa.workflows.sim2real_loop import (
     run_full_loop,
     run_inner_loop,
 )
+from npa.workflows.sim2real_loop import build_config_from_env
+from npa.workflows.sim2real_rerun_regen import (
+    Sim2RealRerunRegenError,
+    default_regen_local_dir,
+    download_rrd_from_s3,
+    regen_sim2real_rrd,
+    rerun_heldout_eval_only,
+    resolve_local_rrd_path,
+)
 from npa.workflows.sim2real_rerun_serve import (
     DEFAULT_NAMESPACE,
     DEFAULT_PORT,
@@ -384,20 +393,25 @@ def _emit_rerun_serve_result(payload: dict, *, output: OutputFormat) -> None:
     typer.echo(f"rrd_s3_uri: {payload['rrd_s3_uri']}")
     if payload.get("public_url"):
         typer.echo(f"public_url: {payload['public_url']}")
-        return
-    service_type = str(payload.get("service_type", "")).strip().lower()
-    if service_type in {"loadbalancer", "lb"}:
-        deployment = payload.get("deployment_name", "npa-sim2real-rerun")
-        namespace = payload.get("namespace", DEFAULT_NAMESPACE)
-        typer.echo(
-            "public_url: pending — LoadBalancer external IP not assigned yet. "
-            "Wait and re-run serve, or inspect cluster networking (for example "
-            f"`kubectl describe svc {deployment} -n {namespace}` for quota or cloud-controller errors).",
-            err=True,
-        )
-        return
-    typer.echo(f"cluster_url: {payload['cluster_url']}")
-    typer.echo(f"port_forward: {payload['port_forward_command']}")
+    else:
+        service_type = str(payload.get("service_type", "")).strip().lower()
+        if service_type in {"loadbalancer", "lb"}:
+            deployment = payload.get("deployment_name", "npa-sim2real-rerun")
+            namespace = payload.get("namespace", DEFAULT_NAMESPACE)
+            typer.echo(
+                "public_url: pending — LoadBalancer external IP not assigned yet. "
+                "Wait and re-run serve, or inspect cluster networking (for example "
+                f"`kubectl describe svc {deployment} -n {namespace}` for quota or cloud-controller errors).",
+                err=True,
+            )
+    if payload.get("local_url"):
+        typer.echo(f"local_url: {payload['local_url']}")
+    if payload.get("port_forward_command"):
+        typer.echo(f"port_forward: {payload['port_forward_command']}")
+    if payload.get("local_rrd_path"):
+        typer.echo(f"local_rrd_path: {payload['local_rrd_path']}")
+    if not payload.get("public_url") and not payload.get("local_url"):
+        typer.echo(f"cluster_url: {payload['cluster_url']}")
 
 
 def _rerun_serve_credentials() -> tuple[str, str]:
@@ -462,6 +476,16 @@ def rerun_serve_command(
         help="When used with --destroy, wait for Kubernetes to confirm resource deletion.",
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print the Kubernetes manifest only."),
+    local_record: bool = typer.Option(
+        False,
+        "--local-record",
+        help="Also download reports/sim2real.rrd to disk (LOCAL_RRD_PATH or /tmp/sim2real-regen/<run-id>/reports/sim2real.rrd).",
+    ),
+    local_rrd_path: Optional[Path] = typer.Option(
+        None,
+        "--local-rrd-path",
+        help="Override local .rrd destination when using --local-record.",
+    ),
     output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
 ) -> None:
     """Deploy a hosted Rerun viewer; pod init container pulls reports/sim2real.rrd from S3."""
@@ -514,4 +538,136 @@ def rerun_serve_command(
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(1) from exc
 
-    _emit_rerun_serve_result(result.to_dict(), output=output)
+    payload = result.to_dict()
+    if local_record and not destroy:
+        loop_config = build_config_from_env(
+            run_id=run_id,
+            s3_bucket=s3_bucket,
+            s3_prefix=s3_prefix,
+            s3_endpoint=s3_endpoint,
+        )
+        dest = resolve_local_rrd_path(
+            run_id,
+            override=str(local_rrd_path) if local_rrd_path is not None else "",
+        )
+        try:
+            download_rrd_from_s3(loop_config, dest_path=dest)
+        except Sim2RealRerunRegenError as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(1) from exc
+        payload["local_rrd_path"] = str(dest)
+
+    _emit_rerun_serve_result(payload, output=output)
+
+
+@rerun_app.command("regen")
+def rerun_regen_command(
+    run_id: str = typer.Option(..., "--run-id", help="Completed Sim2Real run id."),
+    project: str = typer.Option("", "--project", "-p", help="Project alias for storage resolution."),
+    s3_bucket: str = typer.Option("", "--s3-bucket", help="S3 bucket override."),
+    s3_prefix: str = typer.Option(DEFAULT_S3_PREFIX, "--s3-prefix", help="S3 prefix parent for runs."),
+    s3_endpoint: str = typer.Option("", "--s3-endpoint", help="S3-compatible endpoint override."),
+    local_dir: Optional[Path] = typer.Option(
+        None,
+        "--local-dir",
+        help="Working directory for synced artifacts (default: /tmp/sim2real-regen/<run-id>).",
+    ),
+    local_rrd_path: Optional[Path] = typer.Option(
+        None,
+        "--local-rrd-path",
+        help="Destination .rrd path (default: LOCAL_RRD_PATH or <local-dir>/reports/sim2real.rrd).",
+    ),
+    upload: bool = typer.Option(
+        True,
+        "--upload/--no-upload",
+        help="Upload regenerated reports/sim2real.rrd (and held-out artifacts) to S3.",
+    ),
+    no_sync: bool = typer.Option(
+        False,
+        "--no-sync",
+        help="Skip S3 download; use artifacts already under --local-dir.",
+    ),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Regenerate reports/sim2real.rrd locally from S3 artifacts (held-out PNG sync included)."""
+    try:
+        config = build_config_from_env(
+            run_id=run_id,
+            s3_bucket=s3_bucket,
+            s3_prefix=s3_prefix,
+            s3_endpoint=s3_endpoint,
+        )
+        work_dir = local_dir or default_regen_local_dir(run_id)
+        result = regen_sim2real_rrd(
+            config,
+            local_dir=work_dir,
+            local_rrd_path=local_rrd_path,
+            upload=upload,
+            sync_inputs=not no_sync,
+        )
+    except Sim2RealRerunRegenError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    payload = result.to_dict()
+    if output == OutputFormat.json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"local_rrd_path: {payload['local_rrd_path']}")
+    typer.echo(f"heldout_frame_count: {payload['heldout_frame_count']}")
+    if payload.get("upload_uri"):
+        typer.echo(f"upload_uri: {payload['upload_uri']}")
+
+
+@rerun_app.command("heldout-only")
+def rerun_heldout_only_command(
+    run_id: str = typer.Option(..., "--run-id", help="Existing Sim2Real run id."),
+    project: str = typer.Option("", "--project", "-p", help="Project alias for storage resolution."),
+    s3_bucket: str = typer.Option("", "--s3-bucket", help="S3 bucket override."),
+    s3_prefix: str = typer.Option(DEFAULT_S3_PREFIX, "--s3-prefix", help="S3 prefix parent for runs."),
+    s3_endpoint: str = typer.Option("", "--s3-endpoint", help="S3-compatible endpoint override."),
+    local_dir: Optional[Path] = typer.Option(
+        None,
+        "--local-dir",
+        help="Local working directory (default: /tmp/sim2real-regen/<run-id>).",
+    ),
+    outer_iteration: int = typer.Option(1, "--outer-iteration", help="Outer loop index for stage 10."),
+    no_publish: bool = typer.Option(
+        False,
+        "--no-publish",
+        help="Skip uploading held-out report/renders to the run prefix on S3.",
+    ),
+    output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
+) -> None:
+    """Re-run Isaac held-out eval (stage 10) on cluster for an existing run (~5–15 min)."""
+    try:
+        config = build_config_from_env(
+            run_id=run_id,
+            s3_bucket=s3_bucket,
+            s3_prefix=s3_prefix,
+            s3_endpoint=s3_endpoint,
+        )
+        work_dir = local_dir or default_regen_local_dir(run_id)
+        report = rerun_heldout_eval_only(
+            config,
+            local_dir=work_dir,
+            outer_iteration=outer_iteration,
+            publish=not no_publish,
+        )
+    except Sim2RealRerunRegenError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    payload = {
+        "run_id": run_id,
+        "success_rate": report.get("success_rate"),
+        "render_manifest_episodes": len((report.get("render_manifest") or {}).get("episodes") or []),
+        "sim_backend": report.get("sim_backend"),
+        "rollout_backend": report.get("rollout_backend"),
+    }
+    if output == OutputFormat.json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"run_id: {run_id}")
+    typer.echo(f"success_rate: {payload['success_rate']}")
+    typer.echo(f"render_manifest_episodes: {payload['render_manifest_episodes']}")

--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -97,6 +97,9 @@ from npa.workflows.sim2real.utils import (
 
 # Isaac Sim app handle — closed only after held-out report upload.
 _ISAAC_SIMULATION_APP: Any = None
+HELDOUT_VIZ_CAMERA_NAME = "heldout_viz_camera"
+DEFAULT_HELDOUT_RENDER_FRAMES = 8
+SCHEMA_HELDOUT_RENDERS = "npa.sim2real.heldout_renders.v1"
 # Per-run sibling source tarball (Isaac held-out eval cannot git-clone inside Isaac Sim).
 _SIBLING_SOURCE_TARBALL_BY_RUN: dict[str, str] = {}
 
@@ -589,6 +592,8 @@ def run_finalize(
                     ),
                     {
                         "public_url": rerun_serve.get("public_url", ""),
+                        "local_url": rerun_serve.get("local_url", ""),
+                        "port_forward_command": rerun_serve.get("port_forward_command", ""),
                         "deployment_name": rerun_serve.get("deployment_name", ""),
                     },
                 )
@@ -691,9 +696,10 @@ def _run_sim2real_viz_stage(
             "WORKS",
             (
                 f"Wrote Rerun recording with {result.rollout_count} rollout(s), "
-                f"{result.frame_count} camera frame(s), and {result.heldout_env_count} "
-                "held-out env score(s); camera streams, VLM critiques, RL signal, and "
-                "held-out scores are logged."
+                f"{result.frame_count} policy camera frame(s), "
+                f"{result.heldout_frame_count} held-out sim frame(s), and "
+                f"{result.heldout_env_count} held-out env score(s); camera streams, "
+                "VLM critiques, RL signal, and held-out scores are logged."
             ),
             {"rrd": str(rrd_path)},
         ),
@@ -3032,6 +3038,11 @@ def run_heldout_eval(
                 threshold=config.threshold,
                 sim_backend=local_backend,
                 isaac_task=config.isaac_task,
+                renders_dir=(
+                    output_dir / "renders"
+                    if local_backend == SIM_BACKEND_ISAAC
+                    else None
+                ),
             )
         else:
             payload = _reference_heldout_payload(
@@ -3174,6 +3185,8 @@ def _normalize_heldout_report(
     if "robot_provenance" in payload:
         report["robot_provenance"] = payload["robot_provenance"]
         report["robot_fallback_used"] = bool(payload.get("robot_fallback_used", False))
+    if payload.get("render_manifest"):
+        report["render_manifest"] = payload["render_manifest"]
     return report
 
 
@@ -3407,9 +3420,30 @@ def run_heldout_eval_component_from_s3(
             robot=robot,
             sim_backend=sim_backend,
             isaac_task=isaac_task,
+            renders_dir=(
+                root / "heldout-renders"
+                if sim_backend == SIM_BACKEND_ISAAC
+                else None
+            ),
         )
         _write_json_artifact(output_path, payload)
         client.upload_file(str(output_path), output_uri)
+        render_manifest = payload.get("render_manifest") or {}
+        if render_manifest.get("episodes"):
+            renders_dir = root / "heldout-renders"
+            renders_prefix = _sibling_uri(output_uri, "renders")
+            for frame_path in sorted(renders_dir.rglob("*.png")):
+                relative = frame_path.relative_to(renders_dir).as_posix()
+                client.upload_file(
+                    str(frame_path),
+                    f"{renders_prefix.rstrip('/')}/{relative}",
+                )
+            manifest_path = root / "render-manifest.json"
+            _write_json_artifact(manifest_path, render_manifest)
+            client.upload_file(
+                str(manifest_path),
+                _sibling_uri(output_uri, "render-manifest.json"),
+            )
         if scene is not None:
             spec_path = root / "consumed-scene-spec.json"
             _write_json_artifact(spec_path, scene.provenance_block())
@@ -3707,6 +3741,7 @@ def _component_heldout_payload(
     robot: Any = None,
     sim_backend: str = DEFAULT_SIM_BACKEND,
     isaac_task: str = DEFAULT_ISAAC_TASK,
+    renders_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Run the held-out rollout on the selected backend and shape report.json.
 
@@ -3725,6 +3760,7 @@ def _component_heldout_payload(
             scene=scene,
             robot=robot,
             isaac_task=isaac_task,
+            renders_dir=renders_dir,
         )
         payload = {
             "schema": SCHEMA_HELDOUT_REPORT,
@@ -3774,6 +3810,14 @@ def _component_heldout_payload(
             )
         payload["asset_provenance"] = provenance
         payload["asset_fallback_used"] = provenance["asset_fallback_used"]
+    if renders_dir is not None:
+        manifest = _build_heldout_render_manifest(
+            renders_dir,
+            sim_backend=sim_backend,
+            isaac_task=isaac_task,
+        )
+        if manifest.get("episodes"):
+            payload["render_manifest"] = manifest
     return payload
 
 
@@ -4199,6 +4243,162 @@ def _isaac_adapter_actions(action_dim: int, adapter: dict[str, Any], *, n_envs: 
     return torch.clamp(actions, -1.0, 1.0)
 
 
+
+def _heldout_render_frames_enabled() -> bool:
+    return _bool_value(os.environ.get("NPA_SIM2REAL_HELDOUT_RENDER_FRAMES", "1"))
+
+
+def _heldout_render_step_indices(
+    max_steps: int,
+    *,
+    max_frames: int = DEFAULT_HELDOUT_RENDER_FRAMES,
+) -> set[int]:
+    if max_steps <= 0 or max_frames <= 0:
+        return set()
+    if max_steps <= max_frames:
+        return set(range(max_steps))
+    stride = max(1, max_steps // max_frames)
+    indices = list(range(0, max_steps, stride))
+    if indices[-1] != max_steps - 1:
+        indices.append(max_steps - 1)
+    if len(indices) > max_frames:
+        keep = {0, max_steps - 1}
+        middle = indices[1:-1]
+        pick_stride = max(1, len(middle) // max(1, max_frames - len(keep)))
+        keep.update(middle[::pick_stride])
+        indices = sorted(keep)
+        while len(indices) > max_frames:
+            indices.pop(len(indices) // 2)
+    return set(indices)
+
+
+def _attach_isaac_viz_camera(env_cfg: Any) -> None:
+    import isaaclab.sim as sim_utils
+
+    try:
+        from isaaclab.sensors import TiledCameraCfg as _CameraCfg
+    except ImportError:  # pragma: no cover
+        from isaaclab.sensors import CameraCfg as _CameraCfg
+
+    camera_cfg = _CameraCfg(
+        prim_path="{ENV_REGEX_NS}/HeldoutVizCamera",
+        offset=_CameraCfg.OffsetCfg(
+            pos=(1.35, 1.05, 0.95),
+            rot=(0.8829, 0.0, 0.4695, 0.0),
+            convention="world",
+        ),
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=24.0,
+            focus_distance=400.0,
+            horizontal_aperture=20.955,
+            clipping_range=(0.1, 20.0),
+        ),
+        width=128,
+        height=128,
+    )
+    setattr(env_cfg.scene, HELDOUT_VIZ_CAMERA_NAME, camera_cfg)
+
+
+def _isaac_extract_rgb_frame(env: Any, *, env_index: int = 0) -> Any:
+    import numpy as np
+
+    unwrapped = getattr(env, "unwrapped", env)
+    scene = getattr(unwrapped, "scene", None)
+    if scene is None:
+        return None
+    camera = None
+    for name in (HELDOUT_VIZ_CAMERA_NAME, "tiled_camera"):
+        try:
+            camera = scene[name]
+            break
+        except (KeyError, TypeError, AttributeError):
+            continue
+    if camera is None:
+        sensors = getattr(scene, "sensors", None)
+        if sensors is not None:
+            for name in (HELDOUT_VIZ_CAMERA_NAME, "tiled_camera"):
+                try:
+                    camera = sensors[name]
+                    break
+                except (KeyError, TypeError, AttributeError):
+                    continue
+    if camera is None:
+        return None
+    output = getattr(getattr(camera, "data", None), "output", None)
+    if not output or "rgb" not in output:
+        return None
+    rgb = output["rgb"]
+    if hasattr(rgb, "detach"):
+        rgb = rgb.detach()
+    if hasattr(rgb, "cpu"):
+        rgb = rgb.cpu()
+    array = np.asarray(rgb)
+    if array.ndim == 4:
+        array = array[env_index]
+    if array.ndim != 3 or array.shape[-1] < 3:
+        return None
+    frame = array[..., :3]
+    if frame.dtype != np.uint8:
+        frame = np.clip(frame, 0, 255).astype(np.uint8)
+    return np.ascontiguousarray(frame)
+
+
+def _write_render_png(path: Path, frame: Any) -> None:
+    import struct
+    import zlib
+
+    import numpy as np
+
+    array = np.asarray(frame, dtype=np.uint8)
+    height, width = int(array.shape[0]), int(array.shape[1])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    raw = bytearray()
+    for row in range(height):
+        raw.append(0)
+        raw.extend(array[row].tobytes())
+
+    def _chunk(tag: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack("!I", len(payload))
+            + tag
+            + payload
+            + struct.pack("!I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+        )
+
+    header = struct.pack("!IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", header)
+    png += _chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+    png += _chunk(b"IEND", b"")
+    path.write_bytes(png)
+
+
+def _build_heldout_render_manifest(
+    renders_dir: Path,
+    *,
+    sim_backend: str,
+    isaac_task: str = "",
+) -> dict[str, Any]:
+    episodes: list[dict[str, Any]] = []
+    if renders_dir.is_dir():
+        for env_dir in sorted(path for path in renders_dir.iterdir() if path.is_dir()):
+            frames = sorted(env_dir.glob("camera-*.png"))
+            if not frames:
+                continue
+            episodes.append(
+                {
+                    "env_id": env_dir.name,
+                    "frames": [frame.name for frame in frames],
+                }
+            )
+    return {
+        "schema": SCHEMA_HELDOUT_RENDERS,
+        "sim_backend": sim_backend,
+        "isaac_task": isaac_task,
+        "episodes": episodes,
+    }
+
 def _run_isaac_heldout_rollouts(
     envs: list[dict[str, Any]],
     *,
@@ -4207,6 +4407,7 @@ def _run_isaac_heldout_rollouts(
     scene: Any = None,
     robot: Any = None,
     isaac_task: str = DEFAULT_ISAAC_TASK,
+    renders_dir: Path | None = None,
 ) -> list[dict[str, Any]]:
     """Run the adapter policy through headless Isaac Lab held-out episodes.
 
@@ -4227,7 +4428,14 @@ def _run_isaac_heldout_rollouts(
             f"Isaac rollout eval requires isaaclab/Isaac Sim in the image: {exc}"
         ) from exc
 
-    simulation_app = AppLauncher(headless=True).app
+    capture_renders = renders_dir is not None and _heldout_render_frames_enabled()
+    if capture_renders:
+        renders_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        launcher = AppLauncher(headless=True, enable_cameras=capture_renders)
+    except TypeError:  # pragma: no cover
+        launcher = AppLauncher(headless=True)
+    simulation_app = launcher.app
     # Isaac Sim's SimulationApp.close() hard-terminates the process, so it must
     # NOT be called here (the held-out report has to be uploaded first). The
     # handle is stashed and closed by the component entrypoint after upload.
@@ -4312,12 +4520,17 @@ def _run_isaac_heldout_rollouts(
     max_steps = max(1, int(os.environ.get("NPA_SIM2REAL_ISAAC_MAX_STEPS", "120")))
     reward_norm = float(os.environ.get("NPA_SIM2REAL_ISAAC_REWARD_NORM", "20.0"))
     success_dist = float(os.environ.get("NPA_SIM2REAL_ISAAC_SUCCESS_DIST", "0.05"))
+    render_steps = (
+        _heldout_render_step_indices(max_steps) if capture_renders else set()
+    )
     per_env: list[dict[str, Any]] = []
     for start in range(0, len(envs), batch_size):
         batch = envs[start : start + batch_size]
         seed = int(batch[0].get("seed") or (42 + start))
         torch.manual_seed(seed)
         env_cfg = parse_env_cfg(isaac_task, device=device, num_envs=len(batch))
+        if capture_renders and start == 0:
+            _attach_isaac_viz_camera(env_cfg)
         if usd_override:
             _set_isaac_object_usd(env_cfg, usd_override, scale=manip_scale)
         if robot_usd_override:
@@ -4328,11 +4541,27 @@ def _run_isaac_heldout_rollouts(
         n = len(batch)
         max_reward = torch.full((n,), -1.0e9, device=device)
         final_distance = torch.full((n,), 1.0e9, device=device)
+        if capture_renders and start == 0 and 0 in render_steps:
+            frame = _isaac_extract_rgb_frame(env, env_index=0)
+            if frame is not None:
+                env_id = str(batch[0].get("env_id") or "heldout-0000")
+                _write_render_png(
+                    renders_dir / env_id / "camera-000.png",
+                    frame,
+                )
         for step in range(max_steps):
             actions = _isaac_adapter_actions(
                 action_dim, adapter, n_envs=n, step=step, device=device
             )
             obs, reward, terminated, truncated, _ = env.step(actions)
+            if capture_renders and start == 0 and (step + 1) in render_steps:
+                frame = _isaac_extract_rgb_frame(env, env_index=0)
+                if frame is not None:
+                    env_id = str(batch[0].get("env_id") or "heldout-0000")
+                    _write_render_png(
+                        renders_dir / env_id / f"camera-{step + 1:03d}.png",
+                        frame,
+                    )
             reward_t = torch.as_tensor(reward, device=device, dtype=torch.float32).reshape(-1)
             max_reward = torch.maximum(max_reward, reward_t)
             final_distance = _isaac_goal_distance(env.unwrapped).reshape(-1).detach()

--- a/npa/src/npa/workflows/sim2real_rerun_regen.py
+++ b/npa/src/npa/workflows/sim2real_rerun_regen.py
@@ -1,0 +1,361 @@
+"""Regenerate Sim2Real Rerun recordings and optionally re-run held-out Isaac capture."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from npa.clients.storage import StorageClient, StorageError
+from npa.workflows.sim2real.models import Sim2RealLoopConfig
+from npa.workflows.sim2real.utils import _artifact_root_uri
+from npa.workflows.sim2real_viz import Sim2RealVizResult, emit_sim2real_rerun
+
+
+class Sim2RealRerunRegenError(ValueError):
+    """Raised when regen sync, held-out rerun, or .rrd emission fails."""
+
+
+DEFAULT_REGEN_ROOT = Path("/tmp/sim2real-regen")
+
+
+@dataclass(frozen=True)
+class RegenResult:
+    run_id: str
+    local_dir: str
+    local_rrd_path: str
+    upload_uri: str
+    heldout_frame_count: int
+    rollout_count: int
+    frame_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "local_dir": self.local_dir,
+            "local_rrd_path": self.local_rrd_path,
+            "upload_uri": self.upload_uri,
+            "heldout_frame_count": self.heldout_frame_count,
+            "rollout_count": self.rollout_count,
+            "frame_count": self.frame_count,
+        }
+
+
+def resolve_local_rrd_path(
+    run_id: str,
+    *,
+    override: str = "",
+    local_dir: Path | None = None,
+) -> Path:
+    """Return the on-disk .rrd path (LOCAL_RRD_PATH env or run-scoped default)."""
+
+    explicit = (override or os.environ.get("LOCAL_RRD_PATH", "")).strip()
+    if explicit:
+        return Path(explicit)
+    if local_dir is not None:
+        return local_dir / "reports" / "sim2real.rrd"
+    return DEFAULT_REGEN_ROOT / run_id / "reports" / "sim2real.rrd"
+
+
+def default_regen_local_dir(run_id: str, *, override: str = "") -> Path:
+    explicit = (override or os.environ.get("NPA_SIM2REAL_REGEN_LOCAL_DIR", "")).strip()
+    if explicit:
+        return Path(explicit)
+    return DEFAULT_REGEN_ROOT / run_id
+
+
+def run_prefix_uri(config: Sim2RealLoopConfig) -> str:
+    return f"{_artifact_root_uri(config).rstrip('/')}/"
+
+
+def _sibling_uri(uri: str, filename: str) -> str:
+    base = uri.rsplit("/", 1)[0] if "/" in uri else uri
+    return f"{base.rstrip('/')}/{filename}"
+
+
+def _storage_client_for_config(config: Sim2RealLoopConfig) -> StorageClient:
+    from npa.workflows.sim2real.engine import _storage_client
+
+    return _storage_client(config)
+
+
+def _list_common_prefixes(client: StorageClient, prefix_uri: str) -> list[str]:
+    bucket, prefix = _parse_s3(prefix_uri)
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    paginator = client._s3.get_paginator("list_objects_v2")
+    names: list[str] = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/"):
+        for item in page.get("CommonPrefixes", []) or []:
+            names.append(str(item.get("Prefix", "")))
+    return [name for name in names if name]
+
+
+def _parse_s3(uri: str) -> tuple[str, str]:
+    from npa.clients.storage import _parse_bucket_uri
+
+    return _parse_bucket_uri(uri)
+
+
+def _download_if_exists(client: StorageClient, uri: str, local_path: Path) -> bool:
+    try:
+        client.download_path(uri, str(local_path))
+    except (StorageError, OSError):
+        return False
+    return local_path.exists() and local_path.stat().st_size > 0
+
+
+def sync_regen_inputs(
+    config: Sim2RealLoopConfig,
+    local_dir: Path,
+    *,
+    client: StorageClient | None = None,
+) -> None:
+    """Download artifacts required for emit_sim2real_rerun from the run prefix."""
+
+    storage = client or _storage_client_for_config(config)
+    prefix = run_prefix_uri(config)
+    local_dir = Path(local_dir)
+    local_dir.mkdir(parents=True, exist_ok=True)
+
+    singles = {
+        "inner_loop/outer-01/evidence.json": local_dir / "inner_loop/outer-01/evidence.json",
+        "eval/heldout/report.json": local_dir / "eval/heldout/report.json",
+    }
+    for rel, dest in singles.items():
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        _download_if_exists(storage, f"{prefix}{rel}", dest)
+
+    for rel in ("actions", "vlm_eval", "training_signal"):
+        try:
+            storage.download_directory(f"{prefix}{rel}/", str(local_dir / rel))
+        except (StorageError, OSError):
+            pass
+
+    heldout_report: dict[str, Any] = {}
+    heldout_path = local_dir / "eval" / "heldout/report.json"
+    if heldout_path.is_file():
+        heldout_report = json.loads(heldout_path.read_text(encoding="utf-8"))
+    sync_heldout_renders(config, local_dir, heldout_report=heldout_report, client=storage)
+
+
+def sync_heldout_renders(
+    config: Sim2RealLoopConfig,
+    local_dir: Path,
+    *,
+    heldout_report: dict[str, Any] | None = None,
+    client: StorageClient | None = None,
+) -> bool:
+    """Sync held-out PNG tree into local_dir/eval/heldout/renders; return True if any PNGs."""
+
+    storage = client or _storage_client_for_config(config)
+    prefix = run_prefix_uri(config)
+    renders_dir = Path(local_dir) / "eval" / "heldout" / "renders"
+    renders_dir.mkdir(parents=True, exist_ok=True)
+
+    canonical = f"{prefix}eval/heldout/renders/"
+    try:
+        storage.download_directory(canonical, str(renders_dir))
+    except (StorageError, OSError):
+        pass
+    if _has_camera_pngs(renders_dir):
+        return True
+
+    component_root = f"{prefix}component-io/heldout-eval/"
+    bucket, _ = _parse_s3(component_root)
+    prefixes = sorted(_list_common_prefixes(storage, component_root))
+    for component_prefix in reversed(prefixes):
+        sibling_renders = f"s3://{bucket}/{component_prefix}output/renders/"
+        try:
+            storage.download_directory(sibling_renders, str(renders_dir))
+        except (StorageError, OSError):
+            continue
+        if _has_camera_pngs(renders_dir):
+            manifest_uri = f"s3://{bucket}/{component_prefix}output/render-manifest.json"
+            manifest_path = Path(local_dir) / "eval" / "heldout" / "render-manifest.sibling.json"
+            if _download_if_exists(storage, manifest_uri, manifest_path) and heldout_report is not None:
+                report_path = Path(local_dir) / "eval" / "heldout/report.json"
+                if report_path.is_file():
+                    report = json.loads(report_path.read_text(encoding="utf-8"))
+                else:
+                    report = dict(heldout_report or {})
+                report["render_manifest"] = json.loads(manifest_path.read_text(encoding="utf-8"))
+                report_path.parent.mkdir(parents=True, exist_ok=True)
+                report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            return True
+    return _has_camera_pngs(renders_dir)
+
+
+def _has_camera_pngs(renders_dir: Path) -> bool:
+    return any(renders_dir.rglob("camera-*.png"))
+
+
+def download_rrd_from_s3(
+    config: Sim2RealLoopConfig,
+    *,
+    dest_path: Path,
+    client: StorageClient | None = None,
+) -> Path:
+    """Download reports/sim2real.rrd for a run to dest_path."""
+
+    storage = client or _storage_client_for_config(config)
+    uri = f"{run_prefix_uri(config)}reports/sim2real.rrd"
+    dest_path = Path(dest_path)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    if not _download_if_exists(storage, uri, dest_path):
+        raise Sim2RealRerunRegenError(f"Rerun recording not found at {uri}")
+    return dest_path
+
+
+def publish_regen_outputs(
+    config: Sim2RealLoopConfig,
+    local_dir: Path,
+    *,
+    client: StorageClient | None = None,
+) -> str:
+    """Upload regenerated held-out report/renders and .rrd back to the run prefix."""
+
+    storage = client or _storage_client_for_config(config)
+    prefix = run_prefix_uri(config)
+    local_dir = Path(local_dir)
+
+    report_path = local_dir / "eval" / "heldout/report.json"
+    if report_path.is_file():
+        storage.upload_file(str(report_path), f"{prefix}eval/heldout/report.json")
+
+    renders_dir = local_dir / "eval" / "heldout/renders"
+    if renders_dir.is_dir() and _has_camera_pngs(renders_dir):
+        storage.upload_directory(str(renders_dir), f"{prefix}eval/heldout/renders")
+
+    rrd_path = local_dir / "reports" / "sim2real.rrd"
+    if not rrd_path.is_file():
+        raise Sim2RealRerunRegenError(f"missing regenerated recording: {rrd_path}")
+    upload_uri = storage.upload_file(str(rrd_path), f"{prefix}reports/sim2real.rrd")
+    return upload_uri
+
+
+def regen_sim2real_rrd(
+    config: Sim2RealLoopConfig,
+    *,
+    local_dir: Path | None = None,
+    local_rrd_path: Path | None = None,
+    upload: bool = False,
+    sync_inputs: bool = True,
+    client: StorageClient | None = None,
+) -> RegenResult:
+    """Sync artifacts (optional), emit .rrd locally, optionally upload to S3."""
+
+    work_dir = Path(local_dir) if local_dir is not None else default_regen_local_dir(config.run_id)
+    output_rrd = (
+        Path(local_rrd_path)
+        if local_rrd_path is not None
+        else resolve_local_rrd_path(config.run_id, local_dir=work_dir)
+    )
+    storage = client or _storage_client_for_config(config)
+
+    if sync_inputs:
+        sync_regen_inputs(config, work_dir, client=storage)
+
+    inner_path = work_dir / "inner_loop/outer-01/evidence.json"
+    heldout_path = work_dir / "eval/heldout/report.json"
+    if not inner_path.is_file():
+        raise Sim2RealRerunRegenError(f"missing inner evidence: {inner_path}")
+    if not heldout_path.is_file():
+        raise Sim2RealRerunRegenError(f"missing held-out report: {heldout_path}")
+
+    inner_evidence = json.loads(inner_path.read_text(encoding="utf-8"))
+    heldout_report = json.loads(heldout_path.read_text(encoding="utf-8"))
+    result = emit_sim2real_rerun(
+        local_dir=work_dir,
+        inner_evidence=inner_evidence,
+        heldout_report=heldout_report,
+        output_rrd=output_rrd,
+    )
+    upload_uri = ""
+    if upload:
+        upload_uri = publish_regen_outputs(config, work_dir, client=storage)
+    return _regen_result_from_viz(config.run_id, work_dir, result, upload_uri=upload_uri)
+
+
+def rerun_heldout_eval_only(
+    config: Sim2RealLoopConfig,
+    *,
+    local_dir: Path | None = None,
+    outer_iteration: int = 1,
+    publish: bool = True,
+    client: StorageClient | None = None,
+) -> dict[str, Any]:
+    """Re-run stage 10 Isaac held-out eval on cluster for an existing run."""
+
+    from npa.workflows.sim2real.engine import run_heldout_eval
+
+    work_dir = Path(local_dir) if local_dir is not None else default_regen_local_dir(config.run_id)
+    storage = client or _storage_client_for_config(config)
+    prefix = run_prefix_uri(config)
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        storage.download_directory(f"{prefix}envs/heldout/", str(work_dir / "envs" / "heldout"))
+    except (StorageError, OSError) as exc:
+        raise Sim2RealRerunRegenError(
+            f"failed to sync envs/heldout for {config.run_id}: {exc}"
+        ) from exc
+
+    inner_path = work_dir / "inner_loop/outer-01/evidence.json"
+    inner_path.parent.mkdir(parents=True, exist_ok=True)
+    if not _download_if_exists(storage, f"{prefix}inner_loop/outer-01/evidence.json", inner_path):
+        raise Sim2RealRerunRegenError(f"missing inner evidence at {prefix}inner_loop/outer-01/evidence.json")
+
+    inner_evidence = json.loads(inner_path.read_text(encoding="utf-8"))
+    report = run_heldout_eval(
+        config,
+        local_dir=work_dir,
+        inner_evidence=inner_evidence,
+        outer_iteration=outer_iteration,
+    )
+
+    invocation = report.get("component_invocation") or {}
+    output_uri = str(invocation.get("output_uri") or "").strip()
+    renders_dir = work_dir / "eval" / "heldout" / "renders"
+    renders_dir.mkdir(parents=True, exist_ok=True)
+    if output_uri:
+        try:
+            storage.download_directory(_sibling_uri(output_uri, "renders/"), str(renders_dir))
+        except (StorageError, OSError):
+            sync_heldout_renders(config, work_dir, heldout_report=report, client=storage)
+    else:
+        sync_heldout_renders(config, work_dir, heldout_report=report, client=storage)
+
+    if not _has_camera_pngs(renders_dir):
+        raise Sim2RealRerunRegenError(
+            "held-out rerun completed but no camera-*.png renders were synced; "
+            "check NPA_SIM2REAL_HELDOUT_RENDER_FRAMES=1 and Isaac sibling logs"
+        )
+
+    if publish:
+        publish_regen_outputs(config, work_dir, client=storage)
+    return report
+
+
+def _regen_result_from_viz(
+    run_id: str,
+    local_dir: Path,
+    result: Sim2RealVizResult,
+    *,
+    upload_uri: str = "",
+) -> RegenResult:
+    if result.heldout_frame_count <= 0:
+        raise Sim2RealRerunRegenError(
+            "regenerated .rrd has heldout_frame_count=0; sync eval/heldout/renders or rerun held-out eval"
+        )
+    return RegenResult(
+        run_id=run_id,
+        local_dir=str(local_dir),
+        local_rrd_path=result.output_rrd_path,
+        upload_uri=upload_uri,
+        heldout_frame_count=result.heldout_frame_count,
+        rollout_count=result.rollout_count,
+        frame_count=result.frame_count,
+    )

--- a/npa/src/npa/workflows/sim2real_rerun_serve.py
+++ b/npa/src/npa/workflows/sim2real_rerun_serve.py
@@ -26,6 +26,8 @@ DEFAULT_PORT = 9090
 # Rerun web viewer binds here; nginx sidecar exposes DEFAULT_PORT with cache headers.
 RERUN_INTERNAL_WEB_PORT = 9091
 DEFAULT_GRPC_PORT = 9876
+# Browser gRPC origin for kubectl port-forward (must match forwarded local ports).
+DEFAULT_LOCAL_VIEWER_HOST = "127.0.0.1"
 DEFAULT_NGINX_IMAGE = "nginx:1.27-alpine"
 # Browser-cache static wasm/js (~40 MiB) so refresh does not re-download the app bundle.
 RERUN_STATIC_CACHE_CONTROL = "public, max-age=604800, immutable"
@@ -105,6 +107,7 @@ class RerunServeResult:
     port: int
     cluster_url: str
     public_url: str
+    local_url: str
     port_forward_command: str
 
     def to_dict(self) -> dict[str, Any]:
@@ -339,13 +342,24 @@ def _rerun_serve_command(config: RerunServeConfig) -> str:
 
 
 def public_viewer_url(host: str, *, http_port: int, grpc_port: int = DEFAULT_GRPC_PORT) -> str:
-    """Return a LoadBalancer URL that points the browser at the external gRPC proxy."""
+    """Return a viewer URL whose gRPC origin matches the HTTP page host."""
 
     host = host.strip()
     if not host:
         return ""
     proxy = f"rerun+http://{host}:{grpc_port}/proxy"
     return f"http://{host}:{http_port}/?url={quote(proxy, safe='')}"
+
+
+def local_viewer_url(
+    *,
+    http_port: int,
+    grpc_port: int = DEFAULT_GRPC_PORT,
+    host: str = DEFAULT_LOCAL_VIEWER_HOST,
+) -> str:
+    """Return a port-forward URL (127.0.0.1) with matching local gRPC proxy origin."""
+
+    return public_viewer_url(host, http_port=http_port, grpc_port=grpc_port)
 
 
 def build_rerun_serve_config(
@@ -590,7 +604,8 @@ def rerun_serve_result(
     port_forward = _port_forward_command(
         deployment_name=config.deployment_name,
         namespace=config.namespace,
-        port=config.port,
+        http_port=config.port,
+        grpc_port=DEFAULT_GRPC_PORT,
         kubeconfig=kubeconfig,
     )
     return RerunServeResult(
@@ -603,6 +618,7 @@ def rerun_serve_result(
         port=config.port,
         cluster_url=cluster_url,
         public_url=public_url,
+        local_url=local_viewer_url(http_port=config.port, grpc_port=DEFAULT_GRPC_PORT),
         port_forward_command=port_forward,
     )
 
@@ -875,11 +891,27 @@ def _node_port(service: dict[str, Any]) -> int:
     return 0
 
 
-def _port_forward_command(*, deployment_name: str, namespace: str, port: int, kubeconfig: str) -> str:
+def _port_forward_command(
+    *,
+    deployment_name: str,
+    namespace: str,
+    http_port: int,
+    grpc_port: int = DEFAULT_GRPC_PORT,
+    kubeconfig: str,
+) -> str:
     cmd = ["kubectl"]
     if kubeconfig:
         cmd.extend(["--kubeconfig", kubeconfig])
-    cmd.extend(["port-forward", "-n", namespace, f"deployment/{deployment_name}", f"{port}:{port}"])
+    cmd.extend(
+        [
+            "port-forward",
+            "-n",
+            namespace,
+            f"deployment/{deployment_name}",
+            f"{http_port}:{http_port}",
+            f"{grpc_port}:{grpc_port}",
+        ]
+    )
     return " ".join(cmd)
 
 
@@ -1039,4 +1071,8 @@ def maybe_auto_rerun_serve(
     payload = result.to_dict()
     if payload.get("public_url"):
         print(f"public_url: {payload['public_url']}", flush=True)
+    if payload.get("local_url"):
+        print(f"local_url: {payload['local_url']}", flush=True)
+    if payload.get("port_forward_command"):
+        print(f"port_forward: {payload['port_forward_command']}", flush=True)
     return payload

--- a/npa/src/npa/workflows/sim2real_viz.py
+++ b/npa/src/npa/workflows/sim2real_viz.py
@@ -23,6 +23,8 @@ from typing import Any
 import numpy as np
 
 
+REFERENCE_ROLLOUT_SCHEMA = "npa.sim2real.action_rollout.v1"
+REFERENCE_STUB_FRAME_SHAPE = (32, 32)
 APPLICATION_ID = "npa_sim2real_loop"
 TIMELINE = "frame_time"
 ROLLOUT_FRAME_SECONDS = 0.5
@@ -48,6 +50,7 @@ class Sim2RealVizResult:
     rollout_count: int = 0
     frame_count: int = 0
     heldout_env_count: int = 0
+    heldout_frame_count: int = 0
     mp4_paths: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
@@ -58,6 +61,7 @@ class Sim2RealVizResult:
             "rollout_count": self.rollout_count,
             "frame_count": self.frame_count,
             "heldout_env_count": self.heldout_env_count,
+            "heldout_frame_count": self.heldout_frame_count,
             "mp4_paths": list(self.mp4_paths),
         }
 
@@ -70,13 +74,7 @@ def emit_sim2real_rerun(
     output_rrd: Path | None = None,
     write_mp4: bool = False,
 ) -> Sim2RealVizResult:
-    """Write ``reports/sim2real.rrd`` for a completed run's artifacts.
-
-    Raises ``RerunUnavailableError`` when the ``rerun`` SDK is missing so the
-    caller can WARN and continue. Any other failure (rerun present but logging
-    failed) raises ``Sim2RealVizError`` so a broken recording is never silently
-    accepted.
-    """
+    """Write ``reports/sim2real.rrd`` for a completed run's artifacts."""
 
     rr, rrb = _import_rerun()
     local_dir = Path(local_dir)
@@ -85,7 +83,9 @@ def emit_sim2real_rerun(
         raise Sim2RealVizError(f"Rerun output path must end in .rrd, got: {output_rrd}")
     output_rrd.parent.mkdir(parents=True, exist_ok=True)
 
-    blueprint = _build_blueprint(rrb)
+    heldout_episodes = _heldout_render_episodes(local_dir, heldout_report)
+    has_heldout_cameras = bool(heldout_episodes)
+    blueprint = _build_blueprint(rrb, has_heldout_cameras=has_heldout_cameras)
     recording = rr.RecordingStream(APPLICATION_ID)
     rr.save(output_rrd, default_blueprint=blueprint, recording=recording)
     _send_blueprint(rr, blueprint, recording)
@@ -94,6 +94,7 @@ def emit_sim2real_rerun(
     seconds = 0.0
     rollout_count = 0
     frame_count = 0
+    heldout_frame_count = 0
     mp4_paths: list[str] = []
     critique_panel_rows: list[str] = []
 
@@ -104,12 +105,14 @@ def emit_sim2real_rerun(
         eval_dir = _maybe_path(record.get("vlm_eval_dir"))
         signal_dir = _maybe_path(record.get("signal_dir"))
         for rollout_dir in _rollout_dirs(actions_dir):
+            frames = _rollout_frames(rollout_dir)
+            if has_heldout_cameras and is_reference_stub_rollout(rollout_dir, frames):
+                continue
             rollout_id = rollout_dir.name
             iter_root = f"rollouts/iter_{iteration:02d}/{rollout_id}"
             evaluation = _read_json(eval_dir / f"{rollout_id}.json") if eval_dir else {}
             signal = _read_json(signal_dir / f"{rollout_id}.json") if signal_dir else {}
             manifest = _read_json(rollout_dir / "manifest.json")
-            frames = _rollout_frames(rollout_dir)
             seconds = _log_rollout(
                 rr,
                 recording,
@@ -131,6 +134,14 @@ def emit_sim2real_rerun(
 
     _log_vlm_critique_panel(rr, recording, critique_panel_rows, counts)
     _log_reward_trend(rr, recording, inner_evidence.get("reward_trend") or [], counts)
+    heldout_frame_count, heldout_seconds = _log_heldout_cameras(
+        rr,
+        recording,
+        heldout_episodes,
+        counts,
+        start_seconds=seconds,
+    )
+    seconds = max(seconds, heldout_seconds)
     heldout_env_count = _log_heldout(
         rr,
         recording,
@@ -143,9 +154,14 @@ def emit_sim2real_rerun(
 
     if not output_rrd.exists() or output_rrd.stat().st_size == 0:
         raise Sim2RealVizError(f"Rerun recording was not written: {output_rrd}")
-    if frame_count == 0 and rollout_count == 0 and heldout_env_count == 0:
+    if (
+        frame_count == 0
+        and rollout_count == 0
+        and heldout_env_count == 0
+        and heldout_frame_count == 0
+    ):
         raise Sim2RealVizError(
-            "Sim2Real Rerun recording has no rollout frames, signal, or held-out content"
+            "Sim2Real Rerun recording has no rollout frames, held-out cameras, signal, or held-out content"
         )
 
     return Sim2RealVizResult(
@@ -155,6 +171,7 @@ def emit_sim2real_rerun(
         rollout_count=rollout_count,
         frame_count=frame_count,
         heldout_env_count=heldout_env_count,
+        heldout_frame_count=heldout_frame_count,
         mp4_paths=mp4_paths,
     )
 
@@ -282,10 +299,108 @@ def _log_heldout(
     return logged
 
 
-def _build_blueprint(rrb: Any) -> Any:
+def _log_heldout_cameras(
+    rr: Any,
+    recording: Any,
+    episodes: list[tuple[str, list[np.ndarray]]],
+    counts: dict[str, int],
+    *,
+    start_seconds: float,
+) -> tuple[int, float]:
+    seconds = start_seconds
+    logged = 0
+    for env_id, frames in episodes:
+        root = f"heldout/camera/{env_id}"
+        for frame in frames:
+            _set_time(rr, recording, seconds)
+            rr.log(f"{root}/camera", rr.Image(frame), recording=recording)
+            _bump(counts, f"{root}/camera")
+            seconds += ROLLOUT_FRAME_SECONDS
+            logged += 1
+    return logged, seconds
+
+
+def is_reference_stub_rollout(rollout_dir: Path, frames: list[np.ndarray]) -> bool:
+    """Return True for stage-7 reference adapter solid-color PPM fixtures."""
+
+    manifest = _read_json(rollout_dir / "manifest.json")
+    if manifest.get("schema") != REFERENCE_ROLLOUT_SCHEMA:
+        return False
+    observations = list(manifest.get("camera_observations") or [])
+    if observations and not all(str(item).endswith(".ppm") for item in observations):
+        return False
+    if frames and not all(frame.shape[:2] == REFERENCE_STUB_FRAME_SHAPE for frame in frames):
+        return False
+    return "quality" in manifest
+
+
+def _heldout_render_episodes(
+    local_dir: Path,
+    heldout_report: dict[str, Any] | None,
+) -> list[tuple[str, list[np.ndarray]]]:
+    renders_root = local_dir / "eval" / "heldout" / "renders"
+    manifest = (heldout_report or {}).get("render_manifest") or {}
+    episodes: list[tuple[str, list[np.ndarray]]] = []
+    for item in manifest.get("episodes") or []:
+        if not isinstance(item, dict):
+            continue
+        env_id = str(item.get("env_id") or "")
+        if not env_id:
+            continue
+        env_dir = renders_root / env_id
+        frames = [
+            frame
+            for name in item.get("frames") or []
+            if (frame := _read_image(env_dir / str(name))) is not None
+        ]
+        if frames:
+            episodes.append((env_id, frames))
+    if episodes:
+        return episodes
+    if not renders_root.is_dir():
+        return []
+    for env_dir in sorted(path for path in renders_root.iterdir() if path.is_dir()):
+        frames = [
+            frame
+            for frame_path in sorted(env_dir.glob("camera-*.png"))
+            if (frame := _read_image(frame_path)) is not None
+        ]
+        if frames:
+            episodes.append((env_dir.name, frames))
+    return episodes
+
+
+def _build_blueprint(rrb: Any, *, has_heldout_cameras: bool = False) -> Any:
+    camera_view = (
+        rrb.Spatial2DView(
+            origin="heldout",
+            contents="heldout/**/camera",
+            name="Held-out sim cameras",
+        )
+        if has_heldout_cameras
+        else rrb.Spatial2DView(
+            origin="rollouts",
+            contents="rollouts/**",
+            name="Rollout cameras",
+        )
+    )
+    secondary_camera = (
+        rrb.Spatial2DView(
+            origin="rollouts",
+            contents="rollouts/**/camera",
+            name="Policy rollouts",
+        )
+        if has_heldout_cameras
+        else None
+    )
+    left_column = (
+        rrb.Vertical(camera_view, secondary_camera, row_shares=[2.0, 1.0])
+        if secondary_camera is not None
+        else camera_view
+    )
     return rrb.Blueprint(
         rrb.Horizontal(
-            rrb.Spatial2DView(origin="rollouts", contents="rollouts/**", name="Rollout cameras"),
+            left_column,
             rrb.TextDocumentView(origin="rollouts", contents="rollouts/**/critique", name="VLM critiques"),
             rrb.Vertical(
                 rrb.TimeSeriesView(origin="signal", contents="signal/**", name="VLM->RL signal"),
@@ -307,10 +422,70 @@ def _rollout_dirs(actions_dir: Path | None) -> list[Path]:
 def _rollout_frames(rollout_dir: Path) -> list[np.ndarray]:
     frames: list[np.ndarray] = []
     for frame_path in sorted(rollout_dir.glob("camera-*.ppm")):
-        frame = _read_ppm(frame_path)
+        frame = _read_image(frame_path)
         if frame is not None:
             frames.append(frame)
+    if frames:
+        return frames
+    for frame_path in sorted(rollout_dir.iterdir()):
+        if frame_path.suffix.lower() in {".png", ".jpg", ".jpeg", ".webp"}:
+            frame = _read_image(frame_path)
+            if frame is not None:
+                frames.append(frame)
     return frames
+
+
+def _read_image(path: Path) -> np.ndarray | None:
+    suffix = path.suffix.lower()
+    if suffix == ".ppm":
+        return _read_ppm(path)
+    if suffix == ".png":
+        return _read_png(path)
+    return None
+
+
+def _read_png(path: Path) -> np.ndarray | None:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    if not data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return None
+    import struct
+    import zlib
+
+    index = 8
+    width = height = 0
+    idat = bytearray()
+    while index + 8 <= len(data):
+        length = struct.unpack("!I", data[index : index + 4])[0]
+        chunk_type = data[index + 4 : index + 8]
+        chunk = data[index + 8 : index + 8 + length]
+        index += 12 + length
+        if chunk_type == b"IHDR" and len(chunk) >= 8:
+            width, height = struct.unpack("!II", chunk[:8])
+        elif chunk_type == b"IDAT":
+            idat.extend(chunk)
+        elif chunk_type == b"IEND":
+            break
+    if width <= 0 or height <= 0 or not idat:
+        return None
+    try:
+        raw = zlib.decompress(bytes(idat))
+    except zlib.error:
+        return None
+    stride = width * 3 + 1
+    if len(raw) < height * stride:
+        return None
+    pixels = np.empty((height, width, 3), dtype=np.uint8)
+    offset = 0
+    for row in range(height):
+        offset += 1
+        pixels[row] = np.frombuffer(raw, dtype=np.uint8, count=width * 3, offset=offset).reshape(
+            width, 3
+        )
+        offset += width * 3
+    return pixels.copy()
 
 
 def _read_ppm(path: Path) -> np.ndarray | None:
@@ -336,7 +511,7 @@ def _read_ppm(path: Path) -> np.ndarray | None:
     if len(fields) < 3:
         return None
     width, height, _maxval = (int(field) for field in fields)
-    index += 1  # single whitespace separator after maxval
+    index += 1
     pixels = data[index:index + width * height * 3]
     if len(pixels) < width * height * 3:
         return None
@@ -344,8 +519,6 @@ def _read_ppm(path: Path) -> np.ndarray | None:
 
 
 def _maybe_write_mp4(rollout_dir: Path, frames: list[np.ndarray]) -> Path | None:
-    """Best-effort per-rollout MP4 via ffmpeg; returns None if ffmpeg is missing."""
-
     import shutil
     import subprocess
     import tempfile
@@ -470,7 +643,7 @@ def _import_rerun() -> tuple[Any, Any]:
     try:
         import rerun as rr
         import rerun.blueprint as rrb
-    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch in tests
+    except ImportError as exc:  # pragma: no cover
         raise RerunUnavailableError(
             "rerun-sdk is not installed; skipping Sim2Real Rerun visualization"
         ) from exc

--- a/npa/tests/cli/test_sim2real_rerun_serve_cli.py
+++ b/npa/tests/cli/test_sim2real_rerun_serve_cli.py
@@ -116,9 +116,10 @@ def test_sim2real_rerun_serve_deploy_emits_public_url(mocker) -> None:
                 "status": "deployed",
                 "run_id": "demo-run",
                 "rrd_s3_uri": "s3://bucket/sim2real-b/demo-run/reports/sim2real.rrd",
-                "public_url": "http://203.0.113.10:9090/",
+                "public_url": "http://203.0.113.10:9090/?url=rerun%2Bhttp%3A%2F%2F203.0.113.10%3A9876%2Fproxy",
+                "local_url": "http://127.0.0.1:9090/?url=rerun%2Bhttp%3A%2F%2F127.0.0.1%3A9876%2Fproxy",
                 "cluster_url": "http://svc.default.svc.cluster.local:9090",
-                "port_forward_command": "kubectl port-forward ...",
+                "port_forward_command": "kubectl port-forward -n default deployment/x 9090:9090 9876:9876",
             }
         ),
     )
@@ -130,9 +131,11 @@ def test_sim2real_rerun_serve_deploy_emits_public_url(mocker) -> None:
 
     assert result.exit_code == 0
     assert "public_url: http://203.0.113.10:9090/" in result.output
+    assert "local_url: http://127.0.0.1:9090/" in result.output
+    assert "port_forward:" in result.output
 
 
-def test_sim2real_rerun_serve_loadbalancer_pending_omits_port_forward(mocker) -> None:
+def test_sim2real_rerun_serve_deploy_emits_local_url_when_public_pending(mocker) -> None:
     mocker.patch(
         "npa.cli.workbench.sim2real._rerun_serve_credentials",
         return_value=("ak", "sk"),
@@ -151,11 +154,12 @@ def test_sim2real_rerun_serve_loadbalancer_pending_omits_port_forward(mocker) ->
                 "run_id": "demo-run",
                 "rrd_s3_uri": "s3://bucket/sim2real-b/demo-run/reports/sim2real.rrd",
                 "public_url": "",
+                "local_url": "http://127.0.0.1:9090/?url=rerun%2Bhttp%3A%2F%2F127.0.0.1%3A9876%2Fproxy",
                 "service_type": "LoadBalancer",
                 "deployment_name": "npa-sim2real-rerun-npa-rtxpro-mk8s",
                 "namespace": "default",
                 "cluster_url": "http://svc.default.svc.cluster.local:9090",
-                "port_forward_command": "kubectl port-forward ...",
+                "port_forward_command": "kubectl port-forward -n default deployment/x 9090:9090 9876:9876",
             }
         ),
     )
@@ -167,7 +171,8 @@ def test_sim2real_rerun_serve_loadbalancer_pending_omits_port_forward(mocker) ->
 
     assert result.exit_code == 0
     assert "public_url: pending" in result.output
-    assert "port_forward" not in result.output
+    assert "local_url: http://127.0.0.1:9090/" in result.output
+    assert "port_forward:" in result.output
 
 
 def test_sim2real_hidden_from_workbench_help() -> None:

--- a/npa/tests/workflows/test_sim2real_rerun_regen.py
+++ b/npa/tests/workflows/test_sim2real_rerun_regen.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from npa.workflows.sim2real.models import Sim2RealLoopConfig
+from npa.workflows.sim2real_rerun_regen import (
+    Sim2RealRerunRegenError,
+    regen_sim2real_rrd,
+    resolve_local_rrd_path,
+)
+
+
+def _config(run_id: str = "sim2real-staged-20260616t093101z") -> Sim2RealLoopConfig:
+    return Sim2RealLoopConfig(
+        run_id=run_id,
+        s3_bucket="demo-bucket",
+        s3_prefix="sim2real-b",
+        s3_endpoint="https://storage.example",
+    )
+
+
+def test_resolve_local_rrd_path_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LOCAL_RRD_PATH", str(tmp_path / "custom.rrd"))
+    assert resolve_local_rrd_path("sim2real-staged-20260616t093101z") == tmp_path / "custom.rrd"
+
+
+def test_regen_sim2real_rrd_requires_heldout_frames(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    local_dir = tmp_path / "run"
+    (local_dir / "inner_loop/outer-01").mkdir(parents=True)
+    (local_dir / "eval/heldout").mkdir(parents=True)
+    (local_dir / "inner_loop/outer-01/evidence.json").write_text(
+        json.dumps({"iterations": []}),
+        encoding="utf-8",
+    )
+    (local_dir / "eval/heldout/report.json").write_text(
+        json.dumps({"success_rate": 1.0, "render_manifest": {"episodes": []}}),
+        encoding="utf-8",
+    )
+
+    class FakeResult:
+        output_rrd_path = str(local_dir / "reports" / "sim2real.rrd")
+        heldout_frame_count = 0
+        rollout_count = 0
+        frame_count = 0
+
+    monkeypatch.setattr(
+        "npa.workflows.sim2real_rerun_regen.emit_sim2real_rerun",
+        lambda **_kwargs: FakeResult(),
+    )
+
+    with pytest.raises(Sim2RealRerunRegenError, match="heldout_frame_count=0"):
+        regen_sim2real_rrd(_config(), local_dir=local_dir, sync_inputs=False)
+
+
+def test_regen_sim2real_rrd_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    local_dir = tmp_path / "run"
+    (local_dir / "inner_loop/outer-01").mkdir(parents=True)
+    (local_dir / "eval/heldout").mkdir(parents=True)
+    (local_dir / "inner_loop/outer-01/evidence.json").write_text(
+        json.dumps({"iterations": []}),
+        encoding="utf-8",
+    )
+    (local_dir / "eval/heldout/report.json").write_text(
+        json.dumps({"success_rate": 1.0}),
+        encoding="utf-8",
+    )
+
+    class FakeResult:
+        output_rrd_path = str(local_dir / "reports" / "sim2real.rrd")
+        heldout_frame_count = 4
+        rollout_count = 0
+        frame_count = 0
+
+    monkeypatch.setattr(
+        "npa.workflows.sim2real_rerun_regen.emit_sim2real_rerun",
+        lambda **_kwargs: FakeResult(),
+    )
+
+    result = regen_sim2real_rrd(_config(), local_dir=local_dir, sync_inputs=False, upload=False)
+    assert result.heldout_frame_count == 4
+    assert result.local_rrd_path.endswith("sim2real.rrd")

--- a/npa/tests/workflows/test_sim2real_rerun_serve.py
+++ b/npa/tests/workflows/test_sim2real_rerun_serve.py
@@ -22,6 +22,7 @@ from npa.workflows.sim2real_rerun_serve import (
     deployment_name_for_run,
     destroy_rerun_serve,
     in_cluster_kubernetes,
+    local_viewer_url,
     maybe_auto_rerun_serve,
     public_viewer_url,
     redact_rerun_serve_manifest,
@@ -190,6 +191,14 @@ def test_public_viewer_url_points_at_external_grpc_proxy() -> None:
     assert "9876" in url
 
 
+def test_local_viewer_url_uses_loopback_grpc_origin() -> None:
+    url = local_viewer_url(http_port=9090, grpc_port=9876)
+    assert url == public_viewer_url("127.0.0.1", http_port=9090, grpc_port=9876)
+    assert "127.0.0.1" in url
+    assert "9876" in url
+    assert "rerun%2Bhttp" in url or "rerun+http" in url
+
+
 def test_manifest_uses_direct_rerun_for_prebuilt_image(mocker) -> None:
     mocker.patch(
         "npa.workflows.sim2real_rerun_serve.resolve_project_storage",
@@ -273,7 +282,10 @@ def test_apply_rerun_serve_uses_kubectl_runner(mocker) -> None:
     assert result.public_url == public_viewer_url(
         "203.0.113.10", http_port=DEFAULT_PORT, grpc_port=DEFAULT_GRPC_PORT
     )
+    assert result.local_url == local_viewer_url(http_port=DEFAULT_PORT, grpc_port=DEFAULT_GRPC_PORT)
     assert "port-forward" in result.port_forward_command
+    assert f"{DEFAULT_PORT}:{DEFAULT_PORT}" in result.port_forward_command
+    assert f"{DEFAULT_GRPC_PORT}:{DEFAULT_GRPC_PORT}" in result.port_forward_command
 
 
 def test_destroy_rerun_serve_deletes_resources(mocker) -> None:
@@ -441,6 +453,11 @@ def test_maybe_auto_rerun_serve_uses_in_cluster_kubectl_without_kubeconfig_file(
                         "http://203.0.113.10:9090/?url=rerun%2Bhttp%3A%2F%2F203.0.113.10"
                         "%3A9876%2Fproxy"
                     ),
+                    "local_url": (
+                        "http://127.0.0.1:9090/?url=rerun%2Bhttp%3A%2F%2F127.0.0.1"
+                        "%3A9876%2Fproxy"
+                    ),
+                    "port_forward_command": "kubectl port-forward -n default deployment/x 9090:9090 9876:9876",
                     "run_id": "sim2real-staged-20260615t180818z",
                     "deployment_name": "npa-sim2real-rerun-npa-rtxpro-mk8s",
                 }
@@ -494,6 +511,8 @@ def test_maybe_auto_rerun_serve_deploys_and_prints_public_url(mocker, capsys) ->
                 "to_dict": lambda self: {
                     "status": "deployed",
                     "public_url": "http://203.0.113.10:9090/",
+                    "local_url": "http://127.0.0.1:9090/?url=rerun%2Bhttp%3A%2F%2F127.0.0.1%3A9876%2Fproxy",
+                    "port_forward_command": "kubectl port-forward -n default deployment/x 9090:9090 9876:9876",
                     "run_id": "sim2real-staged-20260615t180818z",
                     "deployment_name": "npa-sim2real-rerun-viewer",
                 }
@@ -510,4 +529,7 @@ def test_maybe_auto_rerun_serve_deploys_and_prints_public_url(mocker, capsys) ->
         k8s_kubeconfig="/tmp/kubeconfig",
     )
     assert result["status"] == "deployed"
-    assert "public_url: http://203.0.113.10:9090/" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "public_url: http://203.0.113.10:9090/" in out
+    assert "local_url: http://127.0.0.1:9090/" in out
+    assert "port_forward:" in out

--- a/npa/tests/workflows/test_sim2real_viz.py
+++ b/npa/tests/workflows/test_sim2real_viz.py
@@ -13,6 +13,7 @@ from npa.workflows.sim2real_viz import (
     RerunUnavailableError,
     Sim2RealVizError,
     emit_sim2real_rerun,
+    is_reference_stub_rollout,
 )
 
 
@@ -203,3 +204,117 @@ def test_emit_raises_when_no_content(monkeypatch, tmp_path: Path) -> None:
             heldout_report={"per_env": []},
             output_rrd=tmp_path / "reports" / "sim2real.rrd",
         )
+
+
+def _write_test_png(path: Path, *, red: int, green: int, blue: int) -> None:
+    import struct
+    import zlib
+
+    width = height = 64
+    raw = bytearray()
+    pixel = bytes([red, green, blue])
+    for _row in range(height):
+        raw.append(0)
+        raw.extend(pixel * width)
+
+    def _chunk(tag: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack("!I", len(payload))
+            + tag
+            + payload
+            + struct.pack("!I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+        )
+
+    header = struct.pack("!IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    png = b"\x89PNG\r\n\x1a\n"
+    png += _chunk(b"IHDR", header)
+    png += _chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+    png += _chunk(b"IEND", b"")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(png)
+
+
+def test_is_reference_stub_rollout_detects_reference_fixture(tmp_path: Path) -> None:
+    actions_dir = tmp_path / "actions"
+    rollouts = generate_action_rollouts(actions_dir, count=1, steps_per_rollout=2, seed=3, quality=0.5)
+    frames = viz_module._rollout_frames(rollouts[0])
+    assert is_reference_stub_rollout(rollouts[0], frames) is True
+
+    rollout_dir = rollouts[0]
+    (rollout_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema": "npa.sim2real.policy_rollout.v1",
+                "rollout_id": rollout_dir.name,
+                "camera_observations": ["camera-000.png"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert is_reference_stub_rollout(rollout_dir, frames) is False
+
+
+def test_emit_prefers_heldout_isaac_cameras_over_stub_rollouts(monkeypatch, tmp_path: Path) -> None:
+    inner_evidence, heldout_report = _build_run_tree(tmp_path)
+    renders_dir = tmp_path / "eval" / "heldout" / "renders" / "heldout-0000"
+    _write_test_png(renders_dir / "camera-000.png", red=40, green=120, blue=200)
+    _write_test_png(renders_dir / "camera-001.png", red=50, green=130, blue=210)
+    heldout_report["render_manifest"] = {
+        "schema": "npa.sim2real.heldout_renders.v1",
+        "sim_backend": "isaac",
+        "isaac_task": "Isaac-Lift-Cube-Franka-v0",
+        "episodes": [
+            {
+                "env_id": "heldout-0000",
+                "frames": ["camera-000.png", "camera-001.png"],
+            }
+        ],
+    }
+
+    fake = _FakeRerun()
+    monkeypatch.setattr(viz_module, "_import_rerun", lambda: (fake, MagicMock()))
+    result = emit_sim2real_rerun(
+        local_dir=tmp_path,
+        inner_evidence=inner_evidence,
+        heldout_report=heldout_report,
+        output_rrd=tmp_path / "reports" / "sim2real.rrd",
+    )
+
+    entities = [entity for entity, _kind in fake.logged]
+    kinds = {entity: kind for entity, kind in fake.logged}
+    assert result.heldout_frame_count == 2
+    assert result.rollout_count == 0
+    assert result.frame_count == 0
+    assert "heldout/camera/heldout-0000/camera" in entities
+    assert kinds["heldout/camera/heldout-0000/camera"] == "image"
+    assert not any(
+        entity.startswith("rollouts/iter_01/rollout-") and entity.endswith("/camera")
+        for entity in entities
+    )
+    assert "signal/reward_trend" in entities
+    assert "heldout/success_rate" in entities
+
+
+def test_heldout_render_step_indices_samples_evenly() -> None:
+    from npa.workflows.sim2real.engine import _heldout_render_step_indices
+
+    indices = _heldout_render_step_indices(120, max_frames=8)
+    assert 0 in indices
+    assert 119 in indices
+    assert len(indices) <= 8
+
+
+def test_build_heldout_render_manifest_from_png_tree(tmp_path: Path) -> None:
+    from npa.workflows.sim2real.engine import _build_heldout_render_manifest
+
+    env_dir = tmp_path / "heldout-0000"
+    env_dir.mkdir(parents=True)
+    (env_dir / "camera-000.png").write_bytes(b"png")
+    (env_dir / "camera-001.png").write_bytes(b"png")
+    manifest = _build_heldout_render_manifest(
+        tmp_path,
+        sim_backend="isaac",
+        isaac_task="Isaac-Lift-Cube-Franka-v0",
+    )
+    assert manifest["episodes"][0]["env_id"] == "heldout-0000"
+    assert manifest["episodes"][0]["frames"] == ["camera-000.png", "camera-001.png"]


### PR DESCRIPTION
## Summary
- Isaac held-out stage 10 captures real Franka camera PNGs to `eval/heldout/renders/` and embeds `render_manifest` in held-out report JSON.
- Rerun viz logs `heldout/camera/**` streams and skips 32×32 reference stub PPMs when held-out cameras exist.
- Rerun serve prints both `public_url` (LoadBalancer) and `local_url` + `port_forward_command` for laptop access.
- Adds `sim2real rerun regen` CLI path and fast `rerun-heldout-only` / `rerun-regen` operator scripts (walkthrough).

## Test plan
- [x] `npa/.venv/bin/python -m pytest npa/tests/workflows/test_sim2real_rerun*.py npa/tests/workflows/test_sim2real_viz.py -q --timeout=120` (39 passed)


Made with [Cursor](https://cursor.com)