### PR TITLE
fix(token-factory): make sim-sweep Job names unique per sweep

### DIFF
--- a/npa/scripts/run_tokenfactory_sim_sweep.py
+++ b/npa/scripts/run_tokenfactory_sim_sweep.py
@@ -103,7 +103,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         {
             **variant,
             "output_uri": sweep_variant_output_uri(sweep_root, variant["id"]),
-            "train_command": _train_command(args, variant, sweep_root),
+            "train_command": _train_command(args, variant, sweep_root, run_id),
         }
         for variant in variants
     ]
@@ -117,9 +117,13 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def _train_command(
-    args: argparse.Namespace, variant: dict[str, Any], sweep_root: str
+    args: argparse.Namespace, variant: dict[str, Any], sweep_root: str, run_id: str
 ) -> list[str]:
-    job_name = triage_job_name(f"{args.run_id or 'tf-sweep'}-{variant['id']}")
+    # Derive the per-variant Job name from the *resolved* run_id (which is
+    # timestamped when --run-id is omitted), not the raw arg. Otherwise two
+    # sweeps launched without --run-id submit colliding serverless Job names
+    # even though their S3 output prefixes differ.
+    job_name = triage_job_name(f"{run_id}-{variant['id']}")
     cmd = [
         "workbench",
         "lerobot",

--- a/npa/tests/workflows/test_token_factory_combos.py
+++ b/npa/tests/workflows/test_token_factory_combos.py
@@ -334,6 +334,32 @@ def test_sweep_runner_full_mode_resolves_rank_root_without_keyerror(monkeypatch)
     assert captured["rank_root"] == "s3://b/sweeps/demo/ranking"
 
 
+def test_sweep_runner_job_names_track_resolved_run_id() -> None:
+    """Without --run-id, per-variant Job names must use the resolved timestamped
+    run_id (matching sweep_root), not a fixed 'tf-sweep' literal that collides
+    across sweeps."""
+    module = _load_sweep_runner()
+    args = module._parse_args(["--num-variants", "2", "--bucket", "s3://b/tf"])
+    plan = module.build_plan(args)
+
+    run_id = plan["run_id"]
+    assert run_id.startswith("tf-sim-sweep-")
+    assert plan["sweep_root"].endswith(run_id)
+
+    job_names = []
+    for variant in plan["variants"]:
+        cmd = variant["train_command"]
+        job_names.append(cmd[cmd.index("--job-name") + 1])
+
+    # Job names embed the (sanitized) resolved run_id, so they are unique per
+    # sweep and never the bare fallback literal.
+    sanitized_run_id = run_id.lower()
+    for name in job_names:
+        assert name.startswith(sanitized_run_id)
+        assert not name.startswith("tf-sweep-v")
+    assert len(set(job_names)) == len(job_names)
+
+
 def test_sweep_runner_disambiguates_colliding_run_labels() -> None:
     module = _load_sweep_runner()
     # Distinct last segments keep their names...


### PR DESCRIPTION
## What

The Token Factory **sim-sweep** combo runner (`npa/scripts/run_tokenfactory_sim_sweep.py`) derived each variant's Nebius serverless Job name from the raw CLI arg `args.run_id or 'tf-sweep'`, **not** the resolved `run_id` that `build_plan()` computes (a timestamped value when `--run-id` is omitted) and that the S3 `sweep_root` already uses.

Effect: two sweeps launched back-to-back without `--run-id` produced **colliding Job names** (`tf-sweep-v0-steps50`, `tf-sweep-v1-steps100`, …) even though their artifact prefixes were timestamp-unique. That violates the "names must be unique under all input combinations" contract for serverless Jobs — the second sweep's Jobs can clash with the first's.

Before (no `--run-id`):
```
sweep_root: s3://b/tf/tf-sim-sweep-20260618T062837Z   # unique
job_name:   tf-sweep-v0-steps50                        # NOT unique across sweeps
```
After:
```
sweep_root: s3://b/tf/tf-sim-sweep-20260618T062918Z
job_name:   tf-sim-sweep-20260618t062918z-v0-steps50   # aligned + unique
```

## Fix

Thread the resolved `run_id` from `build_plan()` into `_train_command()` and use it as the Job-name base, so Job names embed the timestamped run_id and stay aligned with `sweep_root`. The sibling **train-triage** runner already derives its Job name from the resolved run_id; this brings sim-sweep in line.

## Tests

- Added `test_sweep_runner_job_names_track_resolved_run_id` — asserts that, without `--run-id`, every variant's Job name embeds the resolved timestamped run_id (matching `sweep_root`), is not the bare `tf-sweep-*` fallback, and is unique.
- Full Token Factory suite passes (`71 passed, 5 skipped`); changed files lint clean under ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)