### PR TITLE
feat(sim2real): export trained policy to ONNX with obs/action contract

### DIFF
--- a/docs/architecture/policy-export-onnx.md
+++ b/docs/architecture/policy-export-onnx.md
@@ -1,0 +1,104 @@
+# Policy export to ONNX (deployable inference)
+
+## What gap this closes
+
+The sim2real BYO trainer produces an rsl_rl `OnPolicyRunner` checkpoint
+(`model_*.pt`) and uploads it to S3. That checkpoint stores an `ActorCritic`
+`model_state_dict`; running the trained policy from it requires **torch *and*
+Isaac Lab** on the consumer. A robot controller, an edge box, or a lightweight
+inference service should not have to install that stack.
+
+`npa.workflows.sim2real.policy_export` re-materializes the actor MLP directly
+from the checkpoint's `model_state_dict` (no Isaac Lab, no environment
+construction) and exports it to ONNX, plus a `policy_contract.json` sidecar. The
+exported `policy.onnx` then runs with nothing but `onnxruntime` (CPU) — the same
+runtime convention SONIC eval already uses (`npa.workbench.sonic.eval`).
+
+```
+model_975.pt (rsl_rl ActorCritic)            policy.onnx        (single file)
+  actor.0/2/4/6 = MLP 36→256→128→64→8   ──►  policy_contract.json
+  critic.*, std (dropped for inference)      obs[1,36] → action[1,8]
+```
+
+## What you get
+
+- **Portable inference.** `policy.onnx` is a single self-contained file (weights
+  embedded, no external-data sidecar) consumable by any ONNX runtime, in any
+  language, on CPU. No torch, no Isaac, no GPU required.
+- **An explicit obs/action contract** (`policy_contract.json`) describing exactly
+  what the consumer must feed and how to interpret the output.
+- **Faithful export.** The exported graph reproduces the rsl_rl actor's
+  deterministic (mean) action. A real-checkpoint round-trip matches the torch
+  actor to within `~2.4e-6` (see `npa/tests/workflows/test_policy_export.py`).
+
+### CLI
+
+```bash
+npa workbench isaac-lab export-onnx \
+  --input-path s3://<bucket>/sim2real-b/<run>/byo-trainer/.../checkpoints/model_975.pt \
+  --task Isaac-Lift-Cube-Franka-v0 \
+  --output-path s3://<bucket>/<run>/onnx/      # or a local directory
+```
+
+`--input-path`/`--output-path` accept either an `s3://` URI or a local path
+(this is an in-pod/local export step — torch lives in the pod, not the public
+CLI host). `obs_dim`/`act_dim` are inferred from the actor's first/last layer; an
+explicit `--obs-dim`/`--act-dim` is cross-checked and a mismatch is an error.
+
+## The contract the real robot must satisfy
+
+`policy_contract.json` (`format: npa_sim2real_onnx_export_v1`) declares:
+
+| field | meaning |
+|-------|---------|
+| `obs.dim`, `obs.dtype`, `obs.shape` | input is `float32` `[batch, obs_dim]` on the `obs` tensor |
+| `obs.layout` | ordered observation-term names + dims **when recoverable** from the task's observation manager; otherwise `kind: "opaque"` with the guarantee that it is a flat vector in the **same term order the sim used during training** |
+| `action.dim`, `action.dtype` | output is `float32` `[batch, act_dim]` on the `action` tensor |
+| `action.type`, `scaling`, `limits` | declared action-space semantics (e.g. `joint_position`); known-task hints are filled from a conservative registry, everything else is `opaque` and must be confirmed against the Isaac task `ActionManager` |
+| `normalization` | `none` for a raw-obs actor; if the checkpoint carries an rsl_rl `EmpiricalNormalization`, it is **baked into the ONNX graph** so the consumer always feeds raw observations |
+| `network` | `mlp`, activation (rsl_rl default `elu`), hidden dims |
+| `checkpoint` | provenance: source URI/path, filename, size, sha256, train iter |
+
+The consumer's job: build an observation vector of length `obs.dim` in the
+declared order/units/frame, run the session, and apply the `action` vector with
+the declared action semantics.
+
+## ⚠️ Export is necessary, NOT sufficient, for sim-to-real
+
+**ONNX export makes the policy portable. It does NOT make it correct on a real
+robot.** Nothing in this step bridges the sim-to-real gap:
+
+- **No domain randomization.** The policy is exported exactly as trained. If
+  training had no randomization over physics, friction, mass, latency, sensor
+  noise, etc., the exported policy is as brittle as the trained one.
+- **No real-dynamics validation.** The export never touches a real robot or a
+  validated real-dynamics model. A high sim reward says nothing about hardware
+  behavior.
+- **No observation alignment.** The contract *documents* the obs layout; it does
+  not *guarantee* your real sensor pipeline produces the same vector. If the real
+  robot's joint ordering, units, frames, or term order differ from the sim
+  observation manager — even subtly — the policy will receive out-of-distribution
+  input and act unpredictably. Aligning the real observation pipeline to the sim
+  contract is the integrator's responsibility and is the most common failure
+  mode.
+- **No action-space verification.** `action.type`/`scaling`/`limits` are declared
+  best-effort. The exact mapping (absolute vs. delta, scale, default-joint
+  offset, gripper encoding, safety limits) comes from the Isaac task
+  `ActionManager` and **must be re-derived and verified** before sending commands
+  to hardware.
+
+Treat the exported policy as **untrusted on hardware until validated there.**
+Closing the actual sim-to-real gap (randomization during training, real-dynamics
+or hardware-in-the-loop evaluation, and a verified observation/action bridge)
+remains separate, unsolved work outside the scope of this export step.
+
+## Implementation notes
+
+- `build_policy_contract(...)` and `infer_mlp_dims(...)` are pure (no torch) and
+  unit-tested; the heavy `torch`/`onnx` imports are guarded inside functions.
+- The actor is rebuilt as a plain `nn.Sequential` from the `actor.<n>.{weight,
+  bias}` entries; activations carry no parameters, so the activation must match
+  training (default `elu`, overridable via `--activation`).
+- The legacy TorchScript exporter is preferred so weights embed into one file;
+  an external-data sidecar (`policy.onnx.data`) is rejected as a contract
+  violation.

--- a/npa/src/npa/cli/isaac_lab/__init__.py
+++ b/npa/src/npa/cli/isaac_lab/__init__.py
@@ -2838,3 +2838,173 @@ def export_lerobot_cmd(
     if output_format == OutputFormat.json and stdout.strip():
         result["stdout_tail"] = stdout.strip()[-1000:]
     _output(result, output_format)
+
+
+@app.command("export-onnx")
+def export_onnx_cmd(
+    input_path: str = typer.Option(
+        ...,
+        "--input-path",
+        "-i",
+        help="rsl_rl checkpoint to export: an s3:// URI or a local model_*.pt path.",
+    ),
+    output_path: str = typer.Option(
+        ...,
+        "--output-path",
+        "-o",
+        help=(
+            "Destination directory for policy.onnx + policy_contract.json: an "
+            "s3:// URI or a local directory path."
+        ),
+    ),
+    task: str = typer.Option(
+        "",
+        "--task",
+        help="Isaac Lab task id (recorded in the contract; selects known action hints).",
+    ),
+    activation: str = typer.Option(
+        "elu",
+        "--activation",
+        help="Actor MLP activation used at training time (rsl_rl default: elu).",
+    ),
+    opset: int = typer.Option(17, "--opset", help="ONNX opset version (must be > 0)."),
+    obs_dim: int = typer.Option(
+        -1,
+        "--obs-dim",
+        help="Expected observation dim; -1 infers from the actor's first layer.",
+    ),
+    act_dim: int = typer.Option(
+        -1,
+        "--act-dim",
+        help="Expected action dim; -1 infers from the actor's last layer.",
+    ),
+    action_type: str = typer.Option(
+        "",
+        "--action-type",
+        help="Override the declared action-space type (else inferred from --task).",
+    ),
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.text, "--output-format", help="Output format."
+    ),
+) -> None:
+    """Export a trained rsl_rl actor checkpoint to ONNX with an obs/action contract.
+
+    This is an in-pod / local export (no SSH): it loads the checkpoint, rebuilds
+    the actor MLP, and emits a single self-contained policy.onnx that runs with
+    onnxruntime alone -- no torch, no Isaac Lab. Requires torch in the export
+    environment (e.g. the Isaac container python).
+
+    Honest scope: ONNX export makes the policy PORTABLE; it does NOT bridge
+    sim-to-real. The emitted policy_contract.json spells out the observation and
+    action contract the real robot must satisfy and the unresolved sim-to-real
+    caveats. See docs/architecture/policy-export-onnx.md.
+    """
+    if opset <= 0:
+        _fail(f"--opset must be positive, got {opset}")
+    if obs_dim < -1 or obs_dim == 0:
+        _fail(f"--obs-dim must be a positive dim or -1 to infer, got {obs_dim}")
+    if act_dim < -1 or act_dim == 0:
+        _fail(f"--act-dim must be a positive dim or -1 to infer, got {act_dim}")
+
+    input_is_s3 = _is_s3_uri(input_path)
+    output_is_s3 = _is_s3_uri(output_path)
+
+    # s3 endpoints go through the handoff contract; local paths are accepted for
+    # the in-pod export flow (torch lives in the pod, not the public CLI host).
+    try:
+        if input_is_s3:
+            input_path = validate_read_path(
+                input_path, tool="Isaac Lab export-onnx", allow_hf=False
+            )
+        elif not Path(input_path).is_file():
+            _fail(f"--input-path local checkpoint not found: {input_path}")
+            return
+        if output_is_s3:
+            output_path = validate_write_path(
+                output_path, tool="Isaac Lab export-onnx"
+            )
+    except PathContractError as exc:
+        _fail(str(exc))
+        return
+
+    cfg = _get_ssh_config() if (input_is_s3 or output_is_s3) else None
+
+    start = time.time()
+    result: dict[str, Any] = {
+        "status": "success",
+        "task": task,
+        "input_path": input_path,
+        "output_path": output_path,
+    }
+
+    with tempfile.TemporaryDirectory(prefix="npa-isaac-lab-onnx-") as tmp:
+        tmp_path = Path(tmp)
+        # Stage the checkpoint locally.
+        if input_is_s3:
+            local_ckpt = tmp_path / "model.pt"
+            try:
+                _storage_client(cfg).download_path(input_path, str(local_ckpt))
+            except Exception as exc:
+                _fail(f"Failed to download --input-path checkpoint: {exc}")
+                return
+        else:
+            local_ckpt = Path(input_path)
+
+        export_dir = tmp_path / "export" if output_is_s3 else Path(output_path)
+        try:
+            from npa.workflows.sim2real.policy_export import (
+                PolicyExportError,
+                export_policy_onnx,
+            )
+
+            export_result = export_policy_onnx(
+                str(local_ckpt),
+                out_dir=str(export_dir),
+                isaac_task=task,
+                obs_dim=obs_dim if obs_dim > 0 else None,
+                act_dim=act_dim if act_dim > 0 else None,
+                activation=activation,
+                opset=opset,
+                action_type=action_type or None,
+                checkpoint_source=input_path,
+            )
+        except PolicyExportError as exc:
+            result["status"] = "failed"
+            result["export_error"] = str(exc)
+            _output(result, output_format)
+            raise typer.Exit(1) from exc
+
+        result.update(
+            {
+                "obs_dim": export_result["obs_dim"],
+                "act_dim": export_result["act_dim"],
+                "hidden_dims": export_result["hidden_dims"],
+                "activation": export_result["activation"],
+                "normalization": export_result["normalization"],
+            }
+        )
+
+        # Publish artifacts.
+        if output_is_s3:
+            base = output_path.rstrip("/")
+            try:
+                storage = _storage_client(cfg)
+                result["onnx_path"] = storage.upload_file(
+                    export_result["onnx_path"], f"{base}/policy.onnx"
+                )
+                result["contract_path"] = storage.upload_file(
+                    export_result["contract_path"], f"{base}/policy_contract.json"
+                )
+            except Exception as exc:
+                result["status"] = "failed"
+                result["upload_status"] = "failed"
+                result["upload_error"] = str(exc)
+                _output(result, output_format)
+                raise typer.Exit(1) from exc
+            result["upload_status"] = "ok"
+        else:
+            result["onnx_path"] = export_result["onnx_path"]
+            result["contract_path"] = export_result["contract_path"]
+
+    result["duration_seconds"] = round(time.time() - start, 1)
+    _output(result, output_format)

--- a/npa/src/npa/workflows/sim2real/policy_export.py
+++ b/npa/src/npa/workflows/sim2real/policy_export.py
@@ -1,0 +1,572 @@
+"""Export a trained rsl_rl actor policy to ONNX for torch-free robot inference.
+
+The sim2real BYO trainer (:mod:`npa.workflows.sim2real.byo_isaac_trainer`) trains
+an rsl_rl ``OnPolicyRunner`` and uploads ``model_*.pt`` checkpoints to S3. Those
+checkpoints store an ``ActorCritic`` ``model_state_dict`` whose ``actor.*`` keys
+are a plain MLP. Running that policy on a robot otherwise requires torch **and**
+Isaac Lab on the robot, which is not deployable.
+
+This module re-materializes the actor MLP directly from the checkpoint's
+``model_state_dict`` (no Isaac Lab, no env construction) and exports it to ONNX,
+alongside a ``policy_contract.json`` sidecar declaring the observation/action
+contract the real robot must satisfy. The exported ``policy.onnx`` then runs with
+nothing but ``onnxruntime`` (CPU) -- the same runtime contract SONIC eval uses
+(see :mod:`npa.workbench.sonic.eval`).
+
+CAVEAT -- ONNX export is necessary, NOT sufficient, for sim-to-real.
+It makes the trained policy *portable*; it does not make it *correct on a real
+robot*. Export adds no domain randomization, does not validate real-world
+dynamics, and does not align the robot's real observation pipeline with the sim
+observation manager. Closing the sim-to-real gap (obs alignment, dynamics,
+randomization, real-world eval) is out of scope here and remains unsolved by this
+step. See ``docs/architecture/policy-export-onnx.md``.
+
+The heavy ``torch``/``onnx`` imports are guarded inside functions so the pure
+contract builder (:func:`build_policy_contract`) and dim inference
+(:func:`infer_mlp_dims`) are unit-testable without torch installed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+POLICY_EXPORT_FORMAT = "npa_sim2real_onnx_export_v1"
+DEFAULT_INPUT_NAME = "obs"
+DEFAULT_OUTPUT_NAME = "action"
+DEFAULT_OPSET = 17
+DEFAULT_ACTIVATION = "elu"
+ONNX_FILENAME = "policy.onnx"
+CONTRACT_FILENAME = "policy_contract.json"
+
+# rsl_rl ``resolve_nn_activation`` names -> torch.nn module attribute names. The
+# activation is NOT recoverable from the state dict (activations carry no
+# parameters), so it must match the activation used at training time. rsl_rl's
+# ``RslRlPpoActorCriticCfg`` defaults to "elu".
+_ACTIVATIONS = {
+    "elu": "ELU",
+    "relu": "ReLU",
+    "selu": "SELU",
+    "tanh": "Tanh",
+    "sigmoid": "Sigmoid",
+    "leakyrelu": "LeakyReLU",
+    "lrelu": "LeakyReLU",
+    "gelu": "GELU",
+}
+
+# Best-effort, conservative hints for known Isaac Lab tasks. These describe the
+# *declared* action semantics a robot integrator must verify against the task's
+# ActionManager -- they are documentation, not a guarantee. Unknown tasks fall
+# back to an "opaque" action declaration.
+TASK_HINTS: dict[str, dict[str, Any]] = {
+    "Isaac-Lift-Cube-Franka": {
+        "action_type": "joint_position",
+        "note": (
+            "Franka manager-based lift: 7 arm joints (JointPositionAction, "
+            "scaled offset from default joint pos) + 1 binary gripper command. "
+            "Confirm scale/offset against the task ActionManager before deploying."
+        ),
+    },
+    "Isaac-Reach-Franka": {
+        "action_type": "joint_position",
+        "note": (
+            "Franka reach: 7 arm-joint position targets (scaled offset from "
+            "default joint pos). Confirm scale/offset against the ActionManager."
+        ),
+    },
+}
+
+SIM_TO_REAL_CAVEAT = (
+    "ONNX export makes this policy portable (torch/Isaac-free inference via "
+    "onnxruntime); it does NOT bridge sim-to-real. No domain randomization, no "
+    "real-dynamics validation, and no real-robot observation alignment are "
+    "performed here. The obs vector fed at inference MUST be assembled in the "
+    "exact same order/units/frame as the sim observation manager produced during "
+    "training, and the action output MUST be applied with the same action-space "
+    "semantics (scaling, offset, limits) as the sim ActionManager. Validate on "
+    "hardware before trusting outputs."
+)
+
+
+class PolicyExportError(ValueError):
+    """Raised when an rsl_rl checkpoint cannot be exported to ONNX."""
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no torch) -- unit-testable without GPU/heavy deps.
+# --------------------------------------------------------------------------- #
+def actor_weight_shapes(
+    state_dict: Mapping[str, Any],
+) -> dict[str, tuple[int, ...]]:
+    """Return ``{param_name: shape}`` for every ``actor.<n>.weight`` entry.
+
+    Accepts torch tensors or anything exposing ``.shape``; the returned shapes
+    are plain int tuples so downstream pure helpers never touch torch.
+    """
+
+    shapes: dict[str, tuple[int, ...]] = {}
+    for name, value in state_dict.items():
+        if re.fullmatch(r"actor\.\d+\.weight", name) is None:
+            continue
+        shape = getattr(value, "shape", None)
+        if shape is None:
+            raise PolicyExportError(f"actor weight {name!r} has no shape")
+        shapes[name] = tuple(int(dim) for dim in shape)
+    return shapes
+
+
+def infer_mlp_dims(
+    weight_shapes: Mapping[str, Sequence[int]],
+) -> tuple[int, int, list[int]]:
+    """Infer ``(obs_dim, act_dim, hidden_dims)`` from actor linear weight shapes.
+
+    ``weight_shapes`` maps ``actor.<n>.weight`` -> ``(out_features, in_features)``
+    (PyTorch ``nn.Linear`` weight layout). The first layer's ``in_features`` is
+    the observation dim; the last layer's ``out_features`` is the action dim;
+    everything between is a hidden width.
+    """
+
+    if not weight_shapes:
+        raise PolicyExportError(
+            "no actor.<n>.weight entries found in checkpoint; cannot infer the "
+            "policy MLP. Is this an rsl_rl ActorCritic model_state_dict?"
+        )
+
+    def _index(name: str) -> int:
+        match = re.fullmatch(r"actor\.(\d+)\.weight", name)
+        if match is None:
+            raise PolicyExportError(f"unexpected actor weight key: {name!r}")
+        return int(match.group(1))
+
+    ordered = sorted(weight_shapes.items(), key=lambda kv: _index(kv[0]))
+    for name, shape in ordered:
+        if len(shape) != 2:
+            raise PolicyExportError(
+                f"actor weight {name!r} is not 2-D (got shape {tuple(shape)}); "
+                "only plain MLP actors are supported"
+            )
+    out_dims = [int(shape[0]) for _, shape in ordered]
+    in_dims = [int(shape[1]) for _, shape in ordered]
+    obs_dim = in_dims[0]
+    act_dim = out_dims[-1]
+    hidden_dims = out_dims[:-1]
+    # Sanity: each layer's input must equal the previous layer's output.
+    for prev_out, cur_in, (name, _) in zip(out_dims, in_dims[1:], ordered[1:]):
+        if prev_out != cur_in:
+            raise PolicyExportError(
+                f"actor layer dim mismatch at {name!r}: expected in_features "
+                f"{prev_out}, got {cur_in}"
+            )
+    return obs_dim, act_dim, hidden_dims
+
+
+def build_policy_contract(
+    *,
+    obs_dim: int,
+    act_dim: int,
+    isaac_task: str = "",
+    checkpoint: Mapping[str, Any] | None = None,
+    hidden_dims: Sequence[int] | None = None,
+    activation: str = DEFAULT_ACTIVATION,
+    opset: int = DEFAULT_OPSET,
+    input_name: str = DEFAULT_INPUT_NAME,
+    output_name: str = DEFAULT_OUTPUT_NAME,
+    obs_terms: Sequence[Mapping[str, Any]] | None = None,
+    action_type: str | None = None,
+    action_scaling: Any = None,
+    action_limits: Any = None,
+    normalization: Mapping[str, Any] | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Build the ``policy_contract.json`` payload (pure -- no torch).
+
+    Declares the obs/action contract a real robot must satisfy to consume the
+    exported ONNX policy. ``obs_terms`` is an ordered list of
+    ``{"name", "dim", ...}`` describing the observation layout when recoverable
+    from the task's observation manager; when ``None`` the layout is marked
+    ``"opaque"`` (the contract only guarantees the flat ``obs_dim`` ordering used
+    at training time). ``checkpoint`` carries provenance fields (source path/URI,
+    sha256, train iter).
+    """
+
+    if obs_dim <= 0:
+        raise PolicyExportError(f"obs_dim must be positive, got {obs_dim}")
+    if act_dim <= 0:
+        raise PolicyExportError(f"act_dim must be positive, got {act_dim}")
+
+    hint = _task_hint(isaac_task)
+    resolved_action_type = action_type or hint.get("action_type") or "opaque"
+
+    if obs_terms is not None:
+        terms = [dict(term) for term in obs_terms]
+        declared = sum(int(term.get("dim", 0)) for term in terms)
+        if declared != obs_dim:
+            raise PolicyExportError(
+                f"obs_terms dims sum to {declared} but obs_dim is {obs_dim}"
+            )
+        obs_layout: dict[str, Any] = {"kind": "ordered_terms", "terms": terms}
+    else:
+        obs_layout = {
+            "kind": "opaque",
+            "note": (
+                "Ordered observation-term names were not recovered (requires the "
+                "Isaac task observation manager). The contract only guarantees a "
+                f"flat float32 vector of length {obs_dim} in the SAME term order "
+                "the sim observation manager emitted during training."
+            ),
+        }
+
+    action_spec: dict[str, Any] = {
+        "dim": act_dim,
+        "dtype": "float32",
+        "type": resolved_action_type,
+        "scaling": action_scaling,
+        "limits": action_limits,
+        "output_name": output_name,
+    }
+    if hint.get("note"):
+        action_spec["note"] = hint["note"]
+
+    norm_spec = (
+        dict(normalization)
+        if normalization is not None
+        else {"type": "none", "note": "actor consumes raw observations"}
+    )
+
+    payload: dict[str, Any] = {
+        "format": POLICY_EXPORT_FORMAT,
+        "created_at": created_at or datetime.now(timezone.utc).isoformat(),
+        "isaac_task": isaac_task,
+        "input_name": input_name,
+        "output_name": output_name,
+        "opset": opset,
+        "deterministic_action_path": "actor_mean",
+        "network": {
+            "type": "mlp",
+            "activation": activation,
+            "hidden_dims": list(hidden_dims) if hidden_dims is not None else None,
+            "framework": "rsl_rl.modules.ActorCritic",
+        },
+        "obs": {
+            "dim": obs_dim,
+            "dtype": "float32",
+            "shape": [1, obs_dim],
+            "input_name": input_name,
+            "layout": obs_layout,
+        },
+        "action": action_spec,
+        "normalization": norm_spec,
+        "checkpoint": dict(checkpoint) if checkpoint is not None else {},
+        "sim_to_real_caveat": SIM_TO_REAL_CAVEAT,
+    }
+    return payload
+
+
+def _task_hint(isaac_task: str) -> dict[str, Any]:
+    if not isaac_task:
+        return {}
+    for key, hint in TASK_HINTS.items():
+        if key.lower() in isaac_task.lower():
+            return hint
+    return {}
+
+
+# --------------------------------------------------------------------------- #
+# Torch-backed export.
+# --------------------------------------------------------------------------- #
+def _import_torch() -> Any:
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover - exercised via env without torch
+        raise PolicyExportError(
+            "ONNX policy export requires torch. Install it in the export "
+            "environment (e.g. the Isaac container python, or `pip install torch`)."
+        ) from exc
+    return torch
+
+
+def _resolve_activation(torch: Any, activation: str) -> Any:
+    attr = _ACTIVATIONS.get(activation.lower())
+    if attr is None:
+        raise PolicyExportError(
+            f"unsupported activation {activation!r}; supported: "
+            f"{sorted(_ACTIVATIONS)}"
+        )
+    return getattr(torch.nn, attr)
+
+
+def load_state_dict_from_checkpoint(checkpoint: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the ActorCritic state dict from an rsl_rl checkpoint payload.
+
+    rsl_rl ``OnPolicyRunner.save`` writes ``{"model_state_dict": ..., ...}``; a
+    bare state dict (``actor.*`` keys at top level) is also accepted.
+    """
+
+    if "model_state_dict" in checkpoint:
+        state = checkpoint["model_state_dict"]
+        if not isinstance(state, Mapping):
+            raise PolicyExportError("model_state_dict is not a mapping")
+        return state
+    if any(re.fullmatch(r"actor\.\d+\.weight", key) for key in checkpoint):
+        return checkpoint
+    raise PolicyExportError(
+        "checkpoint has neither a 'model_state_dict' nor top-level 'actor.*' "
+        "keys; not an rsl_rl ActorCritic checkpoint"
+    )
+
+
+def _build_actor_module(torch: Any, state_dict: Mapping[str, Any], activation: str) -> Any:
+    """Rebuild the actor MLP (nn.Sequential) from ``actor.<n>.{weight,bias}``."""
+
+    nn = torch.nn
+    indices = sorted(
+        {
+            int(m.group(1))
+            for key in state_dict
+            if (m := re.fullmatch(r"actor\.(\d+)\.weight", key))
+        }
+    )
+    if not indices:
+        raise PolicyExportError("no actor linear layers found in state dict")
+    activation_cls = _resolve_activation(torch, activation)
+    modules: list[Any] = []
+    for position, idx in enumerate(indices):
+        weight = state_dict[f"actor.{idx}.weight"]
+        bias = state_dict[f"actor.{idx}.bias"]
+        out_features, in_features = int(weight.shape[0]), int(weight.shape[1])
+        linear = nn.Linear(in_features, out_features)
+        with torch.no_grad():
+            linear.weight.copy_(weight)
+            linear.bias.copy_(bias)
+        modules.append(linear)
+        if position < len(indices) - 1:
+            modules.append(activation_cls())
+    return nn.Sequential(*modules)
+
+
+def _detect_normalization(
+    torch: Any, checkpoint: Mapping[str, Any], obs_dim: int
+) -> tuple[Any | None, dict[str, Any]]:
+    """Detect an rsl_rl empirical observation normalizer in the checkpoint.
+
+    Returns ``(mean_var_or_None, normalization_spec)``. When present, the
+    normalizer is baked into the exported graph so the ONNX consumer always
+    feeds RAW observations.
+    """
+
+    state = checkpoint.get("obs_norm_state_dict")
+    if not isinstance(state, Mapping):
+        return None, {"type": "none", "note": "actor consumes raw observations"}
+    mean = state.get("mean")
+    var = state.get("var")
+    if mean is None or var is None:
+        return None, {"type": "none", "note": "actor consumes raw observations"}
+    mean_t = torch.as_tensor(mean, dtype=torch.float32).reshape(-1)
+    var_t = torch.as_tensor(var, dtype=torch.float32).reshape(-1)
+    if mean_t.numel() != obs_dim:
+        raise PolicyExportError(
+            f"obs normalizer mean has {mean_t.numel()} elements, expected {obs_dim}"
+        )
+    spec = {
+        "type": "empirical_baked",
+        "eps": 1e-8,
+        "note": (
+            "rsl_rl EmpiricalNormalization detected and BAKED into the ONNX graph "
+            "as (obs - mean) / sqrt(var + eps). Feed RAW observations at inference."
+        ),
+        "mean": [float(v) for v in mean_t.tolist()],
+        "var": [float(v) for v in var_t.tolist()],
+    }
+    return (mean_t, var_t), spec
+
+
+def _make_forward_module(torch: Any, actor: Any, norm: Any | None) -> Any:
+    nn = torch.nn
+
+    class _PolicyForward(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.actor = actor
+            if norm is not None:
+                mean_t, var_t = norm
+                self.register_buffer("_obs_mean", mean_t)
+                self.register_buffer("_obs_var", var_t)
+                self._normalize = True
+            else:
+                self._normalize = False
+
+        def forward(self, obs: Any) -> Any:
+            if self._normalize:
+                obs = (obs - self._obs_mean) / torch.sqrt(self._obs_var + 1e-8)
+            return self.actor(obs)
+
+    module = _PolicyForward()
+    module.eval()
+    return module
+
+
+def export_policy_onnx(
+    checkpoint_path: str,
+    *,
+    out_dir: str,
+    isaac_task: str = "",
+    obs_dim: int | None = None,
+    act_dim: int | None = None,
+    activation: str = DEFAULT_ACTIVATION,
+    opset: int = DEFAULT_OPSET,
+    input_name: str = DEFAULT_INPUT_NAME,
+    output_name: str = DEFAULT_OUTPUT_NAME,
+    obs_terms: Sequence[Mapping[str, Any]] | None = None,
+    action_type: str | None = None,
+    action_scaling: Any = None,
+    action_limits: Any = None,
+    dynamic_batch: bool = True,
+    checkpoint_source: str | None = None,
+) -> dict[str, Any]:
+    """Export an rsl_rl ``model_*.pt`` actor to ``policy.onnx`` + contract.
+
+    Loads the checkpoint, rebuilds the actor MLP from ``model_state_dict``, runs
+    ``torch.onnx.export`` (input ``[1, obs_dim]`` -> output ``[1, act_dim]``),
+    and writes ``policy.onnx`` and ``policy_contract.json`` into ``out_dir``.
+
+    ``obs_dim``/``act_dim`` are inferred from the actor's first/last layer when
+    not given; when given they are cross-checked against the checkpoint and a
+    mismatch is an error. Returns a result dict with output paths and dims.
+    """
+
+    torch = _import_torch()
+    ckpt_path = Path(checkpoint_path)
+    if not ckpt_path.is_file():
+        raise PolicyExportError(f"checkpoint not found: {checkpoint_path}")
+
+    checkpoint = torch.load(str(ckpt_path), map_location="cpu", weights_only=False)
+    if not isinstance(checkpoint, Mapping):
+        raise PolicyExportError(
+            f"checkpoint did not deserialize to a mapping (got {type(checkpoint)})"
+        )
+    state_dict = load_state_dict_from_checkpoint(checkpoint)
+
+    inferred_obs, inferred_act, hidden_dims = infer_mlp_dims(
+        actor_weight_shapes(state_dict)
+    )
+    if obs_dim is not None and obs_dim != inferred_obs:
+        raise PolicyExportError(
+            f"--obs-dim {obs_dim} disagrees with checkpoint actor input "
+            f"dimension {inferred_obs}"
+        )
+    if act_dim is not None and act_dim != inferred_act:
+        raise PolicyExportError(
+            f"--act-dim {act_dim} disagrees with checkpoint actor output "
+            f"dimension {inferred_act}"
+        )
+    obs_dim = inferred_obs
+    act_dim = inferred_act
+
+    actor = _build_actor_module(torch, state_dict, activation)
+    norm, norm_spec = _detect_normalization(torch, checkpoint, obs_dim)
+    forward_model = _make_forward_module(torch, actor, norm)
+
+    sample = torch.zeros(1, obs_dim, dtype=torch.float32)
+    with torch.no_grad():
+        sample_action = forward_model(sample)
+    if int(sample_action.shape[-1]) != act_dim:
+        raise PolicyExportError(
+            f"rebuilt actor produced action dim {int(sample_action.shape[-1])}, "
+            f"expected {act_dim}"
+        )
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    onnx_path = out_path / ONNX_FILENAME
+    contract_path = out_path / CONTRACT_FILENAME
+
+    dynamic_axes = (
+        {input_name: {0: "batch"}, output_name: {0: "batch"}}
+        if dynamic_batch
+        else None
+    )
+    # Prefer the legacy TorchScript exporter: it embeds the (small) MLP weights
+    # directly into a single self-contained ``policy.onnx`` (the newer dynamo
+    # exporter spills weights into a ``policy.onnx.data`` sidecar, which breaks
+    # the single-file portability contract the robot consumer expects). Fall back
+    # to the default exporter on older torch builds that lack the ``dynamo`` kwarg.
+    export_kwargs: dict[str, Any] = {
+        "input_names": [input_name],
+        "output_names": [output_name],
+        "dynamic_axes": dynamic_axes,
+        "opset_version": opset,
+    }
+    with torch.no_grad():
+        try:
+            torch.onnx.export(
+                forward_model, sample, str(onnx_path), dynamo=False, **export_kwargs
+            )
+        except TypeError:
+            torch.onnx.export(forward_model, sample, str(onnx_path), **export_kwargs)
+    # Guard the single-file contract: external-weight sidecars are not portable.
+    sidecar = onnx_path.with_name(onnx_path.name + ".data")
+    if sidecar.exists():
+        raise PolicyExportError(
+            f"ONNX export produced an external-data sidecar {sidecar.name}; the "
+            "policy must be a single self-contained file. Re-run with an exporter "
+            "that embeds weights."
+        )
+
+    provenance = _checkpoint_provenance(
+        ckpt_path, checkpoint, source=checkpoint_source
+    )
+    contract = build_policy_contract(
+        obs_dim=obs_dim,
+        act_dim=act_dim,
+        isaac_task=isaac_task,
+        checkpoint=provenance,
+        hidden_dims=hidden_dims,
+        activation=activation,
+        opset=opset,
+        input_name=input_name,
+        output_name=output_name,
+        obs_terms=obs_terms,
+        action_type=action_type,
+        action_scaling=action_scaling,
+        action_limits=action_limits,
+        normalization=norm_spec,
+    )
+    contract_path.write_text(
+        json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    return {
+        "status": "success",
+        "onnx_path": str(onnx_path),
+        "contract_path": str(contract_path),
+        "obs_dim": obs_dim,
+        "act_dim": act_dim,
+        "hidden_dims": hidden_dims,
+        "activation": activation,
+        "opset": opset,
+        "input_name": input_name,
+        "output_name": output_name,
+        "normalization": norm_spec.get("type"),
+        "isaac_task": isaac_task,
+        "checkpoint": provenance,
+    }
+
+
+def _checkpoint_provenance(
+    ckpt_path: Path, checkpoint: Mapping[str, Any], *, source: str | None
+) -> dict[str, Any]:
+    import hashlib
+
+    digest = hashlib.sha256(ckpt_path.read_bytes()).hexdigest()
+    train_iter = checkpoint.get("iter")
+    return {
+        "source": source or str(ckpt_path),
+        "filename": ckpt_path.name,
+        "size_bytes": ckpt_path.stat().st_size,
+        "sha256": digest,
+        "train_iter": int(train_iter) if isinstance(train_iter, int) else None,
+    }

--- a/npa/tests/cli/test_isaac_lab_cli.py
+++ b/npa/tests/cli/test_isaac_lab_cli.py
@@ -50,6 +50,7 @@ def _access_denied(message: str = "AccessDenied") -> ClientError:
         "train",
         "eval",
         "export-lerobot",
+        "export-onnx",
         "list",
         "cleanup-partial",
     ],
@@ -1148,3 +1149,211 @@ def test_isaac_lab_list_no_projects_message(mocker) -> None:
 
     assert result.exit_code == 0
     assert "No projects configured" in result.output
+
+
+def _onnx_export_result(out_dir: Path) -> dict:
+    onnx = out_dir / "policy.onnx"
+    contract = out_dir / "policy_contract.json"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    onnx.write_bytes(b"ONNX")
+    contract.write_text("{}")
+    return {
+        "status": "success",
+        "onnx_path": str(onnx),
+        "contract_path": str(contract),
+        "obs_dim": 36,
+        "act_dim": 8,
+        "hidden_dims": [256, 128, 64],
+        "activation": "elu",
+        "opset": 17,
+        "input_name": "obs",
+        "output_name": "action",
+        "normalization": "none",
+        "isaac_task": "Isaac-Lift-Cube-Franka-v0",
+        "checkpoint": {},
+    }
+
+
+def test_isaac_lab_export_onnx_local_to_local(tmp_path: Path, mocker) -> None:
+    ckpt = tmp_path / "model_975.pt"
+    ckpt.write_bytes(b"x")
+    out_dir = tmp_path / "out"
+
+    def fake_export(checkpoint_path, *, out_dir, **kwargs):
+        assert checkpoint_path == str(ckpt)
+        return _onnx_export_result(Path(out_dir))
+
+    export = mocker.patch(
+        "npa.workflows.sim2real.policy_export.export_policy_onnx",
+        side_effect=fake_export,
+    )
+    # Local-only export must NOT touch SSH/storage config.
+    ssh_cfg = mocker.patch("npa.cli.isaac_lab._get_ssh_config")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "export-onnx",
+            "--input-path",
+            str(ckpt),
+            "--output-path",
+            str(out_dir),
+            "--task",
+            "Isaac-Lift-Cube-Franka-v0",
+            "--output-format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "success"
+    assert payload["obs_dim"] == 36
+    assert payload["act_dim"] == 8
+    assert payload["onnx_path"].endswith("policy.onnx")
+    export.assert_called_once()
+    assert export.call_args.kwargs["isaac_task"] == "Isaac-Lift-Cube-Franka-v0"
+    ssh_cfg.assert_not_called()
+
+
+def test_isaac_lab_export_onnx_s3_roundtrip_uploads(tmp_path: Path, mocker) -> None:
+    mocker.patch("npa.cli.isaac_lab._get_ssh_config", return_value=_ssh_cfg())
+    storage = mocker.MagicMock()
+    storage.upload_file.side_effect = lambda local, uri: uri
+    mocker.patch("npa.cli.isaac_lab._storage_client", return_value=storage)
+
+    def fake_export(checkpoint_path, *, out_dir, **kwargs):
+        # The s3 checkpoint was staged to a local temp file first.
+        assert Path(checkpoint_path).name == "model.pt"
+        return _onnx_export_result(Path(out_dir))
+
+    mocker.patch(
+        "npa.workflows.sim2real.policy_export.export_policy_onnx",
+        side_effect=fake_export,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "export-onnx",
+            "--input-path",
+            "s3://bucket/run/model_975.pt",
+            "--output-path",
+            "s3://bucket/run/onnx/",
+            "--output-format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["upload_status"] == "ok"
+    storage.download_path.assert_called_once()
+    assert storage.upload_file.call_count == 2
+    uploaded = {c.args[1] for c in storage.upload_file.call_args_list}
+    assert uploaded == {
+        "s3://bucket/run/onnx/policy.onnx",
+        "s3://bucket/run/onnx/policy_contract.json",
+    }
+
+
+def test_isaac_lab_export_onnx_upload_failure_exits_nonzero(tmp_path: Path, mocker) -> None:
+    mocker.patch("npa.cli.isaac_lab._get_ssh_config", return_value=_ssh_cfg())
+    storage = mocker.MagicMock()
+    storage.upload_file.side_effect = _access_denied("denied")
+    mocker.patch("npa.cli.isaac_lab._storage_client", return_value=storage)
+    mocker.patch(
+        "npa.workflows.sim2real.policy_export.export_policy_onnx",
+        side_effect=lambda checkpoint_path, *, out_dir, **kw: _onnx_export_result(Path(out_dir)),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "export-onnx",
+            "--input-path",
+            "s3://bucket/run/model_975.pt",
+            "--output-path",
+            "s3://bucket/run/onnx/",
+            "--output-format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["status"] == "failed"
+    assert payload["upload_status"] == "failed"
+
+
+def test_isaac_lab_export_onnx_export_error_exits_nonzero(tmp_path: Path, mocker) -> None:
+    ckpt = tmp_path / "model.pt"
+    ckpt.write_bytes(b"x")
+    from npa.workflows.sim2real.policy_export import PolicyExportError
+
+    mocker.patch(
+        "npa.workflows.sim2real.policy_export.export_policy_onnx",
+        side_effect=PolicyExportError("bad checkpoint"),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "export-onnx",
+            "--input-path",
+            str(ckpt),
+            "--output-path",
+            str(tmp_path / "out"),
+            "--output-format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["status"] == "failed"
+    assert "bad checkpoint" in payload["export_error"]
+
+
+def test_isaac_lab_export_onnx_rejects_bad_opset() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "export-onnx",
+            "--input-path",
+            "s3://bucket/run/model.pt",
+            "--output-path",
+            "s3://bucket/run/onnx/",
+            "--opset",
+            "0",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "--opset must be positive" in result.output
+
+
+def test_isaac_lab_export_onnx_rejects_missing_local_checkpoint(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "export-onnx",
+            "--input-path",
+            str(tmp_path / "nope.pt"),
+            "--output-path",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "local checkpoint not found" in result.output

--- a/npa/tests/workflows/test_policy_export.py
+++ b/npa/tests/workflows/test_policy_export.py
@@ -1,0 +1,266 @@
+"""Unit tests for sim2real ONNX policy export.
+
+The pure helpers (``build_policy_contract``, ``infer_mlp_dims``,
+``actor_weight_shapes``, ``load_state_dict_from_checkpoint``) run with no torch.
+``test_export_policy_onnx_shapes_mocked`` mocks the torch-backed pieces so the
+export wiring/contract is exercised without torch installed. A torch+onnxruntime
+round-trip is gated behind ``importorskip`` so it runs where those are available
+and skips in the light unit env.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from npa.workflows.sim2real import policy_export as pe
+from npa.workflows.sim2real.policy_export import (
+    PolicyExportError,
+    actor_weight_shapes,
+    build_policy_contract,
+    infer_mlp_dims,
+    load_state_dict_from_checkpoint,
+)
+
+
+def _state_dict(obs_dim: int = 6, act_dim: int = 4, hidden=(16, 8)) -> dict:
+    """A fake rsl_rl ActorCritic model_state_dict (numpy arrays expose .shape)."""
+
+    dims = [obs_dim, *hidden, act_dim]
+    state: dict = {"std": np.zeros((act_dim,), dtype=np.float32)}
+    idx = 0
+    for in_f, out_f in zip(dims, dims[1:]):
+        state[f"actor.{idx}.weight"] = np.zeros((out_f, in_f), dtype=np.float32)
+        state[f"actor.{idx}.bias"] = np.zeros((out_f,), dtype=np.float32)
+        state[f"critic.{idx}.weight"] = np.zeros((out_f, in_f), dtype=np.float32)
+        state[f"critic.{idx}.bias"] = np.zeros((out_f,), dtype=np.float32)
+        idx += 2  # rsl_rl interleaves activation modules at odd indices
+    return state
+
+
+# --------------------------------------------------------------------------- #
+# Pure dim inference.
+# --------------------------------------------------------------------------- #
+def test_infer_mlp_dims_basic() -> None:
+    shapes = actor_weight_shapes(_state_dict(obs_dim=36, act_dim=8, hidden=(256, 128, 64)))
+    obs_dim, act_dim, hidden = infer_mlp_dims(shapes)
+    assert obs_dim == 36
+    assert act_dim == 8
+    assert hidden == [256, 128, 64]
+
+
+def test_actor_weight_shapes_ignores_critic_and_std() -> None:
+    shapes = actor_weight_shapes(_state_dict())
+    assert all(name.startswith("actor.") and name.endswith(".weight") for name in shapes)
+    assert "std" not in shapes
+    assert not any("critic" in name for name in shapes)
+
+
+def test_infer_mlp_dims_empty_raises() -> None:
+    with pytest.raises(PolicyExportError, match="no actor"):
+        infer_mlp_dims({})
+
+
+def test_infer_mlp_dims_dim_mismatch_raises() -> None:
+    # actor.0 out=16 but actor.2 in=8 -> broken topology.
+    shapes = {"actor.0.weight": (16, 6), "actor.2.weight": (4, 8)}
+    with pytest.raises(PolicyExportError, match="dim mismatch"):
+        infer_mlp_dims(shapes)
+
+
+def test_infer_mlp_dims_non_2d_raises() -> None:
+    with pytest.raises(PolicyExportError, match="not 2-D"):
+        infer_mlp_dims({"actor.0.weight": (16,)})
+
+
+def test_load_state_dict_from_checkpoint_variants() -> None:
+    sd = _state_dict()
+    assert load_state_dict_from_checkpoint({"model_state_dict": sd}) is sd
+    # Bare state dict (actor.* at top level) is accepted.
+    assert load_state_dict_from_checkpoint(sd) is sd
+    with pytest.raises(PolicyExportError, match="neither"):
+        load_state_dict_from_checkpoint({"optimizer_state_dict": {}})
+
+
+# --------------------------------------------------------------------------- #
+# Pure contract builder.
+# --------------------------------------------------------------------------- #
+def test_build_policy_contract_opaque_layout_and_caveat() -> None:
+    contract = build_policy_contract(
+        obs_dim=36,
+        act_dim=8,
+        isaac_task="Isaac-Lift-Cube-Franka-v0",
+        hidden_dims=[256, 128, 64],
+        checkpoint={"train_iter": 975},
+        created_at="2026-06-26T00:00:00+00:00",
+    )
+    assert contract["format"] == pe.POLICY_EXPORT_FORMAT
+    assert contract["obs"]["dim"] == 36
+    assert contract["obs"]["layout"]["kind"] == "opaque"
+    assert contract["action"]["dim"] == 8
+    # Known task hint is applied.
+    assert contract["action"]["type"] == "joint_position"
+    assert "ActionManager" in contract["action"]["note"]
+    assert contract["network"]["hidden_dims"] == [256, 128, 64]
+    # Honest sim-to-real caveat is always present.
+    assert "does NOT bridge sim-to-real" in contract["sim_to_real_caveat"]
+    assert contract["checkpoint"]["train_iter"] == 975
+
+
+def test_build_policy_contract_ordered_terms() -> None:
+    terms = [
+        {"name": "joint_pos", "dim": 9},
+        {"name": "joint_vel", "dim": 9},
+        {"name": "object_pose", "dim": 7},
+        {"name": "target", "dim": 11},
+    ]
+    contract = build_policy_contract(obs_dim=36, act_dim=8, obs_terms=terms)
+    assert contract["obs"]["layout"]["kind"] == "ordered_terms"
+    assert contract["obs"]["layout"]["terms"] == terms
+
+
+def test_build_policy_contract_terms_sum_mismatch_raises() -> None:
+    with pytest.raises(PolicyExportError, match="sum to"):
+        build_policy_contract(
+            obs_dim=36, act_dim=8, obs_terms=[{"name": "x", "dim": 10}]
+        )
+
+
+def test_build_policy_contract_unknown_task_action_opaque() -> None:
+    contract = build_policy_contract(obs_dim=12, act_dim=3, isaac_task="Some-Unknown-Task")
+    assert contract["action"]["type"] == "opaque"
+
+
+def test_build_policy_contract_action_type_override() -> None:
+    contract = build_policy_contract(
+        obs_dim=12, act_dim=3, isaac_task="Isaac-Lift-Cube-Franka-v0",
+        action_type="joint_velocity",
+    )
+    assert contract["action"]["type"] == "joint_velocity"
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_build_policy_contract_rejects_nonpositive_dims(bad: int) -> None:
+    with pytest.raises(PolicyExportError):
+        build_policy_contract(obs_dim=bad, act_dim=4)
+    with pytest.raises(PolicyExportError):
+        build_policy_contract(obs_dim=4, act_dim=bad)
+
+
+# --------------------------------------------------------------------------- #
+# Export wiring with torch mocked out (runs without torch installed).
+# --------------------------------------------------------------------------- #
+def test_export_policy_onnx_shapes_mocked(tmp_path: Path, monkeypatch) -> None:
+    ckpt = tmp_path / "model_975.pt"
+    ckpt.write_bytes(b"not-a-real-checkpoint")  # provenance hashes the bytes
+    out_dir = tmp_path / "export"
+
+    state = _state_dict(obs_dim=36, act_dim=8, hidden=(256, 128, 64))
+    checkpoint = {"model_state_dict": state, "iter": 975}
+
+    class _NoGrad:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def _fake_export(model, sample, path, **kwargs):
+        Path(path).write_bytes(b"ONNX")  # single self-contained file, no .data
+
+    fake_torch = SimpleNamespace(
+        load=lambda *a, **k: checkpoint,
+        zeros=lambda *shape, **k: SimpleNamespace(shape=tuple(shape)),
+        no_grad=_NoGrad,
+        float32="float32",
+        onnx=SimpleNamespace(export=_fake_export),
+    )
+
+    monkeypatch.setattr(pe, "_import_torch", lambda: fake_torch)
+    monkeypatch.setattr(pe, "_build_actor_module", lambda t, sd, act: "ACTOR")
+    monkeypatch.setattr(
+        pe, "_detect_normalization", lambda t, c, d: (None, {"type": "none"})
+    )
+    monkeypatch.setattr(
+        pe,
+        "_make_forward_module",
+        lambda t, actor, norm: (lambda obs: SimpleNamespace(shape=(1, 8))),
+    )
+
+    result = pe.export_policy_onnx(
+        str(ckpt),
+        out_dir=str(out_dir),
+        isaac_task="Isaac-Lift-Cube-Franka-v0",
+        checkpoint_source="s3://bucket/run/model_975.pt",
+    )
+
+    assert result["status"] == "success"
+    assert result["obs_dim"] == 36
+    assert result["act_dim"] == 8
+    assert result["hidden_dims"] == [256, 128, 64]
+    assert (out_dir / "policy.onnx").is_file()
+    contract = json.loads((out_dir / "policy_contract.json").read_text())
+    assert contract["obs"]["dim"] == 36
+    assert contract["action"]["dim"] == 8
+    assert contract["checkpoint"]["train_iter"] == 975
+    assert contract["checkpoint"]["source"] == "s3://bucket/run/model_975.pt"
+
+
+def test_export_policy_onnx_dim_override_mismatch_raises(tmp_path: Path, monkeypatch) -> None:
+    ckpt = tmp_path / "model.pt"
+    ckpt.write_bytes(b"x")
+    checkpoint = {"model_state_dict": _state_dict(obs_dim=36, act_dim=8)}
+    monkeypatch.setattr(
+        pe, "_import_torch", lambda: SimpleNamespace(load=lambda *a, **k: checkpoint)
+    )
+    with pytest.raises(PolicyExportError, match="disagrees with checkpoint"):
+        pe.export_policy_onnx(str(ckpt), out_dir=str(tmp_path / "o"), obs_dim=99)
+
+
+# --------------------------------------------------------------------------- #
+# Real torch -> ONNX -> onnxruntime round-trip (gated; the whole point).
+# --------------------------------------------------------------------------- #
+def test_export_real_torch_onnxruntime_roundtrip(tmp_path: Path) -> None:
+    torch = pytest.importorskip("torch")
+    ort = pytest.importorskip("onnxruntime")
+
+    obs_dim, act_dim = 12, 4
+    actor = torch.nn.Sequential(
+        torch.nn.Linear(obs_dim, 16),
+        torch.nn.ELU(),
+        torch.nn.Linear(16, act_dim),
+    )
+    # rsl_rl-style keys: actor.0, actor.2.
+    state = {
+        "actor.0.weight": actor[0].weight.detach(),
+        "actor.0.bias": actor[0].bias.detach(),
+        "actor.2.weight": actor[2].weight.detach(),
+        "actor.2.bias": actor[2].bias.detach(),
+        "std": torch.ones(act_dim),
+    }
+    ckpt = tmp_path / "model_5.pt"
+    torch.save({"model_state_dict": state, "iter": 5}, str(ckpt))
+
+    result = pe.export_policy_onnx(
+        str(ckpt), out_dir=str(tmp_path / "export"), isaac_task="Isaac-Reach-Franka-v0"
+    )
+    assert result["obs_dim"] == obs_dim
+    assert result["act_dim"] == act_dim
+    # Single self-contained file (no external-data sidecar).
+    onnx_path = Path(result["onnx_path"])
+    assert onnx_path.is_file()
+    assert not onnx_path.with_name(onnx_path.name + ".data").exists()
+
+    sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    obs = np.zeros((1, obs_dim), dtype=np.float32)
+    action = sess.run(["action"], {"obs": obs})[0]
+    assert action.shape == (1, act_dim)
+
+    # Parity with the torch actor.
+    with torch.no_grad():
+        expected = actor(torch.from_numpy(obs)).numpy()
+    assert np.allclose(action, expected, atol=1e-4)


### PR DESCRIPTION
## What & why

Closes gap **(b)**: a trained sim policy was only runnable from an rsl_rl
`model_*.pt` checkpoint, which requires **torch + Isaac Lab** on the consumer —
not deployable on a robot. This PR makes the trained policy **portable**: it
re-materializes the actor MLP from the checkpoint's `model_state_dict` (no Isaac
Lab, no env construction) and exports a single self-contained `policy.onnx` that
runs with **`onnxruntime` alone** (CPU, no torch). Mirrors the existing SONIC
onnxruntime + metadata-sidecar runtime convention (`npa.workbench.sonic.eval`).

## Honesty: necessary, NOT sufficient

**ONNX export does NOT solve sim-to-real.** It makes the policy portable; it does
not make it correct on hardware. It adds **no domain randomization**, does **no
real-dynamics validation**, does **not align the real robot's observation
pipeline** with the sim observation manager, and does **not verify action-space
semantics**. The contract sidecar and `docs/architecture/policy-export-onnx.md`
say this explicitly. Treat the exported policy as untrusted on hardware until
validated there.

## What's here

- `npa/src/npa/workflows/sim2real/policy_export.py`
  - `export_policy_onnx(...)` — load checkpoint → rebuild actor MLP → `torch.onnx.export` → write `policy.onnx` + `policy_contract.json`. Bakes an empirical obs-normalizer into the graph when present so the consumer always feeds raw obs. Heavy imports guarded.
  - `build_policy_contract(...)` / `infer_mlp_dims(...)` — pure, torch-free, unit-tested. Contract declares obs layout (ordered terms when recoverable, else `opaque` + flat-vector guarantee), action space (dim/type/scaling/limits), normalization, isaac_task, and checkpoint provenance (source/sha256/iter).
- `npa workbench isaac-lab export-onnx --input-path <s3|local model.pt> --output-path <s3|local dir> --task <task>` — in-pod/local export (no SSH). Surfaces download/upload failures with a non-zero exit + `upload_status`.
- Tests: pure contract/dim tests, a torch-mocked export shape test (runs without torch), a gated torch+onnxruntime round-trip, and CLI tests (local→local, s3 roundtrip upload, upload/export failure exit codes, input validation).
- `docs/architecture/policy-export-onnx.md` (repo-root architecture dir; `npa/docs/` does not exist).

## Validation (real checkpoint, not a fixture)

Pulled a real trained checkpoint from S3 (`sim2real-frankalearn-…/checkpoints/model_975.pt`, iter 975) and exported it:

- actor MLP `36 → 256 → 128 → 64 → 8` → `obs_dim=36`, `act_dim=8`, hidden `[256,128,64]`, ELU.
- Output: single self-contained `policy.onnx` (~205 KB) + `policy_contract.json`.
- **Torch-free inference**: loaded `policy.onnx` in an interpreter with **no torch installed**, fed `obs[1,36]` → got `action[1,8]`; dynamic batch=4 → `[4,8]`. ✅
- **Parity**: ONNX output vs the rsl_rl torch actor, max |diff| = **2.4e-6**. ✅

## Test / lint

- `pytest npa/tests/workflows/test_policy_export.py npa/tests/cli/test_isaac_lab_cli.py` → **63 passed, 1 skipped** (the skip is the torch-gated round-trip; it runs where torch+onnxruntime are installed and mirrors the manual validation above).
- `ruff` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)