### PR TITLE
feat(sim2real): object-scale for BYO Lift + held-out eval applies the robot-aware task config

### DIFF
--- a/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
@@ -643,8 +643,10 @@ def run_isaac_eval_job(
     # spec resolution + payload so train and eval agree on the variant.
     robot_spec_dict = None
     robot_usd_uri = ""
+    task_config_dict = None
     if _env("NPA_BYO_ROBOT_TASK") == "1":
         from npa.workflows.sim2real import byo_isaac_trainer as _trainer
+        from npa.workflows.sim2real import isaac_byo_robot_task as _robotmod
 
         spec = _trainer._resolve_byo_robot_spec()
         usd_dest = ""
@@ -656,8 +658,17 @@ def run_isaac_eval_job(
             elif robot_uri:
                 usd_dest = robot_uri
         robot_spec_dict = _trainer.robot_spec_payload(spec, usd_container_path=usd_dest)
+        # Matched robot-aware task config (object scale / placement / gripper targets)
+        # so the held-out eval spawns and rolls the policy on the SAME scaled task the
+        # trainer used — most importantly the SAME manipuland size. Without this a
+        # shrunk-object policy is scored on the stock ~5 cm cube and reports a false
+        # zero. register() in the eval sibling consumes it via task_config_from_env().
+        task_config_dict = _robotmod.task_config_from_env()
         print(f"byo_isaac_eval: BYO-ROBOT eval path "
               f"{'ON' if robot_spec_dict else 'OFF (no spec)'} -> {robot_spec_dict}", flush=True)
+        print(f"byo_isaac_eval: BYO task config "
+              f"{'-> ' + json.dumps(task_config_dict, sort_keys=True) if task_config_dict else 'none'}",
+              flush=True)
 
     manifest = build_isaac_eval_job_manifest(
         job_name=job_name, run_id=run_id, image=image, task=task, num_envs=num_envs,
@@ -665,7 +676,7 @@ def run_isaac_eval_job(
         s3_endpoint=_env("AWS_ENDPOINT_URL"), namespace=namespace,
         service_account=sa, gpu_product=gpu_product, seed=seed, object_usd=object_usd,
         env_ids_json=json.dumps([e["env_id"] for e in gen]), renders_s3_prefix=renders_prefix,
-        robot_spec=robot_spec_dict, robot_usd_uri=robot_usd_uri,
+        robot_spec=robot_spec_dict, robot_usd_uri=robot_usd_uri, task_config=task_config_dict,
     )
     _kubectl(["delete", "job", job_name, "-n", namespace, "--ignore-not-found"], timeout=60)
     apply = _kubectl(["apply", "-f", "-"], stdin=json.dumps(manifest), timeout=120)

--- a/npa/src/npa/workflows/sim2real/isaac_byo_robot_task.py
+++ b/npa/src/npa/workflows/sim2real/isaac_byo_robot_task.py
@@ -411,6 +411,31 @@ def _range_dict(value: Any) -> dict[str, tuple[float, float]]:
     return out
 
 
+def _scale_triple(value: Any) -> tuple[float, float, float] | None:
+    """Coerce an object-scale value to a positive ``(x, y, z)`` tuple, or ``None``.
+
+    Accepts a scalar (uniform scale) or a 3-element list/tuple. A small-aperture
+    gripper (e.g. a parallel jaw) cannot force-close on the stock ~5 cm Lift cube,
+    so the manipuland must be shrunk to fit; this normalizes whatever the derived
+    task config carries into the tuple the object spawn cfg expects. Non-positive
+    or malformed values return ``None`` (term dropped) rather than corrupting the
+    scene — mirrors the other ``task_config_overrides`` fields.
+    """
+
+    if isinstance(value, bool):  # bool is an int subclass; reject explicitly
+        return None
+    if isinstance(value, (int, float)):
+        s = float(value)
+        return (s, s, s) if s > 0 else None
+    if isinstance(value, (list, tuple)) and len(value) == 3:
+        try:
+            triple = tuple(float(v) for v in value)
+        except (TypeError, ValueError):
+            return None
+        return triple if all(v > 0 for v in triple) else None
+    return None
+
+
 def task_config_overrides(task_cfg: dict[str, Any] | None) -> dict[str, Any]:
     """Map a B2-derived task-config dict to the Lift-env mutations ``register`` applies.
 
@@ -430,6 +455,13 @@ def task_config_overrides(task_cfg: dict[str, Any] | None) -> dict[str, Any]:
             out["action_scale"] = float(action_scale)
         except (TypeError, ValueError):
             pass
+
+    # Object scale: shrink the Lift manipuland to the gripper's aperture. Only
+    # carried when the config explicitly sets it, so the Franka path (never sets
+    # it) and any large-gripper robot keep the stock object. See _scale_triple.
+    scale = _scale_triple(task_cfg.get("object_scale"))
+    if scale is not None:
+        out["object_scale"] = scale
 
     obj_range = _range_dict(task_cfg.get("object_init_range"))
     if obj_range:
@@ -965,6 +997,25 @@ def register(spec: dict[str, Any] | None = None, task_cfg: dict[str, Any] | None
             except Exception as exc:  # noqa: BLE001
                 print("ROBOT_TASKCFG_ERR grasp_hold", repr(exc), flush=True)
                 skipped.append("rewards.grasp_hold")
+
+        # (i) object scale: resize the Lift manipuland to the robot's gripper. A
+        # small parallel-jaw aperture cannot force-close on the stock ~5 cm cube, so
+        # the grasp->lift never completes; scaling the object down is what lets the
+        # STRETCH lift succeed. Applied in BOTH training and held-out eval (register()
+        # runs in each) so the policy is trained and scored on the SAME object size.
+        # Gated on object_scale in the derived config; never set on the Franka path.
+        if "object_scale" in task_over:
+            try:
+                obj = getattr(getattr(env_cfg, "scene", None), "object", None)
+                spawn = getattr(obj, "spawn", None)
+                if spawn is not None and hasattr(spawn, "scale"):
+                    spawn.scale = tuple(task_over["object_scale"])
+                    applied.append("scene.object.spawn.scale%s" % (tuple(task_over["object_scale"]),))
+                else:
+                    skipped.append("scene.object.spawn.scale")
+            except Exception as exc:  # noqa: BLE001
+                print("ROBOT_TASKCFG_ERR object_scale", repr(exc), flush=True)
+                skipped.append("scene.object.spawn.scale")
 
         print("ROBOT_TASKCFG applied=%s skipped=%s" % (applied, skipped), flush=True)
 

--- a/npa/tests/workflows/test_byo_isaac_eval.py
+++ b/npa/tests/workflows/test_byo_isaac_eval.py
@@ -130,6 +130,43 @@ def test_eval_manifest_embeds_custom_object_usd():
     assert 'EVAL_OBJECT_USD="http://assets/custom.usd"' in args
 
 
+def _byo_manifest_args(**kw):
+    m = ev.build_isaac_eval_job_manifest(
+        job_name="j", run_id="r", image="reg/npa-isaac-lab:2.3.2.post1",
+        task="Isaac-Lift-Cube-Franka-v0", num_envs=2, checkpoint_uri="s3://b/m.pt",
+        per_env_s3_uri="s3://b/o/d.json", s3_endpoint="https://s3", namespace="default",
+        service_account="agent-sa", gpu_product="NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition",
+        robot_spec={"name": "lite6", "robot_source": "byo_usd",
+                    "usd_path": "/tmp/npa_robot/robot.usd"},
+        **kw)
+    return m["spec"]["template"]["spec"]["containers"][0]["args"][0]
+
+
+def test_eval_manifest_forwards_task_config_object_scale():
+    # A BYO-robot eval given a task config injects NPA_BYO_TASK_CONFIG_JSON so the
+    # eval sibling's register() sizes the manipuland to the SAME scale as training
+    # (else a shrunk-object policy is scored on the stock cube and reports a false 0).
+    args = _byo_manifest_args(task_config={"object_scale": 0.2, "gripper_open": 0.0089})
+    # Assert the actual env export line (the module source, cat'd into the sibling,
+    # also mentions the constant name, so match the `export ...=` form specifically).
+    assert "export NPA_BYO_TASK_CONFIG_JSON=" in args
+    assert '"object_scale": 0.2' in args  # json.dumps(sort_keys=True)
+
+
+def test_eval_manifest_no_task_config_no_injection():
+    # BYO robot but no task config -> the env var is not exported (stock placement);
+    # and the Franka/no-robot path never exports it at all.
+    assert "export NPA_BYO_TASK_CONFIG_JSON=" not in _byo_manifest_args(task_config=None)
+    m = ev.build_isaac_eval_job_manifest(
+        job_name="j", run_id="r", image="reg/npa-isaac-lab:2.3.2.post1",
+        task="Isaac-Lift-Cube-Franka-v0", num_envs=2, checkpoint_uri="s3://b/m.pt",
+        per_env_s3_uri="s3://b/o/d.json", s3_endpoint="https://s3", namespace="default",
+        service_account="agent-sa", gpu_product="NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition",
+        task_config={"object_scale": 0.2})  # no robot_spec -> Franka path
+    args = m["spec"]["template"]["spec"]["containers"][0]["args"][0]
+    assert "export NPA_BYO_TASK_CONFIG_JSON=" not in args
+
+
 def test_normalize_heldout_preserves_render_manifest_and_provenance():
     """BYO-eval render_manifest + provenance must survive engine normalization."""
     from npa.workflows.sim2real.engine import _normalize_heldout_report

--- a/npa/tests/workflows/test_robot_aware_task_config.py
+++ b/npa/tests/workflows/test_robot_aware_task_config.py
@@ -99,6 +99,19 @@ def test_grasp_hold_weight_passthrough_and_shipped():
     assert "def grasp_lift_hold" in robotmod.module_source()
 
 
+def test_object_scale_normalizes_and_gates():
+    # A scalar becomes a uniform (x, y, z) tuple; an explicit triple is preserved.
+    assert robotmod.task_config_overrides({"object_scale": 0.2})["object_scale"] == (0.2, 0.2, 0.2)
+    assert robotmod.task_config_overrides(
+        {"object_scale": [0.2, 0.3, 0.4]}
+    )["object_scale"] == (0.2, 0.3, 0.4)
+    # Non-positive / malformed / wrong-arity / bool are dropped (never corrupt the
+    # scene), and an absent object_scale is not carried (Franka + large-gripper safe).
+    for bad in (0, -1, "big", [0.2, 0.2], [0.2, 0.2, 0.2, 0.2], True, None):
+        assert "object_scale" not in robotmod.task_config_overrides({"object_scale": bad})
+    assert "object_scale" not in robotmod.task_config_overrides({"action_scale": 0.5})
+
+
 # --------------------------------------------------------------------------- #
 # Franka byte-for-byte: stock spec -> no overrides
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

A small parallel-jaw gripper (e.g. UFactory Lite6, ~1.8 cm aperture) cannot force-close on the stock ~5 cm Lift cube, so the grasp→lift never completes. This adds an `object_scale` knob to the robot-aware task config so the manipuland is sized to the gripper, applied consistently to **both training and the held-out eval**, and wires the held-out eval to actually receive the robot-aware task config — the missing half of train/eval parity.

## Changes

- **`isaac_byo_robot_task.task_config_overrides`** — parse `object_scale` (scalar or 3-tuple) via a new `_scale_triple` helper; non-positive / malformed / wrong-arity values are dropped. Carried only when the config sets it, so the Franka path and large-gripper robots keep the stock object.
- **`isaac_byo_robot_task._apply_task_config`** — apply it to `env.scene.object.spawn.scale` (guarded; records `applied`/`skipped`). `register()` runs in **both** the trainer wrapper and the held-out eval, so the policy is trained and scored on the same object size.
- **`byo_isaac_eval.main`** — forward the robot-aware task config to the eval sibling. The manifest builder already injects `NPA_BYO_TASK_CONFIG_JSON` (and `register()` consumes it via `task_config_from_env()`), but `main` never passed one, so the held-out eval was spawning the stock-size cube and applying none of the robot-aware task numbers. Without this a shrunk-object policy is scored on the full cube and reports a false zero; it also brings gripper-target / placement parity to eval.

**Franka-safe:** no `object_scale` in the Franka-derived config → the stock path is byte-for-byte unchanged.

## Tests

`107 passed` (3 new): `object_scale` normalization + gating; the eval manifest forwards the task config (with `object_scale`) only on the BYO-robot path, not the Franka/no-robot path.

## Measured on GPU (UFactory Lite6 parallel-jaw, staged Sim2Real Lift, RTX-PRO cluster)

Verified end-to-end (`object_scale=0.3`):

- Trainer applies `scene.object.spawn.scale(0.3, 0.3, 0.3)`; the held-out eval applies the **same** scale (`ROBOT_TASKCFG applied=[…, 'scene.object.spawn.scale(0.3, 0.3, 0.3)']`) — train/eval object-size parity.
- The held-out eval now runs to completion for a non-Franka embodiment (`rollout_ok`, 4 envs) and produces a **measured** `success@0.10` — enabled by the train/eval dim parity from #169 plus this task-config forwarding.

### STRETCH (real lift): honest negative

Across object scales (stock ~5 cm, `0.2`, `0.3`) the Lite6 reaches the object and closes the gripper near it (mean reward climbs 0.7 → ~3–6), but **never lifts it**: `dense_lift_progress ≈ 0` in every run, and the measured held-out `success@0.10 = 0.00` (object-to-goal distances 0.25–0.52 m). Shrinking the manipuland is **necessary but not sufficient** — with the object fitting the jaw, the blocker shifts from "can't close around it" to "closes near it but can't achieve a force-closure grasp that lifts." The remaining lever is grasp force / a contact- or VLM-based grasp reward (follow-up), not object size. (The very small `0.2` scale additionally destabilized training with an `action_rate` blow-up; `0.3` trained stably.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
