### PR TITLE
Set up Cloud Agent dev environment for npa

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,31 @@ Compatibility symlinks exist at `.agents/skills` and `.claude/skills`; do not ad
 ## Partner Capability Roadmap
 
 Onboarding NVIDIA Physical AI / Omniverse capabilities (NuRec, CAD-to-SimReady, USD tooling, defect-image SDG, video data augmentation, SDG infrastructure) is tracked in `docs/architecture/partner-skills-roadmap.md`. Those are not yet implemented in the workbench; add each as a real skill only when its solution lands on Nebius + SkyPilot, with tests.
+
+## Cursor Cloud specific instructions
+
+`npa` is a CLI/SDK (Typer), not a long-running server; there is no dev server to
+start. The dev loop is lint + unit tests + invoking the `npa` CLI. The update
+script already provisions the venv at `npa/.venv` and installs `npa[dev]`.
+
+- Always use the venv interpreter: `npa/.venv/bin/python` and `npa/.venv/bin/npa`
+  (per the repo `Key Conventions`).
+- Lint / test / build commands are defined in the root `Makefile` and
+  `CONTRIBUTING.md`. Pass the venv explicitly, e.g.
+  `make test PYTHON=/workspace/npa/.venv/bin/python` (also `make lint`,
+  `make test-smoke`). `make` targets run `pytest`/`ruff` from inside `npa/`.
+- The full `make test` suite (~2240 unit tests) is hermetic (no cloud/GPU/network)
+  but takes ~3.5 min; run it in the background and poll rather than blocking.
+- `make lint` currently reports pre-existing `ruff` failures on a clean tree
+  (mostly unused-import F401 in tests); they are not caused by your changes. Use
+  `make format` to autofix only what you touched, and do not mass-rewrite
+  unrelated files.
+- No-cloud smoke / "hello world": the offline stub VLM-eval benchmark from the
+  README runs with zero credentials and writes a ranked report
+  (`best_config.metrics.accuracy == 1.0`):
+  `npa/.venv/bin/npa workbench vlm-eval benchmark --dataset npa/src/npa/workbench/vlm_eval/fixtures/sample_benchmark/benchmark.json --output /tmp/vlm-eval-benchmark.json --backend stub --thresholds 0.5,0.8,0.9 --rubrics default,strict --models Qwen/Qwen2-VL-7B-Instruct --format json`
+- Anything beyond the stub path (real workbench tools, `npa configure`, e2e
+  markers, SkyPilot, GPU) needs Nebius credentials in `~/.npa/credentials.yaml`
+  and external infra; those are intentionally out of scope for local dev.
+- System dependency note: creating the venv requires the `python3.12-venv` apt
+  package (already present in the snapshot); it is not installed by `pip`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `npa` (Nebius Physical AI) CLI/SDK so future Cloud Agents can lint, test, and run the application out of the box.

`npa` is a Typer-based CLI/SDK (not a long-running server), so the dev loop is **lint + unit tests + invoking the `npa` CLI**. There is no dev server to boot.

## What was done

- **Dependencies:** Provisioned a Python venv at `npa/.venv` (Python 3.12) and installed `npa[dev]` (editable install + pytest/ruff/server extras). The system package `python3.12-venv` is required to create the venv.
- **Update script** (minimal, idempotent — dependency refresh only):

```bash
test -d npa/.venv || python3 -m venv npa/.venv
npa/.venv/bin/python -m pip install -e "npa[dev]"
```

- **AGENTS.md:** Added a `## Cursor Cloud specific instructions` section with durable, non-obvious notes (use `npa/.venv/bin/python`; `make` targets run from `npa/`; full suite is ~3.5 min; `make lint` has pre-existing failures unrelated to changes; the no-cloud stub hello-world command).

## Verification

| Step | Command | Result |
| --- | --- | --- |
| Lint | `make lint PYTHON=/workspace/npa/.venv/bin/python` | Runs (26 pre-existing `ruff` errors on clean tree, not introduced here) |
| Tests | `make test PYTHON=/workspace/npa/.venv/bin/python` | **2230 passed, 14 skipped, 1 xpassed, 0 failures** (~3.5 min) |
| Run (hello-world) | `npa workbench vlm-eval benchmark ... --backend stub` | Ranked report with `best_config.metrics.accuracy == 1.0` (2 pass / 2 fail correctly classified) |

The hello-world task scores a shipped sample robot-rollout set with the offline stub VLM-eval backend (zero credentials, no GPU) and produces a ranked report — exercising the core Workbench evaluation flow.

No application code was modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cf717ac-f675-44ce-84ac-1e2ffe0cd058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cf717ac-f675-44ce-84ac-1e2ffe0cd058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

