### PR TITLE
fix(sim2real-viz): held-out cameras render by default (per-env views, time-aligned)

### DIFF
--- a/npa/src/npa/workflows/sim2real_viz.py
+++ b/npa/src/npa/workflows/sim2real_viz.py
@@ -85,7 +85,11 @@ def emit_sim2real_rerun(
 
     heldout_episodes = _heldout_render_episodes(local_dir, heldout_report)
     has_heldout_cameras = bool(heldout_episodes)
-    blueprint = _build_blueprint(rrb, has_heldout_cameras=has_heldout_cameras)
+    blueprint = _build_blueprint(
+        rrb,
+        has_heldout_cameras=has_heldout_cameras,
+        heldout_env_ids=[env_id for env_id, _frames in heldout_episodes],
+    )
     recording = rr.RecordingStream(APPLICATION_ID)
     rr.save(output_rrd, default_blueprint=blueprint, recording=recording)
     _send_blueprint(rr, blueprint, recording)
@@ -307,17 +311,22 @@ def _log_heldout_cameras(
     *,
     start_seconds: float,
 ) -> tuple[int, float]:
-    seconds = start_seconds
     logged = 0
+    end_seconds = start_seconds
     for env_id, frames in episodes:
         root = f"heldout/camera/{env_id}"
+        # Reset to the same start for every env so all held-out episodes share one
+        # time window and play in sync (frame i of every env at the same t). Without
+        # this, envs are laid end-to-end and only one is ever visible at the cursor.
+        seconds = start_seconds
         for frame in frames:
             _set_time(rr, recording, seconds)
             rr.log(f"{root}/camera", _rerun_image(rr, frame), recording=recording)
             _bump(counts, f"{root}/camera")
             seconds += ROLLOUT_FRAME_SECONDS
             logged += 1
-    return logged, seconds
+        end_seconds = max(end_seconds, seconds)
+    return logged, end_seconds
 
 
 def is_reference_stub_rollout(rollout_dir: Path, frames: list[np.ndarray]) -> bool:
@@ -374,20 +383,41 @@ def _heldout_render_episodes(
     return episodes
 
 
-def _build_blueprint(rrb: Any, *, has_heldout_cameras: bool = False) -> Any:
-    camera_view = (
-        rrb.Spatial2DView(
+def _build_blueprint(
+    rrb: Any,
+    *,
+    has_heldout_cameras: bool = False,
+    heldout_env_ids: list[str] | None = None,
+) -> Any:
+    env_ids = list(heldout_env_ids or [])
+    has_heldout_cameras = has_heldout_cameras or bool(env_ids)
+    if env_ids:
+        # One 2D view per held-out env: a single Spatial2DView cannot lay out
+        # sibling image entities (heldout/camera/env-*/camera), so all envs render
+        # blank. A grid of per-env views shows every held-out episode at once, and
+        # paired with the time-aligned logging they scrub/play in sync.
+        camera_view = rrb.Grid(
+            *[
+                rrb.Spatial2DView(
+                    origin=f"heldout/camera/{env_id}",
+                    name=f"Held-out {env_id}",
+                )
+                for env_id in env_ids
+            ],
+            name="Held-out sim cameras",
+        )
+    elif has_heldout_cameras:
+        camera_view = rrb.Spatial2DView(
             origin="heldout",
             contents="heldout/**/camera",
             name="Held-out sim cameras",
         )
-        if has_heldout_cameras
-        else rrb.Spatial2DView(
+    else:
+        camera_view = rrb.Spatial2DView(
             origin="rollouts",
             contents="rollouts/**",
             name="Rollout cameras",
         )
-    )
     secondary_camera = (
         rrb.Spatial2DView(
             origin="rollouts",

--- a/npa/tests/workflows/test_sim2real_viz.py
+++ b/npa/tests/workflows/test_sim2real_viz.py
@@ -346,3 +346,81 @@ def test_ensure_heldout_renders_builds_manifest_from_local_pngs(
     assert updated is not None
     assert updated["render_manifest"]["episodes"][0]["env_id"] == "env-00003"
     assert updated["render_manifest"]["episodes"][0]["frames"] == ["camera-000.png"]
+
+
+class _RecordingRRB:
+    """Records blueprint view construction so tests can assert structure."""
+
+    class PanelState:
+        Expanded = "expanded"
+
+    def __init__(self) -> None:
+        self.views: list[dict[str, Any]] = []
+
+    def Spatial2DView(self, *, origin: str = "", contents: Any = None, name: str = "", **_: Any) -> dict[str, Any]:
+        view = {"kind": "Spatial2DView", "origin": origin, "name": name}
+        self.views.append(view)
+        return view
+
+    def Grid(self, *args: Any, name: str = "", **_: Any) -> dict[str, Any]:
+        return {"kind": "Grid", "name": name, "children": list(args)}
+
+    def Vertical(self, *args: Any, **_: Any) -> dict[str, Any]:
+        return {"kind": "Vertical", "children": list(args)}
+
+    def Horizontal(self, *args: Any, **_: Any) -> dict[str, Any]:
+        return {"kind": "Horizontal", "children": list(args)}
+
+    def TextDocumentView(self, **kwargs: Any) -> dict[str, Any]:
+        return {"kind": "TextDocumentView", **kwargs}
+
+    def TimeSeriesView(self, **kwargs: Any) -> dict[str, Any]:
+        return {"kind": "TimeSeriesView", **kwargs}
+
+    def TimePanel(self, **_: Any) -> dict[str, Any]:
+        return {"kind": "TimePanel"}
+
+    def Blueprint(self, *args: Any, **_: Any) -> dict[str, Any]:
+        return {"kind": "Blueprint", "children": list(args)}
+
+
+def test_build_blueprint_one_2d_view_per_heldout_env() -> None:
+    rrb = _RecordingRRB()
+    viz_module._build_blueprint(
+        rrb, heldout_env_ids=["env-00006", "env-00009", "env-00018"]
+    )
+    heldout_origins = [
+        v["origin"] for v in rrb.views
+        if v["kind"] == "Spatial2DView" and v["origin"].startswith("heldout/camera/")
+    ]
+    assert heldout_origins == [
+        "heldout/camera/env-00006",
+        "heldout/camera/env-00009",
+        "heldout/camera/env-00018",
+    ]
+
+
+def test_build_blueprint_without_env_ids_keeps_single_camera_view() -> None:
+    rrb = _RecordingRRB()
+    viz_module._build_blueprint(rrb, has_heldout_cameras=False)
+    # No per-env heldout views; falls back to the rollouts camera view.
+    assert not any(
+        v["origin"].startswith("heldout/camera/") for v in rrb.views
+    )
+
+
+def test_log_heldout_cameras_time_aligns_envs() -> None:
+    import numpy as np
+
+    fake = _FakeRerun()
+    frame = np.zeros((2, 2, 3), dtype=np.uint8)
+    episodes = [("env-a", [frame, frame, frame]), ("env-b", [frame, frame, frame])]
+    counts: dict[str, int] = {}
+    logged, end_seconds = viz_module._log_heldout_cameras(
+        fake, None, episodes, counts, start_seconds=10.0
+    )
+    assert logged == 6
+    # Both envs share the same time window -> env-a times == env-b times.
+    assert fake.times[:3] == fake.times[3:6]
+    assert fake.times[0] == 10.0
+    assert end_seconds == 10.0 + 3 * viz_module.ROLLOUT_FRAME_SECONDS


### PR DESCRIPTION
## Problem
The stage-14 Rerun recording made the **"Held-out sim cameras"** panel render blank in the hosted viewer, even though the frames are in the recording (`entity_counts` shows 18 image events per env). Two causes:
1. `_log_heldout_cameras` advanced the time cursor across **all** envs sequentially, so 4 envs × 18 frames landed end-to-end on one ~36s timeline — only one env is ever near the play head.
2. `_build_blueprint` put all four `heldout/camera/env-*/camera` image entities into a **single** `Spatial2DView` rooted at `heldout`. A 2D view can't lay out sibling image entities, so it shows nothing.

The held-out eval is the headline result of a run, so this made the viewer look empty (confirmed live on `sim2real-e2e-main-20260627t195851z`).

## Fix
- **Time-align** held-out frames: reset the cursor per env so every episode shares one time window and plays/scrubs in sync.
- **Per-env views**: `_build_blueprint` takes `heldout_env_ids` and builds a `Grid` of one `Spatial2DView` per env (`origin=heldout/camera/<env_id>`), so all held-out episodes are visible at once. Falls back to the previous single-view behaviour when there are no env ids (rollout-only recordings).

## Tests (`tests/workflows/test_sim2real_viz.py`, 12 pass)
- one 2D view per env id, correct origins
- fallback keeps the single camera view when no env ids
- per-env frames are time-aligned (`env-a` times == `env-b` times)

## Validation
Regenerated the real run's `.rrd` with this code and re-served — held-out camera grid now renders. (Independent of #157, which relaxed the serve run-id guard.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)