### PR TITLE
Stop leaking ids in npa configure; auto-create default S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,46 @@ You should see a ranked report with `accuracy: 1.0` over four labeled rollouts.
 That is the full local loop; the same command swaps `--backend stub` for a real
 `self-hosted` or `api` VLM backend once you add credentials.
 
+### Nebius AI Cloud account
+
+Before `npa configure`, sign in to Nebius AI Cloud and create the tenant and
+project that NPA will use:
+
+1. **Sign up and log in** — create an account at
+   [Nebius signup](https://docs.nebius.com/signup-billing/sign-up). Use a
+   standard email login (not SSO-only) so you can create tenants and projects.
+2. **Tenant** — Nebius creates a tenant on signup. To add another, follow
+   [Creating a tenant](https://docs.nebius.com/iam/create-tenants). Copy your
+   tenant id (`tenant-…`) from the tenant selector in the
+   [web console](https://console.nebius.com) or list tenants with the Nebius
+   CLI ([get tenants](https://docs.nebius.com/iam/get-tenants)).
+3. **Project** — create a project in that tenant for your workloads (for example
+   in `eu-north1`). Use the console
+   ([Manage projects](https://docs.nebius.com/iam/manage-projects)) or the CLI:
+
+   ```bash
+   nebius iam v2 project create --parent-id <tenant-id> --name npa-workbench --region eu-north1
+   ```
+
+   Copy the project id (`project-…`) from the console project selector or
+   `nebius iam v2 project list --parent-id <tenant-id>`.
+4. **Object Storage bucket (optional)** — `npa configure` can create a default
+   bucket for your project when you press Enter at the bucket prompt. To use your
+   own bucket instead, create one in the console (**Storage → Object Storage →
+   Create bucket**) or via the CLI
+   ([Manage buckets](https://docs.nebius.com/object-storage/buckets/manage)):
+
+   ```bash
+   nebius storage bucket create --parent-id <project-id> --name <your-bucket-name>
+   ```
+
+   See the [Object Storage quickstart](https://docs.nebius.com/object-storage/quickstart)
+   for naming rules.
+
+You will enter your project id and tenant id when `npa configure` prompts for
+them. No example ids or bucket names are shown — use the values from your
+account, or press Enter to let NPA create a default bucket.
+
 Next, run a single interactive NPA setup step (install the Nebius CLI binary
 first; `npa configure` reuses or creates the profile and writes your NPA
 credential/config files — see

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -203,12 +203,21 @@ chmod 600 ~/.npa/credentials.yaml
 Nebius account authentication is handled by the `nebius` CLI profile, not by a
 long-lived `NEBIUS_TOKEN` in `~/.npa/credentials.yaml`.
 
+Before running `npa configure`, sign up for Nebius AI Cloud, note your tenant
+id, and create a project in the target region. An Object Storage bucket is
+optional — `npa configure` creates a default bucket when you press Enter at the
+bucket prompt. To use your own bucket, create one first; see the README
+**Nebius AI Cloud account** section,
+[Creating a tenant](https://docs.nebius.com/iam/create-tenants),
+[Manage projects](https://docs.nebius.com/iam/manage-projects), and
+[Manage buckets](https://docs.nebius.com/object-storage/buckets/manage).
+
 Run interactive setup in a terminal. `npa configure` detects an existing
-authenticated Nebius CLI profile (via `nebius iam get-access-token`), pre-fills
-project and tenant from that profile when available, and only runs profile
-creation when none is authenticated. It then writes `~/.npa/credentials.yaml` and
-`~/.npa/config.yaml` (re-run anytime to refresh NPA files from the active
-profile):
+authenticated Nebius CLI profile (via `nebius iam get-access-token`), prompts
+for your tenant id and project id (no defaults are shown), creates a default
+S3 bucket when you press Enter at the bucket prompt, and only runs profile
+creation when none is authenticated. It then writes `~/.npa/credentials.yaml`
+and `~/.npa/config.yaml`:
 
 ```bash
 npa configure

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -69,9 +69,9 @@ Run `npa configure` in a terminal for interactive setup (use
 installed Nebius CLI binary internally (profile setup stays inside
 `npa configure`; no separate Nebius CLI onboarding commands), bootstraps a profile
 when needed, then with an authenticated profile
-auto-creates your S3 bucket and access key, so
-you only supply tenant/project/region (pre-filled from the profile) plus optional
-Hugging Face, Token Factory, and NGC tokens. Use `npa configure --no-provision` to enter
+auto-creates an S3 bucket (and access key) when you press Enter at the bucket
+prompt, so you supply your Nebius tenant id, project id, and region plus optional
+bucket name, Hugging Face, Token Factory, and NGC tokens. Use `npa configure --no-provision` to enter
 existing S3 credentials instead, or create ~/.npa/credentials.yaml by hand for
 user-level tokens, object storage, and BYOVM SSH defaults:
 
@@ -270,8 +270,14 @@ def _provision_object_storage(
     if not (project_id and tenant_id):
         return None
 
-    suggested_bucket = nebius_client.bucket_name_for(tenant_id, project_id)
-    bucket_name = ask("Object-storage bucket name", default=suggested_bucket) or suggested_bucket
+    bucket_name = ask(
+        "Object-storage bucket name (Enter to create a default bucket for this project)"
+    )
+    if not bucket_name:
+        bucket_name = nebius_client.bucket_name_for(tenant_id, project_id)
+        typer.echo(
+            "  No bucket name provided; creating a default bucket for this project."
+        )
 
     try:
         already_exists = nebius_client.bucket_exists(project_id, bucket_name)
@@ -350,12 +356,10 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
             )
         ).strip()
 
-    project_default = nebius_client.current_project_id()
-    tenant_default = nebius_client.current_tenant_id()
-    project_id = ask("Nebius project id", default=project_default)
-    tenant_id = ask("Nebius tenant id", default=tenant_default)
+    project_id = ask("Nebius project id")
+    tenant_id = ask("Nebius tenant id")
     registry_default = (
-        nebius_client.discover_container_registry(project_id or project_default)
+        nebius_client.discover_container_registry(project_id)
         or DEFAULT_CONTAINER_REGISTRY
     )
     region_default = _region_from_registry_host(registry_default) or DEFAULT_REGION
@@ -385,7 +389,7 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
                 "S3 secret access key (AWS_SECRET_ACCESS_KEY)", secret=True
             ),
             "endpoint_url": ask("S3 endpoint URL", default=_endpoint_for_region(region)),
-            "bucket": ask("S3 bucket (e.g. s3://my-bucket/)"),
+            "bucket": ask("S3 bucket URI (e.g. s3://<your-bucket>/)"),
         }
 
     hf_token = ask("Hugging Face token (HF_TOKEN)", secret=True)
@@ -485,8 +489,9 @@ def configure(
         True,
         "--provision/--no-provision",
         help=(
-            "Auto-create the Nebius S3 bucket and access key from your profile "
-            "(default). Use --no-provision to enter existing S3 credentials."
+            "Auto-create a Nebius S3 bucket (when missing) and an access key "
+            "(default). Press Enter at the bucket prompt to use a project-default "
+            "name. Use --no-provision to enter existing S3 credentials."
         ),
     ),
     token_factory_key: str = typer.Option(
@@ -527,8 +532,9 @@ def init(
         True,
         "--provision/--no-provision",
         help=(
-            "Auto-create the Nebius S3 bucket and access key from your profile "
-            "(default). Use --no-provision to enter existing S3 credentials."
+            "Auto-create a Nebius S3 bucket (when missing) and an access key "
+            "(default). Press Enter at the bucket prompt to use a project-default "
+            "name. Use --no-provision to enter existing S3 credentials."
         ),
     ),
     token_factory_key: str = typer.Option(

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -147,12 +147,12 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
 
     monkeypatch.setattr(nebius_module, "bootstrap_environment", fake_bootstrap)
 
-    # Accept derived project/tenant + default region/registry; pick a custom
+    # Enter project/tenant + default region/registry; pick a custom
     # bucket name and a custom size; then HF + NGC.
     answers = "\n".join(
         [
-            "",                  # project id (accept derived)
-            "",                  # tenant id (accept derived)
+            "project-12345",     # project id
+            "tenant-abcde",      # tenant id
             "",                  # region (default eu-north1)
             "",                  # registry (default)
             "my-bucket",         # bucket name (customer choice)
@@ -231,12 +231,12 @@ def test_configure_provision_reuses_existing_bucket_without_size_prompt(
 
     monkeypatch.setattr(nebius_module, "bootstrap_environment", fake_bootstrap)
 
-    # No size prompt is shown when the bucket already exists.
-    # proj, tenant, region, registry, bucket name (default), hf, token factory, ngc
-    answers = "\n".join(["", "", "", "", "", "", "", ""]) + "\n"
+    # proj, tenant, region, registry, bucket name (Enter = default), hf, token factory, ngc
+    answers = "\n".join(["project-1", "tenant-1", "", "", "", "", "", ""]) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
     assert result.exit_code == 0, result.output
+    assert "No bucket name provided" in result.output
     assert "Reusing existing object-storage bucket" in result.output
     assert sizes == [0]
     creds = yaml.safe_load(creds_path.read_text())
@@ -265,11 +265,11 @@ def test_configure_provision_falls_back_to_manual_on_error(monkeypatch, tmp_path
 
     answers = "\n".join(
         [
-            "",                  # project id (accept derived)
-            "",                  # tenant id (accept derived)
+            "project-1",         # project id
+            "tenant-1",          # tenant id
             "",                  # region (default)
             "",                  # registry (default)
-            "",                  # bucket name (accept suggested)
+            "provision-bucket",  # bucket name
             "y",                 # set a size limit?
             "",                  # size GB (default 50)
             "AKIAMANUAL",        # S3 access key (fallback)
@@ -315,8 +315,8 @@ def test_configure_no_provision_uses_manual_entry(monkeypatch, tmp_path) -> None
 
     answers = "\n".join(
         [
-            "",                  # project id
-            "",                  # tenant id
+            "project-1",         # project id
+            "tenant-1",          # tenant id
             "me-central1",       # region
             "",                  # registry (default)
             "AKIAMANUAL",        # S3 access key
@@ -452,7 +452,7 @@ def test_configure_detects_existing_nebius_profile(monkeypatch, tmp_path) -> Non
     assert "Nebius CLI profile detected" in result.output
 
 
-def test_configure_existing_profile_prefills_and_writes_config(
+def test_configure_existing_profile_writes_config_with_explicit_ids(
     monkeypatch, tmp_path
 ) -> None:
     import yaml
@@ -487,11 +487,11 @@ def test_configure_existing_profile_prefills_and_writes_config(
 
     answers = "\n".join(
         [
-            "",                  # project id (accept profile default)
-            "",                  # tenant id (accept profile default)
+            "project-from-profile",  # project id (entered explicitly)
+            "tenant-from-profile",   # tenant id (entered explicitly)
             "",                  # region (accept eu-west1 from registry)
             "",                  # registry (accept discovered)
-            "",                  # bucket name (accept suggested)
+            "",                  # bucket name (Enter = default)
             "hf_from_profile",   # HF token
             "",                  # Token Factory API key (skip)
             "",                  # NGC API key (skip)
@@ -665,11 +665,11 @@ def test_configure_full_interactive_bootstraps_profile_and_provisions(
     answers = "\n".join(
         [
             "y",                 # create Nebius profile
-            "",                  # project id (accept derived)
-            "",                  # tenant id (accept derived)
+            "project-12345",     # project id
+            "tenant-abcde",      # tenant id
             "",                  # region (default eu-north1)
             "",                  # registry (default)
-            "",                  # bucket name (accept suggested)
+            "",                  # bucket name (Enter = default)
             "n",                 # no bucket size limit
             "hf_secret_token",   # HF token
             "",                  # Token Factory API key (skip)
@@ -681,6 +681,7 @@ def test_configure_full_interactive_bootstraps_profile_and_provisions(
     assert result.exit_code == 0, result.output
     assert created == [True]
     assert "Nebius CLI profile is ready." in result.output
+    assert "No bucket name provided" in result.output
     creds = yaml.safe_load(creds_path.read_text())
     assert creds["storage"]["aws_access_key_id"] == "AKIAPROVISIONED"
     assert creds["tokens"]["HF_TOKEN"] == "hf_secret_token"


### PR DESCRIPTION
## Summary
- Remove pre-filled tenant, project, and bucket defaults from `npa configure` so customer ids are never shown as prompt defaults.
- When the bucket prompt is left empty, create a project-default bucket via the existing Nebius bootstrap path (no name shown until after provisioning).
- Document Nebius AI Cloud signup, tenant, project, and optional bucket setup in README and quickstart.
- Update `configure` / `init` `--provision` help text to describe the Enter-to-create-default-bucket behavior.

## Test plan
- [x] `pytest npa/tests/cli/test_main.py -k configure` (18 passed)
- [ ] Run `npa configure --show` and confirm no example tenant/project/bucket defaults
- [ ] Interactive `npa configure` with Enter at bucket prompt creates bucket + access key
- [ ] Interactive `npa configure` with explicit bucket name reuses or creates that bucket


Made with [Cursor](https://cursor.com)