### PR TITLE
feat(sim2real): default Franka manipuland to a real USD sim asset

### DIFF
--- a/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
@@ -547,7 +547,11 @@ def run_isaac_eval_job(
     env_ids = [e["env_id"] for e in gen] or None
     seeds = [e["seed"] for e in gen] or None
     seed = int(gen[0]["seed"]) if gen else 0  # drive randomization from a generated-env seed
-    object_usd = _env("NPA_BYO_ISAAC_OBJECT_USD")
+    # Eval must spawn the SAME manipuland the policy trained on (default: the
+    # proven rigid-ready USD, not the stock primitive cube).
+    from npa.workflows.sim2real.byo_isaac_trainer import resolve_object_usd
+
+    object_usd = resolve_object_usd(_env("NPA_BYO_ISAAC_OBJECT_USD"))
     renders_prefix = f"s3://{bucket}/sim2real-b/{run_id}/byo-eval/{job_name}/renders"
 
     manifest = build_isaac_eval_job_manifest(

--- a/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
@@ -483,7 +483,11 @@ def run_isaac_rollout_job(
     gpu_product = _env("NPA_SIM2REAL_K8S_GPU_PRODUCT", DEFAULT_GPU_PRODUCT)
     endpoint = _env("AWS_ENDPOINT_URL")
     timeout_s = int(_env("NPA_BYO_ISAAC_JOB_TIMEOUT_S", "5400") or 5400)
-    object_usd = _env("NPA_BYO_ISAAC_OBJECT_USD")
+    # Rollouts spawn the SAME manipuland as train/eval (default: the proven
+    # rigid-ready USD, not the stock primitive cube).
+    from npa.workflows.sim2real.byo_isaac_trainer import resolve_object_usd
+
+    object_usd = resolve_object_usd(_env("NPA_BYO_ISAAC_OBJECT_USD"))
 
     checkpoint_uri = latest_checkpoint_uri(bucket, run_id, s3_endpoint=endpoint)
     # Unique per (run, outer, inner) — the engine sets a distinct OUTPUT_DIR name.

--- a/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
@@ -41,6 +41,37 @@ DEFAULT_ITERATIONS = 150
 DEFAULT_GPU_PRODUCT = "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition"
 TRAIN_SCRIPT = "/workspace/isaaclab/scripts/reinforcement_learning/rsl_rl/train.py"
 
+# Root of the public Omniverse Isaac asset CDN (no tenant/private IDs). Override
+# with NPA_ISAAC_NUCLEUS_DIR to point at an internal Nucleus mirror.
+DEFAULT_ISAAC_NUCLEUS_DIR = (
+    "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/5.1/Isaac"
+)
+# Rigid-ready (RigidBodyAPI: collision + mass) instanceable manipuland. Defaulting
+# to it means the Franka loop trains/evals on a real physically simulated USD sim
+# asset instead of the stock primitive cube. A raw visual mesh would fail to spawn.
+DEFAULT_OBJECT_USD_REL = "Props/Blocks/MultiColorCube/multi_color_cube_instanceable.usd"
+# Sentinels that opt back out of the USD default to the built-in primitive cube.
+_STOCK_OBJECT_USD_SENTINELS = frozenset({"stock", "none", "primitive", "builtin"})
+
+
+def default_isaac_object_usd() -> str:
+    """Resolved default manipuland USD (Nucleus root + rigid-ready instanceable)."""
+    nuc = (os.environ.get("NPA_ISAAC_NUCLEUS_DIR", "") or DEFAULT_ISAAC_NUCLEUS_DIR).strip()
+    return f"{nuc.rstrip('/')}/{DEFAULT_OBJECT_USD_REL}"
+
+
+def resolve_object_usd(raw: str) -> str:
+    """Resolve the manipuland USD for an Isaac job.
+
+    An explicit ``NPA_BYO_ISAAC_OBJECT_USD`` wins; a ``stock``/``none`` sentinel
+    forces the built-in primitive cube (empty string); unset defaults to the
+    proven rigid-ready MultiColorCube so Franka uses a real sim asset by default.
+    """
+    val = (raw or "").strip()
+    if val.lower() in _STOCK_OBJECT_USD_SENTINELS:
+        return ""
+    return val or default_isaac_object_usd()
+
 
 # --------------------------------------------------------------------------- #
 # Pure helpers (unit-tested without a cluster)
@@ -444,10 +475,13 @@ def run_isaac_training_job(run_id: str, *, signal_json: str) -> dict[str, Any]:
     stats = read_signal_stats(signal_json)
     reward_overrides = vlm_reward_overrides(stats)
     print(f"byo_isaac_trainer: VLM reward overrides -> {reward_overrides}", flush=True)
-    object_usd = _env("NPA_BYO_ISAAC_OBJECT_USD")
+    object_usd = resolve_object_usd(_env("NPA_BYO_ISAAC_OBJECT_USD"))
     object_scale = _env("NPA_BYO_ISAAC_OBJECT_SCALE")
     if object_usd:
-        print(f"byo_isaac_trainer: CUSTOM object USD -> {object_usd} scale={object_scale}", flush=True)
+        default_tag = " (default)" if not _env("NPA_BYO_ISAAC_OBJECT_USD") else ""
+        print(f"byo_isaac_trainer: object USD -> {object_usd}{default_tag} scale={object_scale}", flush=True)
+    else:
+        print("byo_isaac_trainer: stock primitive cube (object USD opted out)", flush=True)
 
     # GENERATED train-env spec: seed drives Isaac randomization so the policy
     # trains on the envgen-produced distribution (matches the held-out eval).

--- a/npa/tests/workflows/test_byo_isaac_trainer.py
+++ b/npa/tests/workflows/test_byo_isaac_trainer.py
@@ -167,6 +167,32 @@ def test_manifest_embeds_custom_object_usd():
     assert "env.scene.object.spawn.scale='(0.8, 0.8, 0.8)'" in args
 
 
+def test_resolve_object_usd_defaults_to_rigid_ready_cube(monkeypatch):
+    # Unset -> proven rigid-ready MultiColorCube on the public Omniverse CDN.
+    monkeypatch.delenv("NPA_ISAAC_NUCLEUS_DIR", raising=False)
+    usd = byo.resolve_object_usd("")
+    assert usd.endswith(byo.DEFAULT_OBJECT_USD_REL)
+    assert usd.startswith("https://omniverse-content-production")
+    assert usd == byo.default_isaac_object_usd()
+
+
+def test_resolve_object_usd_explicit_wins(monkeypatch):
+    monkeypatch.delenv("NPA_ISAAC_NUCLEUS_DIR", raising=False)
+    assert byo.resolve_object_usd("s3://b/custom.usd") == "s3://b/custom.usd"
+
+
+def test_resolve_object_usd_stock_sentinel_opts_out():
+    # Operator escape hatch: fall back to the built-in primitive cube.
+    for sentinel in ("stock", "none", "PRIMITIVE", " Builtin "):
+        assert byo.resolve_object_usd(sentinel) == ""
+
+
+def test_default_isaac_object_usd_honors_nucleus_override(monkeypatch):
+    monkeypatch.setenv("NPA_ISAAC_NUCLEUS_DIR", "https://mirror.internal/Isaac/")
+    usd = byo.default_isaac_object_usd()
+    assert usd == f"https://mirror.internal/Isaac/{byo.DEFAULT_OBJECT_USD_REL}"
+
+
 def test_read_generated_train_env(tmp_path):
     envs = tmp_path / "envs.jsonl"
     envs.write_text(


### PR DESCRIPTION
## What

Make the Franka Isaac real-RL path use a **real, physically simulated USD sim asset** for the manipuland by default, instead of the stock built-in primitive cube.

Previously the BYO Isaac trainer/eval/rollout only spawned a custom object when the operator explicitly set `NPA_BYO_ISAAC_OBJECT_USD`; unset → stock primitive cube. This wires the proven rigid-ready **MultiColorCube** instanceable (served from the public Omniverse Isaac content CDN) as the default.

## Changes

- `byo_isaac_trainer.py`: add `DEFAULT_ISAAC_NUCLEUS_DIR`, `DEFAULT_OBJECT_USD_REL`, and shared `default_isaac_object_usd()` / `resolve_object_usd()`.
- `byo_isaac_trainer.py`, `byo_isaac_eval.py`, `byo_isaac_policy_rollout.py`: route the `NPA_BYO_ISAAC_OBJECT_USD` read through `resolve_object_usd()` so train, rollout, and eval spawn the **same** manipuland.
- Asset root is overridable via `NPA_ISAAC_NUCLEUS_DIR` (e.g. an internal Nucleus mirror). A `stock`/`none`/`primitive` sentinel opts back out to the built-in cube.
- Unit tests: default, explicit-wins, sentinel opt-out, nucleus-dir override.

## Notes

- No tenant/private IDs — only the public Omniverse content CDN URL.
- Scope is the BYO real-RL path (`trainer_source: byo_command`); the reference-stub default loop is unchanged.
- The USD must be rigid-ready (`RigidBodyAPI`); the MultiColorCube instanceable is (a raw visual mesh would fail to spawn).

## Test

```
pytest npa/tests/workflows/test_byo_isaac_trainer.py \
       npa/tests/workflows/test_byo_isaac_eval.py \
       npa/tests/workflows/test_byo_isaac_policy_rollout.py
# 38 passed
```

Live RTX-cluster validation (staged Franka Isaac run) in progress; will note the result here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)