### PR TITLE
fix(rerun): serve hosted Rerun for any run id, not just sim2real-staged-*

### DIFF
--- a/npa/src/npa/workflows/rerun_serve.py
+++ b/npa/src/npa/workflows/rerun_serve.py
@@ -45,10 +45,11 @@ ROLLOUT_TIMEOUT_SEC = 900
 DEPLOYMENT_PROGRESS_DEADLINE_SEC = 900
 KUBECTL_DELETE_TIMEOUT_SEC = 60
 
-STAGED_RUN_ID_RE = re.compile(
-    r"^(?:sim2real-staged-[0-9]{8}t[0-9]{6}z|rtxpro-staged-[a-z0-9-]*[0-9]{8}t[0-9]{6}z)$",
-    re.IGNORECASE,
-)
+# A run id becomes both an S3 key segment (.../{run_id}/reports/sim2real.rrd) and
+# the seed for k8s label values, so it must be a single safe path segment. It does
+# NOT need to match the staged-loop naming: any real run id (e2e, BYO-robot, custom)
+# has artifacts on S3 and is servable. Guard against junk/traversal, not against shape.
+RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 PLACEHOLDER_RUN_ID_RE = re.compile(
     r"yyyymmdd|hhmmss|your-run-id|<run-id>|placeholder|example-run|tbd|xxxx",
     re.IGNORECASE,
@@ -139,7 +140,15 @@ Sim2RealRerunServeConfig = RerunServeConfig
 Sim2RealRerunServeResult = RerunServeResult
 
 
-def validate_staged_run_id(run_id: str) -> str:
+def validate_run_id(run_id: str) -> str:
+    """Validate a run id for serving: a real, safe S3-key/label segment.
+
+    Accepts any run id (staged-loop, e2e, BYO-robot, custom) — the serve path
+    only needs the id to locate ``{prefix}/{run_id}/reports/sim2real.rrd`` on S3
+    and to seed k8s labels, so it must be one safe path segment. Rejects template
+    placeholders and anything with path separators, traversal, or unsafe chars.
+    """
+
     value = run_id.strip()
     if not value:
         raise RerunServeError("--run-id is required")
@@ -148,12 +157,19 @@ def validate_staged_run_id(run_id: str) -> str:
             f"run-id looks like a template placeholder: {value!r}. "
             "Use a real id from submit output (e.g. sim2real-staged-20260615t180818z)."
         )
-    if not STAGED_RUN_ID_RE.fullmatch(value):
+    if not RUN_ID_RE.fullmatch(value):
         raise RerunServeError(
-            "run-id must match sim2real-staged-YYYYMMDDtHHMMSSz with digit timestamps "
-            f"(got {value!r})."
+            "run-id must be a single safe path segment matching [A-Za-z0-9._-] and "
+            f"start with an alphanumeric (got {value!r}); it is used in the S3 key "
+            "and k8s labels. To serve a recording at an arbitrary path, pass "
+            "--rrd-uri/--report-uri."
         )
     return value
+
+
+# Back-compat alias: serving no longer requires the staged-loop naming shape, but
+# callers/tests still import this name.
+validate_staged_run_id = validate_run_id
 
 
 def verify_rrd_exists_on_s3(
@@ -440,7 +456,7 @@ def build_rerun_serve_config(
     auth_user: str = "",
     auth_password: str = "",
 ) -> RerunServeConfig:
-    normalized_run_id = validate_staged_run_id(run_id)
+    normalized_run_id = validate_run_id(run_id)
     storage = resolve_project_storage(project)
     bucket = resolve_storage_bucket(storage, override=s3_bucket)
     endpoint = s3_endpoint.strip() or storage.endpoint_url or ""
@@ -1176,7 +1192,7 @@ def maybe_auto_rerun_serve(
         }
 
     try:
-        normalized_run_id = validate_staged_run_id(run_id)
+        normalized_run_id = validate_run_id(run_id)
     except RerunServeError as exc:
         return {"status": "skipped", "reason": str(exc)}
 

--- a/npa/tests/workflows/test_sim2real_rerun_serve.py
+++ b/npa/tests/workflows/test_sim2real_rerun_serve.py
@@ -31,6 +31,7 @@ from npa.workflows.rerun_serve import (
     resolve_storage_bucket,
     rrd_s3_uri_from_report_uri,
     should_auto_rerun_serve,
+    validate_run_id,
     validate_staged_run_id,
     verify_rrd_exists_on_s3,
 )
@@ -75,14 +76,51 @@ def test_same_cluster_deployment_name_for_different_runs(mocker) -> None:
     assert first.rrd_s3_uri != second.rrd_s3_uri
 
 
-def test_validate_staged_run_id_rejects_placeholder() -> None:
+def test_validate_run_id_rejects_placeholder() -> None:
     with pytest.raises(Sim2RealRerunServeError, match="placeholder"):
-        validate_staged_run_id("sim2real-staged-YYYYMMDDTHHMMSSz")
+        validate_run_id("sim2real-staged-YYYYMMDDTHHMMSSz")
 
 
-def test_validate_staged_run_id_accepts_canonical() -> None:
-    assert validate_staged_run_id("sim2real-staged-20260615t180818z") == (
+def test_validate_run_id_accepts_canonical_staged() -> None:
+    assert validate_run_id("sim2real-staged-20260615t180818z") == (
         "sim2real-staged-20260615t180818z"
+    )
+
+
+def test_validate_run_id_accepts_custom_run_ids() -> None:
+    # Non-staged ids (e2e, BYO-robot, custom) are real runs with artifacts on S3
+    # and must be servable without renaming to the staged-loop shape.
+    for rid in (
+        "sim2real-e2e-main-20260627t195851z",
+        "kinova-onboard-b5-20260627t190600z",
+        "my_custom.run-01",
+    ):
+        assert validate_run_id(rid) == rid
+
+
+def test_validate_run_id_rejects_path_traversal_and_separators() -> None:
+    for bad in ("../etc/passwd", "a/b", "run id", "-leading-dash", ""):
+        with pytest.raises(Sim2RealRerunServeError):
+            validate_run_id(bad)
+
+
+def test_validate_staged_run_id_is_backcompat_alias() -> None:
+    assert validate_staged_run_id is validate_run_id
+
+
+def test_build_config_accepts_custom_run_id(mocker) -> None:
+    mocker.patch(
+        "npa.workflows.rerun_serve.resolve_project_storage",
+        return_value=_storage(),
+    )
+    config = build_rerun_serve_config(
+        run_id="sim2real-e2e-main-20260627t195851z",
+        s3_prefix="sim2real-b",
+        aws_access_key_id="ak",
+        aws_secret_access_key="sk",
+    )
+    assert config.rrd_s3_uri == (
+        "s3://demo-bucket/sim2real-b/sim2real-e2e-main-20260627t195851z/reports/sim2real.rrd"
     )
 
 


### PR DESCRIPTION
## Problem
`npa workbench sim2real rerun serve` hard-validated the run id against a hardcoded shape (`sim2real-staged-YYYYMMDDtHHMMSSz` / `rtxpro-staged-*`). Any real completed run with a different id — an end-to-end run (`sim2real-e2e-main-*`), a BYO-robot onboarding run, any custom id — was rejected and could not be visualized in hosted Rerun **without renaming the run**. The run id is only used to locate `{prefix}/{run_id}/reports/sim2real.rrd` on S3 and to seed k8s label values, so the shape constraint was unnecessary.

This surfaced during a full E2E run (`sim2real-e2e-main-20260627t195851z`): the `.rrd` was produced and valid, but `rerun serve` refused to serve it.

## Fix
- Replace the staged-shape regex with `validate_run_id`: accept **any** run id that is a single safe path segment (`[A-Za-z0-9][A-Za-z0-9._-]*`).
- Still reject template placeholders (`YYYYMMDD`, `<run-id>`, …) and anything with path separators, `..` traversal, leading dash/dot, whitespace, or other unsafe chars — so it stays a safe S3-key/k8s-label segment.
- `validate_staged_run_id` kept as a back-compat alias (callers/tests still import it).
- `--rrd-uri` / `--report-uri` overrides remain for serving a recording at an arbitrary path.

## Tests
`tests/workflows/test_sim2real_rerun_serve.py` (36 pass; adjacent rerun/viz suites 53 pass):
- custom/e2e/BYO run ids accepted
- traversal / separators / leading-dash / empty rejected
- canonical staged id + placeholder behaviour unchanged
- `build_rerun_serve_config` produces the correct S3 URI for a custom id

## Scope / honesty
Pure validation relaxation in `rerun_serve.py` + tests. No change to manifest generation, S3 path layout, or auth. The operator wrapper `run.sh rerun-host` in the private walkthrough repo has a matching bash guard (`operator_validate_staged_run_id`) relaxed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)