### PR TITLE
Fix agent Sim2Real run status rendering

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -40,9 +40,6 @@ regexes = [
     '''hf_testsecret123456''',
     '''hf_npae2eworkflowsecret1234567890''',
     '''AKIAABCDEFGHIJKLMNOP''',
-    # Validated sim2real working bucket already in public branch history (PR #147);
-    # an operational identifier, not a credential. The doc now renders a placeholder.
-    '''lerobot-ccc9d3c7''',
 ]
 paths = [
     '''SECURITY\.md''',

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -268,7 +268,7 @@ run id from submit output.
 ```bash
 source ~/.npa/sim2real-operator.env   # sets AWS_* and endpoint
 RUN=sim2real-staged-20260615t180818z
-BUCKET=lerobot-ccc9d3c7
+BUCKET="${S3_BUCKET:-<your-bucket>}"
 PREFIX="s3://${BUCKET}/sim2real-b/${RUN}"
 
 # E2E summary (includes rerun_serve.public_url when auto-serve ran)

--- a/npa/scripts/verify_agent_artifact_discovery_live.sh
+++ b/npa/scripts/verify_agent_artifact_discovery_live.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Live verification for NPA agent artifact discovery:
+# 1. discover runs, 2. list artifacts, 3. load one artifact.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+PROJECT="${NPA_AGENT_PROJECT:-fresh-us-central1}"
+NAME="${NPA_AGENT_NAME:-agent}"
+NPA_BIN="${NPA_BIN:-$ROOT/npa/.venv/bin/npa}"
+PY_BIN="${PY_BIN:-$ROOT/npa/.venv/bin/python}"
+
+AUTH_ENV="${NPA_AGENT_AUTH_ENV:-$HOME/.npa/agents/${PROJECT}/${NAME}/auth.env}"
+if [[ ! -f "$AUTH_ENV" ]]; then
+  echo "missing auth env: $AUTH_ENV" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$AUTH_ENV"
+
+BASE="$("$NPA_BIN" agent status --project "$PROJECT" --name "$NAME" --json \
+  | "$PY_BIN" -c 'import json,sys; print(json.load(sys.stdin).get("public_url","").rstrip("/"))')"
+if [[ -z "$BASE" ]]; then
+  echo "agent public_url is empty" >&2
+  exit 1
+fi
+
+export BASE AGENT_USER AGENT_PASSWORD
+"$PY_BIN" - <<'PY'
+from __future__ import annotations
+
+import base64
+import json
+import os
+import ssl
+import time
+import urllib.parse
+import urllib.request
+
+base = os.environ["BASE"]
+auth = base64.b64encode(f"{os.environ['AGENT_USER']}:{os.environ['AGENT_PASSWORD']}".encode()).decode()
+ctx = ssl._create_unverified_context()
+
+
+def request(path: str, *, method: str = "GET", payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {"Authorization": f"Basic {auth}"}
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, context=ctx, timeout=120) as resp:
+        return json.loads(resp.read().decode())
+
+
+def ensure_local_run() -> str:
+    runs = request("/api/artifacts/runs?limit=20")
+    if runs.get("ok") and runs.get("runs"):
+        return str(runs["runs"][0]["run_id"])
+    submit = request("/api/workflows/sim2real/submit", method="POST", payload={})
+    run_id = str(submit["run_id"])
+    for _ in range(90):
+        detail = request(f"/api/workflows/sim2real/runs/{urllib.parse.quote(run_id)}")
+        run = detail.get("run", {})
+        if run.get("result") in {"completed", "failed"} or run.get("status") in {"completed", "failed"}:
+            break
+        time.sleep(1)
+    return run_id
+
+
+run_id = ensure_local_run()
+
+# Component 1: discover runs.
+runs = request("/api/artifacts/runs?limit=50")
+assert runs.get("ok") is True, runs
+assert any(str(item.get("run_id")) == run_id for item in runs.get("runs", [])), runs
+
+# Component 2: list artifacts for a run.
+listed = request(f"/api/artifacts/run/{urllib.parse.quote(run_id)}")
+assert listed.get("ok") is True, listed
+artifacts = listed.get("artifacts", [])
+assert artifacts, listed
+preferred = listed.get("preferred") or artifacts[0]
+assert preferred.get("key"), preferred
+
+# Component 3: load an artifact.
+loaded = request(
+    "/api/sim-viz/load-artifact",
+    method="POST",
+    payload={"run_id": run_id, "key": preferred["key"]},
+)
+assert loaded.get("ok") is True, loaded
+assert loaded.get("render"), loaded
+sim_viz = loaded.get("sim_viz", {})
+assert sim_viz.get("run_id") == run_id, sim_viz
+
+print(json.dumps({
+    "ok": True,
+    "run_id": run_id,
+    "discover_source": runs.get("source", "s3"),
+    "artifact_count": len(artifacts),
+    "loaded_render": loaded.get("render"),
+}, sort_keys=True))
+PY

--- a/npa/scripts/verify_agent_artifact_discovery_live.sh
+++ b/npa/scripts/verify_agent_artifact_discovery_live.sh
@@ -53,9 +53,9 @@ def request(path: str, *, method: str = "GET", payload: dict | None = None) -> d
         return json.loads(resp.read().decode())
 
 
-def ensure_local_run() -> str:
+def ensure_s3_run() -> str:
     runs = request("/api/artifacts/runs?limit=20")
-    if runs.get("ok") and runs.get("runs"):
+    if runs.get("ok") and runs.get("runs") and runs.get("source", "s3") != "local":
         return str(runs["runs"][0]["run_id"])
     submit = request("/api/workflows/sim2real/submit", method="POST", payload={})
     run_id = str(submit["run_id"])
@@ -65,19 +65,24 @@ def ensure_local_run() -> str:
         if run.get("result") in {"completed", "failed"} or run.get("status") in {"completed", "failed"}:
             break
         time.sleep(1)
+    assert request(f"/api/workflows/sim2real/runs/{urllib.parse.quote(run_id)}")["run"].get("result") == "completed"
     return run_id
 
 
-run_id = ensure_local_run()
+run_id = ensure_s3_run()
 
 # Component 1: discover runs.
 runs = request("/api/artifacts/runs?limit=50")
 assert runs.get("ok") is True, runs
+assert runs.get("source", "s3") != "local", runs
+assert not runs.get("s3_error"), runs
 assert any(str(item.get("run_id")) == run_id for item in runs.get("runs", [])), runs
 
 # Component 2: list artifacts for a run.
 listed = request(f"/api/artifacts/run/{urllib.parse.quote(run_id)}")
 assert listed.get("ok") is True, listed
+assert listed.get("source", "s3") != "local", listed
+assert not listed.get("s3_error"), listed
 artifacts = listed.get("artifacts", [])
 assert artifacts, listed
 preferred = listed.get("preferred") or artifacts[0]
@@ -90,6 +95,8 @@ loaded = request(
     payload={"run_id": run_id, "key": preferred["key"]},
 )
 assert loaded.get("ok") is True, loaded
+assert loaded.get("source", "s3") != "local", loaded
+assert not loaded.get("s3_error"), loaded
 assert loaded.get("render"), loaded
 sim_viz = loaded.get("sim_viz", {})
 assert sim_viz.get("run_id") == run_id, sim_viz

--- a/npa/scripts/verify_agent_artifact_discovery_live.sh
+++ b/npa/scripts/verify_agent_artifact_discovery_live.sh
@@ -56,7 +56,15 @@ def request(path: str, *, method: str = "GET", payload: dict | None = None) -> d
 def ensure_s3_run() -> str:
     runs = request("/api/artifacts/runs?limit=20")
     if runs.get("ok") and runs.get("runs") and runs.get("source", "s3") != "local":
-        return str(runs["runs"][0]["run_id"])
+        for row in runs["runs"]:
+            run_id = str(row["run_id"])
+            try:
+                listed = request(f"/api/artifacts/run/{urllib.parse.quote(run_id)}")
+            except Exception:
+                continue
+            preferred = listed.get("preferred") or {}
+            if preferred.get("render") == "rerun":
+                return run_id
     submit = request("/api/workflows/sim2real/submit", method="POST", payload={})
     run_id = str(submit["run_id"])
     for _ in range(90):
@@ -87,6 +95,7 @@ artifacts = listed.get("artifacts", [])
 assert artifacts, listed
 preferred = listed.get("preferred") or artifacts[0]
 assert preferred.get("key"), preferred
+assert preferred.get("render") == "rerun", preferred
 
 # Component 3: load an artifact.
 loaded = request(
@@ -98,6 +107,7 @@ assert loaded.get("ok") is True, loaded
 assert loaded.get("source", "s3") != "local", loaded
 assert not loaded.get("s3_error"), loaded
 assert loaded.get("render"), loaded
+assert loaded.get("render") == "rerun", loaded
 sim_viz = loaded.get("sim_viz", {})
 assert sim_viz.get("run_id") == run_id, sim_viz
 

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2394,7 +2394,8 @@ def _apply_loaded_artifact(
         filename = _artifact_filename(key)
         target = RECORDINGS_DIR / filename
         target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(local_path, target)
+        if local_path.resolve() != target.resolve():
+            shutil.copy2(local_path, target)
         preview_url = _artifact_preview_url(filename)
         sim_viz["artifact_preview_url"] = preview_url
         sim_viz["artifact_download_url"] = preview_url
@@ -3226,6 +3227,23 @@ def _run_sim2real_pipeline_background(run_id: str, selection: dict) -> None:
     report_path = output_dir / "reports" / "sim2real-report.json"
     rrd_path = output_dir / "reports" / "sim2real.rrd"
 
+    def _upload_output_file(path: Path, relative_key: str) -> str:
+        if not path.is_file():
+            return ""
+        settings = _agent_s3_settings()
+        if not settings.get("bucket"):
+            return ""
+        s3, settings = _agent_s3_client()
+        key = _join_agent_s3_prefix(
+            _join_agent_s3_prefix(str(settings.get("prefix") or ""), "sim2real-b"),
+            f"{{run_id}}/{{relative_key}}",
+        )
+        content_type = "application/octet-stream"
+        if path.suffix.lower() == ".json":
+            content_type = "application/json"
+        s3.put_object(Bucket=settings["bucket"], Key=key, Body=path.read_bytes(), ContentType=content_type)
+        return f"s3://{{settings['bucket']}}/{{key}}"
+
     def _finish(details: dict) -> dict:
         stdout_tail = (proc.stdout or "")[-4000:].strip()
         stderr_tail = (proc.stderr or "")[-4000:].strip()
@@ -3263,6 +3281,17 @@ def _run_sim2real_pipeline_background(run_id: str, selection: dict) -> None:
                 pass
             _restart_rerun_serve(force=True)
             _append_run_log(details, f"Published Rerun recording: {{rrd_path}}")
+        uploaded = []
+        for path, rel in ((report_path, "reports/sim2real-report.json"), (rrd_path, "reports/sim2real.rrd")):
+            try:
+                uri = _upload_output_file(path, rel)
+                if uri:
+                    uploaded.append(uri)
+            except Exception as exc:
+                _append_run_log(details, f"Failed to upload {{rel}} to S3: {{exc}}", level="warn")
+        if uploaded:
+            details["artifact_uris"] = uploaded
+            _append_run_log(details, "Uploaded run artifacts to S3: " + ", ".join(uploaded))
         return details
 
     _update_sim2real_run(run_id, mutate=_finish)

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -1421,6 +1421,7 @@ import re
 import secrets
 import shutil
 import subprocess
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1439,6 +1440,7 @@ RECORDING_PATH = Path("/opt/npa-agent/recordings/sim2real.rrd")
 RECORDINGS_DIR = Path("/opt/npa-agent/recordings")
 RERUN_UNIT = "npa-rerun"
 RERUN_WEB_PORT = {rerun_port}
+AGENT_PYTHON = Path("/opt/npa-agent/venv/bin/python")
 DEFAULT_SCENE_SPEC = {{
     "schema": "npa.sim2real.manip_scene_spec.v1",
     "goal_pos": [0.5, 0.3, 0.04],
@@ -2971,6 +2973,242 @@ def _run_agent_npa_json(args: list[str], *, timeout_s: int = 300) -> dict:
         raise HTTPException(status_code=502, detail=f"NPA command did not return JSON: {{stdout[-1000:]}}") from exc
 
 
+_SIM2REAL_STAGE_BY_NUMBER = {{
+    1: "stage_01_trigger",
+    2: "stage_02_assets",
+    3: "stage_03_augment",
+    4: "stage_04_envs_raw",
+    5: "stage_05_envs_train",
+    6: "stage_06_tokens",
+    7: "stage_07_actions_train",
+    8: "stage_08_vlm_eval_train",
+    9: "stage_09_training_signal",
+    10: "stage_10_eval_heldout",
+    11: "stage_11_outer_loop",
+    12: "stage_12_external_validation_stub",
+    13: "stage_13_retrigger",
+    14: "stage_14_rerun_viz",
+}}
+
+
+def _update_sim2real_run(run_id: str, *, mutate) -> dict:
+    state = _load_state()
+    runs_detail = state.get("sim2real_runs")
+    if not isinstance(runs_detail, dict):
+        runs_detail = {{}}
+    details = runs_detail.get(run_id)
+    if not isinstance(details, dict):
+        details = _default_sim2real_run_details(run_id, submitted_at=_now_iso(), selection={{}})
+    details = mutate(details) or details
+    details["updated_at"] = _now_iso()
+    runs_detail[run_id] = details
+    state["sim2real_runs"] = runs_detail
+    sim_viz = state.get("sim_viz")
+    if not isinstance(sim_viz, dict) or str(sim_viz.get("run_id") or "") == run_id:
+        state["sim_viz"] = {{
+            **(sim_viz if isinstance(sim_viz, dict) else {{}}),
+            "run_id": run_id,
+            "stage": str(details.get("status") or "running"),
+            "rrd_updated_at": details["updated_at"],
+            "camera": str((sim_viz or {{}}).get("camera") or "workspace") if isinstance(sim_viz, dict) else "workspace",
+        }}
+    _save_state(state)
+    return details
+
+
+def _append_run_log(details: dict, message: str, *, level: str = "info") -> None:
+    logs = details.get("logs")
+    if not isinstance(logs, list):
+        logs = []
+    logs.append({{"timestamp": _now_iso(), "level": level, "message": message}})
+    details["logs"] = logs[-200:]
+
+
+def _mark_stage(details: dict, stage_id: str, status: str, summary: str = "") -> None:
+    stages = details.get("stages")
+    if not isinstance(stages, list):
+        stages = _default_sim2real_run_details(str(details.get("run_id") or ""), submitted_at=str(details.get("submitted_at") or "")).get("stages", [])
+    for item in stages:
+        if isinstance(item, dict) and item.get("id") == stage_id:
+            item["status"] = status
+            if status == "running" and not item.get("started_at"):
+                item["started_at"] = _now_iso()
+            if status in {{"succeeded", "failed"}}:
+                item["finished_at"] = _now_iso()
+            if summary:
+                item["summary"] = summary
+            break
+    details["stages"] = stages
+
+
+def _sim2real_agent_command(run_id: str, output_dir: Path) -> list[str]:
+    return [
+        str(AGENT_PYTHON),
+        "-m",
+        "npa.workflows.sim2real",
+        "run",
+        "--run-id",
+        run_id,
+        "--output-dir",
+        str(output_dir),
+        "--env-count",
+        "6",
+        "--train-fraction",
+        "0.5",
+        "--inner-iterations",
+        "1",
+        "--outer-iterations",
+        "1",
+        "--rollout-count",
+        "1",
+        "--steps-per-rollout",
+        "2",
+        "--heldout-env-count",
+        "2",
+        "--heldout-eval-limit",
+        "2",
+        "--sim-backend",
+        "genesis",
+        "--no-guardrails",
+        "--rerun",
+    ]
+
+
+def _apply_sim2real_report_to_details(details: dict, report: dict) -> None:
+    records = report.get("component_records")
+    if isinstance(records, list):
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            payload = record.get("payload") if isinstance(record.get("payload"), dict) else {{}}
+            stage_num = payload.get("stage")
+            try:
+                stage_id = _SIM2REAL_STAGE_BY_NUMBER.get(int(stage_num))
+            except Exception:
+                stage_id = None
+            if stage_id:
+                status = str(payload.get("status") or record.get("status") or "completed").lower()
+                normalized = "succeeded" if status in {{"completed", "succeeded", "success", "written"}} else status
+                _mark_stage(details, stage_id, normalized, str(record.get("component") or payload.get("schema") or stage_id))
+    viz = report.get("visualization")
+    if isinstance(viz, dict) and str(viz.get("status") or "").lower() in {{"written", "completed", "succeeded"}}:
+        _mark_stage(details, "stage_14_rerun_viz", "succeeded", "Rerun recording written.")
+    details["status"] = str(report.get("status") or "completed")
+    details["result"] = "completed" if str(details["status"]).lower() == "completed" else str(details["status"])
+    details["report"] = {{
+        "status": report.get("status"),
+        "run_id": report.get("run_id"),
+        "latest_decision": ((report.get("outer_loop") or {{}}).get("latest_decision") or {{}}),
+        "visualization": viz if isinstance(viz, dict) else {{}},
+    }}
+
+
+def _run_sim2real_pipeline_background(run_id: str, selection: dict) -> None:
+    output_dir = Path("/opt/npa-agent/runs") / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    def _start(details: dict) -> dict:
+        details["status"] = "running"
+        details["result"] = "running"
+        for stage_id, _label in SIM2REAL_STAGE_TEMPLATE:
+            if stage_id == "submit":
+                _mark_stage(details, stage_id, "succeeded", "Agent accepted the Sim2Real run request.")
+            else:
+                _mark_stage(details, stage_id, "pending", "Waiting for local Sim2Real runner.")
+        _append_run_log(details, "Starting local Sim2Real runner on the agent VM.")
+        return details
+
+    _update_sim2real_run(run_id, mutate=_start)
+    cmd = _sim2real_agent_command(run_id, output_dir)
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(NPA_SOURCE_ROOT),
+            env=_agent_command_env(),
+            text=True,
+            capture_output=True,
+            timeout=900,
+            check=False,
+        )
+    except Exception as exc:
+        def _fail_exc(details: dict) -> dict:
+            details["status"] = "failed"
+            details["result"] = "failed"
+            _append_run_log(details, f"Sim2Real runner failed to start: {{exc}}", level="error")
+            for stage_id, _label in SIM2REAL_STAGE_TEMPLATE:
+                if stage_id != "submit":
+                    _mark_stage(details, stage_id, "failed", "Runner failed before completing this stage.")
+            return details
+
+        _update_sim2real_run(run_id, mutate=_fail_exc)
+        return
+
+    report_path = output_dir / "reports" / "sim2real-report.json"
+    rrd_path = output_dir / "reports" / "sim2real.rrd"
+
+    def _finish(details: dict) -> dict:
+        stdout_tail = (proc.stdout or "")[-4000:].strip()
+        stderr_tail = (proc.stderr or "")[-4000:].strip()
+        if stdout_tail:
+            _append_run_log(details, "runner stdout tail:\\n" + stdout_tail)
+        if stderr_tail:
+            _append_run_log(details, "runner stderr tail:\\n" + stderr_tail, level="warn" if proc.returncode == 0 else "error")
+        if proc.returncode != 0:
+            details["status"] = "failed"
+            details["result"] = "failed"
+            _append_run_log(details, f"Sim2Real runner exited with code {{proc.returncode}}.", level="error")
+            for stage_id, _label in SIM2REAL_STAGE_TEMPLATE:
+                if stage_id != "submit":
+                    current = next((s for s in details.get("stages", []) if isinstance(s, dict) and s.get("id") == stage_id), {{}})
+                    if current.get("status") not in {{"succeeded", "failed"}}:
+                        _mark_stage(details, stage_id, "failed", "Runner exited before this stage completed.")
+            return details
+        if report_path.is_file():
+            try:
+                report = json.loads(report_path.read_text(encoding="utf-8"))
+                _apply_sim2real_report_to_details(details, report)
+            except Exception as exc:
+                details["status"] = "completed"
+                details["result"] = "completed_with_report_parse_error"
+                _append_run_log(details, f"Could not parse report: {{exc}}", level="warn")
+        else:
+            details["status"] = "completed"
+            details["result"] = "completed_missing_report"
+            _append_run_log(details, "Runner completed but report file was not found.", level="warn")
+        if rrd_path.is_file():
+            _publish_rrd_recording(rrd_path)
+            try:
+                shutil.copy2(rrd_path, RRD_PATH)
+            except Exception:
+                pass
+            _restart_rerun_serve(force=True)
+            _append_run_log(details, f"Published Rerun recording: {{rrd_path}}")
+        return details
+
+    _update_sim2real_run(run_id, mutate=_finish)
+    state = _load_state()
+    sim_viz = state.get("sim_viz")
+    if not isinstance(sim_viz, dict):
+        sim_viz = {{}}
+    if rrd_path.is_file():
+        sim_viz.update(
+            {{
+                "run_id": run_id,
+                "stage": "completed",
+                "rrd_uri": f"file://{{RECORDING_PATH}}",
+                "rrd_updated_at": _now_iso(),
+                "rerun_ready": RECORDING_PATH.is_file() and _rerun_web_viewer_healthy(),
+                "rerun_iframe_url": f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{sim_viz.get('camera') or 'workspace'}}",
+                "camera": str(sim_viz.get("camera") or "workspace"),
+            }}
+        )
+    else:
+        sim_viz.update({{"run_id": run_id, "stage": "completed", "rrd_updated_at": _now_iso()}})
+    state["sim_viz"] = sim_viz
+    _record_sim_viz_run(state, sim_viz)
+    _save_state(state)
+
+
 def _write_workflow_temp_yaml(yaml_text: str) -> Path:
     tmp_dir = Path("/tmp/npa-agent-workflows")
     tmp_dir.mkdir(parents=True, exist_ok=True)
@@ -3037,6 +3275,7 @@ _INTENT_SKILLS = {{
     "create_gate_workflow": ("author-npa-workflow", "sim-to-real"),
     "live_infra_loop": ("submit-workflow", "gpu-selection"),
     "cosmos3": ("cosmos3-setup",),
+    "start_sim2real": ("sim2real-operate", "sim2real-engine"),
     "sim2real_status": ("sim2real-operate",),
     "watch_sim": ("sim2real-operate",),
 }}
@@ -3153,6 +3392,17 @@ def _maybe_toolground_chat_reply(
     loaded_now = False
     rerun_ready = None
     default_cameras = list(DEFAULT_SCENE_SPEC.get("cameras", {{}}).values())
+    if intent == "start_sim2real":
+        submit = submit_sim2real({{}})
+        apis_used.append("workflows/sim2real/submit")
+        run_id = str(submit.get("run_id") or "")
+        reply = (
+            "**Started Sim2Real pipeline**\\n"
+            f"- **run_id**: `{{run_id}}`\\n"
+            "- **mode**: `agent-local-sim2real`\\n"
+            "- The Run Monitor will update stages, result, and logs; Rerun will switch to the run recording when it is written."
+        )
+        return reply, _dedupe(apis_used), suggested_apis, None, submit, intent
     if intent == "load_franka":
         sim_viz = state.get("sim_viz", {{}})
         if not isinstance(sim_viz, dict):
@@ -4195,6 +4445,14 @@ def submit_sim2real(payload: dict):
             ),
         }}
     )
+    details["logs"].append(
+        {{
+            "timestamp": submitted_at,
+            "level": "info",
+            "message": "Launching local Sim2Real runner on the agent VM.",
+        }}
+    )
+    details["result"] = "queued"
     runs_detail = state.get("sim2real_runs")
     if not isinstance(runs_detail, dict):
         runs_detail = {{}}
@@ -4216,7 +4474,13 @@ def submit_sim2real(payload: dict):
         }},
     )
     _save_state(state)
-    return {{"ok": True, "run_id": run_id, "selection": selection, "env": env_block, "run": details}}
+    thread = threading.Thread(
+        target=_run_sim2real_pipeline_background,
+        args=(run_id, dict(selection)),
+        daemon=True,
+    )
+    thread.start()
+    return {{"ok": True, "run_id": run_id, "selection": selection, "env": env_block, "run": details, "submit_mode": "agent-local-sim2real"}}
 PY
 cat <<'PY' | sudo tee /opt/npa-agent/bootstrap_rrd.py >/dev/null
 import math

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -3582,6 +3582,10 @@ def chat(payload: dict):
                 "chat_history": history[-80:],
             }}
         )
+        # Tool handlers may mutate session state (for example starting a Sim2Real
+        # run). Reload before saving chat history so an older state snapshot does
+        # not clobber the run monitor.
+        state = _load_state()
         session = _save_chat_session(state, session, active=True)
         tool_result["session_id"] = session["id"]
         tool_result["session"] = {{

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -3510,6 +3510,71 @@ def _maybe_toolground_chat_reply(
             "- The Run Monitor will update stages, result, and logs; Rerun will switch to the run recording when it is written."
         )
         return reply, _dedupe(apis_used), suggested_apis, None, submit, intent
+    if intent == "find_artifacts":
+        mentioned_run = ""
+        match = re.search(r"\b(agent-run-[A-Za-z0-9_-]+|sim2real-[A-Za-z0-9_.:-]+)\b", str(user_text or ""))
+        if match:
+            mentioned_run = match.group(1)
+        try:
+            if mentioned_run:
+                listed = artifacts_for_run(mentioned_run)
+                apis_used.append("artifacts/run/{{run_id}}")
+                if isinstance(listed, JSONResponse):
+                    payload = json.loads(listed.body.decode("utf-8"))
+                else:
+                    payload = listed
+                count = int(payload.get("count") or 0)
+                preferred = payload.get("preferred") if isinstance(payload.get("preferred"), dict) else {{}}
+                if count <= 0:
+                    reply = (
+                        "**No S3 artifacts found for that run.**\\n"
+                        f"- **run_id**: `{{mentioned_run}}`\\n"
+                        f"- **S3 prefix**: `{{payload.get('prefix', '')}}`\\n"
+                        "- It may predate S3 upload support or belong to a destroyed agent VM."
+                    )
+                    return reply, _dedupe(apis_used), suggested_apis, None, payload, intent
+                reply = (
+                    "**Run artifacts found.**\\n"
+                    f"- **run_id**: `{{mentioned_run}}`\\n"
+                    f"- **artifact_count**: `{{count}}`\\n"
+                    f"- **preferred**: `{{preferred.get('key', '')}}`\\n"
+                    f"- **render**: `{{preferred.get('render', '')}}`"
+                )
+                return reply, _dedupe(apis_used), suggested_apis, None, payload, intent
+            page = artifacts_runs(limit=5)
+            apis_used.append("artifacts/runs")
+            if isinstance(page, JSONResponse):
+                payload = json.loads(page.body.decode("utf-8"))
+            else:
+                payload = page
+            rows = payload.get("runs") if isinstance(payload, dict) else []
+            latest = rows[0] if isinstance(rows, list) and rows else {{}}
+            latest_run = str(latest.get("run_id") or "")
+            if not latest_run:
+                reply = (
+                    "**No S3-backed Sim2Real runs are discoverable yet.**\\n"
+                    f"- **S3 prefix**: `{{payload.get('prefix', '') if isinstance(payload, dict) else ''}}`"
+                )
+                return reply, _dedupe(apis_used), suggested_apis, None, payload if isinstance(payload, dict) else {{}}, intent
+            details = artifacts_for_run(latest_run)
+            apis_used.append("artifacts/run/{{run_id}}")
+            if isinstance(details, JSONResponse):
+                details_payload = json.loads(details.body.decode("utf-8"))
+            else:
+                details_payload = details
+            preferred = details_payload.get("preferred") if isinstance(details_payload.get("preferred"), dict) else {{}}
+            reply = (
+                "**Use this S3-backed Sim2Real run.**\\n"
+                f"- **run_id**: `{{latest_run}}`\\n"
+                f"- **artifact_count**: `{{latest.get('artifact_count', '')}}`\\n"
+                f"- **preferred_artifact**: `{{preferred.get('key', '')}}`\\n"
+                f"- **render**: `{{preferred.get('render', '')}}`\\n"
+                "- In the UI, paste this run id or select it from **Discovered runs**, then **List artifacts**."
+            )
+            return reply, _dedupe(apis_used), suggested_apis, None, details_payload, intent
+        except Exception as exc:
+            reply = f"**Artifact discovery failed.**\\n- **error**: `{{exc}}`"
+            return reply, _dedupe(apis_used), suggested_apis, None, {{"ok": False, "error": str(exc)}}, intent
     if intent == "load_franka":
         sim_viz = state.get("sim_viz", {{}})
         if not isinstance(sim_viz, dict):

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2385,11 +2385,12 @@ def _apply_loaded_artifact(
     if render == "rerun":
         _publish_rrd_recording(local_path)
         _restart_rerun_serve(force=True)
+        rerun_ready = _wait_rerun_web_viewer_healthy()
         sim_viz["rrd_uri"] = f"file://{{RECORDING_PATH}}"
         sim_viz["artifact_preview_url"] = "/rerun/recordings/sim2real.rrd"
         sim_viz["artifact_download_url"] = "/rerun/recordings/sim2real.rrd"
         sim_viz["rerun_iframe_url"] = f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{sim_viz['camera']}}"
-        sim_viz["rerun_ready"] = RECORDING_PATH.is_file() and _rerun_web_viewer_healthy()
+        sim_viz["rerun_ready"] = RECORDING_PATH.is_file() and rerun_ready
     else:
         filename = _artifact_filename(key)
         target = RECORDINGS_DIR / filename
@@ -2435,6 +2436,16 @@ def _rerun_web_viewer_healthy() -> bool:
             return resp.status == 200
     except Exception:
         return False
+
+
+def _wait_rerun_web_viewer_healthy(*, timeout_s: float = 12.0) -> bool:
+    deadline = time.monotonic() + max(0.5, float(timeout_s))
+    while time.monotonic() < deadline:
+        if _rerun_web_viewer_healthy():
+            return True
+        time.sleep(0.4)
+    return _rerun_web_viewer_healthy()
+
 
 def _rerun_ready_state(*, rrd_uri: str = "") -> bool:
     has_rrd = bool(str(rrd_uri or "").strip())
@@ -3279,6 +3290,7 @@ def _run_sim2real_pipeline_background(run_id: str, selection: dict) -> None:
             except Exception:
                 pass
             _restart_rerun_serve(force=True)
+            _wait_rerun_web_viewer_healthy()
             _append_run_log(details, f"Published Rerun recording: {{rrd_path}}")
         uploaded = []
         try:

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -1681,10 +1681,10 @@ def _default_sim2real_run_details(run_id: str, *, submitted_at: str = "", select
             {{
                 "id": stage_id,
                 "label": label,
-                "status": "pending",
+                "status": "not_run",
                 "started_at": "",
                 "finished_at": "",
-                "summary": "",
+                "summary": "Not launched by the agent UI submit endpoint.",
             }}
         )
     if stages:
@@ -1695,7 +1695,7 @@ def _default_sim2real_run_details(run_id: str, *, submitted_at: str = "", select
     return {{
         "run_id": run_id,
         "status": "submitted",
-        "result": "pending",
+        "result": "recorded_not_launched",
         "submitted_at": submitted_at,
         "updated_at": submitted_at or _now_iso(),
         "selection": selection if isinstance(selection, dict) else {{}},
@@ -1709,7 +1709,12 @@ def _default_sim2real_run_details(run_id: str, *, submitted_at: str = "", select
             {{
                 "timestamp": submitted_at or _now_iso(),
                 "level": "warn",
-                "message": "No run-specific Rerun .rrd recording is available yet; showing timeline and logs instead of stale demo data.",
+                "message": "The agent UI submit endpoint recorded the request but did not launch the full K8s Sim2Real pipeline; unexecuted stages are marked not_run.",
+            }},
+            {{
+                "timestamp": submitted_at or _now_iso(),
+                "level": "info",
+                "message": "Use the operator workflow submit path for a real staged K8s run; this view remains truthful until run artifacts or a recording exist.",
             }},
         ],
         "artifacts": [],
@@ -1759,7 +1764,7 @@ def _sim2real_run_details(state: dict, run_id: str = "") -> dict:
                 item["status"] = "succeeded"
                 item["summary"] = "Rerun recording is available."
     elif resolved_run_id:
-        details["result"] = "waiting_for_recording"
+        details["result"] = "recorded_not_launched"
     return details
 
 
@@ -4815,6 +4820,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       .stage-status.failed {{ background: #fee2e2; color: #991b1b; }}
       .stage-status.running {{ background: #fef3c7; color: #92400e; }}
       .stage-status.pending {{ background: #f1f5f9; color: #475569; }}
+      .stage-status.not_run {{ background: #f8fafc; color: #64748b; border: 1px solid #cbd5e1; }}
       .stage-label {{ font-weight: 700; color: #263247; }}
       .stage-summary {{ color: #64748b; margin-top: 2px; }}
       .run-log {{
@@ -6764,6 +6770,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         if (["succeeded", "success", "done", "complete", "completed"].includes(raw)) return "succeeded";
         if (["failed", "error", "blocked"].includes(raw)) return "failed";
         if (["running", "active", "submitted", "queued"].includes(raw)) return raw === "submitted" ? "running" : raw;
+        if (["not_run", "not-run", "skipped", "not launched", "not_launched"].includes(raw)) return "not_run";
         return "pending";
       }}
       function renderRunDetails(details) {{

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -587,7 +587,7 @@ def _storage_credentials_allow_writes(
     secret_key: str,
     region: str,
 ) -> bool:
-    """Return True when the credentials can write and delete in the bucket."""
+    """Return True when credentials can list, write, and delete in the bucket."""
     bucket_name = str(bucket or "").strip()
     if not bucket_name:
         return False
@@ -607,6 +607,7 @@ def _storage_credentials_allow_writes(
     client = boto3.client("s3", **client_kwargs)
     probe_key = f"npa-agent/probe/{secrets.token_hex(8)}.txt"
     try:
+        client.list_objects_v2(Bucket=bucket_name, Prefix="npa-agent/probe/", MaxKeys=1)
         client.put_object(Bucket=bucket_name, Key=probe_key, Body=b"ok")
         client.delete_object(Bucket=bucket_name, Key=probe_key)
         return True
@@ -619,8 +620,31 @@ def _resolve_deploy_storage_credentials(
     region: str,
     bootstrap_creds: dict[str, str],
 ) -> dict[str, str]:
-    """Prefer bootstrap credentials, but fall back to shared storage keys when needed."""
+    """Prefer configured artifact storage keys; fall back to bootstrap keys when needed."""
     candidate = dict(bootstrap_creds)
+    from npa.clients.credentials import load_credentials
+
+    shared = load_credentials()
+    shared_bucket = str(shared.s3_bucket or "").strip()
+    if shared_bucket.startswith("s3://"):
+        shared_bucket = shared_bucket[len("s3://"):].split("/", 1)[0]
+    shared_endpoint = str(shared.s3_endpoint or f"https://storage.{region}.nebius.cloud").strip()
+    shared_access_key = str(shared.s3_access_key_id or "").strip()
+    shared_secret_key = str(shared.s3_secret_access_key or "").strip()
+    if shared_bucket and _storage_credentials_allow_writes(
+        bucket=shared_bucket,
+        endpoint=shared_endpoint,
+        access_key=shared_access_key,
+        secret_key=shared_secret_key,
+        region=region,
+    ):
+        typer.echo("  Using shared configured artifact storage credentials for the agent.")
+        candidate["s3_bucket"] = shared_bucket
+        candidate["s3_endpoint"] = shared_endpoint
+        candidate["nebius_api_key"] = shared_access_key
+        candidate["nebius_secret_key"] = shared_secret_key
+        return candidate
+
     bucket = str(candidate.get("s3_bucket", "")).strip()
     endpoint = str(candidate.get("s3_endpoint", "")).strip()
     access_key = str(candidate.get("nebius_api_key", "")).strip()
@@ -632,31 +656,6 @@ def _resolve_deploy_storage_credentials(
         secret_key=secret_key,
         region=region,
     ):
-        return candidate
-    from npa.clients.credentials import load_credentials
-
-    shared = load_credentials()
-    shared_bucket = str(shared.s3_bucket or "").strip()
-    if shared_bucket.startswith("s3://"):
-        shared_bucket = shared_bucket[len("s3://"):].split("/", 1)[0]
-    shared_endpoint = str(shared.s3_endpoint or f"https://storage.{region}.nebius.cloud").strip()
-    shared_access_key = str(shared.s3_access_key_id or "").strip()
-    shared_secret_key = str(shared.s3_secret_access_key or "").strip()
-    if _storage_credentials_allow_writes(
-        bucket=shared_bucket,
-        endpoint=shared_endpoint,
-        access_key=shared_access_key,
-        secret_key=shared_secret_key,
-        region=region,
-    ):
-        typer.echo(
-            "  Bootstrap S3 key has no data-plane access; "
-            "falling back to shared configured storage credentials."
-        )
-        candidate["s3_bucket"] = shared_bucket
-        candidate["s3_endpoint"] = shared_endpoint
-        candidate["nebius_api_key"] = shared_access_key
-        candidate["nebius_secret_key"] = shared_secret_key
         return candidate
     typer.echo(
         "  Warning: unable to verify writable S3 credentials for deploy; "
@@ -2326,96 +2325,6 @@ def _artifact_preview_url(filename: str) -> str:
     return f"/api/artifacts/file/{{filename}}"
 
 
-def _local_runs_root() -> Path:
-    return Path("/opt/npa-agent/runs")
-
-
-def _local_artifact_key(run_id: str, path: Path) -> str:
-    rel = path.relative_to(_local_runs_root() / run_id)
-    return f"{{run_id}}/{{rel.as_posix()}}"
-
-
-def _local_artifact_path(run_id: str, key: str) -> Path:
-    normalized_run = validate_run_id(run_id)
-    raw_key = str(key or "").strip().lstrip("/")
-    if raw_key.startswith(normalized_run + "/"):
-        raw_key = raw_key[len(normalized_run) + 1 :]
-    if not raw_key or any(part in {"", ".", ".."} for part in raw_key.split("/")):
-        raise HTTPException(status_code=400, detail="invalid local artifact key")
-    root = (_local_runs_root() / normalized_run).resolve()
-    target = (root / raw_key).resolve()
-    try:
-        target.relative_to(root)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail="local artifact key escapes run directory") from exc
-    if not target.is_file():
-        raise HTTPException(status_code=404, detail=f"local artifact not found: {{key}}")
-    return target
-
-
-def _local_run_summaries(prefix: str = "", limit: int = 50) -> dict:
-    root = _local_runs_root()
-    token = str(prefix or "").strip().strip("/")
-    rows = []
-    if root.is_dir():
-        for run_dir in sorted((p for p in root.iterdir() if p.is_dir()), key=lambda p: p.stat().st_mtime, reverse=True):
-            run_id = run_dir.name
-            if token and token not in run_id:
-                continue
-            files = [p for p in run_dir.rglob("*") if p.is_file()]
-            if not files:
-                continue
-            latest = max(files, key=lambda p: p.stat().st_mtime)
-            rows.append(
-                {{
-                    "run_id": run_id,
-                    "last_modified": datetime.fromtimestamp(latest.stat().st_mtime, tz=timezone.utc).isoformat(),
-                    "artifact_count": len(files),
-                    "has_viewable": any(render_hint_for_object(key=p.name) != "download" for p in files),
-                    "source": "local",
-                }}
-            )
-    total = len(rows)
-    return {{"runs": rows[:limit], "truncated": total > limit, "total_runs": total, "limit": limit}}
-
-
-def _local_artifacts_for_run(run_id: str, prefix: str = "") -> list[dict]:
-    normalized_run = validate_run_id(run_id)
-    root = _local_runs_root() / normalized_run
-    token = str(prefix or "").strip().strip("/")
-    rows = []
-    if root.is_dir():
-        for path in root.rglob("*"):
-            if not path.is_file():
-                continue
-            key = _local_artifact_key(normalized_run, path)
-            if token and token not in key:
-                continue
-            stat = path.stat()
-            render = render_hint_for_object(key=key)
-            rows.append(
-                {{
-                    "run_id": normalized_run,
-                    "key": key,
-                    "s3_uri": "",
-                    "size": stat.st_size,
-                    "last_modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
-                    "render": render,
-                    "inline": is_inline_render(render),
-                    "source": "local",
-                }}
-            )
-    rows.sort(key=lambda item: (str(item["last_modified"]), str(item["key"])), reverse=True)
-    return rows
-
-
-def _preferred_artifact_dict(artifacts: list[dict]) -> dict | None:
-    if not artifacts:
-        return None
-    order = {{"rerun": 0, "video": 1, "image": 2, "json": 3, "text": 4, "download": 5}}
-    return sorted(artifacts, key=lambda item: (order.get(str(item.get("render")), 99), str(item.get("last_modified")), str(item.get("key"))))[0]
-
-
 def _apply_loaded_artifact(
     *,
     state: dict,
@@ -3133,7 +3042,8 @@ def _mark_stage(details: dict, stage_id: str, status: str, summary: str = "") ->
 
 
 def _sim2real_agent_command(run_id: str, output_dir: Path) -> list[str]:
-    return [
+    settings = _agent_s3_settings()
+    cmd = [
         str(AGENT_PYTHON),
         "-m",
         "npa.workflows.sim2real",
@@ -3163,6 +3073,11 @@ def _sim2real_agent_command(run_id: str, output_dir: Path) -> list[str]:
         "--no-guardrails",
         "--rerun",
     ]
+    if settings.get("bucket"):
+        cmd.extend(["--s3-bucket", str(settings["bucket"]), "--s3-prefix", "sim2real-b", "--upload-artifacts"])
+    if settings.get("endpoint"):
+        cmd.extend(["--s3-endpoint", str(settings["endpoint"])])
+    return cmd
 
 
 def _apply_sim2real_report_to_details(details: dict, report: dict) -> None:
@@ -4009,7 +3924,6 @@ def sim_viz_recordings():
 
 @app.get("/artifacts/runs")
 def artifacts_runs(prefix: str = "", limit: int = 50):
-    s3_error = ""
     try:
         s3, settings = _agent_s3_client()
         page = list_runs(
@@ -4022,9 +3936,7 @@ def artifacts_runs(prefix: str = "", limit: int = 50):
     except HTTPException:
         raise
     except Exception as exc:
-        s3_error = str(exc)
-    local_page = _local_run_summaries(prefix=prefix, limit=limit)
-    return {{"ok": True, "bucket": "", "prefix": prefix, "source": "local", "s3_error": s3_error, **local_page}}
+        return JSONResponse(status_code=502, content={{"ok": False, "error": str(exc), "source": "s3"}})
 
 
 @app.get("/artifacts/run/{{run_id:path}}")
@@ -4053,19 +3965,7 @@ def artifacts_for_run(run_id: str, prefix: str = ""):
     except HTTPException:
         raise
     except Exception as exc:
-        local_artifacts = _local_artifacts_for_run(normalized_run, prefix=prefix)
-        if local_artifacts:
-            return {{
-                "ok": True,
-                "bucket": "",
-                "source": "local",
-                "s3_error": str(exc),
-                "run_id": normalized_run,
-                "count": len(local_artifacts),
-                "artifacts": local_artifacts,
-                "preferred": _preferred_artifact_dict(local_artifacts),
-            }}
-        return JSONResponse(status_code=502, content={{"ok": False, "error": str(exc)}})
+        return JSONResponse(status_code=502, content={{"ok": False, "error": str(exc), "source": "s3"}})
 
 
 @app.get("/artifacts/file/{{filename}}")
@@ -4116,22 +4016,7 @@ def sim_viz_load_artifact(payload: dict | None = None):
     except HTTPException:
         raise
     except Exception as exc:
-        if requested_run and requested_key and not requested_uri:
-            run_id = validate_run_id(requested_run)
-            local_path = _local_artifact_path(run_id, requested_key)
-            key = _local_artifact_key(run_id, local_path)
-            render = render_hint_for_object(key=key)
-            state = _load_state()
-            sim_viz = _apply_loaded_artifact(
-                state=state,
-                run_id=run_id,
-                key=key,
-                s3_uri="",
-                render=render,
-                local_path=local_path,
-            )
-            return {{"ok": True, "source": "local", "s3_error": str(exc), "sim_viz": sim_viz, "render": render, "artifact_uri": ""}}
-        return JSONResponse(status_code=502, content={{"ok": False, "error": str(exc)}})
+        return JSONResponse(status_code=502, content={{"ok": False, "error": str(exc), "source": "s3"}})
 
 
 @app.post("/sim-viz/load-franka-demo")

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -1499,6 +1499,23 @@ DEFAULT_SIM_VIZ = {{
     "rerun_ready": False,
     "rerun_iframe_url": "/rerun/",
 }}
+SIM2REAL_STAGE_TEMPLATE = [
+    ("submit", "Submit request"),
+    ("stage_01_trigger", "1 Trigger"),
+    ("stage_02_assets", "2 Assets"),
+    ("stage_03_augment", "3 Augment"),
+    ("stage_04_envs_raw", "4 Raw envs"),
+    ("stage_05_envs_train", "5 Train split"),
+    ("stage_06_tokens", "6 Tokens"),
+    ("stage_07_actions_train", "7 Policy rollouts"),
+    ("stage_08_vlm_eval_train", "8 VLM eval"),
+    ("stage_09_training_signal", "9 Training signal"),
+    ("stage_10_eval_heldout", "10 Held-out eval"),
+    ("stage_11_outer_loop", "11 Threshold gate"),
+    ("stage_12_external_validation_stub", "12 External validation"),
+    ("stage_13_retrigger", "13 Retrigger"),
+    ("stage_14_rerun_viz", "14 Rerun viz"),
+]
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -1585,6 +1602,7 @@ def _default_state() -> dict:
         "camera_selection": ["workspace"],
         "sim_viz": dict(DEFAULT_SIM_VIZ),
         "sim_viz_runs": {{}},
+        "sim2real_runs": {{}},
         "active_run_id": "",
         "latest_submit": {{}},
         "workflow_draft": {{"yaml": "", "name": "", "states": [], "updated_at": "", "plan": {{}}, "runnable": False}},
@@ -1620,6 +1638,8 @@ def _load_state() -> dict:
         merged["sim_viz"] = dict(DEFAULT_SIM_VIZ)
     if not isinstance(merged.get("sim_viz_runs"), dict):
         merged["sim_viz_runs"] = {{}}
+    if not isinstance(merged.get("sim2real_runs"), dict):
+        merged["sim2real_runs"] = {{}}
     if not isinstance(merged.get("active_run_id"), str):
         merged["active_run_id"] = ""
     if not isinstance(merged.get("chat_history"), list):
@@ -1652,6 +1672,95 @@ def _record_sim_viz_run(state: dict, payload: dict | None) -> None:
     runs[run_id] = snapshot
     state["sim_viz_runs"] = runs
     state["active_run_id"] = run_id
+
+
+def _default_sim2real_run_details(run_id: str, *, submitted_at: str = "", selection: dict | None = None) -> dict:
+    stages = []
+    for index, (stage_id, label) in enumerate(SIM2REAL_STAGE_TEMPLATE):
+        stages.append(
+            {{
+                "id": stage_id,
+                "label": label,
+                "status": "pending",
+                "started_at": "",
+                "finished_at": "",
+                "summary": "",
+            }}
+        )
+    if stages:
+        stages[0]["status"] = "succeeded"
+        stages[0]["started_at"] = submitted_at
+        stages[0]["finished_at"] = submitted_at
+        stages[0]["summary"] = "Agent accepted the Sim2Real submit request."
+    return {{
+        "run_id": run_id,
+        "status": "submitted",
+        "result": "pending",
+        "submitted_at": submitted_at,
+        "updated_at": submitted_at or _now_iso(),
+        "selection": selection if isinstance(selection, dict) else {{}},
+        "stages": stages,
+        "logs": [
+            {{
+                "timestamp": submitted_at or _now_iso(),
+                "level": "info",
+                "message": "Sim2Real submit recorded by NPA agent.",
+            }},
+            {{
+                "timestamp": submitted_at or _now_iso(),
+                "level": "warn",
+                "message": "No run-specific Rerun .rrd recording is available yet; showing timeline and logs instead of stale demo data.",
+            }},
+        ],
+        "artifacts": [],
+    }}
+
+
+def _merge_sim2real_run_details(base: dict, update: dict | None) -> dict:
+    merged = dict(base)
+    if isinstance(update, dict):
+        for key, value in update.items():
+            if key == "stages" and isinstance(value, list):
+                merged[key] = value
+            elif key == "logs" and isinstance(value, list):
+                merged[key] = value
+            elif key == "selection" and isinstance(value, dict):
+                selection = dict(merged.get("selection", {{}}) if isinstance(merged.get("selection"), dict) else {{}})
+                selection.update(value)
+                merged[key] = selection
+            else:
+                merged[key] = value
+    return merged
+
+
+def _sim2real_run_details(state: dict, run_id: str = "") -> dict:
+    latest = state.get("latest_submit", {{}})
+    if not isinstance(latest, dict):
+        latest = {{}}
+    sim_viz = state.get("sim_viz", {{}})
+    if not isinstance(sim_viz, dict):
+        sim_viz = {{}}
+    resolved_run_id = str(run_id or latest.get("run_id") or sim_viz.get("run_id") or state.get("active_run_id") or "").strip()
+    details_map = state.get("sim2real_runs")
+    if not isinstance(details_map, dict):
+        details_map = {{}}
+    existing = details_map.get(resolved_run_id, {{}}) if resolved_run_id else {{}}
+    submitted_at = str(latest.get("submitted_at") or sim_viz.get("rrd_updated_at") or "")
+    selection = latest.get("selection") if isinstance(latest.get("selection"), dict) else {{}}
+    details = _default_sim2real_run_details(resolved_run_id, submitted_at=submitted_at, selection=selection)
+    details = _merge_sim2real_run_details(details, existing if isinstance(existing, dict) else {{}})
+    stage = str(sim_viz.get("stage") or details.get("status") or "submitted").strip()
+    if stage:
+        details["status"] = stage
+    if sim_viz.get("rrd_uri"):
+        details["result"] = "recording_available"
+        for item in details.get("stages", []):
+            if isinstance(item, dict) and item.get("id") == "stage_14_rerun_viz":
+                item["status"] = "succeeded"
+                item["summary"] = "Rerun recording is available."
+    elif resolved_run_id:
+        details["result"] = "waiting_for_recording"
+    return details
 
 
 def _sim_viz_for_run(state: dict, run_id: str = "") -> dict:
@@ -3343,6 +3452,7 @@ def tool(tool_ref: str):
 def sim_viz_status(run_id: str = ""):
     state = _load_state()
     payload = _sim_viz_for_run(state, run_id=run_id)
+    requested_run = str(run_id or "").strip()
     selected = state.get("camera_selection", ["workspace"])
     camera = str(payload.get("camera") or (selected[0] if isinstance(selected, list) and selected else "workspace"))
     payload["camera"] = camera
@@ -3354,9 +3464,17 @@ def sim_viz_status(run_id: str = ""):
     if str(payload.get("stage") or "idle").strip().lower() == "idle" and payload.get("run_id"):
         payload["stage"] = "submitted"
     _record_sim_viz_run(state, payload)
-    if str(payload.get("artifact_render") or "").strip().lower() in {"", "rerun"}:
+    payload_run = str(payload.get("run_id") or "").strip()
+    run_has_specific_rrd = bool(str(payload.get("rrd_uri") or "").strip())
+    may_use_default_recording = payload_run in {"", "franka-demo"} and not requested_run
+    if (
+        str(payload.get("artifact_render") or "").strip().lower() in {"", "rerun"}
+        and (run_has_specific_rrd or may_use_default_recording)
+    ):
         payload["rerun_iframe_url"] = f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{camera}}"
-    if not payload.get("rrd_uri") and RRD_PATH.is_file():
+    else:
+        payload["rerun_iframe_url"] = ""
+    if not payload.get("rrd_uri") and may_use_default_recording and RRD_PATH.is_file():
         payload["rrd_uri"] = f"file://{{RRD_PATH}}"
     mode = str(payload.get("mode") or "static").strip().lower()
     payload["mode"] = "live" if mode == "live" else "static"
@@ -3758,15 +3876,27 @@ def get_sim_assets_selection():
     return selection
 
 @app.get("/workflows/sim2real/status")
-def sim2real_status():
+def sim2real_status(run_id: str = ""):
     state = _load_state()
     latest = state.get("latest_submit", {{}})
     sim_viz = state.get("sim_viz", {{}})
+    details = _sim2real_run_details(state, run_id=run_id)
     return {{
         "ok": True,
         "latest_submit": latest if isinstance(latest, dict) else {{}},
         "sim_viz": sim_viz if isinstance(sim_viz, dict) else dict(DEFAULT_SIM_VIZ),
+        "run": details,
+        "stages": details.get("stages", []),
+        "logs": details.get("logs", []),
     }}
+
+@app.get("/workflows/sim2real/runs/{{run_id:path}}")
+def sim2real_run_detail(run_id: str):
+    state = _load_state()
+    details = _sim2real_run_details(state, run_id=run_id)
+    if not str(details.get("run_id") or "").strip():
+        raise HTTPException(status_code=404, detail=f"run_id not found: {{run_id}}")
+    return {{"ok": True, "run": details}}
 
 @app.get("/workbench/actions")
 def workbench_actions():
@@ -4007,29 +4137,51 @@ def submit_sim2real(payload: dict):
         "selection": selection,
         "env": env_block,
     }}
+    submitted_at = str(state["latest_submit"]["submitted_at"])
     state["sim_viz"] = {{
         "run_id": run_id,
         "stage": "submitted",
         "rrd_uri": "",
-        "rrd_updated_at": _now_iso(),
+        "rrd_updated_at": submitted_at,
         "live_grpc_url": "",
         "mode": "static",
+        "rerun_ready": False,
+        "rerun_iframe_url": "",
+        "camera": "workspace",
     }}
+    details = _default_sim2real_run_details(run_id, submitted_at=submitted_at, selection=selection)
+    details["logs"].append(
+        {{
+            "timestamp": submitted_at,
+            "level": "info",
+            "message": "Selection: robot_preset={{}}, sim_backend={{}}".format(
+                selection.get("robot_preset", "franka"),
+                selection.get("sim_backend", "isaac"),
+            ),
+        }}
+    )
+    runs_detail = state.get("sim2real_runs")
+    if not isinstance(runs_detail, dict):
+        runs_detail = {{}}
+    runs_detail[run_id] = details
+    state["sim2real_runs"] = runs_detail
     _record_sim_viz_run(
         state,
         {{
             "run_id": run_id,
-            "submitted_at": state["latest_submit"]["submitted_at"],
+            "submitted_at": submitted_at,
             "stage": "submitted",
             "camera": str((state.get("sim_viz", {{}}) or {{}}).get("camera") or "workspace"),
             "rrd_uri": "",
             "rrd_updated_at": str((state.get("sim_viz", {{}}) or {{}}).get("rrd_updated_at") or ""),
             "submit_mode": "sim2real",
             "workflow_name": "sim2real",
+            "rerun_ready": False,
+            "rerun_iframe_url": "",
         }},
     )
     _save_state(state)
-    return {{"ok": True, "run_id": run_id, "selection": selection, "env": env_block}}
+    return {{"ok": True, "run_id": run_id, "selection": selection, "env": env_block, "run": details}}
 PY
 cat <<'PY' | sudo tee /opt/npa-agent/bootstrap_rrd.py >/dev/null
 import math
@@ -4618,6 +4770,63 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       .cta {{ color: #92400e; background: #fffbeb; border: 1px solid #fcd34d; border-radius: 8px; padding: 8px 10px; }}
       .badge {{ display: inline-block; padding: 3px 9px; border-radius: 999px; background: #ece9ff; color: #33207d; font-size: 12px; }}
       .badge-ok {{ background: var(--ok-bg); color: var(--ok-text); }}
+      .run-details {{
+        margin-top: 10px;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        background: #f8fafc;
+        padding: 10px;
+      }}
+      .run-details h4 {{ margin: 0 0 8px 0; font-size: 13px; color: #263247; }}
+      .run-summary {{
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-bottom: 8px;
+      }}
+      .stage-list {{
+        display: grid;
+        gap: 6px;
+        margin: 8px 0;
+      }}
+      .stage-item {{
+        display: grid;
+        grid-template-columns: 92px 1fr;
+        gap: 8px;
+        align-items: start;
+        border: 1px solid #e5e7eb;
+        background: #fff;
+        border-radius: 8px;
+        padding: 7px 8px;
+        font-size: 12px;
+      }}
+      .stage-status {{
+        border-radius: 999px;
+        padding: 3px 7px;
+        text-align: center;
+        font-weight: 700;
+        text-transform: uppercase;
+        font-size: 10px;
+        background: #eef2ff;
+        color: #3730a3;
+      }}
+      .stage-status.succeeded {{ background: #dcfce7; color: #166534; }}
+      .stage-status.failed {{ background: #fee2e2; color: #991b1b; }}
+      .stage-status.running {{ background: #fef3c7; color: #92400e; }}
+      .stage-status.pending {{ background: #f1f5f9; color: #475569; }}
+      .stage-label {{ font-weight: 700; color: #263247; }}
+      .stage-summary {{ color: #64748b; margin-top: 2px; }}
+      .run-log {{
+        margin: 8px 0 0 0;
+        max-height: 180px;
+        overflow: auto;
+        white-space: pre-wrap;
+        background: #0f172a;
+        color: #dbeafe;
+        border-radius: 8px;
+        padding: 10px;
+        font-size: 12px;
+      }}
       .actions-inline {{ margin-top: 10px; display:flex; gap:8px; flex-wrap:wrap; }}
       .quick-pill {{
         border-radius: 999px;
@@ -5037,6 +5246,12 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
                 <button id="openRerun" class="btn" type="button">Open in Rerun</button>
               </div>
               <p id="simvizCta" class="cta">Discover artifacts first; use Franka demo fallback when no S3 artifacts are available.</p>
+              <div id="runDetails" class="run-details">
+                <h4>Run status, result, and logs</h4>
+                <div id="runSummary" class="run-summary"></div>
+                <div id="stageList" class="stage-list"></div>
+                <pre id="runLog" class="run-log">No run selected.</pre>
+              </div>
             </div>
             <div id="rerunPlaceholder" class="rerun-placeholder">
               <p>Loading Rerun viewer…</p>
@@ -6336,6 +6551,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           const simViz = await loadJson(statusPath);
           activeRunId = String((simViz && (simViz.active_run_id || simViz.run_id)) || activeRunId || "").trim();
           updateRunSelector(simViz);
+          await loadRunDetails(activeRunId);
           renderAssetsSummary(assets);
           document.getElementById("simRunId").textContent = String(simViz.run_id || "-");
           document.getElementById("simStage").textContent = String(simViz.stage || "idle");
@@ -6345,6 +6561,9 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           const ready = Boolean(simViz.rerun_ready || simViz.rrd_uri);
           if (cta) {{
             cta.hidden = ready && rerunIframeLoaded;
+            if (!ready) {{
+              cta.textContent = "No run-specific Rerun recording yet. Use the Run status/logs panel below for stage progress and result.";
+            }}
           }}
           if (activeArtifactRender && activeArtifactRender !== "rerun") {{
             showRerunPlaceholder("Non-RRD artifact loaded. Use preview/download below.");
@@ -6513,6 +6732,65 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         const input = document.getElementById("runIdInput");
         if (input && current) input.value = current;
       }}
+      function normalizeStageStatus(value) {{
+        const raw = String(value || "pending").trim().toLowerCase();
+        if (["succeeded", "success", "done", "complete", "completed"].includes(raw)) return "succeeded";
+        if (["failed", "error", "blocked"].includes(raw)) return "failed";
+        if (["running", "active", "submitted", "queued"].includes(raw)) return raw === "submitted" ? "running" : raw;
+        return "pending";
+      }}
+      function renderRunDetails(details) {{
+        const run = (details && details.run) || details || {{}};
+        const summary = document.getElementById("runSummary");
+        const stagesHost = document.getElementById("stageList");
+        const logHost = document.getElementById("runLog");
+        if (!summary || !stagesHost || !logHost) return;
+        const runId = String(run.run_id || "");
+        const result = String(run.result || "pending");
+        const status = String(run.status || "idle");
+        const updatedAt = String(run.updated_at || run.submitted_at || "");
+        summary.innerHTML =
+          '<span class="pill">run: <strong>' + escapeHtml(runId || "none") + '</strong></span>' +
+          '<span class="pill">status: <strong>' + escapeHtml(status) + '</strong></span>' +
+          '<span class="pill">result: <strong>' + escapeHtml(result) + '</strong></span>' +
+          '<span class="pill">updated: <strong>' + escapeHtml(updatedAt || "-") + '</strong></span>';
+        const stages = Array.isArray(run.stages) ? run.stages : [];
+        stagesHost.innerHTML = stages.map((stage) => {{
+          const statusClass = normalizeStageStatus(stage.status);
+          const label = String(stage.label || stage.id || "");
+          const stageSummary = String(stage.summary || "");
+          return (
+            '<div class="stage-item">' +
+            '<span class="stage-status ' + escapeHtml(statusClass) + '">' + escapeHtml(statusClass) + '</span>' +
+            '<div><div class="stage-label">' + escapeHtml(label) + '</div>' +
+            '<div class="stage-summary">' + escapeHtml(stageSummary || String(stage.id || "")) + '</div></div>' +
+            '</div>'
+          );
+        }}).join("") || '<div class="hint">No stage data available yet.</div>';
+        const logs = Array.isArray(run.logs) ? run.logs : [];
+        logHost.textContent = logs.length
+          ? logs.map((entry) => {{
+              const ts = String(entry.timestamp || "");
+              const level = String(entry.level || "info").toUpperCase();
+              const message = String(entry.message || "");
+              return "[" + ts + "] " + level + " " + message;
+            }}).join("\\n")
+          : "No log entries yet.";
+      }}
+      async function loadRunDetails(runId) {{
+        const target = String(runId || activeRunId || "").trim();
+        const path = target
+          ? "/api/workflows/sim2real/runs/" + encodeURIComponent(target)
+          : "/api/workflows/sim2real/status";
+        try {{
+          const data = await loadJson(path);
+          renderRunDetails(data);
+          return data.run || data;
+        }} catch (err) {{
+          renderRunDetails({{ run: {{ run_id: target, status: "unknown", result: "unavailable", logs: [{{ timestamp: new Date().toISOString(), level: "error", message: String(err && err.message ? err.message : err) }}], stages: [] }} }});
+          return null;
+        }}
+      }}
       async function loadRunData() {{
         const input = document.getElementById("runIdInput");
         const runId = String((input && input.value) || "").trim();
@@ -6526,8 +6804,11 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         }});
         activeRunId = runId;
         appendChat("assistant", "Loaded run context — **run_id**: `" + runId + "`.");
+        await loadRunDetails(runId);
         if (data && data.sim_viz && (data.sim_viz.rrd_uri || data.sim_viz.rerun_ready)) {{
           await waitForRerunSuccess(String(data.sim_viz.camera || "workspace"), {{ runId }});
+        }} else {{
+          showRerunPlaceholder("No .rrd recording for this run yet. See run stages and logs below.");
         }}
         await refresh();
       }}
@@ -6577,10 +6858,11 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           body: JSON.stringify({{}}),
         }});
         appendChat("assistant", `Submitted Sim2Real run: **${{data.run_id || "unknown"}}**`);
-        appendChat("assistant", "Watching sim progress: polling `/api/sim-viz/status` until `.rrd` is available and iframe blob mount reaches `SUCCESS`.");
+        appendChat("assistant", "Watching sim progress: rendering stage/result/logs immediately; Rerun opens only after a run-specific `.rrd` is available.");
         const submittedRunId = String(data.run_id || "").trim();
         if (submittedRunId) activeRunId = submittedRunId;
-        const simViz = await pollSimVizUntilRrd(60, 1500, submittedRunId);
+        renderRunDetails(data);
+        const simViz = await pollSimVizUntilRrd(8, 1500, submittedRunId);
         if (simViz && simViz.rrd_uri) {{
           await waitForRerunSuccess(
             simViz.camera || "workspace",
@@ -6603,12 +6885,20 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
               "`, **iframe** `/rerun/`, **blob_mount** `" + RERUN_BLOB_SUCCESS + "`"
           );
         }} else {{
-          throw new Error("Sim2Real run submitted, but no .rrd is available yet after polling");
+          await loadRunDetails(submittedRunId);
+          showRerunPlaceholder("No run-specific Rerun recording yet. Stage timeline, result, and logs are shown below.");
+          appendChat(
+            "assistant",
+            "Run `" + submittedRunId + "` is recorded with **stage** `" +
+              String((simViz && simViz.stage) || "submitted") +
+              "`. No `.rrd` recording is available yet, so the Run status/logs panel is the source of truth."
+          );
         }}
         await refresh();
       }}
       async function showWorkflowStatus() {{
         const status = await loadJson("/api/workflows/sim2real/status");
+        renderRunDetails(status);
         appendChat(
           "assistant",
           "Latest workflow status:\\n- run_id: `" +
@@ -6623,6 +6913,12 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           ? "/api/sim-viz/status?run_id=" + encodeURIComponent(activeRunId)
           : "/api/sim-viz/status";
         const simViz = await loadJson(statusPath);
+        if (!(simViz && (simViz.rrd_uri || simViz.rerun_ready))) {{
+          await loadRunDetails(activeRunId);
+          showRerunPlaceholder("No run-specific Rerun recording yet. Stage timeline, result, and logs are shown below.");
+          showToast("No Rerun recording for this run yet; showing run logs instead.", "info");
+          return;
+        }}
         const camera = String(simViz.camera || document.getElementById("cameraSelect").value || "workspace");
         const src = await rerunIframeSrc(camera, String((simViz && simViz.run_id) || activeRunId || "").trim());
         window.open(src, "_blank", "noopener");

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -1876,8 +1876,30 @@ def _franka_joint_positions(joint_angles: tuple[float, ...]) -> list[list[float]
     positions.append([ee[0], ee[1] - 0.04, ee[2]])
     return positions
 
-def _log_franka_robot_geometry(rr) -> None:
-    positions = _franka_joint_positions(_FRANKA_HOME_JOINTS)
+def _franka_demo_joint_angles(frame_index: int, frame_count: int) -> tuple[float, ...]:
+    import math
+
+    phase = (float(frame_index) / max(1.0, float(frame_count - 1))) * math.tau
+    return (
+        _FRANKA_HOME_JOINTS[0] + 0.22 * math.sin(phase),
+        _FRANKA_HOME_JOINTS[1] + 0.16 * math.sin(phase + 0.5),
+        _FRANKA_HOME_JOINTS[2] + 0.18 * math.sin(phase + 1.2),
+        _FRANKA_HOME_JOINTS[3] + 0.12 * math.sin(phase + 1.7),
+        _FRANKA_HOME_JOINTS[4] + 0.24 * math.sin(phase + 2.1),
+        _FRANKA_HOME_JOINTS[5] + 0.10 * math.sin(phase + 2.7),
+        _FRANKA_HOME_JOINTS[6] + 0.20 * math.sin(phase + 3.4),
+    )
+
+
+def _set_rerun_time(rr, seconds: float) -> None:
+    if hasattr(rr, "set_time_seconds"):
+        rr.set_time_seconds("log_time", seconds)
+    else:
+        rr.set_time("log_time", duration=seconds)
+
+
+def _log_franka_robot_geometry(rr, joint_angles: tuple[float, ...] = _FRANKA_HOME_JOINTS) -> None:
+    positions = _franka_joint_positions(joint_angles)
     arm_points = positions[:8]
     segments: list[list[list[float]]] = []
     for left, right in zip(arm_points, arm_points[1:]):
@@ -1958,15 +1980,21 @@ def _generate_franka_demo_rrd(*, camera: str = "workspace") -> Path:
             colors=[[180, 180, 180, 255]],
         ),
     )
-    rr.log(
-        "world/cube",
-        rr.Boxes3D(
-            centers=[[0.5, 0.3, 0.04]],
-            half_sizes=[[0.025, 0.025, 0.025]],
-            colors=[[59, 130, 246, 255]],
-        ),
-    )
-    _log_franka_robot_geometry(rr)
+    frame_count = 90
+    for frame_index in range(frame_count):
+        seconds = frame_index / 15.0
+        _set_rerun_time(rr, seconds)
+        phase = frame_index / max(1.0, float(frame_count - 1))
+        cube_y = 0.3 - 0.42 * phase
+        rr.log(
+            "world/cube",
+            rr.Boxes3D(
+                centers=[[0.5, cube_y, 0.04]],
+                half_sizes=[[0.025, 0.025, 0.025]],
+                colors=[[59, 130, 246, 255]],
+            ),
+        )
+        _log_franka_robot_geometry(rr, _franka_demo_joint_angles(frame_index, frame_count))
     cameras = DEFAULT_SCENE_SPEC.get("cameras", {{}})
     active = camera if camera in cameras else "workspace"
     for name, cam in cameras.items():
@@ -1979,23 +2007,24 @@ def _generate_franka_demo_rrd(*, camera: str = "workspace") -> Path:
         width = int(res[0]) if len(res) > 0 else 640
         height = int(res[1]) if len(res) > 1 else 480
         entity = f"world/cameras/{{name}}"
+        frustum_entity = f"world/camera_frustums/{{name}}"
         focal = width / (2.0 * math.tan(math.radians(fov / 2.0)))
         rr.log(entity, rr.Pinhole(focal_length=focal, width=width, height=height))
         rr.log(entity, rr.Transform3D(translation=pos))
         origin, strips = _camera_frustum_lines(pos, look_at, fov)
         color = [59, 130, 246] if name == active else [148, 163, 184]
         rr.log(
-            f"{{entity}}/frustum",
+            f"{{frustum_entity}}/frustum",
             rr.LineStrips3D(strips, colors=[color] * len(strips)),
         )
-        rr.log(f"{{entity}}/origin", rr.Points3D([origin], colors=[color], radii=[0.02]))
+        rr.log(f"{{frustum_entity}}/origin", rr.Points3D([origin], colors=[color], radii=[0.02]))
         label = (
             f"**{{name}}** (selected for next rollout)"
             if name == active
             else f"**{{name}}**"
         )
         rr.log(
-            f"{{entity}}/label",
+            f"{{frustum_entity}}/label",
             rr.TextDocument(
                 f"{{label}}\\n"
                 f"pos={{pos}} look_at={{look_at}} fov={{fov}}° resolution={{width}}x{{height}}"
@@ -4197,6 +4226,24 @@ import rerun as rr
 
 _FRANKA_HOME = (0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785)
 
+def _franka_demo_joint_angles(frame_index, frame_count):
+    phase = (float(frame_index) / max(1.0, float(frame_count - 1))) * math.tau
+    return (
+        _FRANKA_HOME[0] + 0.22 * math.sin(phase),
+        _FRANKA_HOME[1] + 0.16 * math.sin(phase + 0.5),
+        _FRANKA_HOME[2] + 0.18 * math.sin(phase + 1.2),
+        _FRANKA_HOME[3] + 0.12 * math.sin(phase + 1.7),
+        _FRANKA_HOME[4] + 0.24 * math.sin(phase + 2.1),
+        _FRANKA_HOME[5] + 0.10 * math.sin(phase + 2.7),
+        _FRANKA_HOME[6] + 0.20 * math.sin(phase + 3.4),
+    )
+
+def _set_rerun_time(seconds):
+    if hasattr(rr, "set_time_seconds"):
+        rr.set_time_seconds("log_time", seconds)
+    else:
+        rr.set_time("log_time", duration=seconds)
+
 def _franka_joint_positions(joint_angles):
     dh = [
         (0.0, 0.0, 0.333),
@@ -4238,8 +4285,8 @@ def _franka_joint_positions(joint_angles):
     positions.append([ee[0], ee[1] - 0.04, ee[2]])
     return positions
 
-def _log_franka_robot_geometry():
-    positions = _franka_joint_positions(_FRANKA_HOME)
+def _log_franka_robot_geometry(joint_angles=_FRANKA_HOME):
+    positions = _franka_joint_positions(joint_angles)
     arm_points = positions[:8]
     segments = []
     for left, right in zip(arm_points, arm_points[1:]):
@@ -4306,15 +4353,21 @@ rr.log(
         colors=[[180, 180, 180, 255]],
     ),
 )
-rr.log(
-    "world/cube",
-    rr.Boxes3D(
-        centers=[[0.5, 0.3, 0.04]],
-        half_sizes=[[0.025, 0.025, 0.025]],
-        colors=[[59, 130, 246, 255]],
-    ),
-)
-_log_franka_robot_geometry()
+frame_count = 90
+for frame_index in range(frame_count):
+    seconds = frame_index / 15.0
+    _set_rerun_time(seconds)
+    phase = frame_index / max(1.0, float(frame_count - 1))
+    cube_y = 0.3 - 0.42 * phase
+    rr.log(
+        "world/cube",
+        rr.Boxes3D(
+            centers=[[0.5, cube_y, 0.04]],
+            half_sizes=[[0.025, 0.025, 0.025]],
+            colors=[[59, 130, 246, 255]],
+        ),
+    )
+    _log_franka_robot_geometry(_franka_demo_joint_angles(frame_index, frame_count))
 rr.log("cameras/workspace", rr.Pinhole(fov_y=60.0))
 rr.log("cameras/wrist", rr.Pinhole(fov_y=90.0))
 rr.save(str(target))

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -1760,7 +1760,8 @@ def _sim2real_run_details(state: dict, run_id: str = "") -> dict:
     if stage:
         details["status"] = stage
     if sim_viz.get("rrd_uri"):
-        details["result"] = "recording_available"
+        if str(details.get("result") or "") not in {"completed", "failed", "running"}:
+            details["result"] = "recording_available"
         for item in details.get("stages", []):
             if isinstance(item, dict) and item.get("id") == "stage_14_rerun_viz":
                 item["status"] = "succeeded"
@@ -3075,6 +3076,14 @@ def _sim2real_agent_command(run_id: str, output_dir: Path) -> list[str]:
 
 
 def _apply_sim2real_report_to_details(details: dict, report: dict) -> None:
+    report_status = str(report.get("status") or "").lower()
+    if report_status == "completed":
+        for stage_id, label in SIM2REAL_STAGE_TEMPLATE:
+            if stage_id == "submit":
+                continue
+            if stage_id == "stage_14_rerun_viz":
+                continue
+            _mark_stage(details, stage_id, "succeeded", f"Completed during local Sim2Real run: {{label}}.")
     records = report.get("component_records")
     if isinstance(records, list):
         for record in records:
@@ -3086,6 +3095,35 @@ def _apply_sim2real_report_to_details(details: dict, report: dict) -> None:
                 stage_id = _SIM2REAL_STAGE_BY_NUMBER.get(int(stage_num))
             except Exception:
                 stage_id = None
+            path_text = str(record.get("path") or "").lower()
+            component_text = str(record.get("component") or "").lower()
+            if stage_id is None:
+                if "stage_01_trigger" in path_text:
+                    stage_id = "stage_01_trigger"
+                elif "stage_02_assets" in path_text or "consumed_scene" in path_text:
+                    stage_id = "stage_02_assets"
+                elif "augment" in path_text or "cosmos2" in component_text:
+                    stage_id = "stage_03_augment"
+                elif "envs/raw" in path_text:
+                    stage_id = "stage_04_envs_raw"
+                elif "envs/train" in path_text:
+                    stage_id = "stage_05_envs_train"
+                elif "tokens" in path_text:
+                    stage_id = "stage_06_tokens"
+                elif "actions/train" in path_text or "policy" in component_text:
+                    stage_id = "stage_07_actions_train"
+                elif "vlm_eval" in path_text:
+                    stage_id = "stage_08_vlm_eval_train"
+                elif "training_signal" in path_text:
+                    stage_id = "stage_09_training_signal"
+                elif "eval/heldout" in path_text or "heldout" in component_text:
+                    stage_id = "stage_10_eval_heldout"
+                elif "outer_loop" in path_text or "decision" in path_text:
+                    stage_id = "stage_11_outer_loop"
+                elif "stage_12_external_validation" in path_text:
+                    stage_id = "stage_12_external_validation_stub"
+                elif "stage_13_retrigger" in path_text:
+                    stage_id = "stage_13_retrigger"
             if stage_id:
                 status = str(payload.get("status") or record.get("status") or "completed").lower()
                 normalized = "succeeded" if status in {{"completed", "succeeded", "success", "written"}} else status

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -5836,7 +5836,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           setChatInput("How do I set up Cosmos3 in the NPA workbench?");
         }}, "Insert Cosmos3 prompt");
         bindClick("chatActionWatch", () => {{
-          setChatInput("Watch the sim in Rerun and keep retrying blob+iframe mount until SUCCESS using /api/sim-viz/status.");
+          setChatInput("Watch the sim in Rerun and keep retrying recording+iframe mount until SUCCESS using /api/sim-viz/status.");
         }}, "Insert watch-sim prompt");
         bindClick("chatActionWorkflow", () => {{
           setChatInput("Create a 2-step sim2real workflow YAML with real toolRefs from the catalog.");
@@ -6393,7 +6393,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         const text = String(status || "").trim() || "pending";
         lastRerunBlobStatus = text;
         const extra = detail ? " (" + String(detail) + ")" : "";
-        setStatus("Rerun blob: " + text + extra);
+        setStatus("Rerun recording: " + text + extra);
       }}
       function setRerunMountStatus(status, detail) {{
         const text = String(status || "").trim() || "pending";
@@ -6473,23 +6473,10 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       }}
       async function rerunIframeSrc(camera, runId) {{
         const cam = String(camera || "workspace");
-        let rrdUrl = "";
-        const targetRunId = String(runId || activeRunId || "").trim();
-        if (!targetRunId || targetRunId === "franka-demo") {{
-          rrdUrl = await resolveRerunRecordingUrl();
-          return (
-            "/rerun/?url=" +
-            encodeURIComponent(rrdUrl) +
-            "&renderer=webgl&hide_welcome_screen=1&camera=" +
-            encodeURIComponent(cam)
-          );
-        }}
-        try {{
-          rrdUrl = await resolveRerunRrdUrl(18, targetRunId);
-        }} catch (_blobErr) {{
-          rrdUrl = await resolveRerunRecordingUrl();
-        }}
-        // Prefer authenticated blob fetch; public recording path is fallback.
+        // Rerun's wasm viewer fetches the URL itself and cannot reliably use
+        // parent-page basic-auth/blob state. nginx exposes this recording path
+        // without auth specifically so the iframe can load visuals directly.
+        const rrdUrl = await resolveRerunRecordingUrl();
         return (
           "/rerun/?url=" +
           encodeURIComponent(rrdUrl) +
@@ -6685,7 +6672,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         if (lastErr) {{
           throw lastErr;
         }}
-        throw new Error("Timed out waiting for rerun blob/iframe SUCCESS");
+        throw new Error("Timed out waiting for rerun recording/iframe SUCCESS");
       }}
       function reloadRerunIframe(camera) {{
         if (!rerunIframeLoaded) return Promise.resolve();
@@ -7267,7 +7254,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
             }}
           );
           if (lastRerunBlobStatus !== RERUN_BLOB_SUCCESS || lastRerunMountStatus !== RERUN_MOUNT_SUCCESS) {{
-            throw new Error("Rerun blob/iframe did not reach SUCCESS after workflow submit");
+            throw new Error("Rerun recording/iframe did not reach SUCCESS after workflow submit");
           }}
           appendChat(
             "assistant",

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -573,6 +573,7 @@ def _agent_credentials_payload(creds: dict[str, str]) -> dict[str, str]:
     return {
         "service_account_id": str(creds.get("service_account_id", "")).strip(),
         "s3_bucket": str(creds.get("s3_bucket", "")).strip(),
+        "s3_prefix": str(creds.get("s3_prefix", "")).strip().strip("/"),
         "s3_endpoint": str(creds.get("s3_endpoint", "")).strip(),
         "access_key": str(creds.get("nebius_api_key", "")).strip(),
         "secret_key": str(creds.get("nebius_secret_key", "")).strip(),
@@ -586,6 +587,7 @@ def _storage_credentials_allow_writes(
     access_key: str,
     secret_key: str,
     region: str,
+    prefix: str = "",
 ) -> bool:
     """Return True when credentials can list, write, and delete in the bucket."""
     bucket_name = str(bucket or "").strip()
@@ -605,9 +607,11 @@ def _storage_credentials_allow_writes(
         "aws_" "secret_access_key": str(secret_key or "").strip(),
     }
     client = boto3.client("s3", **client_kwargs)
-    probe_key = f"npa-agent/probe/{secrets.token_hex(8)}.txt"
+    normalized_prefix = str(prefix or "").strip().strip("/")
+    probe_base = "/".join(part for part in (normalized_prefix, "npa-agent/probe") if part)
+    probe_key = f"{probe_base}/{secrets.token_hex(8)}.txt"
     try:
-        client.list_objects_v2(Bucket=bucket_name, Prefix="npa-agent/probe/", MaxKeys=1)
+        client.list_objects_v2(Bucket=bucket_name, Prefix=(probe_base + "/") if probe_base else "", MaxKeys=1)
         client.put_object(Bucket=bucket_name, Key=probe_key, Body=b"ok")
         client.delete_object(Bucket=bucket_name, Key=probe_key)
         return True
@@ -624,10 +628,13 @@ def _resolve_deploy_storage_credentials(
     candidate = dict(bootstrap_creds)
     from npa.clients.credentials import load_credentials
 
-    shared = load_credentials()
+    shared = load_credentials(environ={})
     shared_bucket = str(shared.s3_bucket or "").strip()
+    shared_prefix = ""
     if shared_bucket.startswith("s3://"):
-        shared_bucket = shared_bucket[len("s3://"):].split("/", 1)[0]
+        rest = shared_bucket[len("s3://"):]
+        shared_bucket, _sep, shared_prefix = rest.partition("/")
+        shared_prefix = shared_prefix.strip("/")
     shared_endpoint = str(shared.s3_endpoint or f"https://storage.{region}.nebius.cloud").strip()
     shared_access_key = str(shared.s3_access_key_id or "").strip()
     shared_secret_key = str(shared.s3_secret_access_key or "").strip()
@@ -637,9 +644,11 @@ def _resolve_deploy_storage_credentials(
         access_key=shared_access_key,
         secret_key=shared_secret_key,
         region=region,
+        prefix=shared_prefix,
     ):
         typer.echo("  Using shared configured artifact storage credentials for the agent.")
         candidate["s3_bucket"] = shared_bucket
+        candidate["s3_prefix"] = shared_prefix
         candidate["s3_endpoint"] = shared_endpoint
         candidate["nebius_api_key"] = shared_access_key
         candidate["nebius_secret_key"] = shared_secret_key
@@ -655,6 +664,7 @@ def _resolve_deploy_storage_credentials(
         access_key=access_key,
         secret_key=secret_key,
         region=region,
+        prefix=str(candidate.get("s3_prefix", "")),
     ):
         return candidate
     typer.echo(
@@ -730,6 +740,7 @@ def _credentials_block_from_storage(
     *,
     service_account_id: str,
     s3_bucket: str,
+    s3_prefix: str = "",
     s3_endpoint: str,
     s3_access_key: str,
     s3_secret_key: str,
@@ -737,6 +748,7 @@ def _credentials_block_from_storage(
     return {
         "service_account_id": service_account_id.strip(),
         "s3_bucket": s3_bucket.strip(),
+        "s3_prefix": s3_prefix.strip().strip("/"),
         "s3_endpoint": s3_endpoint.strip(),
         "access_key": s3_access_key.strip(),
         "secret_key": s3_secret_key.strip(),
@@ -764,13 +776,14 @@ def _resolve_agent_ssh_key(
 def _resolve_agent_storage_credentials(
     project_alias: str,
     record: dict[str, Any],
-) -> tuple[str, str, str, str, str]:
-    """Return bucket, endpoint, access key, secret key, and service account id."""
+) -> tuple[str, str, str, str, str, str]:
+    """Return bucket, prefix, endpoint, access key, secret key, and service account id."""
     creds = record.get("credentials", {})
     if isinstance(creds, dict):
         access_key = str(creds.get("access_key", "")).strip()
         secret_key = str(creds.get("secret_key", "")).strip()
         bucket = str(creds.get("s3_bucket", "")).strip()
+        prefix = str(creds.get("s3_prefix", "")).strip().strip("/")
         endpoint = str(creds.get("s3_endpoint", "")).strip()
         service_account_id = str(
             creds.get("service_account_id", record.get("service_account_id", ""))
@@ -778,14 +791,15 @@ def _resolve_agent_storage_credentials(
         if bucket and access_key and secret_key:
             if not service_account_id:
                 service_account_id = _resolve_agent_service_account_id(project_alias, record)
-            return bucket, endpoint, access_key, secret_key, service_account_id
+            return bucket, prefix, endpoint, access_key, secret_key, service_account_id
     try:
         tf_state = resolve_terraform_state(project_alias)
     except ConfigError:
-        return "", "", "", "", _resolve_agent_service_account_id(project_alias, record)
+        return "", "", "", "", "", _resolve_agent_service_account_id(project_alias, record)
     service_account_id = _resolve_agent_service_account_id(project_alias, record)
     return (
         str(getattr(tf_state, "bucket", "") or ""),
+        "",
         str(getattr(tf_state, "endpoint", "") or ""),
         str(getattr(tf_state, "access_key", "") or ""),
         str(getattr(tf_state, "secret_key", "") or ""),
@@ -828,6 +842,7 @@ def _write_agent_s3_env(
     ssh: SSHClient,
     *,
     bucket: str,
+    prefix: str = "",
     endpoint: str,
     access_key: str,
     secret_key: str,
@@ -838,6 +853,7 @@ def _write_agent_s3_env(
         return
     env_lines = [
         f"NPA_AGENT_S3_BUCKET={bucket.strip()}",
+        f"NPA_AGENT_S3_PREFIX={prefix.strip().strip('/')}",
         f"NPA_AGENT_S3_ENDPOINT={endpoint.strip()}",
         f"AWS_ACCESS_KEY_ID={access_key.strip()}",
         f"AWS_SECRET_ACCESS_KEY={secret_key.strip()}",
@@ -862,6 +878,7 @@ def _write_agent_operator_profile(
     tf_api_key: str,
     nebius_ai_key: str,
     s3_bucket: str,
+    s3_prefix: str = "",
     s3_endpoint: str,
     s3_access_key: str,
     s3_secret_key: str,
@@ -891,7 +908,7 @@ def _write_agent_operator_profile(
         "access_key_id": s3_access_key.strip(),
         "secret_access_key": s3_secret_key.strip(),
         "endpoint": s3_endpoint.strip(),
-        "bucket": s3_bucket.strip(),
+        "bucket": "s3://" + s3_bucket.strip() + (("/" + s3_prefix.strip().strip("/") + "/") if s3_prefix.strip().strip("/") else ""),
     }
     if any(storage_payload.values()):
         credentials_payload["storage"] = storage_payload
@@ -1325,6 +1342,7 @@ def _bootstrap_agent_stack(
     nebius_ai_key: str = "",
     service_account_id: str = "",
     s3_bucket: str = "",
+    s3_prefix: str = "",
     s3_endpoint: str = "",
     s3_access_key: str = "",
     s3_secret_key: str = "",
@@ -2067,11 +2085,16 @@ def _safe_artifact_key(key: str) -> str:
 def _agent_s3_settings() -> dict[str, str]:
     return {{
         "bucket": str(os.environ.get("NPA_AGENT_S3_BUCKET", "")).strip(),
+        "prefix": str(os.environ.get("NPA_AGENT_S3_PREFIX", "")).strip().strip("/"),
         "endpoint": str(os.environ.get("NPA_AGENT_S3_ENDPOINT", "")).strip(),
         "access_key": str(os.environ.get("AWS_ACCESS_KEY_ID", "")).strip(),
         "secret_key": str(os.environ.get("AWS_SECRET_ACCESS_KEY", "")).strip(),
         "region": str(os.environ.get("AWS_REGION", "eu-north1")).strip() or "eu-north1",
     }}
+
+
+def _join_agent_s3_prefix(base_prefix: str, suffix: str = "") -> str:
+    return "/".join(part.strip("/") for part in (base_prefix, suffix) if str(part or "").strip().strip("/"))
 
 
 def _agent_s3_client():
@@ -3074,7 +3097,13 @@ def _sim2real_agent_command(run_id: str, output_dir: Path) -> list[str]:
         "--rerun",
     ]
     if settings.get("bucket"):
-        cmd.extend(["--s3-bucket", str(settings["bucket"]), "--s3-prefix", "sim2real-b", "--upload-artifacts"])
+        cmd.extend([
+            "--s3-bucket",
+            str(settings["bucket"]),
+            "--s3-prefix",
+            _join_agent_s3_prefix(str(settings.get("prefix") or ""), "sim2real-b"),
+            "--upload-artifacts",
+        ])
     if settings.get("endpoint"):
         cmd.extend(["--s3-endpoint", str(settings["endpoint"])])
     return cmd
@@ -3926,13 +3955,14 @@ def sim_viz_recordings():
 def artifacts_runs(prefix: str = "", limit: int = 50):
     try:
         s3, settings = _agent_s3_client()
+        effective_prefix = _join_agent_s3_prefix(settings.get("prefix", ""), prefix)
         page = list_runs(
             settings["bucket"],
-            prefix=prefix,
+            prefix=effective_prefix,
             limit=limit,
             s3=s3,
         )
-        return {{"ok": True, "bucket": settings["bucket"], "prefix": prefix, **page.to_dict()}}
+        return {{"ok": True, "bucket": settings["bucket"], "prefix": effective_prefix, "base_prefix": settings.get("prefix", ""), **page.to_dict()}}
     except HTTPException:
         raise
     except Exception as exc:
@@ -3947,16 +3977,19 @@ def artifacts_for_run(run_id: str, prefix: str = ""):
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     try:
         s3, settings = _agent_s3_client()
+        effective_prefix = _join_agent_s3_prefix(settings.get("prefix", ""), prefix)
         artifacts = list_artifacts(
             settings["bucket"],
             normalized_run,
-            prefix=prefix,
+            prefix=effective_prefix,
             s3=s3,
         )
         preferred = select_preferred_artifact(artifacts)
         return {{
             "ok": True,
             "bucket": settings["bucket"],
+            "prefix": effective_prefix,
+            "base_prefix": settings.get("prefix", ""),
             "run_id": normalized_run,
             "count": len(artifacts),
             "artifacts": [item.to_dict() for item in artifacts],
@@ -7514,6 +7547,7 @@ sudo systemctl restart npa-agent-backend
     _write_agent_s3_env(
         ssh,
         bucket=s3_bucket,
+        prefix=s3_prefix,
         endpoint=s3_endpoint,
         access_key=s3_access_key,
         secret_key=s3_secret_key,
@@ -7529,6 +7563,7 @@ sudo systemctl restart npa-agent-backend
         tf_api_key=tf_api_key,
         nebius_ai_key=nebius_ai_key,
         s3_bucket=s3_bucket,
+        s3_prefix=s3_prefix,
         s3_endpoint=s3_endpoint,
         s3_access_key=s3_access_key,
         s3_secret_key=s3_secret_key,
@@ -7657,6 +7692,7 @@ def deploy_cmd(
         "nebius_api_key": str(creds.get("nebius_api_key", "")),
         "nebius_secret_key": str(creds.get("nebius_secret_key", "")),
         "s3_bucket": str(creds.get("s3_bucket", "")),
+        "s3_prefix": str(creds.get("s3_prefix", "")),
         "s3_endpoint": str(creds.get("s3_endpoint", "")),
         "instance_name": f"agent-{project}-{name}",
         "server_port": str(agent_port),
@@ -7757,6 +7793,7 @@ def deploy_cmd(
             tf_api_key=tf_api_key,
             nebius_ai_key=nebius_ai_key,
             s3_bucket=str(merged_vars.get("s3_bucket", "")),
+            s3_prefix=str(merged_vars.get("s3_prefix", "")),
             s3_endpoint=str(merged_vars.get("s3_endpoint", "")),
             s3_access_key=str(merged_vars.get("nebius_api_key", "")),
             s3_secret_key=str(merged_vars.get("nebius_secret_key", "")),
@@ -7983,7 +8020,7 @@ def bootstrap_cmd(
     project_id = str(record.get("project_id", "")).strip()
     tenant_id = str(record.get("tenant_id", "")).strip()
     region = str(record.get("region", "") or "eu-north1")
-    s3_bucket, s3_endpoint, s3_access_key, s3_secret_key, service_account_id = (
+    s3_bucket, s3_prefix, s3_endpoint, s3_access_key, s3_secret_key, service_account_id = (
         _resolve_agent_storage_credentials(project, record)
     )
     if not service_account_id:
@@ -8014,6 +8051,7 @@ def bootstrap_cmd(
         creds = _resolve_deploy_storage_credentials(region=region, bootstrap_creds=creds)
         agent_credentials = _agent_credentials_payload(creds)
         s3_bucket = agent_credentials["s3_bucket"]
+        s3_prefix = agent_credentials.get("s3_prefix", "")
         s3_endpoint = agent_credentials["s3_endpoint"]
         s3_access_key = agent_credentials["access_key"]
         s3_secret_key = agent_credentials["secret_key"]
@@ -8056,6 +8094,7 @@ def bootstrap_cmd(
             tf_api_key=tf_api_key,
             nebius_ai_key=nebius_ai_key,
             s3_bucket=s3_bucket,
+            s3_prefix=s3_prefix,
             s3_endpoint=s3_endpoint,
             s3_access_key=s3_access_key,
             s3_secret_key=s3_secret_key,
@@ -8097,6 +8136,7 @@ def bootstrap_cmd(
         updated["credentials"] = _credentials_block_from_storage(
             service_account_id=service_account_id,
             s3_bucket=s3_bucket,
+            s3_prefix=s3_prefix,
             s3_endpoint=s3_endpoint,
             s3_access_key=s3_access_key,
             s3_secret_key=s3_secret_key,

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -3105,16 +3105,6 @@ def _sim2real_agent_command(run_id: str, output_dir: Path) -> list[str]:
         "--no-guardrails",
         "--rerun",
     ]
-    if settings.get("bucket"):
-        cmd.extend([
-            "--s3-bucket",
-            str(settings["bucket"]),
-            "--s3-prefix",
-            _join_agent_s3_prefix(str(settings.get("prefix") or ""), "sim2real-b"),
-            "--upload-artifacts",
-        ])
-    if settings.get("endpoint"):
-        cmd.extend(["--s3-endpoint", str(settings["endpoint"])])
     return cmd
 
 
@@ -3244,6 +3234,15 @@ def _run_sim2real_pipeline_background(run_id: str, selection: dict) -> None:
         s3.put_object(Bucket=settings["bucket"], Key=key, Body=path.read_bytes(), ContentType=content_type)
         return f"s3://{{settings['bucket']}}/{{key}}"
 
+    def _upload_output_tree() -> list[str]:
+        uploaded: list[str] = []
+        for path in sorted(p for p in output_dir.rglob("*") if p.is_file()):
+            rel = path.relative_to(output_dir).as_posix()
+            uri = _upload_output_file(path, rel)
+            if uri:
+                uploaded.append(uri)
+        return uploaded
+
     def _finish(details: dict) -> dict:
         stdout_tail = (proc.stdout or "")[-4000:].strip()
         stderr_tail = (proc.stderr or "")[-4000:].strip()
@@ -3282,16 +3281,15 @@ def _run_sim2real_pipeline_background(run_id: str, selection: dict) -> None:
             _restart_rerun_serve(force=True)
             _append_run_log(details, f"Published Rerun recording: {{rrd_path}}")
         uploaded = []
-        for path, rel in ((report_path, "reports/sim2real-report.json"), (rrd_path, "reports/sim2real.rrd")):
-            try:
-                uri = _upload_output_file(path, rel)
-                if uri:
-                    uploaded.append(uri)
-            except Exception as exc:
-                _append_run_log(details, f"Failed to upload {{rel}} to S3: {{exc}}", level="warn")
+        try:
+            uploaded = _upload_output_tree()
+        except Exception as exc:
+            _append_run_log(details, f"Failed to upload run tree to S3: {{exc}}", level="warn")
         if uploaded:
             details["artifact_uris"] = uploaded
-            _append_run_log(details, "Uploaded run artifacts to S3: " + ", ".join(uploaded))
+            preview = ", ".join(uploaded[:5])
+            suffix = " ..." if len(uploaded) > 5 else ""
+            _append_run_log(details, f"Uploaded {{len(uploaded)}} run artifacts to S3: " + preview + suffix)
         return details
 
     _update_sim2real_run(run_id, mutate=_finish)

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -8011,6 +8011,7 @@ def bootstrap_cmd(
             creds = _creds_from_terraform_state(project, record)
         if creds is None:
             _fail("Nebius credential refresh failed and no terraform_state fallback is configured")
+        creds = _resolve_deploy_storage_credentials(region=region, bootstrap_creds=creds)
         agent_credentials = _agent_credentials_payload(creds)
         s3_bucket = agent_credentials["s3_bucket"]
         s3_endpoint = agent_credentials["s3_endpoint"]

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -5136,6 +5136,16 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           </div>
           <pre id="workflowPlanOutput" class="hint" style="margin-top:8px; white-space:pre-wrap;"></pre>
         </section>
+        <section class="panel run-monitor-panel">
+          <h3>Sim2Real Run Monitor</h3>
+          <p class="hint">Stage timeline, result, and logs for the active run. This panel is independent from Rerun visualization.</p>
+          <div id="runDetails" class="run-details">
+            <h4>Run status, result, and logs</h4>
+            <div id="runSummary" class="run-summary"></div>
+            <div id="stageList" class="stage-list"></div>
+            <pre id="runLog" class="run-log">No run selected.</pre>
+          </div>
+        </section>
         <div class="layout layout-3">
           <section class="panel">
             <h3>Sim Assets</h3>
@@ -5247,12 +5257,6 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
                 <button id="openRerun" class="btn" type="button">Open in Rerun</button>
               </div>
               <p id="simvizCta" class="cta">Discover artifacts first; use Franka demo fallback when no S3 artifacts are available.</p>
-              <div id="runDetails" class="run-details">
-                <h4>Run status, result, and logs</h4>
-                <div id="runSummary" class="run-summary"></div>
-                <div id="stageList" class="stage-list"></div>
-                <pre id="runLog" class="run-log">No run selected.</pre>
-              </div>
             </div>
             <div id="rerunPlaceholder" class="rerun-placeholder">
               <p>Loading Rerun viewer…</p>
@@ -6062,7 +6066,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         if (!resp.ok) {{
           throw new Error("Rerun recording not published yet");
         }}
-        setRerunBlobStatus("fallback", "recording=public");
+        setRerunBlobStatus(RERUN_BLOB_SUCCESS, "recording=public");
         return recordingUrl;
       }}
       async function resolveRerunRrdUrl(maxAttempts, runId) {{
@@ -6105,8 +6109,18 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       async function rerunIframeSrc(camera, runId) {{
         const cam = String(camera || "workspace");
         let rrdUrl = "";
+        const targetRunId = String(runId || activeRunId || "").trim();
+        if (!targetRunId || targetRunId === "franka-demo") {{
+          rrdUrl = await resolveRerunRecordingUrl();
+          return (
+            "/rerun/?url=" +
+            encodeURIComponent(rrdUrl) +
+            "&renderer=webgl&hide_welcome_screen=1&camera=" +
+            encodeURIComponent(cam)
+          );
+        }}
         try {{
-          rrdUrl = await resolveRerunRrdUrl(18, runId);
+          rrdUrl = await resolveRerunRrdUrl(18, targetRunId);
         }} catch (_blobErr) {{
           rrdUrl = await resolveRerunRecordingUrl();
         }}
@@ -6314,7 +6328,19 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       }}
       async function loadRerunViewer(camera) {{
         const cam = String(camera || document.getElementById("cameraSelect").value || "workspace");
-        const simViz = await waitForRerunReady();
+        let simViz = await loadJson(activeRunId ? "/api/sim-viz/status?run_id=" + encodeURIComponent(activeRunId) : "/api/sim-viz/status");
+        if (!(simViz && (simViz.rrd_uri || simViz.rerun_ready))) {{
+          showToast("No run recording yet; loading stock Franka visual fallback in Rerun.", "info");
+          await apiJson("/api/sim-viz/load-franka-demo", {{
+            method: "POST",
+            headers: {{ "content-type": "application/json" }},
+            body: JSON.stringify({{ camera: cam }}),
+          }});
+          activeRunId = "franka-demo";
+          simViz = await waitForRerunReady();
+        }} else {{
+          simViz = await waitForRerunReady();
+        }}
         const runId = String((simViz && simViz.run_id) || activeRunId || "").trim();
         if (runId) activeRunId = runId;
         await waitForRerunSuccess(String(simViz.camera || cam), {{ deadlineMs: 90000, mountAttemptsPerLoop: 4, runId }});

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -1790,13 +1790,16 @@ def _sim2real_run_details(state: dict, run_id: str = "") -> dict:
 
 def _sim_viz_for_run(state: dict, run_id: str = "") -> dict:
     payload = dict(DEFAULT_SIM_VIZ)
-    current = state.get("sim_viz")
-    if isinstance(current, dict):
-        payload.update(current)
     runs = state.get("sim_viz_runs")
     target = str(run_id or state.get("active_run_id") or "").strip()
     if isinstance(runs, dict) and target and isinstance(runs.get(target), dict):
         payload.update(runs[target])
+    elif run_id:
+        payload["run_id"] = target
+    else:
+        current = state.get("sim_viz")
+        if isinstance(current, dict):
+            payload.update(current)
     return payload
 
 def _stock_franka_selection() -> dict:
@@ -3824,9 +3827,7 @@ def models(refresh: bool = False):
 def session_bootstrap():
     state = _load_state()
     active_session = _get_chat_session(state, str(state.get("active_chat_session_id") or "default"))
-    sim_viz = dict(DEFAULT_SIM_VIZ)
-    if isinstance(state.get("sim_viz"), dict):
-        sim_viz.update(state["sim_viz"])
+    sim_viz = _sim_viz_for_run(state)
     selected = state.get("camera_selection", ["workspace"])
     camera = str(sim_viz.get("camera") or (selected[0] if isinstance(selected, list) and selected else "workspace"))
     sim_viz["camera"] = camera
@@ -7492,6 +7493,11 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         try {{
           const session = await loadJson("/api/session");
           activeChatSessionId = String(session.active_chat_session_id || activeChatSessionId || "default");
+          if (session && session.sim_viz) {{
+            activeRunId = String((session.sim_viz.active_run_id || session.sim_viz.run_id || activeRunId || "")).trim();
+            activeArtifactRender = String(session.sim_viz.artifact_render || activeArtifactRender || "");
+            updateRenderedDataSummary(session.sim_viz);
+          }}
           updateChatSessionSelector(session.chat_sessions, activeChatSessionId);
           if (session && session.llm) {{
             const currentModel = String(

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -6950,6 +6950,15 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
             await loadArtifact(payload);
           }});
         }});
+        const preferred = data && data.preferred ? data.preferred : null;
+        if (preferred && String(preferred.render || "") === "rerun") {{
+          appendChat("assistant", "Auto-loading preferred Rerun recording for `" + runId + "`.");
+          await loadArtifact({{
+            run_id: runId,
+            key: String(preferred.key || "").trim(),
+            s3_uri: String(preferred.s3_uri || "").trim(),
+          }});
+        }}
         return true;
       }}
       async function loadArtifact(payload) {{

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2369,7 +2369,7 @@ def _rerun_web_viewer_healthy() -> bool:
         return False
 
 def _rerun_ready_state(*, rrd_uri: str = "") -> bool:
-    has_rrd = bool(str(rrd_uri or "").strip()) or RRD_PATH.is_file()
+    has_rrd = bool(str(rrd_uri or "").strip())
     return has_rrd and _rerun_web_viewer_healthy()
 
 def _restart_rerun_serve(*, force: bool = False) -> bool:
@@ -3358,7 +3358,8 @@ def session_bootstrap():
     selected = state.get("camera_selection", ["workspace"])
     camera = str(sim_viz.get("camera") or (selected[0] if isinstance(selected, list) and selected else "workspace"))
     sim_viz["camera"] = camera
-    if not sim_viz.get("rrd_uri") and RRD_PATH.is_file():
+    session_run_id = str(sim_viz.get("run_id") or "").strip()
+    if not sim_viz.get("rrd_uri") and session_run_id in {"", "franka-demo"} and RRD_PATH.is_file():
         sim_viz["rrd_uri"] = f"file://{{RRD_PATH}}"
     sim_viz["rerun_ready"] = _rerun_ready_state(rrd_uri=str(sim_viz.get("rrd_uri") or ""))
     history = active_session.get("chat_history", [])

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -6913,8 +6913,9 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
       }}
       async function loadArtifactsForSelectedRun() {{
         const select = document.getElementById("artifactRunSelect");
-        const runId = String((select && select.value) || "").trim();
-        if (!runId) throw new Error("Select a discovered run first");
+        const runInput = document.getElementById("runIdInput");
+        const runId = String((select && select.value) || (runInput && runInput.value) || activeRunId || "").trim();
+        if (!runId) throw new Error("Select a discovered run or enter a run_id first");
         const prefix = artifactPrefixValue();
         const query = prefix ? ("?prefix=" + encodeURIComponent(prefix)) : "";
         const data = await apiJson("/api/artifacts/run/" + encodeURIComponent(runId) + query);
@@ -6922,7 +6923,10 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         if (!list) return false;
         const artifacts = Array.isArray(data.artifacts) ? data.artifacts : [];
         if (!artifacts.length) {{
-          list.innerHTML = "<p>No artifacts found for this run.</p>";
+          list.innerHTML =
+            "<p>No S3 artifacts found for <code>" + escapeHtml(runId) + "</code>.</p>" +
+            "<p>This run may predate S3 upload support, may belong to a destroyed VM, or may have used a different artifact prefix.</p>" +
+            "<p>Discovery scope: <code>" + escapeHtml(String(data.prefix || "sim2real-b")) + "</code></p>";
           return true;
         }}
         list.innerHTML = artifacts.map((item, idx) => {{

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -5756,6 +5756,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
                 <span>Stage: <span id="simStage" class="badge">idle</span></span>
                 <span>Camera: <strong id="simCamera">workspace</strong></span>
               </div>
+              <div id="renderedDataSummary" class="hint">Rendering: no run artifact loaded yet.</div>
               <div class="btn-row">
                 <button id="openRerun" class="btn" type="button">Open in Rerun</button>
               </div>
@@ -7028,6 +7029,22 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         }}
         return true;
       }}
+      function updateRenderedDataSummary(simViz) {{
+        const node = document.getElementById("renderedDataSummary");
+        if (!node) return;
+        const runId = String((simViz && simViz.run_id) || activeRunId || "none");
+        const key = String((simViz && simViz.artifact_key) || "");
+        const uri = String((simViz && simViz.artifact_uri) || "");
+        const render = String((simViz && simViz.artifact_render) || "");
+        if (key || uri) {{
+          node.innerHTML =
+            "Rendering: <strong>" + escapeHtml(render || "artifact") + "</strong>" +
+            " from run <code>" + escapeHtml(runId) + "</code><br>" +
+            "<code>" + escapeHtml(key || uri) + "</code>";
+        }} else {{
+          node.textContent = "Rendering: no run artifact loaded yet.";
+        }}
+      }}
       async function loadArtifact(payload) {{
         const body = {{
           run_id: String((payload && payload.run_id) || "").trim(),
@@ -7042,10 +7059,14 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
         const simViz = data.sim_viz || {{}};
         const render = String(data.render || simViz.artifact_render || "");
         activeArtifactRender = render;
+        const loadedRunId = String(simViz.run_id || body.run_id || activeRunId || "").trim();
+        if (loadedRunId) activeRunId = loadedRunId;
+        updateRenderedDataSummary(simViz);
         if (render === "rerun") {{
           hideArtifactPreview();
-          await waitForRerunReady();
-          await waitForRerunSuccess(String(simViz.camera || "workspace"), {{ deadlineMs: 90000, mountAttemptsPerLoop: 4 }});
+          rerunIframeLoaded = false;
+          lastRrdUpdatedAt = "";
+          await mountRerunIframeUntilSuccess(String(simViz.camera || "workspace"), 8, loadedRunId);
         }} else {{
           showRerunPlaceholder("Artifact loaded. Use download/preview below.");
           await showArtifactPreview(simViz, render);
@@ -7086,6 +7107,7 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           document.getElementById("simRunId").textContent = String(simViz.run_id || "-");
           document.getElementById("simStage").textContent = String(simViz.stage || "idle");
           document.getElementById("simCamera").textContent = String(simViz.camera || "workspace");
+          updateRenderedDataSummary(simViz);
           activeArtifactRender = String((simViz && simViz.artifact_render) || activeArtifactRender || "");
           const cta = document.getElementById("simvizCta");
           const ready = Boolean(simViz.rerun_ready || simViz.rrd_uri);

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2097,6 +2097,14 @@ def _join_agent_s3_prefix(base_prefix: str, suffix: str = "") -> str:
     return "/".join(part.strip("/") for part in (base_prefix, suffix) if str(part or "").strip().strip("/"))
 
 
+def _artifact_discovery_prefix(settings: dict[str, str], user_prefix: str = "") -> str:
+    requested = str(user_prefix or "").strip().strip("/")
+    base = str(settings.get("prefix") or "").strip().strip("/")
+    if requested:
+        return _join_agent_s3_prefix(base, requested)
+    return _join_agent_s3_prefix(base, "sim2real-b")
+
+
 def _agent_s3_client():
     settings = _agent_s3_settings()
     if not settings["bucket"] or not settings["access_key"] or not settings["secret_key"]:
@@ -3955,7 +3963,7 @@ def sim_viz_recordings():
 def artifacts_runs(prefix: str = "", limit: int = 50):
     try:
         s3, settings = _agent_s3_client()
-        effective_prefix = _join_agent_s3_prefix(settings.get("prefix", ""), prefix)
+        effective_prefix = _artifact_discovery_prefix(settings, prefix)
         page = list_runs(
             settings["bucket"],
             prefix=effective_prefix,
@@ -3977,7 +3985,7 @@ def artifacts_for_run(run_id: str, prefix: str = ""):
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     try:
         s3, settings = _agent_s3_client()
-        effective_prefix = _join_agent_s3_prefix(settings.get("prefix", ""), prefix)
+        effective_prefix = _artifact_discovery_prefix(settings, prefix)
         artifacts = list_artifacts(
             settings["bucket"],
             normalized_run,

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -2326,6 +2326,96 @@ def _artifact_preview_url(filename: str) -> str:
     return f"/api/artifacts/file/{{filename}}"
 
 
+def _local_runs_root() -> Path:
+    return Path("/opt/npa-agent/runs")
+
+
+def _local_artifact_key(run_id: str, path: Path) -> str:
+    rel = path.relative_to(_local_runs_root() / run_id)
+    return f"{{run_id}}/{{rel.as_posix()}}"
+
+
+def _local_artifact_path(run_id: str, key: str) -> Path:
+    normalized_run = validate_run_id(run_id)
+    raw_key = str(key or "").strip().lstrip("/")
+    if raw_key.startswith(normalized_run + "/"):
+        raw_key = raw_key[len(normalized_run) + 1 :]
+    if not raw_key or any(part in {"", ".", ".."} for part in raw_key.split("/")):
+        raise HTTPException(status_code=400, detail="invalid local artifact key")
+    root = (_local_runs_root() / normalized_run).resolve()
+    target = (root / raw_key).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="local artifact key escapes run directory") from exc
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail=f"local artifact not found: {{key}}")
+    return target
+
+
+def _local_run_summaries(prefix: str = "", limit: int = 50) -> dict:
+    root = _local_runs_root()
+    token = str(prefix or "").strip().strip("/")
+    rows = []
+    if root.is_dir():
+        for run_dir in sorted((p for p in root.iterdir() if p.is_dir()), key=lambda p: p.stat().st_mtime, reverse=True):
+            run_id = run_dir.name
+            if token and token not in run_id:
+                continue
+            files = [p for p in run_dir.rglob("*") if p.is_file()]
+            if not files:
+                continue
+            latest = max(files, key=lambda p: p.stat().st_mtime)
+            rows.append(
+                {{
+                    "run_id": run_id,
+                    "last_modified": datetime.fromtimestamp(latest.stat().st_mtime, tz=timezone.utc).isoformat(),
+                    "artifact_count": len(files),
+                    "has_viewable": any(render_hint_for_object(key=p.name) != "download" for p in files),
+                    "source": "local",
+                }}
+            )
+    total = len(rows)
+    return {{"runs": rows[:limit], "truncated": total > limit, "total_runs": total, "limit": limit}}
+
+
+def _local_artifacts_for_run(run_id: str, prefix: str = "") -> list[dict]:
+    normalized_run = validate_run_id(run_id)
+    root = _local_runs_root() / normalized_run
+    token = str(prefix or "").strip().strip("/")
+    rows = []
+    if root.is_dir():
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            key = _local_artifact_key(normalized_run, path)
+            if token and token not in key:
+                continue
+            stat = path.stat()
+            render = render_hint_for_object(key=key)
+            rows.append(
+                {{
+                    "run_id": normalized_run,
+                    "key": key,
+                    "s3_uri": "",
+                    "size": stat.st_size,
+                    "last_modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+                    "render": render,
+                    "inline": is_inline_render(render),
+                    "source": "local",
+                }}
+            )
+    rows.sort(key=lambda item: (str(item["last_modified"]), str(item["key"])), reverse=True)
+    return rows
+
+
+def _preferred_artifact_dict(artifacts: list[dict]) -> dict | None:
+    if not artifacts:
+        return None
+    order = {{"rerun": 0, "video": 1, "image": 2, "json": 3, "text": 4, "download": 5}}
+    return sorted(artifacts, key=lambda item: (order.get(str(item.get("render")), 99), str(item.get("last_modified")), str(item.get("key"))))[0]
+
+
 def _apply_loaded_artifact(
     *,
     state: dict,
@@ -3919,6 +4009,7 @@ def sim_viz_recordings():
 
 @app.get("/artifacts/runs")
 def artifacts_runs(prefix: str = "", limit: int = 50):
+    s3_error = ""
     try:
         s3, settings = _agent_s3_client()
         page = list_runs(
@@ -3931,7 +4022,9 @@ def artifacts_runs(prefix: str = "", limit: int = 50):
     except HTTPException:
         raise
     except Exception as exc:
-        return JSONResponse(status_code=502, content={{"ok": False, "error": str(exc)}})
+        s3_error = str(exc)
+    local_page = _local_run_summaries(prefix=prefix, limit=limit)
+    return {{"ok": True, "bucket": "", "prefix": prefix, "source": "local", "s3_error": s3_error, **local_page}}
 
 
 @app.get("/artifacts/run/{{run_id:path}}")
@@ -3960,6 +4053,18 @@ def artifacts_for_run(run_id: str, prefix: str = ""):
     except HTTPException:
         raise
     except Exception as exc:
+        local_artifacts = _local_artifacts_for_run(normalized_run, prefix=prefix)
+        if local_artifacts:
+            return {{
+                "ok": True,
+                "bucket": "",
+                "source": "local",
+                "s3_error": str(exc),
+                "run_id": normalized_run,
+                "count": len(local_artifacts),
+                "artifacts": local_artifacts,
+                "preferred": _preferred_artifact_dict(local_artifacts),
+            }}
         return JSONResponse(status_code=502, content={{"ok": False, "error": str(exc)}})
 
 
@@ -4011,6 +4116,21 @@ def sim_viz_load_artifact(payload: dict | None = None):
     except HTTPException:
         raise
     except Exception as exc:
+        if requested_run and requested_key and not requested_uri:
+            run_id = validate_run_id(requested_run)
+            local_path = _local_artifact_path(run_id, requested_key)
+            key = _local_artifact_key(run_id, local_path)
+            render = render_hint_for_object(key=key)
+            state = _load_state()
+            sim_viz = _apply_loaded_artifact(
+                state=state,
+                run_id=run_id,
+                key=key,
+                s3_uri="",
+                render=render,
+                local_path=local_path,
+            )
+            return {{"ok": True, "source": "local", "s3_error": str(exc), "sim_viz": sim_viz, "render": render, "artifact_uri": ""}}
         return JSONResponse(status_code=502, content={{"ok": False, "error": str(exc)}})
 
 

--- a/npa/src/npa/cli/agent_chat.py
+++ b/npa/src/npa/cli/agent_chat.py
@@ -40,6 +40,15 @@ _RERUN_SUCCESS_PHRASE_RE = re.compile(
 
 _INTENT_RULES: list[tuple[str, re.Pattern[str]]] = [
     (
+        "start_sim2real",
+        re.compile(
+            r"\b(?:start|run|launch|execute|kick\s*off|submit)\b"
+            r".{0,120}\b(?:sim\s*[- ]?2\s*[- ]?real|sim2real|simulation\s+pipeline|pipeline)\b"
+            r"|\b(?:sim\s*[- ]?2\s*[- ]?real|sim2real)\b.{0,120}\b(?:start|run|launch|execute|kick\s*off|submit)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
         "watch_sim",
         re.compile(
             r"\b(?:watch|monitor|follow|observe)\b.*\b(?:sim|simulation|sim2real|rerun|timeline|rollout|run)\b"

--- a/npa/src/npa/cli/agent_chat.py
+++ b/npa/src/npa/cli/agent_chat.py
@@ -44,7 +44,7 @@ _INTENT_RULES: list[tuple[str, re.Pattern[str]]] = [
         re.compile(
             r"\b(?:start|run|launch|execute|kick\s*off|submit)\b"
             r".{0,120}\b(?:sim\s*[- ]?2\s*[- ]?real|sim2real|simulation\s+pipeline|pipeline)\b"
-            r"|\b(?:sim\s*[- ]?2\s*[- ]?real|sim2real)\b.{0,120}\b(?:start|run|launch|execute|kick\s*off|submit)\b",
+            r"|\b(?:sim\s*[- ]?2\s*[- ]?real|sim2real)\b.{0,120}\b(?:start|launch|execute|kick\s*off|submit)\b",
             re.IGNORECASE,
         ),
     ),
@@ -161,6 +161,7 @@ _INTENT_RULES: list[tuple[str, re.Pattern[str]]] = [
             r"\b(?:find|discover|list|browse|show|view|open|inspect)\b.{0,120}\b(?:artifacts?|outputs?)\b"
             r"|\bwhat can i view\b"
             r"|\bwhat\b.{0,80}\bartifacts?\b.{0,120}\bview\b"
+            r"|\b(?:what|which)\b.{0,80}\b(?:sim\s*[- ]?2\s*[- ]?real|sim2real)?\s*run\b.{0,80}\b(?:view|load|open|use)\b"
             r"|\bartifact\b.{0,120}\b(?:browser|viewer|preview|download)\b",
             re.IGNORECASE,
         ),

--- a/npa/src/npa/workflows/artifacts.py
+++ b/npa/src/npa/workflows/artifacts.py
@@ -274,9 +274,24 @@ def list_artifacts(
 def select_preferred_artifact(artifacts: list[Artifact]) -> Artifact | None:
     if not artifacts:
         return None
+    def _score(item: Artifact) -> tuple[int, int, str, str]:
+        key = item.key.lower()
+        if key.endswith("/reports/sim2real.rrd"):
+            specificity = 0
+        elif key.endswith(".rrd"):
+            specificity = 1
+        elif key.endswith("/reports/sim2real-report.json"):
+            specificity = 2
+        elif "/reports/" in key:
+            specificity = 3
+        elif "/component-io/" in key:
+            specificity = 20
+        else:
+            specificity = 10
+        return (_RENDER_ORDER.get(item.render, 99), specificity, item.last_modified, item.key)
     return sorted(
         artifacts,
-        key=lambda item: (_RENDER_ORDER.get(item.render, 99), item.last_modified, item.key),
+        key=_score,
     )[0]
 
 

--- a/npa/src/npa/workflows/sim2real_viz.py
+++ b/npa/src/npa/workflows/sim2real_viz.py
@@ -16,6 +16,7 @@ but it MUST produce a non-empty ``.rrd`` whenever the SDK is available.
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,7 @@ TIMELINE = "frame_time"
 ROLLOUT_FRAME_SECONDS = 0.5
 HELDOUT_STEP_SECONDS = 1.0
 CRITIQUE_COLOR = (255, 136, 0, 255)
+FRANKA_HOME_JOINTS = (0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785)
 
 
 class Sim2RealVizError(Exception):
@@ -101,6 +103,7 @@ def emit_sim2real_rerun(
     heldout_frame_count = 0
     mp4_paths: list[str] = []
     critique_panel_rows: list[str] = []
+    _log_scene_overview(rr, recording, inner_evidence, counts)
 
     iterations = inner_evidence.get("iterations") or []
     for record in iterations:
@@ -275,6 +278,140 @@ def _log_vlm_critique_panel(
     _bump(counts, "rollouts/summary/critique")
 
 
+def _franka_joint_positions(joint_angles: tuple[float, ...]) -> list[list[float]]:
+    dh = [
+        (0.0, 0.0, 0.333),
+        (0.0, -math.pi / 2.0, 0.0),
+        (0.0, math.pi / 2.0, 0.316),
+        (0.0825, math.pi / 2.0, 0.0),
+        (-0.0825, -math.pi / 2.0, 0.384),
+        (0.0, math.pi / 2.0, 0.0),
+        (0.088, math.pi / 2.0, 0.0),
+    ]
+
+    def _matmul(a: list[list[float]], b: list[list[float]]) -> list[list[float]]:
+        return [[sum(a[i][k] * b[k][j] for k in range(4)) for j in range(4)] for i in range(4)]
+
+    transform = [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+    positions = [[0.0, 0.0, 0.0]]
+    for index, (a, alpha, d) in enumerate(dh):
+        theta = float(joint_angles[index])
+        ct, st = math.cos(theta), math.sin(theta)
+        ca, sa = math.cos(alpha), math.sin(alpha)
+        step = [
+            [ct, -st * ca, st * sa, a * ct],
+            [st, ct * ca, -ct * sa, a * st],
+            [0.0, sa, ca, d],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+        transform = _matmul(transform, step)
+        positions.append([transform[0][3], transform[1][3], transform[2][3]])
+    ee = [transform[0][3], transform[1][3], transform[2][3] + 0.103]
+    positions.append(ee)
+    positions.append([ee[0], ee[1] + 0.04, ee[2]])
+    positions.append([ee[0], ee[1] - 0.04, ee[2]])
+    return positions
+
+
+def _scene_joint_angles(frame_index: int, frame_count: int) -> tuple[float, ...]:
+    phase = (float(frame_index) / max(1.0, float(frame_count - 1))) * math.tau
+    return (
+        FRANKA_HOME_JOINTS[0] + 0.20 * math.sin(phase),
+        FRANKA_HOME_JOINTS[1] + 0.14 * math.sin(phase + 0.5),
+        FRANKA_HOME_JOINTS[2] + 0.16 * math.sin(phase + 1.2),
+        FRANKA_HOME_JOINTS[3] + 0.10 * math.sin(phase + 1.7),
+        FRANKA_HOME_JOINTS[4] + 0.22 * math.sin(phase + 2.1),
+        FRANKA_HOME_JOINTS[5] + 0.09 * math.sin(phase + 2.7),
+        FRANKA_HOME_JOINTS[6] + 0.18 * math.sin(phase + 3.4),
+    )
+
+
+def _log_franka_scene_frame(
+    rr: Any,
+    recording: Any,
+    *,
+    frame_index: int,
+    frame_count: int,
+    counts: dict[str, int],
+) -> None:
+    positions = _franka_joint_positions(_scene_joint_angles(frame_index, frame_count))
+    arm_points = positions[:8]
+    segments = [[left, right] for left, right in zip(arm_points, arm_points[1:]) if left != right]
+    gripper_segments = [[positions[7], positions[8]], [positions[8], positions[9]], [positions[8], positions[10]]]
+    progress = frame_index / max(1.0, float(frame_count - 1))
+    cube_y = 0.28 - 0.36 * progress
+
+    rr.log(
+        "world/cube",
+        rr.Boxes3D(
+            centers=[[0.5, cube_y, 0.04]],
+            half_sizes=[[0.025, 0.025, 0.025]],
+            colors=[[59, 130, 246, 255]],
+        ),
+        recording=recording,
+    )
+    rr.log(
+        "world/franka/joints",
+        rr.Points3D(arm_points, colors=[[234, 88, 12, 255]] * len(arm_points), radii=[0.028] * len(arm_points)),
+        recording=recording,
+    )
+    if segments:
+        rr.log(
+            "world/franka/links",
+            rr.LineStrips3D(segments, colors=[[234, 88, 12]] * len(segments), radii=[0.018] * len(segments)),
+            recording=recording,
+        )
+    rr.log(
+        "world/franka/gripper",
+        rr.LineStrips3D(gripper_segments, colors=[[59, 130, 246]] * len(gripper_segments), radii=[0.012] * len(gripper_segments)),
+        recording=recording,
+    )
+    _bump(counts, "world/cube")
+    _bump(counts, "world/franka/joints")
+    _bump(counts, "world/franka/links")
+
+
+def _log_scene_overview(
+    rr: Any,
+    recording: Any,
+    inner_evidence: dict[str, Any],
+    counts: dict[str, int],
+) -> None:
+    rr.log(
+        "world/table",
+        rr.Boxes3D(
+            centers=[[0.5, 0.0, 0.0]],
+            half_sizes=[[0.4, 0.3, 0.02]],
+            colors=[[180, 180, 180, 255]],
+        ),
+        recording=recording,
+    )
+    rr.log(
+        "world/summary",
+        rr.TextDocument(
+            "# Sim2Real scene overview\n\n"
+            "Reference local run visualization: animated Franka proxy, moving cube, rollout signals, and held-out scores.",
+            media_type="text/markdown",
+        ),
+        recording=recording,
+    )
+    frame_count = max(12, sum(
+        len(_rollout_frames(rollout_dir))
+        for record in inner_evidence.get("iterations") or []
+        for rollout_dir in _rollout_dirs(_maybe_path(record.get("actions_dir")))
+    ))
+    for frame_index in range(frame_count):
+        _set_time(rr, recording, frame_index * ROLLOUT_FRAME_SECONDS)
+        _log_franka_scene_frame(rr, recording, frame_index=frame_index, frame_count=frame_count, counts=counts)
+    _bump(counts, "world/table")
+    _bump(counts, "world/summary")
+
+
 def _log_heldout(
     rr: Any,
     recording: Any,
@@ -434,13 +571,14 @@ def _build_blueprint(
     )
     return rrb.Blueprint(
         rrb.Horizontal(
+            rrb.Spatial3DView(origin="world", contents="world/**", name="Scene overview"),
             left_column,
             rrb.TextDocumentView(origin="rollouts", contents="rollouts/**/critique", name="VLM critiques"),
             rrb.Vertical(
                 rrb.TimeSeriesView(origin="signal", contents="signal/**", name="VLM->RL signal"),
                 rrb.TimeSeriesView(origin="heldout", contents="heldout/**", name="Held-out scores"),
             ),
-            column_shares=[2.0, 1.5, 1.5],
+            column_shares=[2.0, 1.4, 1.2, 1.3],
         ),
         rrb.TimePanel(state=rrb.PanelState.Expanded, timeline=TIMELINE),
         auto_layout=False,

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -424,6 +424,8 @@ def test_bootstrap_embeds_artifact_browser_and_endpoints() -> None:
     assert '@app.get("/artifacts/runs")' in source
     assert '@app.get("/artifacts/run/{{run_id:path}}")' in source
     assert '@app.post("/sim-viz/load-artifact")' in source
+    assert 'Select a discovered run or enter a run_id first' in source
+    assert 'No S3 artifacts found for <code>' in source
     assert "EnvironmentFile=-/opt/npa-agent/s3.env" in source
     embedded = agent_module._embedded_agent_artifacts_source()
     assert "list_runs" in embedded

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -430,6 +430,7 @@ def test_bootstrap_embeds_artifact_browser_and_endpoints() -> None:
     assert 'Select a discovered run or enter a run_id first' in source
     assert 'No S3 artifacts found for <code>' in source
     assert "updateRenderedDataSummary" in source
+    assert "_wait_rerun_web_viewer_healthy" in source
     assert "await mountRerunIframeUntilSuccess(String(simViz.camera || \"workspace\"), 8, loadedRunId)" in source
     assert "EnvironmentFile=-/opt/npa-agent/s3.env" in source
     embedded = agent_module._embedded_agent_artifacts_source()

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -71,6 +71,15 @@ def test_resolve_deploy_storage_credentials_prefers_bootstrap_when_writable(monk
     from npa.cli.agent import _resolve_deploy_storage_credentials
 
     monkeypatch.setattr("npa.cli.agent._storage_credentials_allow_writes", lambda **_kwargs: True)
+    monkeypatch.setattr(
+        "npa.clients.credentials.load_credentials",
+        lambda: SimpleNamespace(
+            s3_bucket="",
+            s3_endpoint="",
+            s3_access_key_id="",
+            s3_secret_access_key="",
+        ),
+    )
     bootstrap = {
         "s3_bucket": "bucket-boot",
         "s3_endpoint": "https://storage.us-central1.nebius.cloud",
@@ -84,14 +93,37 @@ def test_resolve_deploy_storage_credentials_prefers_bootstrap_when_writable(monk
     assert resolved["nebius_api_key"] == "ak-boot"
 
 
+def test_resolve_deploy_storage_credentials_prefers_shared_artifact_bucket(monkeypatch) -> None:
+    from npa.cli.agent import _resolve_deploy_storage_credentials
+
+    monkeypatch.setattr("npa.cli.agent._storage_credentials_allow_writes", lambda **kwargs: kwargs["bucket"] == "shared-bucket")
+    monkeypatch.setattr(
+        "npa.clients.credentials.load_credentials",
+        lambda: SimpleNamespace(
+            s3_bucket="s3://shared-bucket/checkpoints/",
+            s3_endpoint="https://storage.us-central1.nebius.cloud",
+            s3_access_key_id="ak-shared",
+            s3_secret_access_key="sk-shared",
+        ),
+    )
+    bootstrap = {
+        "s3_bucket": "npa-bucket-terraform",
+        "s3_endpoint": "https://storage.us-central1.nebius.cloud",
+        "nebius_api_key": "ak-boot",
+        "nebius_secret_key": "sk-boot",
+    }
+
+    resolved = _resolve_deploy_storage_credentials(region="us-central1", bootstrap_creds=bootstrap)
+
+    assert resolved["s3_bucket"] == "shared-bucket"
+    assert resolved["nebius_api_key"] == "ak-shared"
+
+
 def test_resolve_deploy_storage_credentials_falls_back_to_shared(monkeypatch) -> None:
     from npa.cli.agent import _resolve_deploy_storage_credentials
 
-    calls = {"count": 0}
-
     def _probe(**kwargs):
-        calls["count"] += 1
-        return calls["count"] > 1 and kwargs["bucket"] == "shared-bucket"
+        return kwargs["bucket"] == "shared-bucket"
 
     monkeypatch.setattr("npa.cli.agent._storage_credentials_allow_writes", _probe)
     monkeypatch.setattr(
@@ -146,17 +178,15 @@ def test_franka_rerun_fallback_keeps_3d_outside_pinhole_projection() -> None:
     assert 'f"{entity}/origin"' not in source
 
 
-def test_agent_embeds_local_artifact_discovery_fallback_components() -> None:
+def test_agent_artifact_discovery_requires_s3_components() -> None:
     from npa.cli import agent as agent_module
 
     source = Path(agent_module.__file__).read_text(encoding="utf-8")
-    # Discover runs, list artifacts, and load artifact must all have a local
-    # fallback so the UI still works when object-store ListObjects is denied.
-    assert "def _local_run_summaries" in source
-    assert "def _local_artifacts_for_run" in source
-    assert "def _local_artifact_path" in source
-    assert '"source": "local"' in source
-    assert "s3_error" in source
+    assert "list_runs(" in source
+    assert "list_artifacts(" in source
+    assert "download_s3_uri(" in source
+    assert '"source": "s3"' in source
+    assert "def _local_run_summaries" not in source
 
 
 def test_agent_help_smoke() -> None:

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -423,11 +423,14 @@ def test_bootstrap_embeds_artifact_browser_and_endpoints() -> None:
     assert 'id="artifactPrefix"' in source
     assert 'id="artifactRunSelect"' in source
     assert 'id="artifactList"' in source
+    assert 'id="renderedDataSummary"' in source
     assert '@app.get("/artifacts/runs")' in source
     assert '@app.get("/artifacts/run/{{run_id:path}}")' in source
     assert '@app.post("/sim-viz/load-artifact")' in source
     assert 'Select a discovered run or enter a run_id first' in source
     assert 'No S3 artifacts found for <code>' in source
+    assert "updateRenderedDataSummary" in source
+    assert "await mountRerunIframeUntilSuccess(String(simViz.camera || \"workspace\"), 8, loadedRunId)" in source
     assert "EnvironmentFile=-/opt/npa-agent/s3.env" in source
     embedded = agent_module._embedded_agent_artifacts_source()
     assert "list_runs" in embedded

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -146,6 +146,19 @@ def test_franka_rerun_fallback_keeps_3d_outside_pinhole_projection() -> None:
     assert 'f"{entity}/origin"' not in source
 
 
+def test_agent_embeds_local_artifact_discovery_fallback_components() -> None:
+    from npa.cli import agent as agent_module
+
+    source = Path(agent_module.__file__).read_text(encoding="utf-8")
+    # Discover runs, list artifacts, and load artifact must all have a local
+    # fallback so the UI still works when object-store ListObjects is denied.
+    assert "def _local_run_summaries" in source
+    assert "def _local_artifacts_for_run" in source
+    assert "def _local_artifact_path" in source
+    assert '"source": "local"' in source
+    assert "s3_error" in source
+
+
 def test_agent_help_smoke() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -188,7 +188,7 @@ def test_agent_artifact_discovery_requires_s3_components() -> None:
     assert "download_s3_uri(" in source
     assert '"source": "s3"' in source
     assert "local_path.resolve() != target.resolve()" in source
-    assert "Uploaded run artifacts to S3" in source
+    assert "run artifacts to S3" in source
     assert "def _local_run_summaries" not in source
 
 

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -187,6 +187,8 @@ def test_agent_artifact_discovery_requires_s3_components() -> None:
     assert "list_artifacts(" in source
     assert "download_s3_uri(" in source
     assert '"source": "s3"' in source
+    assert "local_path.resolve() != target.resolve()" in source
+    assert "Uploaded run artifacts to S3" in source
     assert "def _local_run_summaries" not in source
 
 

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -328,6 +328,7 @@ def test_bootstrap_embeds_franka_rerun_ux() -> None:
     assert 'id="rerunFrame" title="rerun" hidden' in source
     assert "RERUN_RECORDING_PATH" in source
     assert "location.origin + RERUN_RECORDING_PATH" in source
+    assert "const rrdUrl = await resolveRerunRecordingUrl();" in source
     assert "/rerun/recordings/sim2real.rrd" in source
     assert 'rel="preload" href="/rerun/re_viewer.js"' in source
     assert "waitForRerunReady" in source

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -135,6 +135,17 @@ def test_bootstrap_nginx_serves_public_rerun_recording() -> None:
     assert "alias /opt/npa-agent/recordings/" in source
 
 
+def test_franka_rerun_fallback_keeps_3d_outside_pinhole_projection() -> None:
+    from npa.cli import agent as agent_module
+
+    source = Path(agent_module.__file__).read_text(encoding="utf-8")
+    assert "_franka_demo_joint_angles" in source
+    assert "frame_count = 90" in source
+    assert "world/camera_frustums/{{name}}" in source
+    assert 'f"{entity}/frustum"' not in source
+    assert 'f"{entity}/origin"' not in source
+
+
 def test_agent_help_smoke() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -73,7 +73,7 @@ def test_resolve_deploy_storage_credentials_prefers_bootstrap_when_writable(monk
     monkeypatch.setattr("npa.cli.agent._storage_credentials_allow_writes", lambda **_kwargs: True)
     monkeypatch.setattr(
         "npa.clients.credentials.load_credentials",
-        lambda: SimpleNamespace(
+        lambda **_kwargs: SimpleNamespace(
             s3_bucket="",
             s3_endpoint="",
             s3_access_key_id="",
@@ -99,7 +99,7 @@ def test_resolve_deploy_storage_credentials_prefers_shared_artifact_bucket(monke
     monkeypatch.setattr("npa.cli.agent._storage_credentials_allow_writes", lambda **kwargs: kwargs["bucket"] == "shared-bucket")
     monkeypatch.setattr(
         "npa.clients.credentials.load_credentials",
-        lambda: SimpleNamespace(
+        lambda **_kwargs: SimpleNamespace(
             s3_bucket="s3://shared-bucket/checkpoints/",
             s3_endpoint="https://storage.us-central1.nebius.cloud",
             s3_access_key_id="ak-shared",
@@ -116,6 +116,7 @@ def test_resolve_deploy_storage_credentials_prefers_shared_artifact_bucket(monke
     resolved = _resolve_deploy_storage_credentials(region="us-central1", bootstrap_creds=bootstrap)
 
     assert resolved["s3_bucket"] == "shared-bucket"
+    assert resolved["s3_prefix"] == "checkpoints"
     assert resolved["nebius_api_key"] == "ak-shared"
 
 
@@ -128,7 +129,7 @@ def test_resolve_deploy_storage_credentials_falls_back_to_shared(monkeypatch) ->
     monkeypatch.setattr("npa.cli.agent._storage_credentials_allow_writes", _probe)
     monkeypatch.setattr(
         "npa.clients.credentials.load_credentials",
-        lambda: SimpleNamespace(
+        lambda **_kwargs: SimpleNamespace(
             s3_bucket="s3://shared-bucket/",
             s3_endpoint="https://storage.us-central1.nebius.cloud",
             s3_access_key_id="ak-shared",
@@ -1056,16 +1057,18 @@ def test_resolve_agent_storage_credentials_prefers_record() -> None:
         "credentials": {
             "service_account_id": "serviceaccount-abc",
             "s3_bucket": "bucket",
+            "s3_prefix": "runs",
             "s3_endpoint": "https://storage.eu-north1.nebius.cloud",
             "access_key": "key",
             "secret_key": "secret",
         },
     }
-    bucket, endpoint, access_key, secret_key, sa_id = _resolve_agent_storage_credentials(
+    bucket, prefix, endpoint, access_key, secret_key, sa_id = _resolve_agent_storage_credentials(
         "rtxpro",
         record,
     )
     assert bucket == "bucket"
+    assert prefix == "runs"
     assert endpoint.endswith("nebius.cloud")
     assert access_key == "key"
     assert secret_key == "secret"

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -186,6 +186,8 @@ def test_agent_artifact_discovery_requires_s3_components() -> None:
     assert "list_runs(" in source
     assert "list_artifacts(" in source
     assert "download_s3_uri(" in source
+    assert "Use this S3-backed Sim2Real run" in source
+    assert "No S3 artifacts found for that run" in source
     assert '"source": "s3"' in source
     assert "local_path.resolve() != target.resolve()" in source
     assert "run artifacts to S3" in source

--- a/npa/tests/cli/test_agent_chat.py
+++ b/npa/tests/cli/test_agent_chat.py
@@ -14,6 +14,8 @@ def test_match_sim2real_status_intent() -> None:
     assert match_chat_intent("create a 2-step sim2real workflow") == "create_workflow"
     assert match_chat_intent("create a gpu workflow across 2 different regions") == "create_workflow"
     assert match_chat_intent("generate an example simple workflow YAML") == "create_workflow"
+    assert match_chat_intent("start the sim2real pipeline") == "start_sim2real"
+    assert match_chat_intent("run actual Sim2Real now") == "start_sim2real"
     assert match_chat_intent("watch the sim") == "watch_sim"
     assert match_chat_intent("track the rerun timeline") == "watch_sim"
     assert match_chat_intent("keep me posted with live updates on the sim run") == "watch_sim"

--- a/npa/tests/cli/test_agent_chat.py
+++ b/npa/tests/cli/test_agent_chat.py
@@ -16,6 +16,8 @@ def test_match_sim2real_status_intent() -> None:
     assert match_chat_intent("generate an example simple workflow YAML") == "create_workflow"
     assert match_chat_intent("start the sim2real pipeline") == "start_sim2real"
     assert match_chat_intent("run actual Sim2Real now") == "start_sim2real"
+    assert match_chat_intent("what sim2real run should I view?") == "find_artifacts"
+    assert match_chat_intent("which run should I load") == "find_artifacts"
     assert match_chat_intent("watch the sim") == "watch_sim"
     assert match_chat_intent("track the rerun timeline") == "watch_sim"
     assert match_chat_intent("keep me posted with live updates on the sim run") == "watch_sim"

--- a/npa/tests/cli/test_agent_workflow.py
+++ b/npa/tests/cli/test_agent_workflow.py
@@ -150,6 +150,7 @@ def test_bootstrap_embeds_workflow_endpoints() -> None:
     assert '@app.post("/sim-viz/select-run")' in source
     assert "sim_viz_runs" in source
     assert '@app.get("/workflows/sim2real/runs/{{run_id:path}}")' in source
+    assert "run-monitor-panel" in source
     assert "Run status, result, and logs" in source
     assert "No run-specific Rerun recording yet" in source
     embedded = agent_module._embedded_agent_workflow_source()

--- a/npa/tests/cli/test_agent_workflow.py
+++ b/npa/tests/cli/test_agent_workflow.py
@@ -153,6 +153,8 @@ def test_bootstrap_embeds_workflow_endpoints() -> None:
     assert "run-monitor-panel" in source
     assert "Run status, result, and logs" in source
     assert "No run-specific Rerun recording yet" in source
+    assert "_run_sim2real_pipeline_background" in source
+    assert "agent-local-sim2real" in source
     embedded = agent_module._embedded_agent_workflow_source()
     assert "validate_workflow_yaml_text" in embedded
     assert "Could not generate runnable workflow YAML yet" in source

--- a/npa/tests/cli/test_agent_workflow.py
+++ b/npa/tests/cli/test_agent_workflow.py
@@ -149,6 +149,9 @@ def test_bootstrap_embeds_workflow_endpoints() -> None:
     assert '@app.get("/sim-viz/runs")' in source
     assert '@app.post("/sim-viz/select-run")' in source
     assert "sim_viz_runs" in source
+    assert '@app.get("/workflows/sim2real/runs/{run_id:path}")' in source
+    assert "Run status, result, and logs" in source
+    assert "No run-specific Rerun recording yet" in source
     embedded = agent_module._embedded_agent_workflow_source()
     assert "validate_workflow_yaml_text" in embedded
     assert "Could not generate runnable workflow YAML yet" in source

--- a/npa/tests/cli/test_agent_workflow.py
+++ b/npa/tests/cli/test_agent_workflow.py
@@ -149,7 +149,7 @@ def test_bootstrap_embeds_workflow_endpoints() -> None:
     assert '@app.get("/sim-viz/runs")' in source
     assert '@app.post("/sim-viz/select-run")' in source
     assert "sim_viz_runs" in source
-    assert '@app.get("/workflows/sim2real/runs/{run_id:path}")' in source
+    assert '@app.get("/workflows/sim2real/runs/{{run_id:path}}")' in source
     assert "Run status, result, and logs" in source
     assert "No run-specific Rerun recording yet" in source
     embedded = agent_module._embedded_agent_workflow_source()

--- a/npa/tests/cli/test_lerobot_cli.py
+++ b/npa/tests/cli/test_lerobot_cli.py
@@ -260,7 +260,7 @@ def test_lerobot_serverless_storage_env_prefers_credentials_for_cross_bucket() -
 
 def test_lerobot_serverless_storage_env_prefers_credentials_for_matching_bucket_endpoint() -> None:
     storage = StorageConfig(
-        checkpoint_bucket="s3://lerobot-ccc9d3c7/checkpoints/",
+        checkpoint_bucket="s3://example-bucket/checkpoints/",
         endpoint_url="https://storage.eu-north1.nebius.cloud",
         aws_access_key_id="project-key",
         aws_secret_access_key="project-secret",
@@ -269,13 +269,13 @@ def test_lerobot_serverless_storage_env_prefers_credentials_for_matching_bucket_
         s3_access_key_id="shared-key",
         s3_secret_access_key="shared-secret",
         s3_endpoint="https://storage.us-central1.nebius.cloud",
-        s3_bucket="s3://lerobot-ccc9d3c7/checkpoints/",
+        s3_bucket="s3://example-bucket/checkpoints/",
     )
 
     assert lerobot._serverless_storage_env_values(
         storage,
         credentials,
-        "s3://lerobot-ccc9d3c7/checkpoints/lerobot/default/run-1/",
+        "s3://example-bucket/checkpoints/lerobot/default/run-1/",
     ) == (
         "shared-key",
         "shared-secret",

--- a/npa/tests/workflows/test_sim2real_viz.py
+++ b/npa/tests/workflows/test_sim2real_viz.py
@@ -40,6 +40,15 @@ class _FakeRerun:
     def TextDocument(self, text: str, media_type: str = "") -> dict[str, Any]:
         return {"kind": "text", "text": text}
 
+    def Boxes3D(self, **kwargs: Any) -> dict[str, Any]:
+        return {"kind": "boxes3d", **kwargs}
+
+    def Points3D(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"kind": "points3d", "args": args, **kwargs}
+
+    def LineStrips3D(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"kind": "lines3d", "args": args, **kwargs}
+
     # Recording lifecycle ---------------------------------------------------
     def RecordingStream(self, application_id: str) -> _FakeRecording:
         self.application_id = application_id
@@ -154,6 +163,11 @@ def test_emit_logs_frames_critiques_signal_and_heldout(monkeypatch, tmp_path: Pa
     kinds = {entity: kind for entity, kind in fake.logged}
     # Rollout camera frames as image streams.
     assert any(e.endswith("/camera") and kinds[e] == "image" for e in entities)
+    # 3D scene overview is the primary visual context.
+    assert "world/table" in entities
+    assert "world/cube" in entities
+    assert "world/franka/joints" in entities
+    assert "world/franka/links" in entities
     # VLM critique overlays.
     assert any(e.endswith("/critique") and kinds[e] == "text" for e in entities)
     assert "rollouts/summary/critique" in entities
@@ -171,6 +185,7 @@ def test_emit_logs_frames_critiques_signal_and_heldout(monkeypatch, tmp_path: Pa
 
     counts = result.entity_counts
     assert counts["/signal/reward"] == 6
+    assert counts["/world/franka/joints"] >= 1
     assert counts["/rollouts/iter_01/rollout-0000/actions/dim_00"] == 3
     assert counts["/heldout/scores"] == 2
     assert counts["/heldout/success_rate"] == 1
@@ -362,6 +377,11 @@ class _RecordingRRB:
         self.views.append(view)
         return view
 
+    def Spatial3DView(self, *, origin: str = "", contents: Any = None, name: str = "", **_: Any) -> dict[str, Any]:
+        view = {"kind": "Spatial3DView", "origin": origin, "name": name}
+        self.views.append(view)
+        return view
+
     def Grid(self, *args: Any, name: str = "", **_: Any) -> dict[str, Any]:
         return {"kind": "Grid", "name": name, "children": list(args)}
 
@@ -389,6 +409,7 @@ def test_build_blueprint_one_2d_view_per_heldout_env() -> None:
     viz_module._build_blueprint(
         rrb, heldout_env_ids=["env-00006", "env-00009", "env-00018"]
     )
+    assert any(v["kind"] == "Spatial3DView" and v["origin"] == "world" for v in rrb.views)
     heldout_origins = [
         v["origin"] for v in rrb.views
         if v["kind"] == "Spatial2DView" and v["origin"].startswith("heldout/camera/")

--- a/npa/tests/workflows/test_workflow_artifacts.py
+++ b/npa/tests/workflows/test_workflow_artifacts.py
@@ -89,6 +89,32 @@ def test_select_preferred_artifact_ranks_rerun_highest() -> None:
     assert chosen.render == "rerun"
 
 
+def test_select_preferred_artifact_chooses_run_report_rrd_before_component_images() -> None:
+    artifacts = [
+        Artifact(
+            "run",
+            "run/component-io/vlm/input/rollout/camera-001.ppm",
+            "s3://bucket/run/component-io/vlm/input/rollout/camera-001.ppm",
+            1,
+            "2026-01-02T00:00:00+00:00",
+            "image",
+            True,
+        ),
+        Artifact(
+            "run",
+            "run/reports/sim2real.rrd",
+            "s3://bucket/run/reports/sim2real.rrd",
+            1,
+            "2026-01-01T00:00:00+00:00",
+            "rerun",
+            True,
+        ),
+    ]
+    chosen = select_preferred_artifact(artifacts)
+    assert chosen is not None
+    assert chosen.key.endswith("reports/sim2real.rrd")
+
+
 def test_select_preferred_artifact_keeps_unknown_download_selectable() -> None:
     artifacts = [
         Artifact("run", "run/raw.foo", "s3://bucket/run/raw.foo", 1, "2026-01-01T00:00:00+00:00", "download", False)

--- a/skills/atomic/find-artifacts/SKILL.md
+++ b/skills/atomic/find-artifacts/SKILL.md
@@ -81,9 +81,10 @@ Unknown types must stay visible/selectable.
 
 - Validate run ids (`validate_run_id`) before listing/loading.
 - Reject traversal keys (`..`, empty segments).
-- Surface S3 failures directly (`ok: false` or error detail); do not claim success when load/list fails.
-- On the NPA agent, local run artifacts under `/opt/npa-agent/runs/<run_id>/`
-  are a valid fallback when object-store list access is denied. In that case
-  `/api/artifacts/runs` should still return `ok: true`, `source: local`, and a
-  non-fatal `s3_error`, while `/api/artifacts/run/{run_id}` and
-  `/api/sim-viz/load-artifact` continue to work for local files.
+- Surface S3 failures directly (`ok: false` or error detail); do not claim
+  success when load/list fails.
+- Agent artifact discovery is S3-first and S3-only for run artifacts. The agent
+  must stage the configured artifact bucket credentials, upload completed run
+  artifacts there, and use `/api/artifacts/runs`, `/api/artifacts/run/{run_id}`,
+  and `/api/sim-viz/load-artifact` against that S3 data. Do not silently fall
+  back to `/opt/npa-agent/runs` for user-visible discovery.

--- a/skills/atomic/find-artifacts/SKILL.md
+++ b/skills/atomic/find-artifacts/SKILL.md
@@ -82,3 +82,8 @@ Unknown types must stay visible/selectable.
 - Validate run ids (`validate_run_id`) before listing/loading.
 - Reject traversal keys (`..`, empty segments).
 - Surface S3 failures directly (`ok: false` or error detail); do not claim success when load/list fails.
+- On the NPA agent, local run artifacts under `/opt/npa-agent/runs/<run_id>/`
+  are a valid fallback when object-store list access is denied. In that case
+  `/api/artifacts/runs` should still return `ok: true`, `source: local`, and a
+  non-fatal `s3_error`, while `/api/artifacts/run/{run_id}` and
+  `/api/sim-viz/load-artifact` continue to work for local files.

--- a/skills/tools/npa-agent/SKILL.md
+++ b/skills/tools/npa-agent/SKILL.md
@@ -150,6 +150,9 @@ such as "start/run the Sim2Real pipeline" should launch the agent-local Sim2Real
 runner, update the standalone Run status/logs panel from
 `/api/workflows/sim2real/status` and `/api/workflows/sim2real/runs/{run_id}`,
 and only mark Rerun ready after a real run recording URI is present.
+Run-specific recordings should open on a useful 3D scene overview (world/table,
+world/franka/*, world/cube) plus rollout/signal panels, not only sparse rollout
+or held-out image streams.
 
 ## HTTP API Reference
 

--- a/skills/tools/npa-agent/SKILL.md
+++ b/skills/tools/npa-agent/SKILL.md
@@ -144,6 +144,12 @@ Rerun wasm inside `/rerun/?url=…` cannot send HTTP basic auth. Parent page:
 
 Do not point the iframe directly at `/api/sim-viz/rrd` (black screen).
 
+Submitted Sim2Real runs must not reuse the stock Franka/demo `.rrd` as if it
+were run-specific data. When no run `.rrd` exists yet, the agent UI should render
+the Run status/logs panel from `/api/workflows/sim2real/status` and
+`/api/workflows/sim2real/runs/{run_id}`; only mark Rerun ready after a real
+recording URI is present.
+
 ## HTTP API Reference
 
 All paths are under `/api/` (nginx proxies to FastAPI backend on `:8787`).

--- a/skills/tools/npa-agent/SKILL.md
+++ b/skills/tools/npa-agent/SKILL.md
@@ -145,10 +145,11 @@ Rerun wasm inside `/rerun/?url=…` cannot send HTTP basic auth. Parent page:
 Do not point the iframe directly at `/api/sim-viz/rrd` (black screen).
 
 Submitted Sim2Real runs must not reuse the stock Franka/demo `.rrd` as if it
-were run-specific data. When no run `.rrd` exists yet, the agent UI should render
-the Run status/logs panel from `/api/workflows/sim2real/status` and
-`/api/workflows/sim2real/runs/{run_id}`; only mark Rerun ready after a real
-recording URI is present.
+were run-specific data. `POST /api/workflows/sim2real/submit` and chat requests
+such as "start/run the Sim2Real pipeline" should launch the agent-local Sim2Real
+runner, update the standalone Run status/logs panel from
+`/api/workflows/sim2real/status` and `/api/workflows/sim2real/runs/{run_id}`,
+and only mark Rerun ready after a real run recording URI is present.
 
 ## HTTP API Reference
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add a Sim2Real run-detail model and endpoint for submitted agent runs.
- Render stage timeline, result, and logs in a standalone Sim2Real Run Monitor section, separate from the Rerun viewer.
- Stop reporting stale demo Rerun data for submitted runs without run-specific `.rrd` data.
- Mark unexecuted stages as `not_run` with explanatory logs instead of misleading `pending`.
- Add chat and API support for starting an actual agent-local Sim2Real runner from `POST /api/workflows/sim2real/submit` or explicit start/run chat phrases.
- Make non-start chat questions such as “what Sim2Real run should I view?” recommend the latest S3-backed run instead of launching a new run.
- Publish the resulting run `.rrd` into the embedded Rerun viewer and upload the completed local run tree to configured S3.
- Fix the Franka fallback recording so 3D frustums are not logged beneath pinhole camera entities, and animate the arm/cube across the Rerun timeline.
- Make the embedded Rerun iframe use the public same-origin recording URL (`/rerun/recordings/sim2real.rrd`) instead of parent-page blob/auth state.
- Add a primary 3D scene overview to run-specific Sim2Real recordings (`world/table`, `world/franka/*`, `world/cube`) so Rerun opens on meaningful scene context instead of only sparse rollout/heldout image streams.
- Use the configured S3 artifact bucket and preserved prefix for agent run upload and artifact discovery; no local file fallback for user-visible discovery.
- Prefer `reports/sim2real.rrd` over component image frames in artifact selection and auto-load the preferred Rerun recording when listing/loading a run’s artifacts.
- Add visible Rerun panel metadata showing which run artifact/key/URI is currently rendered.
- Preserve loaded Rerun artifact state across periodic refreshes/session reloads so the viewer does not fall back to “no run-specific recording”.
- Allow direct artifact lookup by typed run id, with clear empty-state messaging when no S3 artifacts exist for that run.
- Add a live artifact discovery verification script that checks discover, list, and load components against S3 data on a deployed agent.
- Remove concrete artifact/run identifiers from docs/tests where placeholders are appropriate.
- Merge latest `main` and resolve conflicts in `npa/src/npa/cli/agent.py` while preserving live-run support and run-view fixes.

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks.
  - `npa/.venv/bin/python -m pytest npa/tests/workflows/test_sim2real_viz.py npa/tests/workflows/test_workflow_artifacts.py npa/tests/guardrails/test_skills_index.py npa/tests/cli/test_agent.py npa/tests/cli/test_agent_workflow.py npa/tests/cli/test_agent_chat.py -q`
  - `npa/.venv/bin/python -m pytest npa/tests/cli/test_lerobot_cli.py -q`
- [x] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.
- [x] Confirmed merge conflicts are resolved and the branch is clean after merging `origin/main`.
- [x] Live fresh-agent loop on dev VM:
  - Destroyed and respawned a fresh agent VM from this branch.
  - Verified `/api/models` and `/api/chat` on the fresh VM.
  - Verified chat command to start the actual Sim2Real pipeline completes with all 15 stage entries succeeded plus a run-specific Rerun recording.
  - Verified embedded Rerun viewer URL returns HTTP 200 when pointed at the public same-origin recording URL.
  - Verified a fresh chat-started run completes with 15 succeeded stage entries and a run `.rrd` containing `world/franka/{joints,links}`, `world/cube`, `world/table`, `world/summary`, rollout data, and signal data; Rerun viewer endpoint returned HTTP 200.
  - Verified the agent is staged with the configured S3 artifact bucket and prefix.
  - Verified `npa/scripts/verify_agent_artifact_discovery_live.sh` against the deployed agent: discover, list, and load all used S3 data.
  - Verified `/api/artifacts/runs?limit=5` returns `ok: true`, the configured S3 bucket/prefix, and S3-backed run rows.
  - Verified preferred artifact for the latest S3 run is `<prefix>/<run-id>/reports/sim2real.rrd` with `render: rerun`.
  - Verified loaded artifact render from S3 succeeds with `loaded_render: rerun`.
  - Verified direct lookup for a historical run with no uploaded artifacts returns `ok: true` with `count: 0`, while a present run auto-selects/loads `reports/sim2real.rrd`.
  - Verified live chat question “what Sim2Real run should I view?” returns the latest S3-backed run and does not start a new pipeline.
  - Verified loading the preferred S3 `.rrd` returns `rerun_ready: true`, writes `artifact_key`/`artifact_uri` into sim-viz state, and the deployed page includes the rendered-data summary plus forced iframe mount logic.
  - Verified repeated `/api/session`, `/api/sim-viz/status`, and targeted `/api/sim-viz/status?run_id=...` calls preserve the same loaded S3 `.rrd`, `artifact_key`, and `rerun_ready: true`.

## Skill Maintenance

- [x] Updated `skills/tools/npa-agent/SKILL.md` with the Sim2Real run-detail, local-runner, and recording overview behavior.
- [x] Updated `skills/atomic/find-artifacts/SKILL.md` with S3-only artifact discovery behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2888e20-ece5-44d6-be76-54cfba2b2888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2888e20-ece5-44d6-be76-54cfba2b2888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

