### PR TITLE
fix(sim2real): opt held-out eval into the BYO-robot task (match train/eval dims)

### DIFF
--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -2946,14 +2946,18 @@ def _normalize_byo_rl_signal(
     return payload
 
 
-def _byo_robot_trainer_env(config: Sim2RealLoopConfig) -> dict[str, str]:
-    """Robot-spec env for the BYO trainer sibling (opt-in, Franka-safe).
+def _byo_robot_env(config: Sim2RealLoopConfig) -> dict[str, str]:
+    """Robot-spec env that opts a component into the BYO-robot path (Franka-safe).
 
-    Returns the env that opts the trainer into its BYO-robot path and forwards the
-    SAME robot inputs the held-out eval receives (``_run_heldout_*`` sets these),
-    so a customer's ``robot_spec_uri`` / preset reaches RL training and eval as one
-    embodiment. Returns ``{}`` — i.e. leaves the trainer on the stock-Franka path,
-    byte-for-byte unchanged — when no robot is requested or it is stock Franka.
+    Shared by BOTH the BYO trainer sibling and the held-out eval, so a customer's
+    ``robot_spec_uri`` / preset reaches RL training AND eval as ONE embodiment with
+    matching action/observation dims. The ``NPA_BYO_ROBOT_TASK=1`` flag is the gate
+    both ``byo_isaac_trainer`` and ``byo_isaac_eval`` check before resolving the spec
+    and registering the retargeted Lift variant — without it, the eval builds a stock
+    Franka-dimensioned env and a non-Franka checkpoint fails to load.
+
+    Returns ``{}`` — leaving the component on the stock-Franka path, byte-for-byte
+    unchanged — when no robot is requested or it is stock Franka.
     """
 
     uri = (config.robot_spec_uri or "").strip()
@@ -3027,7 +3031,7 @@ def _run_trainer_via_command(
     # stock Franka. Forward the same robot inputs the eval gets + opt in the trainer's
     # BYO-robot path so train and eval share one embodiment. Empty (Franka/no robot)
     # -> nothing added, trainer path byte-for-byte unchanged.
-    extra.update(_byo_robot_trainer_env(config))
+    extra.update(_byo_robot_env(config))
     env = _component_env(
         config,
         component="trainer",
@@ -3080,26 +3084,33 @@ def run_heldout_eval(
     output_path = output_dir / "report.json"
     inner_path = output_dir / f"inner-evidence-outer-{outer_iteration:02d}.json"
     _write_json_artifact(inner_path, inner_evidence)
+    extra = {
+        "NPA_SIM2REAL_HELDOUT_ENVS_DIR": str(local_dir / "envs" / "heldout"),
+        "NPA_SIM2REAL_HELDOUT_ENV_COUNT": str(config.heldout_env_count),
+        "NPA_SIM2REAL_INNER_EVIDENCE_JSON": str(inner_path),
+        "NPA_SIM2REAL_THRESHOLD": str(config.threshold),
+        "NPA_SIM2REAL_EVAL_IMAGE": config.eval_image,
+        "NPA_SIM2REAL_ISAAC_IMAGE": config.isaac_image,
+        "NPA_SIM2REAL_SIM_BACKEND": config.sim_backend,
+        "NPA_SIM2REAL_ISAAC_TASK": config.isaac_task,
+        "NPA_SIM2REAL_SCENE_SPEC_URI": config.scene_spec_uri,
+        "NPA_SIM2REAL_ASSETS_URI": config.assets_uri,
+        "NPA_SIM2REAL_CAMERAS_URI": config.cameras_uri,
+    }
+    # BYO robot: opt the held-out eval into the SAME robot-swapped Lift variant the
+    # policy trained on. This sets NPA_BYO_ROBOT_TASK=1 (+ the robot uri/source/preset)
+    # so byo_isaac_eval resolves the spec, ships the retarget module, and registers the
+    # customer's task variant — giving the eval env the SAME action/observation dims as
+    # training. Without the flag the eval built a stock Franka-dimensioned env, and a
+    # non-Franka checkpoint failed to load into the eval ActorCritic (size mismatch).
+    # Franka-safe: _byo_robot_env returns {} for no-robot / stock, so the eval env is
+    # byte-for-byte unchanged on the stock path.
+    extra.update(_byo_robot_env(config))
     env = _component_env(
         config,
         component="heldout_eval",
         output_json=output_path,
-        extra={
-            "NPA_SIM2REAL_HELDOUT_ENVS_DIR": str(local_dir / "envs" / "heldout"),
-            "NPA_SIM2REAL_HELDOUT_ENV_COUNT": str(config.heldout_env_count),
-            "NPA_SIM2REAL_INNER_EVIDENCE_JSON": str(inner_path),
-            "NPA_SIM2REAL_THRESHOLD": str(config.threshold),
-            "NPA_SIM2REAL_EVAL_IMAGE": config.eval_image,
-            "NPA_SIM2REAL_ISAAC_IMAGE": config.isaac_image,
-            "NPA_SIM2REAL_SIM_BACKEND": config.sim_backend,
-            "NPA_SIM2REAL_ISAAC_TASK": config.isaac_task,
-            "NPA_SIM2REAL_SCENE_SPEC_URI": config.scene_spec_uri,
-            "NPA_SIM2REAL_ASSETS_URI": config.assets_uri,
-            "NPA_SIM2REAL_CAMERAS_URI": config.cameras_uri,
-            "NPA_SIM2REAL_ROBOT_SPEC_URI": config.robot_spec_uri,
-            "NPA_SIM2REAL_ROBOT_SOURCE": config.robot_source,
-            "NPA_SIM2REAL_ROBOT_PRESET": config.robot_preset,
-        },
+        extra=extra,
     )
     # Default the genuine-RL Isaac path to the real-policy held-out eval
     # (byo_isaac_eval loads the trained rsl_rl checkpoint and rolls it in Isaac

--- a/npa/tests/workflows/test_byo_robot_staged_routing.py
+++ b/npa/tests/workflows/test_byo_robot_staged_routing.py
@@ -2,10 +2,14 @@
 
 Previously a BYO ``robot_spec_uri`` reached only the held-out eval USD-swap; the
 trainer sibling never received the robot vars, so the policy trained on the stock
-Franka. These cover the two seams that close that gap:
+Franka. These cover the seams that close that gap:
 
-* ``engine._byo_robot_trainer_env`` — forwards the robot inputs + opts the trainer
-  into the BYO-robot path, and is Franka-safe (empty for no-robot / stock).
+* ``engine._byo_robot_env`` — forwards the robot inputs + opts a component into the
+  BYO-robot path, and is Franka-safe (empty for no-robot / stock). Shared by the
+  trainer sibling AND the held-out eval so both build the SAME embodiment/dims.
+* ``engine.run_heldout_eval`` — merges ``_byo_robot_env`` into the eval env, so the
+  held-out eval opts into ``NPA_BYO_ROBOT_TASK=1`` (else it evaluates a stock
+  Franka-dimensioned env a non-Franka checkpoint can't load into).
 * ``byo_isaac_trainer._resolve_byo_robot_spec`` — resolves a ``robot_spec_uri``
   JSON via the same parser the eval uses (mocked here; no cluster / no network).
 """
@@ -14,26 +18,28 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from npa.workflows.sim2real import byo_isaac_trainer as trainer
 from npa.workflows.sim2real import engine
 from npa.workflows.sim2real.models import Sim2RealLoopConfig
 
 
 # --------------------------------------------------------------------------- #
-# engine._byo_robot_trainer_env — forward robot vars to the trainer sibling
+# engine._byo_robot_env — forward robot vars to the trainer sibling
 # --------------------------------------------------------------------------- #
 def test_trainer_env_empty_for_no_robot():
-    assert engine._byo_robot_trainer_env(Sim2RealLoopConfig(run_id="r")) == {}
+    assert engine._byo_robot_env(Sim2RealLoopConfig(run_id="r")) == {}
 
 
 def test_trainer_env_empty_for_stock_franka_source():
     cfg = Sim2RealLoopConfig(run_id="r", robot_source="stock_franka")
-    assert engine._byo_robot_trainer_env(cfg) == {}
+    assert engine._byo_robot_env(cfg) == {}
 
 
 def test_trainer_env_set_for_spec_uri():
     cfg = Sim2RealLoopConfig(run_id="r", robot_spec_uri="s3://b/kinova/robot-spec.json")
-    env = engine._byo_robot_trainer_env(cfg)
+    env = engine._byo_robot_env(cfg)
     assert env["NPA_BYO_ROBOT_TASK"] == "1"
     assert env["NPA_SIM2REAL_ROBOT_SPEC_URI"] == "s3://b/kinova/robot-spec.json"
     # forwarded even when blank so the trainer sees the same trio the eval does
@@ -42,12 +48,52 @@ def test_trainer_env_set_for_spec_uri():
 
 
 def test_trainer_env_set_for_preset_and_byo_source():
-    assert engine._byo_robot_trainer_env(
+    assert engine._byo_robot_env(
         Sim2RealLoopConfig(run_id="r", robot_preset="ur10e")
     )["NPA_BYO_ROBOT_TASK"] == "1"
-    assert engine._byo_robot_trainer_env(
+    assert engine._byo_robot_env(
         Sim2RealLoopConfig(run_id="r", robot_source="byo_usd")
     )["NPA_BYO_ROBOT_TASK"] == "1"
+
+
+# --------------------------------------------------------------------------- #
+# engine.run_heldout_eval — held-out eval opts into the BYO-robot path too, so it
+# evaluates the SAME retargeted variant (matching dims) the policy trained on.
+# --------------------------------------------------------------------------- #
+class _StopComponentEnv(RuntimeError):
+    """Sentinel to short-circuit run_heldout_eval right after the env is built."""
+
+
+def _capture_heldout_extra(cfg: Sim2RealLoopConfig, tmp_path, monkeypatch) -> dict:
+    captured: dict = {}
+
+    def _fake_component_env(config, *, component, output_json=None, extra=None):
+        captured.update(extra or {})
+        raise _StopComponentEnv
+
+    monkeypatch.setattr(engine, "_component_env", _fake_component_env)
+    with pytest.raises(_StopComponentEnv):
+        engine.run_heldout_eval(
+            cfg, local_dir=tmp_path, inner_evidence={}, outer_iteration=1
+        )
+    return captured
+
+
+def test_heldout_eval_opts_into_byo_robot_task(tmp_path, monkeypatch):
+    cfg = Sim2RealLoopConfig(
+        run_id="r", robot_spec_uri="s3://b/lite6/lite6_parallel.json"
+    )
+    extra = _capture_heldout_extra(cfg, tmp_path, monkeypatch)
+    # The gate byo_isaac_eval checks before resolving the spec + registering the
+    # retargeted task must be present, alongside the robot uri.
+    assert extra["NPA_BYO_ROBOT_TASK"] == "1"
+    assert extra["NPA_SIM2REAL_ROBOT_SPEC_URI"] == "s3://b/lite6/lite6_parallel.json"
+
+
+def test_heldout_eval_stock_franka_unchanged(tmp_path, monkeypatch):
+    cfg = Sim2RealLoopConfig(run_id="r")  # no robot -> stock Franka path
+    extra = _capture_heldout_extra(cfg, tmp_path, monkeypatch)
+    assert "NPA_BYO_ROBOT_TASK" not in extra  # byte-for-byte stock eval
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Let a **non-Franka policy actually be evaluated held-out**. Today the staged
held-out eval builds a stock-Franka-dimensioned Lift env for a non-Franka robot, so
the trained checkpoint can't load into the eval network.

## Root cause

`byo_isaac_eval` only resolves + ships the customer robot spec (and registers the
retargeted task variant) when `NPA_BYO_ROBOT_TASK == "1"` is in its env. But
`engine.run_heldout_eval` forwarded the robot `uri`/`source`/`preset` **without**
that flag — only the trainer path (`_byo_robot_trainer_env`) set it. Result: the
eval built the stock Franka action/obs space while the trainer's retarget built the
robot's own space, so the checkpoint failed to load:

```
size mismatch for actor.0.weight: checkpoint torch.Size([256, 33]) vs current torch.Size([256, 36])
size mismatch for actor.6.weight: checkpoint torch.Size([7, 64])   vs current torch.Size([8, 64])
```

(observed onboarding a UFactory Lite6 parallel-jaw robot: trainer action=7 = 6 arm +
1 binary gripper, obs=33; eval action=8 = Franka, obs=36).

## Fix

Generalize the trainer's robot-env helper to `_byo_robot_env` (it was always
robot-agnostic) and merge it into the held-out eval's component env, so the eval
opts into `NPA_BYO_ROBOT_TASK=1` and registers the SAME retargeted variant the
policy trained on — matching action/observation dims.

**Franka-safe:** `_byo_robot_env` returns `{}` for no-robot / stock, so the stock
eval env is byte-for-byte unchanged.

## Tests

`_byo_robot_env` rename kept under its existing tests; new tests assert
`run_heldout_eval` sets `NPA_BYO_ROBOT_TASK=1` for a BYO config and leaves it unset
for stock Franka (infra untouched — `_component_env` is monkeypatched to capture the
env). Full `test_byo_robot_staged_routing` + `test_byo_robot_wiring` suites pass.

## Relationship to PR #166

Complements #166 (minimal-spec onboarding + the `usd_path` resolver fix). #166 gets a
non-Franka robot to **train**; this PR is needed to **evaluate** it held-out. Both are
required to measure a real `success@0.10` for a non-Franka embodiment. Independent
diffs (this touches only `engine.py`).

## Validation note

Verified off-GPU (env-wiring is pure + unit-tested). The full end-to-end proof — a
non-Franka checkpoint loading and rolling out held-out — requires a GPU staged run;
this change removes the dimensional blocker that made that impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
