### PR TITLE
feat(sim2real): route customer robot_spec into staged RL training (not just eval)

### DIFF
--- a/npa/src/npa/genesis/robot_assets.py
+++ b/npa/src/npa/genesis/robot_assets.py
@@ -101,6 +101,12 @@ class RobotSpec:
     ee_link: str = "hand"  # end-effector link name (IK + ee_pos)
     base_link: str = "panda_link0"  # articulation root link (ee_frame source frame)
     finger_links: tuple[str, ...] = ("left_finger", "right_finger")
+    # Gripper (finger) joint names — the BinaryJointPositionAction targets. Empty
+    # for presets that don't declare them (the BYO task then falls back to the
+    # Franka ``panda_finger.*`` pattern, correct only for a Franka-class hand). A
+    # non-Franka gripper MUST carry these through so the gripper action retargets
+    # to its real finger joints instead of nonexistent panda_finger joints.
+    gripper_joint_names: tuple[str, ...] = ()
     n_arm_joints: int = 7
     n_gripper_joints: int = 2
     joint_names: tuple[str, ...] = ()
@@ -401,8 +407,14 @@ def parse_robot_spec(doc: dict[str, Any]) -> RobotSpec:
         spec.builtin_path = str(doc["builtin_path"]).strip()
     if doc.get("ee_link"):
         spec.ee_link = str(doc["ee_link"]).strip()
+    if doc.get("base_link"):
+        spec.base_link = str(doc["base_link"]).strip()
     if "finger_links" in doc:
         spec.finger_links = _coerce_str_tuple(doc["finger_links"], "finger_links")
+    if "gripper_joint_names" in doc:
+        spec.gripper_joint_names = _coerce_str_tuple(
+            doc["gripper_joint_names"], "gripper_joint_names"
+        )
     if doc.get("joint_names") is not None:
         spec.joint_names = _coerce_str_tuple(doc["joint_names"], "joint_names")
     if doc.get("n_arm_joints") is not None:

--- a/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
@@ -144,18 +144,52 @@ def robot_spec_payload(spec: Any, *, usd_container_path: str = "") -> dict[str, 
 
 
 def _resolve_byo_robot_spec() -> Any:
-    """Resolve a RobotSpec from the trainer's env (preset/source), or ``None``.
+    """Resolve a RobotSpec from the trainer's env, or ``None`` (default Franka).
 
-    Best-effort and dependency-light: uses ``robot_spec_from_inputs`` (no
-    download). A ``robot_spec_uri`` JSON or a URDF→USD conversion is a follow-up;
-    the proven validation path is the Franka preset (a stock_franka spec).
+    Resolution mirrors the held-out eval (``engine._resolve_heldout_robot``) so
+    training and eval agree on the variant:
+
+    * ``NPA_SIM2REAL_ROBOT_SPEC_URI`` (s3://): download the customer robot-spec
+      JSON and parse it with the SAME ``resolve_robot_spec_from_consumed_doc`` the
+      eval uses — this is what routes a genuine CUSTOM robot (not just a named
+      preset) into RL training. The doc must carry ``robot_uri`` (the USD; an
+      Omniverse ``https://`` CDN URL is opened directly by Isaac, an ``s3://`` URL
+      is staged by the sibling job).
+    * else ``NPA_SIM2REAL_ROBOT_PRESET`` / ``NPA_SIM2REAL_ROBOT_SOURCE``: a named
+      preset / bare source, via ``robot_spec_from_inputs`` (no download).
+
+    A spec-uri that fails to download/parse raises rather than silently falling
+    back to Franka — the operator must not be misled into thinking their robot
+    trained when it did not.
     """
 
     from npa.genesis import robot_assets
 
+    spec_uri = _env("NPA_SIM2REAL_ROBOT_SPEC_URI")
+    preset = _env("NPA_SIM2REAL_ROBOT_PRESET")
+    source = _env("NPA_SIM2REAL_ROBOT_SOURCE")
+    if spec_uri:
+        import tempfile
+
+        from npa.clients.storage import StorageClient
+        from npa.workflows.sim2real_assets import resolve_robot_spec_from_consumed_doc
+
+        client = StorageClient.from_environment()
+        with tempfile.TemporaryDirectory() as td:
+            local = str(Path(td) / "robot-spec.json")
+            client.download_path(spec_uri, local)
+            doc = json.loads(Path(local).read_text(encoding="utf-8"))
+        spec = resolve_robot_spec_from_consumed_doc(
+            doc, robot_preset=preset, robot_source=source
+        )
+        print(f"byo_isaac_trainer: resolved robot_spec from {spec_uri} -> "
+              f"{getattr(spec, 'name', None)!r} ({getattr(spec, 'robot_source', None)})",
+              flush=True)
+        return spec
+
     return robot_assets.robot_spec_from_inputs(
-        robot_preset=_env("NPA_SIM2REAL_ROBOT_PRESET"),
-        robot_source=_env("NPA_SIM2REAL_ROBOT_SOURCE"),
+        robot_preset=preset,
+        robot_source=source,
     )
 
 

--- a/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
@@ -130,6 +130,9 @@ def robot_spec_payload(spec: Any, *, usd_container_path: str = "") -> dict[str, 
         "base_link": str(getattr(spec, "base_link", "") or ""),
         "joint_names": [str(j) for j in (getattr(spec, "joint_names", ()) or ())],
         "finger_links": [str(f) for f in (getattr(spec, "finger_links", ()) or ())],
+        "gripper_joint_names": [
+            str(g) for g in (getattr(spec, "gripper_joint_names", ()) or ())
+        ],
         "n_arm_joints": int(getattr(spec, "n_arm_joints", 0) or 0),
         "n_gripper_joints": int(getattr(spec, "n_gripper_joints", 0) or 0),
         "home_qpos": _floats(getattr(spec, "home_qpos", ())),

--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -2946,6 +2946,30 @@ def _normalize_byo_rl_signal(
     return payload
 
 
+def _byo_robot_trainer_env(config: Sim2RealLoopConfig) -> dict[str, str]:
+    """Robot-spec env for the BYO trainer sibling (opt-in, Franka-safe).
+
+    Returns the env that opts the trainer into its BYO-robot path and forwards the
+    SAME robot inputs the held-out eval receives (``_run_heldout_*`` sets these),
+    so a customer's ``robot_spec_uri`` / preset reaches RL training and eval as one
+    embodiment. Returns ``{}`` — i.e. leaves the trainer on the stock-Franka path,
+    byte-for-byte unchanged — when no robot is requested or it is stock Franka.
+    """
+
+    uri = (config.robot_spec_uri or "").strip()
+    source = (config.robot_source or "").strip().lower()
+    preset = (config.robot_preset or "").strip().lower()
+    requested = bool(uri) or bool(preset) or (bool(source) and source != "stock_franka")
+    if not requested:
+        return {}
+    return {
+        "NPA_BYO_ROBOT_TASK": "1",
+        "NPA_SIM2REAL_ROBOT_SPEC_URI": config.robot_spec_uri,
+        "NPA_SIM2REAL_ROBOT_SOURCE": config.robot_source,
+        "NPA_SIM2REAL_ROBOT_PRESET": config.robot_preset,
+    }
+
+
 def _run_trainer_via_command(
     signal_batch_path: Path,
     *,
@@ -2997,6 +3021,13 @@ def _run_trainer_via_command(
     # so stage 11B "send back for more RL" compounds instead of restarting from scratch.
     if resume_checkpoint_uri.strip():
         extra["NPA_SIM2REAL_RESUME_CHECKPOINT_URI"] = resume_checkpoint_uri.strip()
+    # BYO ROBOT: route a customer robot spec into RL TRAINING, not just the held-out
+    # eval. Previously the trainer sibling never received the robot vars, so a custom
+    # robot_spec_uri reached only the eval USD-swap — the policy still trained on the
+    # stock Franka. Forward the same robot inputs the eval gets + opt in the trainer's
+    # BYO-robot path so train and eval share one embodiment. Empty (Franka/no robot)
+    # -> nothing added, trainer path byte-for-byte unchanged.
+    extra.update(_byo_robot_trainer_env(config))
     env = _component_env(
         config,
         component="trainer",

--- a/npa/tests/workflows/test_byo_robot_staged_routing.py
+++ b/npa/tests/workflows/test_byo_robot_staged_routing.py
@@ -1,0 +1,125 @@
+"""Unit tests for routing a customer robot_spec into STAGED RL training.
+
+Previously a BYO ``robot_spec_uri`` reached only the held-out eval USD-swap; the
+trainer sibling never received the robot vars, so the policy trained on the stock
+Franka. These cover the two seams that close that gap:
+
+* ``engine._byo_robot_trainer_env`` — forwards the robot inputs + opts the trainer
+  into the BYO-robot path, and is Franka-safe (empty for no-robot / stock).
+* ``byo_isaac_trainer._resolve_byo_robot_spec`` — resolves a ``robot_spec_uri``
+  JSON via the same parser the eval uses (mocked here; no cluster / no network).
+"""
+
+from __future__ import annotations
+
+import json
+
+from npa.workflows.sim2real import byo_isaac_trainer as trainer
+from npa.workflows.sim2real import engine
+from npa.workflows.sim2real.models import Sim2RealLoopConfig
+
+
+# --------------------------------------------------------------------------- #
+# engine._byo_robot_trainer_env — forward robot vars to the trainer sibling
+# --------------------------------------------------------------------------- #
+def test_trainer_env_empty_for_no_robot():
+    assert engine._byo_robot_trainer_env(Sim2RealLoopConfig(run_id="r")) == {}
+
+
+def test_trainer_env_empty_for_stock_franka_source():
+    cfg = Sim2RealLoopConfig(run_id="r", robot_source="stock_franka")
+    assert engine._byo_robot_trainer_env(cfg) == {}
+
+
+def test_trainer_env_set_for_spec_uri():
+    cfg = Sim2RealLoopConfig(run_id="r", robot_spec_uri="s3://b/kinova/robot-spec.json")
+    env = engine._byo_robot_trainer_env(cfg)
+    assert env["NPA_BYO_ROBOT_TASK"] == "1"
+    assert env["NPA_SIM2REAL_ROBOT_SPEC_URI"] == "s3://b/kinova/robot-spec.json"
+    # forwarded even when blank so the trainer sees the same trio the eval does
+    assert env["NPA_SIM2REAL_ROBOT_SOURCE"] == ""
+    assert env["NPA_SIM2REAL_ROBOT_PRESET"] == ""
+
+
+def test_trainer_env_set_for_preset_and_byo_source():
+    assert engine._byo_robot_trainer_env(
+        Sim2RealLoopConfig(run_id="r", robot_preset="ur10e")
+    )["NPA_BYO_ROBOT_TASK"] == "1"
+    assert engine._byo_robot_trainer_env(
+        Sim2RealLoopConfig(run_id="r", robot_source="byo_usd")
+    )["NPA_BYO_ROBOT_TASK"] == "1"
+
+
+# --------------------------------------------------------------------------- #
+# byo_isaac_trainer._resolve_byo_robot_spec — resolve a robot_spec_uri JSON
+# --------------------------------------------------------------------------- #
+def _kinova_doc() -> dict:
+    # A consumed/bare robot doc keyed on robot_uri (the USD). An Omniverse https
+    # CDN URL is opened directly by Isaac; parse_robot_spec requires robot_uri for
+    # a byo_usd source.
+    return {
+        "robot_source": "byo_usd",
+        "name": "kinova_j2n7s300",
+        "robot_uri": "https://omniverse-content-production.s3-us-west-2.amazonaws.com/"
+        "Assets/Isaac/5.1/Isaac/Robots/Kinova/Jaco2/J2N7S300/j2n7s300_instanceable.usd",
+        "ee_link": "j2n7s300_end_effector",
+        "base_link": "j2n7s300_link_base",
+        "n_arm_joints": 7,
+        "n_gripper_joints": 3,
+        "joint_names": [f"j2n7s300_joint_{i}" for i in range(1, 8)]
+        + [f"j2n7s300_joint_finger_{i}" for i in range(1, 4)],
+        "gripper_joint_names": [f"j2n7s300_joint_finger_{i}" for i in range(1, 4)],
+        "finger_links": [f"j2n7s300_link_finger_{i}" for i in range(1, 4)],
+        "gripper_open": 0.0,
+        "gripper_close": 1.2,
+        # A consumed/validated robot doc is gains-complete: every per-DoF array
+        # (kp/kv/force/home_qpos) has dof_count (10) entries. parse_robot_spec's
+        # validate() enforces this — so a real robot_spec_uri must carry them.
+        "home_qpos": [0.0, 2.9, 0.0, 1.3, 0.0, 2.07, 1.4, 0.0, 0.0, 0.0],
+        "kp": [40.0] * 7 + [20.0] * 3,
+        "kv": [8.0] * 7 + [4.0] * 3,
+        "force_upper": [30.0] * 10,
+        "force_lower": [-30.0] * 10,
+    }
+
+
+def test_resolve_spec_from_uri_downloads_and_parses(monkeypatch, tmp_path):
+    doc = _kinova_doc()
+
+    class _FakeClient:
+        def download_path(self, uri, dest):  # noqa: D401 (test stub)
+            assert uri == "s3://b/kinova/robot-spec.json"
+            with open(dest, "w", encoding="utf-8") as fh:
+                json.dump(doc, fh)
+
+    from npa.clients import storage
+
+    monkeypatch.setattr(storage.StorageClient, "from_environment",
+                        classmethod(lambda cls, *a, **k: _FakeClient()))
+    monkeypatch.setenv("NPA_SIM2REAL_ROBOT_SPEC_URI", "s3://b/kinova/robot-spec.json")
+    monkeypatch.delenv("NPA_SIM2REAL_ROBOT_PRESET", raising=False)
+    monkeypatch.delenv("NPA_SIM2REAL_ROBOT_SOURCE", raising=False)
+
+    spec = trainer._resolve_byo_robot_spec()
+    assert spec is not None
+    assert str(spec.robot_source) == "byo_usd"
+    assert spec.name == "kinova_j2n7s300"
+    # The USD carried through as robot_uri (so run_isaac_training_job can stage/open it).
+    assert spec.robot_uri.endswith("j2n7s300_instanceable.usd")
+
+
+def test_resolve_spec_uri_absent_falls_back_to_preset(monkeypatch):
+    monkeypatch.delenv("NPA_SIM2REAL_ROBOT_SPEC_URI", raising=False)
+    monkeypatch.setenv("NPA_SIM2REAL_ROBOT_PRESET", "franka")
+    monkeypatch.delenv("NPA_SIM2REAL_ROBOT_SOURCE", raising=False)
+    spec = trainer._resolve_byo_robot_spec()
+    # Franka preset resolves to a stock_franka spec (proven default path).
+    assert spec is not None
+    assert str(spec.robot_source) == "stock_franka"
+
+
+def test_resolve_no_robot_returns_none(monkeypatch):
+    for k in ("NPA_SIM2REAL_ROBOT_SPEC_URI", "NPA_SIM2REAL_ROBOT_PRESET",
+              "NPA_SIM2REAL_ROBOT_SOURCE"):
+        monkeypatch.delenv(k, raising=False)
+    assert trainer._resolve_byo_robot_spec() is None

--- a/npa/tests/workflows/test_byo_robot_staged_routing.py
+++ b/npa/tests/workflows/test_byo_robot_staged_routing.py
@@ -106,6 +106,23 @@ def test_resolve_spec_from_uri_downloads_and_parses(monkeypatch, tmp_path):
     assert spec.name == "kinova_j2n7s300"
     # The USD carried through as robot_uri (so run_isaac_training_job can stage/open it).
     assert spec.robot_uri.endswith("j2n7s300_instanceable.usd")
+    # Fidelity: base_link + gripper_joint_names must survive parse (else the ee_frame
+    # source defaults to Franka's panda_link0 and the gripper action retargets to
+    # nonexistent panda_finger.* joints — both crash a non-Franka arm at train time).
+    assert spec.base_link == "j2n7s300_link_base"
+    assert tuple(spec.gripper_joint_names) == (
+        "j2n7s300_joint_finger_1",
+        "j2n7s300_joint_finger_2",
+        "j2n7s300_joint_finger_3",
+    )
+    # ...and they must be serialized into the in-container payload the sibling reads.
+    payload = trainer.robot_spec_payload(spec, usd_container_path=spec.robot_uri)
+    assert payload["base_link"] == "j2n7s300_link_base"
+    assert payload["gripper_joint_names"] == [
+        "j2n7s300_joint_finger_1",
+        "j2n7s300_joint_finger_2",
+        "j2n7s300_joint_finger_3",
+    ]
 
 
 def test_resolve_spec_uri_absent_falls_back_to_preset(monkeypatch):


### PR DESCRIPTION
## Route a customer robot_spec into STAGED RL training (not just eval)

The BYO-robot seam lets a customer `robot_spec_uri` reach the **held-out eval**
(engine `_resolve_heldout_robot` forwards the robot vars + swaps the USD), but the
**RL trainer sibling never received them**:

- `_run_trainer_via_command` built the trainer env with no robot vars, and
- `byo_isaac_trainer._resolve_byo_robot_spec` only read a `robot_preset`/`robot_source` (no download; its docstring even said "a `robot_spec_uri` JSON … is a follow-up").

So a custom robot could run the full 14-stage pipeline yet the **policy still
trained on the stock Franka** — only the eval saw the customer robot. This is the
last blocker to a customer driving their own robot through the product's staged
pipeline (today it requires the direct-trainer workaround).

## Change (trainer now symmetric with eval)

- **`engine._byo_robot_trainer_env(config)`** — Franka-safe helper: opts the
  trainer into `NPA_BYO_ROBOT_TASK=1` and forwards the SAME
  `robot_spec_uri`/`robot_source`/`robot_preset` the eval gets. Returns `{}` (path
  byte-for-byte unchanged) for no-robot / stock Franka. Merged into the trainer
  command env in `_run_trainer_via_command`.
- **`byo_isaac_trainer._resolve_byo_robot_spec`** — when `NPA_SIM2REAL_ROBOT_SPEC_URI`
  is set, downloads the spec JSON (`StorageClient`) and parses it with the SAME
  `resolve_robot_spec_from_consumed_doc` the eval uses → train + eval resolve one
  identical embodiment. Preset/source fallback otherwise; a spec-uri that fails to
  parse **raises** (no silent Franka fallback). The doc carries `robot_uri` (an
  Omniverse `https://` CDN USD is opened directly by Isaac; an `s3://` USD is staged).

## Tests

7 new unit tests (helper Franka-safety + set-for-uri/preset/source; trainer URI
download+parse via a mocked `StorageClient`; preset fallback; no-robot → None).
**215 sim2real workflow tests pass; ruff clean on changed regions.**

## Scope (honest)

This routes the spec into **training** — it does **not** change grasp physics. A
multi-finger force-closure grasp still needs the gripper-drive / grasp-reward work
tracked in #160 and remains an open per-robot problem. Staged GPU validation
(custom Kinova spec reaching the training sibling) noted in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
