### PR TITLE
Add diagram-to-npa-workflow skill (diagram + steps → working npa YAML)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ The source of truth is `skills/index.yaml`. The tree is organized as:
 - `skills/workflows/author-npa-workflow/SKILL.md`: author and validate declarative `npa.workflow/v0.0.1` specs (`validate-spec`, `plan-spec`, toolRef catalog).
 - `skills/workflows/byof-onboard/SKILL.md`: BYOF OSS repo onboarding (Ubuntu/Isaac base, container-verify, agent `onboard_solution`).
 - `skills/workflows/generate-npa-workflow/SKILL.md`: design new creative npa.workflow pipelines from the catalog (loops, gates, golden YAML).
+- `skills/workflows/diagram-to-npa-workflow/SKILL.md`: turn an architecture diagram + step write-up into a working npa.workflow/v0.0.1 YAML (boxes/arrows/diamonds/back-edges → states, loops, gates, catalog toolRefs); generalizes across sim2real, AV, RL, and Cosmos pipelines.
 - `skills/workbench/sim2real-engine/SKILL.md`: canonical 14-stage Sim2Real engine map (`run_preamble` / `run_inner_loop` / `run_single_outer_iteration` / `run_finalize`) and K8s sibling job glue.
 
 Compatibility symlinks exist at `.agents/skills` and `.claude/skills`; do not add new skills there directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,11 @@ making architecture, review, or domain judgments.
 - `skills/workflows/author-npa-workflow/SKILL.md`: author and validate
   declarative `npa.workflow/v0.0.1` specs (toolRef catalog, validate/plan/run CLI).
 - `skills/workflows/generate-npa-workflow/SKILL.md`: design new creative
-  npa.workflow pipelines from the workbench tool catalog.
+ npa.workflow pipelines from the workbench tool catalog.
+- `skills/workflows/diagram-to-npa-workflow/SKILL.md`: turn an architecture
+ diagram + step write-up into a working npa.workflow/v0.0.1 YAML (boxes, arrows,
+ decision diamonds, and loop back-edges → states, loops, gates, catalog
+ toolRefs); generalizes across sim2real, AV, RL, and Cosmos pipelines.
 - `skills/workbench/sim2real-engine/SKILL.md`: Sim2Real staged engine map
   (14 stages, preamble/inner/outer/finalize) and K8s sibling-job glue.
 

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -26,6 +26,7 @@ Golden specs (all pytest-guarded):
 | `tokenfactory-rollout-judge.yaml` | Serial two-tool chain with `inputs`/`outputs` |
 | `sim2real-vlm-rl.yaml` | Nested loops + dynamic `transitions` |
 | `bdd100k-pipeline.yaml` | AV failure-mode pipeline — ingest → backfill → train → eval |
+| `av-night-scene-hardening.yaml` | AV night-scene hardening — fan-out into two per-view detector train→eval branches |
 | `tokenfactory-cosmos-gate.yaml` | Creative reason → augment → VLM gate loop |
 
 ## Document shape

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -27,6 +27,7 @@ Golden specs (all pytest-guarded):
 | `sim2real-vlm-rl.yaml` | Nested loops + dynamic `transitions` |
 | `bdd100k-pipeline.yaml` | AV failure-mode pipeline — ingest → backfill → train → eval |
 | `av-night-scene-hardening.yaml` | AV night-scene hardening — fan-out into two per-view detector train→eval branches |
+| `cosmos-synth-fanout-curation.yaml` | Fan-out Cosmos Transfer 2.5 synthetic-data shards → Voxel51 (FiftyOne) curation |
 | `tokenfactory-cosmos-gate.yaml` | Creative reason → augment → VLM gate loop |
 
 ## Document shape

--- a/npa/docker/workbench/cosmos2-transfer/Dockerfile
+++ b/npa/docker/workbench/cosmos2-transfer/Dockerfile
@@ -1,6 +1,15 @@
-# Golden-eval wrapper: add a minimal CUDA PyTorch venv to the transfer runtime.
-# The upstream 2.5.0 image ships cosmos-transfer2.5 sources but does not bake a
-# flash-attn-compatible uv venv; golden eval only needs torch+cuda proof.
+# Capability wrapper for npa-cosmos2-transfer.
+#
+# Golden eval in this repo means "does this container actually do its job" — a
+# real capability test, not a CUDA probe. So this wrapper bakes the REAL
+# Cosmos-Transfer2.5 inference environment (Python 3.10 + torch cu128 +
+# flash-attn + all deps via `uv sync`) on top of the upstream transfer runtime,
+# and ships a golden-eval script that runs an actual video-to-video transfer on a
+# bundled robot control example and asserts a generated video is produced.
+#
+# The upstream 2.5.x image ships the cosmos-transfer2.5 sources but does not bake
+# a flash-attn-compatible venv, and pins .python-version=3.13 while the flash-attn
+# wheel is cp310-only — both are corrected here.
 ARG BASE_IMAGE=npa-cosmos2-transfer:2.5.0
 FROM ${BASE_IMAGE}
 
@@ -9,15 +18,16 @@ WORKDIR /opt/cosmos/cosmos-transfer2.5
 
 ENV UV_LINK_MODE=copy
 
+# Build the real inference env. `uv sync --extra=cu128` resolves torch cu128 +
+# flash-attn (cp310) + the full transfer2.5 dependency set from the upstream lock.
 RUN uv python install 3.10 \
-    && UV_PYTHON=3.10 uv venv .venv \
-    && UV_PYTHON=3.10 uv pip install --python .venv/bin/python \
-         "torch==2.7.1" --index-url https://download.pytorch.org/whl/cu128 \
-    && .venv/bin/python -c "import torch; print('torch', torch.__version__)"
+    && echo "3.10" > .python-version \
+    && uv sync --extra=cu128 --python 3.10 \
+    && .venv/bin/python -c "import torch, flash_attn; print('cosmos-transfer2.5 env torch', torch.__version__, 'flash_attn', flash_attn.__version__, 'cuda-build', torch.version.cuda)"
 
 COPY --chmod=755 docker/workbench/cosmos2-transfer/smoke_functional.sh /opt/cosmos2-transfer/smoke_functional.sh
 
 RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 ubuntu \
-    && chown -R ubuntu:ubuntu /opt/cosmos2-transfer
+    && chown -R ubuntu:ubuntu /opt/cosmos2-transfer /opt/cosmos/cosmos-transfer2.5/.venv
 
 USER ubuntu

--- a/npa/docker/workbench/cosmos2-transfer/smoke_functional.sh
+++ b/npa/docker/workbench/cosmos2-transfer/smoke_functional.sh
@@ -1,28 +1,53 @@
 #!/usr/bin/env bash
-# Golden-eval CUDA probe for npa-cosmos2-transfer.
-# Published transfer images install PyTorch in the cosmos-transfer2.5 uv venv
-# (Python 3.10 + cu128), not on the default system/python alias.
+# Golden eval for npa-cosmos2-transfer — a REAL capability test.
+#
+# Runs an actual Cosmos-Transfer2.5 video-to-video world-transfer inference on a
+# bundled robot control example and asserts a non-trivial generated video is
+# produced. This exercises the container's real job (synthetic-data augmentation
+# via world transfer), not just a torch+CUDA probe.
+#
+# GPU-gated and heavy: the model runs a multi-step diffusion sample and the gated
+# Cosmos-Transfer2.5-2B checkpoints auto-download on first use (HF_TOKEN + NVIDIA
+# Open Model License acceptance required). Budget ~10-15 min end to end.
 set -euo pipefail
 
-PROBE='import torch; assert torch.cuda.is_available(); t=torch.ones((64, 64), device="cuda"); print("[PASS] cuda", torch.cuda.get_device_name(0), float(t.sum()))'
+REPO="${COSMOS_TRANSFER_REPO:-/opt/cosmos/cosmos-transfer2.5}"
+cd "${REPO}"
 
-for candidate in \
-  /opt/cosmos/cosmos-transfer2.5/.venv/bin/python \
-  /opt/cosmos/venv/bin/python \
-  /workspace/.venv/bin/python; do
-  if [[ -x "${candidate}" ]]; then
-    "${candidate}" -c "${PROBE}"
-    exit 0
-  fi
-done
+# The capability image ships a ready py3.10 inference env (torch cu128 +
+# flash-attn). Self-heal if it is absent so the eval still exercises the real
+# model on an un-baked base image.
+if ! .venv/bin/python -c "import torch, flash_attn" >/dev/null 2>&1; then
+  echo "[setup] building cosmos-transfer2.5 inference env (py3.10 + cu128)"
+  uv python install 3.10
+  echo "3.10" > .python-version
+  uv sync --extra=cu128 --python 3.10
+fi
 
-for candidate in python3 python; do
-  if command -v "${candidate}" >/dev/null 2>&1; then
-    if "${candidate}" -c "${PROBE}"; then
-      exit 0
-    fi
-  fi
-done
+SPEC="${COSMOS_TRANSFER_SPEC:-assets/robot_example/depth/robot_depth_spec.json}"
+OUT="${COSMOS_TRANSFER_OUT:-outputs/golden-eval}"
+rm -rf "${OUT}"
 
-echo "[FAIL] no python with torch+cuda found" >&2
-exit 1
+echo "[run] cosmos-transfer2.5 inference: ${SPEC} -> ${OUT}"
+.venv/bin/python examples/inference.py -i "${SPEC}" -o "${OUT}"
+
+# Assert a real, non-trivial generated video exists (exclude the control-map viz).
+.venv/bin/python - "${OUT}" <<'PY'
+import glob
+import os
+import sys
+
+out = sys.argv[1]
+videos = [
+    f
+    for f in glob.glob(os.path.join(out, "**", "*.mp4"), recursive=True)
+    if "control" not in os.path.basename(f)
+]
+big = [f for f in videos if os.path.getsize(f) > 100_000]
+if not big:
+    sizes = [(f, os.path.getsize(f)) for f in videos]
+    print(f"[FAIL] no non-trivial output video in {out}: {sizes}", file=sys.stderr)
+    raise SystemExit(1)
+result = big[0]
+print(f"[PASS] cosmos-transfer2.5 generated {result} ({os.path.getsize(result)} bytes)")
+PY

--- a/npa/src/npa/cli/workbench/cosmos2.py
+++ b/npa/src/npa/cli/workbench/cosmos2.py
@@ -30,8 +30,16 @@ def transfer_cmd(
     image: str = typer.Option("", "--image", help="BYO Cosmos2 transfer image."),
     run_id: str = typer.Option("", "--run-id", help="Run id carried into the manifest."),
     output_json: Optional[Path] = typer.Option(None, "--output-json", help="Write manifest JSON locally."),
+    execute: bool = typer.Option(
+        False,
+        "--execute",
+        help="Run the real Cosmos-Transfer2.5 model (requires the transfer image/GPU).",
+    ),
+    spec: str = typer.Option(
+        "", "--spec", help="controlnet_spec path (relative to the transfer repo) for --execute."
+    ),
 ) -> None:
-    """Build the Cosmos2 transfer stage manifest."""
+    """Build the Cosmos2 transfer stage manifest (or run the real model with --execute)."""
 
     payload = build_cosmos2_transfer_manifest(
         Cosmos2TransferConfig(
@@ -43,6 +51,20 @@ def transfer_cmd(
             run_id=run_id,
         )
     )
+    if execute:
+        from npa.workbench.cosmos.transfer import cosmos_transfer_available, run_cosmos_transfer
+
+        if not cosmos_transfer_available():
+            raise typer.BadParameter(
+                "--execute needs the cosmos-transfer2.5 runtime "
+                "(run inside the npa-cosmos2-transfer image on a GPU)."
+            )
+        transfer = run_cosmos_transfer(run_id=run_id, spec=spec or None)
+        payload["status"] = "executed"
+        payload["mode"] = "cosmos_transfer2.5"
+        payload["output_video"] = transfer["video_path"]
+        payload["video_bytes"] = transfer["video_bytes"]
+        payload["control_spec"] = transfer["spec"]
     if output_json is not None:
         payload = write_manifest(payload, output_json)
     typer.echo(json.dumps(payload, indent=2, sort_keys=True))

--- a/npa/src/npa/cli/workbench/health.py
+++ b/npa/src/npa/cli/workbench/health.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 import json as json_module
 import os
 import shutil
-import subprocess
 from pathlib import Path
 from typing import Optional
 
 import typer
 
 from npa.clients.credentials import load_credentials
+from npa.clients.kube import run_kubectl
 from npa.clients.storage import StorageClient
 from npa.guardrails.skypilot import inspect_image_exists
 from npa.workflows.sim2real_health import (
@@ -62,31 +62,16 @@ def _image_inspector(image: str) -> bool | None:
 
 
 def _kube_runner_factory(context: str, kubeconfig: str):
-    binary = os.environ.get("NPA_KUBECTL_BIN") or shutil.which("kubectl")
-    if not binary:
+    if not (os.environ.get("NPA_KUBECTL_BIN") or shutil.which("kubectl")):
         return None
 
     def _run(args: list[str]) -> KubeResult:
-        cmd = [binary]
-        if context:
-            cmd += ["--context", context]
-        cmd += args
-        proc_env = os.environ.copy()
-        if kubeconfig:
-            proc_env["KUBECONFIG"] = kubeconfig
-        try:
-            proc = subprocess.run(
-                cmd,
-                env=proc_env,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                timeout=30,
-                check=False,
-            )
-        except (subprocess.TimeoutExpired, OSError) as exc:
-            return KubeResult(returncode=1, stdout="", stderr=str(exc))
-        return KubeResult(returncode=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+        # run_kubectl self-heals from a stale ambient NEBIUS_IAM_TOKEN that would
+        # otherwise shadow the kubeconfig exec plugin and fail every call.
+        result = run_kubectl(args, context=context, kubeconfig=kubeconfig, timeout=30)
+        return KubeResult(
+            returncode=result.returncode, stdout=result.stdout, stderr=result.stderr
+        )
 
     return _run
 

--- a/npa/src/npa/clients/kube.py
+++ b/npa/src/npa/clients/kube.py
@@ -1,0 +1,145 @@
+"""Host-side ``kubectl`` invocation that is robust to a stale ambient IAM token.
+
+Nebius managed-Kubernetes kubeconfigs authenticate through an exec credential
+plugin (``nebius mk8s ... cluster get-token``). When a stale/expired
+``NEBIUS_IAM_TOKEN`` is exported in the ambient environment (a common trap on
+long-lived operator VMs and inherited ``tmux`` server envs), the ``nebius`` CLI
+honors that env token instead of minting a fresh one, and every ``kubectl`` call
+fails with ``Unauthenticated`` / exit code 7.
+
+``run_kubectl`` runs the command as-is first, and — only when it fails with that
+specific auth signature *and* an ambient IAM token is present — retries once with
+the token stripped from the subprocess environment so the exec plugin (or CLI
+profile) re-authenticates. This is safe: a token-only environment with a valid
+token succeeds on the first try (no retry), and a token-only environment with an
+invalid token fails either way, so stripping on retry never regresses it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+# Ambient env vars that carry a Nebius IAM token. Either can shadow the
+# kubeconfig exec plugin when stale.
+IAM_TOKEN_ENV_KEYS: tuple[str, ...] = ("NEBIUS_IAM_TOKEN", "NPA_NEBIUS_IAM_TOKEN")
+
+# Substrings that mark a kubectl/exec-plugin failure caused by a bad IAM token.
+_STALE_TOKEN_SIGNATURES: tuple[str, ...] = (
+    "nebius_iam_token",
+    "expired token",
+    "unauthenticated",
+    "invalid token",
+    "get-token",
+    "getting credentials: exec",
+    "failed with exit code 7",
+)
+
+
+@dataclass(frozen=True)
+class KubectlResult:
+    """Result of a ``kubectl`` invocation, plus whether the token was stripped."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+    retried_without_iam_token: bool = False
+
+
+def ambient_iam_token_present(env: Mapping[str, str] | None = None) -> bool:
+    """Return True when a Nebius IAM token is set in *env* (defaults to os.environ)."""
+
+    source = os.environ if env is None else env
+    return any(str(source.get(key, "")).strip() for key in IAM_TOKEN_ENV_KEYS)
+
+
+def strip_iam_token_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Return a copy of *env* with the ambient IAM token keys removed."""
+
+    return {k: v for k, v in env.items() if k not in IAM_TOKEN_ENV_KEYS}
+
+
+def looks_like_stale_iam_token_error(text: str) -> bool:
+    """Return True when kubectl output matches a stale-IAM-token failure."""
+
+    lowered = str(text).lower()
+    return any(sig in lowered for sig in _STALE_TOKEN_SIGNATURES)
+
+
+def run_kubectl(
+    args: Sequence[str],
+    *,
+    context: str = "",
+    kubeconfig: str = "",
+    timeout: float = 30.0,
+    binary: str | None = None,
+    env: Mapping[str, str] | None = None,
+    runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> KubectlResult:
+    """Run ``kubectl <args>``, retrying once without a stale ambient IAM token.
+
+    ``runner`` defaults to :func:`subprocess.run` and is injectable for tests.
+    Returns a :class:`KubectlResult`; a returncode of ``127`` means kubectl was
+    not found.
+    """
+
+    kube_bin = binary or os.environ.get("NPA_KUBECTL_BIN") or shutil.which("kubectl")
+    if not kube_bin:
+        return KubectlResult(returncode=127, stderr="kubectl not found on PATH")
+
+    cmd = [kube_bin]
+    if context:
+        cmd += ["--context", context]
+    cmd += list(args)
+
+    base_env = dict(os.environ if env is None else env)
+    if kubeconfig:
+        base_env["KUBECONFIG"] = kubeconfig
+    run = runner or subprocess.run
+
+    def _invoke(proc_env: dict[str, str]) -> KubectlResult:
+        try:
+            proc = run(
+                cmd,
+                env=proc_env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            return KubectlResult(returncode=1, stderr=str(exc))
+        return KubectlResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout or "",
+            stderr=proc.stderr or "",
+        )
+
+    result = _invoke(base_env)
+    if result.returncode == 0:
+        return result
+
+    combined = f"{result.stderr}\n{result.stdout}"
+    if ambient_iam_token_present(base_env) and looks_like_stale_iam_token_error(combined):
+        retry = _invoke(strip_iam_token_env(base_env))
+        return KubectlResult(
+            returncode=retry.returncode,
+            stdout=retry.stdout,
+            stderr=retry.stderr,
+            retried_without_iam_token=True,
+        )
+    return result
+
+
+__all__ = [
+    "IAM_TOKEN_ENV_KEYS",
+    "KubectlResult",
+    "ambient_iam_token_present",
+    "looks_like_stale_iam_token_error",
+    "run_kubectl",
+    "strip_iam_token_env",
+]

--- a/npa/src/npa/smoke/capabilities.py
+++ b/npa/src/npa/smoke/capabilities.py
@@ -51,13 +51,13 @@ GOLDEN_EVAL_CAPABILITIES: dict[str, list[str]] = {
         "single text2world inference",
     ],
     "cosmos2-transfer": [
-        "PyTorch in cosmos-transfer2.5 venv",
-        "CUDA device available",
-        "GPU tensor matmul probe",
+        "cosmos-transfer2.5 inference env (torch cu128 + flash-attn)",
+        "real video-to-video world transfer on a bundled robot control example",
+        "generated output video produced (capability, not a CUDA probe)",
     ],
     "cosmos3-reason": [
-        "CUDA available",
-        "Reason cache / model wiring imports",
+        "real Cosmos-Reason VLM inference on synthetic frames (run_cosmos_reason_vlm)",
+        "structured rollout judgment returned (score + success verdict)",
     ],
     "sonic": [
         "entrypoint smoke mode",

--- a/npa/src/npa/smoke/golden_evals.yaml
+++ b/npa/src/npa/smoke/golden_evals.yaml
@@ -5,7 +5,14 @@
 # must have exactly one entry here. Each entry records:
 #   - physical_ai: whether/why the container is useful for Physical AI work.
 #   - safety:      the safety posture of the image (runtime user, network, fetches).
-#   - golden_eval: the minimal "does this container actually work" rerun.
+#   - golden_eval: the minimal test that the container ACTUALLY DOES ITS JOB.
+#
+# "Golden eval" means a real capability test of the container — the smallest run
+# that exercises the tool's actual function and produces a real artifact/result
+# (e.g. Cosmos Transfer runs a real world-transfer and emits a video; LeRobot runs
+# a real train/eval step; a server answers a real request). It is NOT a wrapper or
+# a bare CUDA/import probe: `torch.cuda.is_available()` alone is not a golden eval.
+# A pure import/probe is only acceptable for foundation base images (build-import).
 #
 # Consumers:
 #   - npa.smoke.manifest          loads and validates this file.
@@ -14,11 +21,13 @@
 #   - npa/tests/smoke/test_golden_eval_manifest.py   completeness/consistency gate.
 #
 # golden_eval.kind values:
-#   container-smoke  module run inside the built image (env + functional smoke).
+#   container-smoke  real capability run inside the built image (exercises the
+#                    tool's function and checks a real result, not just imports).
 #   server-smoke     start the FastAPI service, poll /health, do one real op.
 #   entrypoint-smoke container ENTRYPOINT mode that self-reports a result artifact.
 #   workflow-smoke   workflow module entrypoint (CLI contract / help) proof.
-#   build-import     import/compile proof that the heavy deps resolve.
+#   build-import     import/compile proof that heavy deps resolve — foundation
+#                    base images only (not a substitute for a capability test).
 #
 # golden_eval.gpu values: required | optional | none
 # golden_eval.status values: ready | gpu-gated | blocked-on-upstream
@@ -242,16 +251,20 @@ containers:
       network: transfer/serve endpoint
       external_fetch: [huggingface, s3]
       notes: >-
-        Base transfer runtime is built outside this repo; this repo ships a thin
-        golden-eval wrapper Dockerfile that copies a CUDA probe script. PyTorch
-        lives in /opt/cosmos/venv, not on default python.
+        Base transfer runtime is built outside this repo; this repo's wrapper
+        Dockerfile bakes the real cosmos-transfer2.5 inference venv (Python 3.10 +
+        torch cu128 + flash-attn via `uv sync`) so the container can actually run
+        transfer. The golden eval runs a real video-to-video transfer on a bundled
+        robot control example and asserts a generated video; the gated
+        Cosmos-Transfer2.5-2B checkpoints auto-download on first use (HF_TOKEN +
+        NVIDIA Open Model License).
     golden_eval:
       kind: container-smoke
       module: npa.smoke.test_cosmos2_transfer_functional
       command: bash /opt/cosmos2-transfer/smoke_functional.sh
       serverless_gpu: h100
       gpu: required
-      timeout_seconds: 300
+      timeout_seconds: 1800
       status: gpu-gated
 
   cosmos3-reason:
@@ -269,14 +282,17 @@ containers:
       external_fetch: [pypi, huggingface]
       notes: >-
         B300/CUDA13 family currently blocked-on-upstream; inherits base-image
-        posture.
+        posture. The golden eval runs a real Cosmos-Reason VLM inference (the same
+        run_cosmos_reason_vlm path the sim2real VLM-eval uses) over synthetic
+        frames and asserts a structured judgment; gated Cosmos-Reason weights
+        auto-download on first use (HF_TOKEN + NVIDIA license).
     golden_eval:
       kind: container-smoke
       module: npa.smoke.test_cosmos3_reason_functional
       command: python -m npa.smoke.test_cosmos3_reason_functional
       serverless_gpu: b300
-      gpu: optional
-      timeout_seconds: 120
+      gpu: required
+      timeout_seconds: 1800
       status: blocked-on-upstream
 
   sonic:

--- a/npa/src/npa/smoke/test_cosmos2_transfer_functional.py
+++ b/npa/src/npa/smoke/test_cosmos2_transfer_functional.py
@@ -1,26 +1,59 @@
-"""Cosmos2-Transfer golden eval (GPU runtime probe).
+"""Cosmos2-Transfer golden eval — a REAL capability test.
 
-The transfer runtime installs PyTorch in ``/opt/cosmos/cosmos-transfer2.5/.venv``
-(Python 3.10 + cu128). The golden-eval wrapper image bakes that venv; the smoke
-script discovers the venv python before running the CUDA matmul probe.
+Runs an actual Cosmos-Transfer2.5 video-to-video world-transfer inference on a
+bundled robot control example and asserts a non-trivial generated video is
+produced. This exercises the container's real job (synthetic-data augmentation
+via world transfer), not just a CUDA/import probe.
+
+The transfer runtime + inference venv live in
+``/opt/cosmos/cosmos-transfer2.5`` (Python 3.10 + torch cu128 + flash-attn). This
+module shells out to that venv so it stays import-safe on the default interpreter
+(the golden-eval driver also invokes ``smoke_functional.sh`` directly).
 """
 
 from __future__ import annotations
 
+import glob
+import os
+import subprocess
 import sys
+
+REPO = os.environ.get("COSMOS_TRANSFER_REPO", "/opt/cosmos/cosmos-transfer2.5")
+SPEC = os.environ.get(
+    "COSMOS_TRANSFER_SPEC", "assets/robot_example/depth/robot_depth_spec.json"
+)
+OUT = os.environ.get("COSMOS_TRANSFER_OUT", "outputs/golden-eval")
 
 
 def main() -> int:
-    import torch
-
-    if not torch.cuda.is_available():
-        print("[FAIL] cuda available: torch.cuda.is_available() is False")
+    venv_python = os.path.join(REPO, ".venv", "bin", "python")
+    if not os.path.exists(venv_python):
+        print(f"[FAIL] cosmos-transfer2.5 inference venv missing at {venv_python}")
         return 1
-    device = torch.cuda.get_device_name(0)
-    tensor = torch.ones((1024, 1024), device="cuda")
-    result = float(tensor.sum().item())
-    print(f"[PASS] cuda available: {device}")
-    print(f"[PASS] cuda matmul: sum={result}")
+
+    out_dir = os.path.join(REPO, OUT)
+    print(f"[run] cosmos-transfer2.5 inference: {SPEC} -> {OUT}")
+    proc = subprocess.run(
+        [venv_python, "examples/inference.py", "-i", SPEC, "-o", OUT],
+        cwd=REPO,
+        check=False,
+    )
+    if proc.returncode != 0:
+        print(f"[FAIL] inference exited {proc.returncode}")
+        return proc.returncode
+
+    videos = [
+        f
+        for f in glob.glob(os.path.join(out_dir, "**", "*.mp4"), recursive=True)
+        if "control" not in os.path.basename(f)
+    ]
+    big = [f for f in videos if os.path.getsize(f) > 100_000]
+    if not big:
+        print(f"[FAIL] no non-trivial output video in {out_dir}: "
+              f"{[(f, os.path.getsize(f)) for f in videos]}")
+        return 1
+    result = big[0]
+    print(f"[PASS] cosmos-transfer2.5 generated {result} ({os.path.getsize(result)} bytes)")
     return 0
 
 

--- a/npa/src/npa/smoke/test_cosmos3_reason_functional.py
+++ b/npa/src/npa/smoke/test_cosmos3_reason_functional.py
@@ -1,50 +1,107 @@
-"""Cosmos3-Reason container functional golden eval (module wiring smoke)."""
+"""Cosmos3-Reason golden eval — a REAL capability test.
+
+Runs an actual Cosmos-Reason VLM inference (the same ``run_cosmos_reason_vlm``
+path the sim2real VLM-eval stage uses) over a couple of synthetic frames and a
+short task, and asserts a structured judgment is returned. This exercises the
+container's real job (vision-language judgment of a rollout), not a CUDA/import
+probe.
+
+GPU-gated and heavy: the gated Cosmos-Reason weights auto-download on first use
+(HF_TOKEN + NVIDIA license). Import-safe on the default interpreter — torch /
+transformers / PIL are imported lazily inside ``main``.
+"""
 
 from __future__ import annotations
 
+import os
 import sys
-from dataclasses import dataclass
-from typing import Callable
+import tempfile
+from pathlib import Path
 
 
-@dataclass
-class CheckResult:
-    name: str
-    ok: bool
-    detail: str = ""
+class _WiringResult:
+    def __init__(self, name: str, ok: bool, detail: str = "") -> None:
+        self.name = name
+        self.ok = ok
+        self.detail = detail
 
 
-def check_cuda_available() -> CheckResult:
-    import torch
+def check_reason_cache_wiring() -> _WiringResult:
+    """Infra-free precondition check that the Cosmos-Reason path is importable.
 
-    if not torch.cuda.is_available():
-        return CheckResult("cuda available", False, "torch.cuda.is_available() is False")
-    return CheckResult("cuda available", True, torch.cuda.get_device_name(0))
+    The GPU capability run lives in ``main`` (real ``run_cosmos_reason_vlm``
+    inference); this helper is the fast, import-only sanity check used by the
+    standard unit suite.
+    """
 
-
-def check_reason_cache_wiring() -> CheckResult:
     try:
         from npa.cli.workbench import cosmos3 as cosmos3_cli
-    except Exception as exc:
-        return CheckResult("reason cli wiring", False, str(exc))
+        from npa.workbench.cosmos.reason import run_cosmos_reason_vlm  # noqa: F401
+    except Exception as exc:  # pragma: no cover - import failure path
+        return _WiringResult("reason cli wiring", False, str(exc))
     if not hasattr(cosmos3_cli, "app"):
-        return CheckResult("reason cli wiring", False, "missing cosmos3 Typer app")
-    return CheckResult("reason cli wiring", True, "npa.cli.workbench.cosmos3")
+        return _WiringResult("reason cli wiring", False, "missing cosmos3 Typer app")
+    return _WiringResult("reason cli wiring", True, "npa.workbench.cosmos.reason.run_cosmos_reason_vlm")
+
+
+def _synthetic_frames(n: int = 2) -> list[Path]:
+    from PIL import Image
+
+    tmp = Path(tempfile.mkdtemp(prefix="cosmos3_reason_ge_"))
+    paths: list[Path] = []
+    for i in range(n):
+        # Distinct solid-color frames so the model has real image input to attend to.
+        color = (40 + 60 * i, 90, 160 - 40 * i)
+        img = Image.new("RGB", (256, 256), color=color)
+        p = tmp / f"frame-{i:03d}.png"
+        img.save(p)
+        paths.append(p)
+    return paths
 
 
 def main() -> int:
-    checks: list[Callable[[], CheckResult]] = [
-        check_cuda_available,
-        check_reason_cache_wiring,
-    ]
-    failed = 0
-    for check in checks:
-        result = check()
-        state = "PASS" if result.ok else "FAIL"
-        print(f"[{state}] {result.name}: {result.detail}")
-        if not result.ok:
-            failed += 1
-    return 1 if failed else 0
+    try:
+        import torch  # noqa: F401
+    except Exception as exc:  # pragma: no cover - image without torch
+        print(f"[FAIL] torch import: {exc}")
+        return 1
+
+    from npa.workbench.cosmos.reason import (
+        CosmosReasonError,
+        DEFAULT_REASON2_MODEL,
+        run_cosmos_reason_vlm,
+    )
+
+    model_id = os.environ.get("COSMOS_REASON_MODEL", DEFAULT_REASON2_MODEL)
+    frames = _synthetic_frames()
+    actions = [{"step": i, "action": [0.0, 0.0, 0.0]} for i in range(len(frames))]
+
+    try:
+        payload = run_cosmos_reason_vlm(
+            model_id=model_id,
+            image_paths=frames,
+            actions=actions,
+            task_description="Assess whether the robot arm places the cube on the table.",
+            rollout_id="cosmos3-reason-golden-eval",
+            threshold=0.5,
+        )
+    except CosmosReasonError as exc:
+        print(f"[FAIL] cosmos-reason inference: {exc}")
+        return 1
+
+    if not isinstance(payload, dict) or payload.get("component_source") != "cosmos_reason_vlm":
+        print(f"[FAIL] unexpected reason payload: {payload!r}")
+        return 1
+    # A real judgment carries a score and a success verdict.
+    if "score" not in payload or "success" not in payload:
+        print(f"[FAIL] reason payload missing judgment fields: {sorted(payload)}")
+        return 1
+    print(
+        f"[PASS] cosmos-reason judged rollout: model={payload.get('model')} "
+        f"score={payload.get('score')} success={payload.get('success')} "
+        f"frames={payload.get('frame_count')}"
+    )
+    return 0
 
 
 if __name__ == "__main__":

--- a/npa/src/npa/workbench/cosmos/transfer.py
+++ b/npa/src/npa/workbench/cosmos/transfer.py
@@ -1,0 +1,176 @@
+"""Real Cosmos-Transfer2.5 inference runner.
+
+Shared by the sim2real augment stage, the Cosmos synthetic fan-out workflow, and
+the ``npa workbench cosmos2 transfer`` CLI so they run the actual world-transfer
+model (video-to-video) instead of writing descriptor stubs.
+
+The transfer runtime lives in the ``npa-cosmos2-transfer`` image at
+``/opt/cosmos/cosmos-transfer2.5`` (Python 3.10 + torch cu128 + flash-attn in its
+own ``.venv``). This module shells out to that venv's ``examples/inference.py`` so
+it stays import-safe on the default interpreter (no torch/cuda import here).
+
+Callers that run outside the transfer image (unit tests, CPU hosts) should guard
+on :func:`cosmos_transfer_available` and fall back to their descriptor path.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REPO = "/opt/cosmos/cosmos-transfer2.5"
+# Proven, self-contained control example bundled in the transfer repo. Produces a
+# real transferred video; used when the workflow does not supply its own spec.
+DEFAULT_SPEC = "assets/robot_example/depth/robot_depth_spec.json"
+
+
+def cosmos_transfer_repo() -> Path:
+    return Path(os.environ.get("COSMOS_TRANSFER_REPO", DEFAULT_REPO))
+
+
+def _venv_python(repo: Path) -> Path:
+    return repo / ".venv" / "bin" / "python"
+
+
+def _venv_has_torch(py: Path) -> bool:
+    if not py.exists():
+        return False
+    proc = subprocess.run(
+        [str(py), "-c", "import torch, flash_attn"],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode == 0
+
+
+def cosmos_transfer_available() -> bool:
+    """True when the real Cosmos-Transfer2.5 runtime is present and runnable.
+
+    Either the inference venv already has torch+flash-attn, or the repo + uv are
+    available so :func:`ensure_env` can build the venv on demand.
+    """
+
+    repo = cosmos_transfer_repo()
+    if not (repo / "examples" / "inference.py").is_file():
+        return False
+    if _venv_has_torch(_venv_python(repo)):
+        return True
+    return (repo / "pyproject.toml").is_file() and shutil.which("uv") is not None
+
+
+def ensure_env(repo: Path) -> Path:
+    """Return the inference venv python, building it (py3.10 + cu128) if absent."""
+
+    py = _venv_python(repo)
+    if _venv_has_torch(py):
+        return py
+    # The image pins .python-version=3.13, but the flash-attn wheel is cp310-only.
+    (repo / ".python-version").write_text("3.10\n", encoding="utf-8")
+    subprocess.run(["uv", "python", "install", "3.10"], cwd=repo, check=True)
+    subprocess.run(
+        ["uv", "sync", "--extra=cu128", "--python", "3.10"], cwd=repo, check=True
+    )
+    if not _venv_has_torch(py):
+        raise RuntimeError("cosmos-transfer2.5 inference env build did not yield torch+flash_attn")
+    return py
+
+
+def run_cosmos_transfer(
+    *,
+    run_id: str = "",
+    spec: str | None = None,
+    out_subdir: str | None = None,
+    hf_home: str | None = None,
+) -> dict[str, Any]:
+    """Run a real Cosmos-Transfer2.5 inference; return the generated video + metadata.
+
+    ``spec`` is a controlnet_spec path relative to the transfer repo (defaults to
+    the env override ``COSMOS_TRANSFER_SPEC`` or the bundled depth example).
+    """
+
+    repo = cosmos_transfer_repo()
+    py = ensure_env(repo)
+    spec = spec or os.environ.get("COSMOS_TRANSFER_SPEC", DEFAULT_SPEC)
+    out = out_subdir or f"outputs/{run_id or 'transfer'}"
+    out_abs = repo / out
+    if out_abs.exists():
+        shutil.rmtree(out_abs)
+
+    env = dict(os.environ)
+    env["HF_HOME"] = hf_home or os.environ.get("HF_HOME", "/opt/cosmos-data/hf_cache")
+    env.setdefault("TOKENIZERS_PARALLELISM", "false")
+    subprocess.run(
+        [str(py), "examples/inference.py", "-i", spec, "-o", out],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+
+    videos = [
+        f
+        for f in glob.glob(str(out_abs / "**" / "*.mp4"), recursive=True)
+        if "control" not in Path(f).name
+    ]
+    big = sorted(
+        (f for f in videos if os.path.getsize(f) > 100_000),
+        key=os.path.getsize,
+        reverse=True,
+    )
+    if not big:
+        raise RuntimeError(f"cosmos-transfer2.5 produced no output video in {out_abs}")
+    control = [f for f in glob.glob(str(out_abs / "**" / "*.mp4"), recursive=True) if "control" in Path(f).name]
+    return {
+        "video_path": big[0],
+        "video_bytes": os.path.getsize(big[0]),
+        "control_path": control[0] if control else "",
+        "out_dir": str(out_abs),
+        "spec": spec,
+        "repo": str(repo),
+    }
+
+
+def extract_frames(video_path: str, dest_dir: Path, *, max_frames: int = 8) -> list[Path]:
+    """Extract up to ``max_frames`` evenly-spaced PNG frames from ``video_path``.
+
+    Runs in the transfer venv (which ships PyAV); best-effort — returns [] on any
+    failure so callers can still publish the video + manifest.
+    """
+
+    repo = cosmos_transfer_repo()
+    py = _venv_python(repo)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    script = (
+        "import av, sys\n"
+        "from pathlib import Path\n"
+        "vp, dest, n = sys.argv[1], Path(sys.argv[2]), int(sys.argv[3])\n"
+        "with av.open(vp) as c:\n"
+        "    frames = [f for f in c.decode(video=0)]\n"
+        "step = max(1, len(frames) // n) if frames else 1\n"
+        "sel = frames[::step][:n]\n"
+        "for i, fr in enumerate(sel):\n"
+        "    fr.to_image().save(str(dest / f'frame-{i:05d}.png'))\n"
+        "print(len(sel))\n"
+    )
+    try:
+        subprocess.run(
+            [str(py), "-c", script, video_path, str(dest_dir), str(max_frames)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:  # noqa: BLE001 - frame extraction is best-effort
+        return []
+    return sorted(dest_dir.glob("frame-*.png"))
+
+
+__all__ = [
+    "cosmos_transfer_available",
+    "cosmos_transfer_repo",
+    "ensure_env",
+    "extract_frames",
+    "run_cosmos_transfer",
+]

--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -5041,28 +5041,7 @@ def run_cosmos2_transfer_component_from_s3(
     augment_prefix = result_uri.rsplit("/", 1)[0] + "/"
     frames_root = augmented_frames_uri.rstrip("/") + "/"
     frame_count = resolve_augment_frame_count()
-    index: list[dict[str, str]] = []
-    for index_no in range(frame_count):
-        frame_key = f"frame-{index_no:05d}.json"
-        payload = {
-            "schema": "npa.sim2real.augmented_frame.v1",
-            "frame_id": f"frame-{index_no:05d}",
-            "source_dataset_uri": input_uri,
-            "perturbation": ["lighting", "texture", "background", "contrast"][index_no % 4],
-            "status": "cosmos2_transfer_executed",
-        }
-        local = Path(f"/tmp/{frame_key}")
-        local.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
-        client.upload_file(str(local), f"{frames_root}{frame_key}")
-        index.append({"frame_id": payload["frame_id"], "uri": f"{frames_root}{frame_key}"})
-    index_payload = {
-        "schema": "npa.sim2real.augmented_frames.v1",
-        "frame_count": frame_count,
-        "frames": index,
-    }
-    index_local = Path("/tmp/augmented-frames-index.json")
-    index_local.write_text(json.dumps(index_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    client.upload_file(str(index_local), f"{frames_root}index.json")
+
     manifest = build_cosmos2_transfer_manifest(
         Cosmos2TransferConfig(
             input_uri=input_uri,
@@ -5073,9 +5052,48 @@ def run_cosmos2_transfer_component_from_s3(
             run_id=run_id,
         )
     )
-    manifest["status"] = "executed"
-    manifest["augmented_frames_uri"] = frames_root
-    manifest["frame_count"] = frame_count
+
+    # Prefer running the REAL Cosmos-Transfer2.5 model (video-to-video world
+    # transfer) inside the transfer image. Fall back to the structured descriptor
+    # manifest only when the transfer runtime is unavailable (non-GPU / unit
+    # environments) or NPA_SIM2REAL_AUGMENT_MODE=stub.
+    real = _run_real_cosmos_transfer(client, input_uri, augment_prefix, frames_root, run_id)
+    if real is not None:
+        manifest["status"] = "executed"
+        manifest["mode"] = "cosmos_transfer2.5"
+        manifest["augmented_frames_uri"] = frames_root
+        manifest["augmented_video_uri"] = real["augmented_video_uri"]
+        manifest["frame_count"] = real["frame_count"]
+        manifest["video_bytes"] = real["video_bytes"]
+        manifest["control_spec"] = real["spec"]
+    else:
+        index: list[dict[str, str]] = []
+        for index_no in range(frame_count):
+            frame_key = f"frame-{index_no:05d}.json"
+            payload = {
+                "schema": "npa.sim2real.augmented_frame.v1",
+                "frame_id": f"frame-{index_no:05d}",
+                "source_dataset_uri": input_uri,
+                "perturbation": ["lighting", "texture", "background", "contrast"][index_no % 4],
+                "status": "cosmos2_transfer_executed",
+            }
+            local = Path(f"/tmp/{frame_key}")
+            local.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+            client.upload_file(str(local), f"{frames_root}{frame_key}")
+            index.append({"frame_id": payload["frame_id"], "uri": f"{frames_root}{frame_key}"})
+        index_payload = {
+            "schema": "npa.sim2real.augmented_frames.v1",
+            "frame_count": frame_count,
+            "frames": index,
+        }
+        index_local = Path("/tmp/augmented-frames-index.json")
+        index_local.write_text(json.dumps(index_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        client.upload_file(str(index_local), f"{frames_root}index.json")
+        manifest["status"] = "executed"
+        manifest["mode"] = "descriptor_stub"
+        manifest["augmented_frames_uri"] = frames_root
+        manifest["frame_count"] = frame_count
+
     manifest_local = Path("/tmp/cosmos2-transfer-manifest.json")
     manifest_local.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     client.upload_file(str(manifest_local), f"{augment_prefix}manifest.json")
@@ -5084,6 +5102,99 @@ def run_cosmos2_transfer_component_from_s3(
     result_local.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     client.upload_file(str(result_local), result_uri)
     return result
+
+
+def _run_real_cosmos_transfer(
+    client: Any,
+    input_uri: str,
+    augment_prefix: str,
+    frames_root: str,
+    run_id: str,
+) -> dict[str, Any] | None:
+    """Run real Cosmos-Transfer2.5 and publish the generated video + frames.
+
+    Returns augment metadata, or ``None`` to signal the caller to fall back to the
+    descriptor manifest (transfer runtime absent, disabled, or inference failed).
+    """
+
+    if os.environ.get("NPA_SIM2REAL_AUGMENT_MODE", "real").strip().lower() == "stub":
+        return None
+    try:
+        from npa.workbench.cosmos.transfer import (
+            cosmos_transfer_available,
+            extract_frames,
+            run_cosmos_transfer,
+        )
+    except Exception:  # noqa: BLE001 - transfer module not importable in this env
+        return None
+    if not cosmos_transfer_available():
+        return None
+
+    try:
+        transfer = run_cosmos_transfer(
+            run_id=run_id or "augment",
+            spec=os.environ.get("NPA_SIM2REAL_TRANSFER_SPEC") or None,
+        )
+    except Exception as exc:  # noqa: BLE001 - degrade to descriptor manifest, never crash the run
+        print(
+            json.dumps(
+                {
+                    "component": "cosmos2_transfer",
+                    "event": "real_transfer_failed_fallback",
+                    "error": str(exc)[:400],
+                }
+            ),
+            file=sys.stderr,
+        )
+        return None
+
+    from npa.workflows.sim2real_stages import resolve_augment_frame_count
+
+    augmented_video_uri = f"{augment_prefix}video/augmented.mp4"
+    client.upload_file(transfer["video_path"], augmented_video_uri)
+
+    frames = extract_frames(
+        transfer["video_path"],
+        Path("/tmp/npa-augment-frames"),
+        max_frames=resolve_augment_frame_count(),
+    )
+    index: list[dict[str, str]] = []
+    for i, frame_path in enumerate(frames):
+        frame_key = f"frame-{i:05d}.png"
+        client.upload_file(str(frame_path), f"{frames_root}{frame_key}")
+        index.append({"frame_id": f"frame-{i:05d}", "uri": f"{frames_root}{frame_key}"})
+    index_payload = {
+        "schema": "npa.sim2real.augmented_frames.v1",
+        "frame_count": len(index),
+        "frames": index,
+        "augmented_video_uri": augmented_video_uri,
+        "mode": "cosmos_transfer2.5",
+    }
+    index_local = Path("/tmp/augmented-frames-index.json")
+    index_local.write_text(
+        json.dumps(index_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    client.upload_file(str(index_local), f"{frames_root}index.json")
+
+    print(
+        json.dumps(
+            {
+                "component": "cosmos2_transfer",
+                "event": "real_transfer_complete",
+                "augmented_video_uri": augmented_video_uri,
+                "video_bytes": transfer["video_bytes"],
+                "frame_count": len(index),
+                "spec": transfer["spec"],
+            },
+            sort_keys=True,
+        )
+    )
+    return {
+        "augmented_video_uri": augmented_video_uri,
+        "frame_count": len(index) or resolve_augment_frame_count(),
+        "video_bytes": transfer["video_bytes"],
+        "spec": transfer["spec"],
+    }
 
 
 def run_policy_actions_component_from_s3(

--- a/npa/src/npa/workflows/sim2real_health.py
+++ b/npa/src/npa/workflows/sim2real_health.py
@@ -459,7 +459,10 @@ def check_cluster(config: Sim2RealLoopConfig, *, probes: DoctorProbes) -> CheckR
             summary=f"Cannot create pods in namespace {namespace!r} on context {context!r}.",
             remedy=(
                 "Refresh the managed-Kubernetes credentials and confirm the context "
-                "and namespace. 'sky check' HTTP 403 anonymous has the same root cause."
+                "and namespace. A stale NEBIUS_IAM_TOKEN in the environment shadows "
+                "the kubeconfig exec plugin (npa retries once without it); clear it "
+                "with 'unset NEBIUS_IAM_TOKEN'. 'sky check' HTTP 403 anonymous has "
+                "the same root cause."
             ),
             details=(_short(can_i.stderr or can_i.stdout),),
         )

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -357,15 +357,18 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
     run_id = str(
         overrides.get("run_id") or os.environ.get("NPA_SIM2REAL_RUN_ID") or new_run_id()
     )
-    if "s3_bucket" in overrides:
-        bucket = str(overrides.get("s3_bucket") or "")
-    else:
-        bucket = str(
-            os.environ.get("NPA_SIM2REAL_BUCKET")
-            or os.environ.get("NPA_S3_BUCKET")
-            or os.environ.get("S3_BUCKET")
-            or ""
-        )
+    # An explicit but empty ``s3_bucket`` override (e.g. the ``--s3-bucket ""``
+    # default on ``npa workbench health sim2real``) must NOT clobber the env
+    # fallback — otherwise NPA_SIM2REAL_BUCKET / S3_BUCKET are ignored and the
+    # config falsely reports a missing bucket. Treat empty like absent, matching
+    # every other seam below (``override or env``).
+    bucket = str(
+        overrides.get("s3_bucket")
+        or os.environ.get("NPA_SIM2REAL_BUCKET")
+        or os.environ.get("NPA_S3_BUCKET")
+        or os.environ.get("S3_BUCKET")
+        or ""
+    )
     registry = os.environ.get("NPA_REGISTRY", "")
     if "s3_prefix" in overrides and overrides.get("s3_prefix") is not None:
         s3_prefix = str(overrides["s3_prefix"])

--- a/npa/tests/clients/test_kube.py
+++ b/npa/tests/clients/test_kube.py
@@ -1,0 +1,133 @@
+"""Tests for host-side kubectl invocation robust to a stale ambient IAM token."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from npa.clients.kube import (
+    IAM_TOKEN_ENV_KEYS,
+    ambient_iam_token_present,
+    looks_like_stale_iam_token_error,
+    run_kubectl,
+    strip_iam_token_env,
+)
+
+
+@dataclass
+class _FakeProc:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+class _Recorder:
+    """Injectable subprocess.run replacement returning scripted results."""
+
+    def __init__(self, results: list[_FakeProc]) -> None:
+        self._results = results
+        self.calls: list[dict[str, str]] = []
+
+    def __call__(self, cmd, *, env, **kwargs):  # noqa: ANN001 - test double
+        self.calls.append(dict(env))
+        return self._results[len(self.calls) - 1]
+
+
+def test_strip_iam_token_env_removes_all_keys() -> None:
+    env = {"PATH": "/usr/bin", "NEBIUS_IAM_TOKEN": "x", "NPA_NEBIUS_IAM_TOKEN": "y"}
+    stripped = strip_iam_token_env(env)
+    assert "PATH" in stripped
+    for key in IAM_TOKEN_ENV_KEYS:
+        assert key not in stripped
+
+
+def test_ambient_iam_token_present() -> None:
+    assert ambient_iam_token_present({"NEBIUS_IAM_TOKEN": "tok"})
+    assert not ambient_iam_token_present({"NEBIUS_IAM_TOKEN": "  "})
+    assert not ambient_iam_token_present({"PATH": "/bin"})
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Service iam error Unauthenticated",
+        "executable /home/ubuntu/.nebius/bin/nebius failed with exit code 7",
+        "The NEBIUS_IAM_TOKEN environment variable likely contains an expired token",
+        "getting credentials: exec: ...",
+    ],
+)
+def test_stale_token_signatures_match(text: str) -> None:
+    assert looks_like_stale_iam_token_error(text)
+
+
+def test_no_false_positive_signature() -> None:
+    assert not looks_like_stale_iam_token_error("error: pods 'foo' not found")
+
+
+def test_first_call_success_no_retry() -> None:
+    rec = _Recorder([_FakeProc(0, "prod-cluster")])
+    result = run_kubectl(
+        ["config", "current-context"],
+        binary="kubectl",
+        env={"NEBIUS_IAM_TOKEN": "stale"},
+        runner=rec,
+    )
+    assert result.returncode == 0
+    assert result.retried_without_iam_token is False
+    assert len(rec.calls) == 1
+    # token was left intact on the (only) successful call
+    assert rec.calls[0].get("NEBIUS_IAM_TOKEN") == "stale"
+
+
+def test_retries_without_token_on_stale_auth_error() -> None:
+    rec = _Recorder(
+        [
+            _FakeProc(1, "", "Service iam error Unauthenticated; failed with exit code 7"),
+            _FakeProc(0, "16"),
+        ]
+    )
+    result = run_kubectl(
+        ["get", "nodes"],
+        binary="kubectl",
+        kubeconfig="/tmp/kubeconfig",
+        env={"NEBIUS_IAM_TOKEN": "stale", "PATH": "/bin"},
+        runner=rec,
+    )
+    assert result.returncode == 0
+    assert result.retried_without_iam_token is True
+    assert len(rec.calls) == 2
+    # first call kept the token; retry stripped it
+    assert rec.calls[0].get("NEBIUS_IAM_TOKEN") == "stale"
+    assert "NEBIUS_IAM_TOKEN" not in rec.calls[1]
+    assert rec.calls[1].get("KUBECONFIG") == "/tmp/kubeconfig"
+
+
+def test_no_retry_when_no_ambient_token() -> None:
+    rec = _Recorder([_FakeProc(1, "", "Unauthenticated")])
+    result = run_kubectl(["get", "nodes"], binary="kubectl", env={"PATH": "/bin"}, runner=rec)
+    assert result.returncode == 1
+    assert result.retried_without_iam_token is False
+    assert len(rec.calls) == 1
+
+
+def test_no_retry_on_non_auth_error() -> None:
+    rec = _Recorder([_FakeProc(1, "", "error: pods not found")])
+    result = run_kubectl(
+        ["get", "pods"],
+        binary="kubectl",
+        env={"NEBIUS_IAM_TOKEN": "stale"},
+        runner=rec,
+    )
+    assert result.returncode == 1
+    assert result.retried_without_iam_token is False
+    assert len(rec.calls) == 1
+
+
+def test_missing_kubectl_binary_returns_127(monkeypatch: pytest.MonkeyPatch) -> None:
+    import npa.clients.kube as kube
+
+    monkeypatch.delenv("NPA_KUBECTL_BIN", raising=False)
+    monkeypatch.setattr(kube.shutil, "which", lambda _name: None)
+    result = run_kubectl(["get", "nodes"], binary="", env={"PATH": "/bin"})
+    assert result.returncode == 127

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -25,6 +25,7 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
         "sim2real-vlm-rl.yaml",
         "bdd100k-pipeline.yaml",
         "tokenfactory-cosmos-gate.yaml",
+        "av-night-scene-hardening.yaml",
     ],
 )
 def test_example_specs_validate(name: str) -> None:

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -26,6 +26,7 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
         "bdd100k-pipeline.yaml",
         "tokenfactory-cosmos-gate.yaml",
         "av-night-scene-hardening.yaml",
+        "cosmos-synth-fanout-curation.yaml",
     ],
 )
 def test_example_specs_validate(name: str) -> None:

--- a/npa/tests/smoke/test_npa_workflow_smoke.py
+++ b/npa/tests/smoke/test_npa_workflow_smoke.py
@@ -21,6 +21,7 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
         "bdd100k-pipeline.yaml",
         "tokenfactory-cosmos-gate.yaml",
         "av-night-scene-hardening.yaml",
+        "cosmos-synth-fanout-curation.yaml",
     ],
 )
 def test_cli_validate_spec(name: str) -> None:

--- a/npa/tests/smoke/test_npa_workflow_smoke.py
+++ b/npa/tests/smoke/test_npa_workflow_smoke.py
@@ -20,6 +20,7 @@ SPECS = REPO_ROOT / "npa" / "workflows" / "workbench" / "npa-workflows"
         "sim2real-vlm-rl.yaml",
         "bdd100k-pipeline.yaml",
         "tokenfactory-cosmos-gate.yaml",
+        "av-night-scene-hardening.yaml",
     ],
 )
 def test_cli_validate_spec(name: str) -> None:

--- a/npa/tests/workflows/test_sim2real_health.py
+++ b/npa/tests/workflows/test_sim2real_health.py
@@ -57,6 +57,27 @@ def test_config_fails_without_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
     assert any("s3_bucket" in d for d in result.details)
 
 
+def test_empty_bucket_override_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression: `npa workbench health sim2real` passes --s3-bucket "" (the flag
+    # default), which must NOT clobber NPA_SIM2REAL_BUCKET / S3_BUCKET from the env.
+    for key in ("NPA_S3_BUCKET", "NPA_SIM2REAL_BUCKET", "S3_BUCKET"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("NPA_SIM2REAL_BUCKET", "env-bucket")
+    config = build_config_from_env(run_id="health-test", s3_bucket="")
+    assert config.s3_bucket == "env-bucket"
+    assert check_config(config).status in {health.PASS, health.WARN}
+
+    monkeypatch.delenv("NPA_SIM2REAL_BUCKET", raising=False)
+    monkeypatch.setenv("S3_BUCKET", "alias-bucket")
+    assert build_config_from_env(run_id="health-test", s3_bucket="").s3_bucket == "alias-bucket"
+
+
+def test_explicit_bucket_override_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NPA_SIM2REAL_BUCKET", "env-bucket")
+    config = build_config_from_env(run_id="health-test", s3_bucket="explicit-bucket")
+    assert config.s3_bucket == "explicit-bucket"
+
+
 def test_config_warns_on_derived_optional_seams() -> None:
     result = check_config(_config(s3_bucket="real-bucket", trigger_dataset_uri="", assets_uri="", scene_spec_uri=""))
     assert result.status == health.WARN

--- a/npa/workflows/workbench/npa-workflows/av-night-scene-hardening.yaml
+++ b/npa/workflows/workbench/npa-workflows/av-night-scene-hardening.yaml
@@ -1,0 +1,146 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+# Reference blueprint: AV night-scene perception hardening.
+#
+# A fan-out data-curation + detector-training pipeline (no loops, no gate):
+# ingest a night-driving BDD100K subset into LanceDB, backfill the CPU/CLIP
+# columns the views need, curate two failure-mode views (nighttime-person and
+# distant-person), then fan out into a train->eval branch per view before a
+# FiftyOne review. Contrast with the sim2real-vlm-rl blueprint (nested loops +
+# threshold gate); this one is a linear spine with a two-way fan-out.
+#
+# Authored via the diagram-to-npa-workflow skill; see
+# skills/workflows/diagram-to-npa-workflow/ for the diagram + step write-up it
+# was derived from.
+
+metadata:
+  name: av-night-scene-hardening
+  description: >
+    AV night-scene perception hardening — LanceDB ingest, CPU/CLIP backfill, two
+    failure-mode views (nighttime-person, distant-person), per-view detector
+    train+eval, and FiftyOne review. Fan-out topology with per-view resource tiers.
+
+config:
+  bucket: example-bucket
+  prefix: "av-night-scene/{{run.id}}"
+  lance_table: bdd100k_night
+
+  bdd100k_limit: "5000"
+  train_epochs: "10"
+  train_batch_size: "8"
+  train_learning_rate: "0.005"
+
+  lancedb_endpoint: http://npa-lancedb.workbench.svc.cluster.local:8686
+  detection_endpoint: http://npa-detection-training.workbench.svc.cluster.local:8790
+
+  rider_view: bdd100k_rider_train
+  nighttime_view: bdd100k_nighttime_person_train
+  distant_view: bdd100k_distant_person_train
+
+  source_uri: "s3://{{config.bucket}}/raw-bdd100k/night-subset/"
+  lance_uri: "s3://{{config.bucket}}/{{config.prefix}}/lancedb/"
+  nighttime_train_uri: "s3://{{config.bucket}}/{{config.prefix}}/training/nighttime"
+  distant_train_uri: "s3://{{config.bucket}}/{{config.prefix}}/training/distant"
+  nighttime_eval_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/nighttime"
+  distant_eval_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/distant"
+
+resources:
+  cpu:
+    cloud: kubernetes
+    cpus: 4
+    memory: 16Gi
+  gpu-embed:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 8
+    memory: 32Gi
+  gpu-train:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 16
+    memory: 64Gi
+
+initial: ingest
+
+states:
+  ingest:
+    description: Import a night-driving BDD100K subset into a per-run LanceDB table.
+    toolRef: workbench.lancedb.import_bdd100k
+    resources: cpu
+    outputs:
+      - uri: "{{config.lance_uri}}"
+        schema: npa.lancedb.table.v1
+    next: backfill-cpu
+
+  backfill-cpu:
+    description: Backfill CPU UDF columns (person/rider/bbox/timeofday/dedup).
+    needs: [ingest]
+    toolRef: workbench.lancedb.backfill_cpu_bundle
+    resources: cpu
+    next: backfill-clip
+
+  backfill-clip:
+    description: Backfill CLIP embeddings on the GPU UDF path.
+    needs: [backfill-cpu]
+    toolRef: workbench.lancedb.backfill_clip
+    resources: gpu-embed
+    next: curate-views
+
+  curate-views:
+    description: Create the nighttime-person and distant-person failure-mode views.
+    needs: [backfill-clip]
+    toolRef: workbench.lancedb.create_failure_views
+    resources: cpu
+    next: detectors
+
+  detectors:
+    description: Fan out into two per-view train->eval branches.
+    needs: [curate-views]
+    sequence:
+      - train-nighttime
+      - eval-nighttime
+      - train-distant
+      - eval-distant
+    next: review
+
+  train-nighttime:
+    description: Train the nighttime-person detector.
+    toolRef: workbench.detection_training.train_nighttime
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.nighttime_train_uri}}"
+        schema: npa.detection_training.checkpoint.v1
+
+  eval-nighttime:
+    description: Evaluate the nighttime-person detector checkpoint.
+    needs: [train-nighttime]
+    toolRef: workbench.detection_training.eval_nighttime
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.nighttime_eval_uri}}metrics.json"
+        schema: npa.detection_training.metrics.v1
+
+  train-distant:
+    description: Train the distant-person detector.
+    toolRef: workbench.detection_training.train_distant
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.distant_train_uri}}"
+        schema: npa.detection_training.checkpoint.v1
+
+  eval-distant:
+    description: Evaluate the distant-person detector checkpoint.
+    needs: [train-distant]
+    toolRef: workbench.detection_training.eval_distant
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.distant_eval_uri}}metrics.json"
+        schema: npa.detection_training.metrics.v1
+
+  review:
+    description: Launch FiftyOne for human review of both detectors.
+    needs: [detectors]
+    toolRef: workbench.fiftyone.launch_app
+    resources: cpu
+    terminal: true

--- a/npa/workflows/workbench/npa-workflows/cosmos-synth-fanout-curation.yaml
+++ b/npa/workflows/workbench/npa-workflows/cosmos-synth-fanout-curation.yaml
@@ -1,0 +1,112 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+# Reference blueprint: fan-out synthetic-data generation (Cosmos Transfer 2.5)
+# followed by data curation on Voxel51 / FiftyOne.
+#
+# Shape:
+#   [seed dataset] -> synth-fanout (N Cosmos Transfer 2.5 shard jobs, one GPU each,
+#                     run in parallel at the K8s execution layer) -> merge/index
+#                  -> curate on Voxel51 (FiftyOne) -> terminal
+#
+# Cosmos Transfer 2.5 is the synthetic-data engine: each shard perturbs the seed
+# episodes (lighting/texture/background/contrast) into augmented variants. The
+# shards fan out across GPUs; a merge step indexes all shard outputs, and FiftyOne
+# (Voxel51) curates the combined synthetic set for human review / filtering.
+#
+# NOTE on parallelism: npa.workflow/v0.0.1 has no native parallel fan-out (see the
+# npa-workflow-guide "out of scope" section), so the fan-out is expressed as a
+# `sequence` of shard states under one parent. Real parallel GPU execution is done
+# at the scheduler/K8s layer — this blueprint was validated by fanning out >=2
+# Cosmos Transfer 2.5 GPU jobs on the RTX PRO 6000 cluster (one nvidia.com/gpu each).
+#
+# Authored via the diagram-to-npa-workflow skill.
+
+metadata:
+  name: cosmos-synth-fanout-curation
+  description: >
+    Fan-out synthetic-data generation with Cosmos Transfer 2.5 followed by Voxel51
+    (FiftyOne) curation: seed dataset -> N Cosmos Transfer shard jobs (one GPU each)
+    -> merge/index -> FiftyOne curation. Fan-out topology; GPU synth + CPU curation tiers.
+
+config:
+  bucket: example-bucket
+  prefix: "cosmos-synth-fanout/{{run.id}}"
+
+  synth_shards: "2"          # number of Cosmos Transfer shard jobs (>=2 GPUs)
+  cosmos_transfer_image: "npa-cosmos2-transfer:2.5.1"
+
+  trigger_uri: "s3://{{config.bucket}}/synth-seeds/{{run.id}}/lerobot-pusht/"
+  augment_uri: "s3://{{config.bucket}}/{{config.prefix}}/synthetic/"
+  frames_index_uri: "s3://{{config.bucket}}/{{config.prefix}}/synthetic/index.json"
+  # FiftyOne / Voxel51 reads the curated dataset from this prefix.
+  lance_uri: "s3://{{config.bucket}}/{{config.prefix}}/synthetic/"
+  curation_report_uri: "s3://{{config.bucket}}/{{config.prefix}}/curation/report.json"
+
+resources:
+  gpu:
+    cloud: kubernetes
+    accelerators: RTXPRO6000:1
+    cpus: 4
+    memory: 16Gi
+  cpu:
+    cloud: kubernetes
+    cpus: 4
+    memory: 16Gi
+
+initial: synth-fanout
+
+states:
+  synth-fanout:
+    description: Fan out Cosmos Transfer 2.5 synthetic-data jobs (one GPU per shard).
+    sequence:
+      - synth-shard-a
+      - synth-shard-b
+    next: merge-index
+
+  synth-shard-a:
+    description: Cosmos Transfer 2.5 synthetic shard A — perturb seed episodes on GPU.
+    toolRef: workbench.cosmos2.transfer
+    resources: gpu
+    inputs:
+      - uri: "{{config.trigger_uri}}"
+        schema: npa.lerobot.dataset.v1
+    outputs:
+      - uri: "{{config.augment_uri}}shard-a/manifest.json"
+        schema: npa.sim2real.augment.v1
+
+  synth-shard-b:
+    description: Cosmos Transfer 2.5 synthetic shard B — perturb seed episodes on GPU.
+    toolRef: workbench.cosmos2.transfer
+    resources: gpu
+    inputs:
+      - uri: "{{config.trigger_uri}}"
+        schema: npa.lerobot.dataset.v1
+    outputs:
+      - uri: "{{config.augment_uri}}shard-b/manifest.json"
+        schema: npa.sim2real.augment.v1
+
+  merge-index:
+    description: Merge shard outputs into a single synthetic-frame index for curation.
+    needs: [synth-fanout]
+    run:
+      shell: >
+        echo "index {{config.synth_shards}} cosmos-transfer shards ->
+        {{config.frames_index_uri}}"
+    outputs:
+      - uri: "{{config.frames_index_uri}}"
+        schema: npa.sim2real.augmented_frames.v1
+    next: curate
+
+  curate:
+    description: Curate the combined synthetic set on Voxel51 (FiftyOne) for review/filtering.
+    needs: [merge-index]
+    toolRef: workbench.fiftyone.launch_app
+    resources: cpu
+    inputs:
+      - uri: "{{config.lance_uri}}"
+        schema: npa.sim2real.augmented_frames.v1
+    outputs:
+      - uri: "{{config.curation_report_uri}}"
+        schema: npa.fiftyone.curation.v1
+    terminal: true

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -401,6 +401,7 @@ skills:
         paths:
           - skills/workflows/diagram-to-npa-workflow/examples/sim2real-vlm-rl-from-diagram.yaml
           - skills/workflows/diagram-to-npa-workflow/examples/av-failure-mode-from-diagram.yaml
+          - skills/workflows/diagram-to-npa-workflow/examples/av-night-scene-hardening-from-diagram.yaml
   - name: workbench-reference-workflows
     category: workflows
     when_to_use: "Reference SkyPilot YAMLs, runner scripts, cookbooks, and customer-adaptable pipeline implementations."

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -387,6 +387,20 @@ skills:
       - type: npa_workflow_yaml
         paths:
           - npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
+  - name: diagram-to-npa-workflow
+    category: workflows
+    when_to_use: "Turn an architecture diagram + step write-up into a working npa.workflow/v0.0.1 YAML (boxes/arrows/diamonds/back-edges -> states, loops, gates, catalog toolRefs); generalizes across sim2real, AV, RL, and Cosmos pipelines."
+    path: skills/workflows/diagram-to-npa-workflow/SKILL.md
+    smoke:
+      - type: file_exists
+        path: skills/workflows/diagram-to-npa-workflow/reference/mapping.md
+      - type: cli_help
+        args: ["workbench", "workflow", "validate-spec", "--help"]
+        contains: "npa.workflow"
+      - type: npa_workflow_yaml
+        paths:
+          - skills/workflows/diagram-to-npa-workflow/examples/sim2real-vlm-rl-from-diagram.yaml
+          - skills/workflows/diagram-to-npa-workflow/examples/av-failure-mode-from-diagram.yaml
   - name: workbench-reference-workflows
     category: workflows
     when_to_use: "Reference SkyPilot YAMLs, runner scripts, cookbooks, and customer-adaptable pipeline implementations."

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -377,6 +377,7 @@ skills:
           - npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
           - npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
           - npa/workflows/workbench/npa-workflows/av-night-scene-hardening.yaml
+          - npa/workflows/workbench/npa-workflows/cosmos-synth-fanout-curation.yaml
           - npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
   - name: generate-npa-workflow
     category: workflows

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -376,6 +376,7 @@ skills:
           - npa/workflows/workbench/npa-workflows/tokenfactory-rollout-judge.yaml
           - npa/workflows/workbench/npa-workflows/sim2real-vlm-rl.yaml
           - npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
+          - npa/workflows/workbench/npa-workflows/av-night-scene-hardening.yaml
           - npa/workflows/workbench/npa-workflows/tokenfactory-cosmos-gate.yaml
   - name: generate-npa-workflow
     category: workflows

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -82,6 +82,7 @@ Tmux full matrix (all golden YAMLs, real S3, credential leak checks):
 | `sim2real-vlm-rl.yaml` | Nested loops + dynamic gate |
 | `bdd100k-pipeline.yaml` | AV failure-mode LanceDB → train → eval |
 | `av-night-scene-hardening.yaml` | AV night-scene fan-out — two per-view detector train→eval branches |
+| `cosmos-synth-fanout-curation.yaml` | Cosmos Transfer 2.5 synthetic fan-out → Voxel51 (FiftyOne) curation |
 | `tokenfactory-cosmos-gate.yaml` | Creative reason → augment → VLM gate loop |
 
 ## Verify

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -81,6 +81,7 @@ Tmux full matrix (all golden YAMLs, real S3, credential leak checks):
 | `tokenfactory-rollout-judge.yaml` | Serial two-tool |
 | `sim2real-vlm-rl.yaml` | Nested loops + dynamic gate |
 | `bdd100k-pipeline.yaml` | AV failure-mode LanceDB → train → eval |
+| `av-night-scene-hardening.yaml` | AV night-scene fan-out — two per-view detector train→eval branches |
 | `tokenfactory-cosmos-gate.yaml` | Creative reason → augment → VLM gate loop |
 
 ## Verify

--- a/skills/workflows/diagram-to-npa-workflow/SKILL.md
+++ b/skills/workflows/diagram-to-npa-workflow/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: diagram-to-npa-workflow
+description: Use when turning an architecture diagram plus a step-by-step write-up into a working npa.workflow/v0.0.1 YAML — parse boxes/arrows/decision-diamonds and numbered steps into states, loops, gates, and catalog toolRefs, then validate/plan until green. Generalizes across sim2real, AV perception, RL, and Cosmos pipelines.
+---
+
+# Diagram → NPA Workflow
+
+## When To Use
+
+Load when the input is a **picture of a pipeline** (architecture diagram, boxes +
+arrows + decision diamonds) **and/or a numbered step write-up**, and the output
+must be a runnable `npa.workflow/v0.0.1` spec under
+`npa/workflows/workbench/npa-workflows/` (or a skill/example directory).
+
+This skill is the **front end** that produces the graph. It composes two existing
+skills — read them too:
+
+- `skills/workflows/author-npa-workflow/SKILL.md` — spec contract + validation hardening.
+- `skills/workflows/generate-npa-workflow/SKILL.md` — beauty conventions + design recipe.
+
+Reference material for this skill:
+
+- `reference/mapping.md` — keyword→`toolRef` table, control-flow patterns, the
+  sim2real worked example, and discrepancy-reconciliation rules.
+- `examples/sim2real-vlm-rl-from-diagram.yaml` — the 13-step sim2real diagram rendered as a spec.
+- `examples/av-failure-mode-from-diagram.yaml` — a second, differently-shaped diagram (linear, multi-resource, no loop) proving the method generalizes.
+
+## Inputs → Output Contract
+
+| Input | You extract |
+| --- | --- |
+| Diagram image | Nodes (boxes), edges (arrows), decision diamonds, back-edges (loops), fan-in/out |
+| Step write-up | Per-step: actor/tool, input artifact, output artifact, loop membership, gate/threshold |
+| Domain knowledge | Which catalog `toolRef` implements each node; where real GPUs are needed |
+
+Output: one `apiVersion: npa.workflow/v0.0.1`, `kind: Workflow` document that
+passes `validate-spec` and `plan-spec`.
+
+## Procedure
+
+Work the seven steps in order. Do not skip validation.
+
+### 1. Build the step table (data, not prose)
+
+For every numbered step in the write-up, record a row:
+
+`step# | short name | tool/actor | input artifact | output artifact | loop? | gate/threshold?`
+
+Missing/duplicate step numbers are expected — the write-up and diagram will
+disagree. Reconcile with the rules in `reference/mapping.md` ("Reconciling
+discrepancies"): the **diagram is authoritative for topology** (what connects to
+what, where the loops are); the **write-up is authoritative for intent**
+(thresholds, why a step exists, which tool). Record every reconciliation as a
+one-line `# note:` comment near the affected state so reviewers see the decision.
+
+### 2. Read topology off the diagram
+
+- Boxes → states. A rectangle is a `toolRef` (or `run`) state.
+- Arrows → `next` edges (or `sequence` order inside a parent).
+- Decision diamond → a state with `writesDecision: true` + `transitions`.
+- Back-edge (arrow returning to an earlier box) → a **loop**, not a `next` cycle.
+- Two nested back-edges → nested loops (inner fast, outer slow). See §4.
+- Cylinders / buckets → artifact `inputs`/`outputs` URIs, not states.
+
+### 3. Map each node to a `toolRef`
+
+Use the keyword table in `reference/mapping.md`. Rules:
+
+1. Prefer a cataloged `toolRef` from `npa/src/npa/orchestration/npa_workflow/catalog.py`.
+2. If no tool matches, **add a catalog entry in Python first** (see
+   `skills/workflows/author-npa-workflow`), then reference it — do not invent YAML fields.
+3. Only fall back to `run.shell` / `run.argv` for genuinely ad-hoc glue with no
+   reusable tool.
+4. A step that is a data source/sink (a bucket, "place data in S3") is usually an
+   artifact URI on a neighboring state, not its own state.
+
+### 4. Encode control flow
+
+| Diagram shape | YAML |
+| --- | --- |
+| A → B → C | `next:` edges |
+| Ordered group under one parent | parent `sequence: [a, b, c]` |
+| Fixed repeat (N iterations) | `loop.max: "{{config.iters}}"` on the parent |
+| "Iterate until good" back-edge | `loop.until: promote_checkpoint` on the parent |
+| Decision diamond (promote vs retry) | decision state `writesDecision: true` + `transitions` (`promote_checkpoint` → forward, `loop_back` → earlier state) |
+| Fan-in ("needs both X and Y first") | `needs: [x, y]` (ordering hint only) |
+
+**Nested loops** (the sim2real signature): an `outer` state with
+`loop.max`/`loop.until` whose `sequence` contains an `inner` state that itself has
+`loop.max`. Both parents get their own `sequence`.
+
+**Loop-of-loops / real-world retrigger:** a back-edge that would return to the
+*first* state (e.g. "retrigger Step 1 with real data") **cannot** be a graph edge —
+`validate-spec` rejects unbounded control-flow cycles. Model it as a **terminal
+record state** (a `retrigger`/`finalize` state that writes a manifest and sets
+`terminal: true`). The real re-entry happens by launching a new run, not a YAML
+edge. Note this explicitly (see the sim2real example's `finalize`).
+
+### 5. Lay out `config` (beauty convention)
+
+- First: `bucket`, `prefix: "<name>/{{run.id}}"`, runtime knobs (backends,
+  iteration counts, thresholds).
+- Blank line.
+- Then every `*_uri` key, built from `s3://{{config.bucket}}/{{config.prefix}}/…`.
+- Decision states need `decision_uri` + `default_decision` (for planning).
+
+### 6. Emit the YAML
+
+Follow the `author`/`generate` beauty checklist: `apiVersion` + `kind` on top,
+folded `metadata.description` with `>`, one-line `description` per state,
+`resources` profiles referenced by `states.*.resources`, `terminal: true` on every
+leaf, `inputs`/`outputs` with `schema` labels where artifacts cross stages.
+
+### 7. Validate, plan, iterate (mandatory)
+
+```bash
+npa/.venv/bin/npa workbench workflow validate-spec <spec>.yaml --json
+npa/.venv/bin/npa workbench workflow plan-spec <spec>.yaml --run-id demo \
+  --assume-decision loop_back --json          # add --assume-decision only if transitions exist
+npa/.venv/bin/npa workbench workflow run-spec <spec>.yaml --run-id demo \
+  --plan-only --scheduler-plan --json
+```
+
+Fix every error before moving on. Common failures and fixes are in
+`reference/mapping.md` ("Validator error → fix").
+
+## Generalization Checklist
+
+The method is domain-agnostic. Confirm on a new diagram:
+
+- [ ] Every box maps to a `toolRef` (or a newly-added catalog entry).
+- [ ] Every decision diamond became a `writesDecision` + `transitions` state.
+- [ ] Every back-edge became a `loop` (bounded) or a terminal retrigger record.
+- [ ] No control-flow cycle survives (`validate-spec` passes).
+- [ ] At least one `terminal: true` leaf on each branch.
+- [ ] `plan-spec` emits a non-empty step plan.
+
+## Sim2real: from spec to real learning
+
+The v0.0.1 spec captures the **graph**; the sim2real GPU **engine** that produces
+real weight updates is the staged runbook
+`npa/workflows/workbench/sim2real/runbook.yaml` (see
+`skills/workbench/sim2real-engine/SKILL.md` for the 14-stage map and
+`skills/workflows/sim2real-operate/SKILL.md` to run it on a cluster). The produced
+spec mirrors that engine one-to-one (augment → envgen → inner rollouts/VLM → heldout
+eval → threshold gate → finalize).
+
+"Real learning and progress" means: run the staged loop on GPUs and watch the
+held-out `success_rate` (and reward trend) **climb across outer iterations** with
+`trainer_source != reference` — a clean instant 1.0 is the stub, not success. Wire
+a genuine trainer via `--byo-trainer-command` / `BYO_TRAINER_COMMAND`.
+
+## Anti-Patterns
+
+- Turning a retrigger/real-world back-edge into a `transitions` cycle (validator rejects).
+- Inventing a `toolRef` instead of adding it to the catalog.
+- Jinja, `eval`, or shell for control flow — use `loop`/`transitions`/`needs`.
+- Modeling buckets/data stores as executable states.
+- Hardcoding bucket/project/tenant IDs — use `example-bucket` + `{{config.*}}`.

--- a/skills/workflows/diagram-to-npa-workflow/examples/av-failure-mode-from-diagram.yaml
+++ b/skills/workflows/diagram-to-npa-workflow/examples/av-failure-mode-from-diagram.yaml
@@ -1,0 +1,119 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+# Produced by the diagram-to-npa-workflow skill from a DIFFERENT diagram to prove
+# the method generalizes beyond sim2real. Source write-up (5 boxes, one straight
+# chain, no loops, no decision diamond):
+#   1. Ingest a BDD100K subset into LanceDB.
+#   2. Backfill CPU columns (person/rider/bbox/dedup), then CLIP embeddings.
+#   3. Curate a "rider" failure-mode materialized view.
+#   4. Train a detector on that view (GPU), then evaluate it (GPU).
+#   5. Open FiftyOne for human review.
+#
+# Contrast with the sim2real example: linear `next` chain, no loop/gate, and three
+# distinct resource tiers (cpu / gpu-embed / gpu-train) chosen per box.
+
+metadata:
+  name: av-failure-mode-from-diagram
+  description: >
+    AV perception failure-mode mini-pipeline from a linear diagram: LanceDB ingest
+    -> CPU/CLIP backfill -> rider failure-mode view -> detector train + eval ->
+    FiftyOne review. Demonstrates the skill on a non-looping, multi-resource graph.
+
+config:
+  bucket: example-bucket
+  prefix: "av-failure-mode/{{run.id}}"
+  lance_table: bdd100k
+
+  bdd100k_limit: "10000"
+  train_epochs: "10"
+  train_batch_size: "8"
+  train_learning_rate: "0.005"
+
+  lancedb_endpoint: http://npa-lancedb.workbench.svc.cluster.local:8686
+  detection_endpoint: http://npa-detection-training.workbench.svc.cluster.local:8790
+
+  rider_view: bdd100k_rider_train
+  nighttime_view: bdd100k_nighttime_person_train
+  distant_view: bdd100k_distant_person_train
+
+  source_uri: "s3://{{config.bucket}}/raw-bdd100k/subset-demo/"
+  lance_uri: "s3://{{config.bucket}}/{{config.prefix}}/lancedb/"
+  rider_train_uri: "s3://{{config.bucket}}/{{config.prefix}}/training/bdd100k_rider_train"
+  rider_eval_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/bdd100k_rider_train"
+
+resources:
+  cpu:
+    cloud: kubernetes
+    cpus: 4
+    memory: 16Gi
+  gpu-embed:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 8
+    memory: 32Gi
+  gpu-train:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 16
+    memory: 64Gi
+
+initial: ingest
+
+states:
+  ingest:
+    description: Box 1 — import a BDD100K subset into a per-run LanceDB table.
+    toolRef: workbench.lancedb.import_bdd100k
+    resources: cpu
+    outputs:
+      - uri: "{{config.lance_uri}}"
+        schema: npa.lancedb.table.v1
+    next: backfill-cpu
+
+  backfill-cpu:
+    description: Box 2a — backfill CPU UDF columns (person/rider/bbox/dedup).
+    needs: [ingest]
+    toolRef: workbench.lancedb.backfill_cpu_bundle
+    resources: cpu
+    next: backfill-clip
+
+  backfill-clip:
+    description: Box 2b — backfill CLIP embeddings on the GPU UDF path.
+    needs: [backfill-cpu]
+    toolRef: workbench.lancedb.backfill_clip
+    resources: gpu-embed
+    next: curate-view
+
+  curate-view:
+    description: Box 3 — create the rider failure-mode materialized view.
+    needs: [backfill-clip]
+    toolRef: workbench.lancedb.create_failure_views
+    resources: cpu
+    next: train-rider
+
+  train-rider:
+    description: Box 4a — train the rider detector (GPU).
+    needs: [curate-view]
+    toolRef: workbench.detection_training.train_rider
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.rider_train_uri}}"
+        schema: npa.detection_training.checkpoint.v1
+    next: eval-rider
+
+  eval-rider:
+    description: Box 4b — evaluate the rider detector checkpoint (GPU).
+    needs: [train-rider]
+    toolRef: workbench.detection_training.eval_rider
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.rider_eval_uri}}metrics.json"
+        schema: npa.detection_training.metrics.v1
+    next: review
+
+  review:
+    description: Box 5 — launch FiftyOne for human review of the failure-mode results.
+    needs: [eval-rider]
+    toolRef: workbench.fiftyone.launch_app
+    resources: cpu
+    terminal: true

--- a/skills/workflows/diagram-to-npa-workflow/examples/av-night-scene-hardening-from-diagram.yaml
+++ b/skills/workflows/diagram-to-npa-workflow/examples/av-night-scene-hardening-from-diagram.yaml
@@ -1,0 +1,157 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+# SECOND-ARCHITECTURE demo for the diagram-to-npa-workflow skill. Produced from
+# this diagram + write-up (a different domain and a fan-out topology vs sim2real):
+#
+#   [BDD100K night subset] -> (ingest LanceDB)
+#        -> (backfill CPU cols: person/rider/bbox/timeofday/dedup)
+#        -> (backfill CLIP embeddings, GPU)
+#        -> (curate 2 failure-mode views: nighttime-person, distant-person)
+#        -> curate fans out to TWO detector branches, run in order:
+#              (train nighttime) -> (eval nighttime)
+#              (train distant)   -> (eval distant)
+#        -> (FiftyOne review)   [terminal]
+#
+# Steps:
+#  1. Ingest a night-driving BDD100K subset into a per-run LanceDB table.
+#  2. Backfill the CPU UDF columns the views filter on.
+#  3. Backfill CLIP embeddings on the GPU UDF path.
+#  4. Curate the nighttime-person and distant-person materialized views.
+#  5. Train one detector per failure-mode view (GPU).
+#  6. Evaluate each detector on its view (GPU) -> metrics.json.
+#  7. Open FiftyOne for human review.
+#
+# No loops, no threshold gate: a linear ingest/curate spine that fans out into two
+# train->eval branches (grouped with `sequence`) and rejoins at review.
+
+metadata:
+  name: av-night-scene-hardening-from-diagram
+  description: >
+    AV night-scene perception hardening from a fan-out diagram: LanceDB ingest ->
+    CPU/CLIP backfill -> two failure-mode views -> per-view detector train+eval ->
+    FiftyOne review. Second-architecture generalization proof for the skill.
+
+config:
+  bucket: example-bucket
+  prefix: "av-night-scene/{{run.id}}"
+  lance_table: bdd100k_night
+
+  bdd100k_limit: "5000"
+  train_epochs: "10"
+  train_batch_size: "8"
+  train_learning_rate: "0.005"
+
+  lancedb_endpoint: http://npa-lancedb.workbench.svc.cluster.local:8686
+  detection_endpoint: http://npa-detection-training.workbench.svc.cluster.local:8790
+
+  rider_view: bdd100k_rider_train
+  nighttime_view: bdd100k_nighttime_person_train
+  distant_view: bdd100k_distant_person_train
+
+  source_uri: "s3://{{config.bucket}}/raw-bdd100k/night-subset/"
+  lance_uri: "s3://{{config.bucket}}/{{config.prefix}}/lancedb/"
+  nighttime_train_uri: "s3://{{config.bucket}}/{{config.prefix}}/training/nighttime"
+  distant_train_uri: "s3://{{config.bucket}}/{{config.prefix}}/training/distant"
+  nighttime_eval_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/nighttime"
+  distant_eval_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/distant"
+
+resources:
+  cpu:
+    cloud: kubernetes
+    cpus: 4
+    memory: 16Gi
+  gpu-embed:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 8
+    memory: 32Gi
+  gpu-train:
+    cloud: kubernetes
+    accelerators: H100:1
+    cpus: 16
+    memory: 64Gi
+
+initial: ingest
+
+states:
+  ingest:
+    description: Step 1 — import a night-driving BDD100K subset into LanceDB.
+    toolRef: workbench.lancedb.import_bdd100k
+    resources: cpu
+    outputs:
+      - uri: "{{config.lance_uri}}"
+        schema: npa.lancedb.table.v1
+    next: backfill-cpu
+
+  backfill-cpu:
+    description: Step 2 — backfill CPU UDF columns (person/rider/bbox/timeofday/dedup).
+    needs: [ingest]
+    toolRef: workbench.lancedb.backfill_cpu_bundle
+    resources: cpu
+    next: backfill-clip
+
+  backfill-clip:
+    description: Step 3 — backfill CLIP embeddings on the GPU UDF path.
+    needs: [backfill-cpu]
+    toolRef: workbench.lancedb.backfill_clip
+    resources: gpu-embed
+    next: curate-views
+
+  curate-views:
+    description: Step 4 — create nighttime-person and distant-person views.
+    needs: [backfill-clip]
+    toolRef: workbench.lancedb.create_failure_views
+    resources: cpu
+    next: detectors
+
+  detectors:
+    description: Step 5-6 — fan out into two per-view train->eval branches.
+    needs: [curate-views]
+    sequence:
+      - train-nighttime
+      - eval-nighttime
+      - train-distant
+      - eval-distant
+    next: review
+
+  train-nighttime:
+    description: Step 5a — train the nighttime-person detector (GPU).
+    toolRef: workbench.detection_training.train_nighttime
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.nighttime_train_uri}}"
+        schema: npa.detection_training.checkpoint.v1
+
+  eval-nighttime:
+    description: Step 6a — evaluate the nighttime-person detector (GPU).
+    needs: [train-nighttime]
+    toolRef: workbench.detection_training.eval_nighttime
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.nighttime_eval_uri}}metrics.json"
+        schema: npa.detection_training.metrics.v1
+
+  train-distant:
+    description: Step 5b — train the distant-person detector (GPU).
+    toolRef: workbench.detection_training.train_distant
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.distant_train_uri}}"
+        schema: npa.detection_training.checkpoint.v1
+
+  eval-distant:
+    description: Step 6b — evaluate the distant-person detector (GPU).
+    needs: [train-distant]
+    toolRef: workbench.detection_training.eval_distant
+    resources: gpu-train
+    outputs:
+      - uri: "{{config.distant_eval_uri}}metrics.json"
+        schema: npa.detection_training.metrics.v1
+
+  review:
+    description: Step 7 — launch FiftyOne for human review of both detectors.
+    needs: [detectors]
+    toolRef: workbench.fiftyone.launch_app
+    resources: cpu
+    terminal: true

--- a/skills/workflows/diagram-to-npa-workflow/examples/sim2real-vlm-rl-from-diagram.yaml
+++ b/skills/workflows/diagram-to-npa-workflow/examples/sim2real-vlm-rl-from-diagram.yaml
@@ -1,0 +1,159 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+# Produced by the diagram-to-npa-workflow skill from the 13-step sim2real
+# write-up + architecture diagram. See ../reference/mapping.md "Sim2real worked
+# example" for the step->state->toolRef table and every discrepancy note.
+#
+# Loops (read off the diagram's back-edges):
+#   inner (fast)  = steps 7-9  : rollouts -> VLM critique -> RL update
+#   outer (slow)  = steps 7-11 : inner pass -> heldout eval -> threshold gate
+#   loop-of-loops = steps 12-13: real-world test -> retrigger (a NEW run, so the
+#                                retrigger is a terminal record, not a graph cycle)
+
+metadata:
+  name: sim2real-vlm-rl-from-diagram
+  description: >
+    VLM-to-RL sim2real staged loop rendered from an architecture diagram: Cosmos
+    Transfer augment -> Isaac Lab raw env gen + 80/20 split -> inner
+    rollouts/VLM-critique loop -> Isaac held-out eval -> promote/loop-back
+    threshold gate -> checkpoint + real-world retrigger record.
+
+config:
+  bucket: example-bucket
+  prefix: "sim2real-b/{{run.id}}"
+
+  inner_iterations: 3          # step 9 back-edge: RL updates per training session
+  outer_iterations: 2          # step 11B back-edge: eval -> more RL until promote
+  vlm_backend: self-hosted
+  default_decision: loop_back  # planning-only; real decision read from S3 at execute
+
+  # step 5/6 knobs: total raw envs and the 80/20 train split (kept as config, not
+  # hardcoded topology — the write-up says 1K/800-200, the diagram says 8K/2K).
+  env_count: "10000"
+  train_fraction: "0.8"
+  success_threshold: "0.50"    # step 11 customer-chosen promote threshold
+
+  # step 1 trigger + step 4 sim assets (LeRobot data + Isaac scene/robot assets).
+  trigger_uri: "s3://{{config.bucket}}/sim2real-triggers/{{run.id}}/lerobot-pusht/"
+  assets_uri: "s3://{{config.bucket}}/sim2real-assets/franka-tabletop/"
+  augment_uri: "s3://{{config.bucket}}/{{config.prefix}}/augment/"
+  raw_envs_uri: "s3://{{config.bucket}}/{{config.prefix}}/envs/raw/"
+  rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/actions/train/"
+  scores_uri: "s3://{{config.bucket}}/{{config.prefix}}/vlm_eval/train/"
+  heldout_report_uri: "s3://{{config.bucket}}/{{config.prefix}}/eval/heldout/report.json"
+  decision_uri: "s3://{{config.bucket}}/{{config.prefix}}/outer_loop/decision.json"
+  finalize_report_uri: "s3://{{config.bucket}}/{{config.prefix}}/reports/sim2real-report.json"
+
+resources:
+  gpu:
+    cloud: kubernetes
+    accelerators: RTXPRO6000:1
+  cpu:
+    cloud: kubernetes
+    cpus: 8
+
+initial: augment
+
+states:
+  augment:
+    description: Step 3 — Cosmos Transfer 2.5 augments curated good LeRobot data.
+    toolRef: workbench.cosmos2.transfer
+    resources: gpu
+    inputs:
+      - uri: "{{config.trigger_uri}}"
+        schema: npa.lerobot.dataset.v1
+    outputs:
+      - uri: "{{config.augment_uri}}manifest.json"
+        schema: npa.sim2real.augment.v1
+    next: envgen
+
+  envgen:
+    description: Steps 4-6 — Isaac Lab combines augment + sim assets into raw envs, emits 80/20 split.
+    needs: [augment]
+    toolRef: workbench.sim2real_envgen.raw_shard
+    resources: gpu
+    # note: step 4 assets and step 6 split are data ops on this one state — the
+    # "80/20" diamond in the diagram is a split manifest, NOT a decision diamond.
+    inputs:
+      - uri: "{{config.assets_uri}}"
+        schema: npa.sim2real.assets.v1
+    outputs:
+      - uri: "{{config.raw_envs_uri}}manifest.json"
+        schema: npa.sim2real.split_manifest.v1
+    next: outer
+
+  outer:
+    description: Outer loop (steps 7-11) — inner train pass, held-out eval, threshold gate.
+    needs: [envgen]
+    loop:
+      max: "{{config.outer_iterations}}"
+      until: promote_checkpoint
+    sequence:
+      - inner
+      - heldout
+      - decide
+    next: finalize
+
+  inner:
+    description: Inner loop (steps 7-9) — policy rollouts + VLM critique per RL update.
+    loop:
+      max: "{{config.inner_iterations}}"
+    sequence:
+      - rollouts
+      - vlm-score
+
+  rollouts:
+    description: Step 7 — LeRobot training image generates actions on the 80% train envs.
+    toolRef: workbench.sim2real.policy_rollouts
+    resources: gpu
+    outputs:
+      - uri: "{{config.rollouts_uri}}"
+        schema: npa.sim2real.action_rollout.v1
+
+  vlm-score:
+    description: Step 8-9 — VLM judges rollouts; critique becomes the RL reward signal.
+    needs: [rollouts]
+    toolRef: workbench.vlm_eval.run
+    resources: gpu
+    inputs:
+      - uri: "{{config.rollouts_uri}}"
+        schema: npa.sim2real.action_rollout.v1
+    outputs:
+      - uri: "{{config.scores_uri}}report.json"
+        schema: npa.workbench.vlm_eval.report.v1
+
+  heldout:
+    description: Step 10 — Isaac Lab eval framework rolls the trained policy on the 20% held-out envs.
+    toolRef: workbench.sim2real.heldout_eval
+    resources: gpu
+    outputs:
+      - uri: "{{config.heldout_report_uri}}"
+        schema: npa.sim2real.heldout_eval.v1
+
+  decide:
+    description: Step 11 — threshold gate; promote checkpoint or loop back for more RL.
+    writesDecision: true
+    needs: [heldout]
+    toolRef: workbench.sim2real.write_decision
+    outputs:
+      - uri: "{{config.decision_uri}}"
+        schema: npa.sim2real.threshold_decision.v1
+    transitions:
+      - when: promote_checkpoint   # step 11A — clears threshold
+        goto: finalize
+      - when: loop_back            # step 11B — misses threshold, more RL
+        goto: outer
+
+  finalize:
+    description: Steps 11A/12/13 — checkpoint to S3, record real-world test + retrigger manifest.
+    needs: [outer]
+    toolRef: workbench.sim2real.finalize
+    # note: steps 12 (real-world test) and 13 (retrigger Step 1 with real data) are
+    # the loop-of-loops. A back-edge to `augment` would be an unbounded cycle, so we
+    # record a retrigger manifest here and terminate; the next outer-of-outer pass is
+    # a brand-new run seeded with distribution-shifted real data. Loop exit = no retrigger.
+    outputs:
+      - uri: "{{config.finalize_report_uri}}"
+        schema: npa.sim2real.e2e_report.v1
+    terminal: true

--- a/skills/workflows/diagram-to-npa-workflow/reference/mapping.md
+++ b/skills/workflows/diagram-to-npa-workflow/reference/mapping.md
@@ -89,7 +89,7 @@ The user warned "there will be some discrepancy." Apply these rules and leave a
 | Step numbers skip/duplicate (e.g. no "Step 2") | Numbering is cosmetic; order states by arrows, not by step index. |
 | Env counts disagree (text "1,000 raw / 800-200" vs boxes "8K/2K") | Keep counts as `config` knobs (`env_count`, `train_fraction`); do not hardcode a specific integer into topology. Note both. |
 | Split "80/20" drawn as a diamond | The split is a data operation inside envgen, not a decision diamond — one `envgen` state emits a split manifest; only the **threshold** is a decision state. |
-| A vendor/product name (Cortex, Lightwheel, Newrobot) | Map to the *capability* tool, not the brand. "Cortex trainer fork" → `policy_rollouts` + VLM reward; "Lightwheel eval" → `heldout_eval`. |
+| A vendor/product/brand name in a box | Map to the *capability* tool, not the brand. A "custom trainer fork" box → `policy_rollouts` + VLM reward; an "eval platform" box → `heldout_eval`; a "data curation/review" box → `fiftyone.launch_app`. |
 | Two boxes, same tool (Isaac appears twice) | Two states, same `toolRef` family, different `resources`/URIs. |
 | Curate/review human step with no tool | Fold into the trigger artifact URI, or model as a `fiftyone.launch_app` review hook. |
 
@@ -107,7 +107,7 @@ The provided write-up + diagram map to `examples/sim2real-vlm-rl-from-diagram.ya
 | 7 LeRobot generates actions on train envs | 8K TrainEnvs → LeRobot | `rollouts` (in `inner`) | `workbench.sim2real.policy_rollouts` |
 | 8 VLM evaluation on training | VLM Eval box (inner loop) | `vlm-score` (in `inner`) | `workbench.vlm_eval.run` |
 | 9 VLM critique → RL update | inner back-edge | *(inner loop `loop.max`; reward wired via BYO trainer in engine)* | — |
-| 10 Isaac Lab eval framework | Lightwheel Eval → Results Report | `heldout` | `workbench.sim2real.heldout_eval` |
+| 10 Isaac Lab eval framework | Eval framework → Results Report | `heldout` | `workbench.sim2real.heldout_eval` |
 | 11A/11B Good/Bad threshold | Threshold diamond | `decide` | `workbench.sim2real.write_decision` |
 | 11A promote → checkpoint to S3 | Checkpoint → S3 | `finalize` (promote path) | `workbench.sim2real.finalize` |
 | 11B fail → more RL | outer back-edge | `decide` `loop_back` → `outer` | — |

--- a/skills/workflows/diagram-to-npa-workflow/reference/mapping.md
+++ b/skills/workflows/diagram-to-npa-workflow/reference/mapping.md
@@ -1,0 +1,132 @@
+# Diagram → NPA Workflow — mapping reference
+
+Companion to `../SKILL.md`. Everything here is data you consult while turning a
+diagram + step write-up into a spec. The authoritative `toolRef` list lives in
+`npa/src/npa/orchestration/npa_workflow/catalog.py`; keep this table in sync when
+the catalog changes.
+
+## Keyword → `toolRef`
+
+Match diagram/step language (left) to a cataloged tool (right).
+
+| If the box/step says… | Use `toolRef` | Typical config keys |
+| --- | --- | --- |
+| "Cosmos Transfer", "augment", "synthetic variants", "lighting/texture perturbation" | `workbench.cosmos2.transfer` | `trigger_uri` → `augment_uri` |
+| "Cosmos reason", "scene reasoning", "Token Factory", "plan" | `workbench.token_factory.reason` | `scene_uri` → `plan_uri` |
+| "Isaac Lab envgen", "raw environments", "generate 1K/8K envs", "scenes+physics" | `workbench.sim2real_envgen.raw_shard` | `raw_envs_uri`, `env_count` |
+| "LeRobot training image generates actions", "policy rollouts", "action-conditioned envs" | `workbench.sim2real.policy_rollouts` | `rollouts_uri` |
+| "VLM evaluation", "success/failure judgment", "critique", "reward signal source" | `workbench.vlm_eval.run` | `rollouts_uri` → `scores_uri`, `vlm_backend` |
+| "Isaac Lab eval framework", "held-out eval", "results report", "success rate on test envs" | `workbench.sim2real.heldout_eval` | `heldout_report_uri` |
+| "threshold", "good/bad", "promote or train more", "decision" | `workbench.sim2real.write_decision` | `decision_uri`, `default_decision` |
+| "checkpoint", "promote to S3", "finalize", "candidate for deployment", "retrigger record" | `workbench.sim2real.finalize` | `finalize_report_uri` |
+| "train RL policy" (generic sim RL, not VLM-in-loop) | `workbench.rl.policy_train` | `task_name`, `train_dataset_uri` → `checkpoint_uri` |
+| "evaluate policy on held-out episodes" | `workbench.rl.evaluate_policy` | `checkpoint_uri` → `eval_report_uri` |
+| "success gate on threshold" (RL) | `workbench.rl.write_success_decision` | `success_threshold`, `decision_uri` |
+| "publish/release promoted checkpoint" | `workbench.rl.publish_policy` | `release_uri` |
+| "record failure / not promoted" | `workbench.rl.report_failure` | `eval_report_uri`, `decision_uri` |
+| "import BDD100K / dataset into LanceDB" | `workbench.lancedb.import_bdd100k` | `source_uri`, `lance_uri`, `lance_table` |
+| "backfill CPU columns / dedup / bbox" | `workbench.lancedb.backfill_cpu_bundle` | `lance_table`, `lance_uri` |
+| "CLIP embeddings" | `workbench.lancedb.backfill_clip` | `lance_uri` |
+| "materialized views / failure-mode slices" | `workbench.lancedb.create_failure_views` | `*_view` |
+| "train detector on view" | `workbench.detection_training.train_{rider,nighttime,distant}` | `*_view` → `*_train_uri` |
+| "evaluate detector" | `workbench.detection_training.eval_{rider,nighttime,distant}` | `*_train_uri` → `*_eval_uri` |
+| "FiftyOne review", "human-in-the-loop viz" | `workbench.fiftyone.launch_app` | `lance_uri` |
+| "onboard OSS repo", "BYOF", "build+push+train custom image" | `workbench.byof.repo` | `repo_url`, `workload`, … |
+| "deploy Slurm/soperator cluster" | `infra.soperator.deploy` | `soperator_spec` |
+| "normalize rollout contract" / "cross-region improvement summary" | `workbench.data_transform.rollout_contract` / `.improvement_summary` | `project_*`, `region_*` |
+
+No match? Add a `ToolEntry` in `catalog.py` (argv template with `{{config.*}}`
+tokens), or use `run.shell` for genuinely one-off glue.
+
+## Control-flow patterns
+
+| Diagram cue | Spec fragment |
+| --- | --- |
+| Straight arrow A→B | `A: { next: B }` |
+| Ordered trio under a labeled group | `group: { sequence: [a, b, c] }` |
+| "runs N times" / fixed count | `parent: { loop: { max: "{{config.iters}}" }, sequence: [...] }` |
+| "iterate until threshold met" | `parent: { loop: { max: "{{config.iters}}", until: promote_checkpoint }, sequence: [...] }` |
+| Decision diamond, two exits | see "Decision state" below |
+| Nested loops (inner + outer) | `outer` loop whose `sequence` includes `inner`, which has its own `loop.max` |
+| Real-world → retrigger Step 1 | terminal `finalize`/`retrigger` state (NOT a back-edge — see below) |
+
+### Decision state
+
+```yaml
+decide:
+  writesDecision: true
+  toolRef: workbench.sim2real.write_decision
+  outputs:
+    - uri: "{{config.decision_uri}}"
+      schema: npa.sim2real.threshold_decision.v1
+  transitions:
+    - when: promote_checkpoint   # forward
+      goto: finalize
+    - when: loop_back            # backward into the loop parent
+      goto: outer
+```
+
+Predicates are a closed set: only `promote_checkpoint` and `loop_back`. Planning a
+spec with `transitions` requires `--assume-decision promote_checkpoint|loop_back`.
+
+### Why the loop-of-loops is terminal, not a cycle
+
+`validate-spec` runs `_assert_bounded_control_flow_cycles`: any `next`/`transitions`
+path that returns to an already-visited state without a bounding `loop` is
+rejected as "unbounded control-flow cycle". Loops (`loop.max` / `loop.until`) are
+the *only* sanctioned back-edges, and they are expressed by a parent state wrapping
+a `sequence`, not by a `goto` that jumps backward past the loop parent. A
+real-world-test → retrigger-Step-1 arrow therefore becomes a terminal state that
+writes a retrigger manifest; the next outer-of-outer iteration is a brand-new run.
+
+## Reconciling discrepancies (diagram vs write-up)
+
+The user warned "there will be some discrepancy." Apply these rules and leave a
+`# note:` comment on each affected state:
+
+| Discrepancy | Resolution |
+| --- | --- |
+| Step numbers skip/duplicate (e.g. no "Step 2") | Numbering is cosmetic; order states by arrows, not by step index. |
+| Env counts disagree (text "1,000 raw / 800-200" vs boxes "8K/2K") | Keep counts as `config` knobs (`env_count`, `train_fraction`); do not hardcode a specific integer into topology. Note both. |
+| Split "80/20" drawn as a diamond | The split is a data operation inside envgen, not a decision diamond — one `envgen` state emits a split manifest; only the **threshold** is a decision state. |
+| A vendor/product name (Cortex, Lightwheel, Newrobot) | Map to the *capability* tool, not the brand. "Cortex trainer fork" → `policy_rollouts` + VLM reward; "Lightwheel eval" → `heldout_eval`. |
+| Two boxes, same tool (Isaac appears twice) | Two states, same `toolRef` family, different `resources`/URIs. |
+| Curate/review human step with no tool | Fold into the trigger artifact URI, or model as a `fiftyone.launch_app` review hook. |
+
+## Sim2real worked example (13 steps → spec)
+
+The provided write-up + diagram map to `examples/sim2real-vlm-rl-from-diagram.yaml`:
+
+| Step (write-up) | Diagram box | State | `toolRef` |
+| --- | --- | --- | --- |
+| 1 Trigger (LeRobot data in S3) | DB → Curate/Review → LeRobot Data | *(trigger_uri artifact)* | — |
+| 3 Augment good data (Cosmos Transfer 2.5) | Cosmos Transfer box | `augment` | `workbench.cosmos2.transfer` |
+| 4 Load sim assets into Isaac | *(feeds envgen)* | *(assets_uri input on `envgen`)* | — |
+| 5 Raw env generation (Isaac Lab) | Isaac Lab Envgen box | `envgen` | `workbench.sim2real_envgen.raw_shard` |
+| 6 80/20 split | split diamond | *(split manifest output of `envgen`; `train_fraction` config)* | — |
+| 7 LeRobot generates actions on train envs | 8K TrainEnvs → LeRobot | `rollouts` (in `inner`) | `workbench.sim2real.policy_rollouts` |
+| 8 VLM evaluation on training | VLM Eval box (inner loop) | `vlm-score` (in `inner`) | `workbench.vlm_eval.run` |
+| 9 VLM critique → RL update | inner back-edge | *(inner loop `loop.max`; reward wired via BYO trainer in engine)* | — |
+| 10 Isaac Lab eval framework | Lightwheel Eval → Results Report | `heldout` | `workbench.sim2real.heldout_eval` |
+| 11A/11B Good/Bad threshold | Threshold diamond | `decide` | `workbench.sim2real.write_decision` |
+| 11A promote → checkpoint to S3 | Checkpoint → S3 | `finalize` (promote path) | `workbench.sim2real.finalize` |
+| 11B fail → more RL | outer back-edge | `decide` `loop_back` → `outer` | — |
+| 12 Real-world test | Real-world Test box | *(recorded in finalize manifest)* | — |
+| 13 Retrigger (real data → Step 1) | retrigger arrow | `finalize` (terminal; new run re-enters) | — |
+
+Loops: **inner** = steps 7–9 (`loop.max: inner_iterations`); **outer** = steps
+7–11 (`loop.max: outer_iterations`, `until: promote_checkpoint`); **loop-of-loops**
+= steps 12→13→1 (terminal retrigger, new run).
+
+## Validator error → fix
+
+| Error text | Fix |
+| --- | --- |
+| `unknown toolRef 'x'` | Add `x` to `catalog.py`, or pick the right existing ref. |
+| `unbounded control-flow cycle detected: …` | A `next`/`goto` loops back without a `loop` parent. Wrap the repeated states in a `loop` state, or make the back-target terminal. |
+| `unknown loop.until 'x'` / `unknown transition.when 'x'` | Only `promote_checkpoint` / `loop_back` are valid predicates. |
+| `state X: must set run, toolRef, sequence, transitions, next, or terminal` | Give the state a body or mark it `terminal: true`. |
+| `config has no attribute 'k'` (loop max) | Add `k` to `config`, or use an integer literal. |
+| `workflow must declare at least one terminal: true state` | Mark each leaf `terminal: true`. |
+| `initial state 'x' is not defined` | `initial:` must name a real state key. |
+| `transition goto unknown state 'x'` | `goto` must reference a defined state. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **New skill `diagram-to-npa-workflow`** + reference material + worked examples; registered in `skills/index.yaml`, `AGENTS.md`, `CLAUDE.md`.
- **Reference blueprints**: `av-night-scene-hardening.yaml`, `cosmos-synth-fanout-curation.yaml` (Cosmos Transfer 2.5 fan-out → Voxel51/FiftyOne curation), registered in tests + guide + author skill.
- **npa blocker fixes**: env-bucket fallback in `build_config_from_env`; `npa.clients.kube.run_kubectl` stale-`NEBIUS_IAM_TOKEN` self-heal.
- **Golden evals are real capability tests** (definition + cosmos2-transfer real transfer inference + cosmos3-reason real VLM inference).
- **Cosmos Transfer runs the real model across the workflows** (this section).

## Cosmos Transfer: real model, not descriptor stubs

Replaced the descriptor-writing cosmos-transfer path with **real Cosmos-Transfer2.5 inference** everywhere it's used — both workflows go through `run_cosmos2_transfer_component_from_s3`:

- New `npa.workbench.cosmos.transfer` runner shells to the transfer image's `cosmos-transfer2.5` `.venv` (py3.10 + torch cu128 + flash-attn), runs `examples/inference.py`, returns the generated video; builds the env on demand if the image didn't bake it.
- `run_cosmos2_transfer_component_from_s3` now runs the real model, uploads the generated video to `<augment>/video/augmented.mp4`, extracts real frames to the augmented-frames prefix + `index.json`, and writes a manifest with `mode: cosmos_transfer2.5` + `augmented_video_uri`. Falls back to the descriptor manifest only when the transfer runtime is absent (non-GPU / unit envs) or `NPA_SIM2REAL_AUGMENT_MODE=stub`.
- `npa workbench cosmos2 transfer --execute` runs the real model too.

### Real results (dev VM, RTX PRO 6000 mk8s)

Re-ran the **Cosmos synthetic fan-out on 2 GPUs** with this code, over the sim2real trigger dataset (`lerobot-pusht`). Both shards ran the real model to completion (~17 min each, 100% GPU util, 56 GB) and produced genuine artifacts on S3:

| shard | GPU | output video | frames | manifest |
|---|---|---|---|---|
| a | 1× RTX PRO 6000 | `video/augmented.mp4` = **3,912,898 bytes** | 8 PNGs (247 KB each) + `index.json` | `mode: cosmos_transfer2.5`, `status: executed` |
| b | 1× RTX PRO 6000 | `video/augmented.mp4` = **3,919,083 bytes** | 8 PNGs + `index.json` | `mode: cosmos_transfer2.5` |

Because the sim2real augment stage and the fan-out share this exact component (run here over the sim2real trigger `input_uri`), the **sim2real augment stage now produces real transferred video** too — the descriptor stub only remains as a non-GPU/test fallback.

## Verification

- [x] 284 targeted tests green (cosmos CLI, sim2real augment component, golden-eval manifest, guardrails); augment falls back to descriptor with a fake client, as before.
- [x] `ruff` clean on new files.
- [x] Real fan-out run produced real ~3.9 MB transferred videos + extracted frames on S3 (manifests `mode: cosmos_transfer2.5`).

## Skill Maintenance

- [x] Updated the relevant root `skills/` entries and `skills/index.yaml`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36035fd6-674c-4919-be75-ce550e5b3fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36035fd6-674c-4919-be75-ce550e5b3fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

