### PR TITLE
fix(sim2real): sync held-out renders into Rerun and refresh serve on .rrd updates

### DIFF
--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -615,11 +615,7 @@ def run_finalize(
         report["components"] = components
 
     _write_json_artifact(report_path, report)
-    if (
-        str(report.get("upload", {}).get("status")) == "uploaded"
-        and rerun_serve.get("status") in {"deployed", "blocked"}
-        and config.s3_bucket
-    ):
+    if str(report.get("upload", {}).get("status")) == "uploaded" and config.s3_bucket:
         report_refresh = _upload_final_report(config, report_path)
         if report_refresh:
             upload_meta = dict(report.get("upload") or {})
@@ -663,6 +659,16 @@ def _run_sim2real_viz_stage(
 
     if config.byo_rerun_command.strip():
         return _run_byo_rerun_command(config, local_dir=local_dir, rrd_path=rrd_path)
+
+    heldout_report = _ensure_heldout_renders_for_viz(
+        config,
+        local_dir,
+        heldout_report,
+    )
+    if heldout_report is not None:
+        heldout_path = local_dir / "eval" / "heldout" / "report.json"
+        if heldout_path.is_file():
+            _write_json_artifact(heldout_path, heldout_report)
 
     try:
         from npa.workflows.sim2real_viz import (
@@ -3118,6 +3124,13 @@ def run_heldout_eval(
         inner_evidence_uri=str(inner_path),
         invocation=invocation,
     )
+    report = _ensure_heldout_renders_for_viz(
+        config,
+        local_dir,
+        report,
+        invocation=invocation,
+        payload=payload,
+    )
     _write_json_artifact(output_path, report)
     return {**report, "report_uri": str(output_path)}
 
@@ -3187,6 +3200,70 @@ def _normalize_heldout_report(
         report["robot_fallback_used"] = bool(payload.get("robot_fallback_used", False))
     if payload.get("render_manifest"):
         report["render_manifest"] = payload["render_manifest"]
+    return report
+
+
+def _has_heldout_camera_pngs(renders_dir: Path) -> bool:
+    return any(renders_dir.rglob("camera-*.png"))
+
+
+def _ensure_heldout_renders_for_viz(
+    config: Sim2RealLoopConfig,
+    local_dir: Path,
+    heldout_report: dict[str, Any] | None,
+    *,
+    invocation: dict[str, Any] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Sync Isaac held-out camera PNGs locally and attach a render manifest."""
+
+    if not heldout_report:
+        return heldout_report
+
+    report = dict(heldout_report)
+    renders_dir = local_dir / "eval" / "heldout" / "renders"
+    renders_dir.mkdir(parents=True, exist_ok=True)
+
+    if config.s3_bucket.strip():
+        from npa.clients.storage import StorageError
+        from npa.workflows.sim2real_rerun_regen import sync_heldout_renders
+
+        client = _storage_client(config)
+
+        output_uri = str((invocation or {}).get("output_uri") or "").strip()
+        if output_uri:
+            try:
+                client.download_directory(
+                    _sibling_uri(output_uri, "renders/"), str(renders_dir)
+                )
+            except (StorageError, OSError):
+                pass
+            manifest_uri = _sibling_uri(output_uri, "render-manifest.json")
+            manifest_path = local_dir / "eval" / "heldout" / "render-manifest.sibling.json"
+            try:
+                client.download_path(manifest_uri, str(manifest_path))
+                if manifest_path.is_file():
+                    report["render_manifest"] = json.loads(
+                        manifest_path.read_text(encoding="utf-8")
+                    )
+            except (StorageError, OSError, json.JSONDecodeError):
+                pass
+
+        if payload and payload.get("render_manifest") and not report.get("render_manifest"):
+            report["render_manifest"] = payload["render_manifest"]
+
+        sync_heldout_renders(config, local_dir, heldout_report=report, client=client)
+    elif payload and payload.get("render_manifest") and not report.get("render_manifest"):
+        report["render_manifest"] = payload["render_manifest"]
+
+    if not report.get("render_manifest") and _has_heldout_camera_pngs(renders_dir):
+        manifest = _build_heldout_render_manifest(
+            renders_dir,
+            sim_backend=str(report.get("sim_backend") or config.sim_backend),
+            isaac_task=config.isaac_task,
+        )
+        if manifest.get("episodes"):
+            report["render_manifest"] = manifest
     return report
 
 

--- a/npa/src/npa/workflows/sim2real_rerun_serve.py
+++ b/npa/src/npa/workflows/sim2real_rerun_serve.py
@@ -413,7 +413,52 @@ def build_rerun_serve_config(
     )
 
 
-def build_rerun_serve_manifest(config: RerunServeConfig) -> dict[str, Any]:
+def fetch_rrd_sync_token(
+    config: RerunServeConfig,
+    *,
+    head_object: Callable[..., Any] | None = None,
+) -> str:
+    """Return an S3 ETag (or URI fallback) so serve rollouts re-sync updated .rrd files."""
+
+    import boto3
+    from botocore.config import Config
+    from botocore.exceptions import ClientError
+
+    uri = config.rrd_s3_uri
+    if not uri.startswith("s3://"):
+        return uri
+    without_scheme = uri[5:]
+    bucket, _, key = without_scheme.partition("/")
+    if head_object is not None:
+        try:
+            response = head_object(Bucket=bucket, Key=key)
+        except ClientError:
+            return uri
+        etag = str(response.get("ETag") or "").strip('"')
+        return etag or uri
+
+    client_kwargs: dict[str, Any] = {
+        "aws_access_key_id": config.aws_access_key_id,
+        "aws_secret_access_key": config.aws_secret_access_key,
+        "config": Config(signature_version="s3v4"),
+        "region_name": config.aws_region,
+    }
+    if config.s3_endpoint:
+        client_kwargs["endpoint_url"] = config.s3_endpoint
+    client = boto3.client("s3", **client_kwargs)
+    try:
+        response = client.head_object(Bucket=bucket, Key=key)
+    except ClientError:
+        return uri
+    etag = str(response.get("ETag") or "").strip('"')
+    return etag or uri
+
+
+def build_rerun_serve_manifest(
+    config: RerunServeConfig,
+    *,
+    rrd_sync_token: str = "",
+) -> dict[str, Any]:
     labels = {
         "app": config.deployment_name,
         "app.kubernetes.io/name": "npa-sim2real-rerun",
@@ -440,6 +485,11 @@ test -s /data/sim2real.rrd
 """
     serve_command = _rerun_serve_command(config)
     nginx_config = build_rerun_nginx_config(external_port=config.port)
+    sync_token = (rrd_sync_token or config.run_id).strip()
+    pod_annotations = {
+        "npa.nebius.com/rrd-s3-uri": _label_value(config.rrd_s3_uri),
+        "npa.nebius.com/rrd-sync-token": _label_value(sync_token),
+    }
     return {
         "apiVersion": "v1",
         "kind": "List",
@@ -479,7 +529,7 @@ test -s /data/sim2real.rrd
                     "strategy": {"type": "Recreate"},
                     "selector": {"matchLabels": {"app.kubernetes.io/instance": config.deployment_name}},
                     "template": {
-                        "metadata": {"labels": labels},
+                        "metadata": {"labels": labels, "annotations": pod_annotations},
                         "spec": {
                             "initContainers": [
                                 {
@@ -639,8 +689,9 @@ def apply_rerun_serve(
     clock = now or time.monotonic
     waiter = sleep or time.sleep
 
-    manifest = build_rerun_serve_manifest(config)
     verify_rrd_exists_on_s3(config)
+    sync_token = fetch_rrd_sync_token(config)
+    manifest = build_rerun_serve_manifest(config, rrd_sync_token=sync_token)
     runner(["apply", "-f", "-"], stdin=json.dumps(manifest), kubeconfig=kubeconfig)
     try:
         runner(

--- a/npa/src/npa/workflows/sim2real_viz.py
+++ b/npa/src/npa/workflows/sim2real_viz.py
@@ -199,7 +199,7 @@ def _log_rollout(
 
     for step, frame in enumerate(frames):
         _set_time(rr, recording, seconds)
-        rr.log(f"{root}/camera", rr.Image(frame), recording=recording)
+        rr.log(f"{root}/camera", _rerun_image(rr, frame), recording=recording)
         _bump(counts, f"{root}/camera")
 
         eval_step = per_step_eval.get(step, {})
@@ -313,7 +313,7 @@ def _log_heldout_cameras(
         root = f"heldout/camera/{env_id}"
         for frame in frames:
             _set_time(rr, recording, seconds)
-            rr.log(f"{root}/camera", rr.Image(frame), recording=recording)
+            rr.log(f"{root}/camera", _rerun_image(rr, frame), recording=recording)
             _bump(counts, f"{root}/camera")
             seconds += ROLLOUT_FRAME_SECONDS
             logged += 1
@@ -348,11 +348,13 @@ def _heldout_render_episodes(
         if not env_id:
             continue
         env_dir = renders_root / env_id
-        frames = [
-            frame
-            for name in item.get("frames") or []
-            if (frame := _read_image(env_dir / str(name))) is not None
-        ]
+        frames = _usable_camera_frames(
+            [
+                frame
+                for name in item.get("frames") or []
+                if (frame := _read_image(env_dir / str(name))) is not None
+            ]
+        )
         if frames:
             episodes.append((env_id, frames))
     if episodes:
@@ -360,11 +362,13 @@ def _heldout_render_episodes(
     if not renders_root.is_dir():
         return []
     for env_dir in sorted(path for path in renders_root.iterdir() if path.is_dir()):
-        frames = [
-            frame
-            for frame_path in sorted(env_dir.glob("camera-*.png"))
-            if (frame := _read_image(frame_path)) is not None
-        ]
+        frames = _usable_camera_frames(
+            [
+                frame
+                for frame_path in sorted(env_dir.glob("camera-*.png"))
+                if (frame := _read_image(frame_path)) is not None
+            ]
+        )
         if frames:
             episodes.append((env_dir.name, frames))
     return episodes
@@ -571,6 +575,29 @@ def _write_png(path: Path, frame: np.ndarray) -> None:
     png += _chunk(b"IDAT", zlib.compress(bytes(raw), 9))
     png += _chunk(b"IEND", b"")
     path.write_bytes(png)
+
+
+def _usable_camera_frames(frames: list[np.ndarray]) -> list[np.ndarray]:
+    """Drop blank Isaac warmup frames that otherwise render as black/purple tiles."""
+
+    usable: list[np.ndarray] = []
+    for frame in frames:
+        if frame.size == 0:
+            continue
+        if float(frame.mean()) < 1.0:
+            continue
+        usable.append(frame)
+    return usable
+
+
+def _rerun_image(rr: Any, frame: np.ndarray) -> Any:
+    array = np.ascontiguousarray(frame, dtype=np.uint8)
+    if hasattr(rr, "Image"):
+        try:
+            return rr.Image(array, color_model="RGB")
+        except TypeError:
+            return rr.Image(array)
+    return array
 
 
 def _scalar(rr: Any, value: float) -> Any:

--- a/npa/tests/workflows/test_sim2real_rerun_serve.py
+++ b/npa/tests/workflows/test_sim2real_rerun_serve.py
@@ -21,6 +21,7 @@ from npa.workflows.sim2real_rerun_serve import (
     deployment_name_for_cluster,
     deployment_name_for_run,
     destroy_rerun_serve,
+    fetch_rrd_sync_token,
     in_cluster_kubernetes,
     local_viewer_url,
     maybe_auto_rerun_serve,
@@ -227,6 +228,36 @@ def test_build_rerun_nginx_config_sets_static_cache_headers() -> None:
     assert "(wasm|js|ico|svg)" in config_text
 
 
+def test_build_rerun_serve_manifest_includes_rrd_sync_annotation(mocker) -> None:
+    mocker.patch(
+        "npa.workflows.sim2real_rerun_serve.resolve_project_storage",
+        return_value=_storage(),
+    )
+    config = build_rerun_serve_config(
+        run_id="sim2real-staged-20260615t180818z",
+        aws_access_key_id="ak",
+        aws_secret_access_key="sk",
+    )
+    manifest = build_rerun_serve_manifest(config, rrd_sync_token="abc123etag")
+    deployment = next(item for item in manifest["items"] if item["kind"] == "Deployment")
+    annotations = deployment["spec"]["template"]["metadata"]["annotations"]
+    assert annotations["npa.nebius.com/rrd-sync-token"] == "abc123etag"
+
+
+def test_fetch_rrd_sync_token_uses_head_object_etag() -> None:
+    config = build_rerun_serve_config(
+        run_id="sim2real-staged-20260615t180818z",
+        s3_bucket="demo-bucket",
+        aws_access_key_id="ak",
+        aws_secret_access_key="sk",
+    )
+    token = fetch_rrd_sync_token(
+        config,
+        head_object=lambda **_kwargs: {"ETag": '"etag-from-s3"'},
+    )
+    assert token == "etag-from-s3"
+
+
 def test_redact_manifest_hides_secret_values(mocker) -> None:
     mocker.patch(
         "npa.workflows.sim2real_rerun_serve.resolve_project_storage",
@@ -249,6 +280,10 @@ def test_apply_rerun_serve_uses_kubectl_runner(mocker) -> None:
         return_value=_storage(),
     )
     mocker.patch("npa.workflows.sim2real_rerun_serve.verify_rrd_exists_on_s3")
+    mocker.patch(
+        "npa.workflows.sim2real_rerun_serve.fetch_rrd_sync_token",
+        return_value="etag-test",
+    )
     config = build_rerun_serve_config(
         run_id="sim2real-staged-20260615t180818z",
         aws_access_key_id="ak",

--- a/npa/tests/workflows/test_sim2real_viz.py
+++ b/npa/tests/workflows/test_sim2real_viz.py
@@ -318,3 +318,31 @@ def test_build_heldout_render_manifest_from_png_tree(tmp_path: Path) -> None:
     )
     assert manifest["episodes"][0]["env_id"] == "heldout-0000"
     assert manifest["episodes"][0]["frames"] == ["camera-000.png", "camera-001.png"]
+
+
+def test_usable_camera_frames_drops_blank_warmup() -> None:
+    import numpy as np
+
+    from npa.workflows.sim2real_viz import _usable_camera_frames
+
+    blank = np.zeros((64, 64, 3), dtype=np.uint8)
+    real = np.full((64, 64, 3), 120, dtype=np.uint8)
+    assert _usable_camera_frames([blank, real]) == [real]
+
+
+def test_ensure_heldout_renders_builds_manifest_from_local_pngs(
+    tmp_path: Path,
+) -> None:
+    from npa.workflows.sim2real.engine import _ensure_heldout_renders_for_viz
+    from npa.workflows.sim2real.models import Sim2RealLoopConfig
+
+    config = Sim2RealLoopConfig(run_id="sim2real-staged-20260616t032140z")
+    renders_dir = tmp_path / "eval" / "heldout" / "renders" / "env-00003"
+    _write_test_png(renders_dir / "camera-000.png", red=40, green=120, blue=200)
+    heldout_report = {"success_rate": 1.0, "sim_backend": "isaac"}
+
+    updated = _ensure_heldout_renders_for_viz(config, tmp_path, heldout_report)
+
+    assert updated is not None
+    assert updated["render_manifest"]["episodes"][0]["env_id"] == "env-00003"
+    assert updated["render_manifest"]["episodes"][0]["frames"] == ["camera-000.png"]


### PR DESCRIPTION
## Summary
- Sync Isaac held-out camera PNGs into the orchestrator before stage-14 `.rrd` emission so Rerun shows sim frames instead of purple reference stub rollouts.
- Re-upload `sim2real-report.json` after `rerun_serve` metadata is written (not only when deploy succeeds).
- Force mk8s serve rollouts when `sim2real.rrd` changes on S3 by annotating pods with the object ETag.
- Drop blank Isaac warmup frames and log images with explicit RGB color model.

## Test plan
- [x] `npa/.venv/bin/python -m pytest npa/tests/workflows/test_sim2real_viz.py npa/tests/workflows/test_sim2real_rerun_serve.py npa/tests/workflows/test_sim2real_rerun_regen.py -q` (43 passed)
- [x] `npa workbench sim2real rerun regen --run-id sim2real-staged-20260616t032140z --upload` → `heldout_frame_count=3`, `rollout_count=0`
- [x] `npa workbench sim2real rerun serve --run-id sim2real-staged-20260616t032140z` → pod `/data/sim2real.rrd` matches S3 size (~2.2MB)
- [x] Cloud viewer verified: regen `.rrd` has **0** rollout `/camera` entities and **heldout/camera/env-00003/camera** only; pod serves 2,282,074-byte file — use **Held-out sim cameras** panel (not Rollout cameras)