### PR TITLE
Add npa.workflow/v0.0.1 declarative workflow specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ The source of truth is `skills/index.yaml`. The tree is organized as:
 - `skills/atomic/`: reusable actions and review conventions such as GPU selection, workflow submission, testing conventions, image build/push, and Cosmos3 setup/troubleshooting.
 - `skills/tools/`: concrete workbench and platform tools such as LeRobot, FiftyOne, Genesis, Isaac Lab, Cosmos, LanceDB, GR00T, SONIC, MJLab, Retargeting, SkyPilot, and Nebius infra.
 - `skills/workflows/sim2real-operate/SKILL.md`: operate the staged Sim2Real pipeline on a K8s GPU cluster — runbook, direct-K8s submit, preflight health checks, storage secret sync, and job monitoring.
+- `skills/workflows/author-npa-workflow/SKILL.md`: author and validate declarative `npa.workflow/v0.0.1` specs (`validate-spec`, `plan-spec`, toolRef catalog).
+- `skills/workflows/generate-npa-workflow/SKILL.md`: design new creative npa.workflow pipelines from the catalog (loops, gates, golden YAML).
 - `skills/workbench/sim2real-engine/SKILL.md`: canonical 14-stage Sim2Real engine map (`run_preamble` / `run_inner_loop` / `run_single_outer_iteration` / `run_finalize`) and K8s sibling job glue.
 
 Compatibility symlinks exist at `.agents/skills` and `.claude/skills`; do not add new skills there directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ making architecture, review, or domain judgments.
 - `skills/workflows/sim2real-operate/SKILL.md`: run, monitor, and debug the
   staged Sim2Real pipeline on a K8s GPU cluster (runbook, direct-K8s submit,
   health checks, job monitoring).
+- `skills/workflows/author-npa-workflow/SKILL.md`: author and validate
+  declarative `npa.workflow/v0.0.1` specs (toolRef catalog, validate/plan/run CLI).
+- `skills/workflows/generate-npa-workflow/SKILL.md`: design new creative
+  npa.workflow pipelines from the workbench tool catalog.
 - `skills/workbench/sim2real-engine/SKILL.md`: Sim2Real staged engine map
   (14 stages, preamble/inner/outer/finalize) and K8s sibling-job glue.
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,13 @@ checked-in SkyPilot template is
 
 ### Workflows And Routing
 
-Workbench workflow orchestration lives under the Workbench solution:
+Workbench workflow orchestration lives under the Workbench solution. For
+**declarative state-machine specs** (`apiVersion: npa.workflow/v0.0.1`) — tool
+chains, loops, and S3 artifact handoff — see
+[docs/workbench/npa-workflow-guide.md](docs/workbench/npa-workflow-guide.md)
+(golden YAMLs under `npa/workflows/workbench/npa-workflows/`).
+
+SkyPilot pipeline submission (checked-in YAML under `npa/workflows/workbench/skypilot/`):
 
 ```bash
 npa workbench workflow submit npa/workflows/workbench/skypilot/vlm-eval.yaml --run-id vlm-eval
@@ -332,6 +338,8 @@ Workbench runs on Nebius infrastructure rather than hiding it:
 
 - [docs/quickstart.md](docs/quickstart.md): install, Nebius auth, and
   credential setup.
+- [docs/workbench/npa-workflow-guide.md](docs/workbench/npa-workflow-guide.md):
+  authoring **NPA workflow YAML** (`npa.workflow/v0.0.1` state machines).
 - [docs/workbench/getting-started.md](docs/workbench/getting-started.md):
   Workbench setup and first workload path.
 - [docs/workbench/guides/README.md](docs/workbench/guides/README.md): easy,

--- a/docs/workbench/cookbooks/bdd100k-pipeline.md
+++ b/docs/workbench/cookbooks/bdd100k-pipeline.md
@@ -1,5 +1,10 @@
 # BDD100K SkyPilot Pipeline
 
+**Declarative spec:** [bdd100k-pipeline.yaml](../../../npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml)
+(`npa.workflow/v0.0.1`) — readable stage graph with `toolRef`s. See
+[npa-workflow-guide.md](../npa-workflow-guide.md). **SkyPilot execution** (below)
+uses `npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml`.
+
 This cookbook describes the SkyPilot workflow at
 `npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml`.
 

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -25,6 +25,7 @@ Golden specs (all pytest-guarded):
 | `vlm-eval-single.yaml` | Single `toolRef`, terminal state |
 | `tokenfactory-rollout-judge.yaml` | Serial two-tool chain with `inputs`/`outputs` |
 | `sim2real-vlm-rl.yaml` | Nested loops + dynamic `transitions` |
+| `bdd100k-pipeline.yaml` | AV failure-mode pipeline — ingest → backfill → train → eval |
 
 ## Document shape
 

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -137,4 +137,6 @@ NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_npa_work
 - JSON Schema validation of artifact payloads
 - Unified `workflow status` for npa.workflow runs (sim2real path is separate today)
 
-Those belong in spec v0.0.2+ as explicit fields (`parallel`, `gang`, `foreach`), not Jinja.
+`run.shell` resolves `config.*` tokens into `/bin/bash -lc` commands; treat spec files as trusted authored input.
+
+Those advanced scheduling features belong in spec v0.0.2+ as explicit fields (`parallel`, `gang`, `foreach`), not Jinja.

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -70,7 +70,7 @@ states:
 | `loop.max` | Fixed iteration count (`int` or `config.attr`) |
 | `loop.until` | Stop when predicate is true (`promote_checkpoint`) |
 | `transitions` | Branch on predicates after the state runs |
-| `needs` | Declared dependency on other states (validated) |
+| `needs` | Ordering hint only (validated acyclic; not enforced at runtime) |
 | `inputs` / `outputs` | Artifact URIs + optional schema labels |
 | `terminal: true` | End state |
 

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -1,0 +1,140 @@
+# NPA workflow guide (`apiVersion: npa.workflow/v0.0.1`)
+
+Declarative state-machine specs for workbench tool pipelines. One format is consumed
+three ways: YAML file, CLI, and Python SDK.
+
+## Quick start
+
+```bash
+# Validate structure and closed toolRef / predicate registries
+npa workbench workflow validate-spec npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
+
+# Expand loops/branches into a step plan (dry-run)
+npa workbench workflow plan-spec npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml \
+  --run-id demo --assume-decision loop_back
+
+# Plan + optional scheduler hints + S3 run manifest
+npa workbench workflow run-spec npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml \
+  --plan-only --scheduler-plan --persist-state --json
+```
+
+Golden specs (all pytest-guarded):
+
+| File | Shows |
+| --- | --- |
+| `vlm-eval-single.yaml` | Single `toolRef`, terminal state |
+| `tokenfactory-rollout-judge.yaml` | Serial two-tool chain with `inputs`/`outputs` |
+| `sim2real-vlm-rl.yaml` | Nested loops + dynamic `transitions` |
+
+## Document shape
+
+```yaml
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+metadata:
+  name: my-workflow
+
+config:            # parameters; referenced by tokens
+  bucket: my-bucket
+  prefix: "runs/{{run.id}}"
+
+resources:         # named profiles → scheduler hints
+  gpu:
+    cloud: kubernetes
+    accelerators: H100:1
+
+initial: first
+
+states:
+  first:
+    toolRef: workbench.vlm_eval.run
+    resources: gpu
+    outputs:
+      - uri: "s3://{{config.bucket}}/{{config.prefix}}/scores/"
+    next: second
+
+  second:
+    terminal: true
+```
+
+## State mechanics
+
+| Field | Purpose |
+| --- | --- |
+| `toolRef` | Cataloged workbench tool (preferred) |
+| `run.shell` / `run.argv` | Ad-hoc command when no catalog entry exists |
+| `next` | Linear edge to the next state |
+| `sequence` | Ordered sub-states (optionally inside `loop`) |
+| `loop.max` | Fixed iteration count (`int` or `config.attr`) |
+| `loop.until` | Stop when predicate is true (`promote_checkpoint`) |
+| `transitions` | Branch on predicates after the state runs |
+| `needs` | Declared dependency on other states (validated) |
+| `inputs` / `outputs` | Artifact URIs + optional schema labels |
+| `terminal: true` | End state |
+
+## Tokens (no Jinja)
+
+| Token | Meaning |
+| --- | --- |
+| `{{config.key}}` | Value from `config` |
+| `{{run.id}}` | Run id from CLI/SDK |
+| `{{run.prefix}}` | `{metadata.name}/{run.id}` or `config.prefix` |
+| `{{state.NAME.uri}}` | Primary output URI recorded after state `NAME` runs |
+
+## Predicates (closed registry)
+
+| Name | True when |
+| --- | --- |
+| `promote_checkpoint` | Decision artifact says promote |
+| `loop_back` | Decision artifact says loop back |
+
+**Planning:** dynamic branches need `--assume-decision` (or `config.plan_assume_decision`)
+because the full graph is not known until runtime.
+
+**Execution:** with `--execute`, the interpreter walks the graph dynamically and reads
+`config.decision_uri` from S3 after decision states (see `decisions.py`).
+
+## Tool catalog
+
+See `docs/workbench/npa-workflow-tool-catalog.md` and
+`npa/src/npa/orchestration/npa_workflow/catalog.py`. Add new tools in Python, not by
+inventing YAML fields.
+
+## Runtime features (v0.0.1+)
+
+| Flag / module | Behavior |
+| --- | --- |
+| `--persist-state` | Write `npa-workflow/manifest.json` + `status.json` under `config.prefix` |
+| `--require-inputs` | Fail fast when declared input URIs are missing on S3 |
+| `--scheduler-plan` | Emit portable per-step task docs (`resources`, `command`) for SkyPilot/K8s glue |
+| `run_workflow(..., execute=True)` | Dynamic traversal; not a static pre-built plan |
+
+SkyPilot submit per step is **not** wired yet — scheduler output is the integration
+contract for the next layer.
+
+## SDK
+
+```python
+from npa.orchestration.npa_workflow import build_plan, load_spec, run_workflow
+
+spec = load_spec("npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml")
+plan = build_plan(spec, run_id="sdk-demo")
+report = run_workflow(spec, run_id="sdk-demo", persist_state=True)
+```
+
+## Verify (same gates as CI / agent skill)
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/orchestration/npa_workflow/ -q
+npa/.venv/bin/python -m pytest npa/tests/smoke/test_npa_workflow_smoke.py -q
+NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q
+```
+
+## What is intentionally out of scope (v0.0.1)
+
+- Gang scheduling, parallel fan-out, runtime manifest-driven `foreach`
+- JSON Schema validation of artifact payloads
+- Unified `workflow status` for npa.workflow runs (sim2real path is separate today)
+
+Those belong in spec v0.0.2+ as explicit fields (`parallel`, `gang`, `foreach`), not Jinja.

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -89,8 +89,8 @@ states:
 | `promote_checkpoint` | Decision artifact says promote |
 | `loop_back` | Decision artifact says loop back |
 
-**Planning:** dynamic branches need `--assume-decision` (or `config.plan_assume_decision`)
-because the full graph is not known until runtime.
+**Planning:** dynamic branches need `--assume-decision promote_checkpoint|loop_back` on
+`plan-spec` / `run-spec --plan-only` because the full graph is not known until runtime.
 
 **Execution:** with `--execute`, the interpreter walks the graph dynamically and reads
 `config.decision_uri` from S3 after decision states (see `decisions.py`).

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -26,6 +26,7 @@ Golden specs (all pytest-guarded):
 | `tokenfactory-rollout-judge.yaml` | Serial two-tool chain with `inputs`/`outputs` |
 | `sim2real-vlm-rl.yaml` | Nested loops + dynamic `transitions` |
 | `bdd100k-pipeline.yaml` | AV failure-mode pipeline — ingest → backfill → train → eval |
+| `tokenfactory-cosmos-gate.yaml` | Creative reason → augment → VLM gate loop |
 
 ## Document shape
 
@@ -71,6 +72,7 @@ states:
 | `loop.until` | Stop when predicate is true (`promote_checkpoint`) |
 | `transitions` | Branch on predicates after the state runs |
 | `needs` | Ordering hint only (validated acyclic; not enforced at runtime) |
+| `writesDecision` | State writes `config.decision_uri`; engine reads S3 after this state |
 | `inputs` / `outputs` | Artifact URIs + optional schema labels |
 | `terminal: true` | End state |
 
@@ -137,6 +139,14 @@ NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_npa_work
 - Gang scheduling, parallel fan-out, runtime manifest-driven `foreach`
 - JSON Schema validation of artifact payloads
 - Unified `workflow status` for npa.workflow runs (sim2real path is separate today)
+
+## YAML beauty conventions
+
+- Group `config`: runtime knobs (`bucket`, `prefix`, backends, iteration counts), blank line, then `*_uri` keys.
+- Fold long `metadata.description` with `>`.
+- Every state gets a one-line `description`.
+- Prefer `toolRef`; use `run.shell` only when no catalog entry exists.
+- Decision states that write threshold JSON must set `writesDecision: true`.
 
 `run.shell` resolves `config.*` tokens into `/bin/bash -lc` commands; treat spec files as trusted authored input.
 

--- a/docs/workbench/npa-workflow-tool-catalog.md
+++ b/docs/workbench/npa-workflow-tool-catalog.md
@@ -21,6 +21,8 @@ invoked as a container command; artifacts pass via S3 URIs in `config`.
 | `workbench.detection_training.eval_*` | `npa workbench detection-training eval --service` | checkpoint + view | metrics JSON |
 | `workbench.fiftyone.launch_app` | FiftyOne review hook | `config.lance_uri` | review session |
 
+Creative mashup example: `tokenfactory-cosmos-gate.yaml` (reason → augment → VLM gate loop).
+
 Add new entries in `npa/src/npa/orchestration/npa_workflow/catalog.py` when
 exposing a tool to workflow specs.
 

--- a/docs/workbench/npa-workflow-tool-catalog.md
+++ b/docs/workbench/npa-workflow-tool-catalog.md
@@ -1,0 +1,29 @@
+# NPA workflow tool catalog (v0.0.1)
+
+Workbench tools referenced by `toolRef` in NPA workflow specs. Each tool is
+invoked as a container command; artifacts pass via S3 URIs in `config`.
+
+| toolRef | CLI / module | Typical inputs | Typical outputs |
+| --- | --- | --- | --- |
+| `workbench.vlm_eval.run` | `npa workbench vlm-eval run` | `config.rollouts_uri` | `config.scores_uri` |
+| `workbench.token_factory.reason` | `npa workbench token-factory reason` | `config.scene_uri` | `config.plan_uri` |
+| `workbench.cosmos2.transfer` | `npa workbench cosmos2 transfer` | `config.trigger_uri` | `config.augment_uri` |
+| `workbench.sim2real_envgen.raw_shard` | `python -m npa.workflows.sim2real_envgen raw-shard` | `config.raw_envs_uri`, `config.env_count` | raw env manifest on S3 |
+
+Add new entries in `npa/src/npa/orchestration/npa_workflow/catalog.py` when
+exposing a tool to workflow specs.
+
+## Tokens
+
+| Token | Meaning |
+| --- | --- |
+| `{{config.*}}` | Value from spec `config` block (after run-id expansion) |
+| `{{run.id}}` | Run identifier passed to plan/run commands |
+| `{{run.prefix}}` | Default `"{metadata.name}/{run.id}"` or `config.prefix` |
+
+## Predicates
+
+| Name | True when |
+| --- | --- |
+| `promote_checkpoint` | Last decision is promote |
+| `loop_back` | Last decision is loop-back |

--- a/docs/workbench/npa-workflow-tool-catalog.md
+++ b/docs/workbench/npa-workflow-tool-catalog.md
@@ -20,6 +20,9 @@ exposing a tool to workflow specs.
 | `{{config.*}}` | Value from spec `config` block (after run-id expansion) |
 | `{{run.id}}` | Run identifier passed to plan/run commands |
 | `{{run.prefix}}` | Default `"{metadata.name}/{run.id}"` or `config.prefix` |
+| `{{state.NAME.uri}}` | Primary output URI recorded after state `NAME` executes |
+
+See `docs/workbench/npa-workflow-guide.md` for the full authoring guide.
 
 ## Predicates
 

--- a/docs/workbench/npa-workflow-tool-catalog.md
+++ b/docs/workbench/npa-workflow-tool-catalog.md
@@ -9,6 +9,10 @@ invoked as a container command; artifacts pass via S3 URIs in `config`.
 | `workbench.token_factory.reason` | `npa workbench token-factory reason` | `config.scene_uri` | `config.plan_uri` |
 | `workbench.cosmos2.transfer` | `npa workbench cosmos2 transfer` | `config.trigger_uri` | `config.augment_uri` |
 | `workbench.sim2real_envgen.raw_shard` | `python -m npa.workflows.sim2real_envgen raw-shard` | `config.raw_envs_uri`, `config.env_count` | raw env manifest on S3 |
+| `workbench.sim2real.policy_rollouts` | workflow stub (`echo`) | `config.rollouts_uri` | rollout prefix on S3 |
+| `workbench.sim2real.heldout_eval` | workflow stub (`echo`) | — | `config.heldout_report_uri` |
+| `workbench.sim2real.write_decision` | demo decision writer | `config.decision_uri`, `config.default_decision` | threshold decision JSON |
+| `workbench.sim2real.finalize` | workflow stub (`echo`) | `config.finalize_report_uri` | final report URI |
 
 Add new entries in `npa/src/npa/orchestration/npa_workflow/catalog.py` when
 exposing a tool to workflow specs.

--- a/docs/workbench/npa-workflow-tool-catalog.md
+++ b/docs/workbench/npa-workflow-tool-catalog.md
@@ -13,6 +13,13 @@ invoked as a container command; artifacts pass via S3 URIs in `config`.
 | `workbench.sim2real.heldout_eval` | workflow stub (`echo`) | — | `config.heldout_report_uri` |
 | `workbench.sim2real.write_decision` | demo decision writer | `config.decision_uri`, `config.default_decision` | threshold decision JSON |
 | `workbench.sim2real.finalize` | workflow stub (`echo`) | `config.finalize_report_uri` | final report URI |
+| `workbench.lancedb.import_bdd100k` | `npa workbench lancedb import-bdd100k --service` | `config.source_uri`, `config.lance_uri` | LanceDB table |
+| `workbench.lancedb.backfill_cpu_bundle` | five CPU UDF backfills | `config.lance_table`, `config.lance_uri` | enriched table |
+| `workbench.lancedb.backfill_clip` | CLIP embedding UDF | `config.lance_uri` | `clip_embedding` column |
+| `workbench.lancedb.create_failure_views` | three materialized views | `config.rider_view`, … | failure-mode views |
+| `workbench.detection_training.train_*` | `npa workbench detection-training train --service` | view + output URIs | checkpoints |
+| `workbench.detection_training.eval_*` | `npa workbench detection-training eval --service` | checkpoint + view | metrics JSON |
+| `workbench.fiftyone.launch_app` | FiftyOne review hook | `config.lance_uri` | review session |
 
 Add new entries in `npa/src/npa/orchestration/npa_workflow/catalog.py` when
 exposing a tool to workflow specs.

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -1317,10 +1317,7 @@ def validate_spec_cmd(
 ) -> None:
     """Validate an NPA workflow specification file."""
 
-    from npa.orchestration.npa_workflow import validate_spec
-
     spec = _load_npa_workflow(yaml_path)
-    validate_spec(spec)
     payload = {
         "status": "valid",
         "apiVersion": spec.api_version,

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -1380,29 +1380,53 @@ def run_spec_cmd(
         help="Execute tool commands locally (default: plan only).",
     ),
     assume_decision: str = typer.Option("", "--assume-decision", help="Branch assumption for planning."),
+    persist_state: bool = typer.Option(
+        False,
+        "--persist-state",
+        help="Write run manifest and status to S3 (config.bucket + config.prefix).",
+    ),
+    require_inputs: bool = typer.Option(
+        False,
+        "--require-inputs",
+        help="Fail before each step when declared input URIs are missing on S3.",
+    ),
+    scheduler_plan: bool = typer.Option(
+        False,
+        "--scheduler-plan",
+        help="Include portable scheduler task documents in JSON output.",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit JSON report."),
 ) -> None:
     """Run or plan an NPA workflow spec."""
 
-    from npa.orchestration.npa_workflow import NpaWorkflowError, run_workflow
+    from npa.orchestration.npa_workflow import NpaWorkflowError, build_plan, run_workflow
+    from npa.orchestration.npa_workflow.scheduler import build_scheduler_plan
 
     spec = _load_npa_workflow(yaml_path)
     resolved_run_id = run_id or f"{spec.name}-{int(time.time())}"
+    resolved_assume = assume_decision or str(spec.config.get("plan_assume_decision") or "")
     try:
         report = run_workflow(
             spec,
             run_id=resolved_run_id,
             execute=execute,
-            assume_decision=assume_decision,
+            assume_decision=resolved_assume,
+            persist_state=persist_state,
+            require_inputs=require_inputs,
         )
     except NpaWorkflowError as exc:
         _fail(str(exc))
         return
+    if scheduler_plan:
+        plan = build_plan(spec, run_id=resolved_run_id, assume_decision=resolved_assume)
+        report["scheduler"] = build_scheduler_plan(spec, plan.steps, run_id=resolved_run_id)
     if json_output:
         typer.echo(json.dumps(report, indent=2, sort_keys=True))
     else:
         typer.echo(f"status: {report['status']}")
         typer.echo(f"run_id: {report['run_id']}")
+        if report.get("run_prefix_uri"):
+            typer.echo(f"run_prefix_uri: {report['run_prefix_uri']}")
         typer.echo(f"steps: {len(report['plan']['steps'])}")
     if report["status"] == "failed":
         raise typer.Exit(1)

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -1345,11 +1345,15 @@ def plan_spec_cmd(
 ) -> None:
     """Expand an NPA workflow spec into an execution plan (dry-run)."""
 
-    from npa.orchestration.npa_workflow import build_plan
+    from npa.orchestration.npa_workflow import NpaWorkflowError, build_plan
 
     spec = _load_npa_workflow(yaml_path)
     resolved_run_id = run_id or f"{spec.name}-plan"
-    plan = build_plan(spec, run_id=resolved_run_id, assume_decision=assume_decision)
+    try:
+        plan = build_plan(spec, run_id=resolved_run_id, assume_decision=assume_decision)
+    except NpaWorkflowError as exc:
+        _fail(str(exc))
+        return
     if json_output:
         typer.echo(json.dumps(plan.to_dict(), indent=2, sort_keys=True))
         return
@@ -1425,8 +1429,6 @@ def run_spec_cmd(
         if report.get("run_prefix_uri"):
             typer.echo(f"run_prefix_uri: {report['run_prefix_uri']}")
         typer.echo(f"steps: {len(report['plan']['steps'])}")
-    if report["status"] == "failed":
-        raise typer.Exit(1)
 
 
 app.add_typer(trigger_app, name="trigger")

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -1301,4 +1301,111 @@ def distill_cmd(
             console.print(f"  {stage}: {tag}")
 
 
+def _load_npa_workflow(path: Path):
+    from npa.orchestration.npa_workflow import NpaWorkflowError, load_spec
+
+    try:
+        return load_spec(path)
+    except NpaWorkflowError as exc:
+        _fail(str(exc))
+
+
+@app.command("validate-spec")
+def validate_spec_cmd(
+    yaml_path: Path = typer.Argument(help="NPA workflow spec (apiVersion: npa.workflow/v0.0.1)."),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON result."),
+) -> None:
+    """Validate an NPA workflow specification file."""
+
+    from npa.orchestration.npa_workflow import validate_spec
+
+    spec = _load_npa_workflow(yaml_path)
+    validate_spec(spec)
+    payload = {
+        "status": "valid",
+        "apiVersion": spec.api_version,
+        "name": spec.name,
+        "states": sorted(spec.states),
+        "initial": spec.initial,
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        typer.echo(f"valid: {spec.name} ({spec.api_version})")
+        typer.echo(f"states: {', '.join(sorted(spec.states))}")
+
+
+@app.command("plan-spec")
+def plan_spec_cmd(
+    yaml_path: Path = typer.Argument(help="NPA workflow spec path."),
+    run_id: str = typer.Option("", "--run-id", help="Run id for token expansion."),
+    assume_decision: str = typer.Option(
+        "",
+        "--assume-decision",
+        help="Plan branch after decide states (promote_checkpoint or loop_back).",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON plan."),
+) -> None:
+    """Expand an NPA workflow spec into an execution plan (dry-run)."""
+
+    from npa.orchestration.npa_workflow import build_plan
+
+    spec = _load_npa_workflow(yaml_path)
+    resolved_run_id = run_id or f"{spec.name}-plan"
+    plan = build_plan(spec, run_id=resolved_run_id, assume_decision=assume_decision)
+    if json_output:
+        typer.echo(json.dumps(plan.to_dict(), indent=2, sort_keys=True))
+        return
+    typer.echo(f"workflow: {plan.workflow}")
+    typer.echo(f"assume_decision: {plan.assume_decision}")
+    for index, step in enumerate(plan.steps, start=1):
+        label = step.state
+        if step.iteration is not None:
+            label = f"{label}#{step.iteration}"
+        if step.tool_ref:
+            typer.echo(f"  {index:02d}. {label} toolRef={step.tool_ref}")
+        elif step.argv:
+            typer.echo(f"  {index:02d}. {label} argv={' '.join(step.argv[:4])}...")
+        else:
+            typer.echo(f"  {index:02d}. {label} shell=<{len(step.shell)} chars>")
+
+
+@app.command("run-spec")
+def run_spec_cmd(
+    yaml_path: Path = typer.Argument(help="NPA workflow spec path."),
+    run_id: str = typer.Option("", "--run-id", help="Run identifier."),
+    execute: bool = typer.Option(
+        False,
+        "--execute/--plan-only",
+        help="Execute tool commands locally (default: plan only).",
+    ),
+    assume_decision: str = typer.Option("", "--assume-decision", help="Branch assumption for planning."),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON report."),
+) -> None:
+    """Run or plan an NPA workflow spec."""
+
+    from npa.orchestration.npa_workflow import NpaWorkflowError, run_workflow
+
+    spec = _load_npa_workflow(yaml_path)
+    resolved_run_id = run_id or f"{spec.name}-{int(time.time())}"
+    try:
+        report = run_workflow(
+            spec,
+            run_id=resolved_run_id,
+            execute=execute,
+            assume_decision=assume_decision,
+        )
+    except NpaWorkflowError as exc:
+        _fail(str(exc))
+        return
+    if json_output:
+        typer.echo(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        typer.echo(f"status: {report['status']}")
+        typer.echo(f"run_id: {report['run_id']}")
+        typer.echo(f"steps: {len(report['plan']['steps'])}")
+    if report["status"] == "failed":
+        raise typer.Exit(1)
+
+
 app.add_typer(trigger_app, name="trigger")

--- a/npa/src/npa/orchestration/npa_workflow/__init__.py
+++ b/npa/src/npa/orchestration/npa_workflow/__init__.py
@@ -1,0 +1,27 @@
+"""NPA workflow specification (``apiVersion: npa.workflow/v0.0.1``) loader and interpreter."""
+
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+from npa.orchestration.npa_workflow.interpreter import (
+    ExecutionPlan,
+    RunContext,
+    build_plan,
+    run_workflow,
+)
+from npa.orchestration.npa_workflow.spec import (
+    API_VERSION,
+    NpaWorkflowSpec,
+    load_spec,
+    validate_spec,
+)
+
+__all__ = [
+    "API_VERSION",
+    "ExecutionPlan",
+    "NpaWorkflowError",
+    "NpaWorkflowSpec",
+    "RunContext",
+    "build_plan",
+    "load_spec",
+    "run_workflow",
+    "validate_spec",
+]

--- a/npa/src/npa/orchestration/npa_workflow/artifacts.py
+++ b/npa/src/npa/orchestration/npa_workflow/artifacts.py
@@ -32,7 +32,7 @@ def s3_object_exists(uri: str, *, checker: Any | None = None) -> bool:
         return True
     except ClientError as exc:
         code = str(exc.response.get("Error", {}).get("Code", ""))
-        if code in {"404", "NoSuchKey", "NotFound"}:
+        if code in {"404", "NoSuchKey", "NotFound", "403", "AccessDenied"}:
             return False
         raise
 

--- a/npa/src/npa/orchestration/npa_workflow/artifacts.py
+++ b/npa/src/npa/orchestration/npa_workflow/artifacts.py
@@ -1,0 +1,44 @@
+"""Artifact URI checks for NPA workflow steps."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise NpaWorkflowError(f"expected s3:// URI, got {uri!r}")
+    key = parsed.path.lstrip("/")
+    if not key:
+        raise NpaWorkflowError(f"S3 URI missing key: {uri!r}")
+    return parsed.netloc, key
+
+
+def s3_object_exists(uri: str, *, checker: Any | None = None) -> bool:
+    bucket, key = parse_s3_uri(uri)
+    if checker is not None:
+        return bool(checker(bucket, key))
+    from botocore.exceptions import ClientError
+
+    from npa.clients.storage import StorageClient
+
+    client = StorageClient.from_environment()
+    try:
+        client._s3.head_object(Bucket=bucket, Key=key)
+        return True
+    except ClientError as exc:
+        code = str(exc.response.get("Error", {}).get("Code", ""))
+        if code in {"404", "NoSuchKey", "NotFound"}:
+            return False
+        raise
+
+
+def require_input_artifacts(uris: list[str], *, checker: Any | None = None) -> None:
+    missing = [uri for uri in uris if uri and not s3_object_exists(uri, checker=checker)]
+    if missing:
+        joined = ", ".join(missing)
+        raise NpaWorkflowError(f"missing required input artifact(s): {joined}")

--- a/npa/src/npa/orchestration/npa_workflow/catalog.py
+++ b/npa/src/npa/orchestration/npa_workflow/catalog.py
@@ -73,6 +73,33 @@ TOOL_CATALOG: dict[str, ToolEntry] = {
             "{{config.env_count}}",
         ],
     ),
+    "workbench.sim2real.policy_rollouts": ToolEntry(
+        name="workbench.sim2real.policy_rollouts",
+        description="Policy rollouts on train envs (workflow stub until sim2real step wiring).",
+        argv_template=["echo", "policy rollouts -> {{config.rollouts_uri}}"],
+    ),
+    "workbench.sim2real.heldout_eval": ToolEntry(
+        name="workbench.sim2real.heldout_eval",
+        description="Held-out simulation eval (workflow stub).",
+        argv_template=["echo", "heldout eval -> {{config.heldout_report_uri}}"],
+    ),
+    "workbench.sim2real.write_decision": ToolEntry(
+        name="workbench.sim2real.write_decision",
+        description="Write threshold decision artifact for dynamic transitions (demo stub).",
+        argv_template=[
+            "python",
+            "-c",
+            (
+                "from npa.orchestration.npa_workflow.decisions import write_decision; "
+                "write_decision('{{config.decision_uri}}', '{{config.default_decision}}')"
+            ),
+        ],
+    ),
+    "workbench.sim2real.finalize": ToolEntry(
+        name="workbench.sim2real.finalize",
+        description="Finalize run artifacts (workflow stub).",
+        argv_template=["echo", "finalize run {{run.id}} -> {{config.finalize_report_uri}}"],
+    ),
 }
 
 

--- a/npa/src/npa/orchestration/npa_workflow/catalog.py
+++ b/npa/src/npa/orchestration/npa_workflow/catalog.py
@@ -1,0 +1,88 @@
+"""Catalog of workbench tools referenced by ``toolRef`` in NPA workflow specs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+
+
+@dataclass(frozen=True)
+class ToolEntry:
+    name: str
+    argv_template: list[str]
+    description: str = ""
+
+
+TOOL_CATALOG: dict[str, ToolEntry] = {
+    "workbench.vlm_eval.run": ToolEntry(
+        name="workbench.vlm_eval.run",
+        description="Score rollout directories with the VLM eval workbench tool.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "vlm-eval",
+            "run",
+            "--input-path",
+            "{{config.rollouts_uri}}",
+            "--output-path",
+            "{{config.scores_uri}}",
+            "--backend",
+            "{{config.vlm_backend}}",
+        ],
+    ),
+    "workbench.token_factory.reason": ToolEntry(
+        name="workbench.token_factory.reason",
+        description="Run Cosmos reasoner over scene inputs.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "token-factory",
+            "reason",
+            "--input-path",
+            "{{config.scene_uri}}",
+            "--output-path",
+            "{{config.plan_uri}}",
+        ],
+    ),
+    "workbench.cosmos2.transfer": ToolEntry(
+        name="workbench.cosmos2.transfer",
+        description="Cosmos Transfer augment stage.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "cosmos2",
+            "transfer",
+            "--input-path",
+            "{{config.trigger_uri}}",
+            "--output-path",
+            "{{config.augment_uri}}",
+        ],
+    ),
+    "workbench.sim2real_envgen.raw_shard": ToolEntry(
+        name="workbench.sim2real_envgen.raw_shard",
+        description="Generate raw simulation env shard.",
+        argv_template=[
+            "python",
+            "-m",
+            "npa.workflows.sim2real_envgen",
+            "raw-shard",
+            "--output-uri",
+            "{{config.raw_envs_uri}}",
+            "--env-count",
+            "{{config.env_count}}",
+        ],
+    ),
+}
+
+
+def validate_tool_ref(tool_ref: str) -> ToolEntry:
+    entry = TOOL_CATALOG.get(tool_ref)
+    if entry is None:
+        known = ", ".join(sorted(TOOL_CATALOG))
+        raise NpaWorkflowError(f"unknown toolRef {tool_ref!r} (known: {known})")
+    return entry
+
+
+def argv_for_tool(tool_ref: str) -> list[str]:
+    return list(validate_tool_ref(tool_ref).argv_template)

--- a/npa/src/npa/orchestration/npa_workflow/catalog.py
+++ b/npa/src/npa/orchestration/npa_workflow/catalog.py
@@ -100,6 +100,244 @@ TOOL_CATALOG: dict[str, ToolEntry] = {
         description="Finalize run artifacts (workflow stub).",
         argv_template=["echo", "finalize run {{run.id}} -> {{config.finalize_report_uri}}"],
     ),
+    "workbench.lancedb.import_bdd100k": ToolEntry(
+        name="workbench.lancedb.import_bdd100k",
+        description="Import BDD100K rows into LanceDB through the workbench service.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "lancedb",
+            "import-bdd100k",
+            "--source",
+            "{{config.source_uri}}",
+            "--table",
+            "{{config.lance_table}}",
+            "--lance-uri",
+            "{{config.lance_uri}}",
+            "--limit",
+            "{{config.bdd100k_limit}}",
+            "--split",
+            "train",
+            "--split",
+            "val",
+            "--service",
+            "--endpoint",
+            "{{config.lancedb_endpoint}}",
+        ],
+    ),
+    "workbench.lancedb.backfill_cpu_bundle": ToolEntry(
+        name="workbench.lancedb.backfill_cpu_bundle",
+        description="Backfill all CPU UDF columns required by BDD100K failure-mode views.",
+        argv_template=[
+            "bash",
+            "-c",
+            (
+                "set -euo pipefail; "
+                "for udf in has_person has_rider person_bbox_area_pct dhash is_duplicate; do "
+                "npa workbench lancedb backfill "
+                "--udf \"${udf}\" "
+                "--table {{config.lance_table}} "
+                "--lance-uri {{config.lance_uri}} "
+                "--batch-size 512 "
+                "--service "
+                "--endpoint {{config.lancedb_endpoint}}; "
+                "done"
+            ),
+        ],
+    ),
+    "workbench.lancedb.backfill_clip": ToolEntry(
+        name="workbench.lancedb.backfill_clip",
+        description="Backfill CLIP embeddings for BDD100K rows.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "lancedb",
+            "backfill",
+            "--udf",
+            "clip_embedding",
+            "--table",
+            "{{config.lance_table}}",
+            "--lance-uri",
+            "{{config.lance_uri}}",
+            "--batch-size",
+            "32",
+            "--service",
+            "--endpoint",
+            "{{config.lancedb_endpoint}}",
+        ],
+    ),
+    "workbench.lancedb.create_failure_views": ToolEntry(
+        name="workbench.lancedb.create_failure_views",
+        description="Create rider, nighttime-person, and distant-person materialized views.",
+        argv_template=[
+            "bash",
+            "-c",
+            (
+                "set -euo pipefail; "
+                "npa workbench lancedb create-mv "
+                "--name {{config.rider_view}} "
+                "--filter \"has_rider = true AND split = 'train'\" "
+                "--table {{config.lance_table}} "
+                "--lance-uri {{config.lance_uri}} "
+                "--service --endpoint {{config.lancedb_endpoint}}; "
+                "npa workbench lancedb create-mv "
+                "--name {{config.nighttime_view}} "
+                "--filter \"timeofday = 'night' AND has_person = true AND split = 'train'\" "
+                "--table {{config.lance_table}} "
+                "--lance-uri {{config.lance_uri}} "
+                "--service --endpoint {{config.lancedb_endpoint}}; "
+                "npa workbench lancedb create-mv "
+                "--name {{config.distant_view}} "
+                "--filter \"has_person = true AND person_bbox_area_pct < 0.01 AND split = 'train'\" "
+                "--table {{config.lance_table}} "
+                "--lance-uri {{config.lance_uri}} "
+                "--service --endpoint {{config.lancedb_endpoint}}"
+            ),
+        ],
+    ),
+    "workbench.detection_training.train_rider": ToolEntry(
+        name="workbench.detection_training.train_rider",
+        description="Train a detector on the rider failure-mode view.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "detection-training",
+            "train",
+            "--view",
+            "{{config.rider_view}}",
+            "--lance-uri",
+            "{{config.lance_uri}}",
+            "--output-uri",
+            "{{config.rider_train_uri}}",
+            "--epochs",
+            "{{config.train_epochs}}",
+            "--batch-size",
+            "{{config.train_batch_size}}",
+            "--learning-rate",
+            "{{config.train_learning_rate}}",
+            "--service",
+            "--endpoint",
+            "{{config.detection_endpoint}}",
+        ],
+    ),
+    "workbench.detection_training.train_nighttime": ToolEntry(
+        name="workbench.detection_training.train_nighttime",
+        description="Train a detector on the nighttime-person failure-mode view.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "detection-training",
+            "train",
+            "--view",
+            "{{config.nighttime_view}}",
+            "--lance-uri",
+            "{{config.lance_uri}}",
+            "--output-uri",
+            "{{config.nighttime_train_uri}}",
+            "--epochs",
+            "{{config.train_epochs}}",
+            "--batch-size",
+            "{{config.train_batch_size}}",
+            "--learning-rate",
+            "{{config.train_learning_rate}}",
+            "--service",
+            "--endpoint",
+            "{{config.detection_endpoint}}",
+        ],
+    ),
+    "workbench.detection_training.train_distant": ToolEntry(
+        name="workbench.detection_training.train_distant",
+        description="Train a detector on the distant-person failure-mode view.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "detection-training",
+            "train",
+            "--view",
+            "{{config.distant_view}}",
+            "--lance-uri",
+            "{{config.lance_uri}}",
+            "--output-uri",
+            "{{config.distant_train_uri}}",
+            "--epochs",
+            "{{config.train_epochs}}",
+            "--batch-size",
+            "{{config.train_batch_size}}",
+            "--learning-rate",
+            "{{config.train_learning_rate}}",
+            "--service",
+            "--endpoint",
+            "{{config.detection_endpoint}}",
+        ],
+    ),
+    "workbench.detection_training.eval_rider": ToolEntry(
+        name="workbench.detection_training.eval_rider",
+        description="Evaluate the rider detector checkpoint.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "detection-training",
+            "eval",
+            "--checkpoint-uri",
+            "{{config.rider_train_uri}}",
+            "--eval-view",
+            "{{config.rider_view}}",
+            "--lance-uri",
+            "{{config.lance_uri}}",
+            "--output-uri",
+            "{{config.rider_eval_uri}}",
+            "--service",
+            "--endpoint",
+            "{{config.detection_endpoint}}",
+        ],
+    ),
+    "workbench.detection_training.eval_nighttime": ToolEntry(
+        name="workbench.detection_training.eval_nighttime",
+        description="Evaluate the nighttime-person detector checkpoint.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "detection-training",
+            "eval",
+            "--checkpoint-uri",
+            "{{config.nighttime_train_uri}}",
+            "--eval-view",
+            "{{config.nighttime_view}}",
+            "--lance-uri",
+            "{{config.lance_uri}}",
+            "--output-uri",
+            "{{config.nighttime_eval_uri}}",
+            "--service",
+            "--endpoint",
+            "{{config.detection_endpoint}}",
+        ],
+    ),
+    "workbench.detection_training.eval_distant": ToolEntry(
+        name="workbench.detection_training.eval_distant",
+        description="Evaluate the distant-person detector checkpoint.",
+        argv_template=[
+            "npa",
+            "workbench",
+            "detection-training",
+            "eval",
+            "--checkpoint-uri",
+            "{{config.distant_train_uri}}",
+            "--eval-view",
+            "{{config.distant_view}}",
+            "--lance-uri",
+            "{{config.lance_uri}}",
+            "--output-uri",
+            "{{config.distant_eval_uri}}",
+            "--service",
+            "--endpoint",
+            "{{config.detection_endpoint}}",
+        ],
+    ),
+    "workbench.fiftyone.launch_app": ToolEntry(
+        name="workbench.fiftyone.launch_app",
+        description="Launch FiftyOne App for pipeline review (workflow stage hook).",
+        argv_template=["echo", "fiftyone review run {{run.id}} lance {{config.lance_uri}}"],
+    ),
 }
 
 

--- a/npa/src/npa/orchestration/npa_workflow/decisions.py
+++ b/npa/src/npa/orchestration/npa_workflow/decisions.py
@@ -1,0 +1,99 @@
+"""Read and write threshold/decision artifacts for dynamic workflow transitions."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+
+DECISION_PROMOTE = "promote_checkpoint"
+DECISION_LOOP_BACK = "loop_back_to_inner_loop"
+
+
+def normalize_decision(raw: str) -> str:
+    """Map decision file values to predicate names."""
+
+    value = raw.strip()
+    if value in {DECISION_PROMOTE, "promote", "promote_checkpoint"}:
+        return DECISION_PROMOTE
+    if value in {DECISION_LOOP_BACK, "loop_back", "loop_back_to_inner_loop"}:
+        return DECISION_LOOP_BACK
+    return value
+
+
+def decision_from_payload(payload: Mapping[str, Any]) -> str:
+    for key in ("decision", "last_decision", "action"):
+        if key in payload:
+            return normalize_decision(str(payload[key]))
+    raise NpaWorkflowError(f"decision payload missing decision field: {payload!r}")
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise NpaWorkflowError(f"expected s3:// URI, got {uri!r}")
+    return parsed.netloc, parsed.path.lstrip("/")
+
+
+def load_decision(uri: str, *, reader: Any | None = None) -> str:
+    """Load a decision string from ``s3://bucket/key`` (inject ``reader`` in tests)."""
+
+    bucket, key = parse_s3_uri(uri)
+    body = _read_object(bucket, key, reader=reader)
+    payload = json.loads(body)
+    if not isinstance(payload, dict):
+        raise NpaWorkflowError(f"decision at {uri} must be a JSON object")
+    return decision_from_payload(payload)
+
+
+def write_decision(uri: str, decision: str, *, writer: Any | None = None) -> None:
+    """Write a decision JSON object to S3 (inject ``writer`` in tests)."""
+
+    bucket, key = parse_s3_uri(uri)
+    payload = {"decision": normalize_decision(decision)}
+    body = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    _write_object(bucket, key, body, writer=writer)
+
+
+def refresh_context_decision(
+    context: Mapping[str, Any],
+    *,
+    reader: Any | None = None,
+) -> str:
+    """Return ``last_decision`` from context or load ``config.decision_uri`` when set."""
+
+    config = dict(context.get("config") or {})
+    uri = str(config.get("decision_uri") or "").strip()
+    if uri:
+        return load_decision(uri, reader=reader)
+    return normalize_decision(str(context.get("last_decision") or ""))
+
+
+def _read_object(bucket: str, key: str, *, reader: Any | None = None) -> str:
+    if reader is not None:
+        return str(reader(bucket, key))
+    from botocore.exceptions import ClientError
+
+    from npa.clients.storage import StorageClient
+
+    client = StorageClient.from_environment()
+    try:
+        response = client._s3.get_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = str(exc.response.get("Error", {}).get("Code", ""))
+        if code in {"404", "NoSuchKey", "NotFound"}:
+            raise FileNotFoundError(f"s3://{bucket}/{key}") from exc
+        raise
+    return response["Body"].read().decode("utf-8")
+
+
+def _write_object(bucket: str, key: str, body: bytes, *, writer: Any | None = None) -> None:
+    if writer is not None:
+        writer(bucket, key, body)
+        return
+    from npa.clients.storage import StorageClient
+
+    client = StorageClient.from_environment()
+    client._s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")

--- a/npa/src/npa/orchestration/npa_workflow/errors.py
+++ b/npa/src/npa/orchestration/npa_workflow/errors.py
@@ -1,0 +1,5 @@
+"""Shared errors for NPA workflow specs."""
+
+
+class NpaWorkflowError(ValueError):
+    """Raised when a workflow spec is malformed or inconsistent."""

--- a/npa/src/npa/orchestration/npa_workflow/interpreter.py
+++ b/npa/src/npa/orchestration/npa_workflow/interpreter.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 
 from npa.orchestration.npa_workflow.artifacts import require_input_artifacts
 from npa.orchestration.npa_workflow.catalog import argv_for_tool
-from npa.orchestration.npa_workflow.decisions import refresh_context_decision
+from npa.orchestration.npa_workflow.decisions import normalize_decision, refresh_context_decision
 from npa.orchestration.npa_workflow.errors import NpaWorkflowError
 from npa.orchestration.npa_workflow.predicates import evaluate_predicate
 from npa.orchestration.npa_workflow.run_state import RunManifest, RunStateStore, store_for_config
@@ -92,7 +92,8 @@ def build_plan(
     run_id: str = "plan-run",
     assume_decision: str = "",
 ) -> ExecutionPlan:
-    assume = assume_decision or str(spec.config.get("plan_assume_decision") or "loop_back")
+    raw_assume = assume_decision or str(spec.config.get("plan_assume_decision") or "loop_back")
+    assume = normalize_decision(raw_assume)
     ctx = _make_context(spec, run_id=run_id)
     plan = ExecutionPlan(
         workflow=spec.name,
@@ -117,7 +118,8 @@ def run_workflow(
     artifact_checker: Any | None = None,
     state_store: RunStateStore | None = None,
 ) -> dict[str, Any]:
-    assume = assume_decision or str(spec.config.get("plan_assume_decision") or "loop_back")
+    raw_assume = assume_decision or str(spec.config.get("plan_assume_decision") or "loop_back")
+    assume = normalize_decision(raw_assume)
     ctx = _make_context(spec, run_id=run_id)
     store = state_store or (store_for_config(ctx.config, run_id=run_id) if persist_state else None)
     manifest = RunManifest(
@@ -129,38 +131,41 @@ def run_workflow(
     if store is not None:
         store.write_manifest(manifest)
 
-    if execute:
-        results = _execute_state_machine(
-            spec,
-            spec.initial,
-            ctx,
-            assume_decision=assume,
-            require_inputs=require_inputs,
-            on_step=on_step,
-            decision_reader=decision_reader,
-            artifact_checker=artifact_checker,
-        )
-    else:
-        plan = build_plan(spec, run_id=run_id, assume_decision=assume)
-        results = []
-        for step in plan.steps:
-            if on_step is not None:
-                on_step(step)
-            results.append(_execute_step(step, execute=False))
-
-    status = "completed"
-    if any(r.get("status") == "failed" for r in results):
+    results: list[dict[str, Any]] = []
+    status = "planned"
+    error: NpaWorkflowError | None = None
+    try:
+        if execute:
+            _execute_state_machine(
+                spec,
+                spec.initial,
+                ctx,
+                assume_decision=assume,
+                require_inputs=require_inputs,
+                on_step=on_step,
+                decision_reader=decision_reader,
+                artifact_checker=artifact_checker,
+                results_out=results,
+            )
+            status = "completed"
+        else:
+            plan = build_plan(spec, run_id=run_id, assume_decision=assume)
+            for step in plan.steps:
+                if on_step is not None:
+                    on_step(step)
+                results.append(_execute_step(step, execute=False))
+            status = "planned"
+    except NpaWorkflowError as exc:
         status = "failed"
-    elif not execute:
-        status = "planned"
-
-    if store is not None:
-        manifest.status = status
-        manifest.steps = results
-        store.write_manifest(manifest)
+        error = exc
+    finally:
+        if store is not None:
+            manifest.status = status
+            manifest.steps = results
+            store.write_manifest(manifest)
 
     plan = build_plan(spec, run_id=run_id, assume_decision=assume)
-    return {
+    report = {
         "workflow": spec.name,
         "run_id": run_id,
         "status": status,
@@ -168,6 +173,9 @@ def run_workflow(
         "plan": plan.to_dict(),
         "run_prefix_uri": store.run_prefix_uri if store is not None else "",
     }
+    if error is not None:
+        raise error
+    return report
 
 
 def _make_context(spec: NpaWorkflowSpec, *, run_id: str) -> RunContext:
@@ -202,14 +210,17 @@ def _expand_state(
     *,
     assume_decision: str,
     loop_label: str = "",
+    follow_transitions: bool = True,
 ) -> None:
     state = spec.states[state_name]
+    _guard_plan_size(spec, plan)
 
     if state.sequence:
         if state.loop:
             max_iter = resolve_config_int(state.loop.max or 1, ctx.config)
             for iteration in range(1, max_iter + 1):
                 ctx.outer_iteration = iteration
+                ctx.last_decision = ""
                 for child in state.sequence:
                     _expand_state(
                         spec,
@@ -218,20 +229,32 @@ def _expand_state(
                         plan,
                         assume_decision=assume_decision,
                         loop_label=state.name,
+                        follow_transitions=False,
                     )
                 ctx.last_decision = assume_decision
                 if state.loop.until and evaluate_predicate(
                     state.loop.until, ctx.as_predicate_context()
                 ):
                     break
-            next_name = _resolve_transition(state, ctx) or state.next
-            if next_name:
-                _expand_state(spec, next_name, ctx, plan, assume_decision=assume_decision)
+            if state.next:
+                _expand_state(
+                    spec,
+                    state.next,
+                    ctx,
+                    plan,
+                    assume_decision=assume_decision,
+                )
             return
 
         for child in state.sequence:
             _expand_state(
-                spec, child, ctx, plan, assume_decision=assume_decision, loop_label=state.name
+                spec,
+                child,
+                ctx,
+                plan,
+                assume_decision=assume_decision,
+                loop_label=state.name,
+                follow_transitions=False,
             )
         if state.next:
             _expand_state(spec, state.next, ctx, plan, assume_decision=assume_decision)
@@ -249,16 +272,40 @@ def _expand_state(
                 break
         next_name = _resolve_transition(state, ctx) or state.next
         if next_name:
-            _expand_state(spec, next_name, ctx, plan, assume_decision=assume_decision)
+            _expand_state(
+                spec,
+                next_name,
+                ctx,
+                plan,
+                assume_decision=assume_decision,
+            )
         return
 
     _append_state_step(spec, state, ctx, plan, loop_label=loop_label)
     if state.terminal:
         return
     ctx.last_decision = assume_decision if state.transitions else ctx.last_decision
-    next_name = _resolve_transition(state, ctx) or state.next
+    next_name = ""
+    if follow_transitions:
+        next_name = _resolve_transition(state, ctx) or state.next
+    elif not state.transitions:
+        next_name = state.next
     if next_name:
-        _expand_state(spec, next_name, ctx, plan, assume_decision=assume_decision)
+        _expand_state(
+            spec,
+            next_name,
+            ctx,
+            plan,
+            assume_decision=assume_decision,
+        )
+
+
+def _guard_plan_size(spec: NpaWorkflowSpec, plan: ExecutionPlan) -> None:
+    limit = max(256, len(spec.states) * 64)
+    if len(plan.steps) >= limit:
+        raise NpaWorkflowError(
+            "plan exceeded step limit; check for unbounded control-flow cycles"
+        )
 
 
 def _append_state_step(
@@ -353,9 +400,10 @@ def _execute_state_machine(
     artifact_checker: Any | None,
     loop_label: str = "",
     follow_transitions: bool = True,
+    results_out: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     state = spec.states[state_name]
-    results: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = results_out if results_out is not None else []
 
     if state.sequence:
         if state.loop:
@@ -364,19 +412,18 @@ def _execute_state_machine(
                 ctx.outer_iteration = iteration
                 ctx.last_decision = ""
                 for child in state.sequence:
-                    results.extend(
-                        _execute_state_machine(
-                            spec,
-                            child,
-                            ctx,
-                            assume_decision=assume_decision,
-                            require_inputs=require_inputs,
-                            on_step=on_step,
-                            decision_reader=decision_reader,
-                            artifact_checker=artifact_checker,
-                            loop_label=state.name,
-                            follow_transitions=False,
-                        )
+                    _execute_state_machine(
+                        spec,
+                        child,
+                        ctx,
+                        assume_decision=assume_decision,
+                        require_inputs=require_inputs,
+                        on_step=on_step,
+                        decision_reader=decision_reader,
+                        artifact_checker=artifact_checker,
+                        loop_label=state.name,
+                        follow_transitions=False,
+                        results_out=results,
                     )
                 if not ctx.last_decision:
                     _refresh_decision(
@@ -390,39 +437,7 @@ def _execute_state_machine(
                     state.loop.until, ctx.as_predicate_context()
                 ):
                     break
-            next_name = _resolve_transition(state, ctx) or state.next
-            if next_name:
-                results.extend(
-                    _execute_state_machine(
-                        spec,
-                        next_name,
-                        ctx,
-                        assume_decision=assume_decision,
-                        require_inputs=require_inputs,
-                        on_step=on_step,
-                        decision_reader=decision_reader,
-                        artifact_checker=artifact_checker,
-                    )
-                )
-            return results
-
-        for child in state.sequence:
-            results.extend(
-                _execute_state_machine(
-                    spec,
-                    child,
-                    ctx,
-                    assume_decision=assume_decision,
-                    require_inputs=require_inputs,
-                    on_step=on_step,
-                    decision_reader=decision_reader,
-                    artifact_checker=artifact_checker,
-                    loop_label=state.name,
-                    follow_transitions=False,
-                )
-            )
-        if state.next:
-            results.extend(
+            if state.next:
                 _execute_state_machine(
                     spec,
                     state.next,
@@ -432,7 +447,35 @@ def _execute_state_machine(
                     on_step=on_step,
                     decision_reader=decision_reader,
                     artifact_checker=artifact_checker,
+                    results_out=results,
                 )
+            return results
+
+        for child in state.sequence:
+            _execute_state_machine(
+                spec,
+                child,
+                ctx,
+                assume_decision=assume_decision,
+                require_inputs=require_inputs,
+                on_step=on_step,
+                decision_reader=decision_reader,
+                artifact_checker=artifact_checker,
+                loop_label=state.name,
+                follow_transitions=False,
+                results_out=results,
+            )
+        if state.next:
+            _execute_state_machine(
+                spec,
+                state.next,
+                ctx,
+                assume_decision=assume_decision,
+                require_inputs=require_inputs,
+                on_step=on_step,
+                decision_reader=decision_reader,
+                artifact_checker=artifact_checker,
+                results_out=results,
             )
         return results
 
@@ -451,6 +494,8 @@ def _execute_state_machine(
                 artifact_checker=artifact_checker,
             )
             results.append(record)
+            if record.get("status") == "failed":
+                raise NpaWorkflowError(str(record.get("error") or f"state {state.name} failed"))
             _refresh_decision(ctx, reader=decision_reader, read_s3=False)
             if not ctx.last_decision:
                 ctx.last_decision = assume_decision
@@ -458,17 +503,16 @@ def _execute_state_machine(
                 break
         next_name = _resolve_transition(state, ctx) or state.next
         if next_name:
-            results.extend(
-                _execute_state_machine(
-                    spec,
-                    next_name,
-                    ctx,
-                    assume_decision=assume_decision,
-                    require_inputs=require_inputs,
-                    on_step=on_step,
-                    decision_reader=decision_reader,
-                    artifact_checker=artifact_checker,
-                )
+            _execute_state_machine(
+                spec,
+                next_name,
+                ctx,
+                assume_decision=assume_decision,
+                require_inputs=require_inputs,
+                on_step=on_step,
+                decision_reader=decision_reader,
+                artifact_checker=artifact_checker,
+                results_out=results,
             )
         return results
 
@@ -482,6 +526,8 @@ def _execute_state_machine(
         artifact_checker=artifact_checker,
     )
     results.append(record)
+    if record.get("status") == "failed":
+        raise NpaWorkflowError(str(record.get("error") or f"state {state.name} failed"))
     if state.terminal:
         return results
     if state.transitions:
@@ -494,17 +540,16 @@ def _execute_state_machine(
     elif not state.transitions:
         next_name = state.next
     if next_name:
-        results.extend(
-            _execute_state_machine(
-                spec,
-                next_name,
-                ctx,
-                assume_decision=assume_decision,
-                require_inputs=require_inputs,
-                on_step=on_step,
-                decision_reader=decision_reader,
-                artifact_checker=artifact_checker,
-            )
+        _execute_state_machine(
+            spec,
+            next_name,
+            ctx,
+            assume_decision=assume_decision,
+            require_inputs=require_inputs,
+            on_step=on_step,
+            decision_reader=decision_reader,
+            artifact_checker=artifact_checker,
+            results_out=results,
         )
     return results
 
@@ -541,8 +586,17 @@ def _run_single_state(
         )
     if on_step is not None:
         on_step(step)
-    record = _execute_step(step, execute=True)
-    _record_state_outputs(state, ctx, step)
+    try:
+        record = _execute_step(step, execute=True)
+    except NpaWorkflowError as exc:
+        record = {
+            "state": step.state,
+            "iteration": step.iteration,
+            "status": "failed",
+            "error": str(exc),
+        }
+    else:
+        _record_state_outputs(state, ctx, step)
     return record
 
 

--- a/npa/src/npa/orchestration/npa_workflow/interpreter.py
+++ b/npa/src/npa/orchestration/npa_workflow/interpreter.py
@@ -1,0 +1,341 @@
+"""Build execution plans and run NPA workflow state machines."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from npa.orchestration.npa_workflow.catalog import argv_for_tool
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+from npa.orchestration.npa_workflow.predicates import evaluate_predicate
+from npa.orchestration.npa_workflow.spec import (
+    NpaWorkflowSpec,
+    StateSpec,
+    config_truthy,
+    resolve_config_int,
+)
+from npa.orchestration.npa_workflow.tokens import resolve_tokens
+
+
+@dataclass
+class PlanStep:
+    state: str
+    iteration: int | None = None
+    loop_label: str = ""
+    argv: list[str] = field(default_factory=list)
+    shell: str = ""
+    tool_ref: str = ""
+    resources: str = "default"
+    outputs: list[dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class ExecutionPlan:
+    workflow: str
+    api_version: str
+    initial: str
+    assume_decision: str = ""
+    steps: list[PlanStep] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workflow": self.workflow,
+            "api_version": self.api_version,
+            "initial": self.initial,
+            "assume_decision": self.assume_decision,
+            "steps": [
+                {
+                    "state": step.state,
+                    "iteration": step.iteration,
+                    "loop_label": step.loop_label,
+                    "argv": step.argv,
+                    "shell": step.shell,
+                    "tool_ref": step.tool_ref,
+                    "resources": step.resources,
+                    "outputs": step.outputs,
+                }
+                for step in self.steps
+            ],
+        }
+
+
+@dataclass
+class RunContext:
+    config: dict[str, Any]
+    run: dict[str, Any]
+    last_decision: str = ""
+    state_outputs: dict[str, dict[str, str]] = field(default_factory=dict)
+    outer_iteration: int = 0
+    inner_iteration: int = 0
+
+    def as_predicate_context(self) -> dict[str, Any]:
+        return {
+            "last_decision": self.last_decision,
+            "outer_iteration": self.outer_iteration,
+            "inner_iteration": self.inner_iteration,
+            "config": self.config,
+            "run": self.run,
+        }
+
+
+def build_plan(
+    spec: NpaWorkflowSpec,
+    *,
+    run_id: str = "plan-run",
+    assume_decision: str = "",
+) -> ExecutionPlan:
+    assume = assume_decision or str(spec.config.get("plan_assume_decision") or "loop_back")
+    ctx = _make_context(spec, run_id=run_id)
+    plan = ExecutionPlan(
+        workflow=spec.name,
+        api_version=spec.api_version,
+        initial=spec.initial,
+        assume_decision=assume,
+    )
+    _expand_state(spec, spec.initial, ctx, plan, assume_decision=assume)
+    return plan
+
+
+def run_workflow(
+    spec: NpaWorkflowSpec,
+    *,
+    run_id: str,
+    execute: bool = False,
+    assume_decision: str = "",
+    on_step: Callable[[PlanStep], None] | None = None,
+) -> dict[str, Any]:
+    plan = build_plan(spec, run_id=run_id, assume_decision=assume_decision)
+    results: list[dict[str, Any]] = []
+    for step in plan.steps:
+        if on_step is not None:
+            on_step(step)
+        results.append(_execute_step(step, execute=execute))
+    status = "completed"
+    if any(r.get("status") == "failed" for r in results):
+        status = "failed"
+    elif not execute:
+        status = "planned"
+    return {
+        "workflow": spec.name,
+        "run_id": run_id,
+        "status": status,
+        "steps": results,
+        "plan": plan.to_dict(),
+    }
+
+
+def _make_context(spec: NpaWorkflowSpec, *, run_id: str) -> RunContext:
+    run = {"id": run_id, "prefix": f"{spec.name}/{run_id}", **dict(spec.run_defaults)}
+    run["id"] = run_id
+    config = _resolve_config_strings(dict(spec.config), run=run)
+    if config.get("prefix"):
+        run["prefix"] = resolve_tokens(str(config["prefix"]), config=config, run=run)
+    return RunContext(config=config, run=run)
+
+
+def _resolve_config_strings(config: dict[str, Any], *, run: dict[str, Any]) -> dict[str, Any]:
+    resolved: dict[str, Any] = dict(config)
+    for _ in range(4):
+        changed = False
+        for key, value in list(resolved.items()):
+            if isinstance(value, str) and "{{" in value:
+                new_value = resolve_tokens(value, config=resolved, run=run)
+                if new_value != value:
+                    resolved[key] = new_value
+                    changed = True
+        if not changed:
+            break
+    return resolved
+
+
+def _expand_state(
+    spec: NpaWorkflowSpec,
+    state_name: str,
+    ctx: RunContext,
+    plan: ExecutionPlan,
+    *,
+    assume_decision: str,
+    loop_label: str = "",
+) -> None:
+    state = spec.states[state_name]
+
+    if state.sequence:
+        if state.loop:
+            max_iter = resolve_config_int(state.loop.max or 1, ctx.config)
+            for iteration in range(1, max_iter + 1):
+                ctx.outer_iteration = iteration
+                for child in state.sequence:
+                    _expand_state(
+                        spec,
+                        child,
+                        ctx,
+                        plan,
+                        assume_decision=assume_decision,
+                        loop_label=state.name,
+                    )
+                ctx.last_decision = assume_decision
+                if state.loop.until and evaluate_predicate(
+                    state.loop.until, ctx.as_predicate_context()
+                ):
+                    break
+            next_name = _resolve_transition(state, ctx) or state.next
+            if next_name:
+                _expand_state(spec, next_name, ctx, plan, assume_decision=assume_decision)
+            return
+
+        for child in state.sequence:
+            _expand_state(
+                spec, child, ctx, plan, assume_decision=assume_decision, loop_label=state.name
+            )
+        if state.next:
+            _expand_state(spec, state.next, ctx, plan, assume_decision=assume_decision)
+        return
+
+    if state.loop:
+        max_iter = resolve_config_int(state.loop.max or 1, ctx.config)
+        for iteration in range(1, max_iter + 1):
+            ctx.inner_iteration = iteration
+            _append_state_step(
+                spec, state, ctx, plan, iteration=iteration, loop_label=loop_label
+            )
+            ctx.last_decision = assume_decision
+            if state.loop.until and evaluate_predicate(state.loop.until, ctx.as_predicate_context()):
+                break
+        next_name = _resolve_transition(state, ctx) or state.next
+        if next_name:
+            _expand_state(spec, next_name, ctx, plan, assume_decision=assume_decision)
+        return
+
+    _append_state_step(spec, state, ctx, plan, loop_label=loop_label)
+    if state.terminal:
+        return
+    ctx.last_decision = assume_decision if state.transitions else ctx.last_decision
+    next_name = _resolve_transition(state, ctx) or state.next
+    if next_name:
+        _expand_state(spec, next_name, ctx, plan, assume_decision=assume_decision)
+
+
+def _append_state_step(
+    spec: NpaWorkflowSpec,
+    state: StateSpec,
+    ctx: RunContext,
+    plan: ExecutionPlan,
+    *,
+    iteration: int | None = None,
+    loop_label: str = "",
+) -> None:
+    argv, shell, tool_ref = _resolved_run(state, ctx)
+    outputs = [
+        {
+            "uri": resolve_tokens(
+                artifact.uri,
+                config=ctx.config,
+                run=ctx.run,
+                state_outputs=ctx.state_outputs,
+            ),
+            "schema": artifact.schema,
+        }
+        for artifact in state.outputs
+        if artifact.uri
+    ]
+    plan.steps.append(
+        PlanStep(
+            state=state.name,
+            iteration=iteration,
+            loop_label=loop_label,
+            argv=argv,
+            shell=shell,
+            tool_ref=tool_ref,
+            resources=state.resources,
+            outputs=outputs,
+        )
+    )
+
+
+def _resolved_run(state: StateSpec, ctx: RunContext) -> tuple[list[str], str, str]:
+    if state.tool_ref:
+        argv = [
+            resolve_tokens(
+                token,
+                config=ctx.config,
+                run=ctx.run,
+                state_outputs=ctx.state_outputs,
+            )
+            for token in argv_for_tool(state.tool_ref)
+        ]
+        return argv, "", state.tool_ref
+    if state.run is None:
+        return [], "", ""
+    shell = resolve_tokens(
+        state.run.shell,
+        config=ctx.config,
+        run=ctx.run,
+        state_outputs=ctx.state_outputs,
+    )
+    argv = [
+        resolve_tokens(token, config=ctx.config, run=ctx.run, state_outputs=ctx.state_outputs)
+        for token in state.run.argv
+    ]
+    return argv, shell, ""
+
+
+def _resolve_transition(state: StateSpec, ctx: RunContext) -> str:
+    for tr in state.transitions:
+        if tr.if_config and not config_truthy(tr.if_config, ctx.config):
+            continue
+        if tr.when is None:
+            return tr.goto
+        if evaluate_predicate(tr.when, ctx.as_predicate_context()):
+            return tr.goto
+    return ""
+
+
+def _execute_step(step: PlanStep, *, execute: bool) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "state": step.state,
+        "iteration": step.iteration,
+        "status": "planned",
+    }
+    if not execute:
+        if step.argv:
+            record["argv"] = step.argv
+        if step.shell:
+            record["shell"] = step.shell
+        if step.tool_ref:
+            record["tool_ref"] = step.tool_ref
+        return record
+
+    if step.argv:
+        proc = subprocess.run(step.argv, capture_output=True, text=True, check=False)
+        record["argv"] = step.argv
+        record["returncode"] = proc.returncode
+        record["status"] = "ok" if proc.returncode == 0 else "failed"
+        if proc.returncode != 0:
+            raise NpaWorkflowError(
+                f"state {step.state} failed (exit {proc.returncode}): "
+                f"{proc.stderr or proc.stdout}"
+            )
+        return record
+
+    if step.shell.strip():
+        proc = subprocess.run(
+            step.shell,
+            shell=True,
+            executable="/bin/bash",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        record["shell"] = step.shell
+        record["returncode"] = proc.returncode
+        record["status"] = "ok" if proc.returncode == 0 else "failed"
+        if proc.returncode != 0:
+            raise NpaWorkflowError(
+                f"state {step.state} failed (exit {proc.returncode}): "
+                f"{proc.stderr or proc.stdout}"
+            )
+        return record
+
+    record["status"] = "skipped"
+    return record

--- a/npa/src/npa/orchestration/npa_workflow/interpreter.py
+++ b/npa/src/npa/orchestration/npa_workflow/interpreter.py
@@ -129,7 +129,10 @@ def run_workflow(
         status="running" if execute else "planned",
     )
     if store is not None:
-        store.write_manifest(manifest)
+        try:
+            store.write_manifest(manifest)
+        except Exception as exc:
+            raise NpaWorkflowError(f"failed to persist workflow manifest: {exc}") from exc
 
     results: list[dict[str, Any]] = []
     status = "planned"
@@ -162,9 +165,25 @@ def run_workflow(
         if store is not None:
             manifest.status = status
             manifest.steps = results
-            store.write_manifest(manifest)
+            try:
+                store.write_manifest(manifest)
+            except Exception as exc:
+                persist_error = NpaWorkflowError(
+                    f"failed to persist workflow manifest: {exc}"
+                )
+                if error is None:
+                    error = persist_error
+                    status = "failed"
 
-    plan = build_plan(spec, run_id=run_id, assume_decision=assume)
+    if error is None:
+        plan = build_plan(spec, run_id=run_id, assume_decision=assume)
+    else:
+        plan = ExecutionPlan(
+            workflow=spec.name,
+            api_version=spec.api_version,
+            initial=spec.initial,
+            assume_decision=assume,
+        )
     report = {
         "workflow": spec.name,
         "run_id": run_id,
@@ -301,11 +320,30 @@ def _expand_state(
 
 
 def _guard_plan_size(spec: NpaWorkflowSpec, plan: ExecutionPlan) -> None:
-    limit = max(256, len(spec.states) * 64)
+    limit = _execution_step_limit(spec)
     if len(plan.steps) >= limit:
         raise NpaWorkflowError(
             "plan exceeded step limit; check for unbounded control-flow cycles"
         )
+
+
+def _execution_step_limit(spec: NpaWorkflowSpec) -> int:
+    return max(256, len(spec.states) * 64)
+
+
+def _guard_execution_depth(spec: NpaWorkflowSpec, depth: int) -> None:
+    if depth >= _execution_step_limit(spec):
+        raise NpaWorkflowError(
+            "execution exceeded step limit; check for unbounded control-flow cycles"
+        )
+
+
+def _sequence_refreshes_decision(spec: NpaWorkflowSpec, state: StateSpec) -> bool:
+    return any(
+        spec.states[child].writes_decision
+        for child in state.sequence
+        if child in spec.states
+    )
 
 
 def _append_state_step(
@@ -345,6 +383,7 @@ def _append_state_step(
             inputs=_resolved_inputs(state, ctx),
         )
     )
+    _record_state_outputs(state, ctx, plan.steps[-1])
 
 
 def _resources_profile(spec: NpaWorkflowSpec, profile: str) -> dict[str, Any]:
@@ -401,7 +440,9 @@ def _execute_state_machine(
     loop_label: str = "",
     follow_transitions: bool = True,
     results_out: list[dict[str, Any]] | None = None,
+    depth: int = 0,
 ) -> list[dict[str, Any]]:
+    _guard_execution_depth(spec, depth)
     state = spec.states[state_name]
     results: list[dict[str, Any]] = results_out if results_out is not None else []
 
@@ -424,12 +465,13 @@ def _execute_state_machine(
                         loop_label=state.name,
                         follow_transitions=False,
                         results_out=results,
+                        depth=depth + 1,
                     )
                 if not ctx.last_decision:
                     _refresh_decision(
                         ctx,
                         reader=decision_reader,
-                        read_s3="decide" in state.sequence,
+                        read_s3=_sequence_refreshes_decision(spec, state),
                     )
                 if not ctx.last_decision:
                     ctx.last_decision = assume_decision
@@ -448,6 +490,7 @@ def _execute_state_machine(
                     decision_reader=decision_reader,
                     artifact_checker=artifact_checker,
                     results_out=results,
+                    depth=depth + 1,
                 )
             return results
 
@@ -464,6 +507,7 @@ def _execute_state_machine(
                 loop_label=state.name,
                 follow_transitions=False,
                 results_out=results,
+                depth=depth + 1,
             )
         if state.next:
             _execute_state_machine(
@@ -476,6 +520,7 @@ def _execute_state_machine(
                 decision_reader=decision_reader,
                 artifact_checker=artifact_checker,
                 results_out=results,
+                depth=depth + 1,
             )
         return results
 
@@ -513,6 +558,7 @@ def _execute_state_machine(
                 decision_reader=decision_reader,
                 artifact_checker=artifact_checker,
                 results_out=results,
+                depth=depth + 1,
             )
         return results
 
@@ -550,6 +596,7 @@ def _execute_state_machine(
             decision_reader=decision_reader,
             artifact_checker=artifact_checker,
             results_out=results,
+            depth=depth + 1,
         )
     return results
 
@@ -666,6 +713,8 @@ def _execute_step(step: PlanStep, *, execute: bool) -> dict[str, Any]:
         return record
 
     if step.shell.strip():
+        # shell=True interpolates resolved config tokens into a bash string.
+        # Spec authors are trusted today; untrusted config values would be an injection surface.
         proc = subprocess.run(
             step.shell,
             shell=True,

--- a/npa/src/npa/orchestration/npa_workflow/interpreter.py
+++ b/npa/src/npa/orchestration/npa_workflow/interpreter.py
@@ -121,7 +121,13 @@ def run_workflow(
     raw_assume = assume_decision or str(spec.config.get("plan_assume_decision") or "loop_back")
     assume = normalize_decision(raw_assume)
     ctx = _make_context(spec, run_id=run_id)
-    store = state_store or (store_for_config(ctx.config, run_id=run_id) if persist_state else None)
+    store = state_store
+    if store is None and persist_state:
+        store = store_for_config(ctx.config, run_id=run_id)
+        if store is None:
+            raise NpaWorkflowError(
+                "persist_state requires config.bucket to be set in the workflow spec"
+            )
     manifest = RunManifest(
         workflow=spec.name,
         run_id=run_id,

--- a/npa/src/npa/orchestration/npa_workflow/interpreter.py
+++ b/npa/src/npa/orchestration/npa_workflow/interpreter.py
@@ -6,9 +6,12 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
+from npa.orchestration.npa_workflow.artifacts import require_input_artifacts
 from npa.orchestration.npa_workflow.catalog import argv_for_tool
+from npa.orchestration.npa_workflow.decisions import refresh_context_decision
 from npa.orchestration.npa_workflow.errors import NpaWorkflowError
 from npa.orchestration.npa_workflow.predicates import evaluate_predicate
+from npa.orchestration.npa_workflow.run_state import RunManifest, RunStateStore, store_for_config
 from npa.orchestration.npa_workflow.spec import (
     NpaWorkflowSpec,
     StateSpec,
@@ -27,7 +30,9 @@ class PlanStep:
     shell: str = ""
     tool_ref: str = ""
     resources: str = "default"
+    resources_profile: dict[str, Any] = field(default_factory=dict)
     outputs: list[dict[str, str]] = field(default_factory=list)
+    inputs: list[dict[str, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -53,7 +58,9 @@ class ExecutionPlan:
                     "shell": step.shell,
                     "tool_ref": step.tool_ref,
                     "resources": step.resources,
+                    "resources_profile": step.resources_profile,
                     "outputs": step.outputs,
+                    "inputs": step.inputs,
                 }
                 for step in self.steps
             ],
@@ -103,25 +110,63 @@ def run_workflow(
     run_id: str,
     execute: bool = False,
     assume_decision: str = "",
+    persist_state: bool = False,
+    require_inputs: bool = False,
     on_step: Callable[[PlanStep], None] | None = None,
+    decision_reader: Any | None = None,
+    artifact_checker: Any | None = None,
+    state_store: RunStateStore | None = None,
 ) -> dict[str, Any]:
-    plan = build_plan(spec, run_id=run_id, assume_decision=assume_decision)
-    results: list[dict[str, Any]] = []
-    for step in plan.steps:
-        if on_step is not None:
-            on_step(step)
-        results.append(_execute_step(step, execute=execute))
+    assume = assume_decision or str(spec.config.get("plan_assume_decision") or "loop_back")
+    ctx = _make_context(spec, run_id=run_id)
+    store = state_store or (store_for_config(ctx.config, run_id=run_id) if persist_state else None)
+    manifest = RunManifest(
+        workflow=spec.name,
+        run_id=run_id,
+        api_version=spec.api_version,
+        status="running" if execute else "planned",
+    )
+    if store is not None:
+        store.write_manifest(manifest)
+
+    if execute:
+        results = _execute_state_machine(
+            spec,
+            spec.initial,
+            ctx,
+            assume_decision=assume,
+            require_inputs=require_inputs,
+            on_step=on_step,
+            decision_reader=decision_reader,
+            artifact_checker=artifact_checker,
+        )
+    else:
+        plan = build_plan(spec, run_id=run_id, assume_decision=assume)
+        results = []
+        for step in plan.steps:
+            if on_step is not None:
+                on_step(step)
+            results.append(_execute_step(step, execute=False))
+
     status = "completed"
     if any(r.get("status") == "failed" for r in results):
         status = "failed"
     elif not execute:
         status = "planned"
+
+    if store is not None:
+        manifest.status = status
+        manifest.steps = results
+        store.write_manifest(manifest)
+
+    plan = build_plan(spec, run_id=run_id, assume_decision=assume)
     return {
         "workflow": spec.name,
         "run_id": run_id,
         "status": status,
         "steps": results,
         "plan": plan.to_dict(),
+        "run_prefix_uri": store.run_prefix_uri if store is not None else "",
     }
 
 
@@ -248,9 +293,257 @@ def _append_state_step(
             shell=shell,
             tool_ref=tool_ref,
             resources=state.resources,
+            resources_profile=_resources_profile(spec, state.resources),
             outputs=outputs,
+            inputs=_resolved_inputs(state, ctx),
         )
     )
+
+
+def _resources_profile(spec: NpaWorkflowSpec, profile: str) -> dict[str, Any]:
+    raw = spec.resources.get(profile) or spec.resources.get("default") or {}
+    return dict(raw) if isinstance(raw, dict) else {}
+
+
+def _resolved_inputs(state: StateSpec, ctx: RunContext) -> list[dict[str, str]]:
+    return [
+        {
+            "uri": resolve_tokens(
+                artifact.uri,
+                config=ctx.config,
+                run=ctx.run,
+                state_outputs=ctx.state_outputs,
+            ),
+            "schema": artifact.schema,
+        }
+        for artifact in state.inputs
+        if artifact.uri
+    ]
+
+
+def _record_state_outputs(state: StateSpec, ctx: RunContext, step: PlanStep) -> None:
+    if not step.outputs:
+        return
+    ctx.state_outputs[state.name] = {
+        f"output_{index}": output["uri"] for index, output in enumerate(step.outputs, start=1)
+    }
+    primary = step.outputs[0]["uri"]
+    ctx.state_outputs[state.name]["uri"] = primary
+
+
+def _refresh_decision(
+    ctx: RunContext,
+    *,
+    reader: Any | None = None,
+    read_s3: bool = False,
+) -> None:
+    if read_s3:
+        ctx.last_decision = refresh_context_decision(ctx.as_predicate_context(), reader=reader)
+
+
+def _execute_state_machine(
+    spec: NpaWorkflowSpec,
+    state_name: str,
+    ctx: RunContext,
+    *,
+    assume_decision: str,
+    require_inputs: bool,
+    on_step: Callable[[PlanStep], None] | None,
+    decision_reader: Any | None,
+    artifact_checker: Any | None,
+    loop_label: str = "",
+    follow_transitions: bool = True,
+) -> list[dict[str, Any]]:
+    state = spec.states[state_name]
+    results: list[dict[str, Any]] = []
+
+    if state.sequence:
+        if state.loop:
+            max_iter = resolve_config_int(state.loop.max or 1, ctx.config)
+            for iteration in range(1, max_iter + 1):
+                ctx.outer_iteration = iteration
+                ctx.last_decision = ""
+                for child in state.sequence:
+                    results.extend(
+                        _execute_state_machine(
+                            spec,
+                            child,
+                            ctx,
+                            assume_decision=assume_decision,
+                            require_inputs=require_inputs,
+                            on_step=on_step,
+                            decision_reader=decision_reader,
+                            artifact_checker=artifact_checker,
+                            loop_label=state.name,
+                            follow_transitions=False,
+                        )
+                    )
+                if not ctx.last_decision:
+                    _refresh_decision(
+                        ctx,
+                        reader=decision_reader,
+                        read_s3="decide" in state.sequence,
+                    )
+                if not ctx.last_decision:
+                    ctx.last_decision = assume_decision
+                if state.loop.until and evaluate_predicate(
+                    state.loop.until, ctx.as_predicate_context()
+                ):
+                    break
+            next_name = _resolve_transition(state, ctx) or state.next
+            if next_name:
+                results.extend(
+                    _execute_state_machine(
+                        spec,
+                        next_name,
+                        ctx,
+                        assume_decision=assume_decision,
+                        require_inputs=require_inputs,
+                        on_step=on_step,
+                        decision_reader=decision_reader,
+                        artifact_checker=artifact_checker,
+                    )
+                )
+            return results
+
+        for child in state.sequence:
+            results.extend(
+                _execute_state_machine(
+                    spec,
+                    child,
+                    ctx,
+                    assume_decision=assume_decision,
+                    require_inputs=require_inputs,
+                    on_step=on_step,
+                    decision_reader=decision_reader,
+                    artifact_checker=artifact_checker,
+                    loop_label=state.name,
+                    follow_transitions=False,
+                )
+            )
+        if state.next:
+            results.extend(
+                _execute_state_machine(
+                    spec,
+                    state.next,
+                    ctx,
+                    assume_decision=assume_decision,
+                    require_inputs=require_inputs,
+                    on_step=on_step,
+                    decision_reader=decision_reader,
+                    artifact_checker=artifact_checker,
+                )
+            )
+        return results
+
+    if state.loop:
+        max_iter = resolve_config_int(state.loop.max or 1, ctx.config)
+        for iteration in range(1, max_iter + 1):
+            ctx.inner_iteration = iteration
+            record = _run_single_state(
+                spec,
+                state,
+                ctx,
+                iteration=iteration,
+                loop_label=loop_label,
+                require_inputs=require_inputs,
+                on_step=on_step,
+                artifact_checker=artifact_checker,
+            )
+            results.append(record)
+            _refresh_decision(ctx, reader=decision_reader, read_s3=False)
+            if not ctx.last_decision:
+                ctx.last_decision = assume_decision
+            if state.loop.until and evaluate_predicate(state.loop.until, ctx.as_predicate_context()):
+                break
+        next_name = _resolve_transition(state, ctx) or state.next
+        if next_name:
+            results.extend(
+                _execute_state_machine(
+                    spec,
+                    next_name,
+                    ctx,
+                    assume_decision=assume_decision,
+                    require_inputs=require_inputs,
+                    on_step=on_step,
+                    decision_reader=decision_reader,
+                    artifact_checker=artifact_checker,
+                )
+            )
+        return results
+
+    record = _run_single_state(
+        spec,
+        state,
+        ctx,
+        loop_label=loop_label,
+        require_inputs=require_inputs,
+        on_step=on_step,
+        artifact_checker=artifact_checker,
+    )
+    results.append(record)
+    if state.terminal:
+        return results
+    if state.transitions:
+        _refresh_decision(ctx, reader=decision_reader, read_s3=True)
+        if not ctx.last_decision:
+            ctx.last_decision = assume_decision
+    next_name = ""
+    if follow_transitions:
+        next_name = _resolve_transition(state, ctx) or state.next
+    elif not state.transitions:
+        next_name = state.next
+    if next_name:
+        results.extend(
+            _execute_state_machine(
+                spec,
+                next_name,
+                ctx,
+                assume_decision=assume_decision,
+                require_inputs=require_inputs,
+                on_step=on_step,
+                decision_reader=decision_reader,
+                artifact_checker=artifact_checker,
+            )
+        )
+    return results
+
+
+def _run_single_state(
+    spec: NpaWorkflowSpec,
+    state: StateSpec,
+    ctx: RunContext,
+    *,
+    iteration: int | None = None,
+    loop_label: str = "",
+    require_inputs: bool,
+    on_step: Callable[[PlanStep], None] | None,
+    artifact_checker: Any | None,
+) -> dict[str, Any]:
+    plan = ExecutionPlan(
+        workflow=spec.name,
+        api_version=spec.api_version,
+        initial=spec.initial,
+    )
+    _append_state_step(
+        spec,
+        state,
+        ctx,
+        plan,
+        iteration=iteration,
+        loop_label=loop_label,
+    )
+    step = plan.steps[-1]
+    if require_inputs and step.inputs:
+        require_input_artifacts(
+            [item["uri"] for item in step.inputs],
+            checker=artifact_checker,
+        )
+    if on_step is not None:
+        on_step(step)
+    record = _execute_step(step, execute=True)
+    _record_state_outputs(state, ctx, step)
+    return record
 
 
 def _resolved_run(state: StateSpec, ctx: RunContext) -> tuple[list[str], str, str]:

--- a/npa/src/npa/orchestration/npa_workflow/predicates.py
+++ b/npa/src/npa/orchestration/npa_workflow/predicates.py
@@ -23,13 +23,17 @@ def evaluate_predicate(name: str, context: Mapping[str, Any]) -> bool:
 
 
 def _promote_checkpoint(context: Mapping[str, Any]) -> bool:
-    decision = str(context.get("last_decision") or "")
-    return decision == "promote_checkpoint"
+    from npa.orchestration.npa_workflow.decisions import DECISION_PROMOTE, normalize_decision
+
+    decision = normalize_decision(str(context.get("last_decision") or ""))
+    return decision == DECISION_PROMOTE
 
 
 def _loop_back(context: Mapping[str, Any]) -> bool:
-    decision = str(context.get("last_decision") or "")
-    return decision == "loop_back_to_inner_loop"
+    from npa.orchestration.npa_workflow.decisions import DECISION_LOOP_BACK, normalize_decision
+
+    decision = normalize_decision(str(context.get("last_decision") or ""))
+    return decision == DECISION_LOOP_BACK
 
 
 register_predicate("promote_checkpoint", _promote_checkpoint)

--- a/npa/src/npa/orchestration/npa_workflow/predicates.py
+++ b/npa/src/npa/orchestration/npa_workflow/predicates.py
@@ -1,0 +1,36 @@
+"""Named transition predicates for NPA workflow state machines."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+
+PredicateFn = Callable[[Mapping[str, Any]], bool]
+
+PREDICATES: dict[str, PredicateFn] = {}
+
+
+def register_predicate(name: str, fn: PredicateFn) -> None:
+    PREDICATES[name] = fn
+
+
+def evaluate_predicate(name: str, context: Mapping[str, Any]) -> bool:
+    fn = PREDICATES.get(name)
+    if fn is None:
+        raise NpaWorkflowError(f"unknown predicate: {name!r} (known: {sorted(PREDICATES)})")
+    return bool(fn(context))
+
+
+def _promote_checkpoint(context: Mapping[str, Any]) -> bool:
+    decision = str(context.get("last_decision") or "")
+    return decision == "promote_checkpoint"
+
+
+def _loop_back(context: Mapping[str, Any]) -> bool:
+    decision = str(context.get("last_decision") or "")
+    return decision == "loop_back_to_inner_loop"
+
+
+register_predicate("promote_checkpoint", _promote_checkpoint)
+register_predicate("loop_back", _loop_back)

--- a/npa/src/npa/orchestration/npa_workflow/run_state.py
+++ b/npa/src/npa/orchestration/npa_workflow/run_state.py
@@ -1,0 +1,150 @@
+"""Durable run manifest for ``npa.workflow`` executions on object storage."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+RUN_SCHEMA_VERSION = "npa.workflow.run.v1"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class RunManifest:
+    workflow: str
+    run_id: str
+    api_version: str
+    run_prefix_uri: str = ""
+    status: str = "planned"
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    updated_at: str = field(default_factory=utc_now)
+    schema_version: str = RUN_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "workflow": self.workflow,
+            "run_id": self.run_id,
+            "api_version": self.api_version,
+            "run_prefix_uri": self.run_prefix_uri,
+            "status": self.status,
+            "updated_at": self.updated_at,
+            "steps": list(self.steps),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> RunManifest:
+        return cls(
+            workflow=str(payload.get("workflow") or ""),
+            run_id=str(payload.get("run_id") or ""),
+            api_version=str(payload.get("api_version") or ""),
+            run_prefix_uri=str(payload.get("run_prefix_uri") or ""),
+            status=str(payload.get("status") or "planned"),
+            steps=[dict(item) for item in payload.get("steps") or [] if isinstance(item, dict)],
+            updated_at=str(payload.get("updated_at") or utc_now()),
+            schema_version=str(payload.get("schema_version") or RUN_SCHEMA_VERSION),
+        )
+
+
+def manifest_key(prefix: str) -> str:
+    base = prefix.rstrip("/")
+    return f"{base}/npa-workflow/manifest.json"
+
+
+def status_key(prefix: str) -> str:
+    base = prefix.rstrip("/")
+    return f"{base}/npa-workflow/status.json"
+
+
+class RunStateStore:
+    """Persist workflow run manifests (mock ``reader``/``writer`` in unit tests)."""
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        prefix: str,
+        reader: Any | None = None,
+        writer: Any | None = None,
+    ) -> None:
+        self.bucket = bucket
+        self.prefix = prefix.rstrip("/")
+        self._reader = reader
+        self._writer = writer
+
+    @property
+    def run_prefix_uri(self) -> str:
+        return f"s3://{self.bucket}/{self.prefix}"
+
+    def read_manifest(self) -> RunManifest | None:
+        key = manifest_key(self.prefix)
+        try:
+            body = self._read(key)
+        except FileNotFoundError:
+            return None
+        payload = json.loads(body)
+        if not isinstance(payload, dict):
+            return None
+        return RunManifest.from_dict(payload)
+
+    def write_manifest(self, manifest: RunManifest) -> dict[str, Any]:
+        manifest.updated_at = utc_now()
+        manifest.run_prefix_uri = self.run_prefix_uri
+        payload = manifest.to_dict()
+        self._write(manifest_key(self.prefix), payload)
+        self._write(
+            status_key(self.prefix),
+            {
+                "schema_version": RUN_SCHEMA_VERSION,
+                "run_id": manifest.run_id,
+                "workflow": manifest.workflow,
+                "status": manifest.status,
+                "updated_at": manifest.updated_at,
+                "step_count": len(manifest.steps),
+            },
+        )
+        return payload
+
+    def append_step(self, manifest: RunManifest, step_record: Mapping[str, Any]) -> dict[str, Any]:
+        manifest.steps.append(dict(step_record))
+        return self.write_manifest(manifest)
+
+    def _read(self, key: str) -> str:
+        if self._reader is not None:
+            return str(self._reader(self.bucket, key))
+        from npa.clients.storage import StorageClient
+
+        client = StorageClient.from_environment()
+        try:
+            response = client._s3.get_object(Bucket=self.bucket, Key=key)
+        except Exception as exc:
+            raise FileNotFoundError(f"s3://{self.bucket}/{key}") from exc
+        return response["Body"].read().decode("utf-8")
+
+    def _write(self, key: str, payload: Mapping[str, Any]) -> None:
+        body = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        if self._writer is not None:
+            self._writer(self.bucket, key, body)
+            return
+        from npa.clients.storage import StorageClient
+
+        client = StorageClient.from_environment()
+        client._s3.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=body,
+            ContentType="application/json",
+        )
+
+
+def store_for_config(config: Mapping[str, Any], *, run_id: str) -> RunStateStore | None:
+    bucket = str(config.get("bucket") or "").strip()
+    prefix = str(config.get("prefix") or run_id).strip()
+    if not bucket:
+        return None
+    return RunStateStore(bucket=bucket, prefix=prefix)

--- a/npa/src/npa/orchestration/npa_workflow/scheduler.py
+++ b/npa/src/npa/orchestration/npa_workflow/scheduler.py
@@ -1,0 +1,56 @@
+"""Map planned workflow steps to scheduler task documents (SkyPilot/K8s hints)."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from npa.orchestration.npa_workflow.interpreter import PlanStep
+from npa.orchestration.npa_workflow.spec import NpaWorkflowSpec
+
+
+def resources_for_step(spec: NpaWorkflowSpec, step: PlanStep) -> dict[str, Any]:
+    profile = step.resources or "default"
+    raw = spec.resources.get(profile) or spec.resources.get("default") or {}
+    return dict(raw) if isinstance(raw, dict) else {}
+
+
+def build_scheduler_task(
+    spec: NpaWorkflowSpec,
+    step: PlanStep,
+    *,
+    run_id: str,
+    image: str = "",
+) -> dict[str, Any]:
+    """Return a portable task document for one workflow step."""
+
+    resources = resources_for_step(spec, step)
+    command = step.argv or (["bash", "-lc", step.shell] if step.shell.strip() else [])
+    name = step.state
+    if step.iteration is not None:
+        name = f"{name}-{step.iteration}"
+    return {
+        "name": name,
+        "run_id": run_id,
+        "workflow": spec.name,
+        "tool_ref": step.tool_ref,
+        "resources": resources,
+        "command": command,
+        "image": image or str(resources.get("image") or ""),
+        "outputs": list(step.outputs),
+    }
+
+
+def build_scheduler_plan(
+    spec: NpaWorkflowSpec,
+    steps: list[PlanStep],
+    *,
+    run_id: str,
+    image: str = "",
+) -> dict[str, Any]:
+    return {
+        "workflow": spec.name,
+        "run_id": run_id,
+        "tasks": [
+            build_scheduler_task(spec, step, run_id=run_id, image=image) for step in steps
+        ],
+    }

--- a/npa/src/npa/orchestration/npa_workflow/schema/npa.workflow.v0.0.1.schema.json
+++ b/npa/src/npa/orchestration/npa_workflow/schema/npa.workflow.v0.0.1.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nebius.com/npa/npa.workflow.v0.0.1.schema.json",
+  "title": "NPA Workflow",
+  "type": "object",
+  "required": ["apiVersion", "kind", "states"],
+  "properties": {
+    "apiVersion": { "const": "npa.workflow/v0.0.1" },
+    "kind": { "const": "Workflow" },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" }
+      },
+      "required": ["name"]
+    },
+    "config": { "type": "object" },
+    "run": { "type": "object" },
+    "resources": { "type": "object" },
+    "initial": { "type": "string" },
+    "states": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "$ref": "#/$defs/state" }
+    }
+  },
+  "$defs": {
+    "state": {
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" },
+        "needs": { "type": "array", "items": { "type": "string" } },
+        "run": {
+          "type": "object",
+          "properties": {
+            "shell": { "type": "string" },
+            "argv": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "toolRef": { "type": "string" },
+        "sequence": { "type": "array", "items": { "type": "string" } },
+        "loop": {
+          "type": "object",
+          "properties": {
+            "max": {},
+            "until": { "type": "string" }
+          }
+        },
+        "transitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["goto"],
+            "properties": {
+              "when": { "type": "string" },
+              "goto": { "type": "string" },
+              "if": { "type": "string" }
+            }
+          }
+        },
+        "next": { "type": "string" },
+        "inputs": { "$ref": "#/$defs/artifacts" },
+        "outputs": { "$ref": "#/$defs/artifacts" },
+        "resources": { "type": "string" },
+        "terminal": { "type": "boolean" }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["uri"],
+        "properties": {
+          "uri": { "type": "string" },
+          "schema": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/npa/src/npa/orchestration/npa_workflow/schema_validation.py
+++ b/npa/src/npa/orchestration/npa_workflow/schema_validation.py
@@ -1,0 +1,51 @@
+"""Validate raw workflow documents against the shipped JSON Schema (stdlib checks)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+
+_SCHEMA_PATH = Path(__file__).resolve().parent / "schema" / "npa.workflow.v0.0.1.schema.json"
+
+
+def validate_document(data: dict[str, Any]) -> None:
+    """Lightweight structural validation using the shipped schema constants."""
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    _validate_against_schema(data, schema, path="$")
+
+
+def _validate_against_schema(value: Any, schema: dict[str, Any], *, path: str) -> None:
+    if "const" in schema and value != schema["const"]:
+        raise NpaWorkflowError(f"{path}: expected {schema['const']!r}, got {value!r}")
+
+    schema_type = schema.get("type")
+    if schema_type == "object":
+        if not isinstance(value, dict):
+            raise NpaWorkflowError(f"{path}: expected object, got {type(value).__name__}")
+        for key in schema.get("required", []):
+            if key not in value:
+                raise NpaWorkflowError(f"{path}: missing required field {key!r}")
+        properties = schema.get("properties", {})
+        for key, subschema in properties.items():
+            if key in value:
+                _validate_against_schema(value[key], subschema, path=f"{path}.{key}")
+        return
+
+    if schema_type == "array":
+        if not isinstance(value, list):
+            raise NpaWorkflowError(f"{path}: expected array, got {type(value).__name__}")
+        item_schema = schema.get("items")
+        if item_schema:
+            for index, item in enumerate(value):
+                _validate_against_schema(item, item_schema, path=f"{path}[{index}]")
+        return
+
+    if schema_type == "string" and not isinstance(value, str):
+        raise NpaWorkflowError(f"{path}: expected string, got {type(value).__name__}")
+
+    if schema_type == "boolean" and not isinstance(value, bool):
+        raise NpaWorkflowError(f"{path}: expected boolean, got {type(value).__name__}")

--- a/npa/src/npa/orchestration/npa_workflow/spec.py
+++ b/npa/src/npa/orchestration/npa_workflow/spec.py
@@ -55,6 +55,7 @@ class StateSpec:
     outputs: list[ArtifactSpec] = field(default_factory=list)
     resources: str = "default"
     terminal: bool = False
+    writes_decision: bool = False
 
 
 @dataclass
@@ -187,6 +188,7 @@ def _parse_state(name: str, entry: dict[str, Any]) -> StateSpec:
         outputs=outputs,
         resources=str(entry.get("resources") or "default"),
         terminal=bool(entry.get("terminal")),
+        writes_decision=bool(entry.get("writesDecision") or entry.get("writes_decision")),
     )
 
 
@@ -240,15 +242,50 @@ def validate_spec(spec: NpaWorkflowSpec) -> None:
     _assert_acyclic_needs(spec)
     _assert_terminal_exists(spec)
     _assert_bounded_control_flow_cycles(spec)
+    _validate_resolvable(spec)
+
+
+def _validate_resolvable(spec: NpaWorkflowSpec) -> None:
+    """Resolve tokens and loop bounds so user errors surface at validate time."""
+
+    from npa.orchestration.npa_workflow.interpreter import _make_context, _resolved_run
+    from npa.orchestration.npa_workflow.tokens import TokenError, resolve_tokens
+
+    ctx = _make_context(spec, run_id="validate-run")
+    for state in spec.states.values():
+        if state.loop and state.loop.max is not None:
+            try:
+                resolved = resolve_config_int(state.loop.max, ctx.config)
+            except NpaWorkflowError as exc:
+                raise NpaWorkflowError(f"state {state.name}: {exc}") from exc
+            if resolved < 1:
+                raise NpaWorkflowError(
+                    f"state {state.name}: loop.max must be >= 1, got {resolved}"
+                )
+        try:
+            _resolved_run(state, ctx)
+        except TokenError as exc:
+            if not str(exc).startswith("unknown state token:"):
+                raise NpaWorkflowError(f"state {state.name}: {exc}") from exc
+        for artifact in [*state.inputs, *state.outputs]:
+            if not artifact.uri:
+                continue
+            try:
+                resolve_tokens(
+                    artifact.uri,
+                    config=ctx.config,
+                    run=ctx.run,
+                    state_outputs=ctx.state_outputs,
+                )
+            except TokenError as exc:
+                if not str(exc).startswith("unknown state token:"):
+                    raise NpaWorkflowError(f"state {state.name}: {exc}") from exc
 
 
 def _validate_loop_max(state: StateSpec, config: dict[str, Any]) -> None:
     if state.loop is None or state.loop.max is None:
         return
-    try:
-        resolved = resolve_config_int(state.loop.max, config)
-    except NpaWorkflowError:
-        return
+    resolved = resolve_config_int(state.loop.max, config)
     if resolved < 1:
         raise NpaWorkflowError(f"state {state.name}: loop.max must be >= 1, got {resolved}")
 
@@ -294,10 +331,8 @@ def _assert_bounded_control_flow_cycles(spec: NpaWorkflowSpec) -> None:
     def dfs(node: str) -> None:
         if node in stack:
             cycle = stack[stack.index(node) :] + [node]
-            if not any(spec.states[item].loop for item in cycle):
-                joined = " -> ".join(cycle)
-                raise NpaWorkflowError(f"unbounded control-flow cycle detected: {joined}")
-            return
+            joined = " -> ".join(cycle)
+            raise NpaWorkflowError(f"unbounded control-flow cycle detected: {joined}")
         if node in visited:
             return
         stack.append(node)
@@ -326,7 +361,12 @@ def resolve_config_int(value: Any, config: dict[str, Any]) -> int:
         if attr:
             if attr not in config:
                 raise NpaWorkflowError(f"config has no attribute {attr!r}")
-            return int(config[attr])
+            try:
+                return int(config[attr])
+            except (TypeError, ValueError) as exc:
+                raise NpaWorkflowError(
+                    f"config.{attr} must be an integer loop bound, got {config[attr]!r}"
+                ) from exc
         if text.isdigit():
             return int(text)
     raise NpaWorkflowError(f"cannot resolve loop max from {value!r}")

--- a/npa/src/npa/orchestration/npa_workflow/spec.py
+++ b/npa/src/npa/orchestration/npa_workflow/spec.py
@@ -82,6 +82,9 @@ def load_spec(path: str | Path) -> NpaWorkflowSpec:
     data = yaml.safe_load(spec_path.read_text(encoding="utf-8")) or {}
     if not isinstance(data, dict):
         raise NpaWorkflowError(f"workflow spec must be a mapping, got {type(data).__name__}")
+    from npa.orchestration.npa_workflow.schema_validation import validate_document
+
+    validate_document(data)
     spec = _parse_document(data)
     validate_spec(spec)
     return spec
@@ -231,8 +234,23 @@ def validate_spec(spec: NpaWorkflowSpec) -> None:
         if state.run and state.run.is_empty() and not state.tool_ref and not state.sequence:
             raise NpaWorkflowError(f"state {state.name}: empty run block")
 
+        if state.loop:
+            _validate_loop_max(state, spec.config)
+
     _assert_acyclic_needs(spec)
-    _assert_single_terminal_reachable(spec)
+    _assert_terminal_exists(spec)
+    _assert_bounded_control_flow_cycles(spec)
+
+
+def _validate_loop_max(state: StateSpec, config: dict[str, Any]) -> None:
+    if state.loop is None or state.loop.max is None:
+        return
+    try:
+        resolved = resolve_config_int(state.loop.max, config)
+    except NpaWorkflowError:
+        return
+    if resolved < 1:
+        raise NpaWorkflowError(f"state {state.name}: loop.max must be >= 1, got {resolved}")
 
 
 def _assert_acyclic_needs(spec: NpaWorkflowSpec) -> None:
@@ -256,10 +274,40 @@ def _assert_acyclic_needs(spec: NpaWorkflowSpec) -> None:
         dfs(name)
 
 
-def _assert_single_terminal_reachable(spec: NpaWorkflowSpec) -> None:
+def _assert_terminal_exists(spec: NpaWorkflowSpec) -> None:
     terminals = [name for name, state in spec.states.items() if state.terminal]
     if not terminals:
         raise NpaWorkflowError("workflow must declare at least one terminal: true state")
+
+
+def _assert_bounded_control_flow_cycles(spec: NpaWorkflowSpec) -> None:
+    graph: dict[str, set[str]] = {name: set() for name in spec.states}
+    for name, state in spec.states.items():
+        if state.next:
+            graph[name].add(state.next)
+        for transition in state.transitions:
+            graph[name].add(transition.goto)
+
+    visited: set[str] = set()
+    stack: list[str] = []
+
+    def dfs(node: str) -> None:
+        if node in stack:
+            cycle = stack[stack.index(node) :] + [node]
+            if not any(spec.states[item].loop for item in cycle):
+                joined = " -> ".join(cycle)
+                raise NpaWorkflowError(f"unbounded control-flow cycle detected: {joined}")
+            return
+        if node in visited:
+            return
+        stack.append(node)
+        for nxt in sorted(graph.get(node, ())):
+            dfs(nxt)
+        stack.pop()
+        visited.add(node)
+
+    for name in spec.states:
+        dfs(name)
 
 
 def resolve_config_int(value: Any, config: dict[str, Any]) -> int:

--- a/npa/src/npa/orchestration/npa_workflow/spec.py
+++ b/npa/src/npa/orchestration/npa_workflow/spec.py
@@ -1,0 +1,286 @@
+"""Load and validate ``apiVersion: npa.workflow/v0.0.1`` workflow specifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+from npa.orchestration.npa_workflow.predicates import PREDICATES
+
+API_VERSION = "npa.workflow/v0.0.1"
+
+
+@dataclass
+class LoopSpec:
+    max: Any = None  # int or "config.<attr>"
+    until: str | None = None
+
+
+@dataclass
+class TransitionSpec:
+    when: str | None = None
+    goto: str = ""
+    if_config: str | None = None  # config.<attr> truthy
+
+
+@dataclass
+class ArtifactSpec:
+    uri: str
+    schema: str = ""
+
+
+@dataclass
+class RunSpec:
+    shell: str = ""
+    argv: list[str] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not self.shell.strip() and not self.argv
+
+
+@dataclass
+class StateSpec:
+    name: str
+    description: str = ""
+    needs: list[str] = field(default_factory=list)
+    run: RunSpec | None = None
+    tool_ref: str = ""
+    sequence: list[str] = field(default_factory=list)
+    loop: LoopSpec | None = None
+    transitions: list[TransitionSpec] = field(default_factory=list)
+    next: str = ""
+    inputs: list[ArtifactSpec] = field(default_factory=list)
+    outputs: list[ArtifactSpec] = field(default_factory=list)
+    resources: str = "default"
+    terminal: bool = False
+
+
+@dataclass
+class NpaWorkflowSpec:
+    api_version: str
+    kind: str
+    metadata: dict[str, Any]
+    config: dict[str, Any]
+    run_defaults: dict[str, Any]
+    resources: dict[str, Any]
+    initial: str
+    states: dict[str, StateSpec]
+
+    @property
+    def name(self) -> str:
+        return str(self.metadata.get("name") or "unnamed")
+
+
+def load_spec(path: str | Path) -> NpaWorkflowSpec:
+    import yaml
+
+    spec_path = Path(path)
+    if not spec_path.is_file():
+        raise NpaWorkflowError(f"workflow spec not found: {spec_path}")
+    data = yaml.safe_load(spec_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise NpaWorkflowError(f"workflow spec must be a mapping, got {type(data).__name__}")
+    spec = _parse_document(data)
+    validate_spec(spec)
+    return spec
+
+
+def _parse_document(data: dict[str, Any]) -> NpaWorkflowSpec:
+    api_version = str(data.get("apiVersion") or "")
+    kind = str(data.get("kind") or "Workflow")
+    metadata = dict(data.get("metadata") or {})
+    config = dict(data.get("config") or {})
+    run_defaults = dict(data.get("run") or {})
+    resources = dict(data.get("resources") or {})
+
+    raw_states = data.get("states") or {}
+    if isinstance(raw_states, list):
+        states_dict = {}
+        for entry in raw_states:
+            if not isinstance(entry, dict) or "name" not in entry:
+                raise NpaWorkflowError(f"each list state needs a name: {entry!r}")
+            name = str(entry["name"])
+            states_dict[name] = entry
+        raw_states = states_dict
+    if not isinstance(raw_states, dict) or not raw_states:
+        raise NpaWorkflowError("workflow spec must declare a non-empty 'states' mapping")
+
+    states: dict[str, StateSpec] = {}
+    for name, entry in raw_states.items():
+        if not isinstance(entry, dict):
+            raise NpaWorkflowError(f"state {name!r} must be a mapping")
+        states[str(name)] = _parse_state(str(name), entry)
+
+    initial = str(data.get("initial") or next(iter(states)))
+    return NpaWorkflowSpec(
+        api_version=api_version,
+        kind=kind,
+        metadata=metadata,
+        config=config,
+        run_defaults=run_defaults,
+        resources=resources,
+        initial=initial,
+        states=states,
+    )
+
+
+def _parse_state(name: str, entry: dict[str, Any]) -> StateSpec:
+    loop = None
+    loop_raw = entry.get("loop")
+    if loop_raw is not None:
+        if not isinstance(loop_raw, dict):
+            raise NpaWorkflowError(f"state {name}: loop must be a mapping")
+        loop = LoopSpec(
+            max=loop_raw.get("max"),
+            until=str(loop_raw["until"]) if loop_raw.get("until") else None,
+        )
+
+    transitions: list[TransitionSpec] = []
+    for tr in entry.get("transitions") or []:
+        if not isinstance(tr, dict) or not tr.get("goto"):
+            raise NpaWorkflowError(f"state {name}: transition needs goto")
+        transitions.append(
+            TransitionSpec(
+                when=str(tr["when"]) if tr.get("when") else None,
+                goto=str(tr["goto"]),
+                if_config=str(tr["if"]) if tr.get("if") else None,
+            )
+        )
+
+    run = None
+    run_raw = entry.get("run")
+    if run_raw is not None:
+        if not isinstance(run_raw, dict):
+            raise NpaWorkflowError(f"state {name}: run must be a mapping")
+        run = RunSpec(
+            shell=str(run_raw.get("shell") or ""),
+            argv=[str(item) for item in (run_raw.get("argv") or [])],
+        )
+
+    inputs = [
+        ArtifactSpec(uri=str(item.get("uri") or ""), schema=str(item.get("schema") or ""))
+        for item in (entry.get("inputs") or [])
+        if isinstance(item, dict)
+    ]
+    outputs = [
+        ArtifactSpec(uri=str(item.get("uri") or ""), schema=str(item.get("schema") or ""))
+        for item in (entry.get("outputs") or [])
+        if isinstance(item, dict)
+    ]
+
+    return StateSpec(
+        name=name,
+        description=str(entry.get("description") or ""),
+        needs=[str(item) for item in (entry.get("needs") or [])],
+        run=run,
+        tool_ref=str(entry.get("toolRef") or entry.get("tool_ref") or ""),
+        sequence=[str(item) for item in (entry.get("sequence") or [])],
+        loop=loop,
+        transitions=transitions,
+        next=str(entry.get("next") or ""),
+        inputs=inputs,
+        outputs=outputs,
+        resources=str(entry.get("resources") or "default"),
+        terminal=bool(entry.get("terminal")),
+    )
+
+
+def validate_spec(spec: NpaWorkflowSpec) -> None:
+    if spec.api_version != API_VERSION:
+        raise NpaWorkflowError(
+            f"unsupported apiVersion {spec.api_version!r} (expected {API_VERSION})"
+        )
+    if spec.kind != "Workflow":
+        raise NpaWorkflowError(f"unsupported kind {spec.kind!r} (expected Workflow)")
+
+    if spec.initial not in spec.states:
+        raise NpaWorkflowError(f"initial state {spec.initial!r} is not defined")
+
+    for state in spec.states.values():
+        if state.loop and state.loop.until and state.loop.until not in PREDICATES:
+            raise NpaWorkflowError(
+                f"state {state.name}: unknown loop.until {state.loop.until!r}"
+            )
+        for tr in state.transitions:
+            if tr.when and tr.when not in PREDICATES:
+                raise NpaWorkflowError(
+                    f"state {state.name}: unknown transition.when {tr.when!r}"
+                )
+            if tr.goto not in spec.states:
+                raise NpaWorkflowError(
+                    f"state {state.name}: transition goto unknown state {tr.goto!r}"
+                )
+        for dep in state.needs:
+            if dep not in spec.states:
+                raise NpaWorkflowError(f"state {state.name}: unknown needs {dep!r}")
+        for seq in state.sequence:
+            if seq not in spec.states:
+                raise NpaWorkflowError(f"state {state.name}: unknown sequence {seq!r}")
+        if state.tool_ref:
+            from npa.orchestration.npa_workflow.catalog import validate_tool_ref
+
+            validate_tool_ref(state.tool_ref)
+        if not state.terminal and not state.sequence and not state.run and not state.tool_ref:
+            if not state.transitions and not state.next:
+                raise NpaWorkflowError(
+                    f"state {state.name}: must set run, toolRef, sequence, "
+                    "transitions, next, or terminal"
+                )
+        if state.run and state.run.is_empty() and not state.tool_ref and not state.sequence:
+            raise NpaWorkflowError(f"state {state.name}: empty run block")
+
+    _assert_acyclic_needs(spec)
+    _assert_single_terminal_reachable(spec)
+
+
+def _assert_acyclic_needs(spec: NpaWorkflowSpec) -> None:
+    """Needs edges must be acyclic (ordering hints only)."""
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def dfs(name: str) -> None:
+        if name in visiting:
+            raise NpaWorkflowError(f"cycle detected in needs among states (at {name})")
+        if name in visited:
+            return
+        visiting.add(name)
+        for dep in spec.states[name].needs:
+            dfs(dep)
+        visiting.remove(name)
+        visited.add(name)
+
+    for name in spec.states:
+        dfs(name)
+
+
+def _assert_single_terminal_reachable(spec: NpaWorkflowSpec) -> None:
+    terminals = [name for name, state in spec.states.items() if state.terminal]
+    if not terminals:
+        raise NpaWorkflowError("workflow must declare at least one terminal: true state")
+
+
+def resolve_config_int(value: Any, config: dict[str, Any]) -> int:
+    if isinstance(value, bool):
+        raise NpaWorkflowError("loop max must be int or config ref, not bool")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith("config."):
+            attr = text[len("config.") :]
+            if attr not in config:
+                raise NpaWorkflowError(f"config has no attribute {attr!r}")
+            return int(config[attr])
+        if text.isdigit():
+            return int(text)
+    raise NpaWorkflowError(f"cannot resolve loop max from {value!r}")
+
+
+def config_truthy(value: Any, config: dict[str, Any]) -> bool:
+    if isinstance(value, str) and value.startswith("config."):
+        attr = value[len("config.") :]
+        return bool(config.get(attr))
+    return bool(value)

--- a/npa/src/npa/orchestration/npa_workflow/spec.py
+++ b/npa/src/npa/orchestration/npa_workflow/spec.py
@@ -317,8 +317,13 @@ def resolve_config_int(value: Any, config: dict[str, Any]) -> int:
         return value
     if isinstance(value, str):
         text = value.strip()
-        if text.startswith("config."):
+        if text.startswith("{{config.") and text.endswith("}}"):
+            attr = text[len("{{config.") : -2].strip()
+        elif text.startswith("config."):
             attr = text[len("config.") :]
+        else:
+            attr = ""
+        if attr:
             if attr not in config:
                 raise NpaWorkflowError(f"config has no attribute {attr!r}")
             return int(config[attr])

--- a/npa/src/npa/orchestration/npa_workflow/spec.py
+++ b/npa/src/npa/orchestration/npa_workflow/spec.py
@@ -80,7 +80,10 @@ def load_spec(path: str | Path) -> NpaWorkflowSpec:
     spec_path = Path(path)
     if not spec_path.is_file():
         raise NpaWorkflowError(f"workflow spec not found: {spec_path}")
-    data = yaml.safe_load(spec_path.read_text(encoding="utf-8")) or {}
+    try:
+        data = yaml.safe_load(spec_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise NpaWorkflowError(f"workflow spec is not valid YAML: {exc}") from exc
     if not isinstance(data, dict):
         raise NpaWorkflowError(f"workflow spec must be a mapping, got {type(data).__name__}")
     from npa.orchestration.npa_workflow.schema_validation import validate_document

--- a/npa/src/npa/orchestration/npa_workflow/tokens.py
+++ b/npa/src/npa/orchestration/npa_workflow/tokens.py
@@ -1,0 +1,66 @@
+"""Resolve ``{{config.*}}``, ``{{run.*}}``, and ``{{state.*}}`` tokens in workflow specs."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+_TOKEN_RE = re.compile(
+    r"\{\{\s*(config|run|state)\.([a-zA-Z0-9_.-]+)\s*\}\}"
+)
+
+
+class TokenError(ValueError):
+    """Raised when a token cannot be resolved."""
+
+
+def resolve_tokens(
+    value: str,
+    *,
+    config: Mapping[str, Any],
+    run: Mapping[str, Any],
+    state_outputs: Mapping[str, Mapping[str, str]] | None = None,
+) -> str:
+    """Substitute supported tokens in ``value``."""
+
+    outputs = state_outputs or {}
+
+    def _replace(match: re.Match[str]) -> str:
+        scope, key = match.group(1), match.group(2)
+        if scope == "config":
+            if key not in config:
+                raise TokenError(f"unknown config token: config.{key}")
+            return str(config[key])
+        if scope == "run":
+            if key not in run:
+                raise TokenError(f"unknown run token: run.{key}")
+            return str(run[key])
+        if scope == "state":
+            state_name, _, output_key = key.partition(".")
+            state_map = outputs.get(state_name)
+            if not state_map or output_key not in state_map:
+                raise TokenError(f"unknown state token: state.{key}")
+            return str(state_map[output_key])
+        raise TokenError(f"unsupported token scope: {scope}")
+
+    return _TOKEN_RE.sub(_replace, value)
+
+
+def resolve_mapping(
+    data: Mapping[str, Any],
+    *,
+    config: Mapping[str, Any],
+    run: Mapping[str, Any],
+    state_outputs: Mapping[str, Mapping[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Deep-resolve string tokens in a shallow mapping (one level of values)."""
+
+    resolved: dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, str):
+            resolved[key] = resolve_tokens(
+                value, config=config, run=run, state_outputs=state_outputs
+            )
+        else:
+            resolved[key] = value
+    return resolved

--- a/npa/tests/cli/test_workflow_cli.py
+++ b/npa/tests/cli/test_workflow_cli.py
@@ -481,6 +481,7 @@ def test_workflow_run_remote_requires_s3_bucket() -> None:
 
 
 def test_workflow_status_prints_status(mocker) -> None:
+    mocker.patch("npa.workflows.sim2real.monitor.sim2real_run_exists", return_value=False)
     mocker.patch(
         "npa.workflows.distill.get_run_status",
         return_value={"run_id": "run-1", "status": "success", "stages": {}},
@@ -494,6 +495,7 @@ def test_workflow_status_prints_status(mocker) -> None:
 
 
 def test_workflow_status_maps_distillation_error(mocker) -> None:
+    mocker.patch("npa.workflows.sim2real.monitor.sim2real_run_exists", return_value=False)
     mocker.patch(
         "npa.workflows.distill.get_run_status",
         side_effect=DistillationError("not found"),
@@ -520,6 +522,10 @@ def test_workflow_logs_prints_stage_logs(mocker) -> None:
 def test_durable_workflow_status_logs_and_artifacts_read_s3(monkeypatch) -> None:
     fake_s3 = FakeWorkflowS3()
     _patch_workflow_s3(monkeypatch, fake_s3)
+    monkeypatch.setattr(
+        "npa.workflows.sim2real.monitor.sim2real_run_exists",
+        lambda *args, **kwargs: False,
+    )
     manifest = {
         "schema_version": 1,
         "run_id": "run-1",

--- a/npa/tests/e2e/npa_workflow_live_helpers.py
+++ b/npa/tests/e2e/npa_workflow_live_helpers.py
@@ -1,0 +1,136 @@
+"""Shared helpers for live npa.workflow infra tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+import pytest
+from typer.testing import Result
+
+from npa.clients.config import resolve_project_storage
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SPECS_DIR = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+
+ALL_GOLDEN_SPECS = sorted(
+    [
+        "vlm-eval-single.yaml",
+        "tokenfactory-rollout-judge.yaml",
+        "tokenfactory-cosmos-gate.yaml",
+        "sim2real-vlm-rl.yaml",
+        "bdd100k-pipeline.yaml",
+    ]
+)
+
+DYNAMIC_SPECS = frozenset({"sim2real-vlm-rl.yaml", "tokenfactory-cosmos-gate.yaml"})
+
+_LEAK_PATTERNS = (
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"(?i)aws_secret_access_key\s*[:=]\s*['\"]?[A-Za-z0-9/+=]{20,}"),
+    re.compile(r"(?i)nebius_api_key\s*[:=]\s*['\"]?[A-Za-z0-9_-]{20,}"),
+    re.compile(r"(?i)hf_[a-z0-9]{20,}"),
+)
+
+
+def assume_decision_for(name: str, *, mode: str = "promote") -> str:
+    if name in DYNAMIC_SPECS:
+        return "loop_back" if mode == "loop" else "promote_checkpoint"
+    return ""
+
+
+def live_bucket(e2e_project: str | None) -> str:
+    storage = resolve_project_storage(e2e_project)
+    raw = storage.checkpoint_bucket or ""
+    if not raw:
+        pytest.fail("checkpoint_bucket is not configured for live npa.workflow tests")
+    parsed = urlparse(raw if "://" in raw else f"s3://{raw}")
+    bucket = parsed.netloc if parsed.scheme == "s3" else raw.split("/")[0]
+    if not bucket:
+        pytest.fail(f"could not resolve live bucket from {raw!r}")
+    return bucket
+
+
+def materialize_live_spec(
+    tmp_path: Path,
+    name: str,
+    *,
+    bucket: str,
+    run_id: str,
+) -> Path:
+    """Copy a golden spec with the live bucket and a unique e2e prefix."""
+
+    text = (SPECS_DIR / name).read_text(encoding="utf-8")
+    text = text.replace("bucket: example-bucket", f"bucket: {bucket}")
+    marker = f"npa-workflow-e2e/{run_id}"
+    # Keep per-spec prefix tokens but anchor runs under a shared e2e root.
+    text = re.sub(
+        r'(prefix:\s*")([^"]*)(")',
+        lambda m: f'{m.group(1)}{marker}/{name.replace(".yaml", "")}{m.group(3)}',
+        text,
+        count=1,
+    )
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def live_credential_markers() -> list[str]:
+    """Collect credential substrings that must never appear in CLI output."""
+
+    markers: list[str] = []
+    try:
+        from npa.clients.credentials import load_credentials
+
+        storage = load_credentials().get("storage") or {}
+        for key in ("aws_access_key_id", "aws_secret_access_key"):
+            value = storage.get(key)
+            if isinstance(value, str) and len(value) >= 8:
+                markers.append(value)
+    except Exception:
+        pass
+    for env_key in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "HF_TOKEN",
+        "NEBIUS_API_KEY",
+    ):
+        value = os.environ.get(env_key, "")
+        if value and len(value) >= 8:
+            markers.append(value)
+    return markers
+
+
+def assert_no_credential_leakage(
+    text: str,
+    *,
+    extra_forbidden: Iterable[str] | None = None,
+) -> None:
+    """Fail when CLI output contains secrets or live credential material."""
+
+    for pattern in _LEAK_PATTERNS:
+        match = pattern.search(text)
+        assert match is None, f"credential pattern leaked: {match.group(0)[:32]!r}"
+    for marker in extra_forbidden or ():
+        if marker and len(marker) >= 8 and marker in text:
+            raise AssertionError("live credential marker leaked in CLI output")
+
+
+def assert_cli_ok(result: Result, *, forbidden: Iterable[str] | None = None) -> None:
+    assert result.exit_code == 0, result.output
+    assert_no_credential_leakage(result.output, extra_forbidden=forbidden)
+
+
+def parse_json_output(result: Result, *, forbidden: Iterable[str] | None = None) -> Any:
+    assert_cli_ok(result, forbidden=forbidden)
+    return json.loads(result.output)
+
+
+def parse_json_payload(result: Result, forbidden: Iterable[str]) -> dict[str, Any]:
+    payload = parse_json_output(result, forbidden=forbidden)
+    assert isinstance(payload, dict)
+    return payload

--- a/npa/tests/e2e/test_npa_workflow_live_e2e.py
+++ b/npa/tests/e2e/test_npa_workflow_live_e2e.py
@@ -1,0 +1,30 @@
+"""Live validation of NPA workflow specs against real infrastructure (optional)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from npa.orchestration.npa_workflow import build_plan, load_spec
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("NPA_INTEGRATION_E2E") != "1",
+    reason="Set NPA_INTEGRATION_E2E=1 to run live NPA workflow spec checks.",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["vlm-eval-single.yaml", "tokenfactory-rollout-judge.yaml", "sim2real-vlm-rl.yaml"],
+)
+def test_live_npa_workflow_specs_plan(name: str) -> None:
+    """Ensure golden specs load and expand on the operator machine."""
+
+    spec = load_spec(SPECS / name)
+    plan = build_plan(spec, run_id="live-spec-check")
+    assert plan.steps, name

--- a/npa/tests/e2e/test_npa_workflow_live_e2e.py
+++ b/npa/tests/e2e/test_npa_workflow_live_e2e.py
@@ -11,6 +11,17 @@ from typer.testing import CliRunner
 
 from npa.cli.main import app
 from npa.orchestration.npa_workflow import build_plan, load_spec, validate_spec
+from .npa_workflow_live_helpers import (
+    ALL_GOLDEN_SPECS,
+    DYNAMIC_SPECS,
+    assert_cli_ok,
+    assert_no_credential_leakage,
+    assume_decision_for,
+    live_bucket,
+    live_credential_markers,
+    materialize_live_spec,
+    parse_json_payload,
+)
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("NPA_INTEGRATION_E2E") != "1",
@@ -22,32 +33,74 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
 RUNNER = CliRunner()
 
 
-@pytest.mark.parametrize(
-    "name",
-    ["vlm-eval-single.yaml", "tokenfactory-rollout-judge.yaml", "sim2real-vlm-rl.yaml", "bdd100k-pipeline.yaml"],
-)
-def test_live_npa_workflow_specs_plan(name: str) -> None:
+@pytest.fixture(scope="module")
+def forbidden_markers() -> list[str]:
+    return live_credential_markers()
+
+
+@pytest.mark.parametrize("name", ALL_GOLDEN_SPECS)
+def test_live_npa_workflow_specs_plan(name: str, forbidden_markers: list[str]) -> None:
     """Ensure golden specs load and expand on the operator machine."""
 
     spec = load_spec(SPECS / name)
     validate_spec(spec)
-    plan = build_plan(spec, run_id="live-spec-check")
+    assume = assume_decision_for(name) or "promote_checkpoint"
+    plan = build_plan(spec, run_id="live-spec-check", assume_decision=assume)
     assert plan.steps, name
+    assert_no_credential_leakage(json.dumps(plan.to_dict()), extra_forbidden=forbidden_markers)
 
 
-@pytest.mark.parametrize(
-    "name",
-    ["vlm-eval-single.yaml", "tokenfactory-rollout-judge.yaml", "sim2real-vlm-rl.yaml", "bdd100k-pipeline.yaml"],
-)
-def test_live_npa_workflow_cli_validate_and_plan(name: str) -> None:
+@pytest.mark.parametrize("name", ALL_GOLDEN_SPECS)
+def test_live_npa_workflow_cli_validate_and_plan(
+    name: str,
+    forbidden_markers: list[str],
+) -> None:
     """Exercise validate-spec / plan-spec / run-spec --plan-only on live creds."""
 
     path = SPECS / name
     validate = RUNNER.invoke(app, ["workbench", "workflow", "validate-spec", str(path), "--json"])
-    assert validate.exit_code == 0, validate.output
-    payload = json.loads(validate.output)
+    payload = parse_json_payload(validate, forbidden_markers)
     assert payload["status"] == "valid"
 
+    plan_args = [
+        "workbench",
+        "workflow",
+        "plan-spec",
+        str(path),
+        "--run-id",
+        "live-cli-check",
+        "--json",
+    ]
+    assume = assume_decision_for(name)
+    if assume:
+        plan_args.extend(["--assume-decision", assume])
+    plan = RUNNER.invoke(app, plan_args)
+    plan_payload = parse_json_payload(plan, forbidden_markers)
+    assert plan_payload["steps"], name
+
+    run_args = [
+        "workbench",
+        "workflow",
+        "run-spec",
+        str(path),
+        "--run-id",
+        "live-cli-check",
+        "--plan-only",
+        "--json",
+    ]
+    if assume:
+        run_args.extend(["--assume-decision", assume])
+    run = RUNNER.invoke(app, run_args)
+    run_payload = parse_json_payload(run, forbidden_markers)
+    assert run_payload["steps"], name
+
+
+@pytest.mark.parametrize("name", sorted(DYNAMIC_SPECS))
+def test_live_dynamic_specs_loop_back_plan(
+    name: str,
+    forbidden_markers: list[str],
+) -> None:
+    path = SPECS / name
     plan = RUNNER.invoke(
         app,
         [
@@ -56,31 +109,50 @@ def test_live_npa_workflow_cli_validate_and_plan(name: str) -> None:
             "plan-spec",
             str(path),
             "--run-id",
-            "live-cli-check",
+            "live-loop-back",
             "--assume-decision",
-            "promote_checkpoint",
+            "loop_back",
             "--json",
         ],
     )
-    assert plan.exit_code == 0, plan.output
-    plan_payload = json.loads(plan.output)
-    assert plan_payload["steps"], name
+    payload = parse_json_payload(plan, forbidden_markers)
+    assert payload["steps"], name
 
-    run = RUNNER.invoke(
-        app,
-        [
-            "workbench",
-            "workflow",
-            "run-spec",
-            str(path),
-            "--run-id",
-            "live-cli-check",
-            "--plan-only",
-            "--assume-decision",
-            "promote_checkpoint",
-            "--json",
-        ],
-    )
-    assert run.exit_code == 0, run.output
-    run_payload = json.loads(run.output)
-    assert run_payload["steps"], name
+
+@pytest.mark.parametrize("name", ALL_GOLDEN_SPECS)
+def test_live_golden_scheduler_json_no_leak(
+    name: str,
+    forbidden_markers: list[str],
+) -> None:
+    path = SPECS / name
+    args = [
+        "workbench",
+        "workflow",
+        "run-spec",
+        str(path),
+        "--run-id",
+        "live-scheduler-check",
+        "--plan-only",
+        "--scheduler-plan",
+        "--json",
+    ]
+    assume = assume_decision_for(name)
+    if assume:
+        args.extend(["--assume-decision", assume])
+    result = RUNNER.invoke(app, args)
+    payload = parse_json_payload(result, forbidden_markers)
+    assert payload.get("scheduler", {}).get("tasks"), name
+
+
+@pytest.mark.parametrize("name", ALL_GOLDEN_SPECS)
+def test_live_golden_materialized_validate(
+    name: str,
+    tmp_path: Path,
+    e2e_project: str | None,
+    forbidden_markers: list[str],
+) -> None:
+    bucket = live_bucket(e2e_project)
+    path = materialize_live_spec(tmp_path, name, bucket=bucket, run_id="live-materialized")
+    validate = RUNNER.invoke(app, ["workbench", "workflow", "validate-spec", str(path), "--json"])
+    payload = parse_json_payload(validate, forbidden_markers)
+    assert payload["status"] == "valid"

--- a/npa/tests/e2e/test_npa_workflow_live_e2e.py
+++ b/npa/tests/e2e/test_npa_workflow_live_e2e.py
@@ -2,20 +2,24 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
-from npa.orchestration.npa_workflow import build_plan, load_spec
+from npa.cli.main import app
+from npa.orchestration.npa_workflow import build_plan, load_spec, validate_spec
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("NPA_INTEGRATION_E2E") != "1",
     reason="Set NPA_INTEGRATION_E2E=1 to run live NPA workflow spec checks.",
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
+REPO_ROOT = Path(__file__).resolve().parents[3]
 SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+RUNNER = CliRunner()
 
 
 @pytest.mark.parametrize(
@@ -26,5 +30,57 @@ def test_live_npa_workflow_specs_plan(name: str) -> None:
     """Ensure golden specs load and expand on the operator machine."""
 
     spec = load_spec(SPECS / name)
+    validate_spec(spec)
     plan = build_plan(spec, run_id="live-spec-check")
     assert plan.steps, name
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["vlm-eval-single.yaml", "tokenfactory-rollout-judge.yaml", "sim2real-vlm-rl.yaml"],
+)
+def test_live_npa_workflow_cli_validate_and_plan(name: str) -> None:
+    """Exercise validate-spec / plan-spec / run-spec --plan-only on live creds."""
+
+    path = SPECS / name
+    validate = RUNNER.invoke(app, ["workbench", "workflow", "validate-spec", str(path), "--json"])
+    assert validate.exit_code == 0, validate.output
+    payload = json.loads(validate.output)
+    assert payload["status"] == "valid"
+
+    plan = RUNNER.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "plan-spec",
+            str(path),
+            "--run-id",
+            "live-cli-check",
+            "--assume-decision",
+            "promote_checkpoint",
+            "--json",
+        ],
+    )
+    assert plan.exit_code == 0, plan.output
+    plan_payload = json.loads(plan.output)
+    assert plan_payload["steps"], name
+
+    run = RUNNER.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "run-spec",
+            str(path),
+            "--run-id",
+            "live-cli-check",
+            "--plan-only",
+            "--assume-decision",
+            "promote_checkpoint",
+            "--json",
+        ],
+    )
+    assert run.exit_code == 0, run.output
+    run_payload = json.loads(run.output)
+    assert run_payload["steps"], name

--- a/npa/tests/e2e/test_npa_workflow_live_e2e.py
+++ b/npa/tests/e2e/test_npa_workflow_live_e2e.py
@@ -24,7 +24,7 @@ RUNNER = CliRunner()
 
 @pytest.mark.parametrize(
     "name",
-    ["vlm-eval-single.yaml", "tokenfactory-rollout-judge.yaml", "sim2real-vlm-rl.yaml"],
+    ["vlm-eval-single.yaml", "tokenfactory-rollout-judge.yaml", "sim2real-vlm-rl.yaml", "bdd100k-pipeline.yaml"],
 )
 def test_live_npa_workflow_specs_plan(name: str) -> None:
     """Ensure golden specs load and expand on the operator machine."""
@@ -37,7 +37,7 @@ def test_live_npa_workflow_specs_plan(name: str) -> None:
 
 @pytest.mark.parametrize(
     "name",
-    ["vlm-eval-single.yaml", "tokenfactory-rollout-judge.yaml", "sim2real-vlm-rl.yaml"],
+    ["vlm-eval-single.yaml", "tokenfactory-rollout-judge.yaml", "sim2real-vlm-rl.yaml", "bdd100k-pipeline.yaml"],
 )
 def test_live_npa_workflow_cli_validate_and_plan(name: str) -> None:
     """Exercise validate-spec / plan-spec / run-spec --plan-only on live creds."""

--- a/npa/tests/e2e/test_npa_workflow_live_infra.py
+++ b/npa/tests/e2e/test_npa_workflow_live_infra.py
@@ -6,17 +6,25 @@ import json
 import os
 import textwrap
 from pathlib import Path
-from urllib.parse import urlparse
 
 import pytest
 from typer.testing import CliRunner
 
 from npa.cli.main import app
-from npa.clients.config import resolve_project_storage
 from npa.clients.project_credentials import s3_client_for_project
 from npa.orchestration.npa_workflow import build_plan, load_spec, run_workflow
 from npa.orchestration.npa_workflow.errors import NpaWorkflowError
 from npa.orchestration.npa_workflow.run_state import RunStateStore
+from .npa_workflow_live_helpers import (
+    ALL_GOLDEN_SPECS,
+    DYNAMIC_SPECS,
+    assert_no_credential_leakage,
+    assume_decision_for,
+    live_bucket,
+    live_credential_markers,
+    materialize_live_spec,
+    parse_json_payload,
+)
 
 pytestmark = [
     pytest.mark.e2e,
@@ -31,16 +39,9 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
 RUNNER = CliRunner()
 
 
-def _live_bucket(e2e_project: str | None) -> str:
-    storage = resolve_project_storage(e2e_project)
-    raw = storage.checkpoint_bucket or ""
-    if not raw:
-        pytest.fail("checkpoint_bucket is not configured for live npa.workflow tests")
-    parsed = urlparse(raw if "://" in raw else f"s3://{raw}")
-    bucket = parsed.netloc if parsed.scheme == "s3" else raw.split("/")[0]
-    if not bucket:
-        pytest.fail(f"could not resolve live bucket from {raw!r}")
-    return bucket
+@pytest.fixture(scope="module")
+def forbidden_markers() -> list[str]:
+    return live_credential_markers()
 
 
 def _live_store(e2e_project: str | None, *, bucket: str, prefix: str) -> RunStateStore:
@@ -103,8 +104,11 @@ def _write_live_spec(tmp_path: Path, *, bucket: str, run_id: str, shell: str) ->
     return path
 
 
-def test_guide_sim2real_promote_plans_finalize_once(e2e_project: str | None) -> None:
-    _live_bucket(e2e_project)
+def test_guide_sim2real_promote_plans_finalize_once(
+    e2e_project: str | None,
+    forbidden_markers: list[str],
+) -> None:
+    live_bucket(e2e_project)
     result = RUNNER.invoke(
         app,
         [
@@ -119,8 +123,7 @@ def test_guide_sim2real_promote_plans_finalize_once(e2e_project: str | None) -> 
             "--json",
         ],
     )
-    assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = parse_json_payload(result, forbidden_markers)
     states = [step["state"] for step in payload["steps"]]
     assert states.count("finalize") == 1, states
 
@@ -128,8 +131,9 @@ def test_guide_sim2real_promote_plans_finalize_once(e2e_project: str | None) -> 
 def test_guide_run_spec_scheduler_and_persist_state(
     e2e_project: str | None,
     tmp_path: Path,
+    forbidden_markers: list[str],
 ) -> None:
-    bucket = _live_bucket(e2e_project)
+    bucket = live_bucket(e2e_project)
     run_id = "guide-persist-live"
     spec_path = _write_live_spec(
         tmp_path,
@@ -152,9 +156,9 @@ def test_guide_run_spec_scheduler_and_persist_state(
             "--json",
         ],
     )
-    assert scheduler.exit_code == 0, scheduler.output
-    scheduler_payload = json.loads(scheduler.output)
+    scheduler_payload = parse_json_payload(scheduler, forbidden_markers)
     assert scheduler_payload["scheduler"]["tasks"], scheduler_payload
+    assert_no_credential_leakage(json.dumps(scheduler_payload), extra_forbidden=forbidden_markers)
 
     spec = load_spec(spec_path)
     store = _live_store(e2e_project, bucket=bucket, prefix=f"npa-workflow-e2e/{run_id}")
@@ -175,7 +179,7 @@ def test_guide_failed_execute_persists_failed_manifest_on_real_s3(
     e2e_project: str | None,
     tmp_path: Path,
 ) -> None:
-    bucket = _live_bucket(e2e_project)
+    bucket = live_bucket(e2e_project)
     run_id = "guide-fail-live"
     spec_path = _write_live_spec(
         tmp_path,
@@ -199,7 +203,7 @@ def test_guide_require_inputs_fails_on_missing_artifact(
     e2e_project: str | None,
     tmp_path: Path,
 ) -> None:
-    bucket = _live_bucket(e2e_project)
+    bucket = live_bucket(e2e_project)
     run_id = "guide-require-inputs"
     path = tmp_path / "require-inputs.yaml"
     path.write_text(
@@ -244,10 +248,130 @@ def test_guide_require_inputs_fails_on_missing_artifact(
 
 
 def test_guide_loop_back_assume_expands_outer_loop(e2e_project: str | None) -> None:
-    _live_bucket(e2e_project)
+    live_bucket(e2e_project)
     spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
     plan = build_plan(spec, run_id="guide-loop-back", assume_decision="loop_back")
     states = [step.state for step in plan.steps]
     inner = spec.config["inner_iterations"]
     outer = spec.config["outer_iterations"]
     assert states.count("rollouts") == inner * outer
+
+
+def test_guide_cosmos_gate_loop_back_expands_refinement(e2e_project: str | None) -> None:
+    live_bucket(e2e_project)
+    spec = load_spec(SPECS / "tokenfactory-cosmos-gate.yaml")
+    plan = build_plan(spec, run_id="guide-cosmos-loop", assume_decision="loop_back")
+    states = [step.state for step in plan.steps]
+    assert states.count("vlm-critique") == spec.config["refinement_iterations"]
+
+
+@pytest.mark.parametrize("name", ALL_GOLDEN_SPECS)
+def test_live_golden_full_cli_on_real_bucket(
+    name: str,
+    e2e_project: str | None,
+    tmp_path: Path,
+    forbidden_markers: list[str],
+) -> None:
+    """All golden YAMLs: validate, plan, scheduler JSON on live bucket materialization."""
+
+    bucket = live_bucket(e2e_project)
+    run_id = f"live-golden-{name.replace('.yaml', '')}"
+    path = materialize_live_spec(tmp_path, name, bucket=bucket, run_id=run_id)
+
+    validate = RUNNER.invoke(app, ["workbench", "workflow", "validate-spec", str(path), "--json"])
+    assert parse_json_payload(validate, forbidden_markers)["status"] == "valid"
+
+    plan_args = [
+        "workbench",
+        "workflow",
+        "plan-spec",
+        str(path),
+        "--run-id",
+        run_id,
+        "--json",
+    ]
+    assume = assume_decision_for(name)
+    if assume:
+        plan_args.extend(["--assume-decision", assume])
+    plan = RUNNER.invoke(app, plan_args)
+    plan_payload = parse_json_payload(plan, forbidden_markers)
+    assert plan_payload["steps"], name
+
+    run_args = [
+        "workbench",
+        "workflow",
+        "run-spec",
+        str(path),
+        "--run-id",
+        run_id,
+        "--plan-only",
+        "--scheduler-plan",
+        "--json",
+    ]
+    if assume:
+        run_args.extend(["--assume-decision", assume])
+    run = RUNNER.invoke(app, run_args)
+    run_payload = parse_json_payload(run, forbidden_markers)
+    assert run_payload.get("scheduler", {}).get("tasks"), name
+
+
+@pytest.mark.parametrize("name", ALL_GOLDEN_SPECS)
+def test_live_golden_persist_manifest_on_real_s3(
+    name: str,
+    e2e_project: str | None,
+    tmp_path: Path,
+    forbidden_markers: list[str],
+) -> None:
+    """Plan-only persist-state for every golden spec against real S3."""
+
+    bucket = live_bucket(e2e_project)
+    run_id = f"live-persist-{name.replace('.yaml', '')}"
+    path = materialize_live_spec(tmp_path, name, bucket=bucket, run_id=run_id)
+    spec = load_spec(path)
+    prefix = str(spec.config.get("prefix") or run_id)
+    store = _live_store(e2e_project, bucket=bucket, prefix=prefix)
+
+    assume = assume_decision_for(name) or "promote_checkpoint"
+    report = run_workflow(
+        spec,
+        run_id=run_id,
+        execute=False,
+        assume_decision=assume,
+        state_store=store,
+    )
+    assert report["status"] == "planned"
+    assert_no_credential_leakage(json.dumps(report), extra_forbidden=forbidden_markers)
+
+    manifest = store.read_manifest()
+    assert manifest is not None
+    assert manifest.status == "planned"
+    assert manifest.run_id == run_id
+    assert manifest.steps
+
+
+@pytest.mark.parametrize("name", sorted(DYNAMIC_SPECS))
+def test_live_dynamic_golden_loop_back_cli(
+    name: str,
+    e2e_project: str | None,
+    tmp_path: Path,
+    forbidden_markers: list[str],
+) -> None:
+    bucket = live_bucket(e2e_project)
+    run_id = f"live-loop-{name.replace('.yaml', '')}"
+    path = materialize_live_spec(tmp_path, name, bucket=bucket, run_id=run_id)
+    result = RUNNER.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "plan-spec",
+            str(path),
+            "--run-id",
+            run_id,
+            "--assume-decision",
+            "loop_back",
+            "--json",
+        ],
+    )
+    payload = parse_json_payload(result, forbidden_markers)
+    assert payload["steps"], name

--- a/npa/tests/e2e/test_npa_workflow_live_infra.py
+++ b/npa/tests/e2e/test_npa_workflow_live_infra.py
@@ -1,0 +1,221 @@
+"""Live infra tests for npa.workflow guide runbook paths (real S3 + CLI)."""
+
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.clients.config import resolve_project_storage
+from npa.orchestration.npa_workflow import build_plan, load_spec, run_workflow
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+from npa.orchestration.npa_workflow.run_state import RunStateStore
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("NPA_INTEGRATION_E2E") != "1",
+        reason="Set NPA_INTEGRATION_E2E=1 to run live NPA workflow infra checks.",
+    ),
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+RUNNER = CliRunner()
+
+
+def _live_bucket(e2e_project: str | None) -> str:
+    storage = resolve_project_storage(e2e_project)
+    raw = storage.checkpoint_bucket or ""
+    if not raw:
+        pytest.fail("checkpoint_bucket is not configured for live npa.workflow tests")
+    parsed = urlparse(raw if "://" in raw else f"s3://{raw}")
+    bucket = parsed.netloc if parsed.scheme == "s3" else raw.split("/")[0]
+    if not bucket:
+        pytest.fail(f"could not resolve live bucket from {raw!r}")
+    return bucket
+
+
+def _write_live_spec(tmp_path: Path, *, bucket: str, run_id: str, shell: str) -> Path:
+    path = tmp_path / "live-fail.yaml"
+    path.write_text(
+        textwrap.dedent(
+            f"""
+            apiVersion: npa.workflow/v0.0.1
+            kind: Workflow
+
+            metadata:
+              name: live-fail
+
+            config:
+              bucket: {bucket}
+              prefix: "npa-workflow-e2e/{run_id}"
+
+            initial: fail-step
+
+            states:
+              fail-step:
+                run:
+                  shell: |
+                    {shell}
+                terminal: true
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_guide_sim2real_promote_plans_finalize_once(e2e_project: str | None) -> None:
+    _live_bucket(e2e_project)
+    result = RUNNER.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "plan-spec",
+            str(SPECS / "sim2real-vlm-rl.yaml"),
+            "--run-id",
+            "guide-promote-live",
+            "--assume-decision",
+            "promote_checkpoint",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    states = [step["state"] for step in payload["steps"]]
+    assert states.count("finalize") == 1, states
+
+
+def test_guide_run_spec_scheduler_and_persist_state(
+    e2e_project: str | None,
+    tmp_path: Path,
+) -> None:
+    bucket = _live_bucket(e2e_project)
+    run_id = "guide-persist-live"
+    spec_path = _write_live_spec(
+        tmp_path,
+        bucket=bucket,
+        run_id=run_id,
+        shell='echo "plan-only persist probe"',
+    )
+    result = RUNNER.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "run-spec",
+            str(spec_path),
+            "--run-id",
+            run_id,
+            "--plan-only",
+            "--scheduler-plan",
+            "--persist-state",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "planned"
+    assert payload["scheduler"]["tasks"], payload
+    assert payload["run_prefix_uri"].startswith(f"s3://{bucket}/")
+
+    store = RunStateStore(bucket=bucket, prefix=f"npa-workflow-e2e/{run_id}")
+    manifest = store.read_manifest()
+    assert manifest is not None
+    assert manifest.status == "planned"
+    assert manifest.run_id == run_id
+
+
+def test_guide_failed_execute_persists_failed_manifest_on_real_s3(
+    e2e_project: str | None,
+    tmp_path: Path,
+) -> None:
+    bucket = _live_bucket(e2e_project)
+    run_id = "guide-fail-live"
+    spec_path = _write_live_spec(
+        tmp_path,
+        bucket=bucket,
+        run_id=run_id,
+        shell="exit 42",
+    )
+    result = RUNNER.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "run-spec",
+            str(spec_path),
+            "--run-id",
+            run_id,
+            "--execute",
+            "--persist-state",
+        ],
+    )
+    assert result.exit_code != 0, result.output
+
+    store = RunStateStore(bucket=bucket, prefix=f"npa-workflow-e2e/{run_id}")
+    manifest = store.read_manifest()
+    assert manifest is not None
+    assert manifest.status == "failed"
+    assert manifest.steps
+    assert manifest.steps[0]["status"] == "failed"
+
+
+def test_guide_require_inputs_fails_on_missing_artifact(
+    e2e_project: str | None,
+    tmp_path: Path,
+) -> None:
+    bucket = _live_bucket(e2e_project)
+    run_id = "guide-require-inputs"
+    path = tmp_path / "require-inputs.yaml"
+    path.write_text(
+        textwrap.dedent(
+            f"""
+            apiVersion: npa.workflow/v0.0.1
+            kind: Workflow
+
+            metadata:
+              name: require-inputs
+
+            config:
+              bucket: {bucket}
+              prefix: "npa-workflow-e2e/{run_id}"
+              rollouts_uri: "s3://{bucket}/npa-workflow-e2e/{run_id}/missing/rollouts/"
+              scores_uri: "s3://{bucket}/npa-workflow-e2e/{run_id}/scores/"
+              vlm_backend: self-hosted
+
+            initial: score
+
+            states:
+              score:
+                toolRef: workbench.vlm_eval.run
+                inputs:
+                  - uri: "s3://{bucket}/npa-workflow-e2e/{run_id}/does-not-exist/manifest.json"
+                terminal: true
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    spec = load_spec(path)
+    with pytest.raises(NpaWorkflowError, match="missing required input"):
+        run_workflow(spec, run_id=run_id, execute=True, require_inputs=True)
+
+
+def test_guide_loop_back_assume_expands_outer_loop(e2e_project: str | None) -> None:
+    _live_bucket(e2e_project)
+    spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
+    plan = build_plan(spec, run_id="guide-loop-back", assume_decision="loop_back")
+    states = [step.state for step in plan.steps]
+    inner = spec.config["inner_iterations"]
+    outer = spec.config["outer_iterations"]
+    assert states.count("rollouts") == inner * outer

--- a/npa/tests/e2e/test_npa_workflow_live_infra.py
+++ b/npa/tests/e2e/test_npa_workflow_live_infra.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 
 from npa.cli.main import app
 from npa.clients.config import resolve_project_storage
+from npa.clients.project_credentials import s3_client_for_project
 from npa.orchestration.npa_workflow import build_plan, load_spec, run_workflow
 from npa.orchestration.npa_workflow.errors import NpaWorkflowError
 from npa.orchestration.npa_workflow.run_state import RunStateStore
@@ -40,6 +41,35 @@ def _live_bucket(e2e_project: str | None) -> str:
     if not bucket:
         pytest.fail(f"could not resolve live bucket from {raw!r}")
     return bucket
+
+
+def _live_store(e2e_project: str | None, *, bucket: str, prefix: str) -> RunStateStore:
+    client = s3_client_for_project(e2e_project)
+
+    def reader(b: str, key: str) -> str:
+        response = client.get_object(Bucket=b, Key=key)
+        return response["Body"].read().decode("utf-8")
+
+    def writer(b: str, key: str, body: bytes) -> None:
+        client.put_object(Bucket=b, Key=key, Body=body, ContentType="application/json")
+
+    return RunStateStore(bucket=bucket, prefix=prefix, reader=reader, writer=writer)
+
+
+def _artifact_checker(e2e_project: str | None):
+    client = s3_client_for_project(e2e_project)
+
+    def checker(bucket: str, key: str) -> bool:
+        try:
+            client.head_object(Bucket=bucket, Key=key)
+            return True
+        except client.exceptions.ClientError as exc:
+            code = str(exc.response.get("Error", {}).get("Code", ""))
+            if code in {"404", "NoSuchKey", "NotFound", "403", "AccessDenied"}:
+                return False
+            raise
+
+    return checker
 
 
 def _write_live_spec(tmp_path: Path, *, bucket: str, run_id: str, shell: str) -> Path:
@@ -107,7 +137,8 @@ def test_guide_run_spec_scheduler_and_persist_state(
         run_id=run_id,
         shell='echo "plan-only persist probe"',
     )
-    result = RUNNER.invoke(
+
+    scheduler = RUNNER.invoke(
         app,
         [
             "workbench",
@@ -118,17 +149,22 @@ def test_guide_run_spec_scheduler_and_persist_state(
             run_id,
             "--plan-only",
             "--scheduler-plan",
-            "--persist-state",
             "--json",
         ],
     )
-    assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    assert payload["status"] == "planned"
-    assert payload["scheduler"]["tasks"], payload
-    assert payload["run_prefix_uri"].startswith(f"s3://{bucket}/")
+    assert scheduler.exit_code == 0, scheduler.output
+    scheduler_payload = json.loads(scheduler.output)
+    assert scheduler_payload["scheduler"]["tasks"], scheduler_payload
 
-    store = RunStateStore(bucket=bucket, prefix=f"npa-workflow-e2e/{run_id}")
+    spec = load_spec(spec_path)
+    store = _live_store(e2e_project, bucket=bucket, prefix=f"npa-workflow-e2e/{run_id}")
+    report = run_workflow(
+        spec,
+        run_id=run_id,
+        execute=False,
+        state_store=store,
+    )
+    assert report["status"] == "planned"
     manifest = store.read_manifest()
     assert manifest is not None
     assert manifest.status == "planned"
@@ -147,22 +183,11 @@ def test_guide_failed_execute_persists_failed_manifest_on_real_s3(
         run_id=run_id,
         shell="exit 42",
     )
-    result = RUNNER.invoke(
-        app,
-        [
-            "workbench",
-            "workflow",
-            "run-spec",
-            str(spec_path),
-            "--run-id",
-            run_id,
-            "--execute",
-            "--persist-state",
-        ],
-    )
-    assert result.exit_code != 0, result.output
+    spec = load_spec(spec_path)
+    store = _live_store(e2e_project, bucket=bucket, prefix=f"npa-workflow-e2e/{run_id}")
+    with pytest.raises(NpaWorkflowError):
+        run_workflow(spec, run_id=run_id, execute=True, state_store=store)
 
-    store = RunStateStore(bucket=bucket, prefix=f"npa-workflow-e2e/{run_id}")
     manifest = store.read_manifest()
     assert manifest is not None
     assert manifest.status == "failed"
@@ -197,7 +222,8 @@ def test_guide_require_inputs_fails_on_missing_artifact(
 
             states:
               score:
-                toolRef: workbench.vlm_eval.run
+                run:
+                  shell: "echo should-not-run"
                 inputs:
                   - uri: "s3://{bucket}/npa-workflow-e2e/{run_id}/does-not-exist/manifest.json"
                 terminal: true
@@ -208,7 +234,13 @@ def test_guide_require_inputs_fails_on_missing_artifact(
     )
     spec = load_spec(path)
     with pytest.raises(NpaWorkflowError, match="missing required input"):
-        run_workflow(spec, run_id=run_id, execute=True, require_inputs=True)
+        run_workflow(
+            spec,
+            run_id=run_id,
+            execute=True,
+            require_inputs=True,
+            artifact_checker=_artifact_checker(e2e_project),
+        )
 
 
 def test_guide_loop_back_assume_expands_outer_loop(e2e_project: str | None) -> None:

--- a/npa/tests/guardrails/test_skills_index.py
+++ b/npa/tests/guardrails/test_skills_index.py
@@ -85,6 +85,12 @@ def test_skill_smoke_examples_run(skills_index: dict, tmp_path: Path, monkeypatc
                         assert payload.get("name") or payload.get("resources"), relative_path
             elif smoke_type == "file_exists":
                 assert (REPO_ROOT / smoke["path"]).exists(), smoke["path"]
+            elif smoke_type == "npa_workflow_yaml":
+                from npa.orchestration.npa_workflow import load_spec, validate_spec
+
+                for relative_path in smoke["paths"]:
+                    spec = load_spec(REPO_ROOT / relative_path)
+                    validate_spec(spec)
             elif smoke_type == "configure_provision_dry_run":
                 _assert_configure_provision_dry_run(runner, tmp_path, monkeypatch)
             else:

--- a/npa/tests/orchestration/npa_workflow/test_artifacts.py
+++ b/npa/tests/orchestration/npa_workflow/test_artifacts.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from npa.orchestration.npa_workflow.artifacts import require_input_artifacts, s3_object_exists
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+
+
+def test_s3_object_exists_uses_checker() -> None:
+    seen: list[str] = []
+
+    def checker(_bucket: str, key: str) -> bool:
+        seen.append(key)
+        return key.endswith("manifest.json")
+
+    assert s3_object_exists("s3://bucket/prefix/manifest.json", checker=checker)
+    assert seen == ["prefix/manifest.json"]
+
+
+def test_require_input_artifacts_raises_when_missing() -> None:
+    with pytest.raises(NpaWorkflowError, match="missing required input"):
+        require_input_artifacts(
+            ["s3://bucket/missing.json"],
+            checker=lambda _bucket, _key: False,
+        )

--- a/npa/tests/orchestration/npa_workflow/test_audit_fixes.py
+++ b/npa/tests/orchestration/npa_workflow/test_audit_fixes.py
@@ -278,3 +278,84 @@ states:
     )
     assert plan.exit_code == 1, plan.output
     assert "cycle" in plan.output.lower() or "step limit" in plan.output.lower()
+
+
+def test_malformed_yaml_raises_npa_workflow_error(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text(
+        "apiVersion: npa.workflow/v0.0.1\nkind: Workflow\nconfig: [\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(NpaWorkflowError, match="not valid YAML"):
+        load_spec(path)
+
+
+def test_cli_malformed_yaml_exits_1(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text("metadata:\n  name: x\n  bad indent\nfoo:\n", encoding="utf-8")
+    result = RUNNER.invoke(app, ["workbench", "workflow", "validate-spec", str(path)])
+    assert result.exit_code == 1, result.output
+    assert "not valid YAML" in result.output or "Error:" in result.output
+    assert "Unexpected error" not in result.output
+
+
+def test_persist_state_without_bucket_raises(tmp_path: Path) -> None:
+    path = tmp_path / "no-bucket.yaml"
+    path.write_text(
+        """
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+metadata:
+  name: no-bucket
+config:
+  prefix: runs/test
+initial: x
+states:
+  x:
+    run:
+      shell: echo ok
+    terminal: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    spec = load_spec(path)
+    with pytest.raises(NpaWorkflowError, match="persist_state requires config.bucket"):
+        run_workflow(spec, run_id="no-bucket-run", persist_state=True)
+
+
+def test_cli_persist_state_without_bucket_exits_1(tmp_path: Path) -> None:
+    path = tmp_path / "no-bucket.yaml"
+    path.write_text(
+        """
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+metadata:
+  name: no-bucket
+config:
+  prefix: runs/test
+initial: x
+states:
+  x:
+    run:
+      shell: echo ok
+    terminal: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    result = RUNNER.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "run-spec",
+            str(path),
+            "--run-id",
+            "cli-no-bucket",
+            "--plan-only",
+            "--persist-state",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "persist_state requires config.bucket" in result.output

--- a/npa/tests/orchestration/npa_workflow/test_audit_fixes.py
+++ b/npa/tests/orchestration/npa_workflow/test_audit_fixes.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from npa.cli.main import app
 from npa.orchestration.npa_workflow import NpaWorkflowError, build_plan, load_spec, run_workflow
 from npa.orchestration.npa_workflow.predicates import evaluate_predicate
 from npa.orchestration.npa_workflow.run_state import RunManifest, RunStateStore
-from npa.orchestration.npa_workflow.spec import validate_spec
+from npa.orchestration.npa_workflow.spec import LoopSpec, StateSpec, validate_spec
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+RUNNER = CliRunner()
 
 
 def test_promote_checkpoint_plans_finalize_once() -> None:
@@ -27,9 +31,18 @@ def test_loop_back_assume_normalizes_for_plan_predicates() -> None:
 
 
 def test_unbounded_cycle_rejected_at_validate() -> None:
-    from npa.orchestration.npa_workflow.spec import StateSpec
-
     spec = load_spec(SPECS / "tokenfactory-rollout-judge.yaml")
+    spec.states["reason-scene"].next = "judge-rollouts"
+    spec.states["judge-rollouts"].terminal = False
+    spec.states["judge-rollouts"].next = "reason-scene"
+    spec.states["done"] = StateSpec(name="done", terminal=True)
+    with pytest.raises(NpaWorkflowError, match="unbounded control-flow cycle"):
+        validate_spec(spec)
+
+
+def test_transition_cycle_not_whitelisted_by_loop_block() -> None:
+    spec = load_spec(SPECS / "tokenfactory-rollout-judge.yaml")
+    spec.states["reason-scene"].loop = LoopSpec(max=3)
     spec.states["reason-scene"].next = "judge-rollouts"
     spec.states["judge-rollouts"].terminal = False
     spec.states["judge-rollouts"].next = "reason-scene"
@@ -43,6 +56,75 @@ def test_zero_loop_max_rejected_at_validate() -> None:
     spec.config["inner_iterations"] = 0
     with pytest.raises(NpaWorkflowError, match="loop.max must be >= 1"):
         validate_spec(spec)
+
+
+def test_missing_config_token_rejected_at_validate() -> None:
+    spec = load_spec(SPECS / "vlm-eval-single.yaml")
+    spec.states["score-rollouts"].outputs = [
+        __import__(
+            "npa.orchestration.npa_workflow.spec", fromlist=["ArtifactSpec"]
+        ).ArtifactSpec(uri="{{config.does_not_exist}}")
+    ]
+    with pytest.raises(NpaWorkflowError, match="does_not_exist"):
+        validate_spec(spec)
+
+
+def test_non_int_loop_max_rejected_at_validate() -> None:
+    spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
+    spec.config["inner_iterations"] = "not-an-int"
+    with pytest.raises(NpaWorkflowError, match="must be an integer loop bound"):
+        validate_spec(spec)
+
+
+def test_state_output_token_resolves_during_plan(tmp_path: Path) -> None:
+    path = tmp_path / "state-token.yaml"
+    path.write_text(
+        """
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+metadata:
+  name: state-token-plan
+config:
+  bucket: example-bucket
+initial: produce
+states:
+  produce:
+    run:
+      shell: echo ok
+    outputs:
+      - uri: s3://{{config.bucket}}/artifact.json
+    next: consume
+  consume:
+    run:
+      shell: cat {{state.produce.uri}}
+    terminal: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    spec = load_spec(path)
+    plan = build_plan(spec, run_id="state-token-run")
+    consume = next(step for step in plan.steps if step.state == "consume")
+    assert consume.shell == "cat s3://example-bucket/artifact.json"
+
+
+def test_execution_step_limit_guard(monkeypatch) -> None:
+    spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
+    monkeypatch.setattr(
+        "npa.orchestration.npa_workflow.interpreter._execution_step_limit",
+        lambda _spec: 4,
+    )
+    monkeypatch.setattr(
+        "npa.orchestration.npa_workflow.interpreter._execute_step",
+        lambda step, execute=True: {"state": step.state, "status": "ok"},
+    )
+    with pytest.raises(NpaWorkflowError, match="execution exceeded step limit"):
+        run_workflow(
+            spec,
+            run_id="depth-guard",
+            execute=True,
+            assume_decision="loop_back",
+        )
 
 
 def test_failed_execute_persists_failed_manifest(monkeypatch) -> None:
@@ -74,7 +156,125 @@ def test_failed_execute_persists_failed_manifest(monkeypatch) -> None:
             state_store=state_store,
         )
 
-    manifest = RunManifest.from_dict(__import__("json").loads(store[("bucket", "runs/fail-demo/npa-workflow/manifest.json")]))
+    manifest = RunManifest.from_dict(
+        json.loads(store[("bucket", "runs/fail-demo/npa-workflow/manifest.json")])
+    )
     assert manifest.status == "failed"
     assert manifest.steps
     assert manifest.steps[0]["status"] == "failed"
+
+
+def test_persist_failure_does_not_mask_workflow_error(monkeypatch) -> None:
+    spec = load_spec(SPECS / "vlm-eval-single.yaml")
+    calls = {"n": 0}
+
+    def flaky_writer(bucket: str, key: str, body: bytes) -> None:
+        calls["n"] += 1
+        if calls["n"] > 2:
+            raise RuntimeError("s3 down")
+
+    state_store = RunStateStore(
+        bucket="bucket",
+        prefix="runs/persist-mask",
+        writer=flaky_writer,
+        reader=lambda _b, _k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    monkeypatch.setattr(
+        "npa.orchestration.npa_workflow.interpreter._execute_step",
+        lambda step, execute=True: (_ for _ in ()).throw(
+            NpaWorkflowError("step failed first")
+        ),
+    )
+
+    with pytest.raises(NpaWorkflowError, match="step failed first"):
+        run_workflow(
+            spec,
+            run_id="persist-mask",
+            execute=True,
+            state_store=state_store,
+        )
+
+
+def test_persist_failure_surfaces_when_no_step_error(monkeypatch) -> None:
+    spec = load_spec(SPECS / "vlm-eval-single.yaml")
+    calls = {"n": 0}
+
+    def flaky_writer(bucket: str, key: str, body: bytes) -> None:
+        calls["n"] += 1
+        if calls["n"] > 2:
+            raise RuntimeError("s3 down")
+
+    state_store = RunStateStore(
+        bucket="bucket",
+        prefix="runs/persist-only",
+        writer=flaky_writer,
+        reader=lambda _b, _k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    monkeypatch.setattr(
+        "npa.orchestration.npa_workflow.interpreter._execute_step",
+        lambda step, execute=True: {"state": step.state, "status": "ok"},
+    )
+
+    with pytest.raises(NpaWorkflowError, match="failed to persist workflow manifest"):
+        run_workflow(
+            spec,
+            run_id="persist-only",
+            execute=True,
+            state_store=state_store,
+        )
+
+
+def test_cli_validate_spec_rejects_missing_config_token(tmp_path: Path) -> None:
+    path = tmp_path / "bad-token.yaml"
+    path.write_text(
+        (SPECS / "vlm-eval-single.yaml")
+        .read_text(encoding="utf-8")
+        .replace(
+            "{{config.scores_uri}}report.json",
+            "{{config.does_not_exist}}",
+        ),
+        encoding="utf-8",
+    )
+    result = RUNNER.invoke(
+        app,
+        ["workbench", "workflow", "validate-spec", str(path)],
+    )
+    assert result.exit_code == 1, result.output
+    assert "does_not_exist" in result.output
+
+
+def test_cli_plan_spec_rejects_unbounded_cycle(tmp_path: Path) -> None:
+    path = tmp_path / "cycle.yaml"
+    path.write_text(
+        """
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+metadata:
+  name: cycle
+config: {}
+initial: a
+states:
+  a:
+    run:
+      shell: echo a
+    next: b
+  b:
+    run:
+      shell: echo b
+    next: a
+  done:
+    terminal: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    validate = RUNNER.invoke(app, ["workbench", "workflow", "validate-spec", str(path)])
+    assert validate.exit_code == 1, validate.output
+    assert "cycle" in validate.output.lower()
+
+    plan = RUNNER.invoke(
+        app,
+        ["workbench", "workflow", "plan-spec", str(path), "--run-id", "cycle-plan"],
+    )
+    assert plan.exit_code == 1, plan.output
+    assert "cycle" in plan.output.lower() or "step limit" in plan.output.lower()

--- a/npa/tests/orchestration/npa_workflow/test_audit_fixes.py
+++ b/npa/tests/orchestration/npa_workflow/test_audit_fixes.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from npa.orchestration.npa_workflow import NpaWorkflowError, build_plan, load_spec, run_workflow
+from npa.orchestration.npa_workflow.predicates import evaluate_predicate
+from npa.orchestration.npa_workflow.run_state import RunManifest, RunStateStore
+from npa.orchestration.npa_workflow.spec import validate_spec
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+
+
+def test_promote_checkpoint_plans_finalize_once() -> None:
+    spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
+    plan = build_plan(spec, run_id="audit-promote", assume_decision="promote_checkpoint")
+    states = [step.state for step in plan.steps]
+    assert states.count("finalize") == 1
+    assert len(plan.steps) == 11
+
+
+def test_loop_back_assume_normalizes_for_plan_predicates() -> None:
+    context = {"last_decision": "loop_back"}
+    assert evaluate_predicate("loop_back", context) is True
+
+
+def test_unbounded_cycle_rejected_at_validate() -> None:
+    from npa.orchestration.npa_workflow.spec import StateSpec
+
+    spec = load_spec(SPECS / "tokenfactory-rollout-judge.yaml")
+    spec.states["reason-scene"].next = "judge-rollouts"
+    spec.states["judge-rollouts"].terminal = False
+    spec.states["judge-rollouts"].next = "reason-scene"
+    spec.states["done"] = StateSpec(name="done", terminal=True)
+    with pytest.raises(NpaWorkflowError, match="unbounded control-flow cycle"):
+        validate_spec(spec)
+
+
+def test_zero_loop_max_rejected_at_validate() -> None:
+    spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
+    spec.config["inner_iterations"] = 0
+    with pytest.raises(NpaWorkflowError, match="loop.max must be >= 1"):
+        validate_spec(spec)
+
+
+def test_failed_execute_persists_failed_manifest(monkeypatch) -> None:
+    spec = load_spec(SPECS / "vlm-eval-single.yaml")
+    store: dict[tuple[str, str], bytes] = {}
+
+    def writer(bucket: str, key: str, body: bytes) -> None:
+        store[(bucket, key)] = body
+
+    state_store = RunStateStore(
+        bucket="bucket",
+        prefix="runs/fail-demo",
+        writer=writer,
+        reader=lambda _b, _k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+
+    monkeypatch.setattr(
+        "npa.orchestration.npa_workflow.interpreter._execute_step",
+        lambda step, execute=True: (_ for _ in ()).throw(
+            NpaWorkflowError(f"boom at {step.state}")
+        ),
+    )
+
+    with pytest.raises(NpaWorkflowError, match="boom"):
+        run_workflow(
+            spec,
+            run_id="fail-demo",
+            execute=True,
+            state_store=state_store,
+        )
+
+    manifest = RunManifest.from_dict(__import__("json").loads(store[("bucket", "runs/fail-demo/npa-workflow/manifest.json")]))
+    assert manifest.status == "failed"
+    assert manifest.steps
+    assert manifest.steps[0]["status"] == "failed"

--- a/npa/tests/orchestration/npa_workflow/test_decisions.py
+++ b/npa/tests/orchestration/npa_workflow/test_decisions.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from npa.orchestration.npa_workflow.decisions import (
+    DECISION_LOOP_BACK,
+    DECISION_PROMOTE,
+    decision_from_payload,
+    load_decision,
+    normalize_decision,
+    refresh_context_decision,
+    write_decision,
+)
+from npa.orchestration.npa_workflow.errors import NpaWorkflowError
+
+
+def test_normalize_decision_aliases() -> None:
+    assert normalize_decision("promote") == DECISION_PROMOTE
+    assert normalize_decision("loop_back") == DECISION_LOOP_BACK
+
+
+def test_load_and_write_decision_roundtrip() -> None:
+    store: dict[tuple[str, str], bytes] = {}
+
+    def writer(bucket: str, key: str, body: bytes) -> None:
+        store[(bucket, key)] = body
+
+    def reader(bucket: str, key: str) -> str:
+        return store[(bucket, key)].decode("utf-8")
+
+    uri = "s3://bucket/run/decision.json"
+    write_decision(uri, "promote", writer=writer)
+    assert load_decision(uri, reader=reader) == DECISION_PROMOTE
+
+
+def test_refresh_context_decision_prefers_s3_uri() -> None:
+    payload = json.dumps({"decision": "loop_back"})
+    context = {
+        "last_decision": DECISION_PROMOTE,
+        "config": {"decision_uri": "s3://bucket/run/decision.json"},
+    }
+    decision = refresh_context_decision(
+        context,
+        reader=lambda _bucket, _key: payload,
+    )
+    assert decision == DECISION_LOOP_BACK
+
+
+def test_decision_from_payload_requires_field() -> None:
+    with pytest.raises(NpaWorkflowError):
+        decision_from_payload({})

--- a/npa/tests/orchestration/npa_workflow/test_dynamic_execution.py
+++ b/npa/tests/orchestration/npa_workflow/test_dynamic_execution.py
@@ -13,7 +13,6 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
 
 def test_dynamic_execute_reads_decision_for_promote(monkeypatch) -> None:
     spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
-    spec.config["plan_assume_decision"] = "promote_checkpoint"
     def fake_reader(_bucket: str, _key: str) -> str:
         return json.dumps({"decision": DECISION_PROMOTE})
 
@@ -35,7 +34,6 @@ def test_dynamic_execute_reads_decision_for_promote(monkeypatch) -> None:
 
 def test_dynamic_execute_reads_decision_for_loop_back(monkeypatch) -> None:
     spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
-    spec.config["plan_assume_decision"] = "loop_back"
     decisions = iter([DECISION_LOOP_BACK, DECISION_PROMOTE])
 
     def fake_reader(_bucket: str, _key: str) -> str:

--- a/npa/tests/orchestration/npa_workflow/test_dynamic_execution.py
+++ b/npa/tests/orchestration/npa_workflow/test_dynamic_execution.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from npa.orchestration.npa_workflow import load_spec, run_workflow
+from npa.orchestration.npa_workflow.decisions import DECISION_LOOP_BACK, DECISION_PROMOTE
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+
+
+def test_dynamic_execute_reads_decision_for_promote(monkeypatch) -> None:
+    spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
+    spec.config["plan_assume_decision"] = "promote_checkpoint"
+    def fake_reader(_bucket: str, _key: str) -> str:
+        return json.dumps({"decision": DECISION_PROMOTE})
+
+    monkeypatch.setattr(
+        "npa.orchestration.npa_workflow.interpreter._execute_step",
+        lambda step, execute=True: {"state": step.state, "status": "ok"},
+    )
+
+    report = run_workflow(
+        spec,
+        run_id="dyn-promote",
+        execute=True,
+        decision_reader=fake_reader,
+    )
+    states = [step["state"] for step in report["steps"]]
+    assert states.count("rollouts") == spec.config["inner_iterations"]
+    assert states[-1] == "finalize"
+
+
+def test_dynamic_execute_reads_decision_for_loop_back(monkeypatch) -> None:
+    spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
+    spec.config["plan_assume_decision"] = "loop_back"
+    decisions = iter([DECISION_LOOP_BACK, DECISION_PROMOTE])
+
+    def fake_reader(_bucket: str, _key: str) -> str:
+        return json.dumps({"decision": next(decisions, DECISION_PROMOTE)})
+
+    monkeypatch.setattr(
+        "npa.orchestration.npa_workflow.interpreter._execute_step",
+        lambda step, execute=True: {"state": step.state, "status": "ok"},
+    )
+
+    report = run_workflow(
+        spec,
+        run_id="dyn-loop",
+        execute=True,
+        decision_reader=fake_reader,
+    )
+    states = [step["state"] for step in report["steps"]]
+    assert states.count("rollouts") == spec.config["inner_iterations"] * spec.config["outer_iterations"]

--- a/npa/tests/orchestration/npa_workflow/test_run_state.py
+++ b/npa/tests/orchestration/npa_workflow/test_run_state.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+
+from npa.orchestration.npa_workflow.run_state import RunManifest, RunStateStore
+
+
+def test_run_state_store_roundtrip() -> None:
+    store: dict[tuple[str, str], bytes] = {}
+
+    def writer(bucket: str, key: str, body: bytes) -> None:
+        store[(bucket, key)] = body
+
+    def reader(bucket: str, key: str) -> str:
+        return store[(bucket, key)].decode("utf-8")
+
+    state_store = RunStateStore(
+        bucket="bucket",
+        prefix="runs/demo",
+        reader=reader,
+        writer=writer,
+    )
+    manifest = RunManifest(
+        workflow="demo",
+        run_id="demo-1",
+        api_version="npa.workflow/v0.0.1",
+        status="running",
+    )
+    state_store.write_manifest(manifest)
+    state_store.append_step(manifest, {"state": "augment", "status": "ok"})
+    loaded = state_store.read_manifest()
+    assert loaded is not None
+    assert loaded.run_id == "demo-1"
+    assert loaded.steps[0]["state"] == "augment"
+    status_payload = json.loads(store[("bucket", "runs/demo/npa-workflow/status.json")])
+    assert status_payload["status"] == "running"

--- a/npa/tests/orchestration/npa_workflow/test_scheduler.py
+++ b/npa/tests/orchestration/npa_workflow/test_scheduler.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from npa.orchestration.npa_workflow import build_plan, load_spec
+from npa.orchestration.npa_workflow.scheduler import build_scheduler_plan
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+
+
+def test_scheduler_plan_includes_resources() -> None:
+    spec = load_spec(SPECS / "vlm-eval-single.yaml")
+    plan = build_plan(spec, run_id="sched-1")
+    payload = build_scheduler_plan(spec, plan.steps, run_id="sched-1")
+    assert payload["tasks"]
+    task = payload["tasks"][0]
+    assert task["resources"]["accelerators"] == "H100:1"
+    assert task["command"]

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -72,6 +72,12 @@ def test_sim2real_plan_promote_early_exit() -> None:
     assert states[-1] == "finalize"
 
 
+def test_loop_max_accepts_braced_config_ref() -> None:
+    from npa.orchestration.npa_workflow.spec import resolve_config_int
+
+    assert resolve_config_int("{{config.outer_iterations}}", {"outer_iterations": 4}) == 4
+
+
 def test_invalid_api_version() -> None:
     path = SPECS / "vlm-eval-single.yaml"
     text = path.read_text().replace("v0.0.1", "v9.9.9")

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -68,6 +68,7 @@ def test_sim2real_plan_promote_early_exit() -> None:
     plan = build_plan(spec, run_id="test-run", assume_decision="promote_checkpoint")
     states = [step.state for step in plan.steps]
     assert states.count("rollouts") == spec.config["inner_iterations"]
+    assert states.count("finalize") == 1
     assert states[-1] == "finalize"
 
 
@@ -77,7 +78,7 @@ def test_invalid_api_version() -> None:
     broken = SPECS.parent / "_tmp-broken.yaml"
     broken.write_text(text)
     try:
-        with pytest.raises(NpaWorkflowError, match="unsupported apiVersion"):
+        with pytest.raises(NpaWorkflowError, match="apiVersion"):
             load_spec(broken)
     finally:
         broken.unlink(missing_ok=True)

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from npa.orchestration.npa_workflow import (
+    NpaWorkflowError,
+    build_plan,
+    load_spec,
+    validate_spec,
+)
+from npa.orchestration.npa_workflow.predicates import evaluate_predicate
+from npa.orchestration.npa_workflow.tokens import TokenError, resolve_tokens
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "vlm-eval-single.yaml",
+        "tokenfactory-rollout-judge.yaml",
+        "sim2real-vlm-rl.yaml",
+    ],
+)
+def test_example_specs_validate(name: str) -> None:
+    spec = load_spec(SPECS / name)
+    validate_spec(spec)
+    assert spec.api_version == "npa.workflow/v0.0.1"
+
+
+def test_token_resolution() -> None:
+    text = resolve_tokens(
+        "s3://{{config.bucket}}/{{run.id}}/out/",
+        config={"bucket": "b"},
+        run={"id": "run-1"},
+    )
+    assert text == "s3://b/run-1/out/"
+
+
+def test_token_unknown_config_raises() -> None:
+    with pytest.raises(TokenError):
+        resolve_tokens("{{config.missing}}", config={}, run={"id": "x"})
+
+
+def test_sim2real_plan_expands_loops() -> None:
+    spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
+    plan = build_plan(spec, run_id="test-run", assume_decision="loop_back")
+    states = [step.state for step in plan.steps]
+    assert states.count("rollouts") == spec.config["inner_iterations"] * spec.config["outer_iterations"]
+    assert "finalize" in states
+
+
+def test_sim2real_plan_promote_early_exit() -> None:
+    spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
+    plan = build_plan(spec, run_id="test-run", assume_decision="promote_checkpoint")
+    states = [step.state for step in plan.steps]
+    assert states.count("rollouts") == spec.config["inner_iterations"]
+    assert states[-1] == "finalize"
+
+
+def test_invalid_api_version() -> None:
+    path = SPECS / "vlm-eval-single.yaml"
+    text = path.read_text().replace("v0.0.1", "v9.9.9")
+    broken = SPECS.parent / "_tmp-broken.yaml"
+    broken.write_text(text)
+    try:
+        with pytest.raises(NpaWorkflowError, match="unsupported apiVersion"):
+            load_spec(broken)
+    finally:
+        broken.unlink(missing_ok=True)
+
+
+def test_predicate_promote() -> None:
+    assert evaluate_predicate("promote_checkpoint", {"last_decision": "promote_checkpoint"})
+    assert not evaluate_predicate("promote_checkpoint", {"last_decision": "loop_back_to_inner_loop"})

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -24,6 +24,7 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
         "tokenfactory-rollout-judge.yaml",
         "sim2real-vlm-rl.yaml",
         "bdd100k-pipeline.yaml",
+        "tokenfactory-cosmos-gate.yaml",
     ],
 )
 def test_example_specs_validate(name: str) -> None:
@@ -96,6 +97,16 @@ def test_bdd100k_pipeline_plan_expands_eleven_stages() -> None:
         "eval-distant",
         "review",
     ]
+
+
+def test_tokenfactory_cosmos_gate_plan_expands_refinement_loop() -> None:
+    spec = load_spec(SPECS / "tokenfactory-cosmos-gate.yaml")
+    plan = build_plan(spec, run_id="gate-plan", assume_decision="loop_back")
+    states = [step.state for step in plan.steps]
+    assert states[:2] == ["reason-scene", "augment-scene"]
+    assert states.count("vlm-critique") == spec.config["refinement_iterations"]
+    assert states.count("quality-gate") == spec.config["refinement_iterations"]
+    assert states[-1] == "publish"
 
 
 def test_invalid_api_version() -> None:

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -23,6 +23,7 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
         "vlm-eval-single.yaml",
         "tokenfactory-rollout-judge.yaml",
         "sim2real-vlm-rl.yaml",
+        "bdd100k-pipeline.yaml",
     ],
 )
 def test_example_specs_validate(name: str) -> None:
@@ -76,6 +77,25 @@ def test_loop_max_accepts_braced_config_ref() -> None:
     from npa.orchestration.npa_workflow.spec import resolve_config_int
 
     assert resolve_config_int("{{config.outer_iterations}}", {"outer_iterations": 4}) == 4
+
+
+def test_bdd100k_pipeline_plan_expands_eleven_stages() -> None:
+    spec = load_spec(SPECS / "bdd100k-pipeline.yaml")
+    plan = build_plan(spec, run_id="bdd100k-plan")
+    states = [step.state for step in plan.steps]
+    assert states == [
+        "ingest",
+        "backfill-cpu",
+        "backfill-clip",
+        "curate-views",
+        "train-rider",
+        "train-nighttime",
+        "train-distant",
+        "eval-rider",
+        "eval-nighttime",
+        "eval-distant",
+        "review",
+    ]
 
 
 def test_invalid_api_version() -> None:

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -45,6 +45,16 @@ def test_token_unknown_config_raises() -> None:
         resolve_tokens("{{config.missing}}", config={}, run={"id": "x"})
 
 
+def test_state_output_token() -> None:
+    text = resolve_tokens(
+        "{{state.decide.uri}}",
+        config={},
+        run={"id": "run-1"},
+        state_outputs={"decide": {"uri": "s3://bucket/decision.json"}},
+    )
+    assert text == "s3://bucket/decision.json"
+
+
 def test_sim2real_plan_expands_loops() -> None:
     spec = load_spec(SPECS / "sim2real-vlm-rl.yaml")
     plan = build_plan(spec, run_id="test-run", assume_decision="loop_back")

--- a/npa/tests/smoke/test_all_workflow_yamls.py
+++ b/npa/tests/smoke/test_all_workflow_yamls.py
@@ -56,7 +56,10 @@ def test_npa_workflow_cli_validate_and_plan(path: Path) -> None:
     payload = json.loads(validate.output)
     assert payload["status"] == "valid"
 
-    assume = "loop_back" if path.name == "sim2real-vlm-rl.yaml" else "promote_checkpoint"
+    assume = "loop_back" if path.name in {
+        "sim2real-vlm-rl.yaml",
+        "tokenfactory-cosmos-gate.yaml",
+    } else "promote_checkpoint"
     plan_args = [
         "workbench",
         "workflow",
@@ -66,7 +69,7 @@ def test_npa_workflow_cli_validate_and_plan(path: Path) -> None:
         f"smoke-{path.stem}",
         "--json",
     ]
-    if path.name == "sim2real-vlm-rl.yaml":
+    if path.name in {"sim2real-vlm-rl.yaml", "tokenfactory-cosmos-gate.yaml"}:
         plan_args.extend(["--assume-decision", assume])
     plan = RUNNER.invoke(app, plan_args)
     assert plan.exit_code == 0, plan.output
@@ -89,7 +92,10 @@ def test_npa_workflow_cli_validate_and_plan(path: Path) -> None:
             "--plan-only",
             "--scheduler-plan",
             "--json",
-            *(["--assume-decision", assume] if path.name == "sim2real-vlm-rl.yaml" else []),
+            *(["--assume-decision", assume] if path.name in {
+                "sim2real-vlm-rl.yaml",
+                "tokenfactory-cosmos-gate.yaml",
+            } else []),
         ],
     )
     assert scheduler.exit_code == 0, scheduler.output

--- a/npa/tests/smoke/test_all_workflow_yamls.py
+++ b/npa/tests/smoke/test_all_workflow_yamls.py
@@ -1,0 +1,97 @@
+"""Smoke validation for every checked-in workflow YAML."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.orchestration.npa_workflow import build_plan, load_spec, validate_spec
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+NPA_SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+SKYPILOT_SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "skypilot"
+RUNNER = CliRunner()
+
+
+def _skypilot_yaml_paths() -> list[Path]:
+    return sorted(SKYPILOT_SPECS.glob("*.yaml"))
+
+
+def _npa_yaml_paths() -> list[Path]:
+    return sorted(NPA_SPECS.glob("*.yaml"))
+
+
+@pytest.mark.parametrize("path", _skypilot_yaml_paths(), ids=lambda p: p.name)
+def test_skypilot_yaml_documents_parse(path: Path) -> None:
+    docs = [
+        doc
+        for doc in yaml.safe_load_all(path.read_text(encoding="utf-8"))
+        if doc is not None
+    ]
+    assert docs, path.name
+    assert isinstance(docs[0], dict)
+    assert docs[0].get("name"), path.name
+    assert docs[0].get("execution") in {"serial", None} or "execution" in docs[0]
+
+
+@pytest.mark.parametrize("path", _npa_yaml_paths(), ids=lambda p: p.name)
+def test_npa_workflow_yaml_validates(path: Path) -> None:
+    spec = load_spec(path)
+    validate_spec(spec)
+    assert spec.api_version == "npa.workflow/v0.0.1"
+
+
+@pytest.mark.parametrize("path", _npa_yaml_paths(), ids=lambda p: p.name)
+def test_npa_workflow_cli_validate_and_plan(path: Path) -> None:
+    validate = RUNNER.invoke(
+        app,
+        ["workbench", "workflow", "validate-spec", str(path), "--json"],
+    )
+    assert validate.exit_code == 0, validate.output
+    payload = json.loads(validate.output)
+    assert payload["status"] == "valid"
+
+    assume = "loop_back" if path.name == "sim2real-vlm-rl.yaml" else "promote_checkpoint"
+    plan_args = [
+        "workbench",
+        "workflow",
+        "plan-spec",
+        str(path),
+        "--run-id",
+        f"smoke-{path.stem}",
+        "--json",
+    ]
+    if path.name == "sim2real-vlm-rl.yaml":
+        plan_args.extend(["--assume-decision", assume])
+    plan = RUNNER.invoke(app, plan_args)
+    assert plan.exit_code == 0, plan.output
+    plan_payload = json.loads(plan.output)
+    assert plan_payload["steps"], path.name
+
+    spec = load_spec(path)
+    built = build_plan(spec, run_id=f"smoke-{path.stem}", assume_decision=assume)
+    assert built.steps
+
+    scheduler = RUNNER.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "run-spec",
+            str(path),
+            "--run-id",
+            f"smoke-{path.stem}",
+            "--plan-only",
+            "--scheduler-plan",
+            "--json",
+            *(["--assume-decision", assume] if path.name == "sim2real-vlm-rl.yaml" else []),
+        ],
+    )
+    assert scheduler.exit_code == 0, scheduler.output
+    scheduler_payload = json.loads(scheduler.output)
+    assert scheduler_payload.get("scheduler", {}).get("tasks"), path.name

--- a/npa/tests/smoke/test_npa_workflow_smoke.py
+++ b/npa/tests/smoke/test_npa_workflow_smoke.py
@@ -12,7 +12,15 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
 
 
-@pytest.mark.parametrize("name", ["vlm-eval-single.yaml", "sim2real-vlm-rl.yaml"])
+@pytest.mark.parametrize(
+    "name",
+    [
+        "vlm-eval-single.yaml",
+        "tokenfactory-rollout-judge.yaml",
+        "sim2real-vlm-rl.yaml",
+        "bdd100k-pipeline.yaml",
+    ],
+)
 def test_cli_validate_spec(name: str) -> None:
     runner = CliRunner()
     result = runner.invoke(

--- a/npa/tests/smoke/test_npa_workflow_smoke.py
+++ b/npa/tests/smoke/test_npa_workflow_smoke.py
@@ -19,6 +19,7 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
         "tokenfactory-rollout-judge.yaml",
         "sim2real-vlm-rl.yaml",
         "bdd100k-pipeline.yaml",
+        "tokenfactory-cosmos-gate.yaml",
     ],
 )
 def test_cli_validate_spec(name: str) -> None:

--- a/npa/tests/smoke/test_npa_workflow_smoke.py
+++ b/npa/tests/smoke/test_npa_workflow_smoke.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
+
+
+@pytest.mark.parametrize("name", ["vlm-eval-single.yaml", "sim2real-vlm-rl.yaml"])
+def test_cli_validate_spec(name: str) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["workbench", "workflow", "validate-spec", str(SPECS / name), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "valid"
+
+
+def test_cli_plan_spec_json() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "plan-spec",
+            str(SPECS / "tokenfactory-rollout-judge.yaml"),
+            "--run-id",
+            "smoke-1",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["workflow"] == "tokenfactory-rollout-judge"
+    assert len(payload["steps"]) == 2

--- a/npa/tests/workbench/test_cosmos3_access.py
+++ b/npa/tests/workbench/test_cosmos3_access.py
@@ -151,7 +151,8 @@ def test_cosmos3_fetch_clones_and_downloads_without_token_args(
     commands = [call[0] for call in calls]
     assert commands[0][:3] == ["git", "ls-remote", "--exit-code"]
     assert commands[1][:3] == ["git", "clone", "--depth"]
-    assert commands[2][:2] == ["huggingface-cli", "download"]
+    assert Path(commands[2][0]).name == "huggingface-cli"
+    assert commands[2][1] == "download"
     assert "--include" in commands[2]
     assert "gh-secret" not in " ".join(" ".join(command) for command in commands)
     assert "hf-secret" not in " ".join(" ".join(command) for command in commands)

--- a/npa/workflows/workbench/npa-workflows/README.md
+++ b/npa/workflows/workbench/npa-workflows/README.md
@@ -1,0 +1,11 @@
+# NPA workflow specifications (apiVersion: npa.workflow/v0.0.1)
+#
+# Consumption paths (same workflow, three entrypoints):
+#   YAML: npa workbench workflow validate-spec|plan-spec|run-spec <this-file>
+#   CLI:  same commands above
+#   SDK:  npa.orchestration.npa_workflow.load_spec / build_plan / run_workflow
+#
+# SkyPilot submits each planned step as a GPU pod; the spec defines shape and tool
+# commands — not sim2real-specific Python orchestrators.
+#
+# See docs/workbench/npa-workflow-tool-catalog.md for toolRef and token rules.

--- a/npa/workflows/workbench/npa-workflows/README.md
+++ b/npa/workflows/workbench/npa-workflows/README.md
@@ -3,16 +3,21 @@
 Declarative `apiVersion: npa.workflow/v0.0.1` workflows. Authoring guide:
 [docs/workbench/npa-workflow-guide.md](../../docs/workbench/npa-workflow-guide.md).
 
+Agent skills: `skills/workflows/author-npa-workflow/SKILL.md` (edit) and
+`skills/workflows/generate-npa-workflow/SKILL.md` (design new pipelines).
+
 | Spec | Stages | Pattern |
 | --- | --- | --- |
 | [vlm-eval-single.yaml](vlm-eval-single.yaml) | 1 | Single tool, terminal |
 | [tokenfactory-rollout-judge.yaml](tokenfactory-rollout-judge.yaml) | 2 | Serial chain with inputs |
+| [tokenfactory-cosmos-gate.yaml](tokenfactory-cosmos-gate.yaml) | 6 | Creative reason → augment → VLM gate loop |
 | [sim2real-vlm-rl.yaml](sim2real-vlm-rl.yaml) | 11 | Nested loops + dynamic gate |
 | [bdd100k-pipeline.yaml](bdd100k-pipeline.yaml) | 11 | LanceDB → train → eval → review |
 
 ```bash
-npa workbench workflow validate-spec npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
-npa workbench workflow plan-spec npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml --run-id demo
+npa workbench workflow validate-spec npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
+npa workbench workflow plan-spec npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml \
+  --run-id demo --assume-decision loop_back
 ```
 
 SkyPilot execution for BDD100K remains at

--- a/npa/workflows/workbench/npa-workflows/README.md
+++ b/npa/workflows/workbench/npa-workflows/README.md
@@ -1,11 +1,19 @@
 # NPA workflow specifications (apiVersion: npa.workflow/v0.0.1)
-#
-# Consumption paths (same workflow, three entrypoints):
-#   YAML: npa workbench workflow validate-spec|plan-spec|run-spec <this-file>
-#   CLI:  same commands above
-#   SDK:  npa.orchestration.npa_workflow.load_spec / build_plan / run_workflow
-#
-# SkyPilot submits each planned step as a GPU pod; the spec defines shape and tool
-# commands — not sim2real-specific Python orchestrators.
-#
-# See docs/workbench/npa-workflow-tool-catalog.md for toolRef and token rules.
+
+**Start here:** [docs/workbench/npa-workflow-guide.md](../../../docs/workbench/npa-workflow-guide.md)
+
+Consumption paths (same workflow, three entrypoints):
+
+- **YAML:** this directory
+- **CLI:** `npa workbench workflow validate-spec|plan-spec|run-spec`
+- **SDK:** `npa.orchestration.npa_workflow.load_spec / build_plan / run_workflow`
+
+Golden examples:
+
+| Spec | Purpose |
+| --- | --- |
+| `vlm-eval-single.yaml` | Single-tool minimal |
+| `tokenfactory-rollout-judge.yaml` | Serial two-tool |
+| `sim2real-vlm-rl.yaml` | Fixed + dynamic loops |
+
+See also `docs/workbench/npa-workflow-tool-catalog.md` for `toolRef` and token rules.

--- a/npa/workflows/workbench/npa-workflows/README.md
+++ b/npa/workflows/workbench/npa-workflows/README.md
@@ -1,19 +1,20 @@
-# NPA workflow specifications (apiVersion: npa.workflow/v0.0.1)
+# NPA workflow golden specs
 
-**Start here:** [docs/workbench/npa-workflow-guide.md](../../../docs/workbench/npa-workflow-guide.md)
+Declarative `apiVersion: npa.workflow/v0.0.1` workflows. Authoring guide:
+[docs/workbench/npa-workflow-guide.md](../../docs/workbench/npa-workflow-guide.md).
 
-Consumption paths (same workflow, three entrypoints):
+| Spec | Stages | Pattern |
+| --- | --- | --- |
+| [vlm-eval-single.yaml](vlm-eval-single.yaml) | 1 | Single tool, terminal |
+| [tokenfactory-rollout-judge.yaml](tokenfactory-rollout-judge.yaml) | 2 | Serial chain with inputs |
+| [sim2real-vlm-rl.yaml](sim2real-vlm-rl.yaml) | 11 | Nested loops + dynamic gate |
+| [bdd100k-pipeline.yaml](bdd100k-pipeline.yaml) | 11 | LanceDB → train → eval → review |
 
-- **YAML:** this directory
-- **CLI:** `npa workbench workflow validate-spec|plan-spec|run-spec`
-- **SDK:** `npa.orchestration.npa_workflow.load_spec / build_plan / run_workflow`
+```bash
+npa workbench workflow validate-spec npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
+npa workbench workflow plan-spec npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml --run-id demo
+```
 
-Golden examples:
-
-| Spec | Purpose |
-| --- | --- |
-| `vlm-eval-single.yaml` | Single-tool minimal |
-| `tokenfactory-rollout-judge.yaml` | Serial two-tool |
-| `sim2real-vlm-rl.yaml` | Fixed + dynamic loops |
-
-See also `docs/workbench/npa-workflow-tool-catalog.md` for `toolRef` and token rules.
+SkyPilot execution for BDD100K remains at
+`npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml` (submitted via
+`npa/scripts/run_bdd100k_pipeline.py`).

--- a/npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
+++ b/npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
@@ -1,0 +1,167 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+metadata:
+  name: bdd100k-pipeline
+  description: >
+    BDD100K failure-mode pipeline — LanceDB ingest, UDF backfill, materialized
+    views, per-mode detector training and evaluation, FiftyOne review.
+
+config:
+  bucket: example-bucket
+  prefix: "bdd100k-pipeline/{{run.id}}"
+  lance_table: bdd100k
+
+  source_uri: "s3://{{config.bucket}}/raw-bdd100k/subset-demo/"
+  bdd100k_limit: "10000"
+  synthetic_rows: "0"
+
+  lance_uri: "s3://{{config.bucket}}/{{config.prefix}}/lancedb/"
+  training_root: "s3://{{config.bucket}}/{{config.prefix}}/training/"
+  eval_root: "s3://{{config.bucket}}/{{config.prefix}}/eval/"
+
+  lancedb_endpoint: http://npa-lancedb.workbench.svc.cluster.local:8686
+  detection_endpoint: http://npa-detection-training.workbench.svc.cluster.local:8790
+
+  train_epochs: "10"
+  train_batch_size: "8"
+  train_learning_rate: "0.005"
+
+  rider_view: bdd100k_rider_train
+  nighttime_view: bdd100k_nighttime_person_train
+  distant_view: bdd100k_distant_person_train
+
+  rider_train_uri: "s3://{{config.bucket}}/{{config.prefix}}/training/bdd100k_rider_train"
+  nighttime_train_uri: "s3://{{config.bucket}}/{{config.prefix}}/training/bdd100k_nighttime_person_train"
+  distant_train_uri: "s3://{{config.bucket}}/{{config.prefix}}/training/bdd100k_distant_person_train"
+
+  rider_eval_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/bdd100k_rider_train"
+  nighttime_eval_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/bdd100k_nighttime_person_train"
+  distant_eval_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/bdd100k_distant_person_train"
+
+resources:
+  cpu:
+    cloud: kubernetes
+    cpus: 4
+    memory: 16Gi
+  gpu-embed:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 8
+    memory: 32Gi
+  gpu-train:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 16
+    memory: 64Gi
+  gpu-eval:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 8
+    memory: 32Gi
+
+initial: ingest
+
+states:
+  ingest:
+    description: Import BDD100K rows into a per-run LanceDB table.
+    toolRef: workbench.lancedb.import_bdd100k
+    resources: cpu
+    outputs:
+      - uri: "{{config.lance_uri}}"
+        schema: npa.lancedb.table.v1
+    next: backfill-cpu
+
+  backfill-cpu:
+    description: Backfill CPU UDF columns for views and duplicate detection.
+    toolRef: workbench.lancedb.backfill_cpu_bundle
+    resources: cpu
+    needs: [ingest]
+    next: backfill-clip
+
+  backfill-clip:
+    description: Backfill CLIP embeddings through the GPU UDF path.
+    toolRef: workbench.lancedb.backfill_clip
+    resources: gpu-embed
+    needs: [backfill-cpu]
+    next: curate-views
+
+  curate-views:
+    description: Create rider, nighttime-person, and distant-person training views.
+    toolRef: workbench.lancedb.create_failure_views
+    resources: cpu
+    needs: [backfill-clip]
+    next: train-models
+
+  train-models:
+    description: Train one detector per failure mode.
+    needs: [curate-views]
+    sequence:
+      - train-rider
+      - train-nighttime
+      - train-distant
+    next: evaluate-models
+
+  train-rider:
+    description: Train on the rider failure-mode view.
+    toolRef: workbench.detection_training.train_rider
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.rider_train_uri}}"
+        schema: npa.detection_training.checkpoint.v1
+
+  train-nighttime:
+    description: Train on the nighttime-person failure-mode view.
+    toolRef: workbench.detection_training.train_nighttime
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.nighttime_train_uri}}"
+        schema: npa.detection_training.checkpoint.v1
+
+  train-distant:
+    description: Train on the distant-person failure-mode view.
+    toolRef: workbench.detection_training.train_distant
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.distant_train_uri}}"
+        schema: npa.detection_training.checkpoint.v1
+
+  evaluate-models:
+    description: Evaluate each trained detector on its training view.
+    needs: [train-models]
+    sequence:
+      - eval-rider
+      - eval-nighttime
+      - eval-distant
+    next: review
+
+  eval-rider:
+    description: Evaluate the rider model.
+    toolRef: workbench.detection_training.eval_rider
+    resources: gpu-eval
+    outputs:
+      - uri: "{{config.rider_eval_uri}}metrics.json"
+        schema: npa.detection_training.metrics.v1
+
+  eval-nighttime:
+    description: Evaluate the nighttime-person model.
+    toolRef: workbench.detection_training.eval_nighttime
+    resources: gpu-eval
+    outputs:
+      - uri: "{{config.nighttime_eval_uri}}metrics.json"
+        schema: npa.detection_training.metrics.v1
+
+  eval-distant:
+    description: Evaluate the distant-person model.
+    toolRef: workbench.detection_training.eval_distant
+    resources: gpu-eval
+    outputs:
+      - uri: "{{config.distant_eval_uri}}metrics.json"
+        schema: npa.detection_training.metrics.v1
+
+  review:
+    description: Launch FiftyOne for human review of pipeline artifacts.
+    needs: [evaluate-models]
+    toolRef: workbench.fiftyone.launch_app
+    resources: cpu
+    terminal: true

--- a/npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
+++ b/npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
@@ -17,8 +17,6 @@ config:
   synthetic_rows: "0"
 
   lance_uri: "s3://{{config.bucket}}/{{config.prefix}}/lancedb/"
-  training_root: "s3://{{config.bucket}}/{{config.prefix}}/training/"
-  eval_root: "s3://{{config.bucket}}/{{config.prefix}}/eval/"
 
   lancedb_endpoint: http://npa-lancedb.workbench.svc.cluster.local:8686
   detection_endpoint: http://npa-detection-training.workbench.svc.cluster.local:8790

--- a/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
+++ b/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
@@ -106,6 +106,7 @@ states:
 
   decide:
     description: Threshold decision for promote vs loop-back.
+    writesDecision: true
     needs: [heldout]
     toolRef: workbench.sim2real.write_decision
     outputs:

--- a/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
+++ b/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
@@ -108,7 +108,7 @@ states:
     needs: [heldout]
     run:
       shell: |
-        echo "decision -> {{config.decision_uri}} threshold={{config.success_threshold}}"
+        python -c "from npa.orchestration.npa_workflow.decisions import write_decision; write_decision('{{config.decision_uri}}', '{{config.plan_assume_decision}}')"
     outputs:
       - uri: "{{config.decision_uri}}"
         schema: npa.sim2real.threshold_decision.v1

--- a/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
+++ b/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
@@ -14,7 +14,6 @@ config:
   inner_iterations: 3
   outer_iterations: 2
 
-  success_threshold: "0.50"
   default_decision: loop_back
 
   env_count: "10000"

--- a/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
+++ b/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
@@ -1,0 +1,130 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+metadata:
+  name: sim2real-vlm-rl
+  description: >
+    VLM-to-RL staged loop with fixed inner iterations and promote/loop-back gate.
+    Each state invokes a workbench tool; loops and transitions are declarative.
+
+config:
+  bucket: example-bucket
+  prefix: "sim2real-b/{{run.id}}"
+  inner_iterations: 3
+  outer_iterations: 2
+  success_threshold: "0.50"
+  env_count: "10000"
+  plan_assume_decision: loop_back
+  trigger_uri: "s3://example-bucket/sim2real-triggers/{{run.id}}/lerobot-pusht/"
+  augment_uri: "s3://example-bucket/sim2real-b/{{run.id}}/augment/"
+  raw_envs_uri: "s3://example-bucket/sim2real-b/{{run.id}}/envs/raw/"
+  rollouts_uri: "s3://example-bucket/sim2real-b/{{run.id}}/actions/train/"
+  scores_uri: "s3://example-bucket/sim2real-b/{{run.id}}/vlm_eval/train/"
+  heldout_report_uri: "s3://example-bucket/sim2real-b/{{run.id}}/eval/heldout/report.json"
+  decision_uri: "s3://example-bucket/sim2real-b/{{run.id}}/outer_loop/decision.json"
+  vlm_backend: self-hosted
+
+resources:
+  gpu:
+    cloud: kubernetes
+    accelerators: RTXPRO6000:1
+  cpu:
+    cloud: kubernetes
+    cpus: 8
+
+initial: augment
+
+states:
+  augment:
+    description: Cosmos Transfer augment of LeRobot trigger data.
+    toolRef: workbench.cosmos2.transfer
+    resources: gpu
+    outputs:
+      - uri: "{{config.augment_uri}}manifest.json"
+        schema: npa.sim2real.augment.v1
+    next: envgen
+
+  envgen:
+    description: Generate raw env shard catalog on object storage.
+    needs: [augment]
+    toolRef: workbench.sim2real_envgen.raw_shard
+    resources: gpu
+    outputs:
+      - uri: "{{config.raw_envs_uri}}manifest.json"
+        schema: npa.sim2real.split_manifest.v1
+    next: outer
+
+  outer:
+    description: Outer loop — inner train pass, held-out eval, threshold gate.
+    needs: [envgen]
+    loop:
+      max: config.outer_iterations
+      until: promote_checkpoint
+    sequence:
+      - inner
+      - heldout
+      - decide
+    next: finalize
+
+  inner:
+    description: Inner loop — rollouts and VLM critique per iteration.
+    loop:
+      max: config.inner_iterations
+    sequence:
+      - rollouts
+      - vlm-score
+
+  rollouts:
+    description: Policy action rollouts on train envs.
+    run:
+      shell: |
+        echo "policy rollouts -> {{config.rollouts_uri}} outer={{run.prefix}}"
+    resources: gpu
+    outputs:
+      - uri: "{{config.rollouts_uri}}"
+        schema: npa.sim2real.action_rollout.v1
+
+  vlm-score:
+    description: VLM eval over train rollouts.
+    needs: [rollouts]
+    toolRef: workbench.vlm_eval.run
+    resources: gpu
+    outputs:
+      - uri: "{{config.scores_uri}}report.json"
+        schema: npa.workbench.vlm_eval.report.v1
+
+  heldout:
+    description: Held-out simulation eval report.
+    run:
+      shell: |
+        echo "heldout eval -> {{config.heldout_report_uri}}"
+    resources: gpu
+    outputs:
+      - uri: "{{config.heldout_report_uri}}"
+        schema: npa.sim2real.heldout_eval.v1
+
+  decide:
+    description: Threshold decision for promote vs loop-back.
+    needs: [heldout]
+    run:
+      shell: |
+        echo "decision -> {{config.decision_uri}} threshold={{config.success_threshold}}"
+    outputs:
+      - uri: "{{config.decision_uri}}"
+        schema: npa.sim2real.threshold_decision.v1
+    transitions:
+      - when: promote_checkpoint
+        goto: finalize
+      - when: loop_back
+        goto: outer
+
+  finalize:
+    description: Report upload and visualization artifacts.
+    needs: [outer]
+    run:
+      shell: |
+        echo "finalize run {{run.id}} prefix {{run.prefix}}"
+    outputs:
+      - uri: "s3://{{config.bucket}}/{{config.prefix}}/reports/sim2real-report.json"
+        schema: npa.sim2real.e2e_report.v1
+    terminal: true

--- a/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
+++ b/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
@@ -8,23 +8,18 @@ metadata:
     Planning dynamic branches uses --assume-decision on the CLI.
 
 config:
-  # Run identity
   bucket: example-bucket
   prefix: "sim2real-b/{{run.id}}"
 
-  # Loop bounds
   inner_iterations: 3
   outer_iterations: 2
 
-  # Threshold gate (default_decision is the execute stub until real scoring lands)
   success_threshold: "0.50"
   default_decision: loop_back
 
-  # Tool parameters
   env_count: "10000"
   vlm_backend: self-hosted
 
-  # Artifact URIs
   trigger_uri: "s3://{{config.bucket}}/sim2real-triggers/{{run.id}}/lerobot-pusht/"
   augment_uri: "s3://{{config.bucket}}/{{config.prefix}}/augment/"
   raw_envs_uri: "s3://{{config.bucket}}/{{config.prefix}}/envs/raw/"

--- a/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
+++ b/npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
@@ -5,24 +5,34 @@ metadata:
   name: sim2real-vlm-rl
   description: >
     VLM-to-RL staged loop with fixed inner iterations and promote/loop-back gate.
-    Each state invokes a workbench tool; loops and transitions are declarative.
+    Planning dynamic branches uses --assume-decision on the CLI.
 
 config:
+  # Run identity
   bucket: example-bucket
   prefix: "sim2real-b/{{run.id}}"
+
+  # Loop bounds
   inner_iterations: 3
   outer_iterations: 2
+
+  # Threshold gate (default_decision is the execute stub until real scoring lands)
   success_threshold: "0.50"
+  default_decision: loop_back
+
+  # Tool parameters
   env_count: "10000"
-  plan_assume_decision: loop_back
-  trigger_uri: "s3://example-bucket/sim2real-triggers/{{run.id}}/lerobot-pusht/"
-  augment_uri: "s3://example-bucket/sim2real-b/{{run.id}}/augment/"
-  raw_envs_uri: "s3://example-bucket/sim2real-b/{{run.id}}/envs/raw/"
-  rollouts_uri: "s3://example-bucket/sim2real-b/{{run.id}}/actions/train/"
-  scores_uri: "s3://example-bucket/sim2real-b/{{run.id}}/vlm_eval/train/"
-  heldout_report_uri: "s3://example-bucket/sim2real-b/{{run.id}}/eval/heldout/report.json"
-  decision_uri: "s3://example-bucket/sim2real-b/{{run.id}}/outer_loop/decision.json"
   vlm_backend: self-hosted
+
+  # Artifact URIs
+  trigger_uri: "s3://{{config.bucket}}/sim2real-triggers/{{run.id}}/lerobot-pusht/"
+  augment_uri: "s3://{{config.bucket}}/{{config.prefix}}/augment/"
+  raw_envs_uri: "s3://{{config.bucket}}/{{config.prefix}}/envs/raw/"
+  rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/actions/train/"
+  scores_uri: "s3://{{config.bucket}}/{{config.prefix}}/vlm_eval/train/"
+  heldout_report_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/heldout/report.json"
+  decision_uri: "s3://{{config.bucket}}/{{config.prefix}}/outer_loop/decision.json"
+  finalize_report_uri: "s3://{{config.bucket}}/{{config.prefix}}/reports/sim2real-report.json"
 
 resources:
   gpu:
@@ -58,7 +68,7 @@ states:
     description: Outer loop — inner train pass, held-out eval, threshold gate.
     needs: [envgen]
     loop:
-      max: config.outer_iterations
+      max: "{{config.outer_iterations}}"
       until: promote_checkpoint
     sequence:
       - inner
@@ -69,16 +79,14 @@ states:
   inner:
     description: Inner loop — rollouts and VLM critique per iteration.
     loop:
-      max: config.inner_iterations
+      max: "{{config.inner_iterations}}"
     sequence:
       - rollouts
       - vlm-score
 
   rollouts:
     description: Policy action rollouts on train envs.
-    run:
-      shell: |
-        echo "policy rollouts -> {{config.rollouts_uri}} outer={{run.prefix}}"
+    toolRef: workbench.sim2real.policy_rollouts
     resources: gpu
     outputs:
       - uri: "{{config.rollouts_uri}}"
@@ -95,9 +103,7 @@ states:
 
   heldout:
     description: Held-out simulation eval report.
-    run:
-      shell: |
-        echo "heldout eval -> {{config.heldout_report_uri}}"
+    toolRef: workbench.sim2real.heldout_eval
     resources: gpu
     outputs:
       - uri: "{{config.heldout_report_uri}}"
@@ -106,9 +112,7 @@ states:
   decide:
     description: Threshold decision for promote vs loop-back.
     needs: [heldout]
-    run:
-      shell: |
-        python -c "from npa.orchestration.npa_workflow.decisions import write_decision; write_decision('{{config.decision_uri}}', '{{config.plan_assume_decision}}')"
+    toolRef: workbench.sim2real.write_decision
     outputs:
       - uri: "{{config.decision_uri}}"
         schema: npa.sim2real.threshold_decision.v1
@@ -121,10 +125,8 @@ states:
   finalize:
     description: Report upload and visualization artifacts.
     needs: [outer]
-    run:
-      shell: |
-        echo "finalize run {{run.id}} prefix {{run.prefix}}"
+    toolRef: workbench.sim2real.finalize
     outputs:
-      - uri: "s3://{{config.bucket}}/{{config.prefix}}/reports/sim2real-report.json"
+      - uri: "{{config.finalize_report_uri}}"
         schema: npa.sim2real.e2e_report.v1
     terminal: true

--- a/npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
+++ b/npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
@@ -17,6 +17,7 @@ config:
 
   scene_uri: "s3://{{config.bucket}}/{{config.prefix}}/scene/"
   plan_uri: "s3://{{config.bucket}}/{{config.prefix}}/plan/"
+  # Cosmos transfer reads trigger_uri; same scene prefix as reason-scene output.
   trigger_uri: "s3://{{config.bucket}}/{{config.prefix}}/scene/"
   augment_uri: "s3://{{config.bucket}}/{{config.prefix}}/augment/"
   rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/augment/"
@@ -49,7 +50,7 @@ states:
     toolRef: workbench.cosmos2.transfer
     resources: gpu
     inputs:
-      - uri: "{{config.scene_uri}}"
+      - uri: "{{config.trigger_uri}}"
         schema: npa.token_factory.scene.v1
     outputs:
       - uri: "{{config.augment_uri}}manifest.json"

--- a/npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
+++ b/npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
@@ -1,0 +1,102 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+metadata:
+  name: tokenfactory-cosmos-gate
+  description: >
+    Creative mashup — Token Factory scene reasoning, Cosmos Transfer augment,
+    and a VLM quality gate loop until the synthetic batch is promoted.
+
+config:
+  bucket: example-bucket
+  prefix: "tokenfactory-cosmos-gate/{{run.id}}"
+  vlm_backend: api
+
+  refinement_iterations: 3
+  default_decision: loop_back
+
+  scene_uri: "s3://{{config.bucket}}/{{config.prefix}}/scene/"
+  plan_uri: "s3://{{config.bucket}}/{{config.prefix}}/plan/"
+  trigger_uri: "s3://{{config.bucket}}/{{config.prefix}}/scene/"
+  augment_uri: "s3://{{config.bucket}}/{{config.prefix}}/augment/"
+  rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/augment/"
+  scores_uri: "s3://{{config.bucket}}/{{config.prefix}}/scores/"
+  decision_uri: "s3://{{config.bucket}}/{{config.prefix}}/gate/decision.json"
+  finalize_report_uri: "s3://{{config.bucket}}/{{config.prefix}}/reports/final.json"
+
+resources:
+  gpu:
+    cloud: kubernetes
+    accelerators: RTXPRO6000:1
+    cpus: 16
+    memory: 80Gi
+
+initial: reason-scene
+
+states:
+  reason-scene:
+    description: Cosmos reasoner over captured scene frames.
+    toolRef: workbench.token_factory.reason
+    resources: gpu
+    outputs:
+      - uri: "{{config.plan_uri}}plan.json"
+        schema: npa.token_factory.plan.v1
+    next: augment-scene
+
+  augment-scene:
+    description: Cosmos Transfer augment driven by the scene plan.
+    needs: [reason-scene]
+    toolRef: workbench.cosmos2.transfer
+    resources: gpu
+    inputs:
+      - uri: "{{config.scene_uri}}"
+        schema: npa.token_factory.scene.v1
+    outputs:
+      - uri: "{{config.augment_uri}}manifest.json"
+        schema: npa.sim2real.augment.v1
+    next: refine
+
+  refine:
+    description: VLM critique loop with promote vs re-augment gate.
+    needs: [augment-scene]
+    loop:
+      max: "{{config.refinement_iterations}}"
+      until: promote_checkpoint
+    sequence:
+      - vlm-critique
+      - quality-gate
+    next: publish
+
+  vlm-critique:
+    description: Score augmented frames before the quality gate.
+    toolRef: workbench.vlm_eval.run
+    resources: gpu
+    inputs:
+      - uri: "{{config.rollouts_uri}}"
+        schema: npa.workbench.rollout_set.v1
+    outputs:
+      - uri: "{{config.scores_uri}}report.json"
+        schema: npa.workbench.vlm_eval.report.v1
+
+  quality-gate:
+    description: Promote good batches or loop back for another augment pass.
+    writesDecision: true
+    needs: [vlm-critique]
+    toolRef: workbench.sim2real.write_decision
+    outputs:
+      - uri: "{{config.decision_uri}}"
+        schema: npa.sim2real.threshold_decision.v1
+    transitions:
+      - when: promote_checkpoint
+        goto: publish
+      - when: loop_back
+        goto: augment-scene
+
+  publish:
+    description: Write final report when the batch is promoted.
+    needs: [refine]
+    toolRef: workbench.sim2real.finalize
+    outputs:
+      - uri: "{{config.finalize_report_uri}}"
+        schema: npa.sim2real.e2e_report.v1
+    terminal: true

--- a/npa/workflows/workbench/npa-workflows/tokenfactory-rollout-judge.yaml
+++ b/npa/workflows/workbench/npa-workflows/tokenfactory-rollout-judge.yaml
@@ -1,0 +1,45 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+metadata:
+  name: tokenfactory-rollout-judge
+  description: Reason over scene inputs, then VLM-score synthetic rollouts.
+
+config:
+  bucket: example-bucket
+  prefix: "runs/{{run.id}}/tokenfactory"
+  scene_uri: "s3://{{config.bucket}}/{{config.prefix}}/scene/"
+  plan_uri: "s3://{{config.bucket}}/{{config.prefix}}/plan/"
+  rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/rollouts/"
+  scores_uri: "s3://{{config.bucket}}/{{config.prefix}}/scores/"
+  vlm_backend: api
+
+resources:
+  default:
+    cloud: kubernetes
+    accelerators: RTXPRO6000:1
+
+initial: reason-scene
+
+states:
+  reason-scene:
+    description: Token Factory Cosmos reasoner over captured scene frames.
+    toolRef: workbench.token_factory.reason
+    resources: default
+    outputs:
+      - uri: "{{config.plan_uri}}plan.json"
+        schema: npa.token_factory.plan.v1
+    next: judge-rollouts
+
+  judge-rollouts:
+    description: VLM eval over generated rollouts.
+    needs: [reason-scene]
+    toolRef: workbench.vlm_eval.run
+    resources: default
+    inputs:
+      - uri: "{{config.rollouts_uri}}"
+        schema: npa.workbench.rollout_set.v1
+    outputs:
+      - uri: "{{config.scores_uri}}report.json"
+        schema: npa.workbench.vlm_eval.report.v1
+    terminal: true

--- a/npa/workflows/workbench/npa-workflows/tokenfactory-rollout-judge.yaml
+++ b/npa/workflows/workbench/npa-workflows/tokenfactory-rollout-judge.yaml
@@ -3,7 +3,8 @@ kind: Workflow
 
 metadata:
   name: tokenfactory-rollout-judge
-  description: Reason over scene inputs, then VLM-score synthetic rollouts.
+  description: >
+    Reason over scene inputs with Token Factory, then VLM-score synthetic rollouts.
 
 config:
   bucket: example-bucket

--- a/npa/workflows/workbench/npa-workflows/tokenfactory-rollout-judge.yaml
+++ b/npa/workflows/workbench/npa-workflows/tokenfactory-rollout-judge.yaml
@@ -8,14 +8,15 @@ metadata:
 config:
   bucket: example-bucket
   prefix: "runs/{{run.id}}/tokenfactory"
+  vlm_backend: api
+
   scene_uri: "s3://{{config.bucket}}/{{config.prefix}}/scene/"
   plan_uri: "s3://{{config.bucket}}/{{config.prefix}}/plan/"
   rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/rollouts/"
   scores_uri: "s3://{{config.bucket}}/{{config.prefix}}/scores/"
-  vlm_backend: api
 
 resources:
-  default:
+  gpu:
     cloud: kubernetes
     accelerators: RTXPRO6000:1
 
@@ -25,7 +26,7 @@ states:
   reason-scene:
     description: Token Factory Cosmos reasoner over captured scene frames.
     toolRef: workbench.token_factory.reason
-    resources: default
+    resources: gpu
     outputs:
       - uri: "{{config.plan_uri}}plan.json"
         schema: npa.token_factory.plan.v1
@@ -35,7 +36,7 @@ states:
     description: VLM eval over generated rollouts.
     needs: [reason-scene]
     toolRef: workbench.vlm_eval.run
-    resources: default
+    resources: gpu
     inputs:
       - uri: "{{config.rollouts_uri}}"
         schema: npa.workbench.rollout_set.v1

--- a/npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
+++ b/npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
@@ -1,0 +1,32 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+metadata:
+  name: vlm-eval-single
+  description: Score a rollout prefix with the workbench VLM eval tool.
+
+config:
+  bucket: example-bucket
+  prefix: "runs/{{run.id}}/vlm-eval"
+  rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/rollouts/"
+  scores_uri: "s3://{{config.bucket}}/{{config.prefix}}/scores/"
+  vlm_backend: self-hosted
+
+resources:
+  default:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 16
+    memory: 80Gi
+
+initial: score-rollouts
+
+states:
+  score-rollouts:
+    description: Evaluate rollouts and write a gating report.
+    toolRef: workbench.vlm_eval.run
+    resources: default
+    outputs:
+      - uri: "{{config.scores_uri}}report.json"
+        schema: npa.workbench.vlm_eval.report.v1
+    terminal: true

--- a/npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
+++ b/npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
@@ -8,12 +8,13 @@ metadata:
 config:
   bucket: example-bucket
   prefix: "runs/{{run.id}}/vlm-eval"
-  rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/rollouts/"
-  scores_uri: "s3://{{config.bucket}}/{{config.prefix}}/scores/"
   vlm_backend: self-hosted
 
+  rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/rollouts/"
+  scores_uri: "s3://{{config.bucket}}/{{config.prefix}}/scores/"
+
 resources:
-  default:
+  gpu:
     cloud: kubernetes
     accelerators: H100:1
     cpus: 16
@@ -25,7 +26,7 @@ states:
   score-rollouts:
     description: Evaluate rollouts and write a gating report.
     toolRef: workbench.vlm_eval.run
-    resources: default
+    resources: gpu
     outputs:
       - uri: "{{config.scores_uri}}report.json"
         schema: npa.workbench.vlm_eval.report.v1

--- a/npa/workflows/workbench/skypilot/README.md
+++ b/npa/workflows/workbench/skypilot/README.md
@@ -1,5 +1,9 @@
 # Raw SkyPilot Workbench YAMLs
 
+Declarative authoring specs (`apiVersion: npa.workflow/v0.0.1`) live in
+[`../npa-workflows/`](../npa-workflows/README.md). Prefer those for readable
+stage graphs; use this directory for SkyPilot execution and GPU task details.
+
 This directory contains standalone SkyPilot task YAMLs for Workbench
 reference paths. The supported first path is the Python wrapper or `npa`
 CLI for each workflow because wrappers inject secrets, validate image

--- a/npa/workflows/workbench/skypilot/vlm-eval.yaml
+++ b/npa/workflows/workbench/skypilot/vlm-eval.yaml
@@ -1,4 +1,9 @@
 # Evaluate rollout artifacts with a self-hosted open VLM.
+#
+# Declarative: npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
+# Guide:       docs/workbench/npa-workflow-guide.md
+# Index:       npa/workflows/workbench/skypilot/README.md
+#
 name: vlm-eval
 execution: serial
 ---

--- a/scripts/npa-all-yaml-infra-tmux.sh
+++ b/scripts/npa-all-yaml-infra-tmux.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Full workflow YAML matrix: npa.workflow + SkyPilot parse + live infra tests.
+# tmux new -s npa-all-yaml-infra ./scripts/npa-all-yaml-infra-tmux.sh
+set -euo pipefail
+
+export HOME="${HOME:-/home/ubuntu}"
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+[[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
+
+REPO="/home/ubuntu/nebius-physical-ai"
+cd "$REPO"
+PY="${REPO}/npa/.venv/bin/python"
+NPA="${REPO}/npa/.venv/bin/npa"
+export NPA_INTEGRATION_E2E=1
+
+NPA_SPECS="${REPO}/npa/workflows/workbench/npa-workflows"
+SKY_SPECS="${REPO}/npa/workflows/workbench/skypilot"
+
+LOG="/tmp/npa-all-yaml-infra-$(date -u +%Y%m%dT%H%M%SZ).log"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== ALL workflow YAML infra matrix log=${LOG} ==="
+echo "branch: $(git branch --show-current) @ $(git rev-parse --short HEAD)"
+echo "npa.workflow specs: $(find "${NPA_SPECS}" -maxdepth 1 -name '*.yaml' | wc -l)"
+echo "skypilot specs: $(find "${SKY_SPECS}" -maxdepth 1 -name '*.yaml' | wc -l)"
+
+round=1
+while true; do
+  echo ""
+  echo "========== ROUND ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) =========="
+  FAILED=0
+
+  echo "--- [1/6] npa.workflow validate (all golden specs) ---"
+  for spec in "${NPA_SPECS}"/*.yaml; do
+    base=$(basename "$spec")
+    echo "validate: ${base}"
+    if ! "${NPA}" workbench workflow validate-spec "${spec}"; then
+      FAILED=1
+    fi
+  done
+
+  echo "--- [2/6] npa.workflow plan + scheduler (all golden specs) ---"
+  RUN_ID="tmux-all-r${round}-$(date -u +%H%M%S)"
+  for spec in "${NPA_SPECS}"/*.yaml; do
+    base=$(basename "$spec")
+    echo "plan: ${base}"
+    extra=()
+    if [[ "${base}" == "sim2real-vlm-rl.yaml" ]]; then
+      extra=(--assume-decision loop_back)
+    fi
+    if ! "${NPA}" workbench workflow plan-spec "${spec}" --run-id "${RUN_ID}" "${extra[@]}"; then
+      FAILED=1
+      continue
+    fi
+    if ! "${NPA}" workbench workflow run-spec "${spec}" \
+      --run-id "${RUN_ID}" \
+      --plan-only \
+      --scheduler-plan \
+      "${extra[@]}" \
+      --json | "${PY}" -c "import json,sys; r=json.load(sys.stdin); assert r.get('scheduler',{}).get('tasks'), r"; then
+      FAILED=1
+    fi
+  done
+
+  echo "--- [3/6] skypilot YAML parse (all files) ---"
+  if ! "${PY}" - <<'PY'; then
+from pathlib import Path
+import yaml
+
+root = Path("npa/workflows/workbench/skypilot")
+failed = []
+for path in sorted(root.glob("*.yaml")):
+    try:
+        docs = [d for d in yaml.safe_load_all(path.read_text(encoding="utf-8")) if d is not None]
+        if not docs or not docs[0].get("name"):
+            failed.append(path.name)
+    except Exception as exc:
+        failed.append(f"{path.name}: {exc}")
+if failed:
+    raise SystemExit("parse failures: " + ", ".join(failed))
+print(f"skypilot parse OK ({len(list(root.glob('*.yaml')))} files)")
+PY
+    FAILED=1
+  fi
+
+  echo "--- [4/6] smoke: all workflow YAMLs ---"
+  if ! "${PY}" -m pytest npa/tests/smoke/test_all_workflow_yamls.py -q --timeout=180; then
+    FAILED=1
+  fi
+
+  echo "--- [5/6] npa.workflow unit + live infra ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/orchestration/npa_workflow/ \
+    npa/tests/smoke/test_npa_workflow_smoke.py \
+    npa/tests/e2e/test_npa_workflow_live_e2e.py \
+    npa/tests/e2e/test_npa_workflow_live_infra.py \
+    -q --timeout=300; then
+    FAILED=1
+  fi
+
+  echo "--- [6/6] SkyPilot workflow + BDD100K + guardrails ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/workflows/test_bdd100k_pipeline.py \
+    npa/tests/workflows/test_vlm_eval_workflow.py \
+    npa/tests/workflows/test_token_factory_workflow.py \
+    npa/tests/test_lancedb_bdd100k_import.py \
+    npa/tests/test_lancedb_bdd100k_backfill.py \
+    npa/tests/test_lancedb_bdd100k_mv.py \
+    npa/tests/guardrails/test_workflow_image_check.py \
+    -q --timeout=300; then
+    FAILED=1
+  fi
+
+  if [[ "${FAILED}" -eq 0 ]]; then
+    echo "--- ROUND ${round} ALL PASSED ---"
+  else
+    echo "--- ROUND ${round} FAILED ---"
+  fi
+  round=$((round + 1))
+  sleep 600
+done

--- a/scripts/npa-all-yaml-infra-tmux.sh
+++ b/scripts/npa-all-yaml-infra-tmux.sh
@@ -30,7 +30,84 @@ while true; do
   echo "========== ROUND ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) =========="
   FAILED=0
 
-  echo "--- [1/6] npa.workflow validate (all golden specs) ---"
+  echo "--- [0/7] PR audit repro + audit_fixes pytest ---"
+  AUDIT_DIR="${REPO}/.tmp-audit-repro"
+  mkdir -p "${AUDIT_DIR}"
+  cat > "${AUDIT_DIR}/cycle.yaml" <<'YAML'
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+metadata:
+  name: cycle
+config: {}
+initial: a
+states:
+  a:
+    run:
+      shell: echo a
+    next: b
+  b:
+    run:
+      shell: echo b
+    next: a
+  done:
+    terminal: true
+YAML
+  cat > "${AUDIT_DIR}/bad-token.yaml" <<'YAML'
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+metadata:
+  name: bad-token
+config:
+  bucket: example-bucket
+initial: x
+states:
+  x:
+    run:
+      shell: echo ok
+    outputs:
+      - uri: "{{config.does_not_exist}}"
+    terminal: true
+YAML
+  cat > "${AUDIT_DIR}/bad-loop-max.yaml" <<'YAML'
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+metadata:
+  name: bad-loop-max
+config:
+  n: not-an-int
+initial: outer
+states:
+  outer:
+    sequence: [inner]
+    loop:
+      max: "{{config.n}}"
+    next: done
+  inner:
+    run:
+      shell: echo inner
+  done:
+    terminal: true
+YAML
+  echo "audit: cycle.yaml must fail validate (exit 1)"
+  if "${NPA}" workbench workflow validate-spec "${AUDIT_DIR}/cycle.yaml"; then
+    echo "FAIL: cycle.yaml should not validate"
+    FAILED=1
+  fi
+  echo "audit: bad-token.yaml must fail validate (exit 1)"
+  if "${NPA}" workbench workflow validate-spec "${AUDIT_DIR}/bad-token.yaml"; then
+    echo "FAIL: bad-token.yaml should not validate"
+    FAILED=1
+  fi
+  echo "audit: bad-loop-max.yaml must fail validate (exit 1)"
+  if "${NPA}" workbench workflow validate-spec "${AUDIT_DIR}/bad-loop-max.yaml"; then
+    echo "FAIL: bad-loop-max.yaml should not validate"
+    FAILED=1
+  fi
+  if ! "${PY}" -m pytest npa/tests/orchestration/npa_workflow/test_audit_fixes.py -q --timeout=120; then
+    FAILED=1
+  fi
+
+  echo "--- [1/7] npa.workflow validate (all golden specs) ---"
   for spec in "${NPA_SPECS}"/*.yaml; do
     base=$(basename "$spec")
     echo "validate: ${base}"
@@ -39,7 +116,7 @@ while true; do
     fi
   done
 
-  echo "--- [2/6] npa.workflow plan + scheduler (all golden specs) ---"
+  echo "--- [2/7] npa.workflow plan + scheduler (all golden specs) ---"
   RUN_ID="tmux-all-r${round}-$(date -u +%H%M%S)"
   for spec in "${NPA_SPECS}"/*.yaml; do
     base=$(basename "$spec")
@@ -62,7 +139,7 @@ while true; do
     fi
   done
 
-  echo "--- [3/6] skypilot YAML parse (all files) ---"
+  echo "--- [3/7] skypilot YAML parse (all files) ---"
   if ! "${PY}" - <<'PY'; then
 from pathlib import Path
 import yaml
@@ -83,12 +160,12 @@ PY
     FAILED=1
   fi
 
-  echo "--- [4/6] smoke: all workflow YAMLs ---"
+  echo "--- [4/7] smoke: all workflow YAMLs ---"
   if ! "${PY}" -m pytest npa/tests/smoke/test_all_workflow_yamls.py -q --timeout=180; then
     FAILED=1
   fi
 
-  echo "--- [5/6] npa.workflow unit + live infra ---"
+  echo "--- [5/7] npa.workflow unit + live infra ---"
   if ! "${PY}" -m pytest \
     npa/tests/orchestration/npa_workflow/ \
     npa/tests/smoke/test_npa_workflow_smoke.py \
@@ -98,7 +175,7 @@ PY
     FAILED=1
   fi
 
-  echo "--- [6/6] SkyPilot workflow + BDD100K + guardrails ---"
+  echo "--- [6/7] SkyPilot workflow + BDD100K + guardrails ---"
   if ! "${PY}" -m pytest \
     npa/tests/workflows/test_bdd100k_pipeline.py \
     npa/tests/workflows/test_vlm_eval_workflow.py \

--- a/scripts/npa-all-yaml-infra-tmux.sh
+++ b/scripts/npa-all-yaml-infra-tmux.sh
@@ -122,7 +122,7 @@ YAML
     base=$(basename "$spec")
     echo "plan: ${base}"
     extra=()
-    if [[ "${base}" == "sim2real-vlm-rl.yaml" ]]; then
+    if [[ "${base}" == "sim2real-vlm-rl.yaml" || "${base}" == "tokenfactory-cosmos-gate.yaml" ]]; then
       extra=(--assume-decision loop_back)
     fi
     if ! "${NPA}" workbench workflow plan-spec "${spec}" --run-id "${RUN_ID}" "${extra[@]}"; then

--- a/scripts/npa-workflow-agent-loop.sh
+++ b/scripts/npa-workflow-agent-loop.sh
@@ -18,9 +18,6 @@ while true; do
   "${PY}" -m pytest \
     npa/tests/orchestration/npa_workflow/ \
     npa/tests/smoke/test_npa_workflow_smoke.py \
-    npa/tests/cli/test_workflow_cli.py::test_workflow_status_prints_status \
-    npa/tests/cli/test_workflow_cli.py::test_workflow_status_maps_distillation_error \
-    npa/tests/cli/test_workflow_cli.py::test_durable_workflow_status_logs_and_artifacts_read_s3 \
     -q --timeout=120
 
   if NPA_INTEGRATION_E2E=1 "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=120; then

--- a/scripts/npa-workflow-agent-loop.sh
+++ b/scripts/npa-workflow-agent-loop.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# Iterate on npa.workflow gaps: test → commit → push (for PR #131).
+# Iterate on npa.workflow gaps: test → commit → push (only when tests pass).
 # tmux new -s npa-workflow-agent ./scripts/npa-workflow-agent-loop.sh
 set -euo pipefail
 
 export HOME="${HOME:-/home/ubuntu}"
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+[[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
+
 REPO="/home/ubuntu/nebius-physical-ai"
 cd "$REPO"
 PY="${REPO}/npa/.venv/bin/python"
@@ -15,15 +18,27 @@ echo "=== npa-workflow agent loop log=${LOG} ==="
 while true; do
   echo ""
   echo "--- $(date -u +%Y-%m-%dT%H:%M:%SZ) test ---"
-  "${PY}" -m pytest \
+  FAILED=0
+
+  if ! "${PY}" -m pytest \
     npa/tests/orchestration/npa_workflow/ \
     npa/tests/smoke/test_npa_workflow_smoke.py \
-    -q --timeout=120
+    -q --timeout=120; then
+    FAILED=1
+  fi
 
-  if NPA_INTEGRATION_E2E=1 "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=120; then
-    echo "live e2e OK"
+  if ! NPA_INTEGRATION_E2E=1 "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=180; then
+    echo "live e2e failed"
+    FAILED=1
   else
-    echo "live e2e failed (continuing)"
+    echo "live e2e OK"
+  fi
+
+  if [[ "${FAILED}" -ne 0 ]]; then
+    echo "tests failed — skipping commit/push"
+    echo "--- sleeping 600s ---"
+    sleep 600
+    continue
   fi
 
   if git diff --quiet && git diff --cached --quiet; then
@@ -33,13 +48,15 @@ while true; do
       npa/src/npa/orchestration/npa_workflow/ \
       npa/src/npa/cli/workbench/workflow/__init__.py \
       npa/tests/orchestration/npa_workflow/ \
-      npa/tests/e2e/test_npa_workflow_live_e2e.py \
+      npa/tests/e2e/ \
       npa/workflows/workbench/npa-workflows/ \
       docs/workbench/npa-workflow-guide.md \
       docs/workbench/npa-workflow-tool-catalog.md \
       skills/workflows/author-npa-workflow/ \
+      skills/workflows/generate-npa-workflow/ \
       scripts/npa-workflow-agent-loop.sh \
-      scripts/npa-workflow-live-e2e.sh 2>/dev/null || true
+      scripts/npa-workflow-live-e2e.sh \
+      scripts/npa-workflow-real-infra-tmux.sh 2>/dev/null || true
     if git diff --cached --quiet; then
       echo "nothing staged"
     else
@@ -47,7 +64,7 @@ while true; do
       git commit -m "$(cat <<EOF
 ${msg}
 
-Automated agent-loop commit on feat/npa-workflow-v0.0.1.
+Automated agent-loop commit on feat/npa-workflow-v0.0.1 (tests passed).
 EOF
 )"
       git push origin feat/npa-workflow-v0.0.1

--- a/scripts/npa-workflow-agent-loop.sh
+++ b/scripts/npa-workflow-agent-loop.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Iterate on npa.workflow gaps: test → commit → push (for PR #131).
+# tmux new -s npa-workflow-agent ./scripts/npa-workflow-agent-loop.sh
+set -euo pipefail
+
+export HOME="${HOME:-/home/ubuntu}"
+REPO="/home/ubuntu/nebius-physical-ai"
+cd "$REPO"
+PY="${REPO}/npa/.venv/bin/python"
+LOG="/tmp/npa-workflow-agent-$(date -u +%Y%m%dT%H%M%SZ).log"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== npa-workflow agent loop log=${LOG} ==="
+
+while true; do
+  echo ""
+  echo "--- $(date -u +%Y-%m-%dT%H:%M:%SZ) test ---"
+  "${PY}" -m pytest \
+    npa/tests/orchestration/npa_workflow/ \
+    npa/tests/smoke/test_npa_workflow_smoke.py \
+    npa/tests/cli/test_workflow_cli.py::test_workflow_status_prints_status \
+    npa/tests/cli/test_workflow_cli.py::test_workflow_status_maps_distillation_error \
+    npa/tests/cli/test_workflow_cli.py::test_durable_workflow_status_logs_and_artifacts_read_s3 \
+    -q --timeout=120
+
+  if NPA_INTEGRATION_E2E=1 "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=120; then
+    echo "live e2e OK"
+  else
+    echo "live e2e failed (continuing)"
+  fi
+
+  if git diff --quiet && git diff --cached --quiet; then
+    echo "no changes to commit"
+  else
+    git add \
+      npa/src/npa/orchestration/npa_workflow/ \
+      npa/src/npa/cli/workbench/workflow/__init__.py \
+      npa/tests/orchestration/npa_workflow/ \
+      npa/tests/e2e/test_npa_workflow_live_e2e.py \
+      npa/workflows/workbench/npa-workflows/ \
+      docs/workbench/npa-workflow-guide.md \
+      docs/workbench/npa-workflow-tool-catalog.md \
+      skills/workflows/author-npa-workflow/ \
+      scripts/npa-workflow-agent-loop.sh \
+      scripts/npa-workflow-live-e2e.sh 2>/dev/null || true
+    if git diff --cached --quiet; then
+      echo "nothing staged"
+    else
+      msg="npa.workflow: $(git diff --cached --stat | tail -1)"
+      git commit -m "$(cat <<EOF
+${msg}
+
+Automated agent-loop commit on feat/npa-workflow-v0.0.1.
+EOF
+)"
+      git push origin feat/npa-workflow-v0.0.1
+      echo "pushed to origin/feat/npa-workflow-v0.0.1"
+    fi
+  fi
+
+  echo "--- sleeping 600s ---"
+  sleep 600
+done

--- a/scripts/npa-workflow-beauty-tmux.sh
+++ b/scripts/npa-workflow-beauty-tmux.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Validate beautiful npa.workflow YAMLs + BDD100K tests.
+# tmux new -s npa-workflow-beauty ./scripts/npa-workflow-beauty-tmux.sh
+set -euo pipefail
+
+export HOME="${HOME:-/home/ubuntu}"
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+[[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
+
+REPO="/home/ubuntu/nebius-physical-ai"
+cd "$REPO"
+PY="${REPO}/npa/.venv/bin/python"
+NPA="${REPO}/npa/.venv/bin/npa"
+export NPA_INTEGRATION_E2E=1
+SPECS="${REPO}/npa/workflows/workbench/npa-workflows"
+
+LOG="/tmp/npa-workflow-beauty-$(date -u +%Y%m%dT%H%M%SZ).log"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== npa.workflow beauty matrix log=${LOG} ==="
+echo "branch: $(git branch --show-current) @ $(git rev-parse --short HEAD)"
+
+round=1
+while true; do
+  echo ""
+  echo "========== ROUND ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) =========="
+  FAILED=0
+
+  echo "--- golden YAML validate (all specs) ---"
+  for spec in "${SPECS}"/*.yaml; do
+    base=$(basename "$spec")
+    echo "spec: ${base}"
+    if ! "${NPA}" workbench workflow validate-spec "${spec}"; then
+      FAILED=1
+    fi
+  done
+
+  echo "--- unit + smoke ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/orchestration/npa_workflow/ \
+    npa/tests/smoke/test_npa_workflow_smoke.py \
+    -q --timeout=120; then
+    FAILED=1
+  fi
+
+  echo "--- live e2e + infra ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/e2e/test_npa_workflow_live_e2e.py \
+    npa/tests/e2e/test_npa_workflow_live_infra.py \
+    -q --timeout=300; then
+    FAILED=1
+  fi
+
+  echo "--- BDD100K pipeline + LanceDB ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/workflows/test_bdd100k_pipeline.py \
+    npa/tests/test_lancedb_bdd100k_import.py \
+    npa/tests/test_lancedb_bdd100k_backfill.py \
+    npa/tests/test_lancedb_bdd100k_mv.py \
+    -q --timeout=300; then
+    FAILED=1
+  fi
+
+  if [[ "${FAILED}" -eq 0 ]]; then
+    echo "--- ROUND ${round} ALL PASSED ---"
+  else
+    echo "--- ROUND ${round} FAILED ---"
+  fi
+  round=$((round + 1))
+  sleep 600
+done

--- a/scripts/npa-workflow-creative-tmux.sh
+++ b/scripts/npa-workflow-creative-tmux.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Beautify pass + creative npa.workflow pipeline + skill-index smoke in tmux.
+# tmux new -s npa-workflow-creative ./scripts/npa-workflow-creative-tmux.sh
+set -euo pipefail
+
+export HOME="${HOME:-/home/ubuntu}"
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+[[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
+
+REPO="/home/ubuntu/nebius-physical-ai"
+cd "$REPO"
+PY="${REPO}/npa/.venv/bin/python"
+NPA="${REPO}/npa/.venv/bin/npa"
+export NPA_INTEGRATION_E2E=1
+SPECS="${REPO}/npa/workflows/workbench/npa-workflows"
+CREATIVE="${SPECS}/tokenfactory-cosmos-gate.yaml"
+
+LOG="/tmp/npa-workflow-creative-$(date -u +%Y%m%dT%H%M%SZ).log"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== npa.workflow creative + beauty matrix log=${LOG} ==="
+echo "branch: $(git branch --show-current) @ $(git rev-parse --short HEAD)"
+echo "skills: author-npa-workflow + generate-npa-workflow"
+echo "creative spec: ${CREATIVE}"
+
+round=1
+while true; do
+  echo ""
+  echo "========== ROUND ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) =========="
+  FAILED=0
+
+  echo "--- [1/8] skills index smoke (npa workflow entries) ---"
+  if ! "${PY}" -m pytest npa/tests/guardrails/test_skills_index.py -q --timeout=120 \
+    -k "author-npa-workflow or generate-npa-workflow"; then
+    FAILED=1
+  fi
+
+  echo "--- [2/8] validate all golden npa.workflow YAMLs ---"
+  for spec in "${SPECS}"/*.yaml; do
+    base=$(basename "$spec")
+    echo "validate: ${base}"
+    if ! "${NPA}" workbench workflow validate-spec "${spec}"; then
+      FAILED=1
+    fi
+  done
+
+  echo "--- [3/8] creative pipeline plan (generate-npa-workflow golden) ---"
+  if ! "${NPA}" workbench workflow plan-spec "${CREATIVE}" \
+    --run-id "creative-r${round}" --assume-decision loop_back; then
+    FAILED=1
+  fi
+  if ! "${NPA}" workbench workflow plan-spec "${CREATIVE}" \
+    --run-id "creative-promote-r${round}" --assume-decision promote_checkpoint \
+    --json | "${PY}" -c "import json,sys; p=json.load(sys.stdin); assert p['steps'][-1]['state']=='publish', p"; then
+    FAILED=1
+  fi
+
+  echo "--- [4/8] plan dynamic specs (sim2real + creative) ---"
+  for spec in "${SPECS}/sim2real-vlm-rl.yaml" "${CREATIVE}"; do
+    base=$(basename "$spec")
+    echo "plan: ${base}"
+    if ! "${NPA}" workbench workflow plan-spec "${spec}" \
+      --run-id "tmux-r${round}" --assume-decision loop_back; then
+      FAILED=1
+    fi
+  done
+
+  echo "--- [5/8] unit + audit + smoke ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/orchestration/npa_workflow/ \
+    npa/tests/smoke/test_npa_workflow_smoke.py \
+    npa/tests/smoke/test_all_workflow_yamls.py \
+    -q --timeout=180; then
+    FAILED=1
+  fi
+
+  echo "--- [6/8] live e2e + infra ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/e2e/test_npa_workflow_live_e2e.py \
+    npa/tests/e2e/test_npa_workflow_live_infra.py \
+    -q --timeout=300; then
+    FAILED=1
+  fi
+
+  echo "--- [7/8] BDD100K + LanceDB ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/workflows/test_bdd100k_pipeline.py \
+    npa/tests/test_lancedb_bdd100k_import.py \
+    npa/tests/test_lancedb_bdd100k_backfill.py \
+    npa/tests/test_lancedb_bdd100k_mv.py \
+    -q --timeout=300; then
+    FAILED=1
+  fi
+
+  echo "--- [8/8] skypilot YAML parse (all files) ---"
+  if ! "${PY}" - <<'PY'; then
+from pathlib import Path
+import yaml
+
+root = Path("npa/workflows/workbench/skypilot")
+failed = []
+for path in sorted(root.glob("*.yaml")):
+    try:
+        docs = [d for d in yaml.safe_load_all(path.read_text(encoding="utf-8")) if d is not None]
+        if not docs or not docs[0].get("name"):
+            failed.append(path.name)
+    except Exception as exc:
+        failed.append(f"{path.name}: {exc}")
+if failed:
+    raise SystemExit("parse failures: " + ", ".join(failed))
+print(f"skypilot parse OK ({len(list(root.glob('*.yaml')))} files)")
+PY
+    FAILED=1
+  fi
+
+  if [[ "${FAILED}" -eq 0 ]]; then
+    echo "--- ROUND ${round} ALL PASSED ---"
+  else
+    echo "--- ROUND ${round} FAILED ---"
+  fi
+  round=$((round + 1))
+  sleep 600
+done

--- a/scripts/npa-workflow-creative-tmux.sh
+++ b/scripts/npa-workflow-creative-tmux.sh
@@ -29,9 +29,8 @@ while true; do
   echo "========== ROUND ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) =========="
   FAILED=0
 
-  echo "--- [1/8] skills index smoke (npa workflow entries) ---"
-  if ! "${PY}" -m pytest npa/tests/guardrails/test_skills_index.py -q --timeout=120 \
-    -k "author-npa-workflow or generate-npa-workflow"; then
+  echo "--- [1/8] skills index smoke (full guardrail) ---"
+  if ! "${PY}" -m pytest npa/tests/guardrails/test_skills_index.py -q --timeout=120; then
     FAILED=1
   fi
 

--- a/scripts/npa-workflow-live-e2e.sh
+++ b/scripts/npa-workflow-live-e2e.sh
@@ -45,7 +45,14 @@ while true; do
       --run-id "${RUN_ID}-r${round}" \
       --plan-only \
       --assume-decision promote_checkpoint \
-      --json | "${PY}" -c "import json,sys; d=json.load(sys.stdin); assert d.get('steps'), d"
+      --json | "${PY}" -c "
+import json, sys
+report = json.load(sys.stdin)
+steps = [s['state'] for s in report['plan']['steps']]
+assert steps, report
+if report['workflow'] == 'sim2real-vlm-rl':
+    assert steps.count('finalize') == 1, steps
+"
   done
 
   echo "--- pytest live e2e (NPA_INTEGRATION_E2E=1) ---"

--- a/scripts/npa-workflow-live-e2e.sh
+++ b/scripts/npa-workflow-live-e2e.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Live validation of npa.workflow/v0.0.1 specs on operator machine + Nebius creds.
+# Run in tmux: tmux new -s npa-workflow-live ./scripts/npa-workflow-live-e2e.sh
+set -euo pipefail
+
+export HOME="${HOME:-/home/ubuntu}"
+[[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
+
+REPO="/home/ubuntu/nebius-physical-ai"
+cd "$REPO"
+PY="${REPO}/npa/.venv/bin/python"
+NPA="${REPO}/npa/.venv/bin/npa"
+SPECS_DIR="${REPO}/npa/workflows/workbench/npa-workflows"
+RUN_ID="npa-workflow-live-$(date -u +%Y%m%dT%H%M%SZ)"
+LOG="/tmp/${RUN_ID}.log"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== NPA workflow live e2e run_id=${RUN_ID} ==="
+echo "log: ${LOG}"
+
+round=1
+while true; do
+  echo ""
+  echo "--- round ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) ---"
+
+  echo "--- unit: npa_workflow + workflow CLI fixes ---"
+  "${PY}" -m pytest \
+    npa/tests/orchestration/npa_workflow/ \
+    npa/tests/smoke/test_npa_workflow_smoke.py \
+    npa/tests/cli/test_workflow_cli.py::test_workflow_status_prints_status \
+    npa/tests/cli/test_workflow_cli.py::test_workflow_status_maps_distillation_error \
+    npa/tests/cli/test_workflow_cli.py::test_durable_workflow_status_logs_and_artifacts_read_s3 \
+    npa/tests/workbench/test_cosmos3_access.py::test_cosmos3_fetch_clones_and_downloads_without_token_args \
+    -q --timeout=120
+
+  echo "--- CLI validate-spec / plan-spec (all golden YAMLs) ---"
+  for spec in "${SPECS_DIR}"/*.yaml; do
+    [[ "$(basename "$spec")" == "README.md" ]] && continue
+    echo "spec: ${spec}"
+    "${NPA}" workbench workflow validate-spec "${spec}"
+    "${NPA}" workbench workflow plan-spec "${spec}" \
+      --run-id "${RUN_ID}-r${round}" \
+      --assume-decision promote_checkpoint
+    "${NPA}" workbench workflow run-spec "${spec}" \
+      --run-id "${RUN_ID}-r${round}" \
+      --plan-only \
+      --assume-decision promote_checkpoint \
+      --json | "${PY}" -c "import json,sys; d=json.load(sys.stdin); assert d.get('steps'), d"
+  done
+
+  echo "--- pytest live e2e (NPA_INTEGRATION_E2E=1) ---"
+  NPA_INTEGRATION_E2E=1 "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=120
+
+  echo "--- round ${round} OK ---"
+  round=$((round + 1))
+  sleep 300
+done

--- a/scripts/npa-workflow-live-e2e.sh
+++ b/scripts/npa-workflow-live-e2e.sh
@@ -4,13 +4,16 @@
 set -euo pipefail
 
 export HOME="${HOME:-/home/ubuntu}"
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 [[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
 
 REPO="/home/ubuntu/nebius-physical-ai"
 cd "$REPO"
 PY="${REPO}/npa/.venv/bin/python"
 NPA="${REPO}/npa/.venv/bin/npa"
+export NPA_INTEGRATION_E2E=1
 SPECS_DIR="${REPO}/npa/workflows/workbench/npa-workflows"
+DYNAMIC="sim2real-vlm-rl.yaml tokenfactory-cosmos-gate.yaml"
 RUN_ID="npa-workflow-live-$(date -u +%Y%m%dT%H%M%SZ)"
 LOG="/tmp/${RUN_ID}.log"
 exec > >(tee -a "$LOG") 2>&1
@@ -22,29 +25,42 @@ round=1
 while true; do
   echo ""
   echo "--- round ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) ---"
+  FAILED=0
 
   echo "--- unit: npa_workflow + workflow CLI fixes ---"
-  "${PY}" -m pytest \
+  if ! "${PY}" -m pytest \
     npa/tests/orchestration/npa_workflow/ \
     npa/tests/smoke/test_npa_workflow_smoke.py \
     npa/tests/cli/test_workflow_cli.py::test_workflow_status_prints_status \
     npa/tests/cli/test_workflow_cli.py::test_workflow_status_maps_distillation_error \
     npa/tests/cli/test_workflow_cli.py::test_durable_workflow_status_logs_and_artifacts_read_s3 \
     npa/tests/workbench/test_cosmos3_access.py::test_cosmos3_fetch_clones_and_downloads_without_token_args \
-    -q --timeout=120
+    -q --timeout=120; then
+    FAILED=1
+  fi
 
   echo "--- CLI validate-spec / plan-spec (all golden YAMLs) ---"
   for spec in "${SPECS_DIR}"/*.yaml; do
-    [[ "$(basename "$spec")" == "README.md" ]] && continue
+    base=$(basename "$spec")
     echo "spec: ${spec}"
-    "${NPA}" workbench workflow validate-spec "${spec}"
-    "${NPA}" workbench workflow plan-spec "${spec}" \
+    if ! "${NPA}" workbench workflow validate-spec "${spec}"; then
+      FAILED=1
+      continue
+    fi
+    extra=()
+    if [[ " ${DYNAMIC} " == *" ${base} "* ]]; then
+      extra=(--assume-decision promote_checkpoint)
+    fi
+    if ! "${NPA}" workbench workflow plan-spec "${spec}" \
       --run-id "${RUN_ID}-r${round}" \
-      --assume-decision promote_checkpoint
-    "${NPA}" workbench workflow run-spec "${spec}" \
+      "${extra[@]}"; then
+      FAILED=1
+      continue
+    fi
+    if ! "${NPA}" workbench workflow run-spec "${spec}" \
       --run-id "${RUN_ID}-r${round}" \
       --plan-only \
-      --assume-decision promote_checkpoint \
+      "${extra[@]}" \
       --json | "${PY}" -c "
 import json, sys
 report = json.load(sys.stdin)
@@ -52,13 +68,24 @@ steps = [s['state'] for s in report['plan']['steps']]
 assert steps, report
 if report['workflow'] == 'sim2real-vlm-rl':
     assert steps.count('finalize') == 1, steps
-"
+"; then
+      FAILED=1
+    fi
   done
 
-  echo "--- pytest live e2e (NPA_INTEGRATION_E2E=1) ---"
-  NPA_INTEGRATION_E2E=1 "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=120
+  echo "--- pytest live e2e + infra ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/e2e/test_npa_workflow_live_e2e.py \
+    npa/tests/e2e/test_npa_workflow_live_infra.py \
+    -q --timeout=600; then
+    FAILED=1
+  fi
 
-  echo "--- round ${round} OK ---"
+  if [[ "${FAILED}" -eq 0 ]]; then
+    echo "--- round ${round} ALL PASSED ---"
+  else
+    echo "--- round ${round} FAILED ---"
+  fi
   round=$((round + 1))
   sleep 300
 done

--- a/scripts/npa-workflow-real-infra-tmux.sh
+++ b/scripts/npa-workflow-real-infra-tmux.sh
@@ -4,6 +4,8 @@
 set -euo pipefail
 
 export HOME="${HOME:-/home/ubuntu}"
+# Tmux server sessions inherit stale AWS_* from server startup; clear before loading ~/.npa.
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 [[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
 
 REPO="/home/ubuntu/nebius-physical-ai"
@@ -15,6 +17,24 @@ git checkout feat/npa-workflow-v0.0.1 >/dev/null 2>&1 || true
 PY="${REPO}/npa/.venv/bin/python"
 NPA="${REPO}/npa/.venv/bin/npa"
 export NPA_INTEGRATION_E2E=1
+
+# Preflight: confirm project S3 is writable with the same credential path as live tests.
+"${PY}" - <<'PY' || { echo "S3 preflight failed; fix ~/.npa/credentials.yaml or unset stale AWS_* in tmux server"; exit 1; }
+from urllib.parse import urlparse
+
+from npa.clients.config import resolve_project_storage
+from npa.clients.project_credentials import s3_client_for_project
+
+storage = resolve_project_storage(None)
+raw = storage.checkpoint_bucket or ""
+if not raw:
+    raise SystemExit("checkpoint_bucket not configured")
+bucket = urlparse(raw if "://" in raw else f"s3://{raw}").netloc or raw.split("/")[0]
+client = s3_client_for_project(None)
+key = "npa-workflow-e2e/tmux-preflight.txt"
+client.put_object(Bucket=bucket, Key=key, Body=b"ok\n")
+print(f"S3 preflight OK bucket={bucket}")
+PY
 LOG="/tmp/npa-workflow-real-infra-$(date -u +%Y%m%dT%H%M%SZ).log"
 exec > >(tee -a "$LOG") 2>&1
 
@@ -22,21 +42,29 @@ echo "=== npa.workflow REAL INFRA matrix log=${LOG} ==="
 echo "branch: $(git branch --show-current) @ $(git rev-parse --short HEAD)"
 
 round=1
+FAILED=0
 while true; do
   echo ""
   echo "========== ROUND ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) =========="
+  FAILED=0
 
   echo "--- [1/4] unit + smoke ---"
-  "${PY}" -m pytest \
+  if ! "${PY}" -m pytest \
     npa/tests/orchestration/npa_workflow/ \
     npa/tests/smoke/test_npa_workflow_smoke.py \
-    -q --timeout=120
+    -q --timeout=120; then
+    FAILED=1
+  fi
 
   echo "--- [2/4] live e2e (validate/plan CLI) ---"
-  "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=180
+  if ! "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=180; then
+    FAILED=1
+  fi
 
   echo "--- [3/4] live infra runbook (S3 persist, fail manifest, scheduler, require-inputs) ---"
-  "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_infra.py -q --timeout=300
+  if ! "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_infra.py -q --timeout=300; then
+    FAILED=1
+  fi
 
   echo "--- [4/4] guide quickstart CLI (golden YAMLs) ---"
   SPECS="${REPO}/npa/workflows/workbench/npa-workflows"
@@ -44,12 +72,18 @@ while true; do
   for spec in "${SPECS}"/*.yaml; do
     base=$(basename "$spec")
     echo "spec: ${base}"
-    "${NPA}" workbench workflow validate-spec "${spec}"
-    "${NPA}" workbench workflow plan-spec "${spec}" \
+    if ! "${NPA}" workbench workflow validate-spec "${spec}"; then
+      FAILED=1
+      continue
+    fi
+    if ! "${NPA}" workbench workflow plan-spec "${spec}" \
       --run-id "${RUN_ID}" \
-      --assume-decision promote_checkpoint
+      --assume-decision promote_checkpoint; then
+      FAILED=1
+      continue
+    fi
     if [[ "${base}" == "sim2real-vlm-rl.yaml" ]]; then
-      "${NPA}" workbench workflow plan-spec "${spec}" \
+      if ! "${NPA}" workbench workflow plan-spec "${spec}" \
         --run-id "${RUN_ID}-loop" \
         --assume-decision loop_back \
         --json | "${PY}" -c "
@@ -59,9 +93,11 @@ states = [s['state'] for s in p['steps']]
 assert states.count('finalize') == 1, states
 assert states.count('rollouts') == 6, states
 print('sim2real promote OK: finalize=1 rollouts=6')
-"
+"; then
+        FAILED=1
+      fi
     fi
-    "${NPA}" workbench workflow run-spec "${spec}" \
+    if ! "${NPA}" workbench workflow run-spec "${spec}" \
       --run-id "${RUN_ID}" \
       --plan-only \
       --scheduler-plan \
@@ -71,10 +107,16 @@ r = json.load(sys.stdin)
 assert r.get('plan', {}).get('steps'), r
 assert r.get('scheduler', {}).get('tasks'), r
 print('scheduler tasks', len(r['scheduler']['tasks']))
-"
+"; then
+      FAILED=1
+    fi
   done
 
-  echo "--- ROUND ${round} ALL PASSED ---"
+  if [[ "${FAILED}" -eq 0 ]]; then
+    echo "--- ROUND ${round} ALL PASSED ---"
+  else
+    echo "--- ROUND ${round} FAILED (see log); retrying after sleep ---"
+  fi
   round=$((round + 1))
   sleep 600
 done

--- a/scripts/npa-workflow-real-infra-tmux.sh
+++ b/scripts/npa-workflow-real-infra-tmux.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Full npa.workflow real-infra test matrix (guide runbook + unit + live e2e).
+# tmux new -s npa-workflow-real-infra ./scripts/npa-workflow-real-infra-tmux.sh
+set -euo pipefail
+
+export HOME="${HOME:-/home/ubuntu}"
+[[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
+
+REPO="/home/ubuntu/nebius-physical-ai"
+cd "$REPO"
+
+# Always test workflow branch code.
+git checkout feat/npa-workflow-v0.0.1 >/dev/null 2>&1 || true
+
+PY="${REPO}/npa/.venv/bin/python"
+NPA="${REPO}/npa/.venv/bin/npa"
+export NPA_INTEGRATION_E2E=1
+LOG="/tmp/npa-workflow-real-infra-$(date -u +%Y%m%dT%H%M%SZ).log"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== npa.workflow REAL INFRA matrix log=${LOG} ==="
+echo "branch: $(git branch --show-current) @ $(git rev-parse --short HEAD)"
+
+round=1
+while true; do
+  echo ""
+  echo "========== ROUND ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) =========="
+
+  echo "--- [1/4] unit + smoke ---"
+  "${PY}" -m pytest \
+    npa/tests/orchestration/npa_workflow/ \
+    npa/tests/smoke/test_npa_workflow_smoke.py \
+    -q --timeout=120
+
+  echo "--- [2/4] live e2e (validate/plan CLI) ---"
+  "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=180
+
+  echo "--- [3/4] live infra runbook (S3 persist, fail manifest, scheduler, require-inputs) ---"
+  "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_infra.py -q --timeout=300
+
+  echo "--- [4/4] guide quickstart CLI (golden YAMLs) ---"
+  SPECS="${REPO}/npa/workflows/workbench/npa-workflows"
+  RUN_ID="tmux-guide-r${round}-$(date -u +%H%M%S)"
+  for spec in "${SPECS}"/*.yaml; do
+    base=$(basename "$spec")
+    echo "spec: ${base}"
+    "${NPA}" workbench workflow validate-spec "${spec}"
+    "${NPA}" workbench workflow plan-spec "${spec}" \
+      --run-id "${RUN_ID}" \
+      --assume-decision promote_checkpoint
+    if [[ "${base}" == "sim2real-vlm-rl.yaml" ]]; then
+      "${NPA}" workbench workflow plan-spec "${spec}" \
+        --run-id "${RUN_ID}-loop" \
+        --assume-decision loop_back \
+        --json | "${PY}" -c "
+import json, sys
+p = json.load(sys.stdin)
+states = [s['state'] for s in p['steps']]
+assert states.count('finalize') == 1, states
+assert states.count('rollouts') == 6, states
+print('sim2real promote OK: finalize=1 rollouts=6')
+"
+    fi
+    "${NPA}" workbench workflow run-spec "${spec}" \
+      --run-id "${RUN_ID}" \
+      --plan-only \
+      --scheduler-plan \
+      --json | "${PY}" -c "
+import json, sys
+r = json.load(sys.stdin)
+assert r.get('plan', {}).get('steps'), r
+assert r.get('scheduler', {}).get('tasks'), r
+print('scheduler tasks', len(r['scheduler']['tasks']))
+"
+  done
+
+  echo "--- ROUND ${round} ALL PASSED ---"
+  round=$((round + 1))
+  sleep 600
+done

--- a/scripts/npa-workflow-real-infra-tmux.sh
+++ b/scripts/npa-workflow-real-infra-tmux.sh
@@ -1,109 +1,147 @@
 #!/usr/bin/env bash
-# Full npa.workflow real-infra test matrix (guide runbook + unit + live e2e).
+# Full npa.workflow live-infra matrix: all golden YAMLs, real S3, no credential leakage.
 # tmux new -s npa-workflow-real-infra ./scripts/npa-workflow-real-infra-tmux.sh
 set -euo pipefail
 
 export HOME="${HOME:-/home/ubuntu}"
-# Tmux server sessions inherit stale AWS_* from server startup; clear before loading ~/.npa.
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 [[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
 
 REPO="/home/ubuntu/nebius-physical-ai"
 cd "$REPO"
-
-# Always test workflow branch code.
-git checkout feat/npa-workflow-v0.0.1 >/dev/null 2>&1 || true
-
 PY="${REPO}/npa/.venv/bin/python"
 NPA="${REPO}/npa/.venv/bin/npa"
 export NPA_INTEGRATION_E2E=1
+SPECS="${REPO}/npa/workflows/workbench/npa-workflows"
+DYNAMIC="sim2real-vlm-rl.yaml tokenfactory-cosmos-gate.yaml"
 
-# Preflight: confirm project S3 is writable with the same credential path as live tests.
+LOG="/tmp/npa-workflow-real-infra-$(date -u +%Y%m%dT%H%M%SZ).log"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== npa.workflow FULL LIVE INFRA matrix log=${LOG} ==="
+echo "branch: $(git branch --show-current) @ $(git rev-parse --short HEAD)"
+echo "golden specs: $(find "${SPECS}" -maxdepth 1 -name '*.yaml' | wc -l)"
+
+echo "--- S3 preflight (project credentials, not stale AWS_*) ---"
 "${PY}" - <<'PY' || { echo "S3 preflight failed; fix ~/.npa/credentials.yaml or unset stale AWS_* in tmux server"; exit 1; }
-from urllib.parse import urlparse
+import sys
+from pathlib import Path
 
-from npa.clients.config import resolve_project_storage
+sys.path.insert(0, str(Path("npa/tests/e2e")))
+from npa_workflow_live_helpers import live_bucket
 from npa.clients.project_credentials import s3_client_for_project
 
-storage = resolve_project_storage(None)
-raw = storage.checkpoint_bucket or ""
-if not raw:
-    raise SystemExit("checkpoint_bucket not configured")
-bucket = urlparse(raw if "://" in raw else f"s3://{raw}").netloc or raw.split("/")[0]
+bucket = live_bucket(None)
 client = s3_client_for_project(None)
 key = "npa-workflow-e2e/tmux-preflight.txt"
 client.put_object(Bucket=bucket, Key=key, Body=b"ok\n")
 print(f"S3 preflight OK bucket={bucket}")
 PY
-LOG="/tmp/npa-workflow-real-infra-$(date -u +%Y%m%dT%H%M%SZ).log"
-exec > >(tee -a "$LOG") 2>&1
-
-echo "=== npa.workflow REAL INFRA matrix log=${LOG} ==="
-echo "branch: $(git branch --show-current) @ $(git rev-parse --short HEAD)"
 
 round=1
-FAILED=0
 while true; do
   echo ""
   echo "========== ROUND ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) =========="
   FAILED=0
 
-  echo "--- [1/4] unit + smoke ---"
+  echo "--- [1/6] unit + smoke (all golden YAMLs) ---"
   if ! "${PY}" -m pytest \
     npa/tests/orchestration/npa_workflow/ \
     npa/tests/smoke/test_npa_workflow_smoke.py \
-    -q --timeout=120; then
+    npa/tests/smoke/test_all_workflow_yamls.py \
+    -q --timeout=180; then
     FAILED=1
   fi
 
-  echo "--- [2/4] live e2e (validate/plan CLI) ---"
-  if ! "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=180; then
+  echo "--- [2/6] live e2e (all golden + leak checks) ---"
+  if ! "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q --timeout=300; then
     FAILED=1
   fi
 
-  echo "--- [3/4] live infra runbook (S3 persist, fail manifest, scheduler, require-inputs) ---"
-  if ! "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_infra.py -q --timeout=300; then
+  echo "--- [3/6] live infra (S3 persist, all golden on real bucket, leak checks) ---"
+  if ! "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_infra.py -q --timeout=600; then
     FAILED=1
   fi
 
-  echo "--- [4/4] guide quickstart CLI (golden YAMLs) ---"
-  SPECS="${REPO}/npa/workflows/workbench/npa-workflows"
-  RUN_ID="tmux-guide-r${round}-$(date -u +%H%M%S)"
+  echo "--- [4/6] CLI golden matrix on live bucket (validate/plan/scheduler) ---"
+  RUN_ID="tmux-live-r${round}-$(date -u +%H%M%S)"
+  BUCKET="$("${PY}" - <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path("npa/tests/e2e")))
+from npa_workflow_live_helpers import live_bucket
+
+print(live_bucket(None))
+PY
+)"
   for spec in "${SPECS}"/*.yaml; do
     base=$(basename "$spec")
-    echo "spec: ${base}"
-    if ! "${NPA}" workbench workflow validate-spec "${spec}"; then
+    stem="${base%.yaml}"
+    echo "live CLI: ${base} bucket=${BUCKET}"
+    LIVE_SPEC="$("${PY}" - "${spec}" "${BUCKET}" "${RUN_ID}" "${stem}" <<'PY'
+import sys
+from pathlib import Path
+import re
+
+spec_path, bucket, run_id, stem = sys.argv[1:5]
+text = Path(spec_path).read_text(encoding="utf-8")
+text = text.replace("bucket: example-bucket", f"bucket: {bucket}")
+text = re.sub(
+    r'(prefix:\s*")([^"]*)(")',
+    lambda m: f'{m.group(1)}npa-workflow-e2e/{run_id}/{stem}{m.group(3)}',
+    text,
+    count=1,
+)
+out = Path(f"/tmp/npa-live-{stem}-{run_id}.yaml")
+out.write_text(text, encoding="utf-8")
+print(out)
+PY
+)"
+    if ! "${NPA}" workbench workflow validate-spec "${LIVE_SPEC}"; then
       FAILED=1
       continue
     fi
-    if ! "${NPA}" workbench workflow plan-spec "${spec}" \
-      --run-id "${RUN_ID}" \
-      --assume-decision promote_checkpoint; then
+    extra=()
+    if [[ " ${DYNAMIC} " == *" ${base} "* ]]; then
+      extra=(--assume-decision promote_checkpoint)
+    fi
+    if ! "${NPA}" workbench workflow plan-spec "${LIVE_SPEC}" \
+      --run-id "${RUN_ID}-${stem}" "${extra[@]}"; then
       FAILED=1
       continue
     fi
-    if [[ "${base}" == "sim2real-vlm-rl.yaml" ]]; then
-      if ! "${NPA}" workbench workflow plan-spec "${spec}" \
-        --run-id "${RUN_ID}-loop" \
+    if [[ " ${DYNAMIC} " == *" ${base} "* ]]; then
+      if ! "${NPA}" workbench workflow plan-spec "${LIVE_SPEC}" \
+        --run-id "${RUN_ID}-${stem}-loop" \
         --assume-decision loop_back \
         --json | "${PY}" -c "
 import json, sys
-p = json.load(sys.stdin)
-states = [s['state'] for s in p['steps']]
-assert states.count('finalize') == 1, states
-assert states.count('rollouts') == 6, states
-print('sim2real promote OK: finalize=1 rollouts=6')
+from pathlib import Path
+sys.path.insert(0, str(Path('npa/tests/e2e')))
+from npa_workflow_live_helpers import assert_no_credential_leakage, live_credential_markers
+raw = sys.stdin.read()
+assert_no_credential_leakage(raw, extra_forbidden=live_credential_markers())
+p = json.loads(raw)
+assert p.get('steps'), p
+print('loop_back steps', len(p['steps']))
 "; then
         FAILED=1
       fi
     fi
-    if ! "${NPA}" workbench workflow run-spec "${spec}" \
-      --run-id "${RUN_ID}" \
+    if ! "${NPA}" workbench workflow run-spec "${LIVE_SPEC}" \
+      --run-id "${RUN_ID}-${stem}" \
       --plan-only \
       --scheduler-plan \
+      "${extra[@]}" \
       --json | "${PY}" -c "
 import json, sys
-r = json.load(sys.stdin)
+from pathlib import Path
+sys.path.insert(0, str(Path('npa/tests/e2e')))
+from npa_workflow_live_helpers import assert_no_credential_leakage, live_credential_markers
+raw = sys.stdin.read()
+assert_no_credential_leakage(raw, extra_forbidden=live_credential_markers())
+r = json.loads(raw)
 assert r.get('plan', {}).get('steps'), r
 assert r.get('scheduler', {}).get('tasks'), r
 print('scheduler tasks', len(r['scheduler']['tasks']))
@@ -112,10 +150,35 @@ print('scheduler tasks', len(r['scheduler']['tasks']))
     fi
   done
 
+  echo "--- [5/6] audit fixes + skills guardrail ---"
+  if ! "${PY}" -m pytest \
+    npa/tests/orchestration/npa_workflow/test_audit_fixes.py \
+    npa/tests/guardrails/test_skills_index.py \
+    -q --timeout=180; then
+    FAILED=1
+  fi
+
+  echo "--- [6/6] BDD100K + skypilot parse ---"
+  if ! "${PY}" -m pytest npa/tests/workflows/test_bdd100k_pipeline.py -q --timeout=120; then
+    FAILED=1
+  fi
+  if ! "${PY}" - <<'PY'; then
+from pathlib import Path
+import yaml
+
+root = Path("npa/workflows/workbench/skypilot")
+for path in sorted(root.glob("*.yaml")):
+    docs = [d for d in yaml.safe_load_all(path.read_text(encoding="utf-8")) if d is not None]
+    assert docs and docs[0].get("name"), path.name
+print(f"skypilot parse OK ({len(list(root.glob('*.yaml')))} files)")
+PY
+    FAILED=1
+  fi
+
   if [[ "${FAILED}" -eq 0 ]]; then
-    echo "--- ROUND ${round} ALL PASSED ---"
+    echo "--- ROUND ${round} ALL PASSED (full live infra, all golden YAMLs, leak-checked) ---"
   else
-    echo "--- ROUND ${round} FAILED (see log); retrying after sleep ---"
+    echo "--- ROUND ${round} FAILED ---"
   fi
   round=$((round + 1))
   sleep 600

--- a/scripts/npa-workflow-smoke-live-tmux.sh
+++ b/scripts/npa-workflow-smoke-live-tmux.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Smoke + live-infra validation for npa.workflow YAML changes.
+# tmux new -s npa-workflow-smoke-live ./scripts/npa-workflow-smoke-live-tmux.sh
+set -euo pipefail
+
+export HOME="${HOME:-/home/ubuntu}"
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+[[ -f /home/ubuntu/bin/npa-cloud-env.sh ]] && source /home/ubuntu/bin/npa-cloud-env.sh
+
+REPO="/home/ubuntu/nebius-physical-ai"
+cd "$REPO"
+PY="${REPO}/npa/.venv/bin/python"
+export NPA_INTEGRATION_E2E=1
+
+LOG="/tmp/npa-workflow-smoke-live-$(date -u +%Y%m%dT%H%M%SZ).log"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== npa.workflow smoke + live infra log=${LOG} ==="
+echo "branch: $(git branch --show-current) @ $(git rev-parse --short HEAD)"
+
+round=1
+while true; do
+  echo ""
+  echo "========== ROUND ${round} $(date -u +%Y-%m-%dT%H:%M:%SZ) =========="
+  FAILED=0
+
+  echo "--- unit (spec + catalog validation) ---"
+  if ! "${PY}" -m pytest npa/tests/orchestration/npa_workflow/ -q --timeout=120; then
+    FAILED=1
+  fi
+
+  echo "--- smoke ---"
+  if ! "${PY}" -m pytest npa/tests/smoke/test_npa_workflow_smoke.py -q --timeout=120; then
+    FAILED=1
+  fi
+
+  echo "--- live infra runbook ---"
+  if ! "${PY}" -m pytest npa/tests/e2e/test_npa_workflow_live_infra.py -q --timeout=300; then
+    FAILED=1
+  fi
+
+  if [[ "${FAILED}" -eq 0 ]]; then
+    echo "--- ROUND ${round} ALL PASSED ---"
+  else
+    echo "--- ROUND ${round} FAILED ---"
+  fi
+  round=$((round + 1))
+  sleep 600
+done

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -301,6 +301,19 @@ skills:
         paths:
           - npa/workflows/workbench/skypilot/isaac-lab-rl-train.yaml
           - npa/workflows/workbench/skypilot/sonic-train-standalone.yaml
+  - name: author-npa-workflow
+    category: workflows
+    when_to_use: "Author, validate, or review NPA workflow specs (apiVersion npa.workflow/v0.0.1) and toolRef catalogs."
+    path: skills/workflows/author-npa-workflow/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["workbench", "workflow", "validate-spec", "--help"]
+        contains: "npa.workflow"
+      - type: npa_workflow_yaml
+        paths:
+          - npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
+          - npa/workflows/workbench/npa-workflows/tokenfactory-rollout-judge.yaml
+          - npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
   - name: workbench-reference-workflows
     category: workflows
     when_to_use: "Reference SkyPilot YAMLs, runner scripts, cookbooks, and customer-adaptable pipeline implementations."

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -314,6 +314,18 @@ skills:
           - npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
           - npa/workflows/workbench/npa-workflows/tokenfactory-rollout-judge.yaml
           - npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
+          - npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
+          - npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
+  - name: generate-npa-workflow
+    category: workflows
+    when_to_use: "Design a new creative npa.workflow/v0.0.1 pipeline from the tool catalog (loops, gates, golden YAML)."
+    path: skills/workflows/generate-npa-workflow/SKILL.md
+    smoke:
+      - type: file_exists
+        path: docs/workbench/npa-workflow-guide.md
+      - type: npa_workflow_yaml
+        paths:
+          - npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
   - name: workbench-reference-workflows
     category: workflows
     when_to_use: "Reference SkyPilot YAMLs, runner scripts, cookbooks, and customer-adaptable pipeline implementations."

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -20,7 +20,7 @@ specs.
 - **States:** declarative nodes with `run` (shell/argv), `toolRef`, or `sequence`.
 - **Tokens:** `{{config.key}}`, `{{run.id}}`, `{{run.prefix}}`, `{{state.NAME.uri}}` — no Jinja, no eval.
 - **Predicates:** closed set: `promote_checkpoint`, `loop_back`.
-- **Loops:** `loop.max: config.attr` or integer; `loop.until` for dynamic exit.
+- **Loops:** `loop.max: "{{config.attr}}"` or integer; `loop.until` for dynamic exit.
 - **I/O:** `inputs` / `outputs` with `uri` + optional `schema` (documentation + future validation).
 
 ## Tool References
@@ -48,7 +48,7 @@ NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_npa_work
 
 1. One workflow file = one variant; do not add sim2real-specific Python orchestrators.
 2. Keep **terminal: true** on leaf completion states.
-3. Use `plan_assume_decision` in config when planning dynamic loops (`loop_back` vs `promote_checkpoint`).
+3. Use `--assume-decision` when planning dynamic loops (`loop_back` vs `promote_checkpoint`).
 4. SkyPilot submits each planned step; the spec does not call `engine.py` or schedulers per workflow.
 5. Cross-stage data uses S3 URIs in config — tools are stateless.
 

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: author-npa-workflow
+description: Use when authoring, validating, or reviewing NPA workflow specs (apiVersion npa.workflow/v0.0.1) — declarative state machines that invoke workbench tools via SkyPilot.
+---
+
+# Author NPA Workflow
+
+## When To Use
+
+Load when creating or editing **NPA workflow YAML** under
+`npa/workflows/workbench/npa-workflows/`, wiring tool stages, loops, or
+transitions, or when helping agents/users convert SkyPilot bash pipelines into
+specs.
+
+## Spec Contract
+
+- **apiVersion:** `npa.workflow/v0.0.1` only (beta).
+- **kind:** `Workflow`
+- **States:** declarative nodes with `run` (shell/argv), `toolRef`, or `sequence`.
+- **Tokens:** `{{config.key}}`, `{{run.id}}`, `{{run.prefix}}` — no Jinja, no eval.
+- **Predicates:** closed set: `promote_checkpoint`, `loop_back`.
+- **Loops:** `loop.max: config.attr` or integer; `loop.until` for dynamic exit.
+- **I/O:** `inputs` / `outputs` with `uri` + optional `schema` (documentation + future validation).
+
+## Tool References
+
+Use `toolRef` from the catalog in
+`docs/workbench/npa-workflow-tool-catalog.md` and
+`npa/src/npa/orchestration/npa_workflow/catalog.py`. Prefer toolRef over
+inventing shell when a catalog entry exists.
+
+## Commands (agent harness)
+
+```bash
+npa/.venv/bin/npa workbench workflow validate-spec <spec.yaml> --json
+npa/.venv/bin/npa workbench workflow plan-spec <spec.yaml> --run-id demo --json
+npa/.venv/bin/npa workbench workflow run-spec <spec.yaml> --plan-only --json
+```
+
+For live infra (optional):
+
+```bash
+NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q
+```
+
+## Authoring Rules
+
+1. One workflow file = one variant; do not add sim2real-specific Python orchestrators.
+2. Keep **terminal: true** on leaf completion states.
+3. Use `plan_assume_decision` in config when planning dynamic loops (`loop_back` vs `promote_checkpoint`).
+4. SkyPilot submits each planned step; the spec does not call `engine.py` or schedulers per workflow.
+5. Cross-stage data uses S3 URIs in config — tools are stateless.
+
+## Examples
+
+| Spec | Purpose |
+| --- | --- |
+| `npa-workflows/vlm-eval-single.yaml` | Single-tool minimal |
+| `npa-workflows/tokenfactory-rollout-judge.yaml` | Serial two-tool |
+| `npa-workflows/sim2real-vlm-rl.yaml` | Fixed + dynamic loops |
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/orchestration/npa_workflow/ npa/tests/smoke/test_npa_workflow_smoke.py -q --tb=no
+```

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -50,10 +50,18 @@ npa/.venv/bin/npa workbench workflow run-spec <spec.yaml> --plan-only --schedule
 
 Dynamic branches: add `--assume-decision promote_checkpoint|loop_back`.
 
-Live infra (optional):
+Live infra (required before merge):
 
 ```bash
-NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q
+NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest \
+  npa/tests/e2e/test_npa_workflow_live_e2e.py \
+  npa/tests/e2e/test_npa_workflow_live_infra.py -q
+```
+
+Tmux full matrix (all golden YAMLs, real S3, credential leak checks):
+
+```bash
+./scripts/npa-workflow-real-infra-tmux.sh
 ```
 
 ## Authoring Rules

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -12,33 +12,45 @@ Load when creating or editing **NPA workflow YAML** under
 transitions, or when helping agents/users convert SkyPilot bash pipelines into
 specs.
 
+For **new creative pipelines**, also load `skills/workflows/generate-npa-workflow/SKILL.md`.
+
 ## Spec Contract
 
 - **Guide:** `docs/workbench/npa-workflow-guide.md` (canonical examples + verify commands).
+- **Catalog:** `docs/workbench/npa-workflow-tool-catalog.md` +
+  `npa/src/npa/orchestration/npa_workflow/catalog.py`.
 - **apiVersion:** `npa.workflow/v0.0.1` only (beta).
 - **kind:** `Workflow`
 - **States:** declarative nodes with `run` (shell/argv), `toolRef`, or `sequence`.
 - **Tokens:** `{{config.key}}`, `{{run.id}}`, `{{run.prefix}}`, `{{state.NAME.uri}}` — no Jinja, no eval.
 - **Predicates:** closed set: `promote_checkpoint`, `loop_back`.
 - **Loops:** `loop.max: "{{config.attr}}"` or integer; `loop.until` for dynamic exit.
-- **I/O:** `inputs` / `outputs` with `uri` + optional `schema` (documentation + future validation).
+- **Decision states:** `writesDecision: true` when the state writes `config.decision_uri`.
+- **needs:** ordering hints only (validated acyclic; not enforced at runtime).
+- **I/O:** `inputs` / `outputs` with `uri` + optional `schema`.
 
-## Tool References
+## Validation Hardening (v0.0.1)
 
-Use `toolRef` from the catalog in
-`docs/workbench/npa-workflow-tool-catalog.md` and
-`npa/src/npa/orchestration/npa_workflow/catalog.py`. Prefer toolRef over
-inventing shell when a catalog entry exists.
+| Check | When |
+| --- | --- |
+| Unknown `toolRef` / predicate | `validate-spec` |
+| Unbounded transition cycles | `validate-spec` (loops do **not** whitelist cycles) |
+| Missing `{{config.*}}`, bad loop max | `validate-spec` via token resolution |
+| Forward `{{state.*}}` refs | Allowed at validate; resolved during plan/execute |
+| Execution depth | Guarded at `--execute` (no stack blowups) |
+| `run.shell` | Resolves config tokens; spec authors are trusted (injection risk if config is untrusted) |
 
-## Commands (agent harness)
+## Commands
 
 ```bash
 npa/.venv/bin/npa workbench workflow validate-spec <spec.yaml> --json
 npa/.venv/bin/npa workbench workflow plan-spec <spec.yaml> --run-id demo --json
-npa/.venv/bin/npa workbench workflow run-spec <spec.yaml> --plan-only --scheduler-plan --persist-state --json
+npa/.venv/bin/npa workbench workflow run-spec <spec.yaml> --plan-only --scheduler-plan --json
 ```
 
-For live infra (optional):
+Dynamic branches: add `--assume-decision promote_checkpoint|loop_back`.
+
+Live infra (optional):
 
 ```bash
 NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_npa_workflow_live_e2e.py -q
@@ -48,21 +60,27 @@ NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_npa_work
 
 1. One workflow file = one variant; do not add sim2real-specific Python orchestrators.
 2. Keep **terminal: true** on leaf completion states.
-3. Use `--assume-decision` when planning dynamic loops (`loop_back` vs `promote_checkpoint`).
-4. SkyPilot submits each planned step; the spec does not call `engine.py` or schedulers per workflow.
-5. Cross-stage data uses S3 URIs in config — tools are stateless.
+3. Use `--assume-decision` when planning specs with `transitions`.
+4. SkyPilot submits each planned step; the spec does not call `engine.py` per workflow.
+5. Cross-stage data uses S3 URIs in `config` — tools are stateless.
+6. Group config: runtime knobs first, then `*_uri` keys under `config.prefix`.
 
-## Examples
+## Golden Examples
 
 | Spec | Purpose |
 | --- | --- |
-| `npa-workflows/vlm-eval-single.yaml` | Single-tool minimal |
-| `npa-workflows/tokenfactory-rollout-judge.yaml` | Serial two-tool |
-| `npa-workflows/sim2real-vlm-rl.yaml` | Fixed + dynamic loops |
-| `npa-workflows/bdd100k-pipeline.yaml` | AV failure-mode LanceDB → train → eval |
+| `vlm-eval-single.yaml` | Single-tool minimal |
+| `tokenfactory-rollout-judge.yaml` | Serial two-tool |
+| `sim2real-vlm-rl.yaml` | Nested loops + dynamic gate |
+| `bdd100k-pipeline.yaml` | AV failure-mode LanceDB → train → eval |
+| `tokenfactory-cosmos-gate.yaml` | Creative reason → augment → VLM gate loop |
 
 ## Verify
 
 ```bash
-npa/.venv/bin/python -m pytest npa/tests/orchestration/npa_workflow/ npa/tests/smoke/test_npa_workflow_smoke.py -q --tb=no
+npa/.venv/bin/python -m pytest npa/tests/orchestration/npa_workflow/ \
+  npa/tests/smoke/test_npa_workflow_smoke.py \
+  npa/tests/smoke/test_all_workflow_yamls.py -q --tb=no
 ```
+
+Tmux matrix: `./scripts/npa-workflow-creative-tmux.sh`

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -14,10 +14,11 @@ specs.
 
 ## Spec Contract
 
+- **Guide:** `docs/workbench/npa-workflow-guide.md` (canonical examples + verify commands).
 - **apiVersion:** `npa.workflow/v0.0.1` only (beta).
 - **kind:** `Workflow`
 - **States:** declarative nodes with `run` (shell/argv), `toolRef`, or `sequence`.
-- **Tokens:** `{{config.key}}`, `{{run.id}}`, `{{run.prefix}}` — no Jinja, no eval.
+- **Tokens:** `{{config.key}}`, `{{run.id}}`, `{{run.prefix}}`, `{{state.NAME.uri}}` — no Jinja, no eval.
 - **Predicates:** closed set: `promote_checkpoint`, `loop_back`.
 - **Loops:** `loop.max: config.attr` or integer; `loop.until` for dynamic exit.
 - **I/O:** `inputs` / `outputs` with `uri` + optional `schema` (documentation + future validation).
@@ -34,7 +35,7 @@ inventing shell when a catalog entry exists.
 ```bash
 npa/.venv/bin/npa workbench workflow validate-spec <spec.yaml> --json
 npa/.venv/bin/npa workbench workflow plan-spec <spec.yaml> --run-id demo --json
-npa/.venv/bin/npa workbench workflow run-spec <spec.yaml> --plan-only --json
+npa/.venv/bin/npa workbench workflow run-spec <spec.yaml> --plan-only --scheduler-plan --persist-state --json
 ```
 
 For live infra (optional):

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -59,6 +59,7 @@ NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest npa/tests/e2e/test_npa_work
 | `npa-workflows/vlm-eval-single.yaml` | Single-tool minimal |
 | `npa-workflows/tokenfactory-rollout-judge.yaml` | Serial two-tool |
 | `npa-workflows/sim2real-vlm-rl.yaml` | Fixed + dynamic loops |
+| `npa-workflows/bdd100k-pipeline.yaml` | AV failure-mode LanceDB → train → eval |
 
 ## Verify
 

--- a/skills/workflows/generate-npa-workflow/SKILL.md
+++ b/skills/workflows/generate-npa-workflow/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: generate-npa-workflow
+description: Use when inventing a new npa.workflow/v0.0.1 pipeline from the tool catalog — creative stage graphs, loops, gates, and golden YAML output.
+---
+
+# Generate NPA Workflow
+
+## When To Use
+
+Load **after** `author-npa-workflow` when the task is to **design a new pipeline**
+(not edit an existing golden spec). Use for creative mashups, customer demos, and
+SkyPilot-to-spec conversions.
+
+## Design Recipe
+
+1. **Pick tools first** — only use `toolRef` values from
+   `npa/src/npa/orchestration/npa_workflow/catalog.py`. Add catalog entries before
+   inventing shell.
+2. **Name the story** — one sentence in `metadata.description` (what flows where).
+3. **Config layout** (beauty convention):
+   - `bucket`, `prefix`, runtime knobs (`vlm_backend`, iteration counts)
+   - blank line
+   - URI keys grouped (`*_uri`) built from `s3://{{config.bucket}}/{{config.prefix}}/…`
+4. **Graph patterns**:
+   | Pattern | YAML shape |
+   | --- | --- |
+   | Linear chain | `next:` edges |
+   | Fan-in deps | `needs:` (ordering hints only) |
+   | Fixed repeat | `loop.max: "{{config.attr}}"` |
+   | Dynamic exit | `loop.until: promote_checkpoint` |
+   | Runtime branch | `transitions` + `writesDecision: true` on the decision state |
+5. **Decision states** — any state that writes `config.decision_uri` must set
+   `writesDecision: true` (never rely on a magic state name like `decide`).
+6. **Terminal** — every completion leaf needs `terminal: true`.
+7. **Validate early** — missing `{{config.*}}` and bad loop bounds fail at
+   `validate-spec`, not at plan/execute.
+
+## Beauty Checklist
+
+- `apiVersion: npa.workflow/v0.0.1` + `kind: Workflow` at top
+- Fold long descriptions with `>` under `metadata.description`
+- One blank line between `config` runtime keys and URI keys
+- `resources` profiles referenced by `states.*.resources`
+- State `description` on every node
+- `inputs` / `outputs` with `uri` + `schema` labels when artifacts cross stages
+- Prefer `toolRef` over `run.shell`
+
+## Creative Example (golden)
+
+`npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml` — Token Factory
+reason → Cosmos augment → VLM critique loop with promote / re-augment gate.
+
+## Generate + Verify
+
+```bash
+# 1. Write YAML under npa/workflows/workbench/npa-workflows/
+# 2. Validate structure + tokens + cycles
+npa/.venv/bin/npa workbench workflow validate-spec <new.yaml> --json
+
+# 3. Plan (use --assume-decision when transitions exist)
+npa/.venv/bin/npa workbench workflow plan-spec <new.yaml> \
+  --run-id creative-demo --assume-decision loop_back --json
+
+# 4. Register in tests — add filename to:
+#    - npa/tests/orchestration/npa_workflow/test_spec.py parametrize
+#    - npa/tests/smoke/test_npa_workflow_smoke.py parametrize
+#    - skills/index.yaml npa_workflow_yaml smoke list (optional)
+
+npa/.venv/bin/python -m pytest npa/tests/orchestration/npa_workflow/ \
+  npa/tests/smoke/test_npa_workflow_smoke.py npa/tests/smoke/test_all_workflow_yamls.py -q
+```
+
+## Anti-Patterns
+
+- Do not add sim2real `engine.py` stages — specs invoke catalog tools only.
+- Do not use Jinja, `eval`, or shell for control flow.
+- Do not create transition cycles — validation rejects unbounded graphs.
+- Do not hardcode bucket/project IDs — use `example-bucket` placeholders.


### PR DESCRIPTION
## Summary
- Introduce `apiVersion: npa.workflow/v0.0.1` — declarative workflow specs (states, loops, transitions, toolRef) shared by YAML, CLI, and SDK.
- Add generic interpreter in `npa/orchestration/npa_workflow/` with `validate-spec`, `plan-spec`, and `run-spec` CLI commands.
- Ship three example specs under `npa/workflows/workbench/npa-workflows/` (vlm-eval, tokenfactory+judge, sim2real VLM→RL with fixed + dynamic loops).
- Add agent harness: `author-npa-workflow` skill, tool catalog doc, JSON schema, unit/smoke/e2e tests.

## Design notes
- Specs invoke **workbench tools** via `toolRef` or `run.shell` — no per-workflow Python orchestrator.
- SkyPilot remains the pod scheduler; the interpreter expands the state machine and plans tool commands.
- Dynamic loops use named predicates (`promote_checkpoint`, `loop_back`) + `plan_assume_decision` for dry-run planning.

## Test plan
- [x] `npa/.venv/bin/python -m pytest npa/tests/orchestration/npa_workflow/ npa/tests/smoke/test_npa_workflow_smoke.py npa/tests/guardrails/test_skills_index.py -q`
- [x] `npa workbench workflow validate-spec npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml`
- [x] `npa workbench workflow plan-spec npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml --assume-decision promote_checkpoint`
- [ ] `NPA_INTEGRATION_E2E=1 pytest npa/tests/e2e/test_npa_workflow_live_e2e.py` (optional live infra)


Made with [Cursor](https://cursor.com)