### PR TITLE
Live architect workbench demo guides + Rerun absolute-URL fix

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -3,3 +3,5 @@
 Reproducible demo guides:
 
 - [8-GPU H200 Physical AI workbench demo](8gpu-h200.md)
+- [Architect live pack (rtxpro / us-central1)](architect-live-rtxpro.md)
+- [Present on new agent UI (`workbench-demo`)](architect-live-agent-ui.md)

--- a/docs/demo/architect-live-agent-ui.md
+++ b/docs/demo/architect-live-agent-ui.md
@@ -1,0 +1,252 @@
+# Present the workbench demo on a **new** agent UI
+
+Use a dedicated agent deployment — **not** an existing shared `rtxpro/agent`
+instance.
+
+| Field | Value |
+|-------|-------|
+| Agent | `$PROJECT_ALIAS` / `workbench-demo` |
+| Public URL | `$AGENT_PUBLIC_URL` (from `npa agent status`) |
+| Rerun | `$AGENT_PUBLIC_URL/rerun/` |
+| Auth file | `~/.npa/agents/$PROJECT_ALIAS/workbench-demo/auth.env` |
+| Demo pack (S3) | `s3://$BUCKET/checkpoints/sim2real-b/demo-workbench-ui/reports/` |
+| **Run ID (Artifacts / Rerun)** | `demo-workbench-ui` |
+
+Story: **G1 sim → GR00T overlay → multi-env closed-loop → world model → curation**.
+
+The default Rerun recording is **Unitree G1 + GR00T predictions** (cyan skeleton /
+orange predictions). It is **not** the stock Franka `/world/franka` scene.
+
+In the agent UI, select run **`demo-workbench-ui`**, then open
+`groot-predictions-overlay.rrd` (or the default `sim2real.rrd` alias).
+
+---
+
+## 0) Resolve URLs and sign in (once)
+
+On the operator/dev VM:
+
+```bash
+export PROJECT_ALIAS=rtxpro
+export AGENT_NAME=workbench-demo
+export NPA_NEBIUS_PROFILE="${NPA_NEBIUS_PROFILE:-npa-mk8s}"
+
+source ~/.npa/agents/$PROJECT_ALIAS/$AGENT_NAME/auth.env
+# AGENT_USER / AGENT_PASSWORD come from auth.env — do not commit them
+
+eval "$(npa/.venv/bin/npa agent status --project "$PROJECT_ALIAS" --name "$AGENT_NAME" \
+  | awk '/^public_url:/{print "export AGENT_PUBLIC_URL="$2}
+         /^rerun_url:/{print "export AGENT_RERUN_URL="$2}')"
+echo "AGENT_PUBLIC_URL=$AGENT_PUBLIC_URL"
+```
+
+In the browser:
+
+1. Open `$AGENT_PUBLIC_URL/healthz` and accept the self-signed cert if prompted.
+2. Open `$AGENT_PUBLIC_URL/login-help.html` and sign in with `AGENT_USER` /
+   `AGENT_PASSWORD`.
+3. Land on `$AGENT_PUBLIC_URL/`.
+
+Keep this tab as the **only** demo UI. Do not reuse an older agent deployment.
+
+---
+
+## 1) Open with infra (30s)
+
+**Terminal (dev VM):**
+
+```bash
+# RTX PRO cluster (Isaac / RT-core)
+export KUBECONFIG=~/.npa/clusters/npa-rtxpro-mk8s/kubeconfig
+kubectl get nodes -L nvidia.com/gpu.product,nvidia.com/gpu.count
+
+# 8× H200 demo host (start if STOPPED) — use the instance id from your live run
+export NPA_NEBIUS_PROFILE=npa-mk8s
+nebius profile activate npa-mk8s
+# nebius compute instance get --id "$H200_INSTANCE_ID" | grep -E "name:|state:"
+# if STOPPED: nebius compute instance start --id "$H200_INSTANCE_ID"
+# then: ssh -i "$NPA_SSH_KEY" ubuntu@"$H200_VM_IP" 'nvidia-smi -L'
+```
+
+Talk track: “One 8× H200 host for Cosmos/GR00T; RTX PRO mk8s for Isaac/RT-core.”
+
+---
+
+## 2) Non-stock sim → policy (main visual)
+
+### 2a. G1 Isaac trajectory + GR00T overlay (Rerun) — **open this first**
+
+**Run ID:** `demo-workbench-ui`
+
+In the UI: **Artifacts / Runs** → `demo-workbench-ui` →
+`groot-predictions-overlay.rrd` (or `sim2real.rrd`).
+
+Or from the operator VM:
+
+```bash
+source ~/.npa/agents/$PROJECT_ALIAS/$AGENT_NAME/auth.env
+: "${AGENT_PUBLIC_URL:?set via npa agent status}"
+: "${BUCKET:?set your artifact bucket}"
+
+curl -sk -u "$AGENT_USER:$AGENT_PASSWORD" -H "Content-Type: application/json" \
+  -d "{\"run_id\":\"demo-workbench-ui\",\"s3_uri\":\"s3://${BUCKET}/checkpoints/sim2real-b/demo-workbench-ui/reports/groot-predictions-overlay.rrd\"}" \
+  "$AGENT_PUBLIC_URL/api/sim-viz/load-artifact"
+```
+
+**Rerun URL rule:** always pass an **absolute** `https://…/rerun/recordings/….rrd`
+in the `?url=` query. Path-only values like `/rerun/recordings/sim2real.rrd` are
+parsed by the Rerun web viewer as host `rerun` and fail under HTTPS.
+
+```bash
+# Encode an absolute recording URL for the viewer
+REC="${AGENT_PUBLIC_URL%/}/rerun/recordings/sim2real.rrd"
+OPEN="${AGENT_PUBLIC_URL%/}/rerun/?url=$(python3 -c 'import os,urllib.parse; print(urllib.parse.quote(os.environ["REC"], safe=""))' REC="$REC")&hide_welcome_screen=1&camera=workspace"
+echo "$OPEN"
+```
+
+Or from the agent home page, use **Reload Rerun data** / **Open full Rerun**.
+
+What you should see (not Franka):
+
+- `/world/skeleton/*` — cyan G1 joints/bones + hip/knee/shoulder angle series
+- `/world/predictions/*` — orange GR00T predicted trajectory overlaid
+
+Optional: Isaac-only G1 skeleton (no predictions):
+
+```bash
+curl -sk -u "$AGENT_USER:$AGENT_PASSWORD" -H "Content-Type: application/json" \
+  -d "{\"s3_uri\":\"s3://${BUCKET}/checkpoints/sim2real-b/demo-workbench-ui/reports/isaac-lab-trajectory.rrd\"}" \
+  "$AGENT_PUBLIC_URL/api/sim-viz/load-artifact"
+```
+
+MP4 companions (Artifacts / preview URL):
+
+- `isaac-lab-trajectory.mp4`
+- `groot-predictions-overlay.mp4`
+
+### 2b. Multi-env closed-loop Rerun (rich camera / critique pack)
+
+```bash
+curl -sk -u "$AGENT_USER:$AGENT_PASSWORD" -H "Content-Type: application/json" \
+  -d "{\"s3_uri\":\"s3://${BUCKET}/checkpoints/sim2real-b/demo-workbench-ui/reports/sim2real-closedloop-multienv.rrd\"}" \
+  "$AGENT_PUBLIC_URL/api/sim-viz/load-artifact"
+```
+
+Entities include `/heldout/camera/env-*`, `/heldout/scores`, `/signal/reward*`,
+`/critique`. After loading, open the returned `rerun_iframe_url` (or **Reload
+Rerun data**).
+
+Also available: `sim2real-e2e-main.rrd`, `kinova-heldout-env06.mp4`.
+
+### 2c. Stock Franka (optional contrast only)
+
+Kept aside as `sim2real-franka-stock.rrd` / `isaac-franka-working-sim.mp4` —
+do **not** lead with these.
+
+Talk track: “G1 locomotion skeleton → GR00T action overlay → closed-loop
+multi-env eval cameras.”
+
+---
+
+## 3) World model / Cosmos (1–2 min)
+
+```bash
+curl -sk -u "$AGENT_USER:$AGENT_PASSWORD" -H "Content-Type: application/json" \
+  -d "{\"s3_uri\":\"s3://${BUCKET}/checkpoints/sim2real-b/demo-workbench-ui/reports/cosmos-augmented-a.mp4\"}" \
+  "$AGENT_PUBLIC_URL/api/sim-viz/load-artifact"
+```
+
+Play the preview URL in the agent UI (or Artifacts → `cosmos-augmented-a.mp4`).
+
+Optional live infer (only if the H200 host is RUNNING and Cosmos is healthy):
+
+```bash
+npa/.venv/bin/npa workbench cosmos -p "$PROJECT_ALIAS" -n "$COSMOS_ALIAS" status
+# prefer staged mp4 above if live infer is unavailable
+```
+
+---
+
+## 4) Curation (1 min)
+
+FiftyOne may be unavailable (registry image pull). Prefer the alt GR00T overlay
+vs primary, or the second Cosmos clip:
+
+```bash
+curl -sk -u "$AGENT_USER:$AGENT_PASSWORD" -H "Content-Type: application/json" \
+  -d "{\"s3_uri\":\"s3://${BUCKET}/checkpoints/sim2real-b/demo-workbench-ui/reports/groot-predictions-overlay-alt.rrd\"}" \
+  "$AGENT_PUBLIC_URL/api/sim-viz/load-artifact"
+
+curl -sk -u "$AGENT_USER:$AGENT_PASSWORD" -H "Content-Type: application/json" \
+  -d "{\"s3_uri\":\"s3://${BUCKET}/checkpoints/sim2real-b/demo-workbench-ui/reports/cosmos-augmented-b.mp4\"}" \
+  "$AGENT_PUBLIC_URL/api/sim-viz/load-artifact"
+```
+
+Talk track: “Rank / pick the better synthetic or predicted trajectory before
+training.”
+
+---
+
+## 5) Close (30s)
+
+```bash
+set -a; source ~/.npa/live-e2e.env; set +a
+aws --endpoint-url "$AWS_ENDPOINT_URL" s3 ls \
+  "s3://${BUCKET}/checkpoints/sim2real-b/demo-workbench-ui/reports/"
+```
+
+In the agent chat panel, ask: “what artifacts can I view?” — grounded reply
+should list runs under `checkpoints/sim2real-b`.
+
+Talk track: “Same HTTPS agent UI an LLM drives — Rerun, MP4, S3 artifacts.”
+
+---
+
+## Room tab checklist (this UI only)
+
+| Beat | Open |
+|------|------|
+| Login | `$AGENT_PUBLIC_URL/login-help.html` |
+| Home | `$AGENT_PUBLIC_URL/` |
+| **Run ID** | `demo-workbench-ui` |
+| **G1 + GR00T Rerun** | Artifacts → `demo-workbench-ui` → `groot-predictions-overlay.rrd` (absolute `?url=https://…/recordings/…`) |
+| Multi-env closed-loop | same run → `sim2real-closedloop-multienv.rrd` |
+| Policy / Cosmos / curation | Artifacts → `demo-workbench-ui` → mp4 / alt overlay |
+| Infra | `kubectl get nodes …` + `nvidia-smi` on H200 |
+
+Do **not** open an older agent URL (for example a previous `rtxpro/agent`
+deployment).
+
+---
+
+## Pack contents (non-stock)
+
+| Artifact | Role |
+|----------|------|
+| `groot-predictions-overlay.rrd` | **Default** — G1 skeleton + GR00T predictions |
+| `isaac-lab-trajectory.rrd` / `.mp4` | G1 Isaac-only trajectory |
+| `groot-predictions-overlay.mp4` | Overlay video companion |
+| `groot-predictions-overlay-alt.rrd` | Curation alt overlay |
+| `sim2real-closedloop-multienv.rrd` | Multi-env cameras / scores / critique |
+| `sim2real-e2e-main.rrd` | Large e2e held-out camera pack |
+| `kinova-heldout-env06.mp4` | Held-out camera sequence |
+| `sim2real-franka-stock.rrd` | Old Franka scene (contrast only) |
+
+---
+
+## Recreate this agent later
+
+```bash
+cd ~/nebius-physical-ai
+export NPA_NEBIUS_PROFILE=npa-mk8s NPA_SSH_KEY=~/.ssh/id_ed25519
+# PROJECT_ID / TENANT_ID / REGION from your Nebius project — do not hardcode
+nebius profile activate npa-mk8s
+npa/.venv/bin/npa agent fresh-setup \
+  --project rtxpro --name workbench-demo \
+  --project-id "$PROJECT_ID" \
+  --tenant-id "$TENANT_ID" \
+  --region "$REGION"
+# if TF refresh fails after VM create, register IP/instance_id then:
+npa/.venv/bin/npa agent bootstrap --project rtxpro --name workbench-demo \
+  --ssh-key "$NPA_SSH_KEY" --refresh-credentials
+```

--- a/docs/demo/architect-live-rtxpro.md
+++ b/docs/demo/architect-live-rtxpro.md
@@ -1,0 +1,59 @@
+# Live Workbench Demo (Architect Pack)
+
+Operator runbook for reproducing the multi-tool Physical AI demo on live Nebius
+infrastructure for project alias `rtxpro`.
+
+Canonical product flow: [8gpu-h200.md](./8gpu-h200.md).
+
+Presentation on a **dedicated** agent UI (not a reused agent):
+[architect-live-agent-ui.md](./architect-live-agent-ui.md).
+
+## What this demo provisions
+
+| Role | GPU | Runtime | Tools |
+|------|-----|---------|-------|
+| Shared inference host | 8× H200 (`gpu-h200-sxm` / `8gpu-128vcpu-1600gb`) | managed VM + BYOVM siblings | Cosmos `:8081`, GR00T `:8082`, FiftyOne `:5151` |
+| Simulation host | 1× RTX PRO 6000 (`gpu-rtx6000` / `1gpu-24vcpu-218gb`) | managed VM | Isaac Lab (RT cores) |
+
+Artifacts land under `s3://$BUCKET/demo-8gpu-h200/<run-tag>/`.
+
+This project does not expose L40S platforms; Isaac Lab is routed to RTX PRO 6000
+Blackwell instead of the historical L40S host from the original May demo.
+
+## Prerequisites
+
+```bash
+export NPA_NEBIUS_PROFILE=npa-mk8s
+export PROJECT_ALIAS=rtxpro
+export REGION=us-central1
+# Set from your Nebius console / ~/.npa config — never commit these values:
+export PROJECT_ID=...
+export TENANT_ID=...
+export BUCKET=...
+export NPA_SSH_KEY=~/.ssh/id_ed25519
+```
+
+## Runner
+
+```bash
+cd ~/nebius-physical-ai
+./scripts/run_workbench_demo_live.sh
+```
+
+The runner provisions sequentially (Cosmos, then Isaac) to reduce
+`compute.disk.count` quota races. If disk quota is exhausted, delete orphan
+disks / unused instances before retrying.
+
+## Known gaps from live validation
+
+| Area | Notes |
+|------|-------|
+| Managed Isaac on `gpu-rtx6000` | Some image families need driver ≥580; prefer a validated Ubuntu/CUDA family |
+| Cosmos `infer` | Serve/status can be healthy while text-to-world hits `_execution_device` |
+| FiftyOne | Registry deny for `npa-fiftyone` until IAM docker login succeeds |
+| Historical `demo-prestage` | May be absent; regenerate/stage media instead of `npa demo stage` |
+
+## Presentation
+
+Use [architect-live-agent-ui.md](./architect-live-agent-ui.md) with run id
+`demo-workbench-ui` and absolute HTTPS Rerun recording URLs.

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -61,7 +61,7 @@ DEFAULT_LLM_MODELS = (
     DEFAULT_LLM_MODEL,
     "Qwen/Qwen2.5-VL-72B-Instruct",
 )
-AGENT_UI_VERSION = "2026070601"
+AGENT_UI_VERSION = "2026070901"
 DEFAULT_HTTPS_PORT = 443
 AGENT_SOURCE_ROOT = "/opt/npa-agent/npa-src"
 _AGENT_TERRAFORM_RUNTIME_ONLY_VARS = frozenset({"s3_prefix"})
@@ -1361,6 +1361,9 @@ def _nginx_agent_site_body(
     alias /opt/npa-agent/recordings/;
     default_type application/octet-stream;
     add_header Cache-Control "no-cache" always;
+    add_header Access-Control-Allow-Origin * always;
+    add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
+    add_header Cross-Origin-Resource-Policy "cross-origin" always;
   }}
   location ~* ^/rerun/.+\\.(wasm|js|ico|svg)$ {{
     auth_basic off;
@@ -1506,6 +1509,10 @@ if [ -s /mnt/cloud-metadata/token ]; then
   fi
 fi
 sudo mkdir -p /opt/npa-agent
+cat <<'ENV' | sudo tee /opt/npa-agent/public.env >/dev/null
+NPA_AGENT_PUBLIC_URL=https://{host}
+NPA_AGENT_PUBLIC_HOST={host}
+ENV
 cat <<'PY' | sudo tee /opt/npa-agent/backend.py >/dev/null
 import json
 import os
@@ -1531,6 +1538,42 @@ STATE_PATH = Path("/opt/npa-agent/session_state.json")
 RRD_PATH = Path("/opt/npa-agent/sim2real.rrd")
 RECORDING_PATH = Path("/opt/npa-agent/recordings/sim2real.rrd")
 RECORDINGS_DIR = Path("/opt/npa-agent/recordings")
+
+RERUN_RECORDING_HTTP_PATH = "/rerun/recordings/sim2real.rrd"
+
+
+def _agent_public_origin() -> str:
+    # HTTPS origin for Rerun .rrd fetches (must be absolute; path-only URLs break).
+    for key in ("NPA_AGENT_PUBLIC_URL", "NPA_AGENT_PUBLIC_ORIGIN"):
+        raw = str(os.environ.get(key, "")).strip().rstrip("/")
+        if raw.startswith("https://") or raw.startswith("http://"):
+            return raw
+    host = str(os.environ.get("NPA_AGENT_PUBLIC_HOST", "")).strip()
+    if host:
+        return f"https://{{host}}"
+    return ""
+
+
+def _rerun_recording_url(*, cache_bust: bool = False) -> str:
+    origin = _agent_public_origin()
+    path = RERUN_RECORDING_HTTP_PATH
+    if origin:
+        url = f"{{origin}}{{path}}"
+    else:
+        url = path
+    if cache_bust:
+        url = f"{{url}}?t={{int(time.time() * 1000)}}"
+    return url
+
+
+def _rerun_iframe_url(camera: str = "workspace", *, live_url: str = "") -> str:
+    cam = (camera or "workspace").strip() or "workspace"
+    if live_url:
+        return f"/rerun/?url={{quote(live_url, safe='')}}&hide_welcome_screen=1&camera={{cam}}"
+    recording = _rerun_recording_url()
+    # Rerun web viewer treats path-only values like `/rerun/...` as host `rerun`.
+    return f"/rerun/?url={{quote(recording, safe='')}}&hide_welcome_screen=1&camera={{cam}}"
+
 RERUN_UNIT = "npa-rerun"
 RERUN_WEB_PORT = {rerun_port}
 AGENT_PYTHON = Path("/opt/npa-agent/venv/bin/python")
@@ -2468,7 +2511,7 @@ def _apply_loaded_artifact(
         sim_viz["rrd_uri"] = f"file://{{RECORDING_PATH}}"
         sim_viz["artifact_preview_url"] = "/rerun/recordings/sim2real.rrd"
         sim_viz["artifact_download_url"] = "/rerun/recordings/sim2real.rrd"
-        sim_viz["rerun_iframe_url"] = f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{sim_viz['camera']}}"
+        sim_viz["rerun_iframe_url"] = _rerun_iframe_url(str(sim_viz.get("camera") or "workspace"))
         sim_viz["rerun_ready"] = RECORDING_PATH.is_file() and rerun_ready
     else:
         filename = _artifact_filename(key)
@@ -2587,7 +2630,7 @@ def _wire_active_sim2real_recording(state: dict, *, camera: str = "workspace") -
     iframe_url = (
         f"/rerun/?url={{quote(live_url, safe='')}}&camera={{cam}}"
         if live_url
-        else f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{cam}}"
+        else _rerun_iframe_url(cam)
     )
     viz = {{
         "run_id": run_id,
@@ -2649,7 +2692,7 @@ def _wire_franka_demo(state: dict, *, camera: str = "workspace") -> dict:
         "preview_camera": cam,
         "preview_entity": f"world/camera_frustums/{{cam}}/frustum",
         "rerun_ready": target.is_file() and viewer_ready,
-        "rerun_iframe_url": f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{cam}}",
+        "rerun_iframe_url": _rerun_iframe_url(cam),
     }}
     state["sim_viz"] = viz
     _record_sim_viz_run(state, viz)
@@ -2675,7 +2718,7 @@ def _wire_sim2real_run_preview(state: dict, *, run_id: str, camera: str = "works
         "preview_camera": cam,
         "preview_entity": f"world/camera_frustums/{{cam}}/frustum",
         "rerun_ready": target.is_file() and viewer_ready,
-        "rerun_iframe_url": f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{cam}}",
+        "rerun_iframe_url": _rerun_iframe_url(cam),
         "submit_mode": "sim2real",
         "workflow_name": "sim2real",
         "pipeline_visualization": True,
@@ -3533,7 +3576,7 @@ def _run_sim2real_pipeline_background(run_id: str, selection: dict) -> None:
                 "rrd_uri": f"file://{{RECORDING_PATH}}",
                 "rrd_updated_at": _now_iso(),
                 "rerun_ready": RECORDING_PATH.is_file() and _rerun_web_viewer_healthy(),
-                "rerun_iframe_url": f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{sim_viz.get('camera') or 'workspace'}}",
+                "rerun_iframe_url": _rerun_iframe_url(str(sim_viz.get("camera") or "workspace")),
                 "camera": str(sim_viz.get("camera") or "workspace"),
             }}
         )
@@ -4368,7 +4411,7 @@ def sim_viz_status(run_id: str = ""):
         if live_url:
             payload["rerun_iframe_url"] = f"/rerun/?url={{quote(live_url, safe='')}}&camera={{camera}}"
         else:
-            payload["rerun_iframe_url"] = f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{camera}}"
+            payload["rerun_iframe_url"] = _rerun_iframe_url(camera)
     else:
         payload["rerun_iframe_url"] = ""
     if not payload.get("rrd_uri") and may_use_default_recording and RRD_PATH.is_file():
@@ -4683,7 +4726,7 @@ def _boot_preload_sim_viz() -> None:
         "preview_camera": cam,
         "preview_entity": f"world/camera_frustums/{{cam}}/frustum",
         "rerun_ready": _rerun_ready_state(rrd_uri=f"file://{{RRD_PATH}}"),
-        "rerun_iframe_url": f"/rerun/?url=/rerun/recordings/sim2real.rrd&camera={{cam}}",
+        "rerun_iframe_url": _rerun_iframe_url(cam),
     }}
     _record_sim_viz_run(state, state["sim_viz"])
     _save_state(state)
@@ -6226,9 +6269,9 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
             <div id="rerunPlaceholder" class="rerun-placeholder" hidden>
               <p>Rerun recording is embedded below.</p>
               <p class="hint">Loading the active Sim2Real recording.</p>
-              <button id="loadRerunViewer" class="btn btn-primary" type="button">Reload Rerun data</button> <a class="btn" href="/rerun/?url=/rerun/recordings/sim2real.rrd&camera=workspace" target="_blank" rel="noopener">Open full Rerun</a>
+              <button id="loadRerunViewer" class="btn btn-primary" type="button">Reload Rerun data</button> <a id="openFullRerun" class="btn" href="/rerun/?hide_welcome_screen=1&camera=workspace" target="_blank" rel="noopener">Open full Rerun</a>
             </div>
-            <iframe id="rerunFrame" title="rerun" src="/rerun/?url=/rerun/recordings/sim2real.rrd&camera=workspace" style="height: min(78vh, 820px); min-height: 620px;"></iframe>
+            <iframe id="rerunFrame" title="rerun" src="about:blank" style="height: min(78vh, 820px); min-height: 620px;"></iframe>
             <div id="artifactPreviewHost" class="hint" hidden style="margin-top:10px;"></div>
           </section>
         </div>
@@ -7062,12 +7105,21 @@ cat <<'HTML' | sudo tee /opt/npa-agent/ui.html >/dev/null
           rrdUrl = await resolveRerunRrdUrl(18, runId);
         }}
         // Prefer the public recording copy; authenticated blob fetch remains the fallback.
-        return (
+        // Rerun parses path-only `/rerun/...` as host `rerun` → http://rerun/... (broken).
+        if (rrdUrl.startsWith("/")) {{
+          rrdUrl = location.origin + rrdUrl;
+        }} else if (rrdUrl && !/^https?:\/\//i.test(rrdUrl)) {{
+          rrdUrl = location.origin + "/" + String(rrdUrl).replace(/^\/+/, "");
+        }}
+        const fullHref = (
           "/rerun/?url=" +
           encodeURIComponent(rrdUrl) +
           "&hide_welcome_screen=1&camera=" +
           encodeURIComponent(cam)
         );
+        const openLink = document.getElementById("openFullRerun");
+        if (openLink) openLink.href = fullHref;
+        return fullHref;
       }}
       function showRerunPlaceholder(message, options) {{
         const opts = options || {{}};
@@ -8122,6 +8174,7 @@ Type=simple
 EnvironmentFile=-/opt/npa-agent/llm.env
 EnvironmentFile=-/opt/npa-agent/nebius.env
 EnvironmentFile=-/opt/npa-agent/s3.env
+EnvironmentFile=-/opt/npa-agent/public.env
 ExecStart=/opt/npa-agent/venv/bin/uvicorn backend:app --host 0.0.0.0 --port {backend_port}
 WorkingDirectory=/opt/npa-agent
 Restart=always

--- a/npa/tests/browser/cypress/support/e2e.js
+++ b/npa/tests/browser/cypress/support/e2e.js
@@ -41,7 +41,7 @@ const SIM_VIZ = {
   rrd_uri: "file:///opt/npa-agent/sim2real.rrd",
   rrd_updated_at: "2026-07-07T03:33:00Z",
   rerun_ready: true,
-  rerun_iframe_url: "/rerun/?url=/rerun/recordings/sim2real.rrd&camera=workspace",
+  rerun_iframe_url: "/rerun/?url=https://example.test/rerun/recordings/sim2real.rrd&hide_welcome_screen=1&camera=workspace",
   available_run_ids: ["mock-run", "submitted-run"],
 };
 
@@ -55,7 +55,7 @@ const NON_STOCK_SIM_VIZ = {
   rrd_uri: "file:///opt/npa-agent/recordings/sim2real.rrd",
   rrd_updated_at: "2026-07-07T04:12:00Z",
   rerun_ready: true,
-  rerun_iframe_url: "/rerun/?url=/rerun/recordings/sim2real.rrd&camera=customer-overhead",
+  rerun_iframe_url: "/rerun/?url=https://example.test/rerun/recordings/sim2real.rrd&hide_welcome_screen=1&camera=customer-overhead",
   available_run_ids: [NON_STOCK_RUN_ID, "mock-run", "submitted-run"],
   artifact_render: "rerun",
   artifact_key: `${NON_STOCK_RUN_ID}/reports/sim2real.rrd`,

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -546,13 +546,19 @@ def test_bootstrap_embeds_franka_rerun_ux() -> None:
     assert "height: min(78vh, 820px)" in source
     assert "robotPreset" in source
     assert "rerunPlaceholder" in source
-    assert 'id="rerunFrame" title="rerun" src="/rerun/?url=/rerun/recordings/sim2real.rrd&camera=workspace"' in source
+    assert 'id="rerunFrame" title="rerun" src="about:blank"' in source
     assert "RERUN_RECORDING_PATH" in source
     assert "location.origin + RERUN_RECORDING_PATH" in source
     assert "rrdUrl = await resolveRerunRecordingUrl();" in source
+    assert "rrdUrl.startsWith" in source
+    assert "location.origin + rrdUrl" in source
+    assert "_rerun_iframe_url" in source
+    assert "NPA_AGENT_PUBLIC_URL" in source
     assert "/rerun/recordings/sim2real.rrd" in source
     assert "Prefer the public recording copy; authenticated blob fetch remains the fallback" in source
     assert "does not reliably consume parent-created blob URLs" in source
+    # Path-only `/rerun/...` is parsed by Rerun as host `rerun` and must not be emitted.
+    assert "url=/rerun/recordings/sim2real.rrd" not in source
     assert '"&renderer=webgl&hide_welcome_screen=1&camera="' not in source
     assert 'rel="preload" href="/rerun/re_viewer.js"' in source
     assert "waitForRerunReady" in source

--- a/scripts/run_workbench_demo_live.sh
+++ b/scripts/run_workbench_demo_live.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# Live Nebius Physical AI workbench demo (Cosmos + Isaac Lab + GR00T + FiftyOne).
+# Run on the operator/dev VM with ~/.npa configured and nebius profile active.
+#
+# Adapts docs/demo/8gpu-h200.md to the rtxpro project shape:
+# - 8x H200 managed VM hosts Cosmos / GR00T / FiftyOne (shared host, distinct ports)
+# - 1x RTX PRO 6000 managed VM hosts Isaac Lab (RT cores)
+# - Regenerates pipeline artifacts when the historical demo-prestage bucket is absent
+set -euo pipefail
+
+REPO_PATH="${REPO_PATH:-$HOME/nebius-physical-ai}"
+NPA_BIN="${NPA_BIN:-$REPO_PATH/npa/.venv/bin/npa}"
+PYTHON_BIN="${PYTHON_BIN:-$REPO_PATH/npa/.venv/bin/python}"
+
+PROJECT_ALIAS="${PROJECT_ALIAS:-rtxpro}"
+REGION="${REGION:-us-central1}"
+# Required — set from your Nebius project / ~/.npa config (never commit values):
+PROJECT_ID="${PROJECT_ID:?set PROJECT_ID}"
+TENANT_ID="${TENANT_ID:?set TENANT_ID}"
+TARGET_BUCKET="${TARGET_BUCKET:?set TARGET_BUCKET}"
+
+RUN_TAG="${RUN_TAG:-$(date -u +%Y%m%dT%H%M%SZ)}"
+DEMO_PREFIX="${DEMO_PREFIX:-demo-arch-${RUN_TAG}}"
+
+COSMOS_ALIAS="${COSMOS_ALIAS:-${DEMO_PREFIX}-cosmos}"
+GROOT_ALIAS="${GROOT_ALIAS:-${DEMO_PREFIX}-groot}"
+FIFTYONE_ALIAS="${FIFTYONE_ALIAS:-${DEMO_PREFIX}-fiftyone}"
+ISAAC_ALIAS="${ISAAC_ALIAS:-${DEMO_PREFIX}-isaac}"
+
+COSMOS_PORT="${COSMOS_PORT:-8081}"
+GROOT_PORT="${GROOT_PORT:-8082}"
+FIFTYONE_PORT="${FIFTYONE_PORT:-5151}"
+
+H200_GPU_TYPE="${H200_GPU_TYPE:-gpu-h200-sxm}"
+H200_GPU_PRESET="${H200_GPU_PRESET:-8gpu-128vcpu-1600gb}"
+H200_GPU_COUNT="${H200_GPU_COUNT:-8}"
+
+ISAAC_GPU_TYPE="${ISAAC_GPU_TYPE:-gpu-rtx6000}"
+ISAAC_GPU_PRESET="${ISAAC_GPU_PRESET:-1gpu-24vcpu-218gb}"
+ISAAC_GPU_COUNT="${ISAAC_GPU_COUNT:-1}"
+
+COSMOS_MODEL="${COSMOS_MODEL:-nvidia/Cosmos-1.0-Diffusion-7B-Text2World}"
+GROOT_MODEL="${GROOT_MODEL:-nvidia/GR00T-N1.7-3B}"
+GROOT_EMBODIMENT="${GROOT_EMBODIMENT:-REAL_G1}"
+ISAAC_TASK="${ISAAC_TASK:-Isaac-Velocity-Flat-G1-v0}"
+COSMOS_PROMPT="${COSMOS_PROMPT:-humanoid robot carries a red cube around obstacles}"
+
+TARGET_BUCKET_URI="${TARGET_BUCKET_URI:-s3://${TARGET_BUCKET}/demo-8gpu-h200/${RUN_TAG}}"
+SSH_USER="${SSH_USER:-ubuntu}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
+SOURCE_CIDR="${SOURCE_CIDR:-}"
+NPA_NEBIUS_PROFILE="${NPA_NEBIUS_PROFILE:-npa-mk8s}"
+SKIP_DEPLOY="${SKIP_DEPLOY:-0}"
+SKIP_PIPELINE="${SKIP_PIPELINE:-0}"
+TEARDOWN="${TEARDOWN:-0}"
+STATE_DIR="${STATE_DIR:-$HOME/.npa/demo-runs/${RUN_TAG}}"
+LOG_DIR="${LOG_DIR:-$STATE_DIR/logs}"
+
+mkdir -p "$STATE_DIR" "$LOG_DIR"
+cd "$REPO_PATH"
+
+export NPA_NEBIUS_PROFILE
+if command -v nebius >/dev/null 2>&1; then
+  nebius profile activate "$NPA_NEBIUS_PROFILE" >/dev/null || true
+fi
+
+if [[ -f "$HOME/.npa/live-e2e.env" ]]; then
+  # shellcheck disable=SC1090
+  set -a; source "$HOME/.npa/live-e2e.env"; set +a
+fi
+
+log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*" | tee -a "$LOG_DIR/demo.log"; }
+fail() { log "ERROR: $*"; exit 1; }
+
+require_bin() {
+  [[ -x "$1" ]] || fail "missing executable: $1"
+}
+
+workbench_field() {
+  local tool="$1" alias="$2" field="$3"
+  "$PYTHON_BIN" - "$tool" "$alias" "$field" <<'PY'
+import sys, yaml
+from pathlib import Path
+tool, alias, field = sys.argv[1:4]
+cfg = yaml.safe_load(Path.home().joinpath(".npa/config.yaml").read_text())
+projects = cfg.get("projects") or {}
+# Prefer explicit project alias from env via NPA_DEMO_PROJECT if set later; scan all.
+hits = []
+for pname, proj in projects.items():
+    wbs = (proj.get("workbenches") or {})
+    # tool-specific nesting varies; also check flat aliases under projects.
+    for key, wb in wbs.items():
+        if key == alias or (isinstance(wb, dict) and wb.get("alias") == alias):
+            hits.append(wb)
+# Fallback: npa stores per-tool under ~/.npa sometimes only via CLI status.
+if not hits:
+    print("")
+    raise SystemExit(0)
+wb = hits[-1]
+val = wb.get(field) if isinstance(wb, dict) else ""
+print(val or "")
+PY
+}
+
+resolve_source_cidr() {
+  if [[ -n "$SOURCE_CIDR" ]]; then
+    echo "$SOURCE_CIDR"
+    return
+  fi
+  local ip
+  ip="$(curl -4 -fsS --max-time 5 ifconfig.me 2>/dev/null || true)"
+  if [[ -n "$ip" ]]; then
+    echo "${ip}/32"
+  else
+    echo "0.0.0.0/0"
+  fi
+}
+
+save_env() {
+  cat >"$STATE_DIR/demo.env" <<EOF
+REPO_PATH=$REPO_PATH
+PROJECT_ALIAS=$PROJECT_ALIAS
+PROJECT_ID=$PROJECT_ID
+TENANT_ID=$TENANT_ID
+REGION=$REGION
+RUN_TAG=$RUN_TAG
+TARGET_BUCKET_URI=$TARGET_BUCKET_URI
+COSMOS_ALIAS=$COSMOS_ALIAS
+GROOT_ALIAS=$GROOT_ALIAS
+FIFTYONE_ALIAS=$FIFTYONE_ALIAS
+ISAAC_ALIAS=$ISAAC_ALIAS
+COSMOS_PORT=$COSMOS_PORT
+GROOT_PORT=$GROOT_PORT
+FIFTYONE_PORT=$FIFTYONE_PORT
+H200_GPU_TYPE=$H200_GPU_TYPE
+H200_GPU_PRESET=$H200_GPU_PRESET
+ISAAC_GPU_TYPE=$ISAAC_GPU_TYPE
+ISAAC_GPU_PRESET=$ISAAC_GPU_PRESET
+ISAAC_TASK=$ISAAC_TASK
+GROOT_EMBODIMENT=$GROOT_EMBODIMENT
+COSMOS_MODEL=$COSMOS_MODEL
+GROOT_MODEL=$GROOT_MODEL
+EOF
+}
+
+status_json() {
+  local tool="$1" alias="$2"
+  "$NPA_BIN" workbench "$tool" -p "$PROJECT_ALIAS" -n "$alias" status --output-format json 2>/dev/null \
+    || "$NPA_BIN" workbench "$tool" -p "$PROJECT_ALIAS" -n "$alias" status --json 2>/dev/null \
+    || "$NPA_BIN" workbench "$tool" -p "$PROJECT_ALIAS" -n "$alias" status 2>&1 | tee -a "$LOG_DIR/${tool}-status.txt"
+}
+
+deploy_cosmos_h200() {
+  log "Deploying Cosmos on ${H200_GPU_COUNT}x H200 (${COSMOS_ALIAS})"
+  "$NPA_BIN" workbench cosmos -p "$PROJECT_ALIAS" -n "$COSMOS_ALIAS" deploy \
+    --runtime vm \
+    --project-id "$PROJECT_ID" \
+    --tenant-id "$TENANT_ID" \
+    --region "$REGION" \
+    --gpu-type "$H200_GPU_TYPE" \
+    --gpu-preset "$H200_GPU_PRESET" \
+    --gpu-count "$H200_GPU_COUNT" \
+    --server-port "$COSMOS_PORT" \
+    --model "$COSMOS_MODEL" \
+    --yes \
+    2>&1 | tee "$LOG_DIR/cosmos-deploy.log"
+}
+
+deploy_isaac_rtx() {
+  log "Deploying Isaac Lab on RTX PRO (${ISAAC_ALIAS})"
+  "$NPA_BIN" workbench isaac-lab -p "$PROJECT_ALIAS" -n "$ISAAC_ALIAS" deploy \
+    --runtime vm \
+    --project-id "$PROJECT_ID" \
+    --tenant-id "$TENANT_ID" \
+    --region "$REGION" \
+    --gpu-type "$ISAAC_GPU_TYPE" \
+    --gpu-preset "$ISAAC_GPU_PRESET" \
+    --yes \
+    2>&1 | tee "$LOG_DIR/isaac-deploy.log"
+}
+
+wait_for_host() {
+  local tool="$1" alias="$2" tries="${3:-90}"
+  local host=""
+  for ((i=1; i<=tries; i++)); do
+    host="$("$NPA_BIN" workbench "$tool" -p "$PROJECT_ALIAS" -n "$alias" status --output-format json 2>/dev/null \
+      | "$PYTHON_BIN" -c 'import json,sys; d=json.load(sys.stdin); print(d.get("host") or d.get("public_ip") or d.get("ip") or "")' 2>/dev/null || true)"
+    if [[ -z "$host" ]]; then
+      host="$("$PYTHON_BIN" - <<PY
+import yaml
+from pathlib import Path
+cfg=yaml.safe_load(Path.home().joinpath(".npa/config.yaml").read_text())
+# Search nested workbench records for alias
+alias="$alias"
+found=""
+def walk(obj):
+    global found
+    if isinstance(obj, dict):
+        if obj.get("alias")==alias or False:
+            found = obj.get("host") or obj.get("public_ip") or obj.get("ip") or found
+        for k,v in obj.items():
+            if k==alias and isinstance(v, dict):
+                found = v.get("host") or v.get("public_ip") or v.get("ip") or found
+            walk(v)
+    elif isinstance(obj, list):
+        for i in obj: walk(i)
+walk(cfg)
+print(found or "")
+PY
+)"
+    fi
+    if [[ -n "$host" && "$host" != "<pending>" ]]; then
+      echo "$host"
+      return 0
+    fi
+    sleep 20
+  done
+  return 1
+}
+
+deploy_shared_h200_services() {
+  local host="$1"
+  local instance_id="$2"
+  local cidr
+  cidr="$(resolve_source_cidr)"
+  log "Ensuring ingress on $instance_id for ports ${FIFTYONE_PORT},${COSMOS_PORT},${GROOT_PORT} from $cidr"
+  "$NPA_BIN" network ensure-ingress \
+    --vm "$instance_id" \
+    --ports "${FIFTYONE_PORT},${COSMOS_PORT},${GROOT_PORT}" \
+    --source "$cidr" \
+    --tool physical-ai-demo \
+    2>&1 | tee "$LOG_DIR/ingress.log" || log "WARN: ensure-ingress returned non-zero (continuing)"
+
+  log "Deploying GR00T BYOVM on $host"
+  "$NPA_BIN" workbench groot -p "$PROJECT_ALIAS" -n "$GROOT_ALIAS" deploy \
+    --runtime byovm \
+    --host "$host" \
+    --ssh-user "$SSH_USER" \
+    --ssh-key "$SSH_KEY" \
+    --project-id "$PROJECT_ID" \
+    --tenant-id "$TENANT_ID" \
+    --region "$REGION" \
+    --gpu-type "$H200_GPU_TYPE" \
+    --gpu-preset "$H200_GPU_PRESET" \
+    --gpu-count "$H200_GPU_COUNT" \
+    --server-port "$GROOT_PORT" \
+    --model "$GROOT_MODEL" \
+    --robot-embodiment "$GROOT_EMBODIMENT" \
+    --yes \
+    2>&1 | tee "$LOG_DIR/groot-deploy.log"
+
+  log "Deploying FiftyOne BYOVM on $host"
+  "$NPA_BIN" workbench fiftyone -p "$PROJECT_ALIAS" -n "$FIFTYONE_ALIAS" deploy \
+    --runtime byovm \
+    --host "$host" \
+    --ssh-user "$SSH_USER" \
+    --ssh-key "$SSH_KEY" \
+    --project-id "$PROJECT_ID" \
+    --tenant-id "$TENANT_ID" \
+    --region "$REGION" \
+    --gpu-count "$H200_GPU_COUNT" \
+    --port "$FIFTYONE_PORT" \
+    --yes \
+    2>&1 | tee "$LOG_DIR/fiftyone-deploy.log"
+}
+
+run_pipeline() {
+  local isaac_export="${TARGET_BUCKET_URI}/demo-prestage/isaac-lab/${ISAAC_TASK}/"
+  local groot_dataset="${TARGET_BUCKET_URI}/demo-prestage/groot-lerobot/${ISAAC_TASK}/"
+  local groot_output="${TARGET_BUCKET_URI}/demo-live/groot-predictions/stage-demo/"
+  local cosmos_output="${TARGET_BUCKET_URI}/demo-live/cosmos/stage-demo.mp4"
+  local fiftyone_source="${TARGET_BUCKET_URI}/demo-prestage/cosmos/fiftyone-ranked/"
+  local fiftyone_dataset="demo_cosmos_ranked_${RUN_TAG}"
+
+  log "Isaac Lab short train"
+  "$NPA_BIN" workbench isaac-lab -p "$PROJECT_ALIAS" -n "$ISAAC_ALIAS" train \
+    --task "$ISAAC_TASK" \
+    --num-envs 64 \
+    --steps 1000 \
+    --output-path "${TARGET_BUCKET_URI}/isaac-lab-train/${ISAAC_TASK}/" \
+    --output-format json \
+    2>&1 | tee "$LOG_DIR/isaac-train.log" || log "WARN: isaac train returned non-zero"
+
+  log "Isaac Lab export-lerobot"
+  "$NPA_BIN" workbench isaac-lab -p "$PROJECT_ALIAS" -n "$ISAAC_ALIAS" export-lerobot \
+    --task "$ISAAC_TASK" \
+    --num-episodes 10 \
+    --steps-per-episode 30 \
+    --output-path "$isaac_export" \
+    --output-format json \
+    2>&1 | tee "$LOG_DIR/isaac-export.log"
+
+  log "GR00T convert lerobot-to-groot"
+  "$NPA_BIN" workbench groot -p "$PROJECT_ALIAS" -n "$GROOT_ALIAS" convert \
+    --input-path "$isaac_export" \
+    --output-path "$groot_dataset" \
+    --direction lerobot-to-groot \
+    --robot-embodiment "$GROOT_EMBODIMENT" \
+    --output-format json \
+    2>&1 | tee "$LOG_DIR/groot-convert.log"
+
+  log "GR00T infer"
+  "$NPA_BIN" workbench groot -p "$PROJECT_ALIAS" -n "$GROOT_ALIAS" infer \
+    --input-path "$GROOT_MODEL" \
+    --dataset-path "$groot_dataset" \
+    --output-path "$groot_output" \
+    --embodiment-tag "$GROOT_EMBODIMENT" \
+    --steps 32 \
+    --output json \
+    2>&1 | tee "$LOG_DIR/groot-infer.log"
+
+  log "Cosmos infer"
+  "$NPA_BIN" workbench cosmos -p "$PROJECT_ALIAS" -n "$COSMOS_ALIAS" infer \
+    --prompt "$COSMOS_PROMPT" \
+    --output-path "$cosmos_output" \
+    --output-format json \
+    2>&1 | tee "$LOG_DIR/cosmos-infer.log" || \
+  "$NPA_BIN" workbench cosmos -p "$PROJECT_ALIAS" -n "$COSMOS_ALIAS" infer \
+    --prompt "$COSMOS_PROMPT" \
+    --output-path "$cosmos_output" \
+    2>&1 | tee -a "$LOG_DIR/cosmos-infer.log"
+
+  # Seed a tiny FiftyOne-ranked prefix from the cosmos output when present.
+  mkdir -p "$STATE_DIR/fiftyone-ranked"
+  if command -v aws >/dev/null 2>&1; then
+    local endpoint
+    endpoint="$(grep -E '^[[:space:]]*endpoint_url:' "$HOME/.npa/credentials.yaml" | head -1 | awk '{print $2}')"
+    aws --endpoint-url "${endpoint:-${AWS_ENDPOINT_URL:-https://storage.us-central1.nebius.cloud}}" \
+      s3 cp "$cosmos_output" "s3://${TARGET_BUCKET}/demo-8gpu-h200/${RUN_TAG}/demo-prestage/cosmos/fiftyone-ranked/sample-000.mp4" \
+      2>&1 | tee "$LOG_DIR/fiftyone-seed.log" || true
+  fi
+
+  log "FiftyOne load-dataset"
+  "$NPA_BIN" workbench fiftyone -p "$PROJECT_ALIAS" -n "$FIFTYONE_ALIAS" load-dataset \
+    --name "$fiftyone_dataset" \
+    --input-path "${TARGET_BUCKET_URI}/demo-prestage/cosmos/fiftyone-ranked/" \
+    --format auto \
+    2>&1 | tee "$LOG_DIR/fiftyone-load.log" || log "WARN: fiftyone load returned non-zero"
+
+  cat >"$STATE_DIR/artifacts.txt" <<EOF
+TARGET_BUCKET_URI=$TARGET_BUCKET_URI
+ISAAC_EXPORT=$isaac_export
+GROOT_DATASET=$groot_dataset
+GROOT_OUTPUT=$groot_output
+COSMOS_OUTPUT=$cosmos_output
+FIFTYONE_DATASET=$fiftyone_dataset
+EOF
+}
+
+teardown_all() {
+  log "Teardown requested"
+  "$NPA_BIN" workbench fiftyone -p "$PROJECT_ALIAS" -n "$FIFTYONE_ALIAS" deploy --destroy --yes 2>&1 | tee "$LOG_DIR/fiftyone-destroy.log" || true
+  "$NPA_BIN" workbench groot -p "$PROJECT_ALIAS" -n "$GROOT_ALIAS" deploy --destroy --yes 2>&1 | tee "$LOG_DIR/groot-destroy.log" || true
+  "$NPA_BIN" workbench cosmos -p "$PROJECT_ALIAS" -n "$COSMOS_ALIAS" deploy --destroy --yes 2>&1 | tee "$LOG_DIR/cosmos-destroy.log" || true
+  "$NPA_BIN" workbench isaac-lab -p "$PROJECT_ALIAS" -n "$ISAAC_ALIAS" deploy --destroy --yes 2>&1 | tee "$LOG_DIR/isaac-destroy.log" || true
+}
+
+main() {
+  require_bin "$NPA_BIN"
+  require_bin "$PYTHON_BIN"
+  save_env
+  log "Starting workbench demo RUN_TAG=$RUN_TAG project=$PROJECT_ALIAS ($PROJECT_ID)"
+  log "Artifacts -> $TARGET_BUCKET_URI"
+  log "State dir -> $STATE_DIR"
+
+  if [[ "$TEARDOWN" == "1" ]]; then
+    teardown_all
+    exit 0
+  fi
+
+  if [[ "$SKIP_DEPLOY" != "1" ]]; then
+    # Sequential infra bring-up avoids racing the tenant compute.disk.count quota.
+    deploy_cosmos_h200 || fail "Cosmos H200 deploy failed (see $LOG_DIR/cosmos-deploy.log)"
+    deploy_isaac_rtx || fail "Isaac deploy failed (see $LOG_DIR/isaac-deploy.log)"
+
+    local host instance_id
+    host="$(wait_for_host cosmos "$COSMOS_ALIAS" 30 || true)"
+    instance_id="$("$PYTHON_BIN" - <<PY
+import yaml
+from pathlib import Path
+cfg=yaml.safe_load(Path.home().joinpath(".npa/config.yaml").read_text())
+alias="$COSMOS_ALIAS"
+found=""
+def walk(obj):
+    global found
+    if isinstance(obj, dict):
+        if obj.get("alias")==alias:
+            found = obj.get("instance_id") or found
+        for k,v in obj.items():
+            if k==alias and isinstance(v, dict):
+                found = v.get("instance_id") or found
+            walk(v)
+    elif isinstance(obj, list):
+        for i in obj: walk(i)
+walk(cfg)
+print(found or "")
+PY
+)"
+    [[ -n "$host" ]] || fail "Could not resolve Cosmos VM host after deploy"
+    [[ -n "$instance_id" ]] || log "WARN: instance_id not found in config; ingress may need manual VM id"
+    echo "$host" >"$STATE_DIR/h200_host.txt"
+    echo "$instance_id" >"$STATE_DIR/h200_instance_id.txt"
+    if [[ -n "$instance_id" ]]; then
+      deploy_shared_h200_services "$host" "$instance_id"
+    else
+      log "Skipping BYOVM groot/fiftyone until instance_id is known; host=$host"
+    fi
+  fi
+
+  log "Service status snapshot"
+  status_json cosmos "$COSMOS_ALIAS" | tee "$LOG_DIR/cosmos-status.out" || true
+  status_json isaac-lab "$ISAAC_ALIAS" | tee "$LOG_DIR/isaac-status.out" || true
+  status_json groot "$GROOT_ALIAS" | tee "$LOG_DIR/groot-status.out" || true
+  status_json fiftyone "$FIFTYONE_ALIAS" | tee "$LOG_DIR/fiftyone-status.out" || true
+
+  if [[ "$SKIP_PIPELINE" != "1" ]]; then
+    run_pipeline
+  fi
+
+  log "Demo packaging complete. Review $STATE_DIR"
+  cat "$STATE_DIR/demo.env"
+}
+
+main "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds scrubbed architect live-demo guides/runner and a Rerun viewer bug fix. Guides use **env placeholders only** (no public IPs, instance IDs, tenant/project IDs, bucket names, or credentials). History was rewritten so Gitleaks no longer sees earlier leaked identifiers.

### Guides
- `docs/demo/architect-live-rtxpro.md` — live pack runbook (placeholders)
- `docs/demo/architect-live-agent-ui.md` — present on `workbench-demo` agent; run id `demo-workbench-ui`
- `scripts/run_workbench_demo_live.sh` — requires `PROJECT_ID` / `TENANT_ID` / `TARGET_BUCKET` from the environment

### Bug fix
Rerun web viewer treats path-only `/rerun/recordings/...` as host `rerun` → broken `http://rerun/...` under HTTPS.

In `npa/src/npa/cli/agent.py`:
- Emit **absolute HTTPS** recording URLs via `NPA_AGENT_PUBLIC_URL` / `location.origin`
- CORS headers on `/rerun/recordings/`
- UI guard so relative RRD URLs are never passed to the viewer

### Workflow (high level)
1. Fresh agent: `$PROJECT_ALIAS` / `workbench-demo`
2. Artifacts run id: **`demo-workbench-ui`**
3. Load `groot-predictions-overlay.rrd` → Reload Rerun (absolute `?url=https://…/recordings/…`)
4. Optional: closed-loop RRD → Cosmos MP4 → curation alt

### Test plan
- [x] Guides contain no hardcoded live IPs / tenant / project / bucket IDs
- [x] Gitleaks clean on PR commit range
- [x] Absolute Rerun URL loads recording successfully
- [ ] Operator walkthrough with local env vars only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd77dbe5-c3dd-4f4c-bf48-f024a00a408b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd77dbe5-c3dd-4f4c-bf48-f024a00a408b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

