### PR TITLE
Install dev extras in agent VM loop

### DIFF
--- a/npa/scripts/agent_mature_verify_loop.sh
+++ b/npa/scripts/agent_mature_verify_loop.sh
@@ -7,6 +7,7 @@ cd "$ROOT"
 export NPA_AGENT_PROJECT="${NPA_AGENT_PROJECT:-us-central1}"
 export NPA_AGENT_NAME="${NPA_AGENT_NAME:-agent}"
 export NPA_SSH_KEY="${NPA_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+PIP_EDITABLE_SPEC="${NPA_DEV_VM_LOOP_EDITABLE_SPEC:-npa[dev]}"
 SLEEP_SECONDS="${NPA_LOOP_SLEEP_SECONDS:-60}"
 MAX_ATTEMPTS="${NPA_MAX_ATTEMPTS:-0}"
 
@@ -20,7 +21,7 @@ except Exception:
 }
 
 run_success() {
-  npa/.venv/bin/pip install -e npa -q || return 1
+  npa/.venv/bin/pip install -e "$PIP_EDITABLE_SPEC" -q || return 1
   if ! NPA_SSH_KEY="$NPA_SSH_KEY" npa/.venv/bin/npa agent bootstrap --project "$NPA_AGENT_PROJECT" --name "$NPA_AGENT_NAME"; then
     echo "bootstrap failed; attempting deploy for ${NPA_AGENT_PROJECT}/${NPA_AGENT_NAME}..."
     NPA_SSH_KEY="$NPA_SSH_KEY" npa/.venv/bin/npa agent deploy --project "$NPA_AGENT_PROJECT" --name "$NPA_AGENT_NAME" || return 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- update `npa/scripts/agent_mature_verify_loop.sh` to install editable package with dev extras by default (`npa[dev]`) so pytest/timeout and other dev-loop dependencies are present in the loop context
- add `NPA_DEV_VM_LOOP_EDITABLE_SPEC` env override so operators can pin a different editable spec without modifying the script

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks.
- [ ] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

### Commands run

- `bash -n npa/scripts/agent_mature_verify_loop.sh`
- `NPA_MAX_ATTEMPTS=1 timeout 120 bash npa/scripts/agent_mature_verify_loop.sh`

## Skill Maintenance

- [x] This PR does not change behavior that needs a new or updated root `skills/` guidance entry.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f534b860-0c20-4f5e-bb83-ce5cd15941fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f534b860-0c20-4f5e-bb83-ce5cd15941fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

