### PR TITLE
Add fresh NPA agent setup, mobile UI tweaks, and model picker

### DIFF
--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -45,7 +45,12 @@ DEFAULT_AGENT_NAME = "agent"
 DEFAULT_AGENT_USER = "npa"
 DEFAULT_LLM_PROVIDER = "token_factory"
 DEFAULT_LLM_MODEL = "nvidia/Cosmos3-Super-Reasoner"
-AGENT_UI_VERSION = "2026063001"
+DEFAULT_LLM_MODELS = (
+    DEFAULT_LLM_MODEL,
+    "meta-llama/Llama-3.3-70B-Instruct",
+    "Qwen/Qwen2.5-VL-72B-Instruct",
+)
+AGENT_UI_VERSION = "2026070101"
 DEFAULT_HTTPS_PORT = 443
 
 
@@ -105,11 +110,12 @@ class AgentConfig:
     auth_secret_path: str
     llm_provider: str
     llm_model: str
+    service_account_id: str = ""
+    llm_models: tuple[str, ...] = ()
     public_url: str = ""
     public_https: bool = True
     direct_url: str = ""
     ssh_key_path: str = ""
-    service_account_id: str = ""
     credentials: dict[str, str] | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -119,6 +125,7 @@ class AgentConfig:
             "region": self.region,
             "public_ip": self.public_ip,
             "instance_id": self.instance_id,
+            "service_account_id": self.service_account_id,
             "agent_url": self.agent_url,
             "rerun_url": self.rerun_url,
             "sim_viz_url": self.sim_viz_url,
@@ -126,7 +133,11 @@ class AgentConfig:
             "cameras_api_url": self.cameras_api_url,
             "auth_user": self.auth_user,
             "auth_secret_path": self.auth_secret_path,
-            "llm": {"provider": self.llm_provider, "model": self.llm_model},
+            "llm": {
+                "provider": self.llm_provider,
+                "model": self.llm_model,
+                "models": list(self.llm_models or (self.llm_model,)),
+            },
         }
         if self.public_url:
             payload["public_url"] = self.public_url
@@ -289,6 +300,33 @@ def _resolve_deploy_llm_credentials() -> tuple[str, str]:
     return creds.token_factory_api_key, DEFAULT_LLM_MODEL
 
 
+def _resolve_operator_credentials() -> tuple[str, str]:
+    """Return Nebius AI Cloud key and Token Factory API key from operator credentials."""
+    from npa.clients.credentials import load_credentials
+
+    creds = load_credentials()
+    return creds.ai_cloud_api_key, creds.token_factory_api_key
+
+
+def _normalize_llm_models(models: list[str] | tuple[str, ...] | str) -> list[str]:
+    """Return an ordered, unique model list from repeated or comma-separated values."""
+    if isinstance(models, str):
+        raw_items = [models]
+    else:
+        raw_items = list(models)
+    normalized: list[str] = []
+    for raw in raw_items:
+        for chunk in str(raw).replace("\n", ",").split(","):
+            value = chunk.strip()
+            if value and value not in normalized:
+                normalized.append(value)
+    if not normalized:
+        normalized = list(DEFAULT_LLM_MODELS)
+    if DEFAULT_LLM_MODEL not in normalized:
+        normalized.insert(0, DEFAULT_LLM_MODEL)
+    return normalized
+
+
 def _agent_credentials_payload(creds: dict[str, str]) -> dict[str, str]:
     """Normalize Nebius bootstrap output for persistence on the agent record."""
     return {
@@ -433,11 +471,17 @@ def _write_agent_llm_env(
     *,
     tf_api_key: str,
     llm_model: str,
+    llm_models: list[str] | tuple[str, ...] = DEFAULT_LLM_MODELS,
 ) -> None:
     """Stage Token Factory credentials on the VM (chmod 600, not baked into image)."""
     if not tf_api_key.strip():
         return
-    env_content = f"NEBIUS_TOKEN_FACTORY_KEY={tf_api_key.strip()}\nNPA_AGENT_LLM_MODEL={llm_model}\n"
+    models_csv = ",".join(_normalize_llm_models(list(llm_models)))
+    env_content = (
+        f"NEBIUS_TOKEN_FACTORY_KEY={tf_api_key.strip()}\n"
+        f"NPA_AGENT_LLM_MODEL={llm_model}\n"
+        f"NPA_AGENT_LLM_MODELS={models_csv}\n"
+    )
     env_b64 = base64.b64encode(env_content.encode("utf-8")).decode("ascii")
     ssh.run_or_raise(
         f"echo {shlex.quote(env_b64)} | base64 -d | sudo tee /opt/npa-agent/llm.env >/dev/null "
@@ -469,6 +513,88 @@ def _write_agent_s3_env(
     ssh.run_or_raise(
         f"echo {shlex.quote(env_b64)} | base64 -d | sudo tee /opt/npa-agent/s3.env >/dev/null "
         "&& sudo chmod 600 /opt/npa-agent/s3.env"
+    )
+
+
+def _write_agent_operator_profile(
+    ssh: SSHClient,
+    *,
+    ssh_user: str,
+    project_alias: str,
+    project_id: str,
+    tenant_id: str,
+    region: str,
+    tf_api_key: str,
+    nebius_ai_key: str,
+    s3_bucket: str,
+    s3_endpoint: str,
+    s3_access_key: str,
+    s3_secret_key: str,
+    service_account_id: str = "",
+) -> None:
+    """Write ~/.npa/config.yaml + credentials.yaml on the agent VM for operator workflows."""
+    if not (project_alias and project_id and tenant_id and region):
+        return
+    config_payload: dict[str, Any] = {
+        "default_project": project_alias,
+        "projects": {
+            project_alias: {
+                "project_id": project_id,
+                "tenant_id": tenant_id,
+                "region": region,
+            }
+        },
+    }
+    credentials_payload: dict[str, Any] = {"tokens": {}}
+    tokens = credentials_payload["tokens"]
+    if isinstance(tokens, dict):
+        if nebius_ai_key.strip():
+            tokens["NEBIUS_AI_CLOUD_KEY"] = nebius_ai_key.strip()
+        if tf_api_key.strip():
+            tokens["NEBIUS_TOKEN_FACTORY_KEY"] = tf_api_key.strip()
+    storage_payload = {
+        "access_key_id": s3_access_key.strip(),
+        "secret_access_key": s3_secret_key.strip(),
+        "endpoint": s3_endpoint.strip(),
+        "bucket": s3_bucket.strip(),
+    }
+    if any(storage_payload.values()):
+        credentials_payload["storage"] = storage_payload
+    if service_account_id.strip():
+        credentials_payload["nebius"] = {"service_account_id": service_account_id.strip()}
+    config_b64 = base64.b64encode(json.dumps(config_payload, indent=2).encode("utf-8")).decode("ascii")
+    creds_b64 = base64.b64encode(json.dumps(credentials_payload, indent=2).encode("utf-8")).decode("ascii")
+    user_home = f"/home/{ssh_user}"
+    npa_dir = f"{user_home}/.npa"
+    config_path = f"{npa_dir}/config.yaml"
+    creds_path = f"{npa_dir}/credentials.yaml"
+    ssh.run_or_raise(
+        " && ".join(
+            [
+                f"sudo mkdir -p {shlex.quote(npa_dir)}",
+                f"echo {shlex.quote(config_b64)} | base64 -d | sudo tee {shlex.quote(config_path)} >/dev/null",
+                f"echo {shlex.quote(creds_b64)} | base64 -d | sudo tee {shlex.quote(creds_path)} >/dev/null",
+                f"sudo chown -R {shlex.quote(ssh_user)}:{shlex.quote(ssh_user)} {shlex.quote(npa_dir)}",
+                f"sudo chmod 700 {shlex.quote(npa_dir)}",
+                f"sudo chmod 600 {shlex.quote(config_path)} {shlex.quote(creds_path)}",
+            ]
+        )
+    )
+
+
+def _store_project_environment(*, project: str, project_id: str, tenant_id: str, region: str) -> None:
+    """Persist a project-scoped Nebius environment like a fresh configure step."""
+    write_config(
+        {
+            "default_project": project,
+            "projects": {
+                project: {
+                    "project_id": project_id,
+                    "tenant_id": tenant_id,
+                    "region": region,
+                }
+            },
+        }
     )
 
 
@@ -648,13 +774,20 @@ def _bootstrap_agent_stack(
     host: str,
     ssh_user: str,
     ssh_key_path: str,
+    project_alias: str,
+    project_id: str,
+    tenant_id: str,
+    region: str,
     auth_user: str,
     auth_password: str,
     agent_port: int,
     backend_port: int,
     rerun_port: int,
     llm_model: str = DEFAULT_LLM_MODEL,
+    llm_models: list[str] | tuple[str, ...] = DEFAULT_LLM_MODELS,
     tf_api_key: str = "",
+    nebius_ai_key: str = "",
+    service_account_id: str = "",
     s3_bucket: str = "",
     s3_endpoint: str = "",
     s3_access_key: str = "",
@@ -662,7 +795,6 @@ def _bootstrap_agent_stack(
     s3_region: str = "eu-north1",
     nebius_project_id: str = "",
     nebius_tenant_id: str = "",
-    service_account_id: str = "",
     public_https: bool = True,
 ) -> None:
     ssh = SSHClient(
@@ -678,6 +810,8 @@ def _bootstrap_agent_stack(
     agent_chat_source = _embedded_agent_chat_source()
     agent_workflow_source = _embedded_agent_workflow_source()
     agent_artifacts_source = _embedded_agent_artifacts_source()
+    llm_models = _normalize_llm_models(list(llm_models))
+    default_llm_models_json = json.dumps(llm_models)
     nginx_site_body = _nginx_agent_site_body(backend_port=backend_port, rerun_port=rerun_port)
     login_form_html = _agent_public_login_form_html(auth_user)
     strip_url_credentials_js = _agent_strip_url_credentials_js()
@@ -704,9 +838,30 @@ server {{
 {nginx_site_body}
 }}
 """
+    nebius_profile = "cursor-sa"
+    nebius_parent_id = shlex.quote((nebius_project_id or project_id).strip())
     setup_script = f"""set -euo pipefail
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nginx apache2-utils python3-venv python3-pip
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nginx apache2-utils python3-venv python3-pip curl
+if ! command -v nebius >/dev/null 2>&1; then
+  curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
+fi
+if ! grep -q 'export PATH="$HOME/.nebius/bin:$PATH"' "$HOME/.profile" 2>/dev/null; then
+  echo 'export PATH="$HOME/.nebius/bin:$PATH"' >> "$HOME/.profile"
+fi
+NEBIUS_BIN="$(command -v nebius || true)"
+if [ -z "$NEBIUS_BIN" ] && [ -x "$HOME/.nebius/bin/nebius" ]; then
+  NEBIUS_BIN="$HOME/.nebius/bin/nebius"
+fi
+if [ -z "$NEBIUS_BIN" ] || [ ! -x "$NEBIUS_BIN" ]; then
+  echo "nebius CLI binary not found after install" >&2
+  exit 1
+fi
+if [ -s /mnt/cloud-metadata/token ]; then
+  if ! "$NEBIUS_BIN" profile create --endpoint api.eu.nebius.cloud --token-file /mnt/cloud-metadata/token --profile {nebius_profile} --parent-id {nebius_parent_id} >/dev/null 2>&1; then
+    "$NEBIUS_BIN" --profile {nebius_profile} iam get-access-token >/dev/null
+  fi
+fi
 sudo mkdir -p /opt/npa-agent
 cat <<'PY' | sudo tee /opt/npa-agent/backend.py >/dev/null
 import json
@@ -1295,12 +1450,80 @@ def _wire_franka_demo(state: dict, *, camera: str = "workspace") -> dict:
     return viz
 
 LLM_MODEL = os.environ.get("NPA_AGENT_LLM_MODEL", "{DEFAULT_LLM_MODEL}")
+LLM_MODELS_ENV = os.environ.get("NPA_AGENT_LLM_MODELS", "")
+DEFAULT_LLM_MODELS = {default_llm_models_json}
 TF_BASE_URL = os.environ.get(
     "NEBIUS_TOKEN_FACTORY_BASE_URL", "https://api.tokenfactory.nebius.com/v1/"
 ).rstrip("/")
 _THINK_RE = re.compile(
     r"\\A\\s*<think>(?P<reasoning>.*?)</think>\\s*", re.DOTALL
 )
+_MODELS_CACHE = {{"expires_at": 0.0, "models": []}}
+
+def _normalize_llm_models(raw: str) -> list[str]:
+    models: list[str] = []
+    for part in str(raw or "").replace("\\n", ",").split(","):
+        value = part.strip()
+        if value and value not in models:
+            models.append(value)
+    return models
+
+def _configured_llm_models() -> list[str]:
+    configured = _normalize_llm_models(LLM_MODELS_ENV)
+    if not configured:
+        configured = [str(item) for item in DEFAULT_LLM_MODELS if str(item).strip()]
+    if LLM_MODEL not in configured:
+        configured.insert(0, LLM_MODEL)
+    return configured
+
+def _fetch_token_factory_models() -> list[str]:
+    api_key = os.environ.get("NEBIUS_TOKEN_FACTORY_KEY", "").strip()
+    if not api_key:
+        return []
+    url = f"{{TF_BASE_URL}}/models"
+    try:
+        response = httpx.get(
+            url,
+            headers={{
+                "Authorization": f"Bearer {{api_key}}",
+                "Content-Type": "application/json",
+            }},
+            timeout=20.0,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception:
+        return []
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return []
+    models: list[str] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        value = str(item.get("id") or "").strip()
+        if value and value not in models:
+            models.append(value)
+    return models
+
+def _available_llm_models(*, refresh: bool = False) -> list[str]:
+    configured = _configured_llm_models()
+    now = time.monotonic()
+    cache = _MODELS_CACHE
+    if not refresh and cache.get("expires_at", 0.0) > now:
+        cached = cache.get("models", [])
+        if isinstance(cached, list) and cached:
+            return cached
+    live = _fetch_token_factory_models()
+    if live:
+        allowed = [model for model in configured if model in live]
+        extras = [model for model in live if model not in allowed]
+        resolved = (allowed + extras)[:32]
+    else:
+        resolved = configured
+    cache["models"] = resolved
+    cache["expires_at"] = now + 300.0
+    return resolved
 
 def _agent_system_prompt() -> str:
     lines = [
@@ -1323,6 +1546,7 @@ def _agent_system_prompt() -> str:
         "- POST /api/workflows/validate — validate npa.workflow/v0.0.1 or npa.workflow/v0.0.1-beta YAML",
         "- POST /api/workflows/plan — dry-run plan-spec for workflow YAML",
         "- POST /api/workflows/submit — validate + plan workflow YAML (validate-only on agent VM)",
+        "- GET /api/models — list Token Factory chat models available to this VM key",
         "- GET /api/tools — workbench toolRef catalog",
         "",
         "To view Franka immediately, tell users to click **Load Franka in Rerun** in the Sim Assets panel",
@@ -1550,8 +1774,8 @@ def _maybe_toolground_chat_reply(user_text: str) -> tuple[str | None, list[str],
         if not runnable:
             fail_reason = str(validation.get("error") or plan.get("error") or "validate+plan gate did not pass")
             reply = (
-                "**Could not generate runnable workflow YAML yet.**\\n"
-                f"- **reason**: `{{fail_reason}}`\\n"
+                "**Could not generate runnable workflow YAML yet.**\n"
+                f"- **reason**: `{{fail_reason}}`\n"
                 "- Adjust your request or template details and retry;"
                 " chat returns YAML only after both validation and planning succeed."
             )
@@ -1661,6 +1885,15 @@ def chat(payload: dict):
 def health():
     return {{"ok": True, "tool_refs": len(TOOL_REFS)}}
 
+@app.get("/models")
+def models(refresh: bool = False):
+    return {{
+        "ok": True,
+        "default": LLM_MODEL,
+        "default_model": LLM_MODEL,
+        "models": _available_llm_models(refresh=bool(refresh)),
+    }}
+
 @app.get("/session")
 def session_bootstrap():
     state = _load_state()
@@ -1685,6 +1918,12 @@ def session_bootstrap():
         "workflow_submit": state.get("workflow_submit", {{}}),
         "camera_selection": state.get("camera_selection", ["workspace"]),
         "chat_history": history,
+        "llm": {{
+            "default": LLM_MODEL,
+            "default_model": LLM_MODEL,
+            "model": LLM_MODEL,
+            "models": _available_llm_models(),
+        }},
     }}
 
 @app.get("/tools")
@@ -2640,6 +2879,29 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       .camera-frustum {{ display: flex; justify-content: center; }}
       .rollout-hint {{ font-size: 13px; color: #39465c; margin: 0 0 10px 0; }}
       .chat-panel {{ margin-bottom: 12px; }}
+      .chat-toolbar {{
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 10px;
+        margin: 8px 0 10px;
+        flex-wrap: wrap;
+      }}
+      .chat-model {{
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        color: #4f5668;
+      }}
+      .chat-model select {{
+        border: 1px solid #d4d8e2;
+        border-radius: 999px;
+        padding: 6px 10px;
+        background: #fff;
+        color: #1f2430;
+        font: inherit;
+      }}
       .chat-log {{
         height: 320px; overflow-y: auto; background: #f9fafc; border: 1px solid var(--border);
         border-radius: 10px; padding: 10px; margin-bottom: 10px;
@@ -2754,6 +3016,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         flex: 1; min-height: 58px; resize: vertical; font-family: inherit; padding: 10px 12px;
         border: 1px solid var(--border);
         border-radius: 12px;
+        font-size: 16px;
         outline: none;
       }}
       .chat-input textarea:focus {{ border-color: #c2bae7; box-shadow: 0 0 0 3px rgba(94, 67, 243, 0.12); }}
@@ -2850,6 +3113,36 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       @media (max-width: 1280px) {{
         .layout-3 {{ grid-template-columns: 1fr; }}
       }}
+      @media (max-width: 900px) {{
+        .topbar {{
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 8px;
+        }}
+        .page {{ padding: 12px; gap: 12px; }}
+        .panel {{ padding: 12px; }}
+        .field-row {{ grid-template-columns: 1fr; }}
+        .msg-card {{ max-width: 92%; }}
+        iframe {{ height: 300px; }}
+      }}
+      @media (max-width: 640px) {{
+        body {{ padding-bottom: calc(52px + env(safe-area-inset-bottom)); }}
+        .chrome {{ min-height: auto; }}
+        .brand {{ font-size: 12px; }}
+        .brand-sub {{ font-size: 11px; line-height: 1.35; }}
+        .chat-input {{
+          flex-direction: column;
+          align-items: stretch;
+        }}
+        .chat-input .btn {{ width: 100%; }}
+        .btn, .quick-pill {{
+          min-height: 40px;
+          font-size: 13px;
+        }}
+        .status-bar {{
+          padding-bottom: calc(8px + env(safe-area-inset-bottom));
+        }}
+      }}
       .workflow-panel textarea {{
         width: 100%;
         min-height: 220px;
@@ -2916,6 +3209,15 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         <section class="panel chat-panel">
           <h3>Workbench Chat</h3>
           <p class="hint">Ask about configure, provision, Cosmos3, S3, workflows, sim assets, and Rerun visualization.</p>
+          <div class="chat-toolbar">
+            <span class="hint">Grounded responses use live `/api/*` context from this VM.</span>
+            <label for="chatModel" class="chat-model">
+              Token Factory model
+              <select id="chatModel">
+                <option value="{DEFAULT_LLM_MODEL}" selected>{DEFAULT_LLM_MODEL}</option>
+              </select>
+            </label>
+          </div>
           <div id="chatLog" class="chat-log"></div>
           <div class="chat-input">
             <textarea id="chatInput" placeholder="How do I configure S3 for Sim2Real?"></textarea>
@@ -3403,8 +3705,34 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       function setChatBusy(isBusy) {{
         const btn = document.getElementById("chatSend");
         const input = document.getElementById("chatInput");
+        const model = document.getElementById("chatModel");
         btn.disabled = Boolean(isBusy);
         input.disabled = Boolean(isBusy);
+        if (model) model.disabled = Boolean(isBusy);
+      }}
+      function setChatModels(models, selectedModel) {{
+        const select = document.getElementById("chatModel");
+        if (!select) return;
+        const values = Array.isArray(models)
+          ? [...new Set(models.map((item) => String(item || "").trim()).filter(Boolean))]
+          : [];
+        if (!values.length) {{
+          values.push("{DEFAULT_LLM_MODEL}");
+        }}
+        const preferred = String(selectedModel || select.value || values[0] || "").trim();
+        const chosen = values.includes(preferred) ? preferred : values[0];
+        select.innerHTML = "";
+        for (const model of values) {{
+          const opt = document.createElement("option");
+          opt.value = model;
+          opt.textContent = model;
+          if (model === chosen) opt.selected = true;
+          select.appendChild(opt);
+        }}
+      }}
+      function selectedChatModel() {{
+        const select = document.getElementById("chatModel");
+        return String((select && select.value) || "").trim() || "{DEFAULT_LLM_MODEL}";
       }}
       function setWorkflowYaml(text, validation) {{
         const area = document.getElementById("workflowYaml");
@@ -3485,6 +3813,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       async function sendChat() {{
         const input = document.getElementById("chatInput");
         const text = String(input.value || "").trim();
+        const model = selectedChatModel();
         if (!text) {{
           showToast("Enter a message first", "info");
           return false;
@@ -3498,9 +3827,13 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           const data = await apiJson("/api/chat", {{
             method: "POST",
             headers: {{ "content-type": "application/json" }},
-            body: JSON.stringify({{ messages: chatHistory }}),
+            body: JSON.stringify({{ messages: chatHistory, model }}),
           }});
           clearThinkingBubble();
+          if (data && data.model) {{
+            const select = document.getElementById("chatModel");
+            if (select) select.value = String(data.model);
+          }}
           const reply = normalizeAssistantReply(data.reply || "");
           if (reply) {{
             appendChat("assistant", reply);
@@ -4036,6 +4369,12 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       async function refresh() {{
         try {{
           const session = await loadJson("/api/session");
+          if (session && session.llm) {{
+            const currentModel = String(
+              (session.llm.model || session.llm.default_model || session.llm.default || "")
+            );
+            setChatModels(session.llm.models, currentModel);
+          }}
           if (session && session.workflow_draft && session.workflow_draft.yaml) {{
             setWorkflowYaml(session.workflow_draft.yaml, session.workflow_draft.validation || {{}});
           }}
@@ -4341,6 +4680,12 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       async function restoreSession() {{
         try {{
           const session = await loadJson("/api/session");
+          if (session && session.llm) {{
+            const currentModel = String(
+              (session.llm.model || session.llm.default_model || session.llm.default || "")
+            );
+            setChatModels(session.llm.models, currentModel);
+          }}
           const hist = Array.isArray(session.chat_history) ? session.chat_history : [];
           for (const msg of hist) {{
             const role = String(msg.role || "");
@@ -4517,7 +4862,7 @@ sudo systemctl restart npa-agent-backend
         if local_setup_script:
             Path(local_setup_script).unlink(missing_ok=True)
         ssh.run(f"rm -f {shlex.quote(remote_setup_script)}")
-    _write_agent_llm_env(ssh, tf_api_key=tf_api_key, llm_model=llm_model)
+    _write_agent_llm_env(ssh, tf_api_key=tf_api_key, llm_model=llm_model, llm_models=llm_models)
     _write_agent_s3_env(
         ssh,
         bucket=s3_bucket,
@@ -4526,10 +4871,25 @@ sudo systemctl restart npa-agent-backend
         secret_key=s3_secret_key,
         region=s3_region,
     )
+    _write_agent_operator_profile(
+        ssh,
+        ssh_user=ssh_user,
+        project_alias=project_alias,
+        project_id=project_id,
+        tenant_id=tenant_id,
+        region=region,
+        tf_api_key=tf_api_key,
+        nebius_ai_key=nebius_ai_key,
+        s3_bucket=s3_bucket,
+        s3_endpoint=s3_endpoint,
+        s3_access_key=s3_access_key,
+        s3_secret_key=s3_secret_key,
+        service_account_id=service_account_id,
+    )
     _write_agent_nebius_env(
         ssh,
-        project_id=nebius_project_id,
-        tenant_id=nebius_tenant_id,
+        project_id=nebius_project_id or project_id,
+        tenant_id=nebius_tenant_id or tenant_id,
         region=s3_region,
         service_account_id=service_account_id,
         bucket=s3_bucket,
@@ -4540,7 +4900,7 @@ sudo systemctl restart npa-agent-backend
     if (
         tf_api_key.strip()
         or (s3_bucket.strip() and s3_access_key.strip() and s3_secret_key.strip())
-        or (nebius_project_id.strip() and s3_access_key.strip() and s3_secret_key.strip())
+        or ((nebius_project_id or project_id).strip() and s3_access_key.strip() and s3_secret_key.strip())
     ):
         ssh.run_or_raise(
             "sudo systemctl reset-failed npa-agent-backend || true; "
@@ -4576,6 +4936,16 @@ def deploy_cmd(
     agent_port: int = typer.Option(DEFAULT_AGENT_PORT, "--agent-port", help="Public agent UI port."),
     backend_port: int = typer.Option(DEFAULT_BACKEND_PORT, "--backend-port", help="Internal agent backend port."),
     rerun_port: int = typer.Option(DEFAULT_RERUN_PORT, "--rerun-port", help="Rerun service port."),
+    llm_model: str = typer.Option(
+        DEFAULT_LLM_MODEL,
+        "--llm-model",
+        help="Default Token Factory model for agent chat.",
+    ),
+    llm_models: list[str] = typer.Option(
+        [],
+        "--llm-models",
+        help="Additional Token Factory model IDs (repeat flag or comma-separate values).",
+    ),
     no_public_https: bool = typer.Option(
         False,
         "--no-public-https",
@@ -4664,7 +5034,10 @@ def deploy_cmd(
         user=DEFAULT_AGENT_USER,
         password=auth_password,
     )
-    tf_api_key, llm_model = _resolve_deploy_llm_credentials()
+    tf_api_key, default_llm_model = _resolve_deploy_llm_credentials()
+    configured_llm_model = str(llm_model or "").strip() or default_llm_model
+    configured_llm_models = _normalize_llm_models([configured_llm_model, *llm_models])
+    nebius_ai_key, _ = _resolve_operator_credentials()
     if not tf_api_key:
         typer.echo(
             "Warning: Token Factory API key not found in credentials; "
@@ -4677,13 +5050,19 @@ def deploy_cmd(
             host=public_ip,
             ssh_user=ssh_user,
             ssh_key_path=ssh_key_path,
+            project_alias=project,
+            project_id=env_project_id,
+            tenant_id=env_tenant_id,
+            region=env_region,
             auth_user=DEFAULT_AGENT_USER,
             auth_password=auth_password,
             agent_port=agent_port,
             backend_port=backend_port,
             rerun_port=rerun_port,
-            llm_model=llm_model,
+            llm_model=configured_llm_model,
+            llm_models=configured_llm_models,
             tf_api_key=tf_api_key,
+            nebius_ai_key=nebius_ai_key,
             s3_bucket=str(merged_vars.get("s3_bucket", "")),
             s3_endpoint=str(merged_vars.get("s3_endpoint", "")),
             s3_access_key=str(merged_vars.get("nebius_api_key", "")),
@@ -4723,7 +5102,8 @@ def deploy_cmd(
         auth_user=DEFAULT_AGENT_USER,
         auth_secret_path=str(auth_path),
         llm_provider=DEFAULT_LLM_PROVIDER,
-        llm_model=DEFAULT_LLM_MODEL,
+        llm_model=configured_llm_model,
+        llm_models=tuple(configured_llm_models),
         public_url=urls["public_url"],
         public_https=public_https,
         direct_url=urls["direct_url"],
@@ -4762,10 +5142,78 @@ def deploy_cmd(
     typer.echo(f"sim_viz_url: {urls['sim_viz_url']}")
     typer.echo(f"sim_assets_url: {urls['sim_assets_url']}")
     typer.echo(f"cameras_api_url: {urls['cameras_api_url']}")
-    typer.echo(f"llm: {DEFAULT_LLM_PROVIDER}:{DEFAULT_LLM_MODEL}")
+    typer.echo(f"llm: {DEFAULT_LLM_PROVIDER}:{configured_llm_model}")
+    typer.echo(f"llm_models: {', '.join(configured_llm_models)}")
     typer.echo(f"auth_user: {DEFAULT_AGENT_USER}")
     typer.echo(f"auth_secret_path: {auth_path}")
     typer.echo(f"auth_password: {redact_value(auth_password)}")
+
+
+@app.command("fresh-setup")
+def fresh_setup_cmd(
+    project: str = typer.Option(DEFAULT_PROJECT_ALIAS, "--project", help="NPA project alias for this fresh environment."),
+    name: str = typer.Option(DEFAULT_AGENT_NAME, "--name", help="Agent deployment name."),
+    project_id: str = typer.Option(..., "--project-id", help="Nebius project ID."),
+    tenant_id: str = typer.Option(..., "--tenant-id", help="Nebius tenant ID."),
+    region: str = typer.Option("us-central1", "--region", help="Nebius region."),
+    ssh_user: str = typer.Option("ubuntu", "--ssh-user", help="SSH username."),
+    ssh_public_key_path: str = typer.Option("~/.ssh/id_ed25519.pub", "--ssh-public-key-path", help="SSH public key path for Terraform."),
+    tf_var: list[str] = typer.Option([], "--tf-var", help="Additional Terraform var key=value."),
+    agent_port: int = typer.Option(DEFAULT_AGENT_PORT, "--agent-port", help="Public agent UI port."),
+    backend_port: int = typer.Option(DEFAULT_BACKEND_PORT, "--backend-port", help="Internal agent backend port."),
+    rerun_port: int = typer.Option(DEFAULT_RERUN_PORT, "--rerun-port", help="Rerun service port."),
+    llm_model: str = typer.Option(
+        DEFAULT_LLM_MODEL,
+        "--llm-model",
+        help="Default Token Factory model for agent chat.",
+    ),
+    llm_models: list[str] = typer.Option(
+        [],
+        "--llm-models",
+        help="Additional Token Factory model IDs (repeat flag or comma-separate values).",
+    ),
+    no_public_https: bool = typer.Option(
+        False,
+        "--no-public-https",
+        help="Disable HTTPS on port 443 (customer access uses http://IP:agent-port only).",
+    ),
+    replace: bool = typer.Option(
+        False,
+        "--replace",
+        help="Destroy an existing agent with the same project/name before fresh deploy.",
+    ),
+) -> None:
+    """Initialize fresh project config and deploy a new agent from scratch."""
+    existing = _agent_record(project, name)
+    if existing and not replace:
+        _fail(
+            f"Agent {project}/{name} already exists. Use --replace or choose a new --project/--name."
+        )
+    _store_project_environment(
+        project=project,
+        project_id=project_id.strip(),
+        tenant_id=tenant_id.strip(),
+        region=region.strip(),
+    )
+    if existing and replace:
+        typer.echo(f"Replacing existing agent {project}/{name} ...")
+        destroy_cmd(project=project, name=name)
+    deploy_cmd(
+        project=project,
+        name=name,
+        project_id=project_id,
+        tenant_id=tenant_id,
+        region=region,
+        ssh_user=ssh_user,
+        ssh_public_key_path=ssh_public_key_path,
+        tf_var=tf_var,
+        agent_port=agent_port,
+        backend_port=backend_port,
+        rerun_port=rerun_port,
+        llm_model=llm_model,
+        llm_models=llm_models,
+        no_public_https=no_public_https,
+    )
 
 
 @app.command("bootstrap")
@@ -4777,6 +5225,12 @@ def bootstrap_cmd(
     agent_port: int = typer.Option(DEFAULT_AGENT_PORT, "--agent-port", help="Public agent UI port."),
     backend_port: int = typer.Option(DEFAULT_BACKEND_PORT, "--backend-port", help="Internal agent backend port."),
     rerun_port: int = typer.Option(DEFAULT_RERUN_PORT, "--rerun-port", help="Rerun service port."),
+    llm_model: str = typer.Option("", "--llm-model", help="Override the active Token Factory model."),
+    llm_models: list[str] = typer.Option(
+        [],
+        "--llm-models",
+        help="Override additional Token Factory model IDs (repeat flag or comma-separated values).",
+    ),
     refresh_credentials: bool = typer.Option(
         False,
         "--refresh-credentials",
@@ -4806,10 +5260,20 @@ def bootstrap_cmd(
         auth_user, auth_password = _load_auth_secret(str(record.get("auth_secret_path", "")))
     except ValueError as exc:
         _fail(str(exc))
-    tf_api_key, llm_model = _resolve_deploy_llm_credentials()
+    tf_api_key, default_llm_model = _resolve_deploy_llm_credentials()
+    requested_llm_model = str(llm_model or "").strip()
+    resolved_llm_model = requested_llm_model or default_llm_model
+    resolved_llm_models = _normalize_llm_models([resolved_llm_model, *llm_models])
+    nebius_ai_key, _ = _resolve_operator_credentials()
     llm_block = record.get("llm", {}) if isinstance(record.get("llm"), dict) else {}
-    if isinstance(llm_block.get("model"), str) and llm_block["model"].strip():
-        llm_model = llm_block["model"].strip()
+    if isinstance(llm_block.get("models"), list):
+        resolved_llm_models = _normalize_llm_models(
+            [*resolved_llm_models, *[str(item) for item in llm_block.get("models", [])]]
+        )
+    if not requested_llm_model and isinstance(llm_block.get("model"), str) and llm_block["model"].strip():
+        resolved_llm_model = llm_block["model"].strip()
+    if resolved_llm_model not in resolved_llm_models:
+        resolved_llm_models.insert(0, resolved_llm_model)
     if not tf_api_key:
         typer.echo(
             "Warning: Token Factory API key not found; chat endpoint will return 503.",
@@ -4823,6 +5287,7 @@ def bootstrap_cmd(
     )
     if not service_account_id:
         service_account_id = _resolve_agent_service_account_id(project, record)
+    agent_credentials: dict[str, str] | None = None
     if refresh_credentials:
         if not (project_id and tenant_id and region):
             _fail("agent record is missing project_id, tenant_id, or region for credential refresh")
@@ -4874,13 +5339,19 @@ def bootstrap_cmd(
             host=public_ip,
             ssh_user=ssh_user,
             ssh_key_path=ssh_key_path,
+            project_alias=project,
+            project_id=str(record.get("project_id", "") or ""),
+            tenant_id=str(record.get("tenant_id", "") or ""),
+            region=str(record.get("region", "") or "eu-north1"),
             auth_user=auth_user,
             auth_password=auth_password,
             agent_port=agent_port,
             backend_port=backend_port,
             rerun_port=rerun_port,
-            llm_model=llm_model,
+            llm_model=resolved_llm_model,
+            llm_models=resolved_llm_models,
             tf_api_key=tf_api_key,
+            nebius_ai_key=nebius_ai_key,
             s3_bucket=s3_bucket,
             s3_endpoint=s3_endpoint,
             s3_access_key=s3_access_key,
@@ -4910,6 +5381,11 @@ def bootstrap_cmd(
     updated = dict(record)
     updated.update(urls)
     updated["public_https"] = public_https
+    llm_payload = dict(updated.get("llm", {}) if isinstance(updated.get("llm"), dict) else {})
+    llm_payload["provider"] = DEFAULT_LLM_PROVIDER
+    llm_payload["model"] = resolved_llm_model
+    llm_payload["models"] = list(resolved_llm_models)
+    updated["llm"] = llm_payload
     updated["ssh_key_path"] = ssh_key_path
     if service_account_id:
         updated["service_account_id"] = service_account_id
@@ -4922,7 +5398,7 @@ def bootstrap_cmd(
             s3_access_key=s3_access_key,
             s3_secret_key=s3_secret_key,
         )
-    elif refresh_credentials:
+    elif refresh_credentials and agent_credentials is not None:
         updated["credentials"] = agent_credentials
     _store_agent_record(project, name, updated)
     typer.echo(f"Customer URL: {urls['public_url']}")

--- a/npa/src/npa/clients/nebius.py
+++ b/npa/src/npa/clients/nebius.py
@@ -9,13 +9,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
 import warnings
 from datetime import datetime, timezone
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
+from urllib import request as urllib_request
 
 from npa.smoke._versions import supported_tool_version
 
@@ -124,12 +127,87 @@ def _run_json(args: list[str], *, check: bool = True) -> dict[str, Any]:
 # ── IAM token ────────────────────────────────────────────────────────────
 
 
+_IAM_TOKEN_ENV_KEYS = ("NPA_NEBIUS_IAM_TOKEN", "NEBIUS_IAM_TOKEN")
+_IAM_TOKEN_FILE_ENV_KEYS = ("NPA_NEBIUS_IAM_TOKEN_FILE", "NEBIUS_IAM_TOKEN_FILE")
+_DEFAULT_IAM_TOKEN_FILES = (
+    "/mnt/cloud-metadata/token",
+    "/run/secrets/nebius/iam_token",
+)
+_METADATA_SA_TOKEN_URL = "http://metadata.nebius.internal/v1/iam/sa/token/access_token"
+
+
+def _env_iam_token() -> str:
+    for key in _IAM_TOKEN_ENV_KEYS:
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _candidate_iam_token_files() -> list[str]:
+    candidates: list[str] = []
+    for key in _IAM_TOKEN_FILE_ENV_KEYS:
+        path = os.environ.get(key, "").strip()
+        if path and path not in candidates:
+            candidates.append(path)
+    for path in _DEFAULT_IAM_TOKEN_FILES:
+        if path not in candidates:
+            candidates.append(path)
+    return candidates
+
+
+def _read_iam_token_file(path: str) -> str:
+    candidate = path.strip()
+    if not candidate:
+        return ""
+    try:
+        return Path(candidate).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _metadata_iam_token(timeout_s: float = 2.0) -> str:
+    req = urllib_request.Request(
+        _METADATA_SA_TOKEN_URL,
+        method="GET",
+        headers={"Metadata": "true"},
+    )
+    try:
+        with urllib_request.urlopen(req, timeout=timeout_s) as resp:
+            return resp.read().decode("utf-8", errors="ignore").strip()
+    except Exception:
+        return ""
+
+
 def get_iam_token() -> str:
-    """Obtain a short-lived IAM access token via ``nebius iam get-access-token``."""
-    token = _run(["iam", "get-access-token"])
-    if not token:
-        raise NebiusError("nebius iam get-access-token returned an empty token")
-    return token
+    """Resolve an IAM token from CLI profile, env/file overrides, or VM metadata."""
+    cli_error: str = ""
+    try:
+        token = _run(["iam", "get-access-token"])
+    except NebiusError as exc:
+        token = ""
+        cli_error = str(exc)
+    if token:
+        return token
+
+    env_token = _env_iam_token()
+    if env_token:
+        return env_token
+
+    for candidate in _candidate_iam_token_files():
+        file_token = _read_iam_token_file(candidate)
+        if file_token:
+            return file_token
+
+    metadata_token = _metadata_iam_token()
+    if metadata_token:
+        return metadata_token
+
+    detail = f" Last CLI error: {cli_error}" if cli_error else ""
+    raise NebiusError(
+        "Unable to resolve IAM token from Nebius CLI profile, environment, token files, "
+        f"or metadata endpoint ({_METADATA_SA_TOKEN_URL}).{detail}"
+    )
 
 
 # ── Profile-derived defaults ─────────────────────────────────────────────

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from npa.cli.agent import AGENT_UI_VERSION, app, build_agent_urls
+from npa.cli.agent import AGENT_UI_VERSION, _normalize_llm_models, app, build_agent_urls
 
 runner = CliRunner()
 
@@ -51,6 +51,7 @@ def test_agent_help_smoke() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "deploy" in result.output
+    assert "fresh-setup" in result.output
     assert "bootstrap" in result.output
     assert "verify-live" in result.output
 
@@ -61,8 +62,11 @@ def test_bootstrap_embeds_chat_endpoint() -> None:
     source = Path(agent_module.__file__).read_text(encoding="utf-8")
     assert '@app.post("/chat")' in source
     assert '@app.get("/session")' in source
+    assert '@app.get("/models")' in source
     assert "Workbench Chat" in source
     assert "NEBIUS_TOKEN_FACTORY_KEY" in source
+    assert "NPA_AGENT_LLM_MODELS" in source
+    assert 'id="chatModel"' in source
     assert "llm.env" in source
     assert "renderInlineMarkdownLite" in source
     assert "showThinkingBubble" in source
@@ -80,7 +84,7 @@ def test_bootstrap_embeds_chat_endpoint() -> None:
     assert "Always use real registry-qualified images" in source
     assert "`<your-registry-id>` placeholders" in source
     assert "sky gpus list" in source
-    bootstrap_split = f'        const lines = String(text || "").split(/\\r?\\n/);'
+    bootstrap_split = '        const lines = String(text || "").split(/\\r?\\n/);'
     assert "\r" not in bootstrap_split
     assert "\\r?\\n" in bootstrap_split
     assert "restoreSession" in source
@@ -100,6 +104,8 @@ def test_bootstrap_embeds_chat_endpoint() -> None:
     assert "normalizedPath === \"/welcome\"" in source
     assert "showRerunPlaceholder" in source
     assert "rerunIframeLoaded" in source
+    assert "setChatModels" in source
+    assert "selectedChatModel" in source
     assert "startApp()" in source
     assert "function bindClick(" in source
     assert "function wireUi()" in source
@@ -110,6 +116,8 @@ def test_bootstrap_embeds_chat_endpoint() -> None:
     assert "initNpaAgentUi" in source
     assert "AGENT_UI_VERSION" in source or "npa-ui-version" in source
     assert 'add_header Cache-Control "no-store, no-cache, must-revalidate"' in source
+    assert "@media (max-width: 900px)" in source
+    assert "safe-area-inset-bottom" in source
 
 
 def test_watch_intent_uses_live_sim_viz_status() -> None:
@@ -319,6 +327,19 @@ def test_resolve_deploy_llm_credentials_reads_credentials(monkeypatch) -> None:
     key, model = _resolve_deploy_llm_credentials()
     assert key == "tf-test-key"
     assert model == "nvidia/Cosmos3-Super-Reasoner"
+
+
+def test_normalize_llm_models_supports_repeated_and_csv_values() -> None:
+    models = _normalize_llm_models(
+        [
+            "nvidia/Cosmos3-Super-Reasoner,meta-llama/Llama-3.3-70B-Instruct",
+            "Qwen/Qwen2.5-VL-72B-Instruct",
+            "meta-llama/Llama-3.3-70B-Instruct",
+        ]
+    )
+    assert models[0] == "nvidia/Cosmos3-Super-Reasoner"
+    assert "meta-llama/Llama-3.3-70B-Instruct" in models
+    assert "Qwen/Qwen2.5-VL-72B-Instruct" in models
 
 
 def test_agent_status_json(monkeypatch) -> None:
@@ -715,6 +736,19 @@ def test_bootstrap_installs_boto3_for_artifact_endpoints() -> None:
 
     source = Path(agent_module.__file__).read_text(encoding="utf-8")
     assert "pip install fastapi uvicorn httpx pyyaml boto3" in source
+
+
+def test_bootstrap_installs_nebius_cli_and_sa_profile() -> None:
+    from npa.cli import agent as agent_module
+
+    source = Path(agent_module.__file__).read_text(encoding="utf-8")
+    assert "storage.eu-north1.nebius.cloud/cli/install.sh" in source
+    assert "--token-file /mnt/cloud-metadata/token" in source
+    assert 'nebius_profile = "cursor-sa"' in source
+    assert "--profile {nebius_profile}" in source
+    assert '"$NEBIUS_BIN" --profile {nebius_profile} iam get-access-token >/dev/null' in source
+    assert "nebius CLI binary not found after install" in source
+    assert "--parent-id" in source
 
 
 def test_list_recordings_intent_routing() -> None:

--- a/npa/tests/e2e/test_agent_live.py
+++ b/npa/tests/e2e/test_agent_live.py
@@ -238,6 +238,18 @@ def test_agent_chat_sim_assets_intent(ctx: AgentLiveContext) -> None:
     assert any(token in reply for token in ("franka", "isaac", "selection", "robot_preset"))
 
 
+def test_agent_models_endpoint(ctx: AgentLiveContext) -> None:
+    models = ctx.get("/api/models")
+    models.raise_for_status()
+    payload = models.json()
+    assert payload.get("ok") is True
+    model_list = payload.get("models")
+    assert isinstance(model_list, list) and model_list
+    default_model = str(payload.get("default_model") or payload.get("default") or "").strip()
+    assert default_model
+    assert default_model in [str(item) for item in model_list]
+
+
 def test_agent_chat_onboard_solution_intent(ctx: AgentLiveContext) -> None:
     from .agent_live_helpers import ONBOARD_SOLUTION_PROMPT, assert_grounded_onboard_solution_reply
 
@@ -264,3 +276,30 @@ def test_agent_chat_live(ctx: AgentLiveContext) -> None:
     payload = chat.json()
     assert payload.get("ok") is True
     assert payload.get("reply")
+
+
+@pytest.mark.skipif(
+    os.environ.get("NPA_AGENT_CHAT_LIVE") != "1",
+    reason="Set NPA_AGENT_CHAT_LIVE=1 to live-test explicit model switching.",
+)
+def test_agent_chat_live_model_switch(ctx: AgentLiveContext) -> None:
+    model_resp = ctx.get("/api/models")
+    model_resp.raise_for_status()
+    model_payload = model_resp.json()
+    default_model = str(model_payload.get("default_model") or model_payload.get("default") or "").strip()
+    models = [str(item) for item in (model_payload.get("models") or []) if str(item).strip()]
+    assert models
+    alternate = next((item for item in models if item != default_model), models[0])
+    chat = ctx.post(
+        "/api/chat",
+        json={
+            "messages": [{"role": "user", "content": "Reply with the word ok."}],
+            "model": alternate,
+        },
+        timeout=60.0,
+    )
+    chat.raise_for_status()
+    payload = chat.json()
+    assert payload.get("ok") is True
+    assert payload.get("reply")
+    assert str(payload.get("model") or "") == alternate

--- a/npa/tests/test_clients.py
+++ b/npa/tests/test_clients.py
@@ -329,18 +329,51 @@ def test_nebius_warns_once_on_cli_version_mismatch(mocker) -> None:
 
 
 def test_nebius_run_json_and_token(mocker) -> None:
-    mocker.patch("npa.clients.nebius._run", side_effect=['{"ok": true}', "", "token"])
+    mocker.patch("npa.clients.nebius._run", side_effect=['{"ok": true}', "token"])
 
     assert nebius._run_json(["cmd"]) == {"ok": True}
-    assert nebius._run_json(["empty"]) == {}
     assert nebius.get_iam_token() == "token"
 
 
-def test_nebius_empty_token_errors(mocker) -> None:
+def test_nebius_run_json_empty_payload(mocker) -> None:
     mocker.patch("npa.clients.nebius._run", return_value="")
 
-    with pytest.raises(NebiusError, match="empty token"):
+    assert nebius._run_json(["empty"]) == {}
+
+
+def test_nebius_iam_token_errors_when_all_sources_missing(mocker) -> None:
+    mocker.patch("npa.clients.nebius._run", return_value="")
+    mocker.patch("npa.clients.nebius._env_iam_token", return_value="")
+    mocker.patch("npa.clients.nebius._candidate_iam_token_files", return_value=[])
+    mocker.patch("npa.clients.nebius._metadata_iam_token", return_value="")
+
+    with pytest.raises(NebiusError, match="Unable to resolve IAM token"):
         nebius.get_iam_token()
+
+
+def test_nebius_iam_token_from_env(mocker) -> None:
+    mocker.patch("npa.clients.nebius._run", return_value="")
+    mocker.patch("npa.clients.nebius._env_iam_token", return_value="env-token")
+
+    assert nebius.get_iam_token() == "env-token"
+
+
+def test_nebius_iam_token_from_file_when_cli_unconfigured(mocker) -> None:
+    mocker.patch("npa.clients.nebius._run", side_effect=NebiusError("no profile"))
+    mocker.patch("npa.clients.nebius._env_iam_token", return_value="")
+    mocker.patch("npa.clients.nebius._candidate_iam_token_files", return_value=["/tmp/token"])
+    mocker.patch("npa.clients.nebius._read_iam_token_file", return_value="file-token")
+
+    assert nebius.get_iam_token() == "file-token"
+
+
+def test_nebius_iam_token_from_metadata_fallback(mocker) -> None:
+    mocker.patch("npa.clients.nebius._run", side_effect=NebiusError("no profile"))
+    mocker.patch("npa.clients.nebius._env_iam_token", return_value="")
+    mocker.patch("npa.clients.nebius._candidate_iam_token_files", return_value=[])
+    mocker.patch("npa.clients.nebius._metadata_iam_token", return_value="meta-token")
+
+    assert nebius.get_iam_token() == "meta-token"
 
 
 def test_nebius_service_account_reuses_existing(mocker) -> None:

--- a/skills/tools/nebius-infra/SKILL.md
+++ b/skills/tools/nebius-infra/SKILL.md
@@ -65,6 +65,10 @@ workflow environment variables.
 ## Gotchas
 
 - Use `https://storage.eu-north1.nebius.cloud` for the current primary region.
+- On Nebius VMs with an attached service account, IAM token resolution can use
+  service-account token sources (`/mnt/cloud-metadata/token` and IMDS) even
+  when `~/.nebius/config.yaml` is absent. Keep this as fallback behavior, not a
+  substitute for explicit operator-machine profile setup.
 - Nebius IAM registry tokens expire. If Kubernetes image pulls fail with `401
   Unauthorized`, refresh the registry pull secret in the namespace that owns the
   pod.

--- a/skills/tools/npa-agent/SKILL.md
+++ b/skills/tools/npa-agent/SKILL.md
@@ -18,6 +18,7 @@ Sim Assets + Cameras panels, embedded Rerun viewer, and Sim2Real submit hooks.
 ## Bootstrap And Verify
 
 ```bash
+npa/.venv/bin/npa agent fresh-setup --project rtxpro --name agent --project-id <project-id> --tenant-id <tenant-id> --region us-central1
 npa/.venv/bin/npa agent bootstrap --project rtxpro --name agent
 # Existing agents missing credentials: refresh long-lived npa-agent SA + restage VM env
 npa/.venv/bin/npa agent bootstrap --project rtxpro --name agent --refresh-credentials
@@ -69,6 +70,8 @@ access. GPU train YAML and SkyPilot config resolve from the project `kubernetes`
 block (`gpu_profile: rtxpro`, `byof_train_yaml`, `skypilot_config`).
 
 Auth secrets live at `~/.npa/agents/<project>/<name>/auth.env` (`AGENT_USER`, `AGENT_PASSWORD`).
+Agent bootstrap now stages operator config + credentials on the VM at `~/.npa/{config,credentials}.yaml` so the VM can run infra commands without re-entering project metadata. Bootstrap also installs Nebius CLI (if missing) and seeds a `cursor-sa` profile backed by `/mnt/cloud-metadata/token` when the VM has attached SA metadata; if token-backed profile setup is present but unusable, bootstrap fails fast instead of silently skipping it.
+Token Factory model selection is configurable via `--llm-model` and `--llm-models` (`NPA_AGENT_LLM_MODEL` and `NPA_AGENT_LLM_MODELS` on the VM), with `/api/models` exposed for UI/model picker refresh.
 
 ## Customer HTTPS Access
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Added `npa agent fresh-setup` to initialize a new project environment and deploy/bootstrap an agent VM from scratch in one command.
- Extended agent bootstrap/deploy to support multi-model Token Factory chat configuration (`--llm-model`, `--llm-models`) and exposed `/api/models` + session model metadata for UI-driven selection.
- Improved mobile/iPhone usability in the embedded UI with responsive layout updates, safe-area handling, and a chat model selector control.
- Staged operator profile files (`~/.npa/config.yaml`, `~/.npa/credentials.yaml`) onto the agent VM during bootstrap so the VM can run infra-oriented NPA commands without re-entering project metadata.
- Updated `skills/tools/npa-agent/SKILL.md` with the new fresh-setup and model-selection workflow notes.

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks.
  - `npa/.venv/bin/python -m ruff check npa/src/npa/cli/agent.py npa/tests/cli/test_agent.py`
  - `PYTHONPATH=/workspace/npa/src npa/.venv/bin/python -m pytest npa/tests/cli/test_agent.py -q`
  - `PYTHONPATH=/workspace/npa/src npa/.venv/bin/python -m pytest npa/tests/smoke/test_agent_smoke.py npa/tests/smoke/test_agent_chat_smoke.py -q`
- [x] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`.
  - `PYTHONPATH=/workspace/npa/src npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q`
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Skill Maintenance

- [x] I updated the relevant root `skills/` entry and `skills/index.yaml`, or this PR does not change behavior that needs skill guidance.
  - Updated `skills/tools/npa-agent/SKILL.md` for the new setup/model flow; no `skills/index.yaml` entry change was required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5d82fc9-0254-495a-b600-adb39b6cd343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5d82fc9-0254-495a-b600-adb39b6cd343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

