### PR TITLE
feat(sim2real): minimal-spec BYO robot onboarding (Lite6 parallel-jaw) + usd_path resolver fix

### DIFF
--- a/npa/src/npa/genesis/robot_assets.py
+++ b/npa/src/npa/genesis/robot_assets.py
@@ -83,6 +83,38 @@ STOCK_FRANKA_MJCF = "xml/franka_emika_panda/panda.xml"
 # env_pick_place.py so the default path is byte-for-byte identical.
 FRANKA_HOME = (0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785, 0.04, 0.04)
 
+# --------------------------------------------------------------------------- #
+# Minimal-spec onboarding defaults
+# --------------------------------------------------------------------------- #
+# Without these, a customer onboarding a BYO robot must hand-write dof_count-long
+# ``kp``/``kv``/``force_*``/``home_qpos`` arrays, and a missing/short array is
+# rejected. When those arrays are OMITTED we synthesize robot-agnostic,
+# position-control defaults from the joint counts, so a MINIMAL spec (name + usd +
+# joint/link names) onboards. Values are per-joint-type — an arm joint gets a
+# moderate position-control drive, a gripper finger a lighter one — and are
+# deliberately conservative: each sits well inside every clamp in
+# ``isaac_byo_robot_task`` and inside the proven-stable range of prior on-cluster
+# BYO runs. Franka / preset specs ship full-length arrays, so this path never
+# touches them (see ``parse_robot_spec``).
+DEFAULT_ARM_KP = 80.0
+DEFAULT_ARM_KV = 8.0
+DEFAULT_ARM_FORCE = 50.0
+DEFAULT_GRIPPER_KP = 20.0
+DEFAULT_GRIPPER_KV = 4.0
+DEFAULT_GRIPPER_FORCE = 20.0
+
+
+def _auto_gain_array(
+    n_arm: int, n_gripper: int, arm_val: float, gripper_val: float
+) -> tuple[float, ...]:
+    """Build a dof_count-length array: ``arm_val`` per arm joint, ``gripper_val``
+    per gripper joint. Used to fill an omitted gain array for a minimal spec."""
+
+    return tuple(
+        [float(arm_val)] * max(int(n_arm), 0)
+        + [float(gripper_val)] * max(int(n_gripper), 0)
+    )
+
 
 class RobotSpecError(RuntimeError):
     """Raised when a RobotSpec is malformed or a robot asset cannot load."""
@@ -397,8 +429,14 @@ def parse_robot_spec(doc: dict[str, Any]) -> RobotSpec:
         spec.robot_source = str(doc["robot_source"]).strip()
     if doc.get("name"):
         spec.name = str(doc["name"]).strip()
-    if doc.get("robot_uri") is not None:
-        spec.robot_uri = str(doc["robot_uri"]).strip()
+    # ``usd_path`` is accepted as an alias for ``robot_uri`` so a customer can hand
+    # us the same field name the Isaac spawn config uses (isaac_byo_robot_task reads
+    # ``usd_path``); ``robot_uri`` wins when both are present.
+    robot_uri_in = doc.get("robot_uri")
+    if robot_uri_in is None:
+        robot_uri_in = doc.get("usd_path")
+    if robot_uri_in is not None:
+        spec.robot_uri = str(robot_uri_in).strip()
     if not explicit_source and spec.robot_uri:
         inferred = _infer_robot_source_from_uri(spec.robot_uri)
         if inferred is not None:
@@ -437,6 +475,40 @@ def parse_robot_spec(doc: dict[str, Any]) -> RobotSpec:
         spec.gripper_close = float(doc["gripper_close"])
     if doc.get("isaac_robot_hint"):
         spec.isaac_robot_hint = str(doc["isaac_robot_hint"]).strip()
+
+    # Minimal-spec joint-count inference: when the counts are omitted but joint
+    # names are supplied, derive them so the customer need not restate the
+    # arithmetic. Gripper count = len(gripper_joint_names); arm count = the
+    # remaining joints. Only fills a count the doc did not set.
+    if doc.get("n_gripper_joints") is None and "gripper_joint_names" in doc:
+        spec.n_gripper_joints = len(spec.gripper_joint_names)
+    if doc.get("n_arm_joints") is None and doc.get("joint_names") is not None:
+        spec.n_arm_joints = max(len(spec.joint_names) - spec.n_gripper_joints, 0)
+
+    # Auto-derive a dof_count-length array for each gain/home field the doc omits,
+    # so a minimal BYO spec (no hand-written per-joint arrays) still validates.
+    # Guard on ``len(...) != dof_count``: a Franka/preset spec ships correct-length
+    # arrays (dof_count == len), so those paths are never touched; only a custom
+    # embodiment whose DoF differs from the seeded default gets synthesized gains.
+    dof = spec.dof_count
+    n_arm, n_grip = spec.n_arm_joints, spec.n_gripper_joints
+    if doc.get("kp") is None and len(spec.kp) != dof:
+        spec.kp = _auto_gain_array(n_arm, n_grip, DEFAULT_ARM_KP, DEFAULT_GRIPPER_KP)
+    if doc.get("kv") is None and len(spec.kv) != dof:
+        spec.kv = _auto_gain_array(n_arm, n_grip, DEFAULT_ARM_KV, DEFAULT_GRIPPER_KV)
+    if doc.get("force_upper") is None and len(spec.force_upper) != dof:
+        spec.force_upper = _auto_gain_array(
+            n_arm, n_grip, DEFAULT_ARM_FORCE, DEFAULT_GRIPPER_FORCE
+        )
+    if doc.get("force_lower") is None and len(spec.force_lower) != dof:
+        spec.force_lower = tuple(
+            -abs(f)
+            for f in _auto_gain_array(
+                n_arm, n_grip, DEFAULT_ARM_FORCE, DEFAULT_GRIPPER_FORCE
+            )
+        )
+    if doc.get("home_qpos") is None and len(spec.home_qpos) != dof:
+        spec.home_qpos = tuple([0.0] * dof)
 
     spec.validate()
     return spec

--- a/npa/src/npa/workflows/sim2real_assets.py
+++ b/npa/src/npa/workflows/sim2real_assets.py
@@ -60,8 +60,16 @@ def resolve_robot_spec_from_consumed_doc(
             robot_source=source,
             robot_preset=preset,
         )
+    # Fall back to a NAMED PRESET only when the inner spec selects one AND carries
+    # no concrete robot URI of its own (e.g. ``preset: ur5e`` + gain overrides, with
+    # the URDF filled in later). The URI check MUST recognize ``usd_path`` (the
+    # ``robot_uri`` alias): Stage-2 consumption injects a default top-level
+    # ``robot_preset`` (e.g. ``franka``) that leaks into ``preset_in_inner``, so a
+    # minimal BYO spec keyed on ``usd_path`` (no ``robot_uri``) would otherwise
+    # short-circuit to the stock Franka preset and never reach training/eval.
+    inner_uri = str(inner.get("robot_uri") or inner.get("usd_path") or "").strip()
     preset_in_inner = str(inner.get("preset") or preset or "").strip().lower()
-    if preset_in_inner and not str(inner.get("robot_uri") or "").strip():
+    if preset_in_inner and not inner_uri:
         return robot_assets.robot_spec_from_preset(preset_in_inner)
     return robot_assets.parse_robot_spec(inner)
 

--- a/npa/tests/test_robot_assets.py
+++ b/npa/tests/test_robot_assets.py
@@ -96,6 +96,111 @@ def test_parse_robot_spec_byo_urdf_full() -> None:
     assert spec.dof_count == 6
 
 
+def test_parse_robot_spec_accepts_usd_path_alias_for_robot_uri() -> None:
+    # A customer may hand us ``usd_path`` (the Isaac spawn field name) instead of
+    # ``robot_uri``; it is accepted as an alias and the source is inferred as USD.
+    doc = {
+        "name": "arm_usd",
+        "usd_path": "s3://bucket/robots/arm.usd",
+        "ee_link": "tool0",
+        "n_arm_joints": 6,
+        "n_gripper_joints": 2,
+    }
+    spec = ra.parse_robot_spec(doc)
+    assert spec.robot_uri == "s3://bucket/robots/arm.usd"
+    assert spec.robot_source == ra.ROBOT_SOURCE_BYO_USD
+
+
+def test_parse_robot_spec_robot_uri_wins_over_usd_path_alias() -> None:
+    doc = {
+        "robot_source": "byo_usd",
+        "name": "arm",
+        "robot_uri": "s3://bucket/robots/primary.usd",
+        "usd_path": "s3://bucket/robots/alias.usd",
+        "ee_link": "tool0",
+        "n_arm_joints": 6,
+        "n_gripper_joints": 0,
+    }
+    spec = ra.parse_robot_spec(doc)
+    assert spec.robot_uri.endswith("primary.usd")
+
+
+def test_parse_robot_spec_minimal_usd_auto_derives_gains_and_home() -> None:
+    # A MINIMAL BYO spec (name + usd + joint/link names) — no per-joint gain or
+    # home arrays — must onboard: the omitted arrays are synthesized to dof_count.
+    doc = {
+        "robot_source": "byo_usd",
+        "name": "lite6_parallel",
+        "usd_path": "s3://bucket/robots/lite6_combined.usda",
+        "base_link": "world",
+        "ee_link": "tcp_ee",
+        "n_arm_joints": 6,
+        "n_gripper_joints": 2,
+        "joint_names": [
+            "joint1", "joint2", "joint3", "joint4", "joint5", "joint6",
+            "finger_joint1", "finger_joint2",
+        ],
+        "gripper_joint_names": ["finger_joint1", "finger_joint2"],
+        "finger_links": ["uflite_finger1", "uflite_finger2"],
+    }
+    spec = ra.parse_robot_spec(doc)  # must not raise
+    assert spec.dof_count == 8
+    for arr in (spec.kp, spec.kv, spec.force_upper, spec.force_lower, spec.home_qpos):
+        assert len(arr) == 8
+    # arm joints get the arm default, gripper joints the (lighter) gripper default.
+    assert spec.kp[:6] == (ra.DEFAULT_ARM_KP,) * 6
+    assert spec.kp[6:] == (ra.DEFAULT_GRIPPER_KP,) * 2
+    assert spec.force_lower == tuple(-abs(f) for f in spec.force_upper)
+    assert spec.home_qpos == (0.0,) * 8
+    assert spec.has_gripper
+
+
+def test_parse_robot_spec_infers_joint_counts_from_joint_names() -> None:
+    # Counts omitted, but joint_names + gripper_joint_names given: infer them.
+    doc = {
+        "robot_source": "byo_usd",
+        "name": "inferred_counts",
+        "usd_path": "s3://bucket/robots/arm.usd",
+        "ee_link": "tcp_ee",
+        "joint_names": ["j1", "j2", "j3", "j4", "j5", "j6", "f1", "f2"],
+        "gripper_joint_names": ["f1", "f2"],
+        "finger_links": ["fl1", "fl2"],
+    }
+    spec = ra.parse_robot_spec(doc)
+    assert spec.n_gripper_joints == 2
+    assert spec.n_arm_joints == 6
+    assert spec.dof_count == 8
+
+
+def test_parse_robot_spec_explicit_gains_not_overridden() -> None:
+    # A customer who DOES supply arrays keeps them verbatim (no auto-derive).
+    doc = {
+        "robot_source": "byo_usd",
+        "name": "explicit",
+        "usd_path": "s3://bucket/robots/arm.usd",
+        "ee_link": "tool0",
+        "n_arm_joints": 6,
+        "n_gripper_joints": 0,
+        "kp": [11, 12, 13, 14, 15, 16],
+        "kv": [1, 1, 1, 1, 1, 1],
+        "force_upper": [9, 9, 9, 9, 9, 9],
+        "force_lower": [-9, -9, -9, -9, -9, -9],
+        "home_qpos": [0.1, 0, 0, 0, 0, 0],
+    }
+    spec = ra.parse_robot_spec(doc)
+    assert spec.kp == (11.0, 12.0, 13.0, 14.0, 15.0, 16.0)
+    assert spec.home_qpos[0] == 0.1
+
+
+def test_parse_robot_spec_franka_default_untouched_by_auto_derive() -> None:
+    # An empty doc is the stock Franka default — its 9-length arrays must be kept
+    # byte-for-byte (auto-derive only fires when a field's length != dof_count).
+    spec = ra.parse_robot_spec({})
+    assert spec.robot_source == ra.ROBOT_SOURCE_STOCK_FRANKA
+    assert spec.kp == ra.RobotSpec().kp
+    assert spec.home_qpos == ra.FRANKA_HOME
+
+
 def test_parse_robot_spec_preset_with_uri_override() -> None:
     # A customer supplies just a preset + their URDF uri on top.
     doc = {"preset": "ur5e", "robot_uri": "s3://bucket/robots/ur5e.urdf"}

--- a/npa/tests/workflows/test_sim2real_assets.py
+++ b/npa/tests/workflows/test_sim2real_assets.py
@@ -104,6 +104,42 @@ def test_resolve_robot_spec_from_consumed_ur5e_envelope() -> None:
     assert spec.ee_link == "tool0"
 
 
+def test_resolve_robot_spec_from_consumed_byo_usd_path_not_leaked_preset() -> None:
+    # Regression: Stage-2 consumption injects a default top-level robot_preset
+    # ("franka") even for a BYO robot. A minimal inner spec keyed on the usd_path
+    # alias (no robot_uri) must still resolve to the BYO robot — NOT short-circuit
+    # to the leaked Franka preset. Mirrors the real consumed_byo envelope.
+    from npa.genesis import robot_assets as ra
+
+    consumed = {
+        "schema": "npa.sim2real.consumed_robot_spec.v1",
+        "status": "consumed_byo",
+        "robot_preset": "franka",
+        "robot_source": "",
+        "robot_spec": {
+            "name": "lite6_parallel",
+            "robot_source": ra.ROBOT_SOURCE_BYO_USD,
+            "usd_path": "s3://bucket/robots/lite6_combined.usda",
+            "base_link": "world",
+            "ee_link": "tcp_ee",
+            "n_arm_joints": 6,
+            "n_gripper_joints": 2,
+            "joint_names": [
+                "joint1", "joint2", "joint3", "joint4", "joint5", "joint6",
+                "finger_joint1", "finger_joint2",
+            ],
+            "gripper_joint_names": ["finger_joint1", "finger_joint2"],
+            "finger_links": ["uflite_finger1", "uflite_finger2"],
+        },
+    }
+    spec = resolve_robot_spec_from_consumed_doc(consumed)
+    assert spec is not None
+    assert spec.robot_source == ra.ROBOT_SOURCE_BYO_USD  # not stock_franka
+    assert spec.name == "lite6_parallel"
+    assert spec.robot_uri.endswith("lite6_combined.usda")
+    assert spec.dof_count == 8
+
+
 def test_resolve_stage_cameras_from_scene_spec_file(tmp_path: Path) -> None:
     stage_dir = tmp_path / "stage_02_assets"
     stage_dir.mkdir()


### PR DESCRIPTION
## What

Make **BYO customer-robot onboarding work from a minimal spec**, validated end-to-end
by onboarding a brand-new embodiment — the **UFactory Lite6 (6-DoF) + parallel-jaw
gripper** — through the staged Sim2Real Lift pipeline (not Franka, not the previously
characterized Kinova).

Before this change a customer had to hand-write a **gains-complete** `robot_spec` (a
`dof_count`-length `kp`, `kv`, `force_upper`, `force_lower`, and `home_qpos` array
each) or the spec was rejected — real friction for anyone bringing a new arm. Two
issues also meant a `usd_path`-keyed BYO spec silently never reached RL training.

## Changes

**1. Minimal-spec onboarding — `npa/genesis/robot_assets.py::parse_robot_spec`**
- Accept **`usd_path` as an alias for `robot_uri`** (the field name the Isaac spawn
  cfg / `isaac_byo_robot_task` already use); `robot_uri` wins when both are present.
- **Infer joint counts** from names (`n_gripper_joints = len(gripper_joint_names)`,
  `n_arm_joints = remaining`) when omitted.
- **Auto-derive** any omitted `kp`/`kv`/`force_*`/`home_qpos` array to `dof_count`
  length from robot-agnostic, per-joint-type defaults (arm vs gripper).

**2. Complete the `usd_path` plumbing — `npa/workflows/sim2real_assets.py::resolve_robot_spec_from_consumed_doc`**
- The Stage-2 `consumed_robot_spec` envelope injects a default top-level
  `robot_preset` (e.g. `franka`) even for a BYO robot. The preset-fallback guard
  only checked `robot_uri`, so a minimal spec keyed on `usd_path` short-circuited to
  the stock Franka preset — the customer robot silently never reached RL training or
  the held-out eval. The guard now recognizes `usd_path` alongside `robot_uri`.

**Franka-safety is structural.** The auto-derive fires only when a field is omitted
AND its length `!= dof_count`; stock-Franka / preset specs ship correct-length
arrays and are byte-for-byte untouched. The resolver still falls back to a named
preset for a contentless preset-selection spec (e.g. `preset: ur5e` + overrides).
Customer-supplied fields are never overridden.

## Tests

`npa/tests/test_robot_assets.py` + `npa/tests/workflows/test_sim2real_assets.py`
(infra untouched): `usd_path` alias + precedence, minimal-spec auto-derive, count
inference, explicit-arrays-preserved, Franka-default-untouched, and a regression for
the consumed-envelope preset leak. Full `test_robot_assets` + `test_sim2real_assets`
+ BYO routing/wiring suites pass locally.

## Measured evidence (staged E2E on the GPU cluster)

The Lite6 has no pre-combined arm+gripper USD (the staged task swaps a single
`robot_uri` USD as the articulation), so a combined single-articulation USD was
authored off-GPU with `usd-core` (8 movable DoF: `joint1..joint6` + `finger_joint1/2`;
`base_link=world`, `ee_link=tcp_ee`). The run uses a **minimal spec** (no
hand-written gain arrays), exercising the new auto-derive on-cluster.

**Before this branch (measured):** the BYO robot resolved to stock Franka — the
trainer ran `Isaac-Lift-Cube-Franka-v0`, `robot=None`, despite a `byo_usd` spec.

**After (this branch), PRIMARY — onboards + trains cleanly:**
- `ROBOT_SUMMARY task=NPA-Lift-Cube-lite6-parallel-v0 robot=lite6_parallel usd_live=True ckpts=22 task_robot_compatible=True`
- `ROBOT_RETARGET applied=[ee_frame, arm_action.joint_names, gripper_action, commands.object_pose.body_name] skipped=[]`
- `ROBOT_TASKCFG applied=[gripper_action.command_exprs, dense_lift_progress, grasp_shaping, grasp_hold] skipped=[]`
- `ROBOT_USD want==got` (combined USD spawned; no silent Franka fallback), `TRAIN_RC=0`
- Learning: mean reward `0.68 → ~4.8`; `reaching_object 0.0→0.64`, `grasp_shaping 0.0→0.46`
  (the arm learns to reach and to close on the object).

**STRETCH — honest negative (not reached):**
- Training shows `dense_lift_progress ≈ 0` and `grasp_hold ≈ 0` across all 1000 iters:
  the object is never lifted. The Lite6's ~1.8 cm jaw aperture cannot force-close the
  stock ~5 cm cube (aperture-limited — a distinct wall from the Kinova's 3-finger
  force-closure failure).
- A held-out `success@0.10` number could **not** be produced: the held-out eval builds
  a stock-Franka-dimensioned action space (8 = 7 arm + 1 gripper) while the staged
  trainer's retarget builds the Lite6 space (7 = 6 arm + 1 binary gripper), so the
  trained checkpoint fails to load into the eval's ActorCritic (`size mismatch [7] vs [8]`).
  Making the held-out eval reuse the same `isaac_byo_robot_task.register` action-space
  retarget as the trainer is a separate follow-up; it does not affect this PR's
  onboarding/training result.

## Follow-ups (out of scope, surfaced by this run)

1. **Held-out eval action-space retarget.** The held-out eval builds a
   Franka-dimensioned action/obs space for a non-Franka robot (does not apply the
   trainer's `isaac_byo_robot_task.register` retarget), so a trained non-Franka
   checkpoint cannot load into the eval ActorCritic. Reusing the same retarget on the
   eval path would let a customer policy actually be evaluated held-out.
2. **Staged task config.** `engine._byo_robot_trainer_env` does not wire
   `NPA_BYO_TASK_CONFIG_JSON`, so the grasp-seam rewards reach a staged customer run
   only via the `BYO_TRAINER_COMMAND` prefix (as done here). Wiring a derived
   robot-aware task config into the staged env is a clean follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)