### PR TITLE
Store Nebius Token Factory key in credentials.yaml

### DIFF
--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -428,9 +428,25 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
     typer.echo("Setup complete. Run `npa configure --show` to see the file layout.")
 
 
+def _store_token_factory_key(api_key: str) -> None:
+    from npa.clients.credentials import set_token_factory_api_key
+
+    path = set_token_factory_api_key(api_key)
+    typer.echo(
+        f"Stored Nebius Token Factory API key in {path} under tokens.NEBIUS_API_KEY."
+    )
+
+
 def _configure_impl(
-    *, show: bool, interactive: Optional[bool], provision: bool = True
+    *,
+    show: bool,
+    interactive: Optional[bool],
+    provision: bool = True,
+    token_factory_key: str = "",
 ) -> None:
+    if token_factory_key.strip():
+        _store_token_factory_key(token_factory_key.strip())
+        return
     if show:
         typer.echo(_SETUP_GUIDANCE)
         return
@@ -469,9 +485,22 @@ def configure(
             "(default). Use --no-provision to enter existing S3 credentials."
         ),
     ),
+    token_factory_key: str = typer.Option(
+        "",
+        "--token-factory-key",
+        help=(
+            "Store a Nebius Token Factory API key in ~/.npa/credentials.yaml "
+            "under tokens.NEBIUS_API_KEY (skips interactive setup)."
+        ),
+    ),
 ) -> None:
     """Interactively write ~/.npa credentials and config, or show guidance."""
-    _configure_impl(show=show, interactive=interactive, provision=provision)
+    _configure_impl(
+        show=show,
+        interactive=interactive,
+        provision=provision,
+        token_factory_key=token_factory_key,
+    )
 
 
 @app.command(
@@ -498,9 +527,22 @@ def init(
             "(default). Use --no-provision to enter existing S3 credentials."
         ),
     ),
+    token_factory_key: str = typer.Option(
+        "",
+        "--token-factory-key",
+        help=(
+            "Store a Nebius Token Factory API key in ~/.npa/credentials.yaml "
+            "under tokens.NEBIUS_API_KEY (skips interactive setup)."
+        ),
+    ),
 ) -> None:
     """Interactively write ~/.npa credentials and config, or show guidance."""
-    _configure_impl(show=show, interactive=interactive, provision=provision)
+    _configure_impl(
+        show=show,
+        interactive=interactive,
+        provision=provision,
+        token_factory_key=token_factory_key,
+    )
 
 
 def app_entry() -> None:

--- a/npa/src/npa/clients/credentials.py
+++ b/npa/src/npa/clients/credentials.py
@@ -51,7 +51,13 @@ class CredentialsConfig:
 
     @property
     def nebius_api_key(self) -> str:
+        """Nebius Token Factory API key (``tokens.NEBIUS_API_KEY``)."""
         return self.tokens.get(TOKEN_FACTORY_ENV_KEY, "")
+
+    @property
+    def token_factory_api_key(self) -> str:
+        """Explicit alias for the Nebius Token Factory hosted-inference key."""
+        return self.nebius_api_key
 
     @property
     def ngc_api_key(self) -> str:
@@ -278,6 +284,18 @@ def _prune_empty(data: dict[str, Any]) -> dict[str, Any]:
         elif value not in ("", None):
             pruned[key] = value
     return pruned
+
+
+def set_token_factory_api_key(api_key: str, *, path: Path | None = None) -> Path:
+    """Persist the Nebius Token Factory key under ``tokens.NEBIUS_API_KEY``."""
+
+    cleaned = api_key.strip()
+    if not cleaned:
+        raise ValueError("Token Factory API key must be non-empty")
+    return write_credentials_file(
+        {"tokens": {TOKEN_FACTORY_ENV_KEY: cleaned}},
+        path=path,
+    )
 
 
 def write_credentials_file(

--- a/npa/src/npa/clients/token_factory.py
+++ b/npa/src/npa/clients/token_factory.py
@@ -76,7 +76,7 @@ def resolve_config(
     otherwise from ``api_key_env`` and the standard Token Factory env keys.
     """
 
-    env = environ if environ is not None else os.environ
+    env = _resolve_env(environ)
     resolved_base = base_url.strip() or _first_env(env, BASE_URL_ENV_KEYS) or DEFAULT_BASE_URL
     resolved_key = api_key.strip()
     if not resolved_key:
@@ -193,6 +193,26 @@ class TokenFactoryClient:
         finally:
             if owns_client:
                 client.close()
+
+
+def _resolve_env(environ: dict[str, str] | None) -> dict[str, str]:
+    """Build the env map used for Token Factory config resolution.
+
+    When callers use the default (``environ=None``), merge in
+    ``tokens.NEBIUS_API_KEY`` from ``~/.npa/credentials.yaml`` so hosted
+    inference works outside ``npa workbench`` entrypoints.
+    """
+
+    if environ is not None:
+        return environ
+    from npa.clients.credentials import load_credentials
+
+    env = dict(os.environ)
+    credentials = load_credentials(environ=env)
+    file_key = credentials.token_factory_api_key
+    if file_key and not _first_env(env, API_KEY_ENV_KEYS):
+        env[DEFAULT_API_KEY_ENV] = file_key
+    return env
 
 
 def _first_env(env: dict[str, str], keys: Sequence[str]) -> str:

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -376,6 +376,31 @@ def test_configure_non_tty_prints_guidance() -> None:
     assert "npa configure --interactive" in result.output
 
 
+def test_configure_token_factory_key_stores_under_tokens_nebius_api_key(
+    monkeypatch, tmp_path
+) -> None:
+    import yaml
+
+    from npa.clients import credentials as credentials_module
+
+    creds_path = tmp_path / "credentials.yaml"
+    creds_path.write_text(
+        yaml.safe_dump({"tokens": {"HF_TOKEN": "hf-existing"}})
+    )
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
+
+    result = runner.invoke(
+        app,
+        ["configure", "--token-factory-key", "tf-cli-key"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "tokens.NEBIUS_API_KEY" in result.output
+    stored = yaml.safe_load(creds_path.read_text())
+    assert stored["tokens"]["NEBIUS_API_KEY"] == "tf-cli-key"
+    assert stored["tokens"]["HF_TOKEN"] == "hf-existing"
+
+
 def test_configure_creates_nebius_profile_when_missing(monkeypatch, tmp_path) -> None:
     from npa.clients import config as config_module
     from npa.clients import credentials as credentials_module

--- a/npa/tests/clients/test_token_factory.py
+++ b/npa/tests/clients/test_token_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import httpx
 import pytest
@@ -28,6 +29,26 @@ def test_resolve_config_defaults_to_token_factory_base_url() -> None:
 def test_resolve_config_reads_nebius_api_key_from_env() -> None:
     config = resolve_config(environ={"NEBIUS_API_KEY": "env-key"})
     assert config.api_key == "env-key"
+
+
+def test_resolve_config_reads_token_factory_key_from_credentials_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import yaml
+
+    from npa.clients import credentials as credentials_module
+
+    credentials_path = tmp_path / "credentials.yaml"
+    credentials_path.write_text(
+        yaml.safe_dump({"tokens": {"NEBIUS_API_KEY": "tf-file-key"}})
+    )
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", credentials_path)
+    monkeypatch.delenv("NEBIUS_API_KEY", raising=False)
+    monkeypatch.delenv("NEBIUS_TOKEN_FACTORY_API_KEY", raising=False)
+
+    config = resolve_config()
+
+    assert config.api_key == "tf-file-key"
 
 
 def test_resolve_config_base_url_override() -> None:

--- a/npa/tests/test_credentials.py
+++ b/npa/tests/test_credentials.py
@@ -11,6 +11,7 @@ from npa.clients.config import SSHConfig
 from npa.clients.credentials import (
     CredentialsConfig,
     load_credentials,
+    set_token_factory_api_key,
     shared_credential_env,
     warn_if_hf_token_missing,
 )
@@ -111,6 +112,30 @@ def test_nebius_api_key_env_overrides_file(tmp_path: Path) -> None:
     resolved = load_credentials(path=credentials_path, environ={"NEBIUS_API_KEY": "tf-env"})
 
     assert resolved.nebius_api_key == "tf-env"
+    assert resolved.token_factory_api_key == "tf-env"
+
+
+def test_set_token_factory_api_key_merges_into_existing_credentials(
+    tmp_path: Path,
+) -> None:
+    credentials_path = tmp_path / "credentials.yaml"
+    credentials_path.write_text(
+        yaml.safe_dump(
+            {
+                "tokens": {"HF_TOKEN": "hf-existing"},
+                "storage": {"aws_access_key_id": "AKIAEXISTING"},
+            }
+        )
+    )
+
+    set_token_factory_api_key("tf-new-key", path=credentials_path)
+
+    resolved = load_credentials(path=credentials_path, environ={})
+    stored = yaml.safe_load(credentials_path.read_text())
+    assert resolved.token_factory_api_key == "tf-new-key"
+    assert resolved.hf_token == "hf-existing"
+    assert stored["tokens"]["NEBIUS_API_KEY"] == "tf-new-key"
+    assert stored["storage"]["aws_access_key_id"] == "AKIAEXISTING"
 
 
 def test_load_credentials_reads_byovm_ssh_config(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add `npa configure --token-factory-key` (and `npa init --token-factory-key`) to persist the Nebius Token Factory API key under `tokens.NEBIUS_API_KEY` in `~/.npa/credentials.yaml` without rerunning full interactive setup.
- Add `set_token_factory_api_key()` helper that deep-merges into the existing credentials file.
- Teach `resolve_config()` to read `tokens.NEBIUS_API_KEY` from the credentials file when no env var is set, so Token Factory works outside `npa workbench` entrypoints (scripts, SDK, e2e).

## Test plan
- [x] Unit tests for `set_token_factory_api_key`, configure flag, and credentials-file resolution in `resolve_config`
- [x] Local live verify: `npa workbench token-factory verify` authenticated successfully after storing key via `npa configure --token-factory-key`


Made with [Cursor](https://cursor.com)