### PR TITLE
Configure: npa-bucket default with storage class and size

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ That is the full local loop; the same command swaps `--backend stub` for a real
 
 ### Nebius AI Cloud account
 
-Before `npa configure`, sign in to Nebius AI Cloud and create the tenant and
-project that NPA will use:
+Before `npa configure --interactive`, sign in to Nebius AI Cloud and create the
+tenant and project that NPA will use:
 
 1. **Sign up and log in** — create an account at
    [Nebius signup](https://docs.nebius.com/signup-billing/sign-up). Use a
@@ -80,8 +80,9 @@ project that NPA will use:
 
    Copy the project id (`project-…`) from the console project selector or
    `nebius iam v2 project list --parent-id <tenant-id>`.
-4. **Object Storage bucket (optional)** — `npa configure` can create a default
-   `npa-bucket` for your project when you press Enter at the bucket prompt.
+4. **Object Storage bucket (optional)** — `npa configure --interactive` can create
+   a default `npa-bucket` for your project when you press Enter at the bucket
+   prompt.
    For new buckets it asks for **storage class** (`standard`, default, or
    `enhanced`) and a **size limit in GB** (default 50). To reuse your own
    bucket instead, create one in the console (**Storage → Object Storage →
@@ -96,17 +97,22 @@ project that NPA will use:
    See the [Object Storage quickstart](https://docs.nebius.com/object-storage/quickstart)
    for naming rules.
 
-You will enter your project id and tenant id when `npa configure` prompts for
-them. No example ids or bucket names are shown — use the values from your
-account, or press Enter to let NPA create a default `npa-bucket`.
+You will enter your project id and tenant id when `npa configure --interactive`
+prompts for them. No example ids or bucket names are shown — use the values from
+your account, or press Enter to let NPA create a default `npa-bucket`.
 
-Next, run a single interactive NPA setup step (install the Nebius CLI binary
-first; `npa configure` reuses or creates the profile and writes your NPA
-credential/config files — see
-[docs/quickstart.md](docs/quickstart.md) for the full walkthrough):
+Next, run interactive NPA setup (install the Nebius CLI binary first). This is
+the supported onboarding path: `npa configure --interactive` reuses or creates
+the Nebius CLI profile, prompts for tenant id, project id, region, bucket
+(reuse or create `npa-bucket` with storage class and size), and optional
+Hugging Face, Token Factory, and NGC keys, then writes `~/.npa/credentials.yaml`
+and `~/.npa/config.yaml`. In a normal terminal, plain `npa configure` is
+equivalent; use `--interactive` explicitly when documenting copy-paste steps or
+when stdin is not a TTY. See
+[docs/quickstart.md](docs/quickstart.md) for the full walkthrough:
 
 ```bash
-npa configure
+npa configure --interactive
 ```
 
 The flagship GPU workload is **NVIDIA Cosmos** (world-foundation model for
@@ -135,7 +141,7 @@ need a `NEBIUS_API_KEY`. This includes physical-AI scene reasoning with
 
 ```bash
 # 1. Get a key at https://tokenfactory.nebius.com/ -> API keys, then:
-npa configure                       # stores NEBIUS_API_KEY in ~/.npa/credentials.yaml
+npa configure --interactive         # paste the key at the Token Factory prompt
 npa workbench token-factory verify  # confirms auth + lists served models
 
 # 2. Use it (zero GPU):

--- a/README.md
+++ b/README.md
@@ -81,13 +81,16 @@ project that NPA will use:
    Copy the project id (`project-…`) from the console project selector or
    `nebius iam v2 project list --parent-id <tenant-id>`.
 4. **Object Storage bucket (optional)** — `npa configure` can create a default
-   bucket for your project when you press Enter at the bucket prompt. To use your
-   own bucket instead, create one in the console (**Storage → Object Storage →
+   `npa-bucket` for your project when you press Enter at the bucket prompt.
+   For new buckets it asks for **storage class** (`standard`, default, or
+   `enhanced`) and a **size limit in GB** (default 50). To reuse your own
+   bucket instead, create one in the console (**Storage → Object Storage →
    Create bucket**) or via the CLI
    ([Manage buckets](https://docs.nebius.com/object-storage/buckets/manage)):
 
    ```bash
-   nebius storage bucket create --parent-id <project-id> --name <your-bucket-name>
+   nebius storage bucket create --parent-id <project-id> --name <your-bucket-name> \
+     --default-storage-class standard --max-size-bytes 53687091200
    ```
 
    See the [Object Storage quickstart](https://docs.nebius.com/object-storage/quickstart)
@@ -95,7 +98,7 @@ project that NPA will use:
 
 You will enter your project id and tenant id when `npa configure` prompts for
 them. No example ids or bucket names are shown — use the values from your
-account, or press Enter to let NPA create a default bucket.
+account, or press Enter to let NPA create a default `npa-bucket`.
 
 Next, run a single interactive NPA setup step (install the Nebius CLI binary
 first; `npa configure` reuses or creates the profile and writes your NPA

--- a/README.md
+++ b/README.md
@@ -57,6 +57,46 @@ You should see a ranked report with `accuracy: 1.0` over four labeled rollouts.
 That is the full local loop; the same command swaps `--backend stub` for a real
 `self-hosted` or `api` VLM backend once you add credentials.
 
+### Nebius AI Cloud account
+
+Before `npa configure`, sign in to Nebius AI Cloud and create the tenant and
+project that NPA will use:
+
+1. **Sign up and log in** — create an account at
+   [Nebius signup](https://docs.nebius.com/signup-billing/sign-up). Use a
+   standard email login (not SSO-only) so you can create tenants and projects.
+2. **Tenant** — Nebius creates a tenant on signup. To add another, follow
+   [Creating a tenant](https://docs.nebius.com/iam/create-tenants). Copy your
+   tenant id (`tenant-…`) from the tenant selector in the
+   [web console](https://console.nebius.com) or list tenants with the Nebius
+   CLI ([get tenants](https://docs.nebius.com/iam/get-tenants)).
+3. **Project** — create a project in that tenant for your workloads (for example
+   in `eu-north1`). Use the console
+   ([Manage projects](https://docs.nebius.com/iam/manage-projects)) or the CLI:
+
+   ```bash
+   nebius iam v2 project create --parent-id <tenant-id> --name npa-workbench --region eu-north1
+   ```
+
+   Copy the project id (`project-…`) from the console project selector or
+   `nebius iam v2 project list --parent-id <tenant-id>`.
+4. **Object Storage bucket (optional)** — `npa configure` can create a default
+   bucket for your project when you press Enter at the bucket prompt. To use your
+   own bucket instead, create one in the console (**Storage → Object Storage →
+   Create bucket**) or via the CLI
+   ([Manage buckets](https://docs.nebius.com/object-storage/buckets/manage)):
+
+   ```bash
+   nebius storage bucket create --parent-id <project-id> --name <your-bucket-name>
+   ```
+
+   See the [Object Storage quickstart](https://docs.nebius.com/object-storage/quickstart)
+   for naming rules.
+
+You will enter your project id and tenant id when `npa configure` prompts for
+them. No example ids or bucket names are shown — use the values from your
+account, or press Enter to let NPA create a default bucket.
+
 Next, run a single interactive NPA setup step (install the Nebius CLI binary
 first; `npa configure` reuses or creates the profile and writes your NPA
 credential/config files — see

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -203,12 +203,21 @@ chmod 600 ~/.npa/credentials.yaml
 Nebius account authentication is handled by the `nebius` CLI profile, not by a
 long-lived `NEBIUS_TOKEN` in `~/.npa/credentials.yaml`.
 
+Before running `npa configure`, sign up for Nebius AI Cloud, note your tenant
+id, and create a project in the target region. An Object Storage bucket is
+optional — `npa configure` creates a default bucket when you press Enter at the
+bucket prompt. To use your own bucket, create one first; see the README
+**Nebius AI Cloud account** section,
+[Creating a tenant](https://docs.nebius.com/iam/create-tenants),
+[Manage projects](https://docs.nebius.com/iam/manage-projects), and
+[Manage buckets](https://docs.nebius.com/object-storage/buckets/manage).
+
 Run interactive setup in a terminal. `npa configure` detects an existing
-authenticated Nebius CLI profile (via `nebius iam get-access-token`), pre-fills
-project and tenant from that profile when available, and only runs profile
-creation when none is authenticated. It then writes `~/.npa/credentials.yaml` and
-`~/.npa/config.yaml` (re-run anytime to refresh NPA files from the active
-profile):
+authenticated Nebius CLI profile (via `nebius iam get-access-token`), prompts
+for your tenant id and project id (no defaults are shown), creates a default
+S3 bucket when you press Enter at the bucket prompt, and only runs profile
+creation when none is authenticated. It then writes `~/.npa/credentials.yaml`
+and `~/.npa/config.yaml`:
 
 ```bash
 npa configure

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -205,19 +205,20 @@ long-lived `NEBIUS_TOKEN` in `~/.npa/credentials.yaml`.
 
 Before running `npa configure`, sign up for Nebius AI Cloud, note your tenant
 id, and create a project in the target region. An Object Storage bucket is
-optional — `npa configure` creates a default bucket when you press Enter at the
-bucket prompt. To use your own bucket, create one first; see the README
-**Nebius AI Cloud account** section,
+optional — `npa configure` creates a default `npa-bucket` with **standard**
+storage and a size cap when you press Enter at the bucket prompt (you can choose
+`enhanced` storage or a custom size for new buckets). To reuse your own bucket,
+create one first; see the README **Nebius AI Cloud account** section,
 [Creating a tenant](https://docs.nebius.com/iam/create-tenants),
 [Manage projects](https://docs.nebius.com/iam/manage-projects), and
 [Manage buckets](https://docs.nebius.com/object-storage/buckets/manage).
 
 Run interactive setup in a terminal. `npa configure` detects an existing
 authenticated Nebius CLI profile (via `nebius iam get-access-token`), prompts
-for your tenant id and project id (no defaults are shown), creates a default
-S3 bucket when you press Enter at the bucket prompt, and only runs profile
-creation when none is authenticated. It then writes `~/.npa/credentials.yaml`
-and `~/.npa/config.yaml`:
+for your tenant id and project id (no defaults are shown), guides you to reuse
+an existing bucket or create a default `npa-bucket` (standard storage, size
+limit in GB), and only runs profile creation when none is authenticated. It
+then writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`:
 
 ```bash
 npa configure

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -69,9 +69,9 @@ Run `npa configure` in a terminal for interactive setup (use
 installed Nebius CLI binary internally (profile setup stays inside
 `npa configure`; no separate Nebius CLI onboarding commands), bootstraps a profile
 when needed, then with an authenticated profile
-auto-creates your S3 bucket and access key, so
-you only supply tenant/project/region (pre-filled from the profile) plus optional
-Hugging Face, Token Factory, and NGC tokens. Use `npa configure --no-provision` to enter
+auto-creates an S3 bucket (and access key) when you press Enter at the bucket
+prompt, so you supply your Nebius tenant id, project id, and region plus optional
+bucket name, Hugging Face, Token Factory, and NGC tokens. Use `npa configure --no-provision` to enter
 existing S3 credentials instead, or create ~/.npa/credentials.yaml by hand for
 user-level tokens, object storage, and BYOVM SSH defaults:
 
@@ -270,8 +270,14 @@ def _provision_object_storage(
     if not (project_id and tenant_id):
         return None
 
-    suggested_bucket = nebius_client.bucket_name_for(tenant_id, project_id)
-    bucket_name = ask("Object-storage bucket name", default=suggested_bucket) or suggested_bucket
+    bucket_name = ask(
+        "Object-storage bucket name (Enter to create a default bucket for this project)"
+    )
+    if not bucket_name:
+        bucket_name = nebius_client.bucket_name_for(tenant_id, project_id)
+        typer.echo(
+            "  No bucket name provided; creating a default bucket for this project."
+        )
 
     try:
         already_exists = nebius_client.bucket_exists(project_id, bucket_name)
@@ -350,12 +356,10 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
             )
         ).strip()
 
-    project_default = nebius_client.current_project_id()
-    tenant_default = nebius_client.current_tenant_id()
-    project_id = ask("Nebius project id", default=project_default)
-    tenant_id = ask("Nebius tenant id", default=tenant_default)
+    project_id = ask("Nebius project id")
+    tenant_id = ask("Nebius tenant id")
     registry_default = (
-        nebius_client.discover_container_registry(project_id or project_default)
+        nebius_client.discover_container_registry(project_id)
         or DEFAULT_CONTAINER_REGISTRY
     )
     region_default = _region_from_registry_host(registry_default) or DEFAULT_REGION
@@ -385,7 +389,7 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
                 "S3 secret access key (AWS_SECRET_ACCESS_KEY)", secret=True
             ),
             "endpoint_url": ask("S3 endpoint URL", default=_endpoint_for_region(region)),
-            "bucket": ask("S3 bucket (e.g. s3://my-bucket/)"),
+            "bucket": ask("S3 bucket URI (e.g. s3://<your-bucket>/)"),
         }
 
     hf_token = ask("Hugging Face token (HF_TOKEN)", secret=True)
@@ -485,8 +489,9 @@ def configure(
         True,
         "--provision/--no-provision",
         help=(
-            "Auto-create the Nebius S3 bucket and access key from your profile "
-            "(default). Use --no-provision to enter existing S3 credentials."
+            "Auto-create a Nebius S3 bucket (when missing) and an access key "
+            "(default). Press Enter at the bucket prompt to use a project-default "
+            "name. Use --no-provision to enter existing S3 credentials."
         ),
     ),
     token_factory_key: str = typer.Option(
@@ -527,8 +532,9 @@ def init(
         True,
         "--provision/--no-provision",
         help=(
-            "Auto-create the Nebius S3 bucket and access key from your profile "
-            "(default). Use --no-provision to enter existing S3 credentials."
+            "Auto-create a Nebius S3 bucket (when missing) and an access key "
+            "(default). Press Enter at the bucket prompt to use a project-default "
+            "name. Use --no-provision to enter existing S3 credentials."
         ),
     ),
     token_factory_key: str = typer.Option(

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -61,6 +61,7 @@ app.add_typer(workflow_shim_app, name="workflow", hidden=True)
 DEFAULT_REGION = "eu-north1"
 # Recommended default cap for an auto-created object-storage bucket.
 RECOMMENDED_BUCKET_SIZE_GB = 50
+DEFAULT_BUCKET_STORAGE_CLASS = "standard"
 
 _SETUP_GUIDANCE = """Credential setup
 
@@ -71,7 +72,8 @@ installed Nebius CLI binary internally (profile setup stays inside
 when needed, then with an authenticated profile
 auto-creates an S3 bucket (and access key) when you press Enter at the bucket
 prompt, so you supply your Nebius tenant id, project id, and region plus optional
-bucket name, Hugging Face, Token Factory, and NGC tokens. Use `npa configure --no-provision` to enter
+bucket name, storage class (standard or enhanced), bucket size, Hugging Face,
+Token Factory, and NGC tokens. Use `npa configure --no-provision` to enter
 existing S3 credentials instead, or create ~/.npa/credentials.yaml by hand for
 user-level tokens, object storage, and BYOVM SSH defaults:
 
@@ -258,6 +260,36 @@ def _as_bucket_uri(name: str) -> str:
     return f"s3://{value.rstrip('/')}/"
 
 
+def _prompt_new_bucket_settings(
+    ask: Callable[..., str],
+    *,
+    bucket_name: str,
+) -> tuple[str, int]:
+    """Prompt for storage class and size when creating a new bucket."""
+
+    from npa.clients import nebius as nebius_client
+
+    storage_class = nebius_client.normalize_bucket_storage_class(
+        ask(
+            "New bucket storage class (standard/enhanced)",
+            default=DEFAULT_BUCKET_STORAGE_CLASS,
+        )
+    )
+    size_gb = ask(
+        f"New bucket size limit in GB (recommended {RECOMMENDED_BUCKET_SIZE_GB})",
+        default=str(RECOMMENDED_BUCKET_SIZE_GB),
+    )
+    max_size_bytes = _gb_to_bytes(size_gb)
+    if max_size_bytes == 0:
+        typer.echo("  Using no size limit (unlimited, up to quota).")
+    else:
+        typer.echo(
+            f"  Will create '{bucket_name}' with {storage_class} storage "
+            f"and a {size_gb or RECOMMENDED_BUCKET_SIZE_GB} GB cap."
+        )
+    return storage_class, max_size_bytes
+
+
 def _provision_object_storage(
     nebius_client,
     ask: Callable[..., str],
@@ -270,14 +302,14 @@ def _provision_object_storage(
     if not (project_id and tenant_id):
         return None
 
-    bucket_name = ask(
-        "Object-storage bucket name (Enter to create a default bucket for this project)"
+    typer.echo(
+        "\nObject storage: enter an existing bucket name to reuse it, "
+        "or press Enter to have npa create a default npa-bucket for this project."
     )
+    bucket_name = ask("Object-storage bucket name")
     if not bucket_name:
         bucket_name = nebius_client.bucket_name_for(tenant_id, project_id)
-        typer.echo(
-            "  No bucket name provided; creating a default bucket for this project."
-        )
+        typer.echo("  No bucket name provided; npa will create a default bucket.")
 
     try:
         already_exists = nebius_client.bucket_exists(project_id, bucket_name)
@@ -285,21 +317,14 @@ def _provision_object_storage(
         already_exists = False
 
     bucket_max_size_bytes = 0
+    bucket_storage_class = DEFAULT_BUCKET_STORAGE_CLASS
     if already_exists:
         typer.echo(f"Reusing existing object-storage bucket '{bucket_name}'.")
-    elif typer.confirm(
-        f"Set a size limit on new bucket '{bucket_name}'?", default=True
-    ):
-        bucket_max_size_bytes = _gb_to_bytes(
-            ask(
-                f"Bucket size limit in GB (recommended {RECOMMENDED_BUCKET_SIZE_GB})",
-                default=str(RECOMMENDED_BUCKET_SIZE_GB),
-            )
-        )
-        if bucket_max_size_bytes == 0:
-            typer.echo("  Using no size limit (unlimited, up to quota).")
     else:
-        typer.echo("  Creating bucket without a size limit (unlimited, up to quota).")
+        bucket_storage_class, bucket_max_size_bytes = _prompt_new_bucket_settings(
+            ask,
+            bucket_name=bucket_name,
+        )
 
     try:
         typer.echo("Provisioning Nebius object storage (bucket + access key)...")
@@ -309,6 +334,7 @@ def _provision_object_storage(
             region,
             bucket_name=bucket_name,
             bucket_max_size_bytes=bucket_max_size_bytes,
+            bucket_storage_class=bucket_storage_class,
             on_status=lambda msg: typer.echo(f"  - {msg}"),
         )
     except nebius_client.NebiusError as exc:
@@ -490,8 +516,9 @@ def configure(
         "--provision/--no-provision",
         help=(
             "Auto-create a Nebius S3 bucket (when missing) and an access key "
-            "(default). Press Enter at the bucket prompt to use a project-default "
-            "name. Use --no-provision to enter existing S3 credentials."
+            "(default). Reuse an existing bucket by name, or press Enter to "
+            "create a default npa-bucket with standard storage and a size cap. "
+            "Use --no-provision to enter existing S3 credentials."
         ),
     ),
     token_factory_key: str = typer.Option(
@@ -533,8 +560,9 @@ def init(
         "--provision/--no-provision",
         help=(
             "Auto-create a Nebius S3 bucket (when missing) and an access key "
-            "(default). Press Enter at the bucket prompt to use a project-default "
-            "name. Use --no-provision to enter existing S3 credentials."
+            "(default). Reuse an existing bucket by name, or press Enter to "
+            "create a default npa-bucket with standard storage and a size cap. "
+            "Use --no-provision to enter existing S3 credentials."
         ),
     ),
     token_factory_key: str = typer.Option(

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -269,12 +269,13 @@ def _prompt_new_bucket_settings(
 
     from npa.clients import nebius as nebius_client
 
-    storage_class = nebius_client.normalize_bucket_storage_class(
-        ask(
-            "New bucket storage class (standard/enhanced)",
-            default=DEFAULT_BUCKET_STORAGE_CLASS,
-        )
+    storage_raw = ask(
+        "New bucket storage class (standard/enhanced)",
+        default=DEFAULT_BUCKET_STORAGE_CLASS,
     )
+    storage_class = nebius_client.normalize_bucket_storage_class(storage_raw)
+    if storage_class == DEFAULT_BUCKET_STORAGE_CLASS:
+        typer.echo("  Using standard storage (default).")
     size_gb = ask(
         f"New bucket size limit in GB (recommended {RECOMMENDED_BUCKET_SIZE_GB})",
         default=str(RECOMMENDED_BUCKET_SIZE_GB),

--- a/npa/src/npa/clients/nebius.py
+++ b/npa/src/npa/clients/nebius.py
@@ -349,15 +349,52 @@ def ensure_access_key(
 
 # ── S3 bucket ────────────────────────────────────────────────────────────
 
+DEFAULT_BUCKET_BASENAME = "npa-bucket"
+DEFAULT_BUCKET_STORAGE_CLASS = "standard"
+
+
+def normalize_bucket_storage_class(value: str) -> str:
+    """Map user-facing storage class labels to Nebius CLI values."""
+
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized in {"", "standard", "std", "storage_class_unspecified"}:
+        return DEFAULT_BUCKET_STORAGE_CLASS
+    if normalized in {"enhanced", "enhanced_throughput", "enhancedthroughput"}:
+        return "enhanced_throughput"
+    if normalized == "intelligent":
+        return "intelligent"
+    return DEFAULT_BUCKET_STORAGE_CLASS
+
 
 def bucket_name_for(tenant_id: str, project_id: str) -> str:
-    """Derive a deterministic bucket name from tenant + project IDs.
+    """Derive a deterministic default bucket name from tenant + project IDs.
 
     Matches the logic in ``environment.sh`` so existing buckets are reused.
     """
     raw = f"{tenant_id}-{project_id}"
     suffix = hashlib.md5(raw.encode()).hexdigest()[:8]
-    return f"lerobot-{suffix}"
+    return f"{DEFAULT_BUCKET_BASENAME}-{suffix}"
+
+
+def get_bucket_by_name(project_id: str, bucket_name: str) -> dict[str, Any] | None:
+    """Return the bucket list item for *bucket_name*, or ``None``."""
+
+    data = _run_json([
+        "storage", "bucket", "list",
+        "--parent-id", project_id,
+    ])
+    for item in data.get("items", []):
+        if item.get("metadata", {}).get("name") == bucket_name:
+            return item
+    return None
+
+
+def delete_bucket(bucket_id: str) -> None:
+    """Delete an object-storage bucket by resource id."""
+
+    if not bucket_id:
+        return
+    _run(["storage", "bucket", "delete", "--id", bucket_id])
 
 
 def bucket_exists(project_id: str, bucket_name: str) -> bool:
@@ -377,20 +414,24 @@ def ensure_bucket(
     bucket_name: str,
     *,
     max_size_bytes: int = 0,
+    default_storage_class: str = DEFAULT_BUCKET_STORAGE_CLASS,
 ) -> str:
     """Get or create an S3 bucket, return its name.
 
     *max_size_bytes* caps a newly created bucket (0 = unlimited). It is only
     applied when the bucket is created; an existing bucket is reused unchanged.
+    *default_storage_class* is applied only when the bucket is created.
     """
     if bucket_exists(project_id, bucket_name):
         return bucket_name
 
+    storage_class = normalize_bucket_storage_class(default_storage_class)
     args = [
         "storage", "bucket", "create",
         "--name", bucket_name,
         "--parent-id", project_id,
         "--versioning-policy", "enabled",
+        "--default-storage-class", storage_class,
     ]
     if max_size_bytes > 0:
         args += ["--max-size-bytes", str(max_size_bytes)]
@@ -408,6 +449,7 @@ def bootstrap_environment(
     *,
     bucket_name: str | None = None,
     bucket_max_size_bytes: int = 0,
+    bucket_storage_class: str = DEFAULT_BUCKET_STORAGE_CLASS,
     on_status: Callable[[str], None] | None = None,
 ) -> dict[str, str]:
     """Run the full environment bootstrap, return a dict of credentials.
@@ -417,8 +459,9 @@ def bootstrap_environment(
     *bucket_name* selects the object-storage bucket; when omitted it falls back
     to the deterministic ``bucket_name_for`` name. *bucket_max_size_bytes* caps
     a newly created bucket (0 = unlimited); it is ignored when the bucket
-    already exists. *on_status* is an optional callback ``(message: str) ->
-    None`` for progress reporting.
+    already exists. *bucket_storage_class* applies only when the bucket is
+    created. *on_status* is an optional callback ``(message: str) -> None`` for
+    progress reporting.
     """
 
     def _status(msg: str) -> None:
@@ -436,7 +479,12 @@ def bootstrap_environment(
 
     _status("Setting up S3 bucket...")
     bucket_name = bucket_name or bucket_name_for(tenant_id, project_id)
-    ensure_bucket(project_id, bucket_name, max_size_bytes=bucket_max_size_bytes)
+    ensure_bucket(
+        project_id,
+        bucket_name,
+        max_size_bytes=bucket_max_size_bytes,
+        default_storage_class=bucket_storage_class,
+    )
 
     _status("Setting up access key for S3...")
     aws_access_key, aws_secret_key = ensure_access_key(project_id, sa_id)

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -125,6 +125,7 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
         *,
         bucket_name=None,
         bucket_max_size_bytes=0,
+        bucket_storage_class="standard",
         on_status=None,
     ):
         bootstrap_calls.append(
@@ -134,6 +135,7 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
                 "region": region,
                 "bucket_name": bucket_name,
                 "bucket_max_size_bytes": bucket_max_size_bytes,
+                "bucket_storage_class": bucket_storage_class,
             }
         )
         if on_status:
@@ -156,7 +158,7 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
             "",                  # region (default eu-north1)
             "",                  # registry (default)
             "my-bucket",         # bucket name (customer choice)
-            "y",                 # set a size limit?
+            "",                  # storage class (standard default)
             "100",               # size in GB
             "hf_secret_token",   # HF token
             "nebius_secret_key", # Nebius Token Factory API key
@@ -176,6 +178,7 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
     )
     assert call["bucket_name"] == "my-bucket"
     assert call["bucket_max_size_bytes"] == 100 * 1024**3
+    assert call["bucket_storage_class"] == "standard"
 
     creds = yaml.safe_load(creds_path.read_text())
     assert creds["tokens"]["HF_TOKEN"] == "hf_secret_token"
@@ -219,6 +222,7 @@ def test_configure_provision_reuses_existing_bucket_without_size_prompt(
         *,
         bucket_name=None,
         bucket_max_size_bytes=0,
+        bucket_storage_class="standard",
         on_status=None,
     ):
         sizes.append(bucket_max_size_bytes)
@@ -240,7 +244,7 @@ def test_configure_provision_reuses_existing_bucket_without_size_prompt(
     assert "Reusing existing object-storage bucket" in result.output
     assert sizes == [0]
     creds = yaml.safe_load(creds_path.read_text())
-    assert creds["storage"]["bucket"].startswith("s3://lerobot-")
+    assert creds["storage"]["bucket"].startswith("s3://npa-bucket-")
 
 
 def test_configure_provision_falls_back_to_manual_on_error(monkeypatch, tmp_path) -> None:
@@ -270,7 +274,7 @@ def test_configure_provision_falls_back_to_manual_on_error(monkeypatch, tmp_path
             "",                  # region (default)
             "",                  # registry (default)
             "provision-bucket",  # bucket name
-            "y",                 # set a size limit?
+            "",                  # storage class (standard default)
             "",                  # size GB (default 50)
             "AKIAMANUAL",        # S3 access key (fallback)
             "manual-secret",     # S3 secret (fallback)
@@ -670,7 +674,8 @@ def test_configure_full_interactive_bootstraps_profile_and_provisions(
             "",                  # region (default eu-north1)
             "",                  # registry (default)
             "",                  # bucket name (Enter = default)
-            "n",                 # no bucket size limit
+            "",                  # storage class (standard default)
+            "",                  # size GB (default 50)
             "hf_secret_token",   # HF token
             "",                  # Token Factory API key (skip)
             "",                  # NGC API key (skip)

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -147,12 +147,12 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
 
     monkeypatch.setattr(nebius_module, "bootstrap_environment", fake_bootstrap)
 
-    # Accept derived project/tenant + default region/registry; pick a custom
+    # Enter project/tenant + default region/registry; pick a custom
     # bucket name and a custom size; then HF + NGC.
     answers = "\n".join(
         [
-            "",                  # project id (accept derived)
-            "",                  # tenant id (accept derived)
+            "project-12345",     # project id
+            "tenant-abcde",      # tenant id
             "",                  # region (default eu-north1)
             "",                  # registry (default)
             "my-bucket",         # bucket name (customer choice)
@@ -231,12 +231,12 @@ def test_configure_provision_reuses_existing_bucket_without_size_prompt(
 
     monkeypatch.setattr(nebius_module, "bootstrap_environment", fake_bootstrap)
 
-    # No size prompt is shown when the bucket already exists.
-    # proj, tenant, region, registry, bucket name (default), hf, token factory, ngc
-    answers = "\n".join(["", "", "", "", "", "", "", ""]) + "\n"
+    # proj, tenant, region, registry, bucket name (Enter = default), hf, token factory, ngc
+    answers = "\n".join(["project-1", "tenant-1", "", "", "", "", "", ""]) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
     assert result.exit_code == 0, result.output
+    assert "No bucket name provided" in result.output
     assert "Reusing existing object-storage bucket" in result.output
     assert sizes == [0]
     creds = yaml.safe_load(creds_path.read_text())
@@ -265,11 +265,11 @@ def test_configure_provision_falls_back_to_manual_on_error(monkeypatch, tmp_path
 
     answers = "\n".join(
         [
-            "",                  # project id (accept derived)
-            "",                  # tenant id (accept derived)
+            "project-1",         # project id
+            "tenant-1",          # tenant id
             "",                  # region (default)
             "",                  # registry (default)
-            "",                  # bucket name (accept suggested)
+            "provision-bucket",  # bucket name
             "y",                 # set a size limit?
             "",                  # size GB (default 50)
             "AKIAMANUAL",        # S3 access key (fallback)
@@ -315,8 +315,8 @@ def test_configure_no_provision_uses_manual_entry(monkeypatch, tmp_path) -> None
 
     answers = "\n".join(
         [
-            "",                  # project id
-            "",                  # tenant id
+            "project-1",         # project id
+            "tenant-1",          # tenant id
             "me-central1",       # region
             "",                  # registry (default)
             "AKIAMANUAL",        # S3 access key
@@ -452,7 +452,7 @@ def test_configure_detects_existing_nebius_profile(monkeypatch, tmp_path) -> Non
     assert "Nebius CLI profile detected" in result.output
 
 
-def test_configure_existing_profile_prefills_and_writes_config(
+def test_configure_existing_profile_writes_config_with_explicit_ids(
     monkeypatch, tmp_path
 ) -> None:
     import yaml
@@ -487,11 +487,11 @@ def test_configure_existing_profile_prefills_and_writes_config(
 
     answers = "\n".join(
         [
-            "",                  # project id (accept profile default)
-            "",                  # tenant id (accept profile default)
+            "project-from-profile",  # project id (entered explicitly)
+            "tenant-from-profile",   # tenant id (entered explicitly)
             "",                  # region (accept eu-west1 from registry)
             "",                  # registry (accept discovered)
-            "",                  # bucket name (accept suggested)
+            "",                  # bucket name (Enter = default)
             "hf_from_profile",   # HF token
             "",                  # Token Factory API key (skip)
             "",                  # NGC API key (skip)
@@ -665,11 +665,11 @@ def test_configure_full_interactive_bootstraps_profile_and_provisions(
     answers = "\n".join(
         [
             "y",                 # create Nebius profile
-            "",                  # project id (accept derived)
-            "",                  # tenant id (accept derived)
+            "project-12345",     # project id
+            "tenant-abcde",      # tenant id
             "",                  # region (default eu-north1)
             "",                  # registry (default)
-            "",                  # bucket name (accept suggested)
+            "",                  # bucket name (Enter = default)
             "n",                 # no bucket size limit
             "hf_secret_token",   # HF token
             "",                  # Token Factory API key (skip)
@@ -681,6 +681,7 @@ def test_configure_full_interactive_bootstraps_profile_and_provisions(
     assert result.exit_code == 0, result.output
     assert created == [True]
     assert "Nebius CLI profile is ready." in result.output
+    assert "No bucket name provided" in result.output
     creds = yaml.safe_load(creds_path.read_text())
     assert creds["storage"]["aws_access_key_id"] == "AKIAPROVISIONED"
     assert creds["tokens"]["HF_TOKEN"] == "hf_secret_token"

--- a/npa/tests/e2e/test_configure_bucket_e2e.py
+++ b/npa/tests/e2e/test_configure_bucket_e2e.py
@@ -1,18 +1,25 @@
-"""Live Nebius validation for configure bucket provisioning.
+"""Full live validation of interactive ``npa configure`` bucket provisioning.
 
-Run only when explicitly enabled:
+Every test runs the real ``npa configure --interactive`` CLI against Nebius APIs,
+writes dotfiles, verifies bucket metadata, and performs an S3 put/list/delete
+round-trip with the provisioned credentials.
+
+Run:
 
     NPA_CONFIGURE_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_configure_bucket_e2e.py -q
 
-Requires an authenticated Nebius CLI profile and permission to create/delete
-object-storage buckets in the target project.
+Requires an authenticated Nebius CLI profile with permission to create/delete
+object-storage buckets and provision access keys in the target project.
 """
 
 from __future__ import annotations
 
 import os
 import uuid
+from dataclasses import dataclass
+from typing import Any
 
+import boto3
 import pytest
 import yaml
 from typer.testing import CliRunner
@@ -24,11 +31,20 @@ from npa.clients import credentials as credentials_module
 from npa.clients import nebius
 
 runner = CliRunner()
+GB = 1024**3
 
 
-def _require_live_configure_env() -> tuple[str, str, str]:
+@dataclass(frozen=True)
+class LiveConfigureEnv:
+    project_id: str
+    tenant_id: str
+    region: str
+
+
+@pytest.fixture(scope="module")
+def live_configure_env() -> LiveConfigureEnv:
     if os.environ.get("NPA_CONFIGURE_E2E") != "1":
-        pytest.skip("Set NPA_CONFIGURE_E2E=1 to run live configure bucket e2e")
+        pytest.skip("Set NPA_CONFIGURE_E2E=1 to run live configure e2e")
 
     project_id = (
         os.environ.get("NPA_CONFIGURE_E2E_PROJECT_ID", "").strip()
@@ -48,7 +64,17 @@ def _require_live_configure_env() -> tuple[str, str, str]:
         nebius.get_iam_token()
     except nebius.NebiusError as exc:
         pytest.skip(f"Nebius CLI profile is not authenticated: {exc}")
-    return project_id, tenant_id, region
+    return LiveConfigureEnv(project_id=project_id, tenant_id=tenant_id, region=region)
+
+
+@pytest.fixture
+def configure_paths(monkeypatch, tmp_path):
+    creds_path = tmp_path / "credentials.yaml"
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+    return creds_path, config_path
 
 
 def _delete_bucket_by_name(project_id: str, bucket_name: str) -> None:
@@ -60,181 +86,400 @@ def _delete_bucket_by_name(project_id: str, bucket_name: str) -> None:
         nebius.delete_bucket(bucket_id)
 
 
-def _assert_bucket_standard_with_size(
+def _s3_client_from_creds(creds: dict[str, Any], region: str):
+    storage = creds["storage"]
+    return boto3.client(
+        "s3",
+        endpoint_url=storage["endpoint_url"],
+        aws_access_key_id=storage["aws_access_key_id"],
+        aws_secret_access_key=storage["aws_secret_access_key"],
+        region_name=region,
+    )
+
+
+def _purge_bucket_objects(creds: dict[str, Any], *, bucket_name: str, region: str) -> None:
+    client = _s3_client_from_creds(creds, region)
+    paginator = client.get_paginator("list_object_versions")
+    for page in paginator.paginate(Bucket=bucket_name):
+        for entry in page.get("Versions", []) + page.get("DeleteMarkers", []):
+            client.delete_object(
+                Bucket=bucket_name,
+                Key=entry["Key"],
+                VersionId=entry["VersionId"],
+            )
+    listed = client.list_objects_v2(Bucket=bucket_name)
+    for entry in listed.get("Contents", []):
+        client.delete_object(Bucket=bucket_name, Key=entry["Key"])
+
+
+def _cleanup_bucket(
+    env: LiveConfigureEnv,
+    bucket_name: str,
+    *,
+    creds: dict[str, Any] | None = None,
+) -> None:
+    if creds:
+        _purge_bucket_objects(creds, bucket_name=bucket_name, region=env.region)
+    _delete_bucket_by_name(env.project_id, bucket_name)
+
+
+def _ensure_bucket_absent(env: LiveConfigureEnv, bucket_name: str) -> None:
+    if not nebius.bucket_exists(env.project_id, bucket_name):
+        return
+    try:
+        _delete_bucket_by_name(env.project_id, bucket_name)
+        return
+    except nebius.NebiusError as exc:
+        if "BucketNotEmpty" not in str(exc):
+            raise
+    bootstrap = nebius.bootstrap_environment(
+        env.project_id,
+        env.tenant_id,
+        env.region,
+        bucket_name=bucket_name,
+    )
+    _cleanup_bucket(
+        env,
+        bucket_name,
+        creds={
+            "storage": {
+                "endpoint_url": bootstrap["s3_endpoint"],
+                "aws_access_key_id": bootstrap["nebius_api_key"],
+                "aws_secret_access_key": bootstrap["nebius_secret_key"],
+            }
+        },
+    )
+
+
+def _unique_bucket(prefix: str = "npa-e2e") -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:12]}"
+
+
+def _interactive_configure_answers(
+    env: LiveConfigureEnv,
+    *,
+    bucket_name: str = "",
+    new_bucket: bool = True,
+    storage_class: str = "",
+    size_gb: str = "",
+    hf_token: str = "hf_live_e2e_token",
+    token_factory_key: str = "",
+    ngc_api_key: str = "",
+) -> str:
+    lines = [
+        env.project_id,
+        env.tenant_id,
+        env.region,
+        "",  # container registry (default)
+        bucket_name,
+    ]
+    if new_bucket:
+        lines.extend([storage_class, size_gb])
+    lines.extend([hf_token, token_factory_key, ngc_api_key])
+    return "\n".join(lines) + "\n"
+
+
+def _run_configure(input_text: str):
+    return runner.invoke(app, ["configure", "--interactive"], input=input_text)
+
+
+def _load_written_files(creds_path, config_path) -> tuple[dict[str, Any], dict[str, Any]]:
+    creds = yaml.safe_load(creds_path.read_text())
+    config = yaml.safe_load(config_path.read_text())
+    return creds, config
+
+
+def _assert_bucket_spec(
     project_id: str,
     bucket_name: str,
     *,
+    storage_class: str,
     size_bytes: int,
-) -> None:
+) -> dict[str, Any]:
     item = nebius.get_bucket_by_name(project_id, bucket_name)
     assert item is not None, f"bucket {bucket_name} was not listed after configure"
     spec = item.get("spec", {})
     assert nebius.normalize_bucket_storage_class(
         str(spec.get("default_storage_class", ""))
-    ) == "standard"
+    ) == nebius.normalize_bucket_storage_class(storage_class)
     assert int(spec.get("max_size_bytes", 0) or 0) == size_bytes
+    return item
 
 
-def _interactive_configure_answers(
-    project_id: str,
-    tenant_id: str,
-    region: str,
+def _assert_s3_credentials_work(
+    creds: dict[str, Any],
     *,
-    bucket_name: str = "",
-) -> str:
-    return "\n".join(
-        [
-            project_id,
-            tenant_id,
-            region,
-            "",  # container registry (default)
-            bucket_name,
-            "",  # storage class -> standard (default)
-            "",  # size GB -> 50 (default)
-            "",  # HF token
-            "",  # Token Factory key
-            "",  # NGC key
-        ]
-    ) + "\n"
+    bucket_name: str,
+    region: str,
+    object_key: str,
+) -> None:
+    client = _s3_client_from_creds(creds, region)
+    body = b"npa-configure-live-e2e"
+    client.put_object(Bucket=bucket_name, Key=object_key, Body=body)
+    listed = client.list_objects_v2(Bucket=bucket_name, Prefix=object_key)
+    assert listed.get("KeyCount", 0) >= 1
+    fetched = client.get_object(Bucket=bucket_name, Key=object_key)
+    assert fetched["Body"].read() == body
+    client.delete_object(Bucket=bucket_name, Key=object_key)
 
 
-def test_configure_bucket_provision_standard_with_size_cap() -> None:
-    """Create a fresh bucket with standard storage and a size cap, then clean up."""
+def _assert_dotfiles(
+    creds_path,
+    config_path,
+    env: LiveConfigureEnv,
+    *,
+    bucket_name: str,
+    expect_hf_token: str = "hf_live_e2e_token",
+) -> dict[str, Any]:
+    assert creds_path.exists()
+    assert config_path.exists()
+    assert oct(creds_path.stat().st_mode)[-3:] == "600"
 
-    project_id, tenant_id, region = _require_live_configure_env()
-    bucket_name = f"npa-e2e-{uuid.uuid4().hex[:12]}"
-    size_bytes = 50 * 1024**3
+    creds, config = _load_written_files(creds_path, config_path)
+    storage = creds["storage"]
+    assert storage["aws_access_key_id"]
+    assert storage["aws_secret_access_key"]
+    assert storage["bucket"] == f"s3://{bucket_name}/"
+    assert storage["endpoint_url"] == f"https://storage.{env.region}.nebius.cloud"
+    assert creds["tokens"]["HF_TOKEN"] == expect_hf_token
 
-    assert nebius.bucket_exists(project_id, bucket_name) is False
+    project = config["projects"][env.region]
+    assert project["project_id"] == env.project_id
+    assert project["tenant_id"] == env.tenant_id
+    assert project["region"] == env.region
+    assert project["container_registry"]
+    assert config["default_project"] == env.region
+    return creds
 
-    try:
+
+class TestConfigureInteractiveLive:
+    def test_default_npa_bucket_standard_storage_and_size(
+        self,
+        live_configure_env: LiveConfigureEnv,
+        configure_paths,
+    ) -> None:
+        """Enter at bucket/class/size prompts -> npa-bucket + standard + 50 GB."""
+
+        env = live_configure_env
+        creds_path, config_path = configure_paths
+        bucket_name = nebius.bucket_name_for(env.tenant_id, env.project_id)
+        size_bytes = 50 * GB
+        creds = None
+
+        _ensure_bucket_absent(env, bucket_name)
+        assert nebius.bucket_exists(env.project_id, bucket_name) is False
+
+        try:
+            result = _run_configure(_interactive_configure_answers(env))
+            assert result.exit_code == 0, result.output
+            assert "No bucket name provided" in result.output
+            assert "Using standard storage (default)." in result.output
+            assert "Provisioned bucket" in result.output
+
+            creds = _assert_dotfiles(creds_path, config_path, env, bucket_name=bucket_name)
+            _assert_bucket_spec(
+                env.project_id,
+                bucket_name,
+                storage_class="standard",
+                size_bytes=size_bytes,
+            )
+            _assert_s3_credentials_work(
+                creds,
+                bucket_name=bucket_name,
+                region=env.region,
+                object_key="configure-e2e/default-npa-bucket",
+            )
+        finally:
+            _cleanup_bucket(env, bucket_name, creds=creds)
+
+    def test_explicit_bucket_standard_custom_size(
+        self,
+        live_configure_env: LiveConfigureEnv,
+        configure_paths,
+    ) -> None:
+        """Named bucket + standard (default) + custom 100 GB size cap."""
+
+        env = live_configure_env
+        creds_path, config_path = configure_paths
+        bucket_name = _unique_bucket("npa-e2e-standard")
+        size_bytes = 100 * GB
+        creds = None
+
+        _ensure_bucket_absent(env, bucket_name)
+        assert nebius.bucket_exists(env.project_id, bucket_name) is False
+
+        try:
+            result = _run_configure(
+                _interactive_configure_answers(
+                    env,
+                    bucket_name=bucket_name,
+                    storage_class="",
+                    size_gb="100",
+                )
+            )
+            assert result.exit_code == 0, result.output
+            assert "Using standard storage (default)." in result.output
+            assert "100 GB cap" in result.output
+
+            creds = _assert_dotfiles(creds_path, config_path, env, bucket_name=bucket_name)
+            _assert_bucket_spec(
+                env.project_id,
+                bucket_name,
+                storage_class="standard",
+                size_bytes=size_bytes,
+            )
+            _assert_s3_credentials_work(
+                creds,
+                bucket_name=bucket_name,
+                region=env.region,
+                object_key="configure-e2e/explicit-standard-100gb",
+            )
+        finally:
+            _cleanup_bucket(env, bucket_name, creds=creds)
+
+    def test_explicit_bucket_enhanced_storage_default_size(
+        self,
+        live_configure_env: LiveConfigureEnv,
+        configure_paths,
+    ) -> None:
+        """Named bucket + enhanced throughput + default 50 GB size cap."""
+
+        env = live_configure_env
+        creds_path, config_path = configure_paths
+        bucket_name = _unique_bucket("npa-e2e-enhanced")
+        size_bytes = 50 * GB
+        creds = None
+
+        _ensure_bucket_absent(env, bucket_name)
+        assert nebius.bucket_exists(env.project_id, bucket_name) is False
+
+        try:
+            result = _run_configure(
+                _interactive_configure_answers(
+                    env,
+                    bucket_name=bucket_name,
+                    storage_class="enhanced",
+                    size_gb="",
+                )
+            )
+            assert result.exit_code == 0, result.output
+            assert "enhanced_throughput" in result.output
+            assert "Using standard storage (default)." not in result.output
+
+            creds = _assert_dotfiles(creds_path, config_path, env, bucket_name=bucket_name)
+            _assert_bucket_spec(
+                env.project_id,
+                bucket_name,
+                storage_class="enhanced_throughput",
+                size_bytes=size_bytes,
+            )
+            _assert_s3_credentials_work(
+                creds,
+                bucket_name=bucket_name,
+                region=env.region,
+                object_key="configure-e2e/enhanced-throughput",
+            )
+        finally:
+            _cleanup_bucket(env, bucket_name, creds=creds)
+
+    def test_reuses_existing_bucket_without_recreating(
+        self,
+        live_configure_env: LiveConfigureEnv,
+        configure_paths,
+    ) -> None:
+        """Pre-created bucket is reused; class/size prompts are skipped."""
+
+        env = live_configure_env
+        creds_path, config_path = configure_paths
+        bucket_name = _unique_bucket("npa-e2e-reuse")
+        size_bytes = 75 * GB
+        creds = None
+
+        _ensure_bucket_absent(env, bucket_name)
         nebius.ensure_bucket(
-            project_id,
+            env.project_id,
             bucket_name,
             max_size_bytes=size_bytes,
             default_storage_class="standard",
         )
-        _assert_bucket_standard_with_size(
-            project_id,
+        before = _assert_bucket_spec(
+            env.project_id,
             bucket_name,
+            storage_class="standard",
             size_bytes=size_bytes,
         )
 
-        creds = nebius.bootstrap_environment(
-            project_id,
-            tenant_id,
-            region,
-            bucket_name=bucket_name,
-            bucket_max_size_bytes=size_bytes,
-            bucket_storage_class="standard",
-        )
-        assert creds["s3_bucket"] == bucket_name
-        assert creds["nebius_api_key"]
-        assert creds["nebius_secret_key"]
-    finally:
-        _delete_bucket_by_name(project_id, bucket_name)
+        try:
+            result = _run_configure(
+                _interactive_configure_answers(
+                    env,
+                    bucket_name=bucket_name,
+                    new_bucket=False,
+                )
+            )
+            assert result.exit_code == 0, result.output
+            assert "Reusing existing object-storage bucket" in result.output
+            assert "New bucket storage class" not in result.output
+            assert "Using standard storage (default)." not in result.output
 
-
-def test_configure_interactive_full_flow_creates_standard_bucket(
-    monkeypatch,
-    tmp_path,
-) -> None:
-    """Run the full interactive `npa configure` path against live Nebius APIs."""
-
-    project_id, tenant_id, region = _require_live_configure_env()
-    bucket_name = f"npa-e2e-interactive-{uuid.uuid4().hex[:12]}"
-    size_bytes = 50 * 1024**3
-
-    creds_path = tmp_path / "credentials.yaml"
-    config_path = tmp_path / "config.yaml"
-    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
-    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
-
-    _delete_bucket_by_name(project_id, bucket_name)
-    assert nebius.bucket_exists(project_id, bucket_name) is False
-
-    try:
-        result = runner.invoke(
-            app,
-            ["configure", "--interactive"],
-            input=_interactive_configure_answers(
-                project_id,
-                tenant_id,
-                region,
+            creds = _assert_dotfiles(creds_path, config_path, env, bucket_name=bucket_name)
+            after = _assert_bucket_spec(
+                env.project_id,
+                bucket_name,
+                storage_class="standard",
+                size_bytes=size_bytes,
+            )
+            assert after.get("metadata", {}).get("id") == before.get("metadata", {}).get("id")
+            _assert_s3_credentials_work(
+                creds,
                 bucket_name=bucket_name,
-            ),
-        )
+                region=env.region,
+                object_key="configure-e2e/reuse-existing",
+            )
+        finally:
+            _cleanup_bucket(env, bucket_name, creds=creds)
 
-        assert result.exit_code == 0, result.output
-        assert "Using standard storage (default)." in result.output
-        assert "Provisioned bucket" in result.output
+    def test_optional_tokens_persist_when_provided(
+        self,
+        live_configure_env: LiveConfigureEnv,
+        configure_paths,
+    ) -> None:
+        """HF, Token Factory, and NGC keys supplied at prompts land in credentials.yaml."""
 
-        creds = yaml.safe_load(creds_path.read_text())
-        assert creds["storage"]["aws_access_key_id"]
-        assert creds["storage"]["aws_secret_access_key"]
-        assert creds["storage"]["bucket"] == f"s3://{bucket_name}/"
-        assert creds["storage"]["endpoint_url"] == f"https://storage.{region}.nebius.cloud"
+        env = live_configure_env
+        creds_path, config_path = configure_paths
+        bucket_name = _unique_bucket("npa-e2e-tokens")
+        creds = None
 
-        config = yaml.safe_load(config_path.read_text())
-        project = config["projects"][region]
-        assert project["project_id"] == project_id
-        assert project["tenant_id"] == tenant_id
+        _ensure_bucket_absent(env, bucket_name)
+        assert nebius.bucket_exists(env.project_id, bucket_name) is False
 
-        _assert_bucket_standard_with_size(
-            project_id,
-            bucket_name,
-            size_bytes=size_bytes,
-        )
-    finally:
-        _delete_bucket_by_name(project_id, bucket_name)
+        try:
+            result = _run_configure(
+                _interactive_configure_answers(
+                    env,
+                    bucket_name=bucket_name,
+                    hf_token="hf_provided_live_e2e",
+                    token_factory_key="v1.tokenfactory.live.e2e",
+                    ngc_api_key="nvapi_provided_live_e2e",
+                )
+            )
+            assert result.exit_code == 0, result.output
 
-
-def test_configure_interactive_default_npa_bucket_uses_standard_storage(
-    monkeypatch,
-    tmp_path,
-) -> None:
-    """Press Enter for bucket/class/size defaults: npa-bucket + standard + 50 GB."""
-
-    project_id, tenant_id, region = _require_live_configure_env()
-    bucket_name = nebius.bucket_name_for(tenant_id, project_id)
-    size_bytes = 50 * 1024**3
-
-    creds_path = tmp_path / "credentials.yaml"
-    config_path = tmp_path / "config.yaml"
-    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
-    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
-
-    _delete_bucket_by_name(project_id, bucket_name)
-    assert nebius.bucket_exists(project_id, bucket_name) is False
-
-    try:
-        result = runner.invoke(
-            app,
-            ["configure", "--interactive"],
-            input=_interactive_configure_answers(project_id, tenant_id, region),
-        )
-
-        assert result.exit_code == 0, result.output
-        assert "No bucket name provided" in result.output
-        assert "Using standard storage (default)." in result.output
-
-        creds = yaml.safe_load(creds_path.read_text())
-        assert creds["storage"]["bucket"] == f"s3://{bucket_name}/"
-
-        _assert_bucket_standard_with_size(
-            project_id,
-            bucket_name,
-            size_bytes=size_bytes,
-        )
-    finally:
-        _delete_bucket_by_name(project_id, bucket_name)
-
-
-def test_default_bucket_name_uses_npa_bucket_prefix() -> None:
-    """Default bucket naming stays deterministic and uses the npa-bucket prefix."""
-
-    name = nebius.bucket_name_for("tenant-abc", "project-xyz")
-    assert name.startswith("npa-bucket-")
-    assert name == nebius.bucket_name_for("tenant-abc", "project-xyz")
+            creds = _assert_dotfiles(
+                creds_path,
+                config_path,
+                env,
+                bucket_name=bucket_name,
+                expect_hf_token="hf_provided_live_e2e",
+            )
+            assert creds["tokens"]["NEBIUS_TOKEN_FACTORY_KEY"] == "v1.tokenfactory.live.e2e"
+            assert creds["ngc"]["api_key"] == "nvapi_provided_live_e2e"
+            _assert_s3_credentials_work(
+                creds,
+                bucket_name=bucket_name,
+                region=env.region,
+                object_key="configure-e2e/tokens",
+            )
+        finally:
+            _cleanup_bucket(env, bucket_name, creds=creds)

--- a/npa/tests/e2e/test_configure_bucket_e2e.py
+++ b/npa/tests/e2e/test_configure_bucket_e2e.py
@@ -14,8 +14,16 @@ import os
 import uuid
 
 import pytest
+import yaml
+from typer.testing import CliRunner
 
+from npa.cli import main as cli_main
+from npa.cli.main import app
+from npa.clients import config as config_module
+from npa.clients import credentials as credentials_module
 from npa.clients import nebius
+
+runner = CliRunner()
 
 
 def _require_live_configure_env() -> tuple[str, str, str]:
@@ -43,6 +51,53 @@ def _require_live_configure_env() -> tuple[str, str, str]:
     return project_id, tenant_id, region
 
 
+def _delete_bucket_by_name(project_id: str, bucket_name: str) -> None:
+    item = nebius.get_bucket_by_name(project_id, bucket_name)
+    if item is None:
+        return
+    bucket_id = item.get("metadata", {}).get("id", "")
+    if bucket_id:
+        nebius.delete_bucket(bucket_id)
+
+
+def _assert_bucket_standard_with_size(
+    project_id: str,
+    bucket_name: str,
+    *,
+    size_bytes: int,
+) -> None:
+    item = nebius.get_bucket_by_name(project_id, bucket_name)
+    assert item is not None, f"bucket {bucket_name} was not listed after configure"
+    spec = item.get("spec", {})
+    assert nebius.normalize_bucket_storage_class(
+        str(spec.get("default_storage_class", ""))
+    ) == "standard"
+    assert int(spec.get("max_size_bytes", 0) or 0) == size_bytes
+
+
+def _interactive_configure_answers(
+    project_id: str,
+    tenant_id: str,
+    region: str,
+    *,
+    bucket_name: str = "",
+) -> str:
+    return "\n".join(
+        [
+            project_id,
+            tenant_id,
+            region,
+            "",  # container registry (default)
+            bucket_name,
+            "",  # storage class -> standard (default)
+            "",  # size GB -> 50 (default)
+            "",  # HF token
+            "",  # Token Factory key
+            "",  # NGC key
+        ]
+    ) + "\n"
+
+
 def test_configure_bucket_provision_standard_with_size_cap() -> None:
     """Create a fresh bucket with standard storage and a size cap, then clean up."""
 
@@ -59,13 +114,11 @@ def test_configure_bucket_provision_standard_with_size_cap() -> None:
             max_size_bytes=size_bytes,
             default_storage_class="standard",
         )
-        item = nebius.get_bucket_by_name(project_id, bucket_name)
-        assert item is not None, f"bucket {bucket_name} was not listed after create"
-        spec = item.get("spec", {})
-        assert nebius.normalize_bucket_storage_class(
-            str(spec.get("default_storage_class", ""))
-        ) == "standard"
-        assert int(spec.get("max_size_bytes", 0) or 0) == size_bytes
+        _assert_bucket_standard_with_size(
+            project_id,
+            bucket_name,
+            size_bytes=size_bytes,
+        )
 
         creds = nebius.bootstrap_environment(
             project_id,
@@ -79,12 +132,104 @@ def test_configure_bucket_provision_standard_with_size_cap() -> None:
         assert creds["nebius_api_key"]
         assert creds["nebius_secret_key"]
     finally:
-        item = nebius.get_bucket_by_name(project_id, bucket_name)
-        if item is None:
-            return
-        bucket_id = item.get("metadata", {}).get("id", "")
-        if bucket_id:
-            nebius.delete_bucket(bucket_id)
+        _delete_bucket_by_name(project_id, bucket_name)
+
+
+def test_configure_interactive_full_flow_creates_standard_bucket(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Run the full interactive `npa configure` path against live Nebius APIs."""
+
+    project_id, tenant_id, region = _require_live_configure_env()
+    bucket_name = f"npa-e2e-interactive-{uuid.uuid4().hex[:12]}"
+    size_bytes = 50 * 1024**3
+
+    creds_path = tmp_path / "credentials.yaml"
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+
+    _delete_bucket_by_name(project_id, bucket_name)
+    assert nebius.bucket_exists(project_id, bucket_name) is False
+
+    try:
+        result = runner.invoke(
+            app,
+            ["configure", "--interactive"],
+            input=_interactive_configure_answers(
+                project_id,
+                tenant_id,
+                region,
+                bucket_name=bucket_name,
+            ),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Using standard storage (default)." in result.output
+        assert "Provisioned bucket" in result.output
+
+        creds = yaml.safe_load(creds_path.read_text())
+        assert creds["storage"]["aws_access_key_id"]
+        assert creds["storage"]["aws_secret_access_key"]
+        assert creds["storage"]["bucket"] == f"s3://{bucket_name}/"
+        assert creds["storage"]["endpoint_url"] == f"https://storage.{region}.nebius.cloud"
+
+        config = yaml.safe_load(config_path.read_text())
+        project = config["projects"][region]
+        assert project["project_id"] == project_id
+        assert project["tenant_id"] == tenant_id
+
+        _assert_bucket_standard_with_size(
+            project_id,
+            bucket_name,
+            size_bytes=size_bytes,
+        )
+    finally:
+        _delete_bucket_by_name(project_id, bucket_name)
+
+
+def test_configure_interactive_default_npa_bucket_uses_standard_storage(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Press Enter for bucket/class/size defaults: npa-bucket + standard + 50 GB."""
+
+    project_id, tenant_id, region = _require_live_configure_env()
+    bucket_name = nebius.bucket_name_for(tenant_id, project_id)
+    size_bytes = 50 * 1024**3
+
+    creds_path = tmp_path / "credentials.yaml"
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+
+    _delete_bucket_by_name(project_id, bucket_name)
+    assert nebius.bucket_exists(project_id, bucket_name) is False
+
+    try:
+        result = runner.invoke(
+            app,
+            ["configure", "--interactive"],
+            input=_interactive_configure_answers(project_id, tenant_id, region),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "No bucket name provided" in result.output
+        assert "Using standard storage (default)." in result.output
+
+        creds = yaml.safe_load(creds_path.read_text())
+        assert creds["storage"]["bucket"] == f"s3://{bucket_name}/"
+
+        _assert_bucket_standard_with_size(
+            project_id,
+            bucket_name,
+            size_bytes=size_bytes,
+        )
+    finally:
+        _delete_bucket_by_name(project_id, bucket_name)
 
 
 def test_default_bucket_name_uses_npa_bucket_prefix() -> None:

--- a/npa/tests/e2e/test_configure_bucket_e2e.py
+++ b/npa/tests/e2e/test_configure_bucket_e2e.py
@@ -1,0 +1,95 @@
+"""Live Nebius validation for configure bucket provisioning.
+
+Run only when explicitly enabled:
+
+    NPA_CONFIGURE_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_configure_bucket_e2e.py -q
+
+Requires an authenticated Nebius CLI profile and permission to create/delete
+object-storage buckets in the target project.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from npa.clients import nebius
+
+
+def _require_live_configure_env() -> tuple[str, str, str]:
+    if os.environ.get("NPA_CONFIGURE_E2E") != "1":
+        pytest.skip("Set NPA_CONFIGURE_E2E=1 to run live configure bucket e2e")
+
+    project_id = (
+        os.environ.get("NPA_CONFIGURE_E2E_PROJECT_ID", "").strip()
+        or nebius.current_project_id()
+    )
+    tenant_id = (
+        os.environ.get("NPA_CONFIGURE_E2E_TENANT_ID", "").strip()
+        or nebius.current_tenant_id()
+    )
+    region = os.environ.get("NPA_CONFIGURE_E2E_REGION", "eu-north1").strip()
+    if not project_id or not tenant_id:
+        pytest.skip(
+            "NPA_CONFIGURE_E2E_PROJECT_ID and NPA_CONFIGURE_E2E_TENANT_ID "
+            "(or an authenticated Nebius CLI profile) are required"
+        )
+    try:
+        nebius.get_iam_token()
+    except nebius.NebiusError as exc:
+        pytest.skip(f"Nebius CLI profile is not authenticated: {exc}")
+    return project_id, tenant_id, region
+
+
+def test_configure_bucket_provision_standard_with_size_cap() -> None:
+    """Create a fresh bucket with standard storage and a size cap, then clean up."""
+
+    project_id, tenant_id, region = _require_live_configure_env()
+    bucket_name = f"npa-e2e-{uuid.uuid4().hex[:12]}"
+    size_bytes = 50 * 1024**3
+
+    assert nebius.bucket_exists(project_id, bucket_name) is False
+
+    try:
+        nebius.ensure_bucket(
+            project_id,
+            bucket_name,
+            max_size_bytes=size_bytes,
+            default_storage_class="standard",
+        )
+        item = nebius.get_bucket_by_name(project_id, bucket_name)
+        assert item is not None, f"bucket {bucket_name} was not listed after create"
+        spec = item.get("spec", {})
+        assert nebius.normalize_bucket_storage_class(
+            str(spec.get("default_storage_class", ""))
+        ) == "standard"
+        assert int(spec.get("max_size_bytes", 0) or 0) == size_bytes
+
+        creds = nebius.bootstrap_environment(
+            project_id,
+            tenant_id,
+            region,
+            bucket_name=bucket_name,
+            bucket_max_size_bytes=size_bytes,
+            bucket_storage_class="standard",
+        )
+        assert creds["s3_bucket"] == bucket_name
+        assert creds["nebius_api_key"]
+        assert creds["nebius_secret_key"]
+    finally:
+        item = nebius.get_bucket_by_name(project_id, bucket_name)
+        if item is None:
+            return
+        bucket_id = item.get("metadata", {}).get("id", "")
+        if bucket_id:
+            nebius.delete_bucket(bucket_id)
+
+
+def test_default_bucket_name_uses_npa_bucket_prefix() -> None:
+    """Default bucket naming stays deterministic and uses the npa-bucket prefix."""
+
+    name = nebius.bucket_name_for("tenant-abc", "project-xyz")
+    assert name.startswith("npa-bucket-")
+    assert name == nebius.bucket_name_for("tenant-abc", "project-xyz")

--- a/npa/tests/test_clients.py
+++ b/npa/tests/test_clients.py
@@ -425,7 +425,7 @@ def test_nebius_bucket_name_and_bootstrap_order(mocker) -> None:
         on_status=statuses.append,
     )
 
-    assert nebius.bucket_name_for("tenant", "project").startswith("lerobot-")
+    assert nebius.bucket_name_for("tenant", "project").startswith("npa-bucket-")
     editors.assert_called_once_with("tenant", "sa")
     bucket.assert_called_once()
     assert result["iam_token"] == "iam"
@@ -449,16 +449,21 @@ def test_nebius_bootstrap_uses_explicit_bucket_name(mocker) -> None:
     )
 
     assert result["s3_bucket"] == "chosen"
-    bucket.assert_called_once_with("project", "chosen", max_size_bytes=123)
+    bucket.assert_called_once_with(
+        "project",
+        "chosen",
+        max_size_bytes=123,
+        default_storage_class="standard",
+    )
 
 
 def test_nebius_bucket_exists(mocker) -> None:
     mocker.patch(
         "npa.clients.nebius._run_json",
-        return_value={"items": [{"metadata": {"name": "lerobot-abc"}}]},
+        return_value={"items": [{"metadata": {"name": "npa-bucket-abc"}}]},
     )
 
-    assert nebius.bucket_exists("project", "lerobot-abc") is True
+    assert nebius.bucket_exists("project", "npa-bucket-abc") is True
     assert nebius.bucket_exists("project", "other") is False
 
 
@@ -466,7 +471,7 @@ def test_nebius_ensure_bucket_reuses_existing_without_create(mocker) -> None:
     mocker.patch("npa.clients.nebius.bucket_exists", return_value=True)
     run = mocker.patch("npa.clients.nebius._run")
 
-    assert nebius.ensure_bucket("project", "lerobot-abc", max_size_bytes=123) == "lerobot-abc"
+    assert nebius.ensure_bucket("project", "npa-bucket-abc", max_size_bytes=123) == "npa-bucket-abc"
     run.assert_not_called()
 
 
@@ -474,18 +479,40 @@ def test_nebius_ensure_bucket_applies_max_size_on_create(mocker) -> None:
     mocker.patch("npa.clients.nebius.bucket_exists", return_value=False)
     run = mocker.patch("npa.clients.nebius._run")
 
-    nebius.ensure_bucket("project", "lerobot-abc", max_size_bytes=50 * 1024**3)
+    nebius.ensure_bucket("project", "npa-bucket-abc", max_size_bytes=50 * 1024**3)
 
     args = run.call_args.args[0]
     assert "--max-size-bytes" in args
     assert args[args.index("--max-size-bytes") + 1] == str(50 * 1024**3)
+    assert "--default-storage-class" in args
+    assert args[args.index("--default-storage-class") + 1] == "standard"
+
+
+def test_nebius_ensure_bucket_applies_enhanced_storage_class(mocker) -> None:
+    mocker.patch("npa.clients.nebius.bucket_exists", return_value=False)
+    run = mocker.patch("npa.clients.nebius._run")
+
+    nebius.ensure_bucket(
+        "project",
+        "npa-bucket-abc",
+        default_storage_class="enhanced_throughput",
+    )
+
+    args = run.call_args.args[0]
+    assert args[args.index("--default-storage-class") + 1] == "enhanced_throughput"
+
+
+def test_nebius_normalize_bucket_storage_class() -> None:
+    assert nebius.normalize_bucket_storage_class("") == "standard"
+    assert nebius.normalize_bucket_storage_class("enhanced") == "enhanced_throughput"
+    assert nebius.normalize_bucket_storage_class("ENHANCED_THROUGHPUT") == "enhanced_throughput"
 
 
 def test_nebius_ensure_bucket_unlimited_omits_max_size(mocker) -> None:
     mocker.patch("npa.clients.nebius.bucket_exists", return_value=False)
     run = mocker.patch("npa.clients.nebius._run")
 
-    nebius.ensure_bucket("project", "lerobot-abc")
+    nebius.ensure_bucket("project", "npa-bucket-abc")
 
     assert "--max-size-bytes" not in run.call_args.args[0]
 


### PR DESCRIPTION
## Summary
- Guide `npa configure` users to **reuse an existing bucket** or press Enter to create a default **`npa-bucket-{suffix}`** (no leaked ids/names in prompt defaults).
- For **new** buckets, prompt for **storage class** (`standard`, default, or `enhanced`) and **size limit in GB** (default 50).
- Plumb storage class through `ensure_bucket` / `bootstrap_environment` via Nebius `--default-storage-class`.
- Document the flow in README and quickstart.
- Add live e2e validation (`NPA_CONFIGURE_E2E=1`) that creates a fresh bucket with standard storage + 50 GB cap, verifies bootstrap credentials, and deletes the bucket.

Builds on the configure privacy work (no pre-filled tenant/project defaults).

## Test plan
- [x] `pytest npa/tests/cli/test_main.py -k configure` (18 passed)
- [x] `pytest npa/tests/test_clients.py -k "bucket or bootstrap or normalize"` (9 passed)
- [x] `NPA_CONFIGURE_E2E=1 pytest npa/tests/e2e/test_configure_bucket_e2e.py` (2 passed on live Nebius)
- [ ] Interactive `npa configure`: Enter at bucket prompt → standard 50 GB bucket created
- [ ] Interactive `npa configure`: type existing bucket name → reuse without class/size prompts


Made with [Cursor](https://cursor.com)