### PR TITLE
ops: point stock Franka operator guide at main (mandatory-stages merged)

### DIFF
--- a/ops/private/sim2real-rtxpro/FRANKA-STOCK-GUIDE.md
+++ b/ops/private/sim2real-rtxpro/FRANKA-STOCK-GUIDE.md
@@ -11,7 +11,7 @@ When `storage.bucket` changes (for example `lerobot-ccc9d3c7` in `us-central1`),
 
 ```bash
 cd ~/npa-sim2real-demo/nebius-physical-ai
-git pull origin feat/sim2real-mandatory-stages
+git pull origin main
 
 # 1) Copy validated stock LeRobot pusht trigger into your bucket
 ./ops/private/sim2real-rtxpro/seed-stock-trigger.sh
@@ -66,7 +66,7 @@ Replace `<RUN_ID>` with the timestamp id (for example `20260615t172625z`).
 | `ValueError: Invalid endpoint:` (empty) during preflight or secret sync | `AWS_ENDPOINT_URL` empty — credentials lacked endpoint while shell exported blank | Re-run `./setup-local-operator.sh` or ensure `~/.npa/config.yaml` has `storage.endpoint_url: https://storage.us-central1.nebius.cloud`; `./sync-cluster-storage-secret.sh` reads config, not empty env |
 | `./run.sh trigger` syncs old failed run instead of submitting | Stale `RUN_ID` still exported in shell | `unset RUN_ID` then `./run.sh trigger` (trigger always clears RUN_ID; unset if you exported it earlier) |
 | Pod: `AccessDenied` on trigger read | Same credential/endpoint mismatch | Sync secret; confirm trigger exists with `seed-stock-trigger.sh` |
-| `git clone` failure in pod | Wrong `NPA_SOURCE_REF` or GitHub outage | Job uses `feat/sim2real-mandatory-stages` by default |
+| `git clone` failure in pod | Wrong `NPA_SOURCE_REF` or GitHub outage | Job uses `main` by default |
 | ImagePullBackOff | Stale registry token | Re-run submit (refreshes `npa-nebius-registry`) |
 
 ### RUN_ID `sim2real-staged-20260615t172625z` (investigated)

--- a/ops/private/sim2real-rtxpro/lib/sync-operator-repo.sh
+++ b/ops/private/sim2real-rtxpro/lib/sync-operator-repo.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   source .../sync-operator-repo.sh
-#   sync_operator_repo /path/to/nebius-physical-ai feat/sim2real-mandatory-stages
+#   sync_operator_repo /path/to/nebius-physical-ai main
 
 sync_operator_find_git() {
   local candidate


### PR DESCRIPTION
Operator-guide currency fix. `feat/sim2real-mandatory-stages` was merged to main via #117 and `submit-k8s-staged-job.sh` already defaults `NPA_SOURCE_REF=main`, so three operator-doc references to the dead branch are stale:

- `FRANKA-STOCK-GUIDE.md`: `git pull origin feat/sim2real-mandatory-stages` → `main`
- `FRANKA-STOCK-GUIDE.md`: "Job uses `feat/sim2real-mandatory-stages` by default" → `main`
- `lib/sync-operator-repo.sh`: usage-example branch → `main`

Docs-only, ops/private only. No code or feature-PR overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)