### PR TITLE
Enable agent-side workflow infra provisioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ The source of truth is `skills/index.yaml`. The tree is organized as:
 - `skills/atomic/`: reusable actions and review conventions such as GPU selection, workflow submission, testing conventions, image build/push, and Cosmos3 setup/troubleshooting.
 - `skills/tools/`: concrete workbench and platform tools such as LeRobot, FiftyOne, Genesis, Isaac Lab, Cosmos, LanceDB, GR00T, SONIC, MJLab, Retargeting, SkyPilot, and Nebius infra.
 - `skills/workflows/sim2real-operate/SKILL.md`: operate the staged Sim2Real pipeline on a K8s GPU cluster — runbook, direct-K8s submit, preflight health checks, storage secret sync, and job monitoring.
+- `skills/workflows/agent-fresh-operate/SKILL.md`: npa-driven agent teardown, fresh-setup, tiered verify gates, and deploy failure recovery on the operator/dev VM.
 - `skills/workflows/author-npa-workflow/SKILL.md`: author and validate declarative `npa.workflow/v0.0.1` specs (`validate-spec`, `plan-spec`, toolRef catalog).
 - `skills/workflows/byof-onboard/SKILL.md`: BYOF OSS repo onboarding (Ubuntu/Isaac base, container-verify, agent `onboard_solution`).
 - `skills/workflows/generate-npa-workflow/SKILL.md`: design new creative npa.workflow pipelines from the catalog (loops, gates, golden YAML).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ making architecture, review, or domain judgments.
 - `skills/workflows/sim2real-operate/SKILL.md`: run, monitor, and debug the
   staged Sim2Real pipeline on a K8s GPU cluster (runbook, direct-K8s submit,
   health checks, job monitoring).
+- `skills/workflows/agent-fresh-operate/SKILL.md`: npa-driven agent teardown,
+  fresh-setup, tiered verify gates, and deploy failure recovery on the
+  operator/dev VM.
 - `skills/workflows/author-npa-workflow/SKILL.md`: author and validate
   declarative `npa.workflow/v0.0.1` specs (toolRef catalog, validate/plan/run CLI).
 - `skills/workflows/generate-npa-workflow/SKILL.md`: design new creative

--- a/npa/scripts/agent_fresh_setup_loop.sh
+++ b/npa/scripts/agent_fresh_setup_loop.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# npa-driven destroy → fresh-setup → smoke chat loop for agent VMs.
+# See skills/workflows/agent-fresh-operate/SKILL.md
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+NPA_BIN="${ROOT}/npa/.venv/bin/npa"
+PY_BIN="${ROOT}/npa/.venv/bin/python"
+
+export NPA_AGENT_PROJECT="${NPA_AGENT_PROJECT:-fresh-us-central1}"
+export NPA_AGENT_NAME="${NPA_AGENT_NAME:-agent}"
+export NPA_AGENT_REGION="${NPA_AGENT_REGION:-us-central1}"
+export NPA_SSH_KEY="${NPA_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+export NPA_NEBIUS_PROFILE="${NPA_NEBIUS_PROFILE:-npa-mk8s}"
+
+NPA_FRESH_SETUP_SKIP_DESTROY="${NPA_FRESH_SETUP_SKIP_DESTROY:-0}"
+NPA_FRESH_SETUP_SKIP_DEPLOY="${NPA_FRESH_SETUP_SKIP_DEPLOY:-0}"
+NPA_FRESH_SETUP_RUN_VERIFY_LIVE="${NPA_FRESH_SETUP_RUN_VERIFY_LIVE:-0}"
+NPA_FRESH_SETUP_RUN_GROUNDED_CHAT="${NPA_FRESH_SETUP_RUN_GROUNDED_CHAT:-1}"
+SLEEP_SECONDS="${NPA_LOOP_SLEEP_SECONDS:-60}"
+MAX_ATTEMPTS="${NPA_MAX_ATTEMPTS:-0}"
+
+agent_public_url() {
+  "${NPA_BIN}" agent status --project "$NPA_AGENT_PROJECT" --name "$NPA_AGENT_NAME" --json 2>/dev/null \
+    | "${PY_BIN}" -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("public_url","").rstrip("/"))
+except Exception:
+    print("")'
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "missing required env: $name" >&2
+    exit 1
+  fi
+}
+
+activate_nebius_profile() {
+  if command -v nebius >/dev/null 2>&1; then
+    nebius profile activate "$NPA_NEBIUS_PROFILE" >/dev/null 2>&1 || true
+  fi
+}
+
+run_destroy() {
+  if [[ "$NPA_FRESH_SETUP_SKIP_DESTROY" == "1" ]]; then
+    echo "skip destroy (NPA_FRESH_SETUP_SKIP_DESTROY=1)"
+    return 0
+  fi
+  echo "=== destroy ${NPA_AGENT_PROJECT}/${NPA_AGENT_NAME} $(date -Is) ==="
+  activate_nebius_profile
+  NPA_NEBIUS_PROFILE="$NPA_NEBIUS_PROFILE" \
+    NPA_SSH_KEY="$NPA_SSH_KEY" \
+    "${NPA_BIN}" agent destroy --project "$NPA_AGENT_PROJECT" --name "$NPA_AGENT_NAME"
+}
+
+run_fresh_setup() {
+  if [[ "$NPA_FRESH_SETUP_SKIP_DEPLOY" == "1" ]]; then
+    echo "skip deploy (NPA_FRESH_SETUP_SKIP_DEPLOY=1)"
+    return 0
+  fi
+  require_env NPA_AGENT_PROJECT_ID
+  require_env NPA_AGENT_TENANT_ID
+  echo "=== fresh-setup ${NPA_AGENT_PROJECT}/${NPA_AGENT_NAME} $(date -Is) ==="
+  activate_nebius_profile
+  NPA_NEBIUS_PROFILE="$NPA_NEBIUS_PROFILE" \
+    NPA_SSH_KEY="$NPA_SSH_KEY" \
+    "${NPA_BIN}" agent fresh-setup \
+      --project "$NPA_AGENT_PROJECT" \
+      --name "$NPA_AGENT_NAME" \
+      --project-id "$NPA_AGENT_PROJECT_ID" \
+      --tenant-id "$NPA_AGENT_TENANT_ID" \
+      --region "$NPA_AGENT_REGION"
+}
+
+run_smoke_verify() {
+  local auth_env="${NPA_AGENT_AUTH_ENV:-$HOME/.npa/agents/${NPA_AGENT_PROJECT}/${NPA_AGENT_NAME}/auth.env}"
+  if [[ ! -f "$auth_env" ]]; then
+    echo "missing auth env: $auth_env" >&2
+    return 1
+  fi
+  # shellcheck disable=SC1090
+  source "$auth_env"
+
+  local base
+  base="$(agent_public_url)"
+  if [[ -z "$base" ]]; then
+    echo "could not resolve agent public_url" >&2
+    return 1
+  fi
+
+  echo "=== smoke verify ${base} $(date -Is) ==="
+  curl -sfk -u "${AGENT_USER}:${AGENT_PASSWORD}" "${base}/api/models" \
+    | "${PY_BIN}" -c "import json,sys; d=json.load(sys.stdin); assert d.get('ok'), d; print('models_ok', len(d.get('models',[])))"
+
+  curl -sfk -u "${AGENT_USER}:${AGENT_PASSWORD}" \
+    -H 'content-type: application/json' \
+    -d '{"messages":[{"role":"user","content":"Say hello in one short sentence."}]}' \
+    "${base}/api/chat" \
+    | "${PY_BIN}" -c "import json,sys; r=json.load(sys.stdin); assert r.get('ok'), r; print('hello_chat_ok')"
+
+  if [[ "$NPA_FRESH_SETUP_RUN_GROUNDED_CHAT" == "1" ]]; then
+    curl -sfk -u "${AGENT_USER}:${AGENT_PASSWORD}" \
+      -H 'content-type: application/json' \
+      -d '{"messages":[{"role":"user","content":"what is the current sim2real status"}]}' \
+      "${base}/api/chat" \
+      | "${PY_BIN}" -c "
+import json,sys
+r=json.load(sys.stdin)
+t=r.get('reply','')
+assert r.get('grounded'), 'expected grounded chat'
+assert 'run_id' in t or 'stage' in t, 'missing run_id/stage'
+assert not t.strip().startswith('GET /api'), 'raw GET path in reply'
+print('grounded_chat_ok')"
+  fi
+
+  if [[ "$NPA_FRESH_SETUP_RUN_VERIFY_LIVE" == "1" ]]; then
+    NPA_AGENT_CHAT_LIVE=1 NPA_SSH_KEY="$NPA_SSH_KEY" \
+      "${NPA_BIN}" agent verify-live --project "$NPA_AGENT_PROJECT" --name "$NPA_AGENT_NAME"
+  fi
+}
+
+run_success() {
+  "${PY_BIN}" -m pip install -e npa -q >/dev/null 2>&1 || return 1
+  run_destroy || return 1
+  run_fresh_setup || return 1
+  run_smoke_verify || return 1
+  echo "=== LOOP SUCCESS $(date -Is) ==="
+}
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  echo "=== attempt ${attempt} $(date -Is) ==="
+  if run_success; then
+    echo "SUCCESS at attempt ${attempt} $(date -Is)"
+    exit 0
+  fi
+  if [[ "$MAX_ATTEMPTS" -gt 0 && "$attempt" -ge "$MAX_ATTEMPTS" ]]; then
+    echo "reached NPA_MAX_ATTEMPTS=${MAX_ATTEMPTS}; exiting with failure" >&2
+    exit 1
+  fi
+  echo "FAILED attempt ${attempt}; sleeping ${SLEEP_SECONDS}s..."
+  sleep "$SLEEP_SECONDS"
+done

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2455,7 +2455,7 @@ def _agent_command_env() -> dict:
     if not env.get("TF_VAR_ssh_public_key"):
         for candidate in ("/home/ubuntu/.ssh/id_ed25519.pub", "/root/.ssh/id_ed25519.pub"):
             if Path(candidate).is_file():
-                env["TF_VAR_ssh_public_key"] = json.dumps({"path": candidate})
+                env["TF_VAR_ssh_public_key"] = json.dumps({{"path": candidate}})
                 break
     return env
 

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -362,6 +362,12 @@ def _cleanup_agent_ingress(instance_id: str) -> None:
         typer.echo(f"  Warning: could not remove npa ingress rules: {exc}", err=True)
 
 
+_AGENT_INSTANCE_DESTROY_TARGETS = (
+    "null_resource.wait_for_cloud_init",
+    "nebius_compute_v1_instance.workbench",
+)
+
+
 def _destroy_agent_terraform(
     project: str,
     name: str,
@@ -392,12 +398,23 @@ def _destroy_agent_terraform(
         tf_dir=tf_dir,
         backend_config={"access_key": state.access_key, "secret_key": state.secret_key},
     )
-    try:
+
+    def _run_destroy() -> None:
         provisioner.destroy(tf_dir=tf_dir, tf_vars=tf_vars)
+
+    def _destroy_compute_first() -> None:
+        managed = set(provisioner.state_list(tf_dir))
+        targets = [t for t in _AGENT_INSTANCE_DESTROY_TARGETS if t in managed]
+        if targets:
+            provisioner.destroy(tf_dir=tf_dir, tf_vars=tf_vars, targets=targets)
+
+    try:
+        _run_destroy()
     except ProvisionerError as first_exc:
         _cleanup_agent_ingress(instance_id)
         try:
-            provisioner.destroy(tf_dir=tf_dir, tf_vars=tf_vars)
+            _destroy_compute_first()
+            _run_destroy()
         except ProvisionerError:
             raise first_exc from None
 

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -25,7 +25,11 @@ from npa.clients.config import (
     write_config,
 )
 from npa.clients.env import redact_value
-from npa.clients.network import NetworkIngressError, ensure_ingress
+from npa.clients.network import (
+    NetworkIngressError,
+    ensure_ingress,
+    remove_ingress_for_instance,
+)
 from npa.clients.ssh import SSHClient, SSHError
 from npa.deploy import provisioner
 from npa.deploy.provisioner import ProvisionerError
@@ -246,6 +250,113 @@ def _remove_agent_record(project_alias: str, name: str) -> None:
     with CONFIG_PATH.open("w", encoding="utf-8") as handle:
         yaml.safe_dump(data, handle, default_flow_style=False, sort_keys=False)
     CONFIG_PATH.chmod(0o600)
+
+
+def _agent_extra_ingress_ports(
+    *,
+    agent_port: int,
+    rerun_port: int,
+    public_https: bool,
+) -> list[int]:
+    extra = [rerun_port]
+    if public_https:
+        extra.append(DEFAULT_HTTPS_PORT)
+    return sorted({port for port in extra if port != agent_port})
+
+
+def _agent_terraform_state_exists(project: str, name: str) -> bool:
+    tf_dir = provisioner.working_dir_path(project, name)
+    return (tf_dir / ".terraform").is_dir()
+
+
+def _resolve_destroy_tf_vars(
+    project: str,
+    name: str,
+    record: dict[str, Any] | None,
+) -> dict[str, str]:
+    state = resolve_terraform_state(project)
+    saved_env = resolve_environment(project)
+    region = str((record or {}).get("region", "") or (saved_env.region if saved_env else "") or "us-central1")
+    project_id = str((record or {}).get("project_id", "") or (saved_env.project_id if saved_env else ""))
+    service_account_id = str((record or {}).get("service_account_id", "")).strip()
+    if not service_account_id:
+        creds = (record or {}).get("credentials", {})
+        if isinstance(creds, dict):
+            service_account_id = str(creds.get("service_account_id", "")).strip()
+    if not service_account_id:
+        service_account_id = _resolve_agent_service_account_id(project, record or {})
+    from npa.clients.nebius import get_iam_token
+
+    iam_token = get_iam_token()
+    return {
+        "nebius_project_id": project_id,
+        "nebius_region": region,
+        "service_account_id": service_account_id,
+        "iam_token": iam_token,
+        "instance_name": f"agent-{project}-{name}",
+        "server_port": str(DEFAULT_AGENT_PORT),
+        "workbench_type": "lerobot",
+        "gpu_platform": "cpu-d3",
+        "gpu_preset": "8vcpu-32gb",
+        "enable_preemptible": "false",
+        "nebius_api_key": state.access_key,
+        "nebius_secret_key": state.secret_key,
+        "s3_bucket": state.bucket,
+        "s3_endpoint": state.endpoint,
+        "extra_ingress_ports": "[]",
+    }
+
+
+def _cleanup_agent_ingress(instance_id: str) -> None:
+    if not str(instance_id or "").strip():
+        return
+    try:
+        remove_ingress_for_instance(
+            str(instance_id).strip(),
+            on_status=lambda msg: typer.echo(f"  {msg}"),
+        )
+    except NetworkIngressError as exc:
+        typer.echo(f"  Warning: could not remove npa ingress rules: {exc}", err=True)
+
+
+def _destroy_agent_terraform(
+    project: str,
+    name: str,
+    *,
+    record: dict[str, Any] | None = None,
+) -> None:
+    """Destroy the agent Terraform stack and optional npa-managed ingress rules."""
+    if not _agent_terraform_state_exists(project, name):
+        return
+    state = resolve_terraform_state(project)
+    if not state.bucket or not state.access_key or not state.secret_key:
+        _fail(
+            f"Terraform state backend is not configured for project {project!r}. "
+            "Run `npa configure` or redeploy once to persist terraform_state."
+        )
+    tf_vars = _resolve_destroy_tf_vars(project, name, record)
+    region = tf_vars["nebius_region"]
+    instance_id = str((record or {}).get("instance_id", "")).strip()
+    _cleanup_agent_ingress(instance_id)
+    tf_dir = provisioner.prepare_working_dir(
+        project,
+        name,
+        bucket=state.bucket,
+        region=region,
+        endpoint=state.endpoint,
+    )
+    provisioner.init(
+        tf_dir=tf_dir,
+        backend_config={"access_key": state.access_key, "secret_key": state.secret_key},
+    )
+    try:
+        provisioner.destroy(tf_dir=tf_dir, tf_vars=tf_vars)
+    except ProvisionerError as first_exc:
+        _cleanup_agent_ingress(instance_id)
+        try:
+            provisioner.destroy(tf_dir=tf_dir, tf_vars=tf_vars)
+        except ProvisionerError:
+            raise first_exc from None
 
 
 def _auth_secret_path(project_alias: str, name: str) -> Path:
@@ -4978,6 +5089,12 @@ def deploy_cmd(
     except NebiusError as exc:
         _fail(f"Nebius bootstrap failed: {exc}")
 
+    public_https = not no_public_https
+    extra_ingress_ports = _agent_extra_ingress_ports(
+        agent_port=agent_port,
+        rerun_port=rerun_port,
+        public_https=public_https,
+    )
     merged_vars: dict[str, str] = {
         "nebius_project_id": env_project_id,
         "nebius_region": env_region,
@@ -4989,6 +5106,11 @@ def deploy_cmd(
         "s3_endpoint": str(creds.get("s3_endpoint", "")),
         "instance_name": f"agent-{project}-{name}",
         "server_port": str(agent_port),
+        "extra_ingress_ports": (
+            "[" + ",".join(str(port) for port in extra_ingress_ports) + "]"
+            if extra_ingress_ports
+            else "[]"
+        ),
         "workbench_type": "lerobot",
         "gpu_platform": "cpu-d3",
         "gpu_preset": "8vcpu-32gb",
@@ -5002,6 +5124,7 @@ def deploy_cmd(
         key, value = item.split("=", 1)
         merged_vars[key.strip()] = value.strip()
 
+    tf_outputs: dict[str, Any] = {}
     try:
         tf_dir = provisioner.prepare_working_dir(
             project,
@@ -5019,12 +5142,24 @@ def deploy_cmd(
         )
         tf_outputs = provisioner.apply(tf_dir=tf_dir, tf_vars=merged_vars)
     except ProvisionerError as exc:
+        try:
+            _destroy_agent_terraform(project, name)
+        except ProvisionerError as cleanup_exc:
+            typer.echo(f"  Warning: terraform rollback failed: {cleanup_exc}", err=True)
         _fail(f"Terraform deploy failed: {exc}")
 
     public_ip = str(tf_outputs.get("vm_ip", ""))
     instance_id = str(tf_outputs.get("instance_id", ""))
     ssh_key_path = str(tf_outputs.get("ssh_key_path", "") or ssh_public_key_path.removesuffix(".pub"))
     if not _is_routable_public_ip(public_ip):
+        try:
+            _destroy_agent_terraform(
+                project,
+                name,
+                record={"instance_id": instance_id, "project_id": env_project_id, "region": env_region},
+            )
+        except ProvisionerError as cleanup_exc:
+            typer.echo(f"  Warning: terraform rollback failed: {cleanup_exc}", err=True)
         _fail("Terraform output did not include a routable public IP")
 
     auth_password = secrets.token_urlsafe(18)
@@ -5044,7 +5179,12 @@ def deploy_cmd(
             "agent chat will return 503 until `npa agent bootstrap` with a configured key.",
             err=True,
         )
-    public_https = not no_public_https
+    rollback_record = {
+        "instance_id": instance_id,
+        "project_id": env_project_id,
+        "region": env_region,
+        "service_account_id": str(creds.get("service_account_id", "")),
+    }
     try:
         _bootstrap_agent_stack(
             host=public_ip,
@@ -5074,6 +5214,10 @@ def deploy_cmd(
             public_https=public_https,
         )
     except (ConfigError, SSHError, ValueError) as exc:
+        try:
+            _destroy_agent_terraform(project, name, record=rollback_record)
+        except ProvisionerError as cleanup_exc:
+            typer.echo(f"  Warning: terraform rollback failed: {cleanup_exc}", err=True)
         _fail(f"VM bootstrap failed: {exc}")
 
     ingress_ports: list[int] = [agent_port, rerun_port]
@@ -5082,6 +5226,10 @@ def deploy_cmd(
     try:
         ensure_ingress(vm_id=instance_id, ports=tuple(ingress_ports), tool="agent")
     except NetworkIngressError as exc:
+        try:
+            _destroy_agent_terraform(project, name, record=rollback_record)
+        except ProvisionerError as cleanup_exc:
+            typer.echo(f"  Warning: terraform rollback failed: {cleanup_exc}", err=True)
         _fail(f"npa network ensure-ingress failed: {exc}")
 
     urls = build_agent_urls(public_ip, agent_port=agent_port, public_https=public_https)
@@ -5463,40 +5611,14 @@ def destroy_cmd(
 ) -> None:
     """Destroy agent VM/resources and remove saved config entry."""
     record = _agent_record(project, name)
-    if not record:
+    if not record and not _agent_terraform_state_exists(project, name):
         _fail(f"Agent config not found for {project}/{name}")
-    state = resolve_terraform_state(project)
-    region = str(record.get("region", "")) or "us-central1"
-    tf_vars = {
-        "nebius_project_id": str(record.get("project_id", "")),
-        "nebius_region": region,
-        "instance_name": f"agent-{project}-{name}",
-        "server_port": str(DEFAULT_AGENT_PORT),
-        "workbench_type": "lerobot",
-        "gpu_platform": "cpu-d3",
-        "gpu_preset": "8vcpu-32gb",
-        "enable_preemptible": "false",
-        "nebius_api_key": state.access_key,
-        "nebius_secret_key": state.secret_key,
-        "s3_bucket": state.bucket,
-        "s3_endpoint": state.endpoint,
-    }
-    tf_dir = provisioner.prepare_working_dir(
-        project,
-        name,
-        bucket=state.bucket,
-        region=region,
-        endpoint=state.endpoint,
-    )
     try:
-        provisioner.init(
-            tf_dir=tf_dir,
-            backend_config={"access_key": state.access_key, "secret_key": state.secret_key},
-        )
-        provisioner.destroy(tf_dir=tf_dir, tf_vars=tf_vars)
+        _destroy_agent_terraform(project, name, record=record or None)
     except ProvisionerError as exc:
         _fail(f"Terraform destroy failed: {exc}")
-    _remove_agent_record(project, name)
+    if record:
+        _remove_agent_record(project, name)
     typer.echo(f"destroyed: {project}/{name}")
 
 

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -843,6 +843,7 @@ def _write_agent_nebius_env(
     if iam_token.strip():
         env_lines.extend(
             [
+                "NEBIUS_PROFILE=agent-bootstrap",
                 f"NEBIUS_IAM_TOKEN={iam_token.strip()}",
                 f"NPA_NEBIUS_IAM_TOKEN={iam_token.strip()}",
                 f"TF_VAR_iam_token={iam_token.strip()}",
@@ -855,6 +856,29 @@ def _write_agent_nebius_env(
         f"echo {shlex.quote(env_b64)} | base64 -d | sudo tee /opt/npa-agent/nebius.env >/dev/null "
         "&& sudo chmod 600 /opt/npa-agent/nebius.env"
     )
+    if iam_token.strip():
+        ssh.run_or_raise(
+            "sudo bash -lc "
+            + shlex.quote(
+                "\n".join(
+                    [
+                        "set -euo pipefail",
+                        "set -a",
+                        ". /opt/npa-agent/nebius.env",
+                        "set +a",
+                        "mkdir -p /root/.npa",
+                        "printf '%s' \"$NEBIUS_IAM_TOKEN\" > /root/.npa/nebius-token",
+                        "chmod 600 /root/.npa/nebius-token",
+                        "NEBIUS_BIN=\"$(command -v nebius || true)\"",
+                        "if [ -z \"$NEBIUS_BIN\" ] && [ -x /usr/local/bin/nebius ]; then NEBIUS_BIN=/usr/local/bin/nebius; fi",
+                        "if [ -n \"$NEBIUS_BIN\" ]; then",
+                        "  \"$NEBIUS_BIN\" profile create --endpoint api.eu.nebius.cloud --token-file /root/.npa/nebius-token --profile agent-bootstrap --parent-id \"$NEBIUS_PROJECT_ID\" >/dev/null 2>&1 || true",
+                        "  NEBIUS_PROFILE=agent-bootstrap \"$NEBIUS_BIN\" iam get-access-token >/dev/null",
+                        "fi",
+                    ]
+                )
+            )
+        )
 
 
 def _create_agent_source_archive() -> str:

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -868,8 +868,21 @@ def _agent_strip_url_credentials_js() -> str:
     </script>"""
 
 
+def _agent_mobile_login_help_html() -> str:
+    """Mobile certificate + sign-in troubleshooting (public pages)."""
+    return """    <details class="mobile-help" style="margin:20px 0;padding:12px 16px;border:1px solid #e0e0e0;border-radius:8px;background:#fffbeb;">
+      <summary style="font-weight:600;cursor:pointer;">Phone / tablet login help</summary>
+      <ol style="margin:12px 0 0;padding-left:20px;line-height:1.55;">
+        <li><strong>Accept the certificate first.</strong> Open <a href="/healthz">/healthz</a> (no login). If Safari/Chrome warns the connection is not private, tap <em>Show Details</em> → <em>visit this website</em> / <em>Proceed</em>.</li>
+        <li>Return here and use the sign-in form (mobile browsers block password-in-URL redirects).</li>
+        <li>If sign-in still fails, try <strong>Chrome on Android</strong> or use a desktop browser.</li>
+        <li>Username is prefilled; password is in your operator <code>auth.env</code> file.</li>
+      </ol>
+    </details>"""
+
+
 def _agent_public_login_form_html(auth_user: str) -> str:
-    """Shared Sign in form for public welcome/login-help pages (basic-auth URL redirect)."""
+    """Shared Sign in form for public welcome/login-help pages (mobile-safe basic auth)."""
     return f"""    <section class="sign-in-panel" aria-labelledby="sign-in-heading">
       <h2 id="sign-in-heading">Sign in</h2>
       <p class="muted">Use the form if your browser does not show an HTTP Basic Auth dialog.</p>
@@ -878,9 +891,10 @@ def _agent_public_login_form_html(auth_user: str) -> str:
         <input id="npa-user" name="username" type="text" value="{auth_user}" autocomplete="username" required>
         <label for="npa-pass">Password</label>
         <input id="npa-pass" name="password" type="password" autocomplete="current-password" required>
-        <button type="submit">Sign in</button>
+        <button type="submit" id="npa-sign-in-btn">Sign in</button>
+        <p id="npa-sign-in-status" class="muted" role="status" aria-live="polite"></p>
       </form>
-      <p class="muted note">Credentials are removed from the address bar immediately after sign-in.</p>
+      <p class="muted note">Credentials are not left in the address bar after sign-in.</p>
     </section>
     <script>
     (function () {{
@@ -891,17 +905,92 @@ def _agent_public_login_form_html(auth_user: str) -> str:
         }}
       }} catch (_err) {{ /* best-effort */ }}
       var form = document.getElementById("npa-sign-in");
+      var statusEl = document.getElementById("npa-sign-in-status");
+      var btn = document.getElementById("npa-sign-in-btn");
       if (!form) return;
+
+      function setStatus(msg, isError) {{
+        if (!statusEl) return;
+        statusEl.textContent = msg || "";
+        statusEl.style.color = isError ? "#991b1b" : "#5f6573";
+      }}
+
+      function isMobileUa() {{
+        return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent || "");
+      }}
+
+      function destPath() {{
+        var rawPath = String(location.pathname || "/");
+        var normalizedPath = rawPath.length > 1 && rawPath.endsWith("/") ? rawPath.slice(0, -1) : rawPath;
+        return (normalizedPath === "/login-help.html" || normalizedPath === "/welcome") ? "/" : normalizedPath;
+      }}
+
+      function basicAuthHeader(user, pass) {{
+        return "Basic " + btoa(unescape(encodeURIComponent(user + ":" + pass)));
+      }}
+
+      function xhrSignIn(user, pass, dest) {{
+        return new Promise(function (resolve, reject) {{
+          var xhr = new XMLHttpRequest();
+          xhr.open("GET", dest, true, user, pass);
+          xhr.onload = function () {{
+            if (xhr.status >= 200 && xhr.status < 400) {{
+              resolve();
+              return;
+            }}
+            if (xhr.status === 401) {{
+              reject(new Error("Invalid username or password."));
+              return;
+            }}
+            reject(new Error("Sign-in failed (HTTP " + xhr.status + ")."));
+          }};
+          xhr.onerror = function () {{
+            reject(new Error("Network error — open /healthz first and accept the certificate warning."));
+          }};
+          xhr.send();
+        }});
+      }}
+
+      function fetchSignIn(user, pass, dest) {{
+        return fetch(dest, {{
+          method: "GET",
+          headers: {{ "Authorization": basicAuthHeader(user, pass) }},
+          credentials: "include",
+          cache: "no-store",
+        }}).then(function (resp) {{
+          if (!resp.ok) {{
+            throw new Error(resp.status === 401 ? "Invalid username or password." : "Sign-in failed (HTTP " + resp.status + ").");
+          }}
+        }});
+      }}
+
+      function urlEmbedSignIn(user, pass, dest) {{
+        var u = encodeURIComponent(user);
+        var p = encodeURIComponent(pass);
+        location.href = location.protocol + "//" + u + ":" + p + "@" + location.host + dest;
+      }}
+
       form.addEventListener("submit", function (ev) {{
         ev.preventDefault();
         var user = document.getElementById("npa-user").value;
         var pass = document.getElementById("npa-pass").value;
-        var u = encodeURIComponent(user);
-        var p = encodeURIComponent(pass);
-        var rawPath = String(location.pathname || "/");
-        var normalizedPath = rawPath.length > 1 && rawPath.endsWith("/") ? rawPath.slice(0, -1) : rawPath;
-        var dest = (normalizedPath === "/login-help.html" || normalizedPath === "/welcome") ? "/" : normalizedPath;
-        location.href = location.protocol + "//" + u + ":" + p + "@" + location.host + dest;
+        var dest = destPath();
+        setStatus("Signing in…", false);
+        if (btn) btn.disabled = true;
+
+        xhrSignIn(user, pass, dest)
+          .catch(function () {{ return fetchSignIn(user, pass, dest); }})
+          .then(function () {{
+            window.location.href = dest;
+          }})
+          .catch(function (err) {{
+            if (!isMobileUa()) {{
+              urlEmbedSignIn(user, pass, dest);
+              return;
+            }}
+            setStatus((err && err.message) ? err.message : "Sign-in failed on this device.", true);
+            if (btn) btn.disabled = false;
+          }});
       }});
     }})();
     </script>"""
@@ -1021,6 +1110,7 @@ def _bootstrap_agent_stack(
     default_llm_models_json = json.dumps(llm_models)
     nginx_site_body = _nginx_agent_site_body(backend_port=backend_port, rerun_port=rerun_port)
     login_form_html = _agent_public_login_form_html(auth_user)
+    mobile_login_help_html = _agent_mobile_login_help_html()
     strip_url_credentials_js = _agent_strip_url_credentials_js()
     https_ssl_setup = ""
     https_server_block = ""
@@ -2917,7 +3007,10 @@ cat <<'WELCOME' | sudo tee /opt/npa-agent/welcome.html >/dev/null
       .sign-in {{ display: grid; gap: 10px; max-width: 360px; }}
       .sign-in label {{ font-weight: 600; font-size: 0.9rem; }}
       .sign-in input {{ padding: 8px 10px; border: 1px solid #c8ccd4; border-radius: 6px; font: inherit; }}
-      .sign-in button {{ justify-self: start; padding: 8px 16px; border: 0; border-radius: 6px; background: #5e43f3; color: #fff; font: inherit; font-weight: 600; cursor: pointer; }}
+      .sign-in button {{ justify-self: start; padding: 8px 16px; border: 0; border-radius: 6px; background: #5e43f3; color: #fff; font: inherit; font-weight: 600; cursor: pointer; min-height: 44px; }}
+      @media (max-width: 640px) {{
+        .sign-in, .sign-in button {{ max-width: none; width: 100%; }}
+      }}
       a {{ color: #5e43f3; }}
     </style>
   </head>
@@ -2926,6 +3019,7 @@ cat <<'WELCOME' | sudo tee /opt/npa-agent/welcome.html >/dev/null
     <p class="ok">This page is public (no login). The workbench UI at <code>/</code> is protected by HTTP Basic Auth.</p>
 {strip_url_credentials_js}
 {login_form_html}
+{mobile_login_help_html}
     <ol>
       <li>Enter your password above and click <strong>Sign in</strong>, or open <a href="/">the workbench UI</a> if your browser shows the auth dialog.</li>
       <li>Username: <code>{auth_user}</code></li>
@@ -2955,7 +3049,10 @@ cat <<'LOGINHELP' | sudo tee /opt/npa-agent/login-help.html >/dev/null
       .sign-in {{ display: grid; gap: 10px; max-width: 360px; }}
       .sign-in label {{ font-weight: 600; font-size: 0.9rem; }}
       .sign-in input {{ padding: 8px 10px; border: 1px solid #c8ccd4; border-radius: 6px; font: inherit; }}
-      .sign-in button {{ justify-self: start; padding: 8px 16px; border: 0; border-radius: 6px; background: #5e43f3; color: #fff; font: inherit; font-weight: 600; cursor: pointer; }}
+      .sign-in button {{ justify-self: start; padding: 8px 16px; border: 0; border-radius: 6px; background: #5e43f3; color: #fff; font: inherit; font-weight: 600; cursor: pointer; min-height: 44px; }}
+      @media (max-width: 640px) {{
+        .sign-in, .sign-in button {{ max-width: none; width: 100%; }}
+      }}
       a {{ color: #5e43f3; }}
     </style>
   </head>
@@ -2964,6 +3061,7 @@ cat <<'LOGINHELP' | sudo tee /opt/npa-agent/login-help.html >/dev/null
     <p>The NPA Agent workbench did not receive valid credentials. Sign in below or use your browser&apos;s Basic-auth dialog for <code>/</code> and <code>/api/*</code>.</p>
 {strip_url_credentials_js}
 {login_form_html}
+{mobile_login_help_html}
     <ul>
       <li>Username: <code>{auth_user}</code></li>
       <li>Password: from your operator&apos;s <code>auth.env</code> file (<code>AGENT_PASSWORD</code>).</li>

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2429,12 +2429,18 @@ def _agent_k8s_backends(project: str = "") -> dict:
                 "state_exists": state_path.is_file(),
             }})
     ready, reason = _agent_npa_ready()
+    cloud_clusters = _agent_cloud_mk8s_clusters(alias)
     return {{
         "ok": True,
         "project": alias,
         "configured": configured,
         "local_clusters": local_clusters,
-        "has_infra": bool(configured or any(item.get("kubeconfig_exists") for item in local_clusters)),
+        "cloud_clusters": cloud_clusters,
+        "has_infra": bool(
+            configured
+            or any(item.get("kubeconfig_exists") for item in local_clusters)
+            or cloud_clusters
+        ),
         "agent_npa_ready": ready,
         "agent_npa_error": reason,
         "terraform_dir": str(NPA_CLUSTER_TERRAFORM_DIR),
@@ -2470,6 +2476,53 @@ def _agent_command_env() -> dict:
                 if env.get("TF_VAR_ssh_public_key"):
                     break
     return env
+
+
+def _agent_cloud_mk8s_clusters(project: str = "") -> list[dict]:
+    config = _load_agent_config_yaml()
+    projects = config.get("projects")
+    if not isinstance(projects, dict):
+        projects = {{}}
+    project_block = projects.get(_agent_project_alias(project))
+    if not isinstance(project_block, dict):
+        project_block = {{}}
+    parent_id = str(os.environ.get("NEBIUS_PROJECT_ID") or project_block.get("project_id") or "").strip()
+    if not parent_id:
+        return []
+    nebius_bin = shutil.which("nebius") or "/usr/local/bin/nebius"
+    if not Path(nebius_bin).exists() and shutil.which(nebius_bin) is None:
+        return []
+    try:
+        proc = subprocess.run(
+            [nebius_bin, "mk8s", "cluster", "list", "--parent-id", parent_id, "--format", "json"],
+            env=_agent_command_env(),
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return []
+        payload = json.loads(proc.stdout or "{{}}")
+    except Exception:
+        return []
+    items = payload.get("items") if isinstance(payload, dict) else []
+    clusters: list[dict] = []
+    if not isinstance(items, list):
+        return clusters
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {{}}
+        status = item.get("status") if isinstance(item.get("status"), dict) else {{}}
+        clusters.append({{
+            "source": "nebius_mk8s",
+            "id": str(metadata.get("id") or ""),
+            "name": str(metadata.get("name") or ""),
+            "status": str(status.get("state") or status.get("status") or ""),
+            "raw_status": {{k: v for k, v in status.items() if k not in {{"token", "secret", "password"}}}},
+        }})
+    return clusters
 
 
 def _run_agent_npa_json(args: list[str], *, timeout_s: int = 300) -> dict:

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2462,7 +2462,14 @@ def _write_workflow_temp_yaml(yaml_text: str) -> Path:
     return path
 
 
-def _provision_agent_infra(project: str, cluster_name: str, *, dry_run: bool = False, validate: bool = True) -> dict:
+def _provision_agent_infra(
+    project: str,
+    cluster_name: str,
+    *,
+    dry_run: bool = False,
+    validate: bool = True,
+    skip_s3: bool = True,
+) -> dict:
     ready, reason = _agent_npa_ready()
     if not ready:
         return {{"ok": False, "status": "blocked", "error": reason}}
@@ -2473,6 +2480,7 @@ def _provision_agent_infra(project: str, cluster_name: str, *, dry_run: bool = F
             project=project or None,
             cluster_name=cluster_name or "npa-cluster",
             terraform_dir=NPA_CLUSTER_TERRAFORM_DIR,
+            skip_s3=skip_s3,
             validate=validate,
             sky_smoke=False,
             dry_run=dry_run,
@@ -3309,7 +3317,8 @@ def provision_infra(payload: dict | None = None):
     cluster_name = str(body.get("cluster_name") or "npa-cluster").strip() or "npa-cluster"
     dry_run = bool(body.get("dry_run", False))
     validate = bool(body.get("validate", True))
-    result = _provision_agent_infra(project, cluster_name, dry_run=dry_run, validate=validate)
+    skip_s3 = bool(body.get("skip_s3", True))
+    result = _provision_agent_infra(project, cluster_name, dry_run=dry_run, validate=validate, skip_s3=skip_s3)
     status = _agent_k8s_backends(project)
     return {{"ok": bool(result.get("ok")), "project": project, "cluster_name": cluster_name, "result": result, "infra": status}}
 
@@ -3399,7 +3408,13 @@ def submit_npa_workflow(payload: dict):
         return _workflow_no_infra_response(validation=validation, plan=plan, run_id=run_id, infra=infra_before)
     provision = {{"ok": True, "status": "skipped", "actions": ["k8s:existing backend detected"]}}
     if allow_provision and (dry_run or not infra_before.get("has_infra")):
-        provision = _provision_agent_infra(project, cluster_name, dry_run=dry_run, validate=validate_infra)
+        provision = _provision_agent_infra(
+            project,
+            cluster_name,
+            dry_run=dry_run,
+            validate=validate_infra,
+            skip_s3=bool(body.get("skip_s3", True)),
+        )
         if not provision.get("ok"):
             infra_error = dict(infra_before)
             infra_error["provision_error"] = provision.get("error") or provision

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -1774,8 +1774,8 @@ def _maybe_toolground_chat_reply(user_text: str) -> tuple[str | None, list[str],
         if not runnable:
             fail_reason = str(validation.get("error") or plan.get("error") or "validate+plan gate did not pass")
             reply = (
-                "**Could not generate runnable workflow YAML yet.**\n"
-                f"- **reason**: `{{fail_reason}}`\n"
+                "**Could not generate runnable workflow YAML yet.**\\n"
+                f"- **reason**: `{{fail_reason}}`\\n"
                 "- Adjust your request or template details and retry;"
                 " chat returns YAML only after both validation and planning succeed."
             )

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -55,7 +55,7 @@ DEFAULT_LLM_MODELS = (
     "meta-llama/Llama-3.3-70B-Instruct",
     "Qwen/Qwen2.5-VL-72B-Instruct",
 )
-AGENT_UI_VERSION = "2026070101"
+AGENT_UI_VERSION = "2026070402"
 DEFAULT_HTTPS_PORT = 443
 
 
@@ -1267,6 +1267,8 @@ def _default_state() -> dict:
         "workflow_draft": {{"yaml": "", "name": "", "states": [], "updated_at": "", "plan": {{}}, "runnable": False}},
         "workflow_submit": {{}},
         "chat_history": [],
+        "active_chat_session_id": "default",
+        "chat_sessions": {{}},
     }}
 
 def _load_state() -> dict:
@@ -1292,6 +1294,10 @@ def _load_state() -> dict:
         merged["active_run_id"] = ""
     if not isinstance(merged.get("chat_history"), list):
         merged["chat_history"] = []
+    if not isinstance(merged.get("chat_sessions"), dict):
+        merged["chat_sessions"] = {{}}
+    if not isinstance(merged.get("active_chat_session_id"), str):
+        merged["active_chat_session_id"] = "default"
     return merged
 
 def _save_state(state: dict) -> None:
@@ -1609,6 +1615,224 @@ def _agent_s3_client():
     except Exception as exc:
         raise HTTPException(status_code=502, detail=f"failed to initialize S3 client: {{exc}}") from exc
     return client, settings
+
+
+def _chat_memory_tenant() -> str:
+    raw = (
+        os.environ.get("NEBIUS_TENANT_ID", "")
+        or os.environ.get("NEBIUS_PROJECT_ID", "")
+        or "default-tenant"
+    )
+    value = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(raw).strip()).strip("-")
+    return value or "default-tenant"
+
+
+def _chat_memory_prefix(settings: dict[str, str] | None = None) -> str:
+    bucket = (settings or {{}}).get("bucket", "")
+    tenant = _chat_memory_tenant()
+    return f"npa-agent/tenants/{{tenant}}/chat-sessions"
+
+
+def _chat_session_key(session_id: str, settings: dict[str, str] | None = None) -> str:
+    safe = _sanitize_chat_session_id(session_id)
+    return f"{{_chat_memory_prefix(settings)}}/{{safe}}.json"
+
+
+def _chat_memory_uri(session_id: str, settings: dict[str, str] | None = None) -> str:
+    resolved = settings or _agent_s3_settings()
+    bucket = str(resolved.get("bucket") or "")
+    if not bucket:
+        return ""
+    return f"s3://{{bucket}}/{{_chat_session_key(session_id, resolved)}}"
+
+
+def _agent_s3_client_optional():
+    try:
+        return _agent_s3_client()
+    except HTTPException:
+        return None, _agent_s3_settings()
+    except Exception:
+        return None, _agent_s3_settings()
+
+
+def _sanitize_chat_session_id(value: str) -> str:
+    session_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "").strip()).strip("-")
+    return session_id[:80] or "default"
+
+
+def _chat_session_title(messages: list[dict] | None, fallback: str = "New chat") -> str:
+    if isinstance(messages, list):
+        for item in messages:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("role") or "") != "user":
+                continue
+            content = str(item.get("content") or "").strip()
+            if content:
+                return content[:64]
+    return fallback
+
+
+def _normalize_chat_history(raw: object) -> list[dict]:
+    history: list[dict] = []
+    if not isinstance(raw, list):
+        return history
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("role") or "").strip()
+        content = str(item.get("content") or "").strip()
+        if role in {{"user", "assistant"}} and content:
+            history.append({{"role": role, "content": content}})
+    return history[-80:]
+
+
+def _normalize_chat_session(session_id: str, payload: object | None = None) -> dict:
+    now = _now_iso()
+    data = payload if isinstance(payload, dict) else {{}}
+    resolved_id = _sanitize_chat_session_id(str(data.get("id") or session_id or "default"))
+    history = _normalize_chat_history(data.get("chat_history") or data.get("messages") or [])
+    title = str(data.get("title") or "").strip() or _chat_session_title(history, "New chat")
+    created_at = str(data.get("created_at") or now)
+    updated_at = str(data.get("updated_at") or now)
+    return {{
+        "id": resolved_id,
+        "title": title[:96],
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "chat_history": history,
+        "memory_uri": str(data.get("memory_uri") or _chat_memory_uri(resolved_id) or ""),
+    }}
+
+
+def _local_chat_sessions(state: dict) -> dict[str, dict]:
+    sessions = state.get("chat_sessions")
+    if not isinstance(sessions, dict):
+        sessions = {{}}
+    normalized: dict[str, dict] = {{}}
+    for session_id, payload in sessions.items():
+        session = _normalize_chat_session(str(session_id), payload)
+        normalized[session["id"]] = session
+    if not normalized:
+        migrated = _normalize_chat_session(
+            "default",
+            {{
+                "id": "default",
+                "title": "Default chat",
+                "chat_history": state.get("chat_history", []),
+            }},
+        )
+        normalized["default"] = migrated
+    state["chat_sessions"] = normalized
+    if str(state.get("active_chat_session_id") or "") not in normalized:
+        state["active_chat_session_id"] = next(iter(normalized.keys()))
+    state["chat_history"] = normalized[str(state["active_chat_session_id"])]["chat_history"]
+    return normalized
+
+
+def _load_chat_session_from_s3(session_id: str) -> dict | None:
+    s3, settings = _agent_s3_client_optional()
+    if s3 is None or not settings.get("bucket"):
+        return None
+    key = _chat_session_key(session_id, settings)
+    try:
+        obj = s3.get_object(Bucket=settings["bucket"], Key=key)
+        body = obj.get("Body")
+        raw = body.read() if hasattr(body, "read") else body
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        payload = json.loads(str(raw or "{}"))
+        return _normalize_chat_session(session_id, payload)
+    except Exception:
+        return None
+
+
+def _persist_chat_session_to_s3(session: dict) -> str:
+    s3, settings = _agent_s3_client_optional()
+    if s3 is None or not settings.get("bucket"):
+        return ""
+    session_id = _sanitize_chat_session_id(str(session.get("id") or "default"))
+    key = _chat_session_key(session_id, settings)
+    memory_uri = _chat_memory_uri(session_id, settings)
+    payload = dict(session)
+    payload["id"] = session_id
+    payload["memory_uri"] = memory_uri
+    payload["tenant_id"] = _chat_memory_tenant()
+    try:
+        s3.put_object(
+            Bucket=settings["bucket"],
+            Key=key,
+            Body=(json.dumps(payload, indent=2, sort_keys=True) + "\\n").encode("utf-8"),
+            ContentType="application/json",
+        )
+        return memory_uri
+    except Exception:
+        return ""
+
+
+def _save_chat_session(state: dict, session: dict, *, active: bool = True) -> dict:
+    sessions = _local_chat_sessions(state)
+    normalized = _normalize_chat_session(str(session.get("id") or "default"), session)
+    normalized["updated_at"] = _now_iso()
+    memory_uri = _persist_chat_session_to_s3(normalized)
+    if memory_uri:
+        normalized["memory_uri"] = memory_uri
+    sessions[normalized["id"]] = normalized
+    state["chat_sessions"] = sessions
+    if active:
+        state["active_chat_session_id"] = normalized["id"]
+        state["chat_history"] = normalized["chat_history"]
+    _save_state(state)
+    return normalized
+
+
+def _get_chat_session(state: dict, session_id: str = "") -> dict:
+    sessions = _local_chat_sessions(state)
+    target = _sanitize_chat_session_id(session_id or str(state.get("active_chat_session_id") or "default"))
+    remote = _load_chat_session_from_s3(target)
+    if remote is not None:
+        sessions[target] = remote
+        state["chat_sessions"] = sessions
+        return remote
+    if target in sessions:
+        return sessions[target]
+    session = _normalize_chat_session(target, {{"id": target, "title": "New chat", "chat_history": []}})
+    sessions[target] = session
+    state["chat_sessions"] = sessions
+    return session
+
+
+def _list_chat_sessions(state: dict) -> list[dict]:
+    sessions = _local_chat_sessions(state)
+    s3, settings = _agent_s3_client_optional()
+    if s3 is not None and settings.get("bucket"):
+        prefix = _chat_memory_prefix(settings) + "/"
+        try:
+            resp = s3.list_objects_v2(Bucket=settings["bucket"], Prefix=prefix, MaxKeys=50)
+            for item in resp.get("Contents", []) or []:
+                key = str(item.get("Key") or "")
+                if not key.endswith(".json"):
+                    continue
+                session_id = _sanitize_chat_session_id(Path(key).stem)
+                remote = _load_chat_session_from_s3(session_id)
+                if remote is not None:
+                    sessions[session_id] = remote
+        except Exception:
+            pass
+    state["chat_sessions"] = sessions
+    _save_state(state)
+    rows = []
+    for session in sessions.values():
+        history = session.get("chat_history") if isinstance(session, dict) else []
+        rows.append({{
+            "id": str(session.get("id") or ""),
+            "title": str(session.get("title") or "New chat"),
+            "created_at": str(session.get("created_at") or ""),
+            "updated_at": str(session.get("updated_at") or ""),
+            "message_count": len(history) if isinstance(history, list) else 0,
+            "memory_uri": str(session.get("memory_uri") or ""),
+        }})
+    return sorted(rows, key=lambda item: str(item.get("updated_at") or ""), reverse=True)
 
 
 def _artifact_filename(key: str) -> str:
@@ -2127,10 +2351,22 @@ def chat(payload: dict):
     if not isinstance(raw_messages, list) or not raw_messages:
         raise HTTPException(status_code=400, detail="messages must be a non-empty list")
     model = str(payload.get("model") or LLM_MODEL).strip() or LLM_MODEL
+    state = _load_state()
+    session_id = _sanitize_chat_session_id(
+        str(payload.get("session_id") or state.get("active_chat_session_id") or "default")
+    )
+    session = _get_chat_session(state, session_id)
+    history = _normalize_chat_history(raw_messages)
+    if len(history) <= 1 and isinstance(session.get("chat_history"), list):
+        prior = _normalize_chat_history(session.get("chat_history", []))
+        if history:
+            history = [*prior, history[-1]]
+        else:
+            history = prior
+    raw_messages = history
     tool_result = _agent_chat_with_tools(raw_messages=raw_messages, model=model)
     if tool_result is not None:
         reply = str(tool_result.get("reply") or "").strip()
-        state = _load_state()
         history: list[dict] = []
         for item in raw_messages:
             if not isinstance(item, dict):
@@ -2141,7 +2377,21 @@ def chat(payload: dict):
                 history.append({{"role": role, "content": content}})
         if reply:
             history.append({{"role": "assistant", "content": reply}})
-        state["chat_history"] = history[-50:]
+        session.update(
+            {{
+                "id": session_id,
+                "title": str(session.get("title") or _chat_session_title(history)),
+                "chat_history": history[-80:],
+            }}
+        )
+        session = _save_chat_session(state, session, active=True)
+        tool_result["session_id"] = session["id"]
+        tool_result["session"] = {{
+            "id": session["id"],
+            "title": session["title"],
+            "memory_uri": session.get("memory_uri", ""),
+            "message_count": len(session.get("chat_history", [])),
+        }}
         _save_state(state)
         return tool_result
     live_ctx = format_live_context_block(_load_state())
@@ -2177,13 +2427,26 @@ def chat(payload: dict):
             history.append({{"role": role, "content": content}})
     if reply:
         history.append({{"role": "assistant", "content": reply}})
-    state["chat_history"] = history[-50:]
-    _save_state(state)
+    session.update(
+        {{
+            "id": session_id,
+            "title": str(session.get("title") or _chat_session_title(history)),
+            "chat_history": history[-80:],
+        }}
+    )
+    session = _save_chat_session(state, session, active=True)
     return {{
         "ok": True,
         "model": model,
         "reply": reply,
         "reasoning": reasoning,
+        "session_id": session["id"],
+        "session": {{
+            "id": session["id"],
+            "title": session["title"],
+            "memory_uri": session.get("memory_uri", ""),
+            "message_count": len(session.get("chat_history", [])),
+        }},
     }}
 
 @app.get("/health")
@@ -2202,6 +2465,7 @@ def models(refresh: bool = False):
 @app.get("/session")
 def session_bootstrap():
     state = _load_state()
+    active_session = _get_chat_session(state, str(state.get("active_chat_session_id") or "default"))
     sim_viz = dict(DEFAULT_SIM_VIZ)
     if isinstance(state.get("sim_viz"), dict):
         sim_viz.update(state["sim_viz"])
@@ -2211,7 +2475,7 @@ def session_bootstrap():
     if not sim_viz.get("rrd_uri") and RRD_PATH.is_file():
         sim_viz["rrd_uri"] = f"file://{{RRD_PATH}}"
     sim_viz["rerun_ready"] = _rerun_ready_state(rrd_uri=str(sim_viz.get("rrd_uri") or ""))
-    history = state.get("chat_history", [])
+    history = active_session.get("chat_history", [])
     if not isinstance(history, list):
         history = []
     return {{
@@ -2223,6 +2487,13 @@ def session_bootstrap():
         "workflow_submit": state.get("workflow_submit", {{}}),
         "camera_selection": state.get("camera_selection", ["workspace"]),
         "chat_history": history,
+        "active_chat_session_id": active_session["id"],
+        "chat_sessions": _list_chat_sessions(state),
+        "chat_memory": {{
+            "tenant": _chat_memory_tenant(),
+            "s3_configured": bool(_agent_s3_settings().get("bucket") and _agent_s3_settings().get("access_key")),
+            "prefix": _chat_memory_prefix(),
+        }},
         "llm": {{
             "default": LLM_MODEL,
             "default_model": LLM_MODEL,
@@ -2230,6 +2501,51 @@ def session_bootstrap():
             "models": _available_llm_models(),
         }},
     }}
+
+
+@app.get("/chat/sessions")
+def chat_sessions():
+    state = _load_state()
+    active_id = str(state.get("active_chat_session_id") or "default")
+    settings = _agent_s3_settings()
+    return {{
+        "ok": True,
+        "active_session_id": active_id,
+        "sessions": _list_chat_sessions(state),
+        "memory": {{
+            "tenant": _chat_memory_tenant(),
+            "s3_configured": bool(settings.get("bucket") and settings.get("access_key")),
+            "prefix": _chat_memory_prefix(settings),
+        }},
+    }}
+
+
+@app.post("/chat/sessions")
+def create_chat_session(payload: dict | None = None):
+    body = payload if isinstance(payload, dict) else {{}}
+    state = _load_state()
+    session_id = _sanitize_chat_session_id(str(body.get("id") or f"chat-{{secrets.token_urlsafe(8)}}"))
+    title = str(body.get("title") or "New chat").strip() or "New chat"
+    session = _normalize_chat_session(session_id, {{"id": session_id, "title": title, "chat_history": []}})
+    saved = _save_chat_session(state, session, active=True)
+    return {{"ok": True, "session": saved, "active_session_id": saved["id"], "sessions": _list_chat_sessions(state)}}
+
+
+@app.get("/chat/sessions/{{session_id}}")
+def get_chat_session(session_id: str):
+    state = _load_state()
+    session = _get_chat_session(state, session_id)
+    return {{"ok": True, "session": session}}
+
+
+@app.post("/chat/sessions/{{session_id}}/select")
+def select_chat_session(session_id: str):
+    state = _load_state()
+    session = _get_chat_session(state, session_id)
+    state["active_chat_session_id"] = session["id"]
+    state["chat_history"] = session.get("chat_history", [])
+    _save_state(state)
+    return {{"ok": True, "session": session, "active_session_id": session["id"], "sessions": _list_chat_sessions(state)}}
 
 @app.get("/tools")
 def tools():
@@ -3264,7 +3580,25 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         font-size: 12px;
         color: #4f5668;
       }}
+      .chat-session {{
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        color: #4f5668;
+      }}
+      .chat-session select {{
+        max-width: 220px;
+      }}
       .chat-model select {{
+        border: 1px solid #d4d8e2;
+        border-radius: 999px;
+        padding: 6px 10px;
+        background: #fff;
+        color: #1f2430;
+        font: inherit;
+      }}
+      .chat-session select {{
         border: 1px solid #d4d8e2;
         border-radius: 999px;
         padding: 6px 10px;
@@ -3556,7 +3890,11 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         width: 100%;
         justify-content: space-between;
       }}
-      body.mobile-agent .chat-model select {{
+      body.mobile-agent .chat-session {{
+        width: 100%;
+      }}
+      body.mobile-agent .chat-model select,
+      body.mobile-agent .chat-session select {{
         flex: 1 1 auto;
         max-width: 100%;
       }}
@@ -3683,6 +4021,13 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           </div>
           <div class="chat-toolbar">
             <span class="hint">Grounded responses use live `/api/*` context from this VM.</span>
+            <label for="chatSessionSelect" class="chat-session">
+              Session
+              <select id="chatSessionSelect">
+                <option value="default" selected>Default chat</option>
+              </select>
+            </label>
+            <button id="newChatSession" class="btn" type="button">New chat</button>
             <label for="chatModel" class="chat-model">
               Token Factory model
               <select id="chatModel">
@@ -3961,6 +4306,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       applyMobileLayout();
       window.addEventListener("resize", applyMobileLayout);
       const chatHistory = [];
+      let activeChatSessionId = "default";
       let chatSendInFlight = false;
       let thinkingNode = null;
       function setStatus(text) {{
@@ -4055,6 +4401,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         bindClick("chatActionWorkflow", () => {{
           setChatInput("Create a 2-step sim2real workflow YAML with real toolRefs from the catalog.");
         }}, "Insert workflow YAML prompt");
+        bindClick("newChatSession", createNewChatSession, "New chat session");
         bindClick("workflowUpload", uploadWorkflowYaml, "Upload workflow YAML");
         bindClick("workflowValidate", validateWorkflowYaml, "Validate workflow YAML");
         bindClick("workflowPlan", planWorkflowYaml, "Plan workflow YAML");
@@ -4074,6 +4421,17 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
             if (e.key === "Enter" && !e.shiftKey) {{
               e.preventDefault();
               sendChat().catch((err) => showToast(String(err), "error"));
+            }}
+          }});
+        }}
+        const chatSessionSelect = document.getElementById("chatSessionSelect");
+        if (chatSessionSelect) {{
+          chatSessionSelect.addEventListener("change", async () => {{
+            const sessionId = String(chatSessionSelect.value || "default");
+            try {{
+              await selectChatSession(sessionId);
+            }} catch (err) {{
+              showToast(String(err && err.message ? err.message : err), "error");
             }}
           }});
         }}
@@ -4349,6 +4707,80 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         const select = document.getElementById("chatModel");
         return String((select && select.value) || "").trim() || "{DEFAULT_LLM_MODEL}";
       }}
+      function clearChatLog() {{
+        const log = document.getElementById("chatLog");
+        if (log) log.innerHTML = "";
+        chatHistory.splice(0, chatHistory.length);
+      }}
+      function renderChatHistory(history) {{
+        clearChatLog();
+        const hist = Array.isArray(history) ? history : [];
+        for (const msg of hist) {{
+          const role = String(msg.role || "");
+          const content = String(msg.content || "").trim();
+          if (!content || (role !== "user" && role !== "assistant")) continue;
+          appendChat(role, content);
+          chatHistory.push({{ role, content }});
+        }}
+      }}
+      function updateChatSessionSelector(sessions, activeId) {{
+        const select = document.getElementById("chatSessionSelect");
+        if (!select) return;
+        const rows = Array.isArray(sessions) ? sessions : [];
+        const active = String(activeId || activeChatSessionId || "default");
+        select.innerHTML = "";
+        if (!rows.length) {{
+          const opt = document.createElement("option");
+          opt.value = active;
+          opt.textContent = "Default chat";
+          opt.selected = true;
+          select.appendChild(opt);
+          return;
+        }}
+        for (const row of rows) {{
+          const id = String(row.id || "").trim();
+          if (!id) continue;
+          const opt = document.createElement("option");
+          opt.value = id;
+          const count = Number(row.message_count || 0);
+          opt.textContent = String(row.title || id) + (count ? " (" + String(count) + ")" : "");
+          if (id === active) opt.selected = true;
+          select.appendChild(opt);
+        }}
+      }}
+      async function refreshChatSessions(activeId) {{
+        const data = await apiJson("/api/chat/sessions");
+        activeChatSessionId = String(data.active_session_id || activeId || activeChatSessionId || "default");
+        updateChatSessionSelector(data.sessions, activeChatSessionId);
+        return data;
+      }}
+      async function selectChatSession(sessionId) {{
+        const safeId = String(sessionId || "default").trim() || "default";
+        const data = await apiJson("/api/chat/sessions/" + encodeURIComponent(safeId) + "/select", {{
+          method: "POST",
+          headers: {{ "content-type": "application/json" }},
+          body: JSON.stringify({{}}),
+        }});
+        const session = data.session || {{}};
+        activeChatSessionId = String(data.active_session_id || session.id || safeId);
+        updateChatSessionSelector(data.sessions, activeChatSessionId);
+        renderChatHistory(session.chat_history || []);
+        showToast("Loaded chat session", "success");
+        return session;
+      }}
+      async function createNewChatSession() {{
+        const data = await apiJson("/api/chat/sessions", {{
+          method: "POST",
+          headers: {{ "content-type": "application/json" }},
+          body: JSON.stringify({{ title: "New chat" }}),
+        }});
+        const session = data.session || {{}};
+        activeChatSessionId = String(data.active_session_id || session.id || "default");
+        updateChatSessionSelector(data.sessions, activeChatSessionId);
+        renderChatHistory([]);
+        showToast("New chat session ready", "success");
+        return true;
+      }}
       function setWorkflowYaml(text, validation) {{
         const area = document.getElementById("workflowYaml");
         if (area) area.value = String(text || "");
@@ -4445,7 +4877,6 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           return false;
         }}
         chatSendInFlight = true;
-        input.value = "";
         appendChat("user", text);
         chatHistory.push({{ role: "user", content: text }});
         setChatBusy(true);
@@ -4454,17 +4885,22 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           const data = await apiJson("/api/chat", {{
             method: "POST",
             headers: {{ "content-type": "application/json" }},
-            body: JSON.stringify({{ messages: chatHistory, model }}),
+            body: JSON.stringify({{ messages: chatHistory, model, session_id: activeChatSessionId }}),
           }});
           clearThinkingBubble();
+          input.value = "";
           if (data && data.model) {{
             const select = document.getElementById("chatModel");
             if (select) select.value = String(data.model);
+          }}
+          if (data && data.session_id) {{
+            activeChatSessionId = String(data.session_id);
           }}
           const reply = normalizeAssistantReply(data.reply || "");
           if (reply) {{
             appendChat("assistant", reply);
             chatHistory.push({{ role: "assistant", content: reply }});
+            refreshChatSessions(activeChatSessionId).catch(() => {{ /* best-effort session list refresh */ }});
           }} else {{
             appendChat("error", "empty reply from model");
           }}
@@ -4477,7 +4913,13 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           }}
         }} catch (err) {{
           clearThinkingBubble();
-          appendChat("error", String(err));
+          const message = String(err && err.message ? err.message : err);
+          input.value = text;
+          const tail = chatHistory[chatHistory.length - 1];
+          if (tail && tail.role === "user" && tail.content === text) {{
+            chatHistory.pop();
+          }}
+          appendChat("error", "Send failed; your draft was restored. " + message);
           throw err;
         }} finally {{
           chatSendInFlight = false;
@@ -5015,6 +5457,10 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
             );
             setChatModels(session.llm.models, currentModel);
           }}
+          if (session && session.chat_sessions) {{
+            activeChatSessionId = String(session.active_chat_session_id || activeChatSessionId || "default");
+            updateChatSessionSelector(session.chat_sessions, activeChatSessionId);
+          }}
           if (session && session.workflow_draft && session.workflow_draft.yaml) {{
             setWorkflowYaml(session.workflow_draft.yaml, session.workflow_draft.validation || {{}});
           }}
@@ -5320,20 +5766,15 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       async function restoreSession() {{
         try {{
           const session = await loadJson("/api/session");
+          activeChatSessionId = String(session.active_chat_session_id || activeChatSessionId || "default");
+          updateChatSessionSelector(session.chat_sessions, activeChatSessionId);
           if (session && session.llm) {{
             const currentModel = String(
               (session.llm.model || session.llm.default_model || session.llm.default || "")
             );
             setChatModels(session.llm.models, currentModel);
           }}
-          const hist = Array.isArray(session.chat_history) ? session.chat_history : [];
-          for (const msg of hist) {{
-            const role = String(msg.role || "");
-            const content = String(msg.content || "").trim();
-            if (!content || (role !== "user" && role !== "assistant")) continue;
-            appendChat(role, content);
-            chatHistory.push({{ role, content }});
-          }}
+          renderChatHistory(session.chat_history || []);
           const draft = session.workflow_draft;
           if (draft && draft.yaml) {{
             setWorkflowYaml(draft.yaml, draft.validation || draft);

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -774,21 +774,25 @@ def _write_agent_operator_profile(
     config_b64 = base64.b64encode(json.dumps(config_payload, indent=2).encode("utf-8")).decode("ascii")
     creds_b64 = base64.b64encode(json.dumps(credentials_payload, indent=2).encode("utf-8")).decode("ascii")
     user_home = f"/home/{ssh_user}"
-    npa_dir = f"{user_home}/.npa"
-    config_path = f"{npa_dir}/config.yaml"
-    creds_path = f"{npa_dir}/credentials.yaml"
-    ssh.run_or_raise(
-        " && ".join(
+    targets = [
+        (f"{user_home}/.npa", f"{ssh_user}:{ssh_user}"),
+        ("/root/.npa", "root:root"),
+    ]
+    commands: list[str] = []
+    for npa_dir, owner in targets:
+        config_path = f"{npa_dir}/config.yaml"
+        creds_path = f"{npa_dir}/credentials.yaml"
+        commands.extend(
             [
                 f"sudo mkdir -p {shlex.quote(npa_dir)}",
                 f"echo {shlex.quote(config_b64)} | base64 -d | sudo tee {shlex.quote(config_path)} >/dev/null",
                 f"echo {shlex.quote(creds_b64)} | base64 -d | sudo tee {shlex.quote(creds_path)} >/dev/null",
-                f"sudo chown -R {shlex.quote(ssh_user)}:{shlex.quote(ssh_user)} {shlex.quote(npa_dir)}",
+                f"sudo chown -R {shlex.quote(owner)} {shlex.quote(npa_dir)}",
                 f"sudo chmod 700 {shlex.quote(npa_dir)}",
                 f"sudo chmod 600 {shlex.quote(config_path)} {shlex.quote(creds_path)}",
             ]
         )
-    )
+    ssh.run_or_raise(" && ".join(commands))
 
 
 def _store_project_environment(*, project: str, project_id: str, tenant_id: str, region: str) -> None:

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2452,6 +2452,11 @@ def _agent_command_env() -> dict:
     env.setdefault("NPA_TERRAFORM_BIN", shutil.which("terraform") or "terraform")
     env.setdefault("NPA_KUBECTL_BIN", shutil.which("kubectl") or "kubectl")
     env.setdefault("NPA_NEBIUS_BIN", shutil.which("nebius") or "nebius")
+    if not env.get("TF_VAR_ssh_public_key"):
+        for candidate in ("/home/ubuntu/.ssh/id_ed25519.pub", "/root/.ssh/id_ed25519.pub"):
+            if Path(candidate).is_file():
+                env["TF_VAR_ssh_public_key"] = json.dumps({"path": candidate})
+                break
     return env
 
 

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -3084,6 +3084,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate">
     <meta name="npa-ui-version" content="{AGENT_UI_VERSION}">
     <title>NPA Agent</title>
@@ -3105,12 +3106,24 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         --shadow: 0 8px 22px rgba(30, 31, 34, 0.08);
       }}
       * {{ box-sizing: border-box; }}
+      html {{
+        overflow-x: hidden;
+        width: 100%;
+        max-width: 100%;
+        -webkit-text-size-adjust: 100%;
+      }}
       body {{
         margin: 0;
         padding-bottom: 36px;
         font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
         background: var(--bg);
         color: var(--text);
+        overflow-x: hidden;
+        width: 100%;
+        max-width: 100%;
+      }}
+      img, video, iframe, pre, textarea, select, input, .panel, .page, .chrome {{
+        max-width: 100%;
       }}
       .chrome {{
         max-width: 1640px;
@@ -3203,6 +3216,34 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       .mobile-only-toggle {{ display: none; }}
       .chat-composer {{
         background: var(--surface);
+      }}
+      .mobile-chat-auth {{
+        display: none;
+        margin: 0 0 10px;
+        padding: 12px;
+        border: 1px solid #fcd34d;
+        border-radius: 10px;
+        background: #fffbeb;
+      }}
+      .mobile-chat-auth-row {{
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }}
+      .mobile-chat-auth-row input {{
+        width: 100%;
+        padding: 10px 12px;
+        border: 1px solid #d4d8e2;
+        border-radius: 10px;
+        font: inherit;
+        font-size: 16px;
+      }}
+      body.mobile-agent.mobile-needs-auth .mobile-chat-auth {{
+        display: block;
+      }}
+      body.mobile-agent.mobile-needs-auth #chatForm {{
+        opacity: 0.55;
+        pointer-events: none;
       }}
       .chat-toolbar {{
         display: flex;
@@ -3472,15 +3513,26 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       }}
       body.mobile-agent {{
         padding-bottom: calc(56px + env(safe-area-inset-bottom));
+        overflow-x: hidden;
       }}
       body.mobile-agent .chrome {{
-        max-width: none;
+        max-width: 100%;
+        width: 100%;
+        overflow-x: hidden;
       }}
       body.mobile-agent .page {{
         display: flex;
         flex-direction: column;
         gap: 10px;
         padding: 10px 10px calc(68px + env(safe-area-inset-bottom));
+        width: 100%;
+        max-width: 100%;
+        overflow-x: hidden;
+      }}
+      body.mobile-agent .panel {{
+        width: 100%;
+        max-width: 100%;
+        overflow-x: hidden;
       }}
       body.mobile-agent .chat-panel {{
         display: flex;
@@ -3541,6 +3593,17 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         min-height: 36px;
       }}
       body.mobile-agent .topbar .badge {{
+        display: none;
+      }}
+      body.mobile-agent .brand-sub {{
+        display: none;
+      }}
+      body.mobile-agent .brand {{
+        font-size: 11px;
+        line-height: 1.35;
+        word-break: break-word;
+      }}
+      body.mobile-agent .chat-toolbar .hint {{
         display: none;
       }}
       .workflow-panel textarea {{
@@ -3624,6 +3687,13 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
             </label>
           </div>
           <div id="chatLog" class="chat-log"></div>
+          <div id="mobileChatAuth" class="mobile-chat-auth" aria-live="polite">
+            <p class="hint">Mobile chat needs your agent password once on this device.</p>
+            <div class="mobile-chat-auth-row">
+              <input id="mobileChatPassword" type="password" placeholder="Agent password" autocomplete="current-password">
+              <button id="mobileChatAuthBtn" class="btn btn-primary" type="button">Unlock chat</button>
+            </div>
+          </div>
           <form id="chatForm" class="chat-composer chat-input" autocomplete="off">
             <textarea id="chatInput" placeholder="How do I configure S3 for Sim2Real?" rows="2" enterkeyhint="send"></textarea>
             <button id="chatSend" class="btn btn-primary" type="submit">Send</button>
@@ -3803,6 +3873,55 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           return "";
         }}
       }}
+      function persistMobileBasicAuth(user, pass) {{
+        const token = "Basic " + btoa(unescape(encodeURIComponent(String(user || "") + ":" + String(pass || ""))));
+        try {{
+          sessionStorage.setItem("npa_agent_basic_auth", token);
+        }} catch (_err) {{ /* ignore */ }}
+        return token;
+      }}
+      function setMobileAuthNeeded(needed) {{
+        if (!document.body.classList.contains("mobile-agent")) return;
+        document.body.classList.toggle("mobile-needs-auth", Boolean(needed));
+        if (!needed) {{
+          document.body.classList.add("mobile-auth-ready");
+        }}
+      }}
+      async function probeMobileChatAuth() {{
+        if (!document.body.classList.contains("mobile-agent")) return true;
+        if (mobileAuthHeader()) {{
+          setMobileAuthNeeded(false);
+          return true;
+        }}
+        try {{
+          const resp = await fetch("/api/health", {{ credentials: "include", cache: "no-store" }});
+          if (resp.ok) {{
+            setMobileAuthNeeded(false);
+            return true;
+          }}
+        }} catch (_err) {{ /* fall through */ }}
+        setMobileAuthNeeded(true);
+        return false;
+      }}
+      async function unlockMobileChatAuth(password) {{
+        const pass = String(password || "").trim();
+        if (!pass) {{
+          throw new Error("Enter your agent password.");
+        }}
+        persistMobileBasicAuth("{DEFAULT_AGENT_USER}", pass);
+        const resp = await fetch("/api/health", {{
+          credentials: "include",
+          cache: "no-store",
+          headers: {{ Authorization: mobileAuthHeader() }},
+        }});
+        if (!resp.ok) {{
+          try {{ sessionStorage.removeItem("npa_agent_basic_auth"); }} catch (_err) {{ /* ignore */ }}
+          throw new Error("Invalid password — try again or reopen /login-help.html.");
+        }}
+        setMobileAuthNeeded(false);
+        showToast("Chat unlocked", "success");
+        return true;
+      }}
       function withMobileAuth(headers) {{
         const merged = {{ ...(headers || {{}}) }};
         const auth = mobileAuthHeader();
@@ -3812,7 +3931,9 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         return merged;
       }}
       applyMobileLayout();
+      window.addEventListener("resize", applyMobileLayout);
       const chatHistory = [];
+      let chatSendInFlight = false;
       let thinkingNode = null;
       function setStatus(text) {{
         const bar = document.getElementById("statusBar");
@@ -3872,6 +3993,26 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
             const open = document.body.classList.toggle("mobile-show-panels");
             mobileToggle.setAttribute("aria-expanded", open ? "true" : "false");
             mobileToggle.textContent = open ? "Hide panels" : "Panels";
+          }});
+        }}
+        const mobileAuthBtn = document.getElementById("mobileChatAuthBtn");
+        const mobileAuthPass = document.getElementById("mobileChatPassword");
+        if (mobileAuthBtn && mobileAuthPass) {{
+          mobileAuthBtn.addEventListener("click", async () => {{
+            try {{
+              mobileAuthBtn.disabled = true;
+              await unlockMobileChatAuth(mobileAuthPass.value);
+              mobileAuthPass.value = "";
+            }} catch (err) {{
+              showToast(String(err && err.message ? err.message : err), "error");
+            }} finally {{
+              mobileAuthBtn.disabled = false;
+            }}
+          }});
+          mobileAuthPass.addEventListener("keydown", async (event) => {{
+            if (event.key !== "Enter") return;
+            event.preventDefault();
+            mobileAuthBtn.click();
           }});
         }}
         bindClick("chatActionS3", () => {{
@@ -4258,12 +4399,23 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       }}
       async function sendChat() {{
         const input = document.getElementById("chatInput");
+        if (!input) {{
+          throw new Error("Chat input missing");
+        }}
+        if (chatSendInFlight) {{
+          return false;
+        }}
+        if (document.body.classList.contains("mobile-agent") && document.body.classList.contains("mobile-needs-auth")) {{
+          showToast("Unlock chat with your agent password first.", "error");
+          return false;
+        }}
         const text = String(input.value || "").trim();
         const model = selectedChatModel();
         if (!text) {{
           showToast("Enter a message first", "info");
           return false;
         }}
+        chatSendInFlight = true;
         input.value = "";
         appendChat("user", text);
         chatHistory.push({{ role: "user", content: text }});
@@ -4299,6 +4451,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           appendChat("error", String(err));
           throw err;
         }} finally {{
+          chatSendInFlight = false;
           setChatBusy(false);
           input.focus();
         }}
@@ -4702,6 +4855,10 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         }}
         if (!resp.ok) {{
           if (resp.status === 401) {{
+            if (document.body.classList.contains("mobile-agent")) {{
+              setMobileAuthNeeded(true);
+              throw new Error("Unlock chat with your agent password.");
+            }}
             window.location.href = "/login-help.html";
             throw new Error("Authentication required. Open / and sign in with HTTP Basic Auth.");
           }}
@@ -5225,10 +5382,14 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           showToast("UI wiring failed: " + String(err), "error");
           console.error(err);
         }}
-        bootPage().catch((err) => {{
-          showToast("Boot failed: " + String(err), "error");
-          console.error(err);
-        }});
+        probeMobileChatAuth()
+          .catch(() => false)
+          .finally(() => {{
+            bootPage().catch((err) => {{
+              showToast("Boot failed: " + String(err), "error");
+              console.error(err);
+            }});
+          }});
         const armPeriodic = () => startPeriodicRefresh();
         document.addEventListener("click", armPeriodic, {{ once: true }});
         document.addEventListener("keydown", armPeriodic, {{ once: true }});
@@ -6251,7 +6412,9 @@ def verify_live_cmd(
         _fail(f"UI html fetch failed (status={ui_resp.status_code})")
     ui_html = ui_resp.text
     for marker in (
+        'name="viewport" content="width=device-width',
         'id="chatForm"',
+        'id="mobileChatAuth"',
         "function sendChat(",
         "function wireUi(",
         "initNpaAgentUi",

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -55,7 +55,7 @@ DEFAULT_LLM_MODELS = (
     "meta-llama/Llama-3.3-70B-Instruct",
     "Qwen/Qwen2.5-VL-72B-Instruct",
 )
-AGENT_UI_VERSION = "2026070402"
+AGENT_UI_VERSION = "2026070403"
 DEFAULT_HTTPS_PORT = 443
 
 
@@ -4588,7 +4588,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       function extractFencedCode(text, preferredLang) {{
         const raw = String(text || "");
         const blocks = [];
-        const re = /```([a-zA-Z0-9_-]+)?\s*\n([\s\S]*?)```/g;
+        const re = /```([a-zA-Z0-9_-]+)?\s*\\n([\\s\\S]*?)```/g;
         let match;
         while ((match = re.exec(raw)) !== null) {{
           blocks.push({{

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -5189,15 +5189,15 @@ def fresh_setup_cmd(
         _fail(
             f"Agent {project}/{name} already exists. Use --replace or choose a new --project/--name."
         )
+    if existing and replace:
+        typer.echo(f"Replacing existing agent {project}/{name} ...")
+        destroy_cmd(project=project, name=name)
     _store_project_environment(
         project=project,
         project_id=project_id.strip(),
         tenant_id=tenant_id.strip(),
         region=region.strip(),
     )
-    if existing and replace:
-        typer.echo(f"Replacing existing agent {project}/{name} ...")
-        destroy_cmd(project=project, name=name)
     deploy_cmd(
         project=project,
         name=name,

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -368,6 +368,39 @@ _AGENT_INSTANCE_DESTROY_TARGETS = (
 )
 
 
+def _cleanup_orphan_agent_instances(project_id: str, instance_name: str) -> None:
+    """Delete cloud VM instances matching the agent name but missing from TF state."""
+    project_id = str(project_id or "").strip()
+    instance_name = str(instance_name or "").strip()
+    if not project_id or not instance_name:
+        return
+    from npa.clients.nebius import NebiusError, _run, _run_json
+
+    try:
+        payload = _run_json(["compute", "instance", "list", "--parent-id", project_id])
+    except NebiusError:
+        return
+    items = payload.get("items", [])
+    if not isinstance(items, list):
+        return
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        meta = item.get("metadata", {})
+        if not isinstance(meta, dict):
+            continue
+        if str(meta.get("name", "")).strip() != instance_name:
+            continue
+        instance_id = str(meta.get("id", "")).strip()
+        if not instance_id:
+            continue
+        try:
+            _run(["compute", "instance", "delete", instance_id], check=False)
+            typer.echo(f"  Deleted orphan agent instance {instance_id}")
+        except NebiusError:
+            continue
+
+
 def _destroy_agent_terraform(
     project: str,
     name: str,
@@ -386,7 +419,10 @@ def _destroy_agent_terraform(
     tf_vars = _resolve_destroy_tf_vars(project, name, record)
     region = tf_vars["nebius_region"]
     instance_id = str((record or {}).get("instance_id", "")).strip()
+    instance_name = tf_vars["instance_name"]
+    project_id = tf_vars["nebius_project_id"]
     _cleanup_agent_ingress(instance_id)
+    _cleanup_orphan_agent_instances(project_id, instance_name)
     tf_dir = provisioner.prepare_working_dir(
         project,
         name,

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -1741,7 +1741,7 @@ def _load_chat_session_from_s3(session_id: str) -> dict | None:
         raw = body.read() if hasattr(body, "read") else body
         if isinstance(raw, bytes):
             raw = raw.decode("utf-8")
-        payload = json.loads(str(raw or "{}"))
+        payload = json.loads(str(raw or "{{}}"))
         return _normalize_chat_session(session_id, payload)
     except Exception:
         return None

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2457,6 +2457,18 @@ def _agent_command_env() -> dict:
             if Path(candidate).is_file():
                 env["TF_VAR_ssh_public_key"] = json.dumps({{"path": candidate}})
                 break
+        if not env.get("TF_VAR_ssh_public_key"):
+            for candidate in ("/home/ubuntu/.ssh/authorized_keys", "/root/.ssh/authorized_keys"):
+                path = Path(candidate)
+                if not path.is_file():
+                    continue
+                for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+                    value = line.strip()
+                    if value.startswith(("ssh-ed25519 ", "ssh-rsa ", "ecdsa-sha2-")):
+                        env["TF_VAR_ssh_public_key"] = json.dumps({{"key": value}})
+                        break
+                if env.get("TF_VAR_ssh_public_key"):
+                    break
     return env
 
 

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -929,6 +929,12 @@ def _agent_public_login_form_html(auth_user: str) -> str:
         return "Basic " + btoa(unescape(encodeURIComponent(user + ":" + pass)));
       }}
 
+      function persistBasicAuth(user, pass) {{
+        try {{
+          sessionStorage.setItem("npa_agent_basic_auth", basicAuthHeader(user, pass));
+        }} catch (_err) {{ /* sessionStorage may be unavailable */ }}
+      }}
+
       function xhrSignIn(user, pass, dest) {{
         return new Promise(function (resolve, reject) {{
           var xhr = new XMLHttpRequest();
@@ -981,10 +987,12 @@ def _agent_public_login_form_html(auth_user: str) -> str:
         xhrSignIn(user, pass, dest)
           .catch(function () {{ return fetchSignIn(user, pass, dest); }})
           .then(function () {{
+            persistBasicAuth(user, pass);
             window.location.href = dest;
           }})
           .catch(function (err) {{
             if (!isMobileUa()) {{
+              persistBasicAuth(user, pass);
               urlEmbedSignIn(user, pass, dest);
               return;
             }}
@@ -3184,6 +3192,18 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       .camera-frustum {{ display: flex; justify-content: center; }}
       .rollout-hint {{ font-size: 13px; color: #39465c; margin: 0 0 10px 0; }}
       .chat-panel {{ margin-bottom: 12px; }}
+      .chat-panel-head {{
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 10px;
+        margin-bottom: 4px;
+      }}
+      .chat-panel-head h3 {{ margin: 0; }}
+      .mobile-only-toggle {{ display: none; }}
+      .chat-composer {{
+        background: var(--surface);
+      }}
       .chat-toolbar {{
         display: flex;
         justify-content: space-between;
@@ -3347,6 +3367,8 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         padding: 8px 12px;
         font-size: 13px;
         cursor: pointer;
+        touch-action: manipulation;
+        -webkit-tap-highlight-color: transparent;
       }}
       .btn:hover {{ background: #f5f6fb; }}
       .btn-primary {{
@@ -3441,12 +3463,85 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         }}
         .chat-input .btn {{ width: 100%; }}
         .btn, .quick-pill {{
-          min-height: 40px;
-          font-size: 13px;
+          min-height: 44px;
+          font-size: 14px;
         }}
         .status-bar {{
           padding-bottom: calc(8px + env(safe-area-inset-bottom));
         }}
+      }}
+      body.mobile-agent {{
+        padding-bottom: calc(56px + env(safe-area-inset-bottom));
+      }}
+      body.mobile-agent .chrome {{
+        max-width: none;
+      }}
+      body.mobile-agent .page {{
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        padding: 10px 10px calc(68px + env(safe-area-inset-bottom));
+      }}
+      body.mobile-agent .chat-panel {{
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: calc(100dvh - 112px);
+        margin-bottom: 0;
+      }}
+      body.mobile-agent .chat-panel .hint:first-of-type {{
+        display: none;
+      }}
+      body.mobile-agent .chat-toolbar {{
+        flex-direction: column;
+        align-items: stretch;
+      }}
+      body.mobile-agent .chat-model {{
+        width: 100%;
+        justify-content: space-between;
+      }}
+      body.mobile-agent .chat-model select {{
+        flex: 1 1 auto;
+        max-width: 100%;
+      }}
+      body.mobile-agent .chat-log {{
+        flex: 1 1 auto;
+        min-height: 38dvh;
+        max-height: 52dvh;
+        height: auto;
+      }}
+      body.mobile-agent .chat-composer {{
+        position: sticky;
+        bottom: calc(52px + env(safe-area-inset-bottom));
+        z-index: 850;
+        margin-top: auto;
+        padding-top: 10px;
+        border-top: 1px solid var(--border);
+      }}
+      body.mobile-agent .actions-inline {{
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }}
+      body.mobile-agent .actions-inline .quick-pill {{
+        width: 100%;
+        justify-content: center;
+      }}
+      body.mobile-agent .workflow-panel,
+      body.mobile-agent .layout-3 {{
+        display: none;
+      }}
+      body.mobile-agent.mobile-show-panels .workflow-panel,
+      body.mobile-agent.mobile-show-panels .layout-3 {{
+        display: grid;
+      }}
+      body.mobile-agent .mobile-only-toggle {{
+        display: inline-flex;
+        flex-shrink: 0;
+        min-height: 36px;
+      }}
+      body.mobile-agent .topbar .badge {{
+        display: none;
       }}
       .workflow-panel textarea {{
         width: 100%;
@@ -3512,8 +3607,13 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       </header>
       <main class="page">
         <section class="panel chat-panel">
-          <h3>Workbench Chat</h3>
-          <p class="hint">Ask about configure, provision, Cosmos3, S3, workflows, sim assets, and Rerun visualization.</p>
+          <div class="chat-panel-head">
+            <div>
+              <h3>Workbench Chat</h3>
+              <p class="hint">Ask about configure, provision, Cosmos3, S3, workflows, sim assets, and Rerun visualization.</p>
+            </div>
+            <button id="mobilePanelsToggle" class="btn mobile-only-toggle" type="button" aria-expanded="false">Panels</button>
+          </div>
           <div class="chat-toolbar">
             <span class="hint">Grounded responses use live `/api/*` context from this VM.</span>
             <label for="chatModel" class="chat-model">
@@ -3524,10 +3624,10 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
             </label>
           </div>
           <div id="chatLog" class="chat-log"></div>
-          <div class="chat-input">
-            <textarea id="chatInput" placeholder="How do I configure S3 for Sim2Real?"></textarea>
-            <button id="chatSend" class="btn btn-primary" type="button">Send</button>
-          </div>
+          <form id="chatForm" class="chat-composer chat-input" autocomplete="off">
+            <textarea id="chatInput" placeholder="How do I configure S3 for Sim2Real?" rows="2" enterkeyhint="send"></textarea>
+            <button id="chatSend" class="btn btn-primary" type="submit">Send</button>
+          </form>
           <div class="actions-inline">
             <button id="chatActionS3" class="btn quick-pill" type="button">Configure S3</button>
             <button id="chatActionCosmos" class="btn quick-pill" type="button">Setup Cosmos3</button>
@@ -3686,6 +3786,32 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         const clean = location.protocol + "//" + location.host + location.pathname + location.search + location.hash;
         history.replaceState(null, "", clean);
       }}
+      function detectMobileLayout() {{
+        const narrow = window.matchMedia("(max-width: 900px)").matches;
+        const coarse = window.matchMedia("(pointer: coarse)").matches;
+        const mobileUa = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent || "");
+        return narrow || (coarse && mobileUa);
+      }}
+      function applyMobileLayout() {{
+        if (!detectMobileLayout()) return;
+        document.body.classList.add("mobile-agent");
+      }}
+      function mobileAuthHeader() {{
+        try {{
+          return String(sessionStorage.getItem("npa_agent_basic_auth") || "").trim();
+        }} catch (_err) {{
+          return "";
+        }}
+      }}
+      function withMobileAuth(headers) {{
+        const merged = {{ ...(headers || {{}}) }};
+        const auth = mobileAuthHeader();
+        if (auth && !merged.Authorization) {{
+          merged.Authorization = auth;
+        }}
+        return merged;
+      }}
+      applyMobileLayout();
       const chatHistory = [];
       let thinkingNode = null;
       function setStatus(text) {{
@@ -3733,7 +3859,21 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         }});
       }}
       function wireUi() {{
-        bindClick("chatSend", sendChat, "Send chat");
+        const chatForm = document.getElementById("chatForm");
+        if (chatForm) {{
+          chatForm.addEventListener("submit", (event) => {{
+            event.preventDefault();
+            sendChat().catch((err) => showToast(String(err), "error"));
+          }});
+        }}
+        const mobileToggle = document.getElementById("mobilePanelsToggle");
+        if (mobileToggle) {{
+          mobileToggle.addEventListener("click", () => {{
+            const open = document.body.classList.toggle("mobile-show-panels");
+            mobileToggle.setAttribute("aria-expanded", open ? "true" : "false");
+            mobileToggle.textContent = open ? "Hide panels" : "Panels";
+          }});
+        }}
         bindClick("chatActionS3", () => {{
           setChatInput("Help me configure S3 credentials and bucket for NPA workflows.");
         }}, "Insert S3 prompt");
@@ -4011,9 +4151,10 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         const btn = document.getElementById("chatSend");
         const input = document.getElementById("chatInput");
         const model = document.getElementById("chatModel");
-        btn.disabled = Boolean(isBusy);
-        input.disabled = Boolean(isBusy);
-        if (model) model.disabled = Boolean(isBusy);
+        const busy = Boolean(isBusy);
+        if (btn) btn.disabled = busy;
+        if (input) input.disabled = busy;
+        if (model) model.disabled = busy;
       }}
       function setChatModels(models, selectedModel) {{
         const select = document.getElementById("chatModel");
@@ -4540,9 +4681,9 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         const opts = {{
           ...req,
           credentials: "include",
-          headers: {{
+          headers: withMobileAuth({{
             ...(req.headers || {{}}),
-          }},
+          }}),
         }};
         let resp;
         try {{
@@ -5048,14 +5189,23 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           }} catch (_artifactErr) {{
             // artifact discovery is optional when S3 credentials are missing.
           }}
-          await ensureFrankaRerunLoaded();
-          setStatus("Ready");
-          showToast("Franka demo ready in Rerun", "success");
+          if (document.body.classList.contains("mobile-agent")) {{
+            setStatus("Ready");
+            showToast("Mobile chat ready", "success");
+          }} else {{
+            await ensureFrankaRerunLoaded();
+            setStatus("Ready");
+            showToast("Franka demo ready in Rerun", "success");
+          }}
         }} catch (err) {{
           console.warn("franka auto-load failed", err);
-          showRerunPlaceholder("Could not auto-load Franka. Click Load Franka in Rerun.");
-          showToast(String(err && err.message ? err.message : err), "error");
-          setStatus("Ready");
+          if (document.body.classList.contains("mobile-agent")) {{
+            setStatus("Ready");
+          }} else {{
+            showRerunPlaceholder("Could not auto-load Franka. Click Load Franka in Rerun.");
+            showToast(String(err && err.message ? err.message : err), "error");
+            setStatus("Ready");
+          }}
         }} finally {{
           rerunBootInProgress = false;
         }}
@@ -6101,9 +6251,11 @@ def verify_live_cmd(
         _fail(f"UI html fetch failed (status={ui_resp.status_code})")
     ui_html = ui_resp.text
     for marker in (
-        'bindClick("chatSend"',
+        'id="chatForm"',
+        "function sendChat(",
         "function wireUi(",
         "initNpaAgentUi",
+        "mobile-agent",
         "history.replaceState",
         "location.username",
         f'name="npa-ui-version" content="{AGENT_UI_VERSION}"',

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -7,6 +7,7 @@ import json
 import os
 import secrets
 import shlex
+import shutil
 import subprocess
 import ipaddress
 import tempfile
@@ -207,6 +208,48 @@ def _record_customer_url(record: dict[str, Any]) -> str:
 def _fail(message: str) -> None:
     typer.echo(f"Error: {message}", err=True)
     raise typer.Exit(code=1)
+
+
+def _looks_like_compute_permission_denied(message: str) -> bool:
+    lowered = str(message or "").lower()
+    return "permissiondenied" in lowered and "service compute" in lowered
+
+
+def _apply_agent_terraform(
+    *,
+    project: str,
+    name: str,
+    merged_vars: dict[str, str],
+    env_region: str,
+) -> dict[str, Any]:
+    """Apply agent Terraform, retrying without VM SA attachment on compute IAM denial."""
+    tf_dir = provisioner.prepare_working_dir(
+        project,
+        name,
+        bucket=merged_vars.get("s3_bucket", ""),
+        region=env_region,
+        endpoint=merged_vars.get("s3_endpoint", ""),
+    )
+    provisioner.init(
+        tf_dir=tf_dir,
+        backend_config={
+            "access_key": merged_vars.get("nebius_api_key", ""),
+            "secret_key": merged_vars.get("nebius_secret_key", ""),
+        },
+    )
+    try:
+        return provisioner.apply(tf_dir=tf_dir, tf_vars=merged_vars)
+    except ProvisionerError as exc:
+        sa_id = str(merged_vars.get("service_account_id", "")).strip()
+        if sa_id and _looks_like_compute_permission_denied(str(exc)):
+            typer.echo(
+                "  Compute create denied with VM service-account attachment; "
+                "retrying without attached service_account_id ..."
+            )
+            retry_vars = dict(merged_vars)
+            retry_vars["service_account_id"] = ""
+            return provisioner.apply(tf_dir=tf_dir, tf_vars=retry_vars)
+        raise
 
 
 def _agent_record(project_alias: str, name: str) -> dict[str, Any]:
@@ -5064,6 +5107,9 @@ def deploy_cmd(
     ),
 ) -> None:
     """Provision VM + bootstrap the public NPA agent stack."""
+    profile = os.environ.get("NPA_NEBIUS_PROFILE", "").strip()
+    if profile and shutil.which("nebius"):
+        subprocess.run(["nebius", "profile", "activate", profile], check=False)
     saved_env = resolve_environment(
         project,
         project_id=project_id or None,
@@ -5126,21 +5172,12 @@ def deploy_cmd(
 
     tf_outputs: dict[str, Any] = {}
     try:
-        tf_dir = provisioner.prepare_working_dir(
-            project,
-            name,
-            bucket=merged_vars.get("s3_bucket", ""),
-            region=env_region,
-            endpoint=merged_vars.get("s3_endpoint", ""),
+        tf_outputs = _apply_agent_terraform(
+            project=project,
+            name=name,
+            merged_vars=merged_vars,
+            env_region=env_region,
         )
-        provisioner.init(
-            tf_dir=tf_dir,
-            backend_config={
-                "access_key": merged_vars.get("nebius_api_key", ""),
-                "secret_key": merged_vars.get("nebius_secret_key", ""),
-            },
-        )
-        tf_outputs = provisioner.apply(tf_dir=tf_dir, tf_vars=merged_vars)
     except ProvisionerError as exc:
         try:
             _destroy_agent_terraform(project, name)

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -10,6 +10,7 @@ import shlex
 import shutil
 import subprocess
 import ipaddress
+import tarfile
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -57,6 +58,7 @@ DEFAULT_LLM_MODELS = (
 )
 AGENT_UI_VERSION = "2026070403"
 DEFAULT_HTTPS_PORT = 443
+AGENT_SOURCE_ROOT = "/opt/npa-agent/npa-src"
 
 
 def _embedded_agent_workflow_source() -> str:
@@ -808,6 +810,7 @@ def _store_project_environment(*, project: str, project_id: str, tenant_id: str,
 def _write_agent_nebius_env(
     ssh: SSHClient,
     *,
+    project_alias: str,
     project_id: str,
     tenant_id: str,
     region: str,
@@ -816,11 +819,13 @@ def _write_agent_nebius_env(
     endpoint: str,
     access_key: str,
     secret_key: str,
+    iam_token: str = "",
 ) -> None:
     """Stage long-lived Nebius project credentials on the agent VM."""
     if not (project_id.strip() and access_key.strip() and secret_key.strip()):
         return
     env_lines = [
+        f"NPA_AGENT_PROJECT_ALIAS={project_alias.strip()}",
         f"NEBIUS_PROJECT_ID={project_id.strip()}",
         f"NEBIUS_TENANT_ID={tenant_id.strip()}",
         f"NEBIUS_REGION={region.strip() or 'eu-north1'}",
@@ -830,13 +835,83 @@ def _write_agent_nebius_env(
         f"AWS_ACCESS_KEY_ID={access_key.strip()}",
         f"AWS_SECRET_ACCESS_KEY={secret_key.strip()}",
         f"AWS_REGION={region.strip() or 'eu-north1'}",
-        "",
     ]
+    if iam_token.strip():
+        env_lines.extend(
+            [
+                f"NEBIUS_IAM_TOKEN={iam_token.strip()}",
+                f"NPA_NEBIUS_IAM_TOKEN={iam_token.strip()}",
+                f"TF_VAR_iam_token={iam_token.strip()}",
+                "NPA_REUSE_IAM_TOKEN=1",
+            ]
+        )
+    env_lines.append("")
     env_b64 = base64.b64encode("\n".join(env_lines).encode("utf-8")).decode("ascii")
     ssh.run_or_raise(
         f"echo {shlex.quote(env_b64)} | base64 -d | sudo tee /opt/npa-agent/nebius.env >/dev/null "
         "&& sudo chmod 600 /opt/npa-agent/nebius.env"
     )
+
+
+def _create_agent_source_archive() -> str:
+    """Package the NPA source tree needed for agent-side workflow execution."""
+    repo_root = Path(__file__).resolve().parents[4]
+    include_roots = [
+        repo_root / "npa",
+        repo_root / "deploy" / "cluster",
+    ]
+    for path in include_roots:
+        if not path.exists():
+            raise ConfigError(f"Required agent source path is missing: {path}")
+
+    exclude_names = {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".terraform",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+    }
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
+    tmp.close()
+
+    def _filter(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
+        parts = set(Path(info.name).parts)
+        if parts & exclude_names:
+            return None
+        if info.name.endswith((".pyc", ".pyo")):
+            return None
+        return info
+
+    with tarfile.open(tmp.name, "w:gz") as archive:
+        archive.add(repo_root / "npa", arcname="npa", filter=_filter)
+        archive.add(repo_root / "deploy" / "cluster", arcname="deploy/cluster", filter=_filter)
+    return tmp.name
+
+
+def _stage_agent_npa_source(ssh: SSHClient) -> None:
+    """Upload NPA package source and deploy assets to the agent VM."""
+    archive_path = _create_agent_source_archive()
+    remote_archive = f"/tmp/npa-agent-source-{secrets.token_hex(6)}.tar.gz"
+    try:
+        ssh.upload_file(archive_path, remote_archive)
+        ssh.run_or_raise(
+            " && ".join(
+                [
+                    f"sudo rm -rf {shlex.quote(AGENT_SOURCE_ROOT)}",
+                    f"sudo mkdir -p {shlex.quote(AGENT_SOURCE_ROOT)}",
+                    f"sudo tar -xzf {shlex.quote(remote_archive)} -C {shlex.quote(AGENT_SOURCE_ROOT)}",
+                    f"sudo chown -R root:root {shlex.quote(AGENT_SOURCE_ROOT)}",
+                    f"rm -f {shlex.quote(remote_archive)}",
+                ]
+            )
+        )
+    finally:
+        Path(archive_path).unlink(missing_ok=True)
+        ssh.run(f"rm -f {shlex.quote(remote_archive)}")
 
 
 def _is_routable_public_ip(value: str) -> bool:
@@ -1147,7 +1222,7 @@ server {{
     nebius_parent_id = shlex.quote((nebius_project_id or project_id).strip())
     setup_script = f"""set -euo pipefail
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nginx apache2-utils python3-venv python3-pip curl
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nginx apache2-utils python3-venv python3-pip curl unzip ca-certificates
 if ! command -v nebius >/dev/null 2>&1; then
   curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
 fi
@@ -1161,6 +1236,19 @@ fi
 if [ -z "$NEBIUS_BIN" ] || [ ! -x "$NEBIUS_BIN" ]; then
   echo "nebius CLI binary not found after install" >&2
   exit 1
+fi
+if ! command -v terraform >/dev/null 2>&1; then
+  tmp_tf="$(mktemp -d)"
+  curl -fsSL -o "$tmp_tf/terraform.zip" https://releases.hashicorp.com/terraform/1.13.3/terraform_1.13.3_linux_amd64.zip
+  (cd "$tmp_tf" && unzip -q terraform.zip)
+  sudo install -m 0755 "$tmp_tf/terraform" /usr/local/bin/terraform
+  rm -rf "$tmp_tf"
+fi
+if ! command -v kubectl >/dev/null 2>&1; then
+  kubectl_version="$(curl -fsSL https://dl.k8s.io/release/stable.txt)"
+  curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/$kubectl_version/bin/linux/amd64/kubectl"
+  sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+  rm -f /tmp/kubectl
 fi
 if [ -s /mnt/cloud-metadata/token ]; then
   if ! "$NEBIUS_BIN" profile create --endpoint api.eu.nebius.cloud --token-file /mnt/cloud-metadata/token --profile {nebius_profile} --parent-id {nebius_parent_id} >/dev/null 2>&1; then
@@ -1981,6 +2069,10 @@ def _wire_franka_demo(state: dict, *, camera: str = "workspace") -> dict:
 LLM_MODEL = os.environ.get("NPA_AGENT_LLM_MODEL", "{DEFAULT_LLM_MODEL}")
 LLM_MODELS_ENV = os.environ.get("NPA_AGENT_LLM_MODELS", "")
 DEFAULT_LLM_MODELS = {default_llm_models_json}
+NPA_PROJECT_ALIAS = os.environ.get("NPA_AGENT_PROJECT_ALIAS", "").strip() or "default"
+NPA_SOURCE_ROOT = Path("{AGENT_SOURCE_ROOT}")
+NPA_CLI = Path("/opt/npa-agent/venv/bin/npa")
+NPA_CLUSTER_TERRAFORM_DIR = NPA_SOURCE_ROOT / "deploy" / "cluster"
 TF_BASE_URL = os.environ.get(
     "NEBIUS_TOKEN_FACTORY_BASE_URL", "https://api.tokenfactory.nebius.com/v1/"
 ).rstrip("/")
@@ -2074,7 +2166,7 @@ def _agent_system_prompt() -> str:
         "- GET/POST /api/workflows/draft — workflow YAML draft in session",
         "- POST /api/workflows/validate — validate npa.workflow/v0.0.1 or npa.workflow/v0.0.1-beta YAML",
         "- POST /api/workflows/plan — dry-run plan-spec for workflow YAML",
-        "- POST /api/workflows/submit — validate + plan workflow YAML (validate-only on agent VM)",
+        "- POST /api/workflows/submit — validate workflow YAML, ensure agent-side Kubernetes infra when needed, and return scheduler plan",
         "- GET /api/models — list Token Factory chat models available to this VM key",
         "- GET /api/tools — workbench toolRef catalog",
         "",
@@ -2236,6 +2328,179 @@ def _resolve_workflow_yaml(payload: dict) -> str:
     draft = _workflow_draft_from_state(_load_state())
     return str(draft.get("yaml") or "").strip()
 
+
+def _agent_npa_ready() -> tuple[bool, str]:
+    if not NPA_CLI.exists():
+        return False, f"NPA CLI is not installed at {{NPA_CLI}}"
+    if not (NPA_SOURCE_ROOT / "npa" / "pyproject.toml").is_file():
+        return False, f"NPA source is not staged at {{NPA_SOURCE_ROOT}}"
+    if not NPA_CLUSTER_TERRAFORM_DIR.is_dir():
+        return False, f"Kubernetes Terraform assets are not staged at {{NPA_CLUSTER_TERRAFORM_DIR}}"
+    return True, ""
+
+
+def _load_agent_config_yaml() -> dict:
+    path = Path.home() / ".npa" / "config.yaml"
+    if not path.is_file():
+        return {{}}
+    try:
+        import yaml
+
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {{}}
+    return loaded if isinstance(loaded, dict) else {{}}
+
+
+def _agent_project_alias(requested: str = "") -> str:
+    requested = str(requested or "").strip()
+    if requested:
+        return requested
+    config = _load_agent_config_yaml()
+    configured = str(config.get("default_project") or "").strip()
+    if configured:
+        return configured
+    return NPA_PROJECT_ALIAS
+
+
+def _agent_k8s_backends(project: str = "") -> dict:
+    config = _load_agent_config_yaml()
+    alias = _agent_project_alias(project)
+    projects = config.get("projects")
+    if not isinstance(projects, dict):
+        projects = {{}}
+    project_block = projects.get(alias)
+    if not isinstance(project_block, dict):
+        project_block = {{}}
+    configured: list[dict] = []
+    kube_block = project_block.get("kubernetes")
+    if isinstance(kube_block, dict) and kube_block:
+        configured.append({{
+            "source": "project_config",
+            "project": alias,
+            "cluster_name": str(kube_block.get("cluster_name") or kube_block.get("name") or ""),
+            "context": str(kube_block.get("context") or kube_block.get("context_name") or ""),
+            "kubeconfig": str(kube_block.get("kubeconfig") or kube_block.get("kubeconfig_path") or ""),
+            "gpu_profile": str(kube_block.get("gpu_profile") or ""),
+            "raw": {{k: v for k, v in kube_block.items() if k not in {{"token", "secret", "password"}}}},
+        }})
+    clusters_root = Path.home() / ".npa" / "clusters"
+    local_clusters: list[dict] = []
+    if clusters_root.is_dir():
+        for item in sorted(clusters_root.iterdir()):
+            if not item.is_dir():
+                continue
+            kubeconfig = item / "kubeconfig"
+            state_path = item / "state.json"
+            local_clusters.append({{
+                "source": "local_state",
+                "cluster_name": item.name,
+                "context": item.name,
+                "kubeconfig": str(kubeconfig),
+                "kubeconfig_exists": kubeconfig.is_file(),
+                "state_exists": state_path.is_file(),
+            }})
+    ready, reason = _agent_npa_ready()
+    return {{
+        "ok": True,
+        "project": alias,
+        "configured": configured,
+        "local_clusters": local_clusters,
+        "has_infra": bool(configured or any(item.get("kubeconfig_exists") for item in local_clusters)),
+        "agent_npa_ready": ready,
+        "agent_npa_error": reason,
+        "terraform_dir": str(NPA_CLUSTER_TERRAFORM_DIR),
+        "options": [
+            "POST /api/infra/provision to let the agent create the minimal Kubernetes backend.",
+            "Add projects.<alias>.kubernetes to ~/.npa/config.yaml on the agent to use an existing backend.",
+            "Pass project/cluster_name in the workflow submit payload to target a known backend.",
+        ],
+    }}
+
+
+def _agent_command_env() -> dict:
+    env = dict(os.environ)
+    env["PATH"] = "/usr/local/bin:/usr/bin:/bin:" + env.get("PATH", "")
+    env.setdefault("NPA_TERRAFORM_BIN", shutil.which("terraform") or "terraform")
+    env.setdefault("NPA_KUBECTL_BIN", shutil.which("kubectl") or "kubectl")
+    env.setdefault("NPA_NEBIUS_BIN", shutil.which("nebius") or "nebius")
+    return env
+
+
+def _run_agent_npa_json(args: list[str], *, timeout_s: int = 300) -> dict:
+    ready, reason = _agent_npa_ready()
+    if not ready:
+        raise HTTPException(status_code=409, detail=reason)
+    proc = subprocess.run(
+        [str(NPA_CLI), *args],
+        cwd=str(NPA_SOURCE_ROOT),
+        env=_agent_command_env(),
+        text=True,
+        capture_output=True,
+        timeout=timeout_s,
+        check=False,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise HTTPException(status_code=502, detail=detail or f"NPA command failed: {{args}}")
+    stdout = (proc.stdout or "").strip()
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=502, detail=f"NPA command did not return JSON: {{stdout[-1000:]}}") from exc
+
+
+def _write_workflow_temp_yaml(yaml_text: str) -> Path:
+    tmp_dir = Path("/tmp/npa-agent-workflows")
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    path = tmp_dir / f"workflow-{{secrets.token_hex(8)}}.yaml"
+    path.write_text(yaml_text, encoding="utf-8")
+    return path
+
+
+def _provision_agent_infra(project: str, cluster_name: str, *, dry_run: bool = False, validate: bool = True) -> dict:
+    ready, reason = _agent_npa_ready()
+    if not ready:
+        return {{"ok": False, "status": "blocked", "error": reason}}
+    try:
+        from npa.provisioning import provision_if_absent
+
+        result = provision_if_absent(
+            project=project or None,
+            cluster_name=cluster_name or "npa-cluster",
+            terraform_dir=NPA_CLUSTER_TERRAFORM_DIR,
+            validate=validate,
+            sky_smoke=False,
+            dry_run=dry_run,
+        )
+        payload = result.to_dict()
+        payload["ok"] = True
+        payload["dry_run"] = dry_run
+        return payload
+    except Exception as exc:
+        return {{"ok": False, "status": "error", "error": str(exc), "dry_run": dry_run}}
+
+
+def _workflow_no_infra_response(*, validation: dict, plan: dict, run_id: str, infra: dict) -> dict:
+    return {{
+        "ok": False,
+        "run_id": run_id,
+        "submitted_at": _now_iso(),
+        "name": str(validation.get("name") or ""),
+        "validation": validation,
+        "plan": plan,
+        "infra": infra,
+        "submit_mode": "blocked-no-infra",
+        "reason": "no infra is specified or available",
+        "message": (
+            "No Kubernetes infra is specified or available for this workflow. "
+            "Choose one option: let the agent deploy minimal Kubernetes infra, "
+            "configure an existing backend in ~/.npa/config.yaml, or pass project/cluster_name in the submit payload."
+        ),
+        "options": infra.get("options", []),
+    }}
+
+
 def _last_user_message(raw_messages: list) -> str:
     for item in reversed(raw_messages):
         if not isinstance(item, dict):
@@ -2285,6 +2550,9 @@ def _maybe_toolground_chat_reply(user_text: str) -> tuple[str | None, list[str],
         if not isinstance(sim_viz, dict):
             sim_viz = {{}}
         rerun_ready = _rerun_ready_state(rrd_uri=str(sim_viz.get("rrd_uri") or ""))
+    elif intent == "infra_backends":
+        state["infra"] = _agent_k8s_backends()
+        _save_state(state)
     elif intent in {{"create_workflow", "create_vlm_rl_workflow", "create_gate_workflow"}}:
         draft = generate_workflow_draft(
             user_text=user_text,
@@ -2483,6 +2751,7 @@ def session_bootstrap():
         "sim_viz": sim_viz,
         "latest_submit": state.get("latest_submit", {{}}),
         "sim_viz_runs": _sim_viz_runs(state),
+        "infra": _agent_k8s_backends(),
         "workflow_draft": _workflow_draft_from_state(state),
         "workflow_submit": state.get("workflow_submit", {{}}),
         "camera_selection": state.get("camera_selection", ["workspace"]),
@@ -3022,6 +3291,25 @@ def get_workflow_draft():
     draft = _workflow_draft_from_state(state)
     return {{"ok": True, "draft": draft}}
 
+
+@app.get("/infra/k8s")
+@app.get("/infra/backends")
+def list_k8s_infra(project: str = ""):
+    return _agent_k8s_backends(project)
+
+
+@app.post("/infra/provision")
+def provision_infra(payload: dict | None = None):
+    body = payload if isinstance(payload, dict) else {{}}
+    project = _agent_project_alias(str(body.get("project") or ""))
+    cluster_name = str(body.get("cluster_name") or "npa-cluster").strip() or "npa-cluster"
+    dry_run = bool(body.get("dry_run", False))
+    validate = bool(body.get("validate", True))
+    result = _provision_agent_infra(project, cluster_name, dry_run=dry_run, validate=validate)
+    status = _agent_k8s_backends(project)
+    return {{"ok": bool(result.get("ok")), "project": project, "cluster_name": cluster_name, "result": result, "infra": status}}
+
+
 @app.post("/workflows/draft")
 @app.put("/workflows/npa/draft")
 def save_workflow_draft(payload: dict):
@@ -3097,6 +3385,46 @@ def submit_npa_workflow(payload: dict):
     )
     if not plan.get("ok"):
         raise HTTPException(status_code=400, detail=str(plan.get("error") or "plan failed"))
+    project = _agent_project_alias(str(body.get("project") or ""))
+    cluster_name = str(body.get("cluster_name") or "npa-cluster").strip() or "npa-cluster"
+    allow_provision = bool(body.get("allow_provision", True))
+    dry_run = bool(body.get("dry_run", False))
+    validate_infra = bool(body.get("validate_infra", True))
+    infra_before = _agent_k8s_backends(project)
+    if not infra_before.get("has_infra") and not allow_provision:
+        return _workflow_no_infra_response(validation=validation, plan=plan, run_id=run_id, infra=infra_before)
+    provision = {{"ok": True, "status": "skipped", "actions": ["k8s:existing backend detected"]}}
+    if allow_provision and (dry_run or not infra_before.get("has_infra")):
+        provision = _provision_agent_infra(project, cluster_name, dry_run=dry_run, validate=validate_infra)
+        if not provision.get("ok"):
+            infra_error = dict(infra_before)
+            infra_error["provision_error"] = provision.get("error") or provision
+            blocked = _workflow_no_infra_response(validation=validation, plan=plan, run_id=run_id, infra=infra_error)
+            blocked["provision"] = provision
+            return blocked
+    scheduler_plan = {{}}
+    yaml_path = _write_workflow_temp_yaml(yaml_text)
+    try:
+        scheduler_plan = _run_agent_npa_json(
+            [
+                "workbench",
+                "workflow",
+                "run-spec",
+                str(yaml_path),
+                "--run-id",
+                run_id,
+                "--plan-only",
+                "--scheduler-plan",
+                "--json",
+            ],
+            timeout_s=180,
+        )
+    finally:
+        try:
+            yaml_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+    infra_after = _agent_k8s_backends(project)
     state = _load_state()
     _save_workflow_draft(state, yaml_text, validation, plan=plan, runnable=True)
     submit_record = {{
@@ -3105,15 +3433,22 @@ def submit_npa_workflow(payload: dict):
         "name": str(validation.get("name") or ""),
         "validation": validation,
         "plan": plan,
-        "submit_mode": "validate-only",
-        "note": "Agent VM records validate+plan; live SkyPilot submit runs on operator machine.",
+        "scheduler_plan": scheduler_plan,
+        "infra": infra_after,
+        "provision": provision,
+        "submit_mode": "agent-live-infra-plan" if not dry_run else "agent-live-infra-dry-run",
+        "note": (
+            "Agent validated the workflow, ensured Kubernetes infra with NPA when needed, "
+            "and produced a scheduler plan. Workload execution uses the planned scheduler tasks."
+        ),
     }}
     state["workflow_submit"] = submit_record
     state["latest_submit"] = {{
         "run_id": run_id,
         "submitted_at": submit_record["submitted_at"],
         "workflow_name": str(validation.get("name") or ""),
-        "submit_mode": "validate-only",
+        "submit_mode": submit_record["submit_mode"],
+        "cluster_name": cluster_name,
     }}
     _record_sim_viz_run(
         state,
@@ -3124,8 +3459,9 @@ def submit_npa_workflow(payload: dict):
             "camera": str((state.get("sim_viz", {{}}) or {{}}).get("camera") or "workspace"),
             "rrd_uri": str((state.get("sim_viz", {{}}) or {{}}).get("rrd_uri") or ""),
             "rrd_updated_at": str((state.get("sim_viz", {{}}) or {{}}).get("rrd_updated_at") or ""),
-            "submit_mode": "validate-only",
+            "submit_mode": submit_record["submit_mode"],
             "workflow_name": str(validation.get("name") or ""),
+            "cluster_name": cluster_name,
         }},
     )
     _save_state(state)
@@ -4854,7 +5190,11 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           body: JSON.stringify({{ yaml }}),
         }});
         updateWorkflowMeta((data.validation) || {{}});
-        appendChat("assistant", "Submitted npa.workflow YAML — **run_id**: `" + String(data.run_id || "") + "` (validate-only on agent VM).");
+        appendChat(
+          "assistant",
+          "Submitted npa.workflow YAML — **run_id**: `" + String(data.run_id || "") +
+            "`, **mode**: `" + String(data.submit_mode || "") + "`."
+        );
         return true;
       }}
       async function sendChat() {{
@@ -5316,7 +5656,12 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           credentials: useExplicitAuth ? "omit" : "include",
           headers,
         }};
-        const timeoutMs = String(path || "") === "/api/chat" ? 90000 : 12000;
+        const pathText = String(path || "");
+        const timeoutMs = (
+          pathText === "/api/chat" ||
+          pathText === "/api/workflows/submit" ||
+          pathText === "/api/infra/provision"
+        ) ? 900000 : 12000;
         let resp;
         try {{
           resp = await fetchWithTimeout(path, opts, timeoutMs);
@@ -5890,6 +6235,7 @@ HTML
 sudo python3 -m venv /opt/npa-agent/venv
 sudo /opt/npa-agent/venv/bin/pip install --upgrade pip
 sudo /opt/npa-agent/venv/bin/pip install fastapi uvicorn httpx pyyaml boto3 "rerun-sdk>=0.32"
+sudo /opt/npa-agent/venv/bin/pip install -e "{AGENT_SOURCE_ROOT}/npa[server]"
 sudo /opt/npa-agent/venv/bin/python /opt/npa-agent/bootstrap_rrd.py
 sudo systemctl restart npa-rerun || true
 cat <<'UNIT' | sudo tee /etc/systemd/system/npa-agent-backend.service >/dev/null
@@ -5947,6 +6293,7 @@ sudo systemctl restart npa-agent-backend
     # Use a unique remote path so concurrent bootstrap runs cannot clobber each other.
     remote_setup_script = f"/tmp/npa-agent-bootstrap-{secrets.token_hex(6)}.sh"
     try:
+        _stage_agent_npa_source(ssh)
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
             handle.write(setup_script)
             local_setup_script = handle.name
@@ -5980,8 +6327,16 @@ sudo systemctl restart npa-agent-backend
         s3_secret_key=s3_secret_key,
         service_account_id=service_account_id,
     )
+    agent_iam_token = ""
+    try:
+        from npa.clients.nebius import get_iam_token
+
+        agent_iam_token = get_iam_token()
+    except Exception:
+        agent_iam_token = ""
     _write_agent_nebius_env(
         ssh,
+        project_alias=project_alias,
         project_id=nebius_project_id or project_id,
         tenant_id=nebius_tenant_id or tenant_id,
         region=s3_region,
@@ -5990,6 +6345,7 @@ sudo systemctl restart npa-agent-backend
         endpoint=s3_endpoint,
         access_key=s3_access_key,
         secret_key=s3_secret_key,
+        iam_token=agent_iam_token,
     )
     if (
         tf_api_key.strip()
@@ -7002,6 +7358,45 @@ def verify_live_cmd(
         _fail(f"workflow validate endpoint failed: {exc}")
     if not isinstance(wf_val_payload, dict) or not wf_val_payload.get("ok"):
         _fail("workflow validate endpoint did not return ok=true")
+    try:
+        infra_resp = httpx.get(
+            f"{agent_base}/api/infra/k8s",
+            auth=(auth_user, auth_password),
+            timeout=15.0,
+            verify=tls_verify,
+        )
+        infra_resp.raise_for_status()
+        infra_payload = infra_resp.json()
+    except Exception as exc:  # noqa: BLE001
+        _fail(f"infra discovery endpoint failed: {exc}")
+    if not isinstance(infra_payload, dict) or not infra_payload.get("ok"):
+        _fail("infra discovery endpoint did not return ok=true")
+    if not infra_payload.get("agent_npa_ready"):
+        _fail(f"agent NPA runtime is not ready: {infra_payload.get('agent_npa_error')}")
+    try:
+        wf_submit = httpx.post(
+            f"{agent_base}/api/workflows/submit",
+            auth=(auth_user, auth_password),
+            json={
+                "yaml": wf_yaml,
+                "run_id": "verify-live-agent-infra",
+                "dry_run": True,
+                "allow_provision": True,
+                "validate_infra": False,
+            },
+            timeout=120.0,
+            verify=tls_verify,
+        )
+        wf_submit.raise_for_status()
+        wf_submit_payload = wf_submit.json()
+    except Exception as exc:  # noqa: BLE001
+        _fail(f"workflow submit dry-run endpoint failed: {exc}")
+    if not isinstance(wf_submit_payload, dict) or not wf_submit_payload.get("ok"):
+        _fail("workflow submit dry-run endpoint did not return ok=true")
+    if "scheduler_plan" not in wf_submit_payload:
+        _fail("workflow submit dry-run missing scheduler_plan")
+    if str(wf_submit_payload.get("submit_mode") or "") != "agent-live-infra-dry-run":
+        _fail("workflow submit dry-run did not report agent-live-infra-dry-run")
 
     try:
         onboard_chat = httpx.post(

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -961,7 +961,7 @@ def _agent_public_login_form_html(auth_user: str) -> str:
         return fetch(dest, {{
           method: "GET",
           headers: {{ "Authorization": basicAuthHeader(user, pass) }},
-          credentials: "include",
+          credentials: "omit",
           cache: "no-store",
         }}).then(function (resp) {{
           if (!resp.ok) {{
@@ -3241,9 +3241,13 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       body.mobile-agent.mobile-needs-auth .mobile-chat-auth {{
         display: block;
       }}
-      body.mobile-agent.mobile-needs-auth #chatForm {{
+      body.mobile-agent.mobile-needs-auth #chatForm,
+      body.mobile-agent.mobile-needs-auth .actions-inline {{
         opacity: 0.55;
         pointer-events: none;
+      }}
+      body.mobile-agent .mobile-chat-auth {{
+        order: -1;
       }}
       .chat-toolbar {{
         display: flex;
@@ -3686,14 +3690,14 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
               </select>
             </label>
           </div>
-          <div id="chatLog" class="chat-log"></div>
           <div id="mobileChatAuth" class="mobile-chat-auth" aria-live="polite">
-            <p class="hint">Mobile chat needs your agent password once on this device.</p>
+            <p class="hint">Mobile chat needs your agent password once on this device (iOS Safari does not send saved login on chat requests).</p>
             <div class="mobile-chat-auth-row">
               <input id="mobileChatPassword" type="password" placeholder="Agent password" autocomplete="current-password">
               <button id="mobileChatAuthBtn" class="btn btn-primary" type="button">Unlock chat</button>
             </div>
           </div>
+          <div id="chatLog" class="chat-log"></div>
           <form id="chatForm" class="chat-composer chat-input" autocomplete="off">
             <textarea id="chatInput" placeholder="How do I configure S3 for Sim2Real?" rows="2" enterkeyhint="send"></textarea>
             <button id="chatSend" class="btn btn-primary" type="submit">Send</button>
@@ -3866,19 +3870,33 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         if (!detectMobileLayout()) return;
         document.body.classList.add("mobile-agent");
       }}
+      let mobileAuthTokenCache = "";
       function mobileAuthHeader() {{
+        if (mobileAuthTokenCache) {{
+          return mobileAuthTokenCache;
+        }}
         try {{
           return String(sessionStorage.getItem("npa_agent_basic_auth") || "").trim();
         }} catch (_err) {{
           return "";
         }}
       }}
+      function hasMobileChatAuth() {{
+        return Boolean(mobileAuthHeader());
+      }}
       function persistMobileBasicAuth(user, pass) {{
         const token = "Basic " + btoa(unescape(encodeURIComponent(String(user || "") + ":" + String(pass || ""))));
+        mobileAuthTokenCache = token;
         try {{
           sessionStorage.setItem("npa_agent_basic_auth", token);
-        }} catch (_err) {{ /* ignore */ }}
+        }} catch (_err) {{ /* sessionStorage may be blocked in private browsing */ }}
         return token;
+      }}
+      function clearMobileBasicAuth() {{
+        mobileAuthTokenCache = "";
+        try {{
+          sessionStorage.removeItem("npa_agent_basic_auth");
+        }} catch (_err) {{ /* ignore */ }}
       }}
       function setMobileAuthNeeded(needed) {{
         if (!document.body.classList.contains("mobile-agent")) return;
@@ -3887,21 +3905,35 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           document.body.classList.add("mobile-auth-ready");
         }}
       }}
-      async function probeMobileChatAuth() {{
-        if (!document.body.classList.contains("mobile-agent")) return true;
-        if (mobileAuthHeader()) {{
-          setMobileAuthNeeded(false);
-          return true;
+      async function verifyMobileChatAuth() {{
+        const auth = mobileAuthHeader();
+        if (!auth) {{
+          return false;
         }}
         try {{
-          const resp = await fetch("/api/health", {{ credentials: "include", cache: "no-store" }});
-          if (resp.ok) {{
-            setMobileAuthNeeded(false);
-            return true;
+          const resp = await fetch("/api/health", {{
+            credentials: "omit",
+            cache: "no-store",
+            headers: {{ Authorization: auth }},
+          }});
+          if (resp.status === 401) {{
+            clearMobileBasicAuth();
+            return false;
           }}
-        }} catch (_err) {{ /* fall through */ }}
-        setMobileAuthNeeded(true);
-        return false;
+          return resp.ok;
+        }} catch (_err) {{
+          return false;
+        }}
+      }}
+      async function probeMobileChatAuth() {{
+        if (!document.body.classList.contains("mobile-agent")) return true;
+        if (!hasMobileChatAuth()) {{
+          setMobileAuthNeeded(true);
+          return false;
+        }}
+        const ok = await verifyMobileChatAuth();
+        setMobileAuthNeeded(!ok);
+        return ok;
       }}
       async function unlockMobileChatAuth(password) {{
         const pass = String(password || "").trim();
@@ -3909,13 +3941,9 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           throw new Error("Enter your agent password.");
         }}
         persistMobileBasicAuth("{DEFAULT_AGENT_USER}", pass);
-        const resp = await fetch("/api/health", {{
-          credentials: "include",
-          cache: "no-store",
-          headers: {{ Authorization: mobileAuthHeader() }},
-        }});
-        if (!resp.ok) {{
-          try {{ sessionStorage.removeItem("npa_agent_basic_auth"); }} catch (_err) {{ /* ignore */ }}
+        const ok = await verifyMobileChatAuth();
+        if (!ok) {{
+          clearMobileBasicAuth();
           throw new Error("Invalid password — try again or reopen /login-help.html.");
         }}
         setMobileAuthNeeded(false);
@@ -4405,7 +4433,8 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         if (chatSendInFlight) {{
           return false;
         }}
-        if (document.body.classList.contains("mobile-agent") && document.body.classList.contains("mobile-needs-auth")) {{
+        if (document.body.classList.contains("mobile-agent") && !hasMobileChatAuth()) {{
+          setMobileAuthNeeded(true);
           showToast("Unlock chat with your agent password first.", "error");
           return false;
         }}
@@ -4831,16 +4860,24 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       }}
       async function apiJson(path, init) {{
         const req = init || {{}};
+        const isMobile = document.body.classList.contains("mobile-agent");
+        const headers = withMobileAuth({{
+          ...(req.headers || {{}}),
+        }});
+        if (isMobile && String(path || "").startsWith("/api/") && !headers.Authorization) {{
+          setMobileAuthNeeded(true);
+          throw new Error("Unlock chat with your agent password.");
+        }}
+        const useExplicitAuth = isMobile && Boolean(headers.Authorization);
         const opts = {{
           ...req,
-          credentials: "include",
-          headers: withMobileAuth({{
-            ...(req.headers || {{}}),
-          }}),
+          credentials: useExplicitAuth ? "omit" : "include",
+          headers,
         }};
+        const timeoutMs = String(path || "") === "/api/chat" ? 90000 : 12000;
         let resp;
         try {{
-          resp = await fetchWithTimeout(path, opts, 12000);
+          resp = await fetchWithTimeout(path, opts, timeoutMs);
         }} catch (err) {{
           if (err && err.name === "AbortError") {{
             throw new Error("Request timed out: " + String(path));

--- a/npa/src/npa/cli/agent_chat.py
+++ b/npa/src/npa/cli/agent_chat.py
@@ -688,6 +688,7 @@ def format_infra_backends(state: dict[str, Any]) -> str:
         infra = {}
     configured = infra.get("configured") if isinstance(infra.get("configured"), list) else []
     local_clusters = infra.get("local_clusters") if isinstance(infra.get("local_clusters"), list) else []
+    cloud_clusters = infra.get("cloud_clusters") if isinstance(infra.get("cloud_clusters"), list) else []
     has_infra = bool(infra.get("has_infra"))
     project = str(infra.get("project") or "default")
     lines = [
@@ -713,6 +714,15 @@ def format_infra_backends(state: dict[str, Any]) -> str:
                     "  - "
                     f"`{item.get('cluster_name') or item.get('context') or 'cluster'}` "
                     f"kubeconfig_exists=`{bool(item.get('kubeconfig_exists'))}`"
+                )
+    if cloud_clusters:
+        lines.append("- **Nebius MK8s clusters**:")
+        for item in cloud_clusters[:5]:
+            if isinstance(item, dict):
+                lines.append(
+                    "  - "
+                    f"`{item.get('name') or item.get('id') or 'cluster'}` "
+                    f"id=`{item.get('id', '')}` status=`{item.get('status', '')}`"
                 )
     if not has_infra:
         lines.extend(

--- a/npa/src/npa/cli/agent_chat.py
+++ b/npa/src/npa/cli/agent_chat.py
@@ -199,6 +199,16 @@ _INTENT_RULES: list[tuple[str, re.Pattern[str]]] = [
         ),
     ),
     (
+        "infra_backends",
+        re.compile(
+            r"\b(?:k8s|kubernetes|cluster|clusters|backend|backends|infra|infrastructure)\b"
+            r".{0,120}\b(?:present|available|configured|exists?|list|show|query|which|what)\b"
+            r"|\b(?:list|show|query|what|which)\b.{0,120}\b(?:k8s|kubernetes|clusters?|backends?|infra)\b"
+            r"|\bno\b.{0,80}\b(?:infra|infrastructure|cluster|backend)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
         "live_infra_loop",
         re.compile(
             r"\b(?:run|submit|launch|test)\b.{0,120}\b(?:live|real)\b.{0,120}\b(?:infra|infrastructure|dev\s*vm)\b"
@@ -263,7 +273,8 @@ INTENT_APIS: dict[str, list[str]] = {
     "create_vlm_rl_workflow": ["workflows/draft", "workflows/validate", "workflows/plan"],
     "create_gate_workflow": ["workflows/draft", "workflows/validate", "workflows/plan"],
     "onboard_solution": ["tools", "workflows/validate", "workflows/plan"],
-    "live_infra_loop": ["workflows/validate", "workflows/plan", "tools"],
+    "infra_backends": ["infra/k8s", "infra/provision", "workflows/submit"],
+    "live_infra_loop": ["infra/k8s", "infra/provision", "workflows/validate", "workflows/plan", "workflows/submit", "tools"],
     "list_recordings": ["sim-viz/recordings", "sim-viz/runs"],
     "sim2real_status": ["sim-viz/status", "workflows/sim2real/status"],
     "sim_assets": ["sim-assets", "sim-assets/selection"],
@@ -671,6 +682,53 @@ def format_live_infra_loop_guidance() -> str:
     )
 
 
+def format_infra_backends(state: dict[str, Any]) -> str:
+    infra = state.get("infra")
+    if not isinstance(infra, dict):
+        infra = {}
+    configured = infra.get("configured") if isinstance(infra.get("configured"), list) else []
+    local_clusters = infra.get("local_clusters") if isinstance(infra.get("local_clusters"), list) else []
+    has_infra = bool(infra.get("has_infra"))
+    project = str(infra.get("project") or "default")
+    lines = [
+        "**Kubernetes / workflow infra status**:",
+        f"- **project**: `{project}`",
+        f"- **agent_npa_ready**: `{bool(infra.get('agent_npa_ready'))}`",
+    ]
+    if configured:
+        lines.append("- **configured backends**:")
+        for item in configured[:5]:
+            if isinstance(item, dict):
+                lines.append(
+                    "  - "
+                    f"`{item.get('cluster_name') or item.get('context') or 'configured'}` "
+                    f"source=`{item.get('source', 'project_config')}` "
+                    f"kubeconfig=`{item.get('kubeconfig', '')}`"
+                )
+    if local_clusters:
+        lines.append("- **local agent clusters**:")
+        for item in local_clusters[:5]:
+            if isinstance(item, dict):
+                lines.append(
+                    "  - "
+                    f"`{item.get('cluster_name') or item.get('context') or 'cluster'}` "
+                    f"kubeconfig_exists=`{bool(item.get('kubeconfig_exists'))}`"
+                )
+    if not has_infra:
+        lines.extend(
+            [
+                "- **No Kubernetes infra is currently specified or available.**",
+                "- Options:",
+                "  1. Let the agent deploy minimal GPU Kubernetes for the workflow (`POST /api/infra/provision`).",
+                "  2. Configure an existing backend in `~/.npa/config.yaml` under `projects.<alias>.kubernetes`.",
+                "  3. Submit with explicit `project` / `cluster_name` once you choose a target.",
+            ]
+        )
+    else:
+        lines.append("- The agent can use the listed backend or provision another one if requested.")
+    return "\n".join(lines)
+
+
 def format_configure_s3() -> str:
     return "\n".join(
         [
@@ -814,6 +872,8 @@ def build_grounded_reply(
         return format_sim_assets(state)
     if intent == "cameras":
         return format_cameras(state, default_cameras=default_cameras)
+    if intent == "infra_backends":
+        return format_infra_backends(state)
     if intent == "live_infra_loop":
         return format_live_infra_loop_guidance()
     if intent == "cosmos_capabilities":

--- a/npa/src/npa/clients/nebius.py
+++ b/npa/src/npa/clients/nebius.py
@@ -281,6 +281,11 @@ def _is_permission_denied(message: str) -> bool:
     return "permissiondenied" in lowered or "permission denied" in lowered or "no permission" in lowered
 
 
+def _is_not_found(message: str) -> bool:
+    lowered = message.lower()
+    return "notfound" in lowered or "not found" in lowered or "resourcenotfound" in lowered
+
+
 def _normalize_bucket_name(value: str) -> str:
     cleaned = value.strip()
     if not cleaned:
@@ -394,15 +399,17 @@ def ensure_service_account(
         sa_id = _resource_id_from_nebius_error(message, prefix="serviceaccount-")
         if sa_id:
             return sa_id
-        saved = _saved_service_account_id()
-        if saved:
-            return saved
         if _is_permission_denied(message):
+            saved = _saved_service_account_id()
+            if saved:
+                return saved
             raise NebiusError(
                 f"Cannot read or create service account {name!r}: {exc}. "
                 "Set NPA_SERVICE_ACCOUNT_ID or nebius.service_account_id in "
                 "~/.npa/credentials.yaml when IAM management is restricted."
             ) from exc
+        if not _is_not_found(message):
+            raise
         # Not found — create below.
 
     try:

--- a/npa/src/npa/clients/network.py
+++ b/npa/src/npa/clients/network.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import re
 from typing import Any
+from collections.abc import Callable
 
 from npa.clients import nebius
 from npa.clients.nebius import NebiusError
@@ -95,6 +96,50 @@ def rule_name(tool: str, ports: tuple[int, ...]) -> str:
     """Return the conventional npa allow rule name for a tool and port set."""
     normalized_tool = re.sub(r"[^a-z0-9-]+", "-", tool.lower()).strip("-") or "manual"
     return f"allow-npa-{normalized_tool}-{'-'.join(str(port) for port in ports)}"
+
+
+NPA_INGRESS_RULE_PREFIX = "allow-npa-"
+
+
+def remove_npa_ingress_rules(
+    security_group_ids: tuple[str, ...],
+    *,
+    on_status: Callable[[str], None] | None = None,
+) -> list[str]:
+    """Delete ingress rules created by :func:`ensure_ingress` (``allow-npa-*``)."""
+    deleted: list[str] = []
+    for group_id in security_group_ids:
+        if not group_id:
+            continue
+        rules = _list_security_rules(group_id)
+        for rule in rules:
+            metadata = _metadata(rule)
+            name = str(metadata.get("name", ""))
+            rule_id = str(metadata.get("id", ""))
+            if not rule_id or not name.startswith(NPA_INGRESS_RULE_PREFIX):
+                continue
+            try:
+                nebius._run(["vpc", "security-rule", "delete", "--id", rule_id])
+                deleted.append(rule_id)
+                if on_status:
+                    on_status(f"Removed ingress rule {name!r} ({rule_id}).")
+            except NebiusError as exc:
+                if on_status:
+                    on_status(f"Could not remove ingress rule {rule_id}: {exc}")
+    return deleted
+
+
+def remove_ingress_for_instance(
+    instance_id: str,
+    *,
+    on_status: Callable[[str], None] | None = None,
+) -> list[str]:
+    """Remove npa-managed ingress rules from the instance security groups."""
+    instance = _get_instance(instance_id)
+    return remove_npa_ingress_rules(
+        _instance_security_group_ids(instance),
+        on_status=on_status,
+    )
 
 
 def ensure_ingress(

--- a/npa/src/npa/deploy/provisioner.py
+++ b/npa/src/npa/deploy/provisioner.py
@@ -6,8 +6,9 @@ import json
 import shutil
 import subprocess
 import sys
+from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 
 class ProvisionerError(Exception):
@@ -55,6 +56,22 @@ def _require_terraform() -> str:
     return tf
 
 
+class _TeeStream(TextIO):
+    """Write to a buffer and an underlying stream (for streamed terraform stderr)."""
+
+    def __init__(self, buffer: StringIO, underlying: TextIO) -> None:
+        self._buffer = buffer
+        self._underlying = underlying
+
+    def write(self, data: str) -> int:
+        self._buffer.write(data)
+        return self._underlying.write(data)
+
+    def flush(self) -> None:
+        self._buffer.flush()
+        self._underlying.flush()
+
+
 def _run(
     args: list[str],
     *,
@@ -66,15 +83,19 @@ def _run(
     cmd = [tf] + args
     kwargs: dict[str, Any] = {"cwd": str(cwd), "text": True}
 
+    stderr_buffer: StringIO | None = None
     if capture:
         kwargs["capture_output"] = True
     elif stream:
+        stderr_buffer = StringIO()
         kwargs["stdout"] = sys.stdout
-        kwargs["stderr"] = sys.stderr
+        kwargs["stderr"] = _TeeStream(stderr_buffer, sys.stderr)
     else:
         kwargs["capture_output"] = True
 
     result = subprocess.run(cmd, **kwargs)
+    if stderr_buffer is not None:
+        result.stderr = stderr_buffer.getvalue()
     if result.returncode != 0 and capture:
         stderr = result.stderr or ""
         raise ProvisionerError(
@@ -223,7 +244,9 @@ def apply(
     args.extend(_build_var_args(tf_vars or {}))
     result = _run(args, cwd=tf_dir, stream=stream)
     if result.returncode != 0:
-        raise ProvisionerError(f"terraform apply failed (exit {result.returncode})")
+        stderr = (result.stderr or "").strip()
+        detail = f":\n{stderr}" if stderr else ""
+        raise ProvisionerError(f"terraform apply failed (exit {result.returncode}){detail}")
     return outputs(tf_dir)
 
 

--- a/npa/src/npa/deploy/provisioner.py
+++ b/npa/src/npa/deploy/provisioner.py
@@ -237,14 +237,20 @@ def destroy(
     tf_vars: dict[str, str] | None = None,
     *,
     stream: bool = True,
+    targets: list[str] | None = None,
 ) -> None:
     """Run terraform destroy -auto-approve."""
     tf_dir = Path(tf_dir) if tf_dir else _BUNDLED_TF_DIR
     args = ["destroy", "-auto-approve", "-input=false"]
+    if targets:
+        for target in targets:
+            args.extend(["-target", target])
     args.extend(_build_var_args(tf_vars or {}))
     result = _run(args, cwd=tf_dir, stream=stream)
     if result.returncode != 0:
-        raise ProvisionerError(f"terraform destroy failed (exit {result.returncode})")
+        stderr = (result.stderr or "").strip()
+        detail = f":\n{stderr}" if stderr else ""
+        raise ProvisionerError(f"terraform destroy failed (exit {result.returncode}){detail}")
 
 
 def state_list(tf_dir: str | Path | None = None) -> list[str]:

--- a/npa/src/npa/deploy/provisioner.py
+++ b/npa/src/npa/deploy/provisioner.py
@@ -6,9 +6,8 @@ import json
 import shutil
 import subprocess
 import sys
-from io import StringIO
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any
 
 
 class ProvisionerError(Exception):
@@ -56,22 +55,6 @@ def _require_terraform() -> str:
     return tf
 
 
-class _TeeStream(TextIO):
-    """Write to a buffer and an underlying stream (for streamed terraform stderr)."""
-
-    def __init__(self, buffer: StringIO, underlying: TextIO) -> None:
-        self._buffer = buffer
-        self._underlying = underlying
-
-    def write(self, data: str) -> int:
-        self._buffer.write(data)
-        return self._underlying.write(data)
-
-    def flush(self) -> None:
-        self._buffer.flush()
-        self._underlying.flush()
-
-
 def _run(
     args: list[str],
     *,
@@ -83,19 +66,18 @@ def _run(
     cmd = [tf] + args
     kwargs: dict[str, Any] = {"cwd": str(cwd), "text": True}
 
-    stderr_buffer: StringIO | None = None
     if capture:
         kwargs["capture_output"] = True
     elif stream:
-        stderr_buffer = StringIO()
         kwargs["stdout"] = sys.stdout
-        kwargs["stderr"] = _TeeStream(stderr_buffer, sys.stderr)
+        kwargs["stderr"] = subprocess.PIPE
     else:
         kwargs["capture_output"] = True
 
     result = subprocess.run(cmd, **kwargs)
-    if stderr_buffer is not None:
-        result.stderr = stderr_buffer.getvalue()
+    if stream and result.stderr:
+        sys.stderr.write(result.stderr)
+        sys.stderr.flush()
     if result.returncode != 0 and capture:
         stderr = result.stderr or ""
         raise ProvisionerError(

--- a/npa/src/npa/deploy/terraform/main.tf
+++ b/npa/src/npa/deploy/terraform/main.tf
@@ -54,7 +54,7 @@ resource "nebius_vpc_v1_security_rule" "allow_server" {
 
   ingress = {
     source_cidrs      = [var.ssh_cidr_block]
-    destination_ports = [var.server_port]
+    destination_ports = distinct(concat([var.server_port], var.extra_ingress_ports))
   }
 }
 

--- a/npa/src/npa/deploy/terraform/main.tf
+++ b/npa/src/npa/deploy/terraform/main.tf
@@ -160,7 +160,7 @@ resource "nebius_compute_v1_instance" "workbench" {
 
   recovery_policy = var.enable_preemptible ? "FAIL" : "RECOVER"
 
-  service_account_id = var.service_account_id
+  service_account_id = trimspace(var.service_account_id) != "" ? trimspace(var.service_account_id) : null
 
   labels = {
     environment = "ml-workbench"

--- a/npa/src/npa/deploy/terraform/variables.tf
+++ b/npa/src/npa/deploy/terraform/variables.tf
@@ -83,6 +83,12 @@ variable "server_port" {
   default     = 8080
 }
 
+variable "extra_ingress_ports" {
+  description = "Additional TCP ingress ports exposed alongside server_port"
+  type        = list(number)
+  default     = []
+}
+
 variable "workbench_type" {
   description = "Workbench bootstrap type rendered into cloud-init"
   type        = string

--- a/npa/src/npa/deploy/terraform/variables.tf
+++ b/npa/src/npa/deploy/terraform/variables.tf
@@ -22,9 +22,10 @@ variable "nebius_region" {
 # ── Service account (created by environment.sh) ───────────────────────────
 
 variable "service_account_id" {
-  description = "Service account ID created by environment.sh"
+  description = "Optional service account ID attached to the VM for metadata/API access"
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 # ── Instance ───────────────────────────────────────────────────────────────

--- a/npa/src/npa/provisioning.py
+++ b/npa/src/npa/provisioning.py
@@ -85,6 +85,9 @@ def provision_if_absent(
                 context_name=context,
                 validate=validate,
                 sky_smoke=sky_smoke,
+                sky_gpus="",
+                capacity_block_group="",
+                validation_timeout=60,
                 timeout=timeout,
             )
         actions.append(f"k8s:ensured terraform cluster {context}")

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -476,6 +476,8 @@ def test_verify_live_runs_pytests(monkeypatch) -> None:
             return _Resp(b"RRD" * 32, status_code=200)
         if url_s.endswith("/api/health"):
             return _Resp({"ok": True})
+        if url_s.endswith("/api/infra/k8s"):
+            return _Resp({"ok": True, "agent_npa_ready": True})
         if url_s.endswith("/api/workflows/sim2real/status"):
             return _Resp({"latest_submit": {"run_id": "agent-run-123"}, "sim_viz": {"stage": "demo"}})
         if url_s.endswith("/welcome"):
@@ -537,6 +539,15 @@ def test_verify_live_runs_pytests(monkeypatch) -> None:
             return _Resp({"ok": True, "selection": {"scene_spec_uri": "stock://scene/default"}})
         if url_s.endswith("/api/workflows/sim2real/submit"):
             return _Resp({"ok": True, "run_id": "agent-run-123"})
+        if url_s.endswith("/api/workflows/submit"):
+            return _Resp(
+                {
+                    "ok": True,
+                    "submit_mode": "agent-live-infra-dry-run",
+                    "scheduler_plan": {"ok": True},
+                    "run_id": "verify-live-agent-infra",
+                }
+            )
         if url_s.endswith("/api/sim-viz/load-franka-demo"):
             return _Resp({"ok": True, "sim_viz": {"rerun_ready": True, "rrd_uri": "/api/sim-viz/rrd"}})
         if url_s.endswith("/api/sim-viz/camera-preview"):
@@ -743,7 +754,12 @@ def test_bootstrap_emitted_ui_script_is_valid_javascript(monkeypatch) -> None:
 
     class _DummySsh:
         def upload_file(self, local_path: str, _remote_path: str) -> None:
-            captured["setup_script"] = Path(local_path).read_text(encoding="utf-8")
+            try:
+                text = Path(local_path).read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                return
+            if "npa-agent-bootstrap" in _remote_path:
+                captured["setup_script"] = text
 
         def run_or_raise(self, _command: str) -> None:
             return None

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -122,6 +122,10 @@ def test_bootstrap_embeds_chat_endpoint() -> None:
     assert "mobileAuthTokenCache" in source
     assert "verifyMobileChatAuth" in source
     assert 'credentials: useExplicitAuth ? "omit" : "include"' in source
+    assert "activeChatSessionId" in source
+    assert "/api/chat/sessions" in source
+    assert "npa-agent/tenants/" in source
+    assert "Send failed; your draft was restored." in source
     assert "AGENT_UI_VERSION" in source or "npa-ui-version" in source
     assert 'add_header Cache-Control "no-store, no-cache, must-revalidate"' in source
     assert "@media (max-width: 900px)" in source

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import json
+import re
+import shutil
+import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
@@ -728,6 +732,65 @@ def test_bootstrap_chat_copy_yaml_support_present() -> None:
     assert "msg-copy-btn" in source
     assert "extractFencedCode" in source
     assert "copyTextToClipboard" in source
+
+
+def test_bootstrap_emitted_ui_script_is_valid_javascript(monkeypatch) -> None:
+    if not shutil.which("node"):
+        return
+    from npa.cli import agent as agent_module
+
+    captured: dict[str, str] = {}
+
+    class _DummySsh:
+        def upload_file(self, local_path: str, _remote_path: str) -> None:
+            captured["setup_script"] = Path(local_path).read_text(encoding="utf-8")
+
+        def run_or_raise(self, _command: str) -> None:
+            return None
+
+        def run(self, _command: str) -> None:
+            return None
+
+    monkeypatch.setattr(agent_module, "SSHClient", lambda config: _DummySsh())
+    monkeypatch.setattr(agent_module, "resolve_ssh_config", lambda **_kwargs: SimpleNamespace(ssh={}))
+
+    agent_module._bootstrap_agent_stack(
+        host="203.0.113.10",
+        ssh_user="ubuntu",
+        ssh_key_path="/tmp/key",
+        project_alias="smoke",
+        project_id="project-id",
+        tenant_id="tenant-id",
+        region="us-central1",
+        auth_user="npa",
+        auth_password="password",
+        agent_port=8088,
+        backend_port=8787,
+        rerun_port=9090,
+        llm_model="nvidia/Cosmos3-Super-Reasoner",
+        llm_models=["nvidia/Cosmos3-Super-Reasoner", "meta-llama/Llama-3.3-70B-Instruct"],
+        tf_api_key="",
+        nebius_ai_key="",
+        public_https=True,
+    )
+
+    setup_script = captured["setup_script"]
+    html_match = re.search(
+        r"cat <<'HTML' \| sudo tee /opt/npa-agent/ui\.html >/dev/null\n(?P<html>.*?)\nHTML",
+        setup_script,
+        flags=re.DOTALL,
+    )
+    assert html_match, "bootstrap setup script must emit ui.html"
+    scripts = re.findall(r"<script>(.*?)</script>", html_match.group("html"), flags=re.DOTALL)
+    assert scripts, "ui.html must include browser JavaScript"
+    proc = subprocess.run(
+        ["node", "--check", "-"],
+        input="\n".join(scripts),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
 
 
 def test_bootstrap_recordings_api_in_system_prompt() -> None:

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -771,7 +771,7 @@ def test_bootstrap_emitted_ui_script_is_valid_javascript(monkeypatch) -> None:
     monkeypatch.setattr(agent_module, "resolve_ssh_config", lambda **_kwargs: SimpleNamespace(ssh={}))
 
     agent_module._bootstrap_agent_stack(
-        host="203.0.113.10",
+        host="203.0.113.50",
         ssh_user="ubuntu",
         ssh_key_path="/tmp/key",
         project_alias="smoke",

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -484,7 +484,7 @@ def test_verify_live_runs_pytests(monkeypatch) -> None:
             html = (
                 f'<html><head><meta name="viewport" content="width=device-width, initial-scale=1">'
                 f'<meta name="npa-ui-version" content="{AGENT_UI_VERSION}"></head>'
-                '<body><script>function wireUi(){} id="chatForm"; function sendChat(){} initNpaAgentUi; mobile-agent; '
+                '<body><div id="mobileChatAuth"></div><script>function wireUi(){} id="chatForm"; function sendChat(){} initNpaAgentUi; mobile-agent; '
                 'history.replaceState(null, "", ""); location.username; location.password</script></body></html>'
             )
             return _Resp(html, status_code=200)

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -114,6 +114,9 @@ def test_bootstrap_embeds_chat_endpoint() -> None:
     assert "id=\"toastHost\"" in source
     assert "DOMContentLoaded" in source
     assert "initNpaAgentUi" in source
+    assert 'id="chatForm"' in source
+    assert "mobile-agent" in source
+    assert "npa_agent_basic_auth" in source
     assert "AGENT_UI_VERSION" in source or "npa-ui-version" in source
     assert 'add_header Cache-Control "no-store, no-cache, must-revalidate"' in source
     assert "@media (max-width: 900px)" in source
@@ -134,13 +137,13 @@ def test_bootstrap_public_login_form() -> None:
 
     html = agent_module._agent_public_login_form_html("npa")
     assert 'id="npa-sign-in"' in html
-    assert 'type="submit">Sign in</button>' in html
+    assert 'id="npa-sign-in-btn">Sign in</button>' in html or 'type="submit">Sign in</button>' in html
     assert 'value="npa"' in html
     assert "encodeURIComponent(user)" in html
     assert "encodeURIComponent(pass)" in html
     assert "history.replaceState" in html
-    assert "normalizedPath === \"/login-help.html\"" in html
-    assert "normalizedPath === \"/welcome\"" in html
+    assert "persistBasicAuth" in html
+    assert 'normalizedPath === "/login-help.html"' in html or '"/login-help.html"' in html
 
 
 def test_bootstrap_ui_button_wiring_patterns() -> None:
@@ -148,7 +151,6 @@ def test_bootstrap_ui_button_wiring_patterns() -> None:
 
     source = Path(agent_module.__file__).read_text(encoding="utf-8")
     for control_id in (
-        "chatSend",
         "chatActionS3",
         "chatActionCosmos",
         "chatActionWatch",
@@ -159,6 +161,8 @@ def test_bootstrap_ui_button_wiring_patterns() -> None:
         "workflowStatus",
     ):
         assert f'bindClick("{control_id}"' in source
+    assert 'id="chatForm"' in source
+    assert "chatForm.addEventListener(\"submit\"" in source
     assert "await apiJson(\"/api/chat\"" in source
     assert "await apiJson(\"/api/sim-viz/load-franka-demo\"" in source
     assert "await apiJson(\"/api/sim-viz/camera-preview\"" in source
@@ -301,8 +305,8 @@ def test_bootstrap_ui_fetch_uses_credentials_include() -> None:
     assert 'credentials: "same-origin"' not in source
     assert "setChatBusy(true)" in source
     assert "setChatBusy(false)" in source
-    assert "btn.disabled = Boolean(isBusy);" in source
-    assert "input.disabled = Boolean(isBusy);" in source
+    assert "if (btn) btn.disabled = busy;" in source
+    assert "if (input) input.disabled = busy;" in source
     assert "JSON.stringify(value)" in source
     assert "JSON.stringify(assets.selection" not in source
 
@@ -470,7 +474,7 @@ def test_verify_live_runs_pytests(monkeypatch) -> None:
         if url_s.rstrip("/").endswith(("203.0.113.50", ":8088")):
             html = (
                 f'<html><head><meta name="npa-ui-version" content="{AGENT_UI_VERSION}"></head>'
-                '<body><script>function wireUi(){} bindClick("chatSend"); initNpaAgentUi; '
+                '<body><script>function wireUi(){} id="chatForm"; function sendChat(){} initNpaAgentUi; mobile-agent; '
                 'history.replaceState(null, "", ""); location.username; location.password</script></body></html>'
             )
             return _Resp(html, status_code=200)

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -116,6 +116,8 @@ def test_bootstrap_embeds_chat_endpoint() -> None:
     assert "initNpaAgentUi" in source
     assert 'id="chatForm"' in source
     assert "mobile-agent" in source
+    assert 'name="viewport" content="width=device-width' in source
+    assert "mobileChatAuth" in source
     assert "npa_agent_basic_auth" in source
     assert "AGENT_UI_VERSION" in source or "npa-ui-version" in source
     assert 'add_header Cache-Control "no-store, no-cache, must-revalidate"' in source

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -119,6 +119,9 @@ def test_bootstrap_embeds_chat_endpoint() -> None:
     assert 'name="viewport" content="width=device-width' in source
     assert "mobileChatAuth" in source
     assert "npa_agent_basic_auth" in source
+    assert "mobileAuthTokenCache" in source
+    assert "verifyMobileChatAuth" in source
+    assert 'credentials: useExplicitAuth ? "omit" : "include"' in source
     assert "AGENT_UI_VERSION" in source or "npa-ui-version" in source
     assert 'add_header Cache-Control "no-store, no-cache, must-revalidate"' in source
     assert "@media (max-width: 900px)" in source

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -482,7 +482,8 @@ def test_verify_live_runs_pytests(monkeypatch) -> None:
             return _Resp(b"console.log('rerun');", status_code=200)
         if url_s.rstrip("/").endswith(("203.0.113.50", ":8088")):
             html = (
-                f'<html><head><meta name="npa-ui-version" content="{AGENT_UI_VERSION}"></head>'
+                f'<html><head><meta name="viewport" content="width=device-width, initial-scale=1">'
+                f'<meta name="npa-ui-version" content="{AGENT_UI_VERSION}"></head>'
                 '<body><script>function wireUi(){} id="chatForm"; function sendChat(){} initNpaAgentUi; mobile-agent; '
                 'history.replaceState(null, "", ""); location.username; location.password</script></body></html>'
             )

--- a/npa/tests/cli/test_agent_workflow.py
+++ b/npa/tests/cli/test_agent_workflow.py
@@ -111,11 +111,37 @@ def test_create_workflow_apis() -> None:
     assert any("validate" in path for path in apis)
 
 
+def test_infra_backend_intent_and_reply() -> None:
+    assert match_chat_intent("which kubernetes clusters are available?") == "infra_backends"
+    apis = apis_for_intent("infra_backends")
+    assert "infra/k8s" in apis
+    reply = build_grounded_reply(
+        "infra_backends",
+        {
+            "infra": {
+                "project": "demo",
+                "has_infra": False,
+                "agent_npa_ready": True,
+                "configured": [],
+                "local_clusters": [],
+            }
+        },
+        [],
+    )
+    assert "No Kubernetes infra" in reply
+    assert "deploy minimal GPU Kubernetes" in reply
+
+
 def test_bootstrap_embeds_workflow_endpoints() -> None:
     source = Path(agent_module.__file__).read_text(encoding="utf-8")
     assert '@app.post("/workflows/validate")' in source
     assert '@app.post("/workflows/plan")' in source
     assert '@app.post("/workflows/submit")' in source
+    assert '@app.get("/infra/k8s")' in source
+    assert '@app.post("/infra/provision")' in source
+    assert "agent-live-infra-plan" in source
+    assert "pip install -e" in source
+    assert "deploy/cluster" in source
     assert '@app.get("/workflows/draft")' in source
     assert "workflowYaml" in source
     assert "validateWorkflowYaml" in source

--- a/npa/tests/cli/test_network_cli.py
+++ b/npa/tests/cli/test_network_cli.py
@@ -371,3 +371,27 @@ def test_network_ensure_ingress_rejects_missing_target() -> None:
 
     assert result.exit_code != 0
     assert "pass exactly one of --vm or (--ip and --project)" in result.output
+
+
+def test_remove_npa_ingress_rules_deletes_allow_npa_rules(mocker) -> None:
+    from npa.clients import network as network_client
+
+    mocker.patch(
+        "npa.clients.network._list_security_rules",
+        return_value=[
+            {
+                "metadata": {"id": "rule-npa", "name": "allow-npa-agent-443"},
+                "spec": {"ingress": {"destination_ports": [443]}},
+            },
+            {
+                "metadata": {"id": "rule-tf", "name": "allow-server"},
+                "spec": {"ingress": {"destination_ports": [8088]}},
+            },
+        ],
+    )
+    run = mocker.patch("npa.clients.network.nebius._run")
+
+    deleted = network_client.remove_npa_ingress_rules(("sg-test",))
+
+    assert deleted == ["rule-npa"]
+    run.assert_called_once_with(["vpc", "security-rule", "delete", "--id", "rule-npa"])

--- a/npa/tests/e2e/agent_live_helpers.py
+++ b/npa/tests/e2e/agent_live_helpers.py
@@ -87,10 +87,10 @@ STOCK_FRANKA_SELECTION = {
 }
 
 UI_BUTTON_IDS = (
-    "chatSend",
     "chatActionS3",
     "chatActionCosmos",
     "chatActionWatch",
+    "newChatSession",
     "loadFrankaRerun",
     "openRerun",
     "applySelection",

--- a/npa/tests/e2e/test_agent_live.py
+++ b/npa/tests/e2e/test_agent_live.py
@@ -38,6 +38,11 @@ def test_agent_ui_html_smoke(ctx: AgentLiveContext) -> None:
     for control_id in UI_BUTTON_IDS:
         assert f'id="{control_id}"' in html
         assert f'bindClick("{control_id}"' in html
+    assert 'id="chatSend"' in html
+    assert 'id="chatForm"' in html
+    assert 'id="chatSessionSelect"' in html
+    assert 'chatForm.addEventListener("submit"' in html
+    assert "/api/chat/sessions" in html
 
 
 def test_agent_health_and_session(ctx: AgentLiveContext) -> None:

--- a/npa/tests/smoke/test_agent_smoke.py
+++ b/npa/tests/smoke/test_agent_smoke.py
@@ -13,10 +13,10 @@ TMUX_SCRIPT = REPO_ROOT / "npa" / "scripts" / "start_agent_live_tmux.sh"
 AGENT_MODULE = REPO_ROOT / "npa" / "src" / "npa" / "cli" / "agent.py"
 
 UI_BUTTON_IDS = (
-    "chatSend",
     "chatActionS3",
     "chatActionCosmos",
     "chatActionWatch",
+    "newChatSession",
     "loadFrankaRerun",
     "openRerun",
     "applySelection",
@@ -50,6 +50,11 @@ def test_agent_bootstrap_source_smoke() -> None:
     assert 'name="npa-ui-version" content="{AGENT_UI_VERSION}"' in source
     for control_id in UI_BUTTON_IDS:
         assert f'bindClick("{control_id}"' in source
+    assert 'id="chatSend"' in source
+    assert 'id="chatForm"' in source
+    assert 'id="chatSessionSelect"' in source
+    assert 'chatForm.addEventListener("submit"' in source
+    assert "/api/chat/sessions" in source
     assert 'add_header Cache-Control "no-store, no-cache, must-revalidate"' in source
 
 

--- a/npa/tests/test_clients.py
+++ b/npa/tests/test_clients.py
@@ -400,6 +400,23 @@ def test_nebius_service_account_reuses_id_from_permission_denied(mocker) -> None
     assert nebius.ensure_service_account("project") == "serviceaccount-u00example"
 
 
+def test_nebius_service_account_creates_when_not_found_despite_saved(mocker) -> None:
+    run_json = mocker.patch(
+        "npa.clients.nebius._run_json",
+        side_effect=[
+            nebius.NebiusError(
+                "nebius iam service-account get-by-name failed (exit 5):\n"
+                "NotFound: 'npa-agent' not found in project"
+            ),
+            {"metadata": {"id": "serviceaccount-new"}},
+        ],
+    )
+    mocker.patch("npa.clients.nebius._saved_service_account_id", return_value="serviceaccount-saved")
+
+    assert nebius.ensure_service_account("project", name="npa-agent") == "serviceaccount-new"
+    assert run_json.call_count == 2
+
+
 def test_nebius_saved_storage_credentials_prefers_configured_bucket(mocker) -> None:
     mocker.patch("npa.clients.nebius.get_iam_token", return_value="iam")
     mocker.patch("npa.clients.nebius._saved_service_account_id", return_value="sa-id")

--- a/npa/tests/test_deploy.py
+++ b/npa/tests/test_deploy.py
@@ -224,10 +224,15 @@ def test_terraform_command_wrappers_delegate_to_run(tmp_path: Path, mocker) -> N
 def test_apply_and_destroy_raise_on_nonzero(tmp_path: Path, mocker) -> None:
     mocker.patch(
         "npa.deploy.provisioner._run",
-        return_value=subprocess.CompletedProcess(args=["terraform"], returncode=1, stdout="", stderr=""),
+        return_value=subprocess.CompletedProcess(
+            args=["terraform"],
+            returncode=1,
+            stdout="",
+            stderr="PermissionDenied: service compute",
+        ),
     )
 
-    with pytest.raises(ProvisionerError, match="terraform apply failed"):
+    with pytest.raises(ProvisionerError, match="PermissionDenied: service compute"):
         provisioner.apply(tmp_path)
     with pytest.raises(ProvisionerError, match="terraform destroy failed"):
         provisioner.destroy(tmp_path)

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -296,6 +296,16 @@ skills:
       - type: cli_help
         args: ["workbench", "health", "sim2real", "--help"]
         contains: "checks"
+  - name: agent-workflow-operate
+    category: workflows
+    when_to_use: "Verify that a bootstrapped NPA agent VM can create, validate, plan, provision for, or run npa.workflow YAMLs using its staged config."
+    path: skills/workflows/agent-workflow-operate/SKILL.md
+    smoke:
+      - type: file_exists
+        path: skills/workflows/agent-workflow-operate/SKILL.md
+      - type: cli_help
+        args: ["workbench", "workflow", "validate-spec", "--help"]
+        contains: "npa.workflow"
   - name: sim2real-engine
     category: tools
     when_to_use: "Navigate or change the Sim2Real staged pipeline engine — 14-stage map, preamble/inner/outer/finalize entrypoints, and K8s sibling jobs."

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -331,6 +331,19 @@ skills:
       - type: workflow_yaml
         paths:
           - npa/workflows/workbench/skypilot/byof-container-smoke-rtxpro.yaml
+  - name: agent-fresh-operate
+    category: workflows
+    when_to_use: "Deploy, teardown, or reproduce a fresh NPA agent VM from scratch; validate /api/models and /api/chat; debug destroy/fresh-setup failures."
+    path: skills/workflows/agent-fresh-operate/SKILL.md
+    smoke:
+      - type: file_exists
+        path: npa/scripts/agent_fresh_setup_loop.sh
+      - type: cli_help
+        args: ["agent", "fresh-setup", "--help"]
+        contains: "project-id"
+      - type: cli_help
+        args: ["agent", "destroy", "--help"]
+        contains: "Destroy agent VM"
   - name: author-npa-workflow
     category: workflows
     when_to_use: "Author, validate, or review NPA workflow specs (apiVersion npa.workflow/v0.0.1) and toolRef catalogs."

--- a/skills/tools/npa-agent/SKILL.md
+++ b/skills/tools/npa-agent/SKILL.md
@@ -79,6 +79,7 @@ Token Factory model selection is configurable via `--llm-model` and `--llm-model
 - Public URL: `https://<public_ip>/` (self-signed cert on VM IP)
 - Sign-in form at `/login-help.html` and `/welcome` (mobile-safe XHR/fetch sign-in; URL-embed fallback on desktop only)
 - On phones: open `/healthz` first to accept the self-signed certificate, then sign in at `/login-help.html`
+- Mobile chat uses `sessionStorage` basic-auth fallback — sign out by clearing site data or use `/login-help.html` again
 - All `fetch` calls use `credentials: "include"` for session basic auth
 - Never suggest `localhost`, `127.0.0.1`, or port `8080` — use same-origin `/api/…` paths
 

--- a/skills/tools/npa-agent/SKILL.md
+++ b/skills/tools/npa-agent/SKILL.md
@@ -11,6 +11,7 @@ Sim Assets + Cameras panels, embedded Rerun viewer, and Sim2Real submit hooks.
 ## When To Use
 
 - Deploy, bootstrap, or verify an agent VM (`npa agent …`)
+- **Fresh deploy / teardown loops:** load `skills/workflows/agent-fresh-operate/SKILL.md`
 - Debug chat hallucinations (raw `GET /api/…` replies) or false “Loaded Franka” messages
 - Fix Rerun iframe black screen (basic auth + wasm fetch)
 - Operate customer HTTPS access and sign-in UX
@@ -238,6 +239,7 @@ Submits workflow with current selection; updates `latest_submit` and `sim_viz.ru
 - CLI + bootstrap: `npa/src/npa/cli/agent.py`
 - Chat router (testable): `npa/src/npa/cli/agent_chat.py`
 - Franka verify script: `npa/scripts/verify_agent_franka.sh`
+- Fresh deploy loop: `npa/scripts/agent_fresh_setup_loop.sh` (see `skills/workflows/agent-fresh-operate/SKILL.md`)
 - Mature deploy loop: `npa/scripts/agent_mature_verify_loop.sh`
 
 ## Security / Guardrails

--- a/skills/tools/npa-agent/SKILL.md
+++ b/skills/tools/npa-agent/SKILL.md
@@ -77,7 +77,8 @@ Token Factory model selection is configurable via `--llm-model` and `--llm-model
 ## Customer HTTPS Access
 
 - Public URL: `https://<public_ip>/` (self-signed cert on VM IP)
-- Sign-in form at `/login-help.html` embeds credentials via URL then **replaceState** strips them
+- Sign-in form at `/login-help.html` and `/welcome` (mobile-safe XHR/fetch sign-in; URL-embed fallback on desktop only)
+- On phones: open `/healthz` first to accept the self-signed certificate, then sign in at `/login-help.html`
 - All `fetch` calls use `credentials: "include"` for session basic auth
 - Never suggest `localhost`, `127.0.0.1`, or port `8080` — use same-origin `/api/…` paths
 

--- a/skills/workflows/agent-fresh-operate/SKILL.md
+++ b/skills/workflows/agent-fresh-operate/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: agent-fresh-operate
+description: Use when deploying, tearing down, or reproducing a fresh NPA agent VM from scratch — npa-driven destroy/fresh-setup, profile selection, tiered verify gates, and teardown failure recovery.
+---
+
+# Agent Fresh Operate
+
+## When To Use
+
+Use this skill to **operate** a clean agent VM lifecycle on the **operator/dev VM**:
+
+- First-time `fresh-setup` on a project alias
+- Teardown → redeploy loops (“reproduce from scratch”)
+- Validate `/api/models` and `/api/chat` after deploy
+- Debug destroy/fresh-setup failures (IAM, orphan VMs, ingress rules)
+
+For chat UX, API shapes, and Rerun iframe behavior, use `npa-agent`. For
+`npa configure` / object-storage provisioning, use `nebius-infra`.
+
+## Entry Points
+
+- `npa/.venv/bin/npa agent fresh-setup` — initialize project env + deploy + bootstrap
+- `npa/.venv/bin/npa agent destroy` — npa-driven teardown (ingress cleanup, TF destroy, orphan VM delete)
+- `npa/scripts/agent_fresh_setup_loop.sh` — destroy → fresh-setup → smoke chat (loop until success)
+- `npa/scripts/agent_mature_verify_loop.sh` — bootstrap-first mature loop (existing agents; not fresh deploy)
+
+All `npa agent …` and `nebius` commands run on the **operator/dev VM** with
+`~/.npa/config.yaml` and `~/.npa/credentials.yaml`. Cloud agents sync the
+target branch to the dev VM before live tests.
+
+## Procedure
+
+1. **Preconditions (dev VM).**
+   ```bash
+   cd ~/nebius-physical-ai
+   git checkout <branch> && npa/.venv/bin/pip install -e npa -q
+   nebius profile activate "${NPA_NEBIUS_PROFILE:-npa-mk8s}"
+   export NPA_NEBIUS_PROFILE="${NPA_NEBIUS_PROFILE:-npa-mk8s}"
+   export NPA_SSH_KEY="${NPA_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+   ```
+
+2. **Teardown (npa-driven — no manual `nebius vpc` edits).**
+   ```bash
+   npa/.venv/bin/npa agent destroy --project <alias> --name agent
+   ```
+
+3. **Fresh deploy.**
+   ```bash
+   npa/.venv/bin/npa agent fresh-setup \
+     --project <alias> --name agent \
+     --project-id <project-id> \
+     --tenant-id <tenant-id> \
+     --region us-central1
+   ```
+   Expect **compute PermissionDenied with VM SA attachment** on some cross-project
+   profiles; npa retries apply without attached `service_account_id`.
+
+4. **Smoke gate (default “done” for fresh deploy).**
+   ```bash
+   source ~/.npa/agents/<alias>/agent/auth.env
+   BASE="$(npa/.venv/bin/npa agent status --project <alias> --name agent --json \
+     | npa/.venv/bin/python -c 'import json,sys; print(json.load(sys.stdin).get("public_url","").rstrip("/"))')"
+   curl -sk -u "${AGENT_USER}:${AGENT_PASSWORD}" "${BASE}/api/models"
+   curl -sk -u "${AGENT_USER}:${AGENT_PASSWORD}" -H 'Content-Type: application/json' \
+     -d '{"messages":[{"role":"user","content":"Say hello in one short sentence."}]}' \
+     "${BASE}/api/chat"
+   ```
+
+5. **Optional full gates.**
+   - Grounded chat: ask “what is the current sim2real status” → `"grounded": true`
+   - Live regression: `NPA_AGENT_CHAT_LIVE=1 npa/.venv/bin/npa agent verify-live --project <alias> --name agent`
+   - Mature loop: `bash npa/scripts/agent_mature_verify_loop.sh` (bootstrap-first)
+
+6. **One-command loop.**
+   ```bash
+   export NPA_AGENT_PROJECT=<alias> NPA_AGENT_NAME=agent
+   export NPA_AGENT_PROJECT_ID=<project-id> NPA_AGENT_TENANT_ID=<tenant-id>
+   export NPA_AGENT_REGION=us-central1 NPA_NEBIUS_PROFILE=npa-mk8s
+   bash npa/scripts/agent_fresh_setup_loop.sh
+   ```
+
+## Verify Tiers
+
+| Tier | Checks | Use when |
+|------|--------|----------|
+| **Smoke** | `status --json`, `/api/models`, hello `/api/chat` | Fresh deploy validated |
+| **Grounded** | sim2real status chat → `grounded: true` | Chat router wired |
+| **Live** | `verify-live` | Pre-merge regression |
+| **Mature** | `agent_mature_verify_loop.sh` + Franka | Chat/router code changes |
+
+Do not block a smoke deploy on `verify-live` UI wiring markers alone.
+
+## Gotchas
+
+- **Profile vs project.** Cross-project deploy needs a profile with compute IAM on
+  the target project (commonly `npa-mk8s`). `cursor-sa` may lack VPC/compute on
+  foreign projects. Never use `tle` in scripts (interactive auth hang).
+- **Compute PermissionDenied + SA.** First TF apply may fail attaching `npa-agent`
+  SA to the VM; npa retries without SA attachment. Bare compute denial → stop and
+  report IAM gap to operator.
+- **Destroy: disk/SG in use.** Orphan cloud VM may exist outside TF state after a
+  failed apply/rollback. `npa agent destroy` deletes matching instances by name
+  before TF destroy; retry destroy if preconditions fail once.
+- **`fresh-setup --replace`.** Destroy must run **before** updating project env
+  (otherwise TF backend keys drift mid-destroy).
+- **502 / SyntaxError on chat.** Re-bootstrap; check embedded `\n` escaping in
+  bootstrap `backend.py` template.
+- **Ingress rules.** Stale `allow-npa-*` rules can block security-group delete;
+  destroy path removes npa-managed ingress first.
+- **Cloud agent → dev VM.** Sync branch (`git pull` or tar/scp), confirm
+  `npa agent --help` lists `fresh-setup`, then run live loop on dev VM.
+
+## Symptom → Action
+
+| Symptom | Action |
+|---------|--------|
+| `PermissionDenied: service compute` then success after retry message | Expected SA-attachment retry; no action |
+| `PermissionDenied: service compute` on retry without SA | Operator IAM on target project |
+| `Agent config not found` after destroy | Run `fresh-setup` |
+| Destroy fails, instance name `agent-<alias>-agent` still listed | Re-run `npa agent destroy` (orphan cleanup) |
+| Chat 502, health false | `npa agent bootstrap --project <alias> --name agent` |
+| `verify-live` UI version mismatch but chat OK | Smoke tier passed; fix UI marker separately |
+
+## Verify (repo)
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+bash -n npa/scripts/agent_fresh_setup_loop.sh
+# Smoke-only against an existing agent (no destroy/deploy):
+NPA_FRESH_SETUP_SKIP_DESTROY=1 NPA_FRESH_SETUP_SKIP_DEPLOY=1 \
+  NPA_AGENT_PROJECT=<alias> bash npa/scripts/agent_fresh_setup_loop.sh
+```

--- a/skills/workflows/agent-workflow-operate/SKILL.md
+++ b/skills/workflows/agent-workflow-operate/SKILL.md
@@ -12,8 +12,8 @@ description: Use when verifying that a bootstrapped NPA agent VM can create, val
   `verify-live` there.
 - **NPA agent VM** is the autonomous workbench execution surface. After
   bootstrap, it must have staged `~/.npa/config.yaml`, `~/.npa/credentials.yaml`,
-  Nebius CLI profile material, and the NPA checkout needed to validate, plan,
-  provision, and run workflow YAMLs.
+  Nebius CLI/profile or token material, and the NPA checkout needed to validate,
+  plan, provision, and run workflow YAMLs.
 - Do not use the dev VM full pytest suite as the acceptance test for agent
   autonomy. The relevant check is whether the agent VM can operate workflows
   with its bootstrapped config.
@@ -34,13 +34,23 @@ agent record SSH key. Do not print credential files or secret values.
    `toolRef` such as `workbench.vlm_eval.run` and include all config tokens
    required by the tool template, including `vlm_backend`.
 
-3. On the agent VM, validate and plan:
+3. On the agent VM or through the agent API, validate and plan:
 
    ```bash
    npa/.venv/bin/npa workbench workflow validate-spec /tmp/spec.yaml --json
    npa/.venv/bin/npa workbench workflow plan-spec /tmp/spec.yaml --run-id agent-smoke --json
    npa/.venv/bin/npa workbench workflow run-spec /tmp/spec.yaml \
      --run-id agent-smoke --plan-only --scheduler-plan --json
+   ```
+
+   Equivalent API checks:
+
+   ```text
+   GET  /api/infra/k8s
+   POST /api/infra/provision
+   POST /api/workflows/validate
+   POST /api/workflows/plan
+   POST /api/workflows/submit
    ```
 
 4. Check K8s provisioning readiness from the agent VM:
@@ -50,9 +60,10 @@ agent record SSH key. Do not print credential files or secret values.
      --output-format json
    ```
 
-5. If the operator explicitly requests live execution, remove `--plan-only`
-   and let NPA provision Kubernetes as needed through normal NPA commands. Do
-   not manually create, delete, or mutate cloud resources outside NPA.
+5. If the operator explicitly requests live execution, let the agent use
+   `POST /api/workflows/submit` or `POST /api/infra/provision` so NPA provisions
+   Kubernetes as needed through normal NPA commands. Do not manually create,
+   delete, or mutate cloud resources outside NPA.
 
 ## Pass Criteria
 
@@ -65,4 +76,10 @@ agent record SSH key. Do not print credential files or secret values.
   requiring real workload execution.
 - `provision-if-absent --dry-run --output-format json` resolves the project and
   reports intended or existing K8s/storage actions without credential errors.
+- `GET /api/infra/k8s` reports configured and locally cached Kubernetes
+  backends. If none are present, chat should say no infra is specified and offer
+  options: deploy minimal infra with the agent, configure an existing backend, or
+  submit with explicit project/cluster target.
+- `POST /api/workflows/submit` validates YAML, provisions minimal Kubernetes
+  when allowed and needed, and records a scheduler plan/run record.
 

--- a/skills/workflows/agent-workflow-operate/SKILL.md
+++ b/skills/workflows/agent-workflow-operate/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: agent-workflow-operate
+description: Use when verifying that a bootstrapped NPA agent VM can create, validate, plan, provision for, or run npa.workflow YAMLs.
+---
+
+# Agent Workflow Operation
+
+## Operating Model
+
+- **Dev/operator VM** is the source of truth for NPA lifecycle, auth, SSH keys,
+  and agent records. Run `npa agent fresh-setup`, `bootstrap`, `status`, and
+  `verify-live` there.
+- **NPA agent VM** is the autonomous workbench execution surface. After
+  bootstrap, it must have staged `~/.npa/config.yaml`, `~/.npa/credentials.yaml`,
+  Nebius CLI profile material, and the NPA checkout needed to validate, plan,
+  provision, and run workflow YAMLs.
+- Do not use the dev VM full pytest suite as the acceptance test for agent
+  autonomy. The relevant check is whether the agent VM can operate workflows
+  with its bootstrapped config.
+
+## Test Framework
+
+Run the framework by SSHing from the dev VM into the active agent VM using the
+agent record SSH key. Do not print credential files or secret values.
+
+1. On the dev VM, resolve the active agent:
+
+   ```bash
+   npa/.venv/bin/npa agent status --project <project> --name <name> --json
+   ```
+
+2. From the dev VM, SSH to the agent public IP with the recorded key and create
+   a temporary `apiVersion: npa.workflow/v0.0.1` YAML. Use a known catalog
+   `toolRef` such as `workbench.vlm_eval.run` and include all config tokens
+   required by the tool template, including `vlm_backend`.
+
+3. On the agent VM, validate and plan:
+
+   ```bash
+   npa/.venv/bin/npa workbench workflow validate-spec /tmp/spec.yaml --json
+   npa/.venv/bin/npa workbench workflow plan-spec /tmp/spec.yaml --run-id agent-smoke --json
+   npa/.venv/bin/npa workbench workflow run-spec /tmp/spec.yaml \
+     --run-id agent-smoke --plan-only --scheduler-plan --json
+   ```
+
+4. Check K8s provisioning readiness from the agent VM:
+
+   ```bash
+   npa/.venv/bin/npa provision-if-absent --project <project> --dry-run \
+     --output-format json
+   ```
+
+5. If the operator explicitly requests live execution, remove `--plan-only`
+   and let NPA provision Kubernetes as needed through normal NPA commands. Do
+   not manually create, delete, or mutate cloud resources outside NPA.
+
+## Pass Criteria
+
+- Agent VM SSH works from the dev VM with the recorded key.
+- Agent VM has non-empty bootstrapped `~/.npa/config.yaml` and
+  `~/.npa/credentials.yaml`; do not print contents.
+- `validate-spec` returns JSON with `status: valid`.
+- `plan-spec` returns at least one planned step with the expected `tool_ref`.
+- `run-spec --plan-only --scheduler-plan` returns scheduler output without
+  requiring real workload execution.
+- `provision-if-absent --dry-run --output-format json` resolves the project and
+  reports intended or existing K8s/storage actions without credential errors.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add agent-side Kubernetes backend discovery and provisioning endpoints.
- Change agent workflow submit to validate YAML, ensure Kubernetes infra when needed, and return scheduler plans from the agent VM.
- Bootstrap the full NPA package plus deploy/cluster assets onto the agent VM so it can run NPA workflow/provision commands itself.
- Update chat routing so users can ask which K8s clusters/backends are present and get explicit options when no infra is specified.
- Carry forward and update the `agent-workflow-operate` skill for the implemented API model.

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks.
  - Local syntax check: `python3 -m py_compile npa/src/npa/cli/agent.py npa/src/npa/cli/agent_chat.py npa/src/npa/provisioning.py`
  - Dev VM focused tests: `npa/.venv/bin/python -m pytest npa/tests/cli/test_agent_workflow.py -q` -> `59 passed`.
  - Dev VM guardrail/agent tests after mergeability fix: `npa/.venv/bin/python -m pytest npa/tests/guardrails/test_agent_secret_guard.py npa/tests/cli/test_agent.py npa/tests/cli/test_agent_workflow.py -q` -> `106 passed, 1 warning`.
  - Dev VM agent verification: `NPA_AGENT_CHAT_LIVE=1 npa/.venv/bin/npa agent verify-live --project fresh-us-central1 --name agent` -> smoke `18 passed`, CLI `102 passed`, live E2E `18 passed`, `verify-live: ok`.
  - Live agent `/api/infra/k8s` reports agent NPA runtime ready and a Nebius MK8s cluster created by the agent.
  - Live agent workflow submit returns `ok=true`, `submit_mode=agent-live-infra-plan`, `scheduler_steps=1` when using existing agent-created infra.
  - Live multi-node workflow smoke succeeded on `npa-sweep-h200-preempt`: two H200 GPU pods completed on two different nodes and each reported `NVIDIA H200` via `nvidia-smi -L`.
- [ ] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`.
  - Not run in Cursor checkout because `npa/.venv` is absent there; agent/skill behavior covered by dev VM venv checks above.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Live infra note

- The agent successfully invoked NPA/Terraform on Nebius live infra.
- Working backend found after quota increase: `npa-sweep-h200-preempt`, 2 preemptible H200 GPU nodes, 1 GPU each.
- Earlier sweep attempts created control planes with failed/provisioning GPU node groups while quotas were zero; no manual cloud resource deletion was performed.

## Skill Maintenance

- [x] I updated the relevant root `skills/` entry and `skills/index.yaml`, or this PR does not change behavior that needs skill guidance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48ad7122-0df1-43a2-aac0-0418bd024712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48ad7122-0df1-43a2-aac0-0418bd024712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

