### PR TITLE
Add dev-loop helper skill for isolated dev VM runs

### DIFF
--- a/scripts/dev-loop.sh
+++ b/scripts/dev-loop.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/dev-loop.sh --name <unique-name> --session <session> --job "<job>" --success "<success-cmd>"
+
+Required environment variables:
+  DEV_VM_SSH_PRIVATE_KEY
+  DEV_VM_SSH_USER
+  DEV_VM_SSH_HOST
+
+Example:
+  scripts/dev-loop.sh \
+    --name sim2real-fix-a1 \
+    --session sim2real-fix-a1 \
+    --job "Fix failing sim2real validation in npa/workflows/..." \
+    --success "cd ~/work/sim2real-fix-a1 && npa/.venv/bin/python -m pytest -q npa/tests/..."
+EOF
+}
+
+die() {
+  echo "dev-loop: $*" >&2
+  exit 1
+}
+
+for required in DEV_VM_SSH_PRIVATE_KEY DEV_VM_SSH_USER DEV_VM_SSH_HOST; do
+  [[ -n "${!required:-}" ]] || die "missing required env var: ${required}"
+done
+
+NAME=""
+SESSION=""
+JOB=""
+SUCCESS_CMD=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      NAME="${2:-}"
+      shift 2
+      ;;
+    --session)
+      SESSION="${2:-}"
+      shift 2
+      ;;
+    --job)
+      JOB="${2:-}"
+      shift 2
+      ;;
+    --success)
+      SUCCESS_CMD="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1 (use --help)"
+      ;;
+  esac
+done
+
+[[ -n "${NAME}" ]] || die "--name is required"
+[[ -n "${SESSION}" ]] || die "--session is required"
+[[ -n "${JOB}" ]] || die "--job is required"
+[[ -n "${SUCCESS_CMD}" ]] || die "--success is required"
+
+[[ "${NAME}" =~ ^[a-z0-9][a-z0-9._-]*$ ]] || die "--name must match ^[a-z0-9][a-z0-9._-]*$"
+[[ "${SESSION}" =~ ^[a-z0-9][a-z0-9._-]*$ ]] || die "--session must match ^[a-z0-9][a-z0-9._-]*$"
+
+mkdir -p "${HOME}/.ssh"
+KEY_PATH="${HOME}/.ssh/k"
+printf '%s\n' "${DEV_VM_SSH_PRIVATE_KEY}" > "${KEY_PATH}"
+chmod 600 "${KEY_PATH}"
+
+SSH_TARGET="${DEV_VM_SSH_USER}@${DEV_VM_SSH_HOST}"
+SSH_OPTS=(-i "${KEY_PATH}" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new)
+SSH_LOG="$(mktemp)"
+
+set +e
+REMOTE_OUTPUT="$(
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" \
+    "bash -s" -- "${NAME}" "${SESSION}" "${JOB}" "${SUCCESS_CMD}" 2>&1 <<'EOF'
+set -euo pipefail
+
+NAME="$1"
+SESSION="$2"
+JOB="$3"
+SUCCESS_CMD="$4"
+
+REPO="${HOME}/nebius-physical-ai"
+WORK_ROOT="${HOME}/work"
+BR="agent/${NAME}"
+WT="${WORK_ROOT}/${NAME}"
+
+if ! command -v cursor-loop >/dev/null 2>&1; then
+  echo "cursor-loop is not installed on the dev VM."
+  exit 12
+fi
+
+cd "${REPO}"
+git fetch origin
+
+if tmux has-session -t "=${SESSION}" 2>/dev/null; then
+  echo "tmux session already exists: ${SESSION}"
+  exit 13
+fi
+
+if [[ -e "${WT}" ]]; then
+  echo "worktree already exists: ${WT}"
+  exit 14
+fi
+
+if git show-ref --verify --quiet "refs/heads/${BR}"; then
+  echo "branch already exists locally: ${BR}"
+  exit 15
+fi
+
+if git ls-remote --exit-code origin "${BR}" >/dev/null 2>&1; then
+  echo "branch already exists on origin: ${BR}"
+  exit 16
+fi
+
+mkdir -p "${WORK_ROOT}"
+git worktree add -b "${BR}" "${WT}" origin/main
+
+PROMPT="$(cat <<PROMPT_EOF
+${JOB}
+
+Commit each logical change with clear commit messages. When done and SUCCESS_CMD passes, push the branch and open a PR:
+git push -u origin ${BR} && gh pr create --fill --base main --head ${BR}
+(if gh is unavailable, push and print the PR compare URL)
+
+Use a unique run ID / S3 prefix / workbench namespace, and do not touch other agents' sessions, worktrees, or infrastructure.
+PROMPT_EOF
+)"
+
+cursor-loop "${SESSION}" "${PROMPT}" "${SUCCESS_CMD}" --workspace "${WT}"
+
+echo "branch=${BR}"
+echo "worktree=${WT}"
+echo "session=${SESSION}"
+echo "log=/tmp/cursor-loop-${SESSION}.log"
+EOF
+)"
+SSH_EXIT=$?
+set -e
+
+printf '%s\n' "${REMOTE_OUTPUT}" | tee "${SSH_LOG}" >/dev/null
+
+if [[ ${SSH_EXIT} -ne 0 ]]; then
+  if [[ "${REMOTE_OUTPUT}" == *"Connection reset by peer"* ]] || \
+     [[ "${REMOTE_OUTPUT}" == *"kex_exchange_identification"* ]] || \
+     [[ "${REMOTE_OUTPUT}" == *"Connection closed by remote host"* ]]; then
+    die "SSH reset before banner; this is likely a dev VM ingress issue."
+  fi
+  cat "${SSH_LOG}" >&2
+  exit "${SSH_EXIT}"
+fi
+
+cat "${SSH_LOG}"
+echo "monitor: ssh ${SSH_OPTS[*]} ${SSH_TARGET} \"tail -f /tmp/cursor-loop-${SESSION}.log\""

--- a/skills/atomic/dev-vm-loop/SKILL.md
+++ b/skills/atomic/dev-vm-loop/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: dev-vm-loop
+description: Bootstrap isolated dev-VM worktrees and launch cursor-loop sessions with push/PR instructions.
+---
+
+# Dev VM Loop
+
+Use this when an operator asks you to run a job on a shared dev VM (not in your own VM) with an isolated branch/worktree and continuous retry loop.
+
+Run this command from the repository root:
+
+```bash
+scripts/dev-loop.sh \
+  --name <unique-name> \
+  --session <unique-session> \
+  --job "<job description>" \
+  --success "<success command>"
+```
+
+Environment variables required in the caller environment:
+
+- `DEV_VM_SSH_PRIVATE_KEY`
+- `DEV_VM_SSH_USER`
+- `DEV_VM_SSH_HOST`
+
+What this command enforces on the dev VM:
+
+1. SSH using the provided key and host/user secrets.
+2. `cd ~/nebius-physical-ai && git fetch origin`
+3. Creates isolated branch/worktree:
+   - branch: `agent/<unique-name>`
+   - worktree: `~/work/<unique-name>`
+   - base: `origin/main`
+4. Launches `cursor-loop` with:
+   - job prompt text
+   - explicit commit-as-you-go instruction
+   - explicit final push + PR instruction:
+     `git push -u origin $BR && gh pr create --fill --base main --head $BR`
+   - gh fallback: print compare URL if `gh` is unavailable
+5. Prints branch/worktree/session/log paths for monitoring.
+
+If SSH resets before banner, treat it as a dev VM ingress issue and stop.
+
+Monitor progress:
+
+```bash
+ssh -i ~/.ssh/k -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new "$DEV_VM_SSH_USER@$DEV_VM_SSH_HOST" \
+  "tail -f /tmp/cursor-loop-<session>.log"
+```

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -68,6 +68,13 @@ skills:
       - type: workflow_yaml
         paths:
           - npa/workflows/workbench/skypilot/cosmos3-ea-fetch.yaml
+  - name: dev-vm-loop
+    category: atomic
+    when_to_use: "Run jobs on the shared dev VM using isolated branch/worktree and a cursor-loop session."
+    path: skills/atomic/dev-vm-loop/SKILL.md
+    smoke:
+      - type: file_exists
+        path: scripts/dev-loop.sh
   - name: gpu-selection
     category: atomic
     when_to_use: "Choose or review GPU targets for training, rendering, inference, and workflow YAML resources."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add `scripts/dev-loop.sh` to standardize dev-VM SSH bootstrap, isolated worktree creation, and `cursor-loop` launch
- add new agent skill at `skills/atomic/dev-vm-loop/SKILL.md` describing when/how to invoke the command
- register the skill in `skills/index.yaml` with a smoke expectation for the helper script

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks.
- [x] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Skill Maintenance

- [x] I updated the relevant root `skills/` entry and `skills/index.yaml`, or this PR does not change behavior that needs skill guidance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-377978d8-9f5f-443b-b472-ee757308f42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-377978d8-9f5f-443b-b472-ee757308f42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

