### PR TITLE
Generated-physics injection into Isaac Franka training (friction/mass)

### DIFF
--- a/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
@@ -189,6 +189,7 @@ def build_isaac_job_manifest(
     object_usd: str = "",
     object_scale: str = "",
     seed: int = 0,
+    physics: dict[str, float] | None = None,
 ) -> dict[str, Any]:
     """Build the Isaac-Lab RSL-RL training Job manifest (proven by recon).
 
@@ -198,6 +199,15 @@ def build_isaac_job_manifest(
     is trained on a CUSTOM asset physically simulated in Isaac, not the stock cube.
     ``seed`` (from a GENERATED train-env spec) drives env + agent randomization so
     training runs on the envgen-produced env distribution.
+
+    ``physics`` (generated ``{friction, mass_scale}``) selects a different code
+    path: a task VARIANT that adds friction/mass startup events (registered
+    post-boot via the shipped ``isaac_physics_task`` wrapper), because the stock
+    Lift task has no friction/mass field a hydra override could touch. This path
+    is opt-in (the caller gates it on ``NPA_BYO_ISAAC_PHYSICS``) and currently
+    trains the variant's stock cube with default reward weights + the generated
+    seed; it does not also apply VLM reward overrides / custom object (the proven
+    default path below keeps those).
     """
 
     overrides = dict(reward_overrides or {})
@@ -215,18 +225,47 @@ def build_isaac_job_manifest(
     # env cfg types `seed` as None, so hydra rejects an int there ("Incorrect type
     # under namespace: /seed. Expected: NoneType, Received: int").
     seed_arg = f" --seed {int(seed)}" if seed else ""
-    train_line = (
-        f'"$PY" {TRAIN_SCRIPT} --task {task} --num_envs {num_envs} '
-        f'--max_iterations {iterations} --headless{seed_arg} agent.save_interval=25 {override_str}'
-    )
+
+    if physics:
+        # Generated-physics path: ship the isaac_physics_task module + its
+        # post-boot train wrapper into the container and run the wrapper (it
+        # registers the friction/mass variant AFTER AppLauncher boots, then
+        # trains via the rsl_rl runner, saving model_*.pt into $OUT).
+        from npa.workflows.sim2real import isaac_physics_task as _physmod
+
+        module_src = _physmod.module_source()
+        wrapper_src = _physmod.TRAIN_WRAPPER_SCRIPT
+        fr = float(physics.get("friction", 1.0))
+        ms = float(physics.get("mass_scale", 1.0))
+        train_block = (
+            "mkdir -p /tmp/npa_phys\n"
+            "cat > /tmp/npa_phys/isaac_physics_task.py <<'PHYSEOF'\n"
+            + module_src + "\nPHYSEOF\n"
+            "cat > /tmp/npa_phys/runner.py <<'RUNEOF'\n"
+            + wrapper_src + "\nRUNEOF\n"
+            f'echo "PHYSICS_INJECTION: friction={fr} mass_scale={ms} seed={int(seed)}"\n'
+            f'export NPA_PHYS_MODULE_DIR=/tmp/npa_phys PHYS_OUT_DIR="$OUT" '
+            f'PHYS_NUM_ENVS={num_envs} PHYS_ITERS={iterations} PHYS_SEED={int(seed)} '
+            f'NPA_GEN_FRICTION={fr} NPA_GEN_MASS_SCALE={ms}\n'
+            '"$PY" /tmp/npa_phys/runner.py 2>&1 | tail -120\n'
+        )
+    else:
+        train_line = (
+            f'"$PY" {TRAIN_SCRIPT} --task {task} --num_envs {num_envs} '
+            f'--max_iterations {iterations} --headless{seed_arg} agent.save_interval=25 {override_str}'
+        )
+        train_block = (
+            f'echo "VLM_REWARD_OVERRIDES: {override_str}"\n'
+            f'{train_line} 2>&1 | tail -120\n'
+        )
+
     script = (
         "set -uo pipefail\n"
         'exec > >(tee -a /tmp/byo-train.log) 2>&1\n'
         'PY="/isaac-sim/python.sh"; [ -x "$PY" ] || PY="$(command -v python3 || command -v python)"\n'
         f'OUT=/workspace/isaaclab/npa-runs/{run_id}; mkdir -p "$OUT"; cd "$OUT"\n'
-        f'echo "VLM_REWARD_OVERRIDES: {override_str}"\n'
         "set +e\n"
-        f'{train_line} 2>&1 | tail -120\n'
+        f'{train_block}'
         "rc=${PIPESTATUS[0]}; set -e\n"
         'echo "TRAIN_RC=$rc"\n'
         'CKPT=$(find "$OUT" -name \'model_*.pt\' 2>/dev/null | sort -V | tail -1)\n'
@@ -399,6 +438,22 @@ def run_isaac_training_job(run_id: str, *, signal_json: str) -> dict[str, Any]:
         print(f"byo_isaac_trainer: GENERATED train env {train_env.get('env_id')} "
               f"seed={gen_seed} physics={train_env.get('physics')}", flush=True)
 
+    # Opt-in generated-physics injection (guarded; default path unchanged): map the
+    # generated env's friction/mass_scale onto NPA_GEN_* and use the physics-variant
+    # task (friction/mass startup events) instead of stock train.py.
+    physics = None
+    if _env("NPA_BYO_ISAAC_PHYSICS") == "1":
+        from npa.workflows.sim2real import isaac_physics_task as _physmod
+
+        gen_phys = (train_env.get("physics") or {}) if train_env else {}
+        phys_env = {
+            "NPA_GEN_FRICTION": _env("NPA_GEN_FRICTION") or str(gen_phys.get("friction", "")),
+            "NPA_GEN_MASS_SCALE": _env("NPA_GEN_MASS_SCALE") or str(gen_phys.get("mass_scale", "")),
+        }
+        physics = _physmod.physics_params_from_env(phys_env)
+        print(f"byo_isaac_trainer: PHYSICS injection {'ON' if physics else 'OFF (no params)'} "
+              f"-> {physics}", flush=True)
+
     manifest = build_isaac_job_manifest(
         job_name=job_name,
         run_id=run_id,
@@ -415,6 +470,7 @@ def run_isaac_training_job(run_id: str, *, signal_json: str) -> dict[str, Any]:
         object_usd=object_usd,
         object_scale=object_scale,
         seed=gen_seed,
+        physics=physics,
     )
     start = time.time()
     _kubectl(["delete", "job", job_name, "-n", namespace, "--ignore-not-found"], timeout=60)

--- a/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
@@ -84,22 +84,8 @@ def read_signal_stats(signal_json_path: str) -> dict[str, float]:
     }
 
 
-def read_generated_train_env(envs_dir: str) -> dict[str, Any]:
-    """Read a representative GENERATED train-env spec (seed + physics).
-
-    The envgen stage writes one record per generated env with a per-env ``seed``
-    and concrete ``physics`` (friction, mass_scale, lighting_lux). We surface the
-    first record so the trainer can train on the generated env distribution (its
-    seed drives Isaac randomization) rather than stock defaults. Returns ``{}``
-    when no spec is present (envgen not wired / stock run).
-    """
-
-    from pathlib import Path as _Path
-
-    path = _Path(envs_dir) / "envs.jsonl"
-    if not envs_dir or not path.is_file():
-        return {}
-    for line in path.read_text(encoding="utf-8").splitlines():
+def _first_env_record(text: str) -> dict[str, Any]:
+    for line in text.splitlines():
         line = line.strip()
         if not line:
             continue
@@ -112,6 +98,39 @@ def read_generated_train_env(envs_dir: str) -> dict[str, Any]:
             "seed": int(rec.get("seed") or 0),
             "physics": rec.get("physics") or {},
         }
+    return {}
+
+
+def read_generated_train_env(envs_dir: str, *, envs_uri: str = "") -> dict[str, Any]:
+    """Read a representative GENERATED train-env spec (seed + physics).
+
+    The envgen stage writes one record per generated env with a per-env ``seed``
+    and concrete ``physics`` (friction, mass_scale, lighting_lux). We surface the
+    first record so the trainer can train on the generated env distribution (its
+    seed + friction/mass) rather than stock defaults.
+
+    Prefers the local ``envs_dir/envs.jsonl``; falls back to downloading
+    ``envs_uri`` (the S3 ``.../envs/train/envs.jsonl``) when the orchestrator
+    didn't sync the train envs locally (it only localizes the held-out split).
+    Returns ``{}`` when neither source is available (stock run / envgen off).
+    """
+
+    from pathlib import Path as _Path
+
+    path = _Path(envs_dir) / "envs.jsonl" if envs_dir else None
+    if path and path.is_file():
+        return _first_env_record(path.read_text(encoding="utf-8"))
+    if envs_uri.startswith("s3://"):
+        try:
+            import boto3
+            from urllib.parse import urlparse
+
+            u = urlparse(envs_uri)
+            s3 = boto3.client("s3", endpoint_url=os.environ.get("AWS_ENDPOINT_URL") or None)
+            obj = s3.get_object(Bucket=u.netloc, Key=u.path.lstrip("/"))
+            return _first_env_record(obj["Body"].read().decode("utf-8"))
+        except Exception as exc:  # pragma: no cover - network/credentials
+            print(f"byo_isaac_trainer: train-env S3 read failed ({envs_uri}): {exc!r}", flush=True)
     return {}
 
 
@@ -432,7 +451,8 @@ def run_isaac_training_job(run_id: str, *, signal_json: str) -> dict[str, Any]:
 
     # GENERATED train-env spec: seed drives Isaac randomization so the policy
     # trains on the envgen-produced distribution (matches the held-out eval).
-    train_env = read_generated_train_env(_env("NPA_SIM2REAL_TRAIN_ENVS_DIR"))
+    train_env = read_generated_train_env(
+        _env("NPA_SIM2REAL_TRAIN_ENVS_DIR"), envs_uri=_env("NPA_SIM2REAL_TRAIN_ENVS_URI"))
     gen_seed = int(train_env.get("seed") or 0)
     if train_env:
         print(f"byo_isaac_trainer: GENERATED train env {train_env.get('env_id')} "

--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -2951,6 +2951,12 @@ def _run_trainer_via_command(
     # (mirrors how the held-out eval consumes NPA_SIM2REAL_HELDOUT_ENVS_DIR).
     if train_envs_dir is not None:
         extra["NPA_SIM2REAL_TRAIN_ENVS_DIR"] = str(train_envs_dir)
+        # S3 fallback: the orchestrator localizes only the held-out split, so the
+        # trainer reads the generated train-env spec (seed + physics) from S3 when
+        # the local dir is absent.
+        extra["NPA_SIM2REAL_TRAIN_ENVS_URI"] = (
+            f"{_artifact_root_uri(config)}/envs/train/envs.jsonl"
+        )
     env = _component_env(
         config,
         component="trainer",

--- a/npa/src/npa/workflows/sim2real/isaac_physics_task.py
+++ b/npa/src/npa/workflows/sim2real/isaac_physics_task.py
@@ -1,0 +1,121 @@
+"""Inject GENERATED-env physics (friction, mass) into Isaac-Lab training.
+
+The BYO Isaac trainer reads a generated train-env spec that carries concrete
+``physics`` (friction, mass_scale). Today those numbers are read but dropped:
+the stock ``Isaac-Lift-Cube-Franka-v0`` task has no object ``mass_props`` /
+physics-material field to override and no friction/mass startup event, so they
+cannot be applied via a plain hydra ``env.*`` override.
+
+This module registers a task *variant* that adds Isaac-Lab startup
+randomization events (``randomize_rigid_body_material`` /
+``randomize_rigid_body_mass``) on the manipuland, parameterised from the
+generated physics. The trainer imports this module IN-PROCESS (so the gym
+registry sees the new id) and then runs the stock ``train.py`` against
+``NPA_PHYSICS_TASK_ID``. With no physics env vars set, ``register`` is a no-op
+and the loop stays on the stock task — the proven path is untouched.
+
+The pure helpers (``clamp``, ``physics_params_from_env``) are unit-tested
+here; ``register`` touches Isaac-Lab internals and is exercised by an
+on-cluster probe (it imports gymnasium/isaaclab, unavailable off-GPU).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+NPA_PHYSICS_TASK_ID = "NPA-Lift-Cube-Franka-Physics-v0"
+STOCK_TASK_ID = "Isaac-Lift-Cube-Franka-v0"
+
+# Bounds keep a noisy/garbage generated value from producing a degenerate sim
+# (frictionless or absurdly heavy object) that would make training meaningless.
+FRICTION_MIN, FRICTION_MAX = 0.1, 2.0
+MASS_SCALE_MIN, MASS_SCALE_MAX = 0.2, 3.0
+
+
+def clamp(value: Any, lo: float, hi: float, default: float) -> float:
+    """Parse ``value`` as float and clamp to [lo, hi]; ``default`` on garbage."""
+    try:
+        x = float(value)
+    except (TypeError, ValueError):
+        return default
+    if x != x:  # NaN
+        return default
+    return max(lo, min(hi, x))
+
+
+def physics_params_from_env(env: dict[str, str] | None = None) -> dict[str, float] | None:
+    """Build clamped physics params from NPA_GEN_FRICTION / NPA_GEN_MASS_SCALE.
+
+    Returns ``None`` when neither is set, so the caller falls back to the stock
+    task (the generated env had no physics, or physics injection is disabled).
+    """
+    env = os.environ if env is None else env
+    fr = env.get("NPA_GEN_FRICTION")
+    ms = env.get("NPA_GEN_MASS_SCALE")
+    if (fr is None or fr == "") and (ms is None or ms == ""):
+        return None
+    return {
+        "friction": clamp(fr, FRICTION_MIN, FRICTION_MAX, 1.0),
+        "mass_scale": clamp(ms, MASS_SCALE_MIN, MASS_SCALE_MAX, 1.0),
+    }
+
+
+def register(params: dict[str, float] | None = None) -> str | None:
+    """Register the physics task variant in the gym registry; return its id.
+
+    No-op (returns ``None``) when no physics params are available. Imports
+    Isaac-Lab lazily so this module is importable off-GPU for unit tests.
+    """
+    params = params if params is not None else physics_params_from_env()
+    if not params:
+        return None
+
+    import gymnasium as gym  # noqa: WPS433 (lazy: GPU-only dep)
+    from isaaclab.envs import mdp  # noqa: WPS433
+    from isaaclab.managers import EventTermCfg as EventTerm  # noqa: WPS433
+    from isaaclab.managers import SceneEntityCfg  # noqa: WPS433
+    from isaaclab_tasks.manager_based.manipulation.lift.config.franka import (  # noqa: WPS433
+        joint_pos_env_cfg as franka_lift,
+    )
+
+    fr = params["friction"]
+    ms = params["mass_scale"]
+
+    class _PhysicsLiftEnvCfg(franka_lift.FrankaCubeLiftEnvCfg):  # type: ignore[name-defined]
+        def __post_init__(self) -> None:  # noqa: WPS610
+            super().__post_init__()
+            # Static == dynamic friction (single deterministic value from the
+            # generated env); restitution left at 0; one material bucket.
+            self.events.npa_object_material = EventTerm(
+                func=mdp.randomize_rigid_body_material,
+                mode="startup",
+                params={
+                    "asset_cfg": SceneEntityCfg("object"),
+                    "static_friction_range": (fr, fr),
+                    "dynamic_friction_range": (fr, fr),
+                    "restitution_range": (0.0, 0.0),
+                    "num_buckets": 1,
+                },
+            )
+            self.events.npa_object_mass = EventTerm(
+                func=mdp.randomize_rigid_body_mass,
+                mode="startup",
+                params={
+                    "asset_cfg": SceneEntityCfg("object"),
+                    "mass_distribution_params": (ms, ms),
+                    "operation": "scale",
+                },
+            )
+
+    stock_kwargs = gym.spec(STOCK_TASK_ID).kwargs
+    gym.register(
+        id=NPA_PHYSICS_TASK_ID,
+        entry_point="isaaclab.envs:ManagerBasedRLEnv",
+        disable_env_checker=True,
+        kwargs={
+            "env_cfg_entry_point": _PhysicsLiftEnvCfg,
+            "rsl_rl_cfg_entry_point": stock_kwargs.get("rsl_rl_cfg_entry_point"),
+        },
+    )
+    return NPA_PHYSICS_TASK_ID

--- a/npa/src/npa/workflows/sim2real/isaac_physics_task.py
+++ b/npa/src/npa/workflows/sim2real/isaac_physics_task.py
@@ -119,3 +119,108 @@ def register(params: dict[str, float] | None = None) -> str | None:
         },
     )
     return NPA_PHYSICS_TASK_ID
+
+
+def module_source() -> str:
+    """Return this module's own source, for shipping into the Isaac container.
+
+    The Isaac-Lab image has no ``npa`` package, so the BYO trainer writes this
+    file into the job (via heredoc) and the train wrapper imports it post-boot.
+    """
+    from pathlib import Path
+
+    return Path(__file__).read_text(encoding="utf-8")
+
+
+# Post-boot train wrapper (runs INSIDE the Isaac-Lab container). The hard
+# constraint (verified on-cluster): isaaclab.envs/mdp + gym.spec of the stock
+# task pull USD ``pxr``, which only exists AFTER ``AppLauncher`` boots — so the
+# variant registration MUST happen post-boot. This wrapper enforces the order:
+#   (1) boot AppLauncher  (2) import isaaclab_tasks  (3) register the variant
+#   (4) run the rsl_rl OnPolicyRunner like stock train.py.
+# It reuses isaac_physics_task.register() (shipped alongside) as the single
+# source of truth for the friction/mass event terms.
+TRAIN_WRAPPER_SCRIPT = r'''
+import os, sys, traceback
+SYS_DIR = os.environ.get("NPA_PHYS_MODULE_DIR", "/tmp/npa_phys")
+sys.path.insert(0, SYS_DIR)
+NUM_ENVS = int(os.environ.get("PHYS_NUM_ENVS", "64"))
+ITERS = int(os.environ.get("PHYS_ITERS", "2"))
+SEED = int(os.environ.get("PHYS_SEED", "0"))
+OUT = os.environ.get("PHYS_OUT_DIR", "/tmp/physrun")
+os.makedirs(OUT, exist_ok=True)
+# (1) boot the sim app FIRST — everything Isaac/pxr must come after this.
+from isaaclab.app import AppLauncher
+app = AppLauncher(headless=True).app
+import torch
+import gymnasium as gym
+# (2) register the stock tasks, then (3) the physics variant (post-boot import).
+import isaaclab_tasks  # noqa: F401
+import isaac_physics_task as physmod
+params = physmod.physics_params_from_env()
+print("PHYS_PARAMS", params, flush=True)
+try:
+    task = physmod.register(params)
+except Exception:
+    print("PHYS_REGISTER_FAILED", flush=True); traceback.print_exc(); os._exit(42)
+task = task or physmod.STOCK_TASK_ID
+print("PHYS_TASK", task, flush=True)
+# (4) build env + rsl_rl runner and train, like stock train.py.
+try:
+    from isaaclab_tasks.utils import parse_env_cfg, load_cfg_from_registry
+    try:
+        from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
+    except Exception:
+        from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper  # older layout
+    from rsl_rl.runners import OnPolicyRunner
+    env_cfg = parse_env_cfg(task, device="cuda:0", num_envs=NUM_ENVS)
+    if SEED:
+        try:
+            env_cfg.seed = SEED
+        except Exception as e:
+            print("could not set env_cfg.seed:", repr(e), flush=True)
+        torch.manual_seed(SEED)
+    agent_cfg = load_cfg_from_registry(task, "rsl_rl_cfg_entry_point")
+    acfg = agent_cfg.to_dict() if hasattr(agent_cfg, "to_dict") else dict(agent_cfg)
+    acfg["max_iterations"] = ITERS
+    # Guarantee a checkpoint even for a tiny probe run.
+    acfg["save_interval"] = max(1, min(int(acfg.get("save_interval", 50) or 50), ITERS))
+    if SEED:
+        acfg["seed"] = SEED
+    print("PHYS_AGENT_CFG_KEYS", sorted(acfg.keys()), flush=True)
+    env = gym.make(task, cfg=env_cfg)
+    # Definitive check that the generated-physics events are LIVE (not a silent
+    # stock fallback): the variant's event manager must carry our startup terms.
+    try:
+        ev_terms = list(getattr(env.unwrapped, "event_manager").active_terms.get("startup", []))
+    except Exception:
+        try:
+            ev_terms = list(env.unwrapped.event_manager.active_terms)
+        except Exception:
+            ev_terms = []
+    has_phys = any("npa_object_material" in str(t) for t in ev_terms) and \
+               any("npa_object_mass" in str(t) for t in ev_terms)
+    print("PHYS_EVENT_TERMS", ev_terms, "has_physics_events", has_phys, flush=True)
+    env = RslRlVecEnvWrapper(env)
+    runner = OnPolicyRunner(env, acfg, log_dir=OUT, device="cuda:0")
+    runner.learn(num_learning_iterations=ITERS, init_at_random_ep_len=True)
+    # Defensive explicit save (learn saves at save_interval; ensure one exists).
+    try:
+        runner.save(os.path.join(OUT, "model_%d.pt" % ITERS))
+    except Exception as e:
+        print("explicit save failed (learn may have saved already):", repr(e), flush=True)
+    import glob
+    ckpts = sorted(glob.glob(os.path.join(OUT, "**", "model_*.pt"), recursive=True))
+    # Final summary (survives any upstream log truncation): task + applied physics
+    # + whether the injected events were present + checkpoint count.
+    print("PHYS_SUMMARY task=%s friction=%s mass_scale=%s physics_events=%s ckpts=%d"
+          % (task, (params or {}).get("friction"), (params or {}).get("mass_scale"),
+             has_phys, len(ckpts)), flush=True)
+    print("PHYS_CKPTS", ckpts, flush=True)
+    print("PHYS_TRAIN_DONE" if (ckpts and has_phys) else "PHYS_TRAIN_NO_CKPT", flush=True)
+except Exception:
+    print("PHYS_TRAIN_FAILED", flush=True); traceback.print_exc(); os._exit(43)
+sys.stdout.flush(); sys.stderr.flush()
+os._exit(0)
+'''
+

--- a/npa/tests/workflows/test_byo_isaac_trainer.py
+++ b/npa/tests/workflows/test_byo_isaac_trainer.py
@@ -241,3 +241,31 @@ def test_manifest_default_path_unchanged_without_physics():
     assert byo.TRAIN_SCRIPT in args
     assert "isaac_physics_task.py" not in args
     assert "--seed 42" in args
+
+
+def test_read_generated_train_env_s3_fallback(tmp_path, monkeypatch):
+    # Local dir missing -> falls back to the S3 URI (orchestrator only syncs heldout).
+    captured = {}
+
+    class _FakeBody:
+        def read(self_inner):
+            return (b'{"env_id": "env-00006", "seed": 99, '
+                    b'"physics": {"friction": 0.71, "mass_scale": 0.93}}\n')
+
+    class _FakeS3:
+        def get_object(self_inner, Bucket, Key):
+            captured["bucket"] = Bucket
+            captured["key"] = Key
+            return {"Body": _FakeBody()}
+
+    import boto3
+
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: _FakeS3())
+    rec = byo.read_generated_train_env(
+        str(tmp_path / "nope"),
+        envs_uri="s3://bucket/sim2real-b/run1/envs/train/envs.jsonl",
+    )
+    assert rec["env_id"] == "env-00006"
+    assert rec["physics"]["friction"] == 0.71
+    assert captured["bucket"] == "bucket"
+    assert captured["key"] == "sim2real-b/run1/envs/train/envs.jsonl"

--- a/npa/tests/workflows/test_byo_isaac_trainer.py
+++ b/npa/tests/workflows/test_byo_isaac_trainer.py
@@ -208,3 +208,36 @@ def test_manifest_no_seed_arg_when_zero():
         seed=0)
     args = m["spec"]["template"]["spec"]["containers"][0]["args"][0]
     assert "--seed" not in args
+
+
+def test_manifest_physics_path_ships_wrapper_and_skips_stock_train():
+    m = byo.build_isaac_job_manifest(
+        job_name="j", run_id="r", image="reg/npa-isaac-lab:2.3.2.post1",
+        task="Isaac-Lift-Cube-Franka-v0", num_envs=64, iterations=2,
+        s3_output_uri="s3://b/o/", s3_endpoint="https://s3", namespace="default",
+        service_account="agent-sa", gpu_product="NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition",
+        seed=736958930, physics={"friction": 0.7, "mass_scale": 0.95})
+    args = m["spec"]["template"]["spec"]["containers"][0]["args"][0]
+    # ships the module + wrapper, sets the generated physics, runs the wrapper
+    assert "isaac_physics_task.py" in args and "runner.py" in args
+    assert "NPA_GEN_FRICTION=0.7" in args and "NPA_GEN_MASS_SCALE=0.95" in args
+    assert "PHYS_SEED=736958930" in args
+    assert "/tmp/npa_phys/runner.py" in args
+    # physics path does NOT invoke stock train.py
+    assert byo.TRAIN_SCRIPT not in args
+    # still uploads model_latest.pt via the shared tail
+    assert "model_latest.pt" in args
+
+
+def test_manifest_default_path_unchanged_without_physics():
+    m = byo.build_isaac_job_manifest(
+        job_name="j", run_id="r", image="reg/npa-isaac-lab:2.3.2.post1",
+        task="Isaac-Lift-Cube-Franka-v0", num_envs=512, iterations=30,
+        s3_output_uri="s3://b/o/", s3_endpoint="https://s3", namespace="default",
+        service_account="agent-sa", gpu_product="NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition",
+        seed=42)
+    args = m["spec"]["template"]["spec"]["containers"][0]["args"][0]
+    # proven path: stock train.py, no physics wrapper
+    assert byo.TRAIN_SCRIPT in args
+    assert "isaac_physics_task.py" not in args
+    assert "--seed 42" in args

--- a/npa/tests/workflows/test_isaac_physics_task.py
+++ b/npa/tests/workflows/test_isaac_physics_task.py
@@ -1,0 +1,40 @@
+"""Unit tests for the pure helpers of the generated-physics task injector.
+
+``register`` itself imports Isaac-Lab (GPU-only) and is verified by an
+on-cluster probe, not here.
+"""
+
+from __future__ import annotations
+
+from npa.workflows.sim2real import isaac_physics_task as pt
+
+
+def test_clamp_parses_and_bounds():
+    assert pt.clamp("0.7", 0.1, 2.0, 1.0) == 0.7
+    assert pt.clamp("5.0", 0.1, 2.0, 1.0) == 2.0   # above max -> max
+    assert pt.clamp("0.0", 0.1, 2.0, 1.0) == 0.1   # below min -> min
+    assert pt.clamp("garbage", 0.1, 2.0, 1.0) == 1.0  # unparseable -> default
+    assert pt.clamp(None, 0.1, 2.0, 1.0) == 1.0
+    assert pt.clamp(float("nan"), 0.1, 2.0, 1.0) == 1.0
+
+
+def test_physics_params_none_when_unset():
+    assert pt.physics_params_from_env({}) is None
+    assert pt.physics_params_from_env({"NPA_GEN_FRICTION": "", "NPA_GEN_MASS_SCALE": ""}) is None
+
+
+def test_physics_params_clamped_from_env():
+    p = pt.physics_params_from_env({"NPA_GEN_FRICTION": "0.717", "NPA_GEN_MASS_SCALE": "0.969"})
+    assert p == {"friction": 0.717, "mass_scale": 0.969}
+
+
+def test_physics_params_one_field_present_uses_default_for_other():
+    p = pt.physics_params_from_env({"NPA_GEN_FRICTION": "1.4"})
+    assert p["friction"] == 1.4
+    assert p["mass_scale"] == 1.0  # missing -> default, still active
+
+
+def test_physics_params_garbage_is_bounded_not_crash():
+    p = pt.physics_params_from_env({"NPA_GEN_FRICTION": "-9", "NPA_GEN_MASS_SCALE": "999"})
+    assert p["friction"] == pt.FRICTION_MIN
+    assert p["mass_scale"] == pt.MASS_SCALE_MAX

--- a/npa/tests/workflows/test_isaac_physics_task.py
+++ b/npa/tests/workflows/test_isaac_physics_task.py
@@ -38,3 +38,24 @@ def test_physics_params_garbage_is_bounded_not_crash():
     p = pt.physics_params_from_env({"NPA_GEN_FRICTION": "-9", "NPA_GEN_MASS_SCALE": "999"})
     assert p["friction"] == pt.FRICTION_MIN
     assert p["mass_scale"] == pt.MASS_SCALE_MAX
+
+
+def test_module_source_is_self_contained():
+    src = pt.module_source()
+    # Shipped into the Isaac container, so it must carry the helpers + register.
+    assert "def physics_params_from_env" in src
+    assert "def register(" in src
+    assert "randomize_rigid_body_material" in src
+
+
+def test_train_wrapper_enforces_boot_before_isaac_imports():
+    s = pt.TRAIN_WRAPPER_SCRIPT
+    # AppLauncher boot MUST precede any isaaclab/isaac_physics_task import — the
+    # whole point of the wrapper (pre-boot isaaclab import pulls pxr and dies).
+    boot = s.index("AppLauncher(headless=True).app")
+    assert boot < s.index("import isaaclab_tasks")
+    assert boot < s.index("import isaac_physics_task")
+    assert s.index("import isaaclab_tasks") < s.index("physmod.register")
+    # trains via the rsl_rl runner and emits the done/ckpt markers
+    assert "OnPolicyRunner" in s and "runner.learn" in s
+    assert "PHYS_TRAIN_DONE" in s


### PR DESCRIPTION
Injects a **generated** sim2real train-env's physics (friction, mass_scale) into Isaac-Lab Franka-lift training, so synthetic env data shapes the trained policy. Opt-in and guarded — the proven default path is unchanged.

## Why a task variant (not a hydra override)
Stock `Isaac-Lift-Cube-Franka-v0` has no object friction/mass field a `env.*` hydra override could touch. So `isaac_physics_task` registers a **variant** that adds `randomize_rigid_body_material` + `randomize_rigid_body_mass` **startup events** on the manipuland, parameterised from the generated `{friction, mass_scale}` (clamped to sane bounds).

## The blocker + the fix (post-boot wrapper)
Verified on-cluster: importing `isaaclab.envs/mdp` or `gym.spec`-ing the stock task **before `AppLauncher` boots** fails — they pull USD `pxr`, which only exists post-boot. So registration must be post-boot. `TRAIN_WRAPPER_SCRIPT` enforces the order: **(1) boot AppLauncher → (2) import `isaaclab_tasks` → (3) register the variant → (4) train via the rsl_rl `OnPolicyRunner`** (like stock `train.py`), saving `model_*.pt`. `module_source()` ships the module into the Isaac container (no `npa` pkg there); `register()` stays the single source of truth.

## Trainer wiring (guarded)
`byo_isaac_trainer` builds the physics path only when **`NPA_BYO_ISAAC_PHYSICS=1`**: it maps the generated env's friction/mass onto `NPA_GEN_*`, ships the module + wrapper into the Isaac job, and runs the wrapper instead of stock `train.py` (the checkpoint-upload tail is reused). When the flag is unset, the proven default path (stock `train.py` + VLM reward overrides + custom object + `--seed`) is byte-for-byte unchanged. The generated train-env spec is read locally, falling back to S3 (`NPA_SIM2REAL_TRAIN_ENVS_URI`) since the orchestrator localizes only the held-out split.

## Cluster verification (npa-rtxpro-mk8s, npa-isaac-lab:2.3.2.post1)
1. **Component probe** `s2r-npa-physics-probe2`: post-boot register + 2-iter train; `PHYS_EVENT_TERMS ['npa_object_material','npa_object_mass']`, `has_physics_events True`, 3 checkpoints, `RUNNER_RC=0`.
2. **Trainer-manifest check** `byo-physics-check`: the actual `build_isaac_job_manifest` physics output trains the variant + uploads `model_latest.pt` (`TRAIN_RC=0`).
3. **Staged auto-resolution** `sim2real-physinj2-20260621t045058z`: end-to-end staged loop, `NPA_BYO_ISAAC_PHYSICS=1`. The trainer read a **real generated env's** physics (friction=1.064, mass_scale=0.872) from S3 and trained the variant — `PHYS_SUMMARY ... physics_events=True`, `PHYS_TRAIN_DONE`, `TRAIN_RC=0`. (A first staged attempt surfaced + fixed the missing-local-train-envs bug.)

## Scope / honest caveats
- Physics mode trains the variant's **stock cube with default reward weights** + the generated seed; composing it with VLM reward shaping / a custom object USD in one run is future work.
- `simready://` scene-catalog URIs (warehouse/tabletop) are placeholders with **no real USD** behind them — loading those needs an asset-pipeline resolver (separate product gap).
- This is real physics randomization, not a stub: the friction/mass values come from the generated env and are live in the env's startup event manager.

8 unit tests (pure helpers + wrapper invariants + manifest shape + S3 fallback); 67 sim2real-loop tests green. `ops/private` operator tooling is intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
