### PR TITLE
fix: registry pull secrets, Isaac S3 endpoints, GR00T storage creds, VM destroy confirm

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -37,7 +37,7 @@ work lives).
 #### [H] GR00T BYOVM env omits inherited S3 credentials
 
 - **Surfaced by**: 2026-05-09 8x H200 validation.
-- **Status**: Still active.
+- **Status**: Fixed.
 - **Current issue**: GR00T BYOVM env files inherited HF/GPU values but omitted
   project storage credentials present in Cosmos and FiftyOne env files.
 - **Next step**: Write merged project storage credentials into
@@ -161,7 +161,7 @@ work lives).
 #### [L] VM `deploy --destroy` runs Terraform destroy with no confirmation
 
 - **Surfaced by**: 2026-06-11 Cosmos VM teardown.
-- **Status**: Still active.
+- **Status**: Fixed.
 - **Current issue**: For Terraform-managed (`--runtime vm`) aliases,
   `cosmos deploy --destroy` proceeds straight to `terraform destroy` with no
   confirmation prompt; `--yes` only gates `--replace`, so a mistyped `-n` alias
@@ -173,6 +173,11 @@ work lives).
 
 ## Resolved (recent)
 
+- 2026-07-09 - GR00T BYOVM/project storage credential inheritance + reload-env
+  parity with Cosmos (`apply_storage_env_vars`, `_shared_groot_env_or_fail(cfg, ...)`).
+- 2026-07-09 - VM `deploy --destroy` confirmation gate via
+  `npa.deploy.confirm.confirm_vm_destroy` across workbench tools; e2e scripts
+  pass `--yes`.
 - 2026-05-22 - BYOVM live commands SSH fallback schema and live routing
   (`9784d25`, W15 Stage B). Original FIXME entry: `BYOVM live commands do not
   SSH-fallback when public endpoints are blocked`.

--- a/docs/workbench/troubleshooting/known-footguns.md
+++ b/docs/workbench/troubleshooting/known-footguns.md
@@ -38,9 +38,11 @@ authentication error such as `401 Unauthorized`.
 Root cause: Nebius IAM-backed registry tokens expire, and an old
 `npa-nebius-registry` pull secret can remain in the namespace.
 
-Current workaround: refresh the registry token and recreate the
-`npa-nebius-registry` image pull secret in the SkyPilot namespace, normally
-`default`.
+Mitigation: Sim2Real sibling Kubernetes Jobs now call
+`ensure_registry_pull_secret_for_images()` immediately before each `kubectl
+apply`, in addition to the initial `k8s_submit` refresh. Manual workaround if
+needed: refresh the registry token and recreate the `npa-nebius-registry`
+image pull secret in the SkyPilot namespace, normally `default`.
 
 Category for follow-up: security.
 
@@ -52,9 +54,10 @@ instead of `https://storage.eu-north1.nebius.cloud`.
 Root cause: SkyPilot 0.12.2 does not interpolate environment variables inside
 YAML `envs` blocks at submission time.
 
-Current workaround: use `npa/scripts/run_isaac_lab_rl.py`, which materializes
-endpoint values before submission, or substitute the literal endpoint value in
-the YAML before submitting.
+Mitigation: reference Isaac Lab / BYOF SkyPilot YAMLs now ship the concrete
+`https://storage.eu-north1.nebius.cloud` endpoint, and
+`npa/scripts/run_isaac_lab_rl.py` always materializes `AWS_ENDPOINT_URL` /
+`NEBIUS_S3_ENDPOINT` before submit. Prefer the runner for custom endpoints.
 
 Category for follow-up: docs + platform.
 

--- a/npa/scripts/run_isaac_lab_rl.py
+++ b/npa/scripts/run_isaac_lab_rl.py
@@ -98,9 +98,19 @@ def render_workflow(
         envs["WANDB_MODE"] = wandb_mode if wandb_enabled else "disabled"
         envs["NPA_CHECKPOINT_S3_URI"] = checkpoint_s3_uri
         envs["NPA_CHECKPOINT_S3_ENDPOINT_URL"] = checkpoint_s3_endpoint_url
-        if checkpoint_s3_endpoint_url:
-            envs["AWS_ENDPOINT_URL"] = checkpoint_s3_endpoint_url
-            envs["NEBIUS_S3_ENDPOINT"] = checkpoint_s3_endpoint_url
+        # SkyPilot does not interpolate ${VAR} inside YAML envs; always materialize.
+        endpoint = (
+            checkpoint_s3_endpoint_url
+            or os.environ.get("AWS_ENDPOINT_URL")
+            or os.environ.get("NEBIUS_S3_ENDPOINT")
+            or "https://storage.eu-north1.nebius.cloud"
+        )
+        if endpoint.startswith("${") or not endpoint.strip():
+            endpoint = "https://storage.eu-north1.nebius.cloud"
+        envs["AWS_ENDPOINT_URL"] = endpoint
+        envs["NEBIUS_S3_ENDPOINT"] = endpoint
+        if not envs.get("NPA_CHECKPOINT_S3_ENDPOINT_URL"):
+            envs["NPA_CHECKPOINT_S3_ENDPOINT_URL"] = endpoint
         envs["ISAAC_LAB_HYDRA_OVERRIDES"] = " ".join(["agent.save_interval=1", *rendered_overrides]).strip()
         variant = str(envs.get("RUN_VARIANT") or doc.get("name") or "").strip()
         prefix = output_root.rstrip("/") + f"/{run_id}/"

--- a/npa/src/npa/cli/cosmos/__init__.py
+++ b/npa/src/npa/cli/cosmos/__init__.py
@@ -115,6 +115,7 @@ from npa.deploy.byovm import (
     ssh_config_for_target,
     workbench_storage_outputs,
 )
+from npa.deploy.confirm import confirm_vm_destroy
 from npa.deploy.images import container_image_for_tool
 from npa.deploy.provisioner import ProvisionerError
 from npa.deploy.safety import (
@@ -2034,7 +2035,7 @@ def deploy_cmd(
         False,
         "--yes",
         "-y",
-        help="Skip confirmation prompts (use with --replace for automation).",
+        help="Skip confirmation prompts (use with --replace or deploy --destroy for automation).",
     ),
     no_shared_creds: bool = typer.Option(
         False,
@@ -2317,6 +2318,13 @@ def deploy_cmd(
     instance_name = f"cosmos-{proj_alias}-{wb_name}"
 
     if destroy:
+        confirm_vm_destroy(
+            proj_alias,
+            wb_name,
+            byovm=byovm,
+            dry_run=dry_run,
+            yes=yes,
+        )
         if byovm:
             console.print(
                 f"  [1/1] Unregistering BYOVM workbench {proj_alias}/{wb_name}..."

--- a/npa/src/npa/cli/fiftyone/__init__.py
+++ b/npa/src/npa/cli/fiftyone/__init__.py
@@ -81,6 +81,7 @@ from npa.deploy.byovm import (
     ssh_config_for_target,
     workbench_storage_outputs,
 )
+from npa.deploy.confirm import confirm_vm_destroy
 from npa.deploy.configurator import (
     HealthCheckMode,
     audit_remote_env,
@@ -2713,7 +2714,7 @@ def deploy_cmd(
         False,
         "--yes",
         "-y",
-        help="Skip confirmation prompts (use with --replace for automation).",
+        help="Skip confirmation prompts (use with --replace or deploy --destroy for automation).",
     ),
     no_shared_creds: bool = typer.Option(False, "--no-shared-creds", help="Do not inject ~/.npa/credentials.yaml shared credentials into the service env."),
     health_check_mode: HealthCheckMode = typer.Option(
@@ -2975,6 +2976,13 @@ def deploy_cmd(
     )
 
     if destroy:
+        confirm_vm_destroy(
+            proj_alias,
+            wb_name,
+            byovm=byovm,
+            dry_run=dry_run,
+            yes=yes,
+        )
         if byovm:
             console.print(f"  [1/1] Unregistering BYOVM workbench {proj_alias}/{wb_name}...")
             if not dry_run:

--- a/npa/src/npa/cli/genesis/__init__.py
+++ b/npa/src/npa/cli/genesis/__init__.py
@@ -47,6 +47,7 @@ from npa.deploy.byovm import (
     ssh_config_for_target,
     workbench_storage_outputs,
 )
+from npa.deploy.confirm import confirm_vm_destroy
 from npa.deploy.images import container_image_for_tool
 from npa.serverless_common import (
     SubnetResolutionError,
@@ -1696,6 +1697,12 @@ def deploy_cmd(
     skip_infra: bool = typer.Option(False, "--skip-infra", help="Skip Terraform, only verify connectivity."),
     destroy: bool = typer.Option(False, "--destroy", help="Destroy infrastructure and clean up config."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would happen without doing it."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompts (use with deploy --destroy for automation).",
+    ),
     no_shared_creds: bool = typer.Option(False, "--no-shared-creds", help="Do not inject ~/.npa/credentials.yaml shared credentials into the service env."),
     preemptible: bool = typer.Option(True, "--preemptible/--no-preemptible", help="Preemptible (spot) instance."),
     runtime: WorkbenchRuntime = typer.Option(WorkbenchRuntime.vm, "--runtime", help=RUNTIME_HELP),
@@ -1857,6 +1864,13 @@ def deploy_cmd(
 
     # ── Destroy flow ─────────────────────────────────────────────────
     if destroy:
+        confirm_vm_destroy(
+            proj_alias,
+            wb_name,
+            byovm=byovm,
+            dry_run=dry_run,
+            yes=yes,
+        )
         if byovm:
             console.print(f"  [1/1] Unregistering BYOVM workbench {proj_alias}/{wb_name}...")
             if not dry_run:

--- a/npa/src/npa/cli/groot/__init__.py
+++ b/npa/src/npa/cli/groot/__init__.py
@@ -88,6 +88,7 @@ from npa.deploy.cleanup import (
 from npa.deploy.byovm import (
     RUNTIME_HELP,
     apply_project_storage_vars,
+    apply_storage_env_vars,
     detect_gpu_info,
     gpu_config_fields,
     gpu_env_fields,
@@ -96,6 +97,7 @@ from npa.deploy.byovm import (
     select_visible_devices,
     workbench_storage_outputs,
 )
+from npa.deploy.confirm import confirm_vm_destroy
 from npa.deploy.images import container_image_for_tool
 from npa.deploy.provisioner import ProvisionerError
 from npa.deploy.safety import (
@@ -648,6 +650,9 @@ def _storage_env_tokens(cfg: Any) -> dict[str, str]:
     aws_secret_access_key = getattr(storage, "aws_secret_access_key", "")
     if aws_secret_access_key:
         tokens["AWS_SECRET_ACCESS_KEY"] = aws_secret_access_key
+    checkpoint_bucket = getattr(storage, "checkpoint_bucket", "")
+    if checkpoint_bucket:
+        tokens["NEBIUS_S3_BUCKET"] = checkpoint_bucket
     return tokens
 
 
@@ -1497,14 +1502,18 @@ def _parse_env_read(stdout: str) -> tuple[str, str, str]:
     return env_path, mode, "\n".join(body) + ("\n" if body else "")
 
 
-def _shared_groot_env_or_fail(credentials: Any) -> dict[str, str]:
+def _shared_groot_env_or_fail(cfg: Any, credentials: Any) -> dict[str, str]:
+    merged = {**_storage_env_tokens(cfg), **shared_credential_env(credentials)}
     credential_env = {
         key: value
-        for key, value in shared_credential_env(credentials).items()
+        for key, value in merged.items()
         if key in GROOT_CREDENTIAL_ENV_NAMES and value
     }
     if not credential_env:
-        _fail("No shared credentials found in environment or ~/.npa/credentials.yaml.")
+        _fail(
+            "No shared credentials found in environment, ~/.npa/credentials.yaml, "
+            "or project config."
+        )
     return credential_env
 
 
@@ -2147,7 +2156,7 @@ def _update_existing_deployment(
         return
 
     credentials = resolve_credentials()
-    credential_env = _shared_groot_env_or_fail(credentials)
+    credential_env = _shared_groot_env_or_fail(cfg, credentials)
     service_port = port or int(getattr(cfg, "service_port", 0) or 0) or DEFAULT_SERVER_PORT
     result = _apply_env_update(
         cfg,
@@ -2344,7 +2353,7 @@ def deploy_cmd(
         False,
         "--yes",
         "-y",
-        help="Skip confirmation prompts (use with --replace for automation).",
+        help="Skip confirmation prompts (use with --replace or deploy --destroy for automation).",
     ),
     no_shared_creds: bool = typer.Option(
         False,
@@ -2534,6 +2543,7 @@ def deploy_cmd(
             project=proj_alias,
             explicit_vars=extra_vars,
         )
+        apply_storage_env_vars(merged_vars, explicit_vars=extra_vars)
     if byovm:
         apply_project_storage_vars(
             merged_vars,
@@ -2541,6 +2551,7 @@ def deploy_cmd(
             explicit_vars=extra_vars,
             warn=console.print,
         )
+        apply_storage_env_vars(merged_vars, explicit_vars=extra_vars)
 
     if use_remote_state and nebius_creds and not dry_run:
         write_config(
@@ -2557,6 +2568,13 @@ def deploy_cmd(
     tf_workbench_type = GROOT_CONTAINER_WORKBENCH_TYPE if container_runtime else "groot"
 
     if destroy:
+        confirm_vm_destroy(
+            proj_alias,
+            wb_name,
+            byovm=byovm,
+            dry_run=dry_run,
+            yes=yes,
+        )
         if byovm:
             if dry_run:
                 console.print(
@@ -3264,7 +3282,7 @@ def reload_env_cmd(
     """Propagate local shared credentials into the running GR00T service env without redeploying."""
     cfg = _get_config()
     credentials = resolve_credentials()
-    credential_env = _shared_groot_env_or_fail(credentials)
+    credential_env = _shared_groot_env_or_fail(cfg, credentials)
 
     service_port = (
         port or int(getattr(cfg, "service_port", 0) or 0) or DEFAULT_SERVER_PORT

--- a/npa/src/npa/cli/isaac_lab/__init__.py
+++ b/npa/src/npa/cli/isaac_lab/__init__.py
@@ -67,6 +67,7 @@ from npa.deploy.byovm import (
     ssh_config_for_target,
     workbench_storage_outputs,
 )
+from npa.deploy.confirm import confirm_vm_destroy
 from npa.deploy.cleanup import (
     CleanupPartialError,
     classify_alias_state,
@@ -1593,7 +1594,7 @@ def deploy_cmd(
         False,
         "--yes",
         "-y",
-        help="Skip confirmation prompts (use with --replace for automation).",
+        help="Skip confirmation prompts (use with --replace or deploy --destroy for automation).",
     ),
     no_shared_creds: bool = typer.Option(
         False,
@@ -1763,6 +1764,13 @@ def deploy_cmd(
     )
 
     if destroy:
+        confirm_vm_destroy(
+            proj_alias,
+            wb_name,
+            byovm=byovm,
+            dry_run=dry_run,
+            yes=yes,
+        )
         if byovm:
             console.print(
                 f"  [1/1] Unregistering BYOVM workbench {proj_alias}/{wb_name}..."

--- a/npa/src/npa/cli/workbench/lerobot.py
+++ b/npa/src/npa/cli/workbench/lerobot.py
@@ -67,6 +67,7 @@ from npa.deploy.byovm import (
     ssh_config_for_target,
     workbench_storage_outputs,
 )
+from npa.deploy.confirm import confirm_vm_destroy
 
 app = typer.Typer(
     name="lerobot",
@@ -1905,6 +1906,12 @@ def deploy(
     skip_app: bool = typer.Option(False, "--skip-app", help="Skip app deployment, only provision infra."),
     destroy: bool = typer.Option(False, "--destroy", help="Destroy infrastructure and clean up config."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would happen without doing it."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompts (use with deploy --destroy for automation).",
+    ),
     no_shared_creds: bool = typer.Option(False, "--no-shared-creds", help="Do not inject ~/.npa/credentials.yaml shared credentials into the service env."),
     checkpoint: str = typer.Option("", "--checkpoint", help="Pre-load a checkpoint after deploy."),
     server_port: int = typer.Option(8080, "--server-port", help="Server port on the VM."),
@@ -2068,6 +2075,13 @@ def deploy(
 
     # ── Destroy flow ─────────────────────────────────────────────────
     if destroy:
+        confirm_vm_destroy(
+            proj_alias,
+            wb_name,
+            byovm=byovm,
+            dry_run=dry_run,
+            yes=yes,
+        )
         if byovm:
             step += 1
             console.print(f"  [{step}/{total_steps}] Unregistering BYOVM workbench {proj_alias}/{wb_name}...")

--- a/npa/src/npa/deploy/confirm.py
+++ b/npa/src/npa/deploy/confirm.py
@@ -1,0 +1,34 @@
+"""Shared confirmation helpers for destructive deploy operations."""
+
+from __future__ import annotations
+
+import typer
+
+
+def confirm_or_exit(prompt: str) -> None:
+    """Prompt the operator and abort the CLI command when they decline."""
+    if not typer.confirm(prompt, default=False):
+        typer.echo("Aborted.")
+        raise typer.Exit(code=1)
+
+
+def confirm_vm_destroy(
+    project: str,
+    name: str,
+    *,
+    byovm: bool,
+    dry_run: bool,
+    yes: bool,
+) -> None:
+    """Require confirmation before Terraform-managed VM destroy.
+
+    BYOVM destroy only unregisters a local alias (non-destructive) and dry-run
+    does not mutate cloud state, so those paths skip the prompt. Pass ``--yes``
+    for non-interactive automation.
+    """
+    if byovm or dry_run or yes:
+        return
+    confirm_or_exit(
+        f"Destroy Terraform-managed VM '{project}/{name}'? "
+        "This deletes cloud infrastructure and cannot be undone."
+    )

--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -1844,6 +1844,29 @@ def _ensure_sibling_source_env(
     return merged
 
 
+def _refresh_registry_pull_secret_for_sibling_job(
+    image: str,
+    *,
+    config: Sim2RealLoopConfig,
+    namespace: str,
+) -> None:
+    """Mint a fresh Nebius registry pull secret before each sibling Job apply.
+
+    Initial ``k8s_submit`` refreshes once, but long Sim2Real runs launch many
+    later sibling Jobs (augment/train/eval/heldout). IAM registry tokens expire,
+    so stale ``npa-nebius-registry`` secrets cause mid-pipeline ImagePullBackOff.
+    """
+
+    from npa.workflows.sim2real.registry_auth import ensure_registry_pull_secret_for_images
+
+    ensure_registry_pull_secret_for_images(
+        image,
+        namespace=namespace,
+        kubeconfig=config.k8s_kubeconfig,
+        k8s_context=config.k8s_context,
+    )
+
+
 def _run_kubernetes_indexed_image_component(
     image: str,
     *,
@@ -1857,6 +1880,9 @@ def _run_kubernetes_indexed_image_component(
     namespace = config.k8s_namespace or _serviceaccount_namespace() or "default"
     job_name = _k8s_job_name(config.run_id, component)
     env = _ensure_sibling_source_env(config, env)
+    _refresh_registry_pull_secret_for_sibling_job(
+        image, config=config, namespace=namespace
+    )
     manifest = _indexed_component_job_manifest(
         image,
         component=component,
@@ -1965,6 +1991,9 @@ def _run_kubernetes_image_component(
     namespace = config.k8s_namespace or _serviceaccount_namespace() or "default"
     job_name = _k8s_job_name(config.run_id, component)
     env = _ensure_sibling_source_env(config, env)
+    _refresh_registry_pull_secret_for_sibling_job(
+        image, config=config, namespace=namespace
+    )
     manifest = _component_job_manifest(
         image,
         component=component,

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -2231,6 +2231,15 @@ def _run_kubernetes_image_component(
     namespace = config.k8s_namespace or _serviceaccount_namespace() or "default"
     job_name = _k8s_job_name(config.run_id, component)
     env = _ensure_sibling_source_env(config, env)
+    # Refresh before each sibling Job: IAM registry tokens expire mid-pipeline.
+    from npa.workflows.sim2real.registry_auth import ensure_registry_pull_secret_for_images
+
+    ensure_registry_pull_secret_for_images(
+        image,
+        namespace=namespace,
+        kubeconfig=config.k8s_kubeconfig,
+        k8s_context=config.k8s_context,
+    )
     manifest = _component_job_manifest(
         image,
         component=component,

--- a/npa/tests/cli/test_fiftyone_cli.py
+++ b/npa/tests/cli/test_fiftyone_cli.py
@@ -1753,6 +1753,7 @@ def test_fiftyone_destroy_removes_provisioning_workbench(tmp_path: Path, mocker)
             "--tf-dir",
             str(tmp_path),
             "--destroy",
+            "--yes",
         ],
     )
 
@@ -1810,6 +1811,7 @@ def test_fiftyone_destroy_reuses_saved_terraform_state_credentials(mocker) -> No
             "curate",
             "deploy",
             "--destroy",
+            "--yes",
         ],
     )
 

--- a/npa/tests/cli/test_groot_cli.py
+++ b/npa/tests/cli/test_groot_cli.py
@@ -928,7 +928,160 @@ def test_groot_storage_env_tokens_include_s3_credentials() -> None:
         "NEBIUS_S3_ENDPOINT": "https://storage.example",
         "AWS_ACCESS_KEY_ID": "key",
         "AWS_SECRET_ACCESS_KEY": "secret",
+        "NEBIUS_S3_BUCKET": "s3://bucket/checkpoints/",
     }
+
+
+def test_shared_groot_env_includes_project_storage(mocker) -> None:
+    from npa.cli.groot import _shared_groot_env_or_fail
+
+    cfg = _cfg()
+    credentials = CredentialsConfig(tokens={"HF_TOKEN": "PLACEHOLDER_HF_TOKEN"})
+    env = _shared_groot_env_or_fail(cfg, credentials)
+    assert env["HF_TOKEN"] == "PLACEHOLDER_HF_TOKEN"
+    assert env["AWS_ACCESS_KEY_ID"] == "key"
+    assert env["AWS_SECRET_ACCESS_KEY"] == "secret"
+    assert env["AWS_ENDPOINT_URL"] == "https://storage.example"
+    assert env["NEBIUS_S3_ENDPOINT"] == "https://storage.example"
+    assert env["NEBIUS_S3_BUCKET"] == "s3://bucket/checkpoints/"
+
+
+def test_groot_deploy_destroy_aborts_without_confirmation(mocker) -> None:
+    mocker.patch("npa.cli.groot.typer.confirm", return_value=False)
+    destroy = mocker.patch("npa.cli.groot.provisioner.destroy")
+    mocker.patch("npa.cli.groot.resolve_environment", return_value=None)
+    mocker.patch(
+        "npa.cli.groot.resolve_credentials",
+        return_value=CredentialsConfig(tokens={"HF_TOKEN": "PLACEHOLDER_HF_TOKEN"}),
+    )
+    mocker.patch("npa.cli.groot.list_projects", return_value={})
+    mocker.patch("npa.cli.groot.workbench_is_byovm", return_value=False)
+    mocker.patch("npa.cli.groot.alias_has_terraform_state", return_value=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "groot",
+            "-p",
+            "proj",
+            "-n",
+            "groot",
+            "deploy",
+            "--destroy",
+            "--project-id",
+            "project",
+            "--tenant-id",
+            "tenant",
+            "--region",
+            "eu-north1",
+            "--tf-dir",
+            "/tmp",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Aborted" in result.output
+    destroy.assert_not_called()
+
+
+def test_groot_deploy_destroy_skips_confirmation_with_yes(tmp_path: Path, mocker) -> None:
+    confirm = mocker.patch("npa.cli.groot.typer.confirm")
+    destroy = mocker.patch("npa.cli.groot.provisioner.destroy")
+    mocker.patch("npa.cli.groot.provisioner.init")
+    mocker.patch("npa.cli.groot.provisioner.cleanup_working_dir")
+    mocker.patch("npa.cli.groot.remove_workbench_config")
+    mocker.patch("npa.cli.groot.resolve_environment", return_value=None)
+    mocker.patch(
+        "npa.cli.groot.resolve_credentials",
+        return_value=CredentialsConfig(tokens={"HF_TOKEN": "PLACEHOLDER_HF_TOKEN"}),
+    )
+    mocker.patch("npa.cli.groot.list_projects", return_value={})
+    mocker.patch("npa.cli.groot.workbench_is_byovm", return_value=False)
+    mocker.patch("npa.cli.groot.alias_has_terraform_state", return_value=False)
+    mocker.patch(
+        "npa.cli.groot.resolve_ssh_config",
+        return_value=_cfg(),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "groot",
+            "-p",
+            "proj",
+            "-n",
+            "groot",
+            "deploy",
+            "--destroy",
+            "--yes",
+            "--project-id",
+            "project",
+            "--tenant-id",
+            "tenant",
+            "--region",
+            "eu-north1",
+            "--tf-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0
+    confirm.assert_not_called()
+    destroy.assert_called_once()
+
+
+def test_groot_byovm_deploy_calls_apply_storage_env_vars(mocker) -> None:
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (0, "connected", "")
+    ssh.run_or_raise.side_effect = [
+        (0, "connected\n", ""),
+        (0, "NVIDIA H200\n", ""),
+        (0, "GR00T_ENV_SMOKE_OK\nISAAC_LAB_ENV_SMOKE_OK\n", ""),
+    ]
+    mocker.patch("npa.cli.groot.SSHClient", return_value=ssh)
+    mocker.patch("npa.cli.groot.provisioner.init")
+    mocker.patch("npa.cli.groot.provisioner.apply")
+    mocker.patch("npa.cli.groot.resolve_environment", return_value=None)
+    mocker.patch(
+        "npa.cli.groot.resolve_credentials",
+        return_value=CredentialsConfig(tokens={"HF_TOKEN": "PLACEHOLDER_HF_TOKEN"}),
+    )
+    mocker.patch("npa.cli.groot.list_projects", return_value={})
+    mocker.patch("npa.cli.groot.write_config")
+    mocker.patch("npa.cli.groot.update_workbench_app_status")
+    mocker.patch("npa.cli.groot.audit_remote_env", return_value=[])
+    mocker.patch("npa.cli.groot.health_check_auto", return_value=(True, ""))
+    mocker.patch("npa.cli.groot.write_manifest")
+    apply_storage = mocker.patch("npa.cli.groot.apply_storage_env_vars")
+    mocker.patch(
+        "npa.cli.groot.apply_project_storage_vars",
+        return_value=True,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "groot",
+            "-p",
+            "proj",
+            "-n",
+            "groot",
+            "deploy",
+            "--runtime",
+            "byovm",
+            "--host",
+            "203.0.113.10",
+            "--ssh-key",
+            "~/.ssh/byovm",
+            "--region",
+            "eu-north1",
+            "--skip-model-check",
+            "--no-auto-serve",
+        ],
+    )
+    assert result.exit_code == 0
+    assert apply_storage.called
 
 
 def test_groot_reload_env_command_updates_credentials_without_embedding_secret() -> None:

--- a/npa/tests/cli/test_groot_cli.py
+++ b/npa/tests/cli/test_groot_cli.py
@@ -1250,7 +1250,16 @@ def test_groot_reload_env_dry_run_shows_changes(mocker) -> None:
 
 
 def test_groot_reload_env_requires_shared_credentials(mocker) -> None:
-    mocker.patch("npa.cli.groot.resolve_config", return_value=_cfg())
+    # Empty workbench storage + empty credentials.yaml must still fail loudly.
+    # Configs with project storage tokens are allowed (Cosmos parity).
+    cfg = _cfg()
+    cfg.storage = StorageConfig(
+        checkpoint_bucket="",
+        endpoint_url="",
+        aws_access_key_id="",
+        aws_secret_access_key="",
+    )
+    mocker.patch("npa.cli.groot.resolve_config", return_value=cfg)
     mocker.patch("npa.cli.groot.resolve_credentials", return_value=CredentialsConfig())
     ssh_cls = mocker.patch("npa.cli.groot.SSHClient")
 

--- a/npa/tests/cli/test_workbench_app_status.py
+++ b/npa/tests/cli/test_workbench_app_status.py
@@ -230,6 +230,7 @@ def test_cosmos_destroy_removes_install_failed_workbench(
             "cosmos",
             "deploy",
             "--destroy",
+            "--yes",
             "--tf-dir",
             str(tmp_path),
             "--gpu-type",

--- a/npa/tests/e2e/test_cosmos_e2e.sh
+++ b/npa/tests/e2e/test_cosmos_e2e.sh
@@ -101,7 +101,7 @@ run_teardown_step() {
     return 0
   fi
   TEARDOWN_DONE=1
-  run_npa_step "destroy workbench" deploy --destroy --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
+  run_npa_step "destroy workbench" deploy --destroy --yes --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
 }
 
 cleanup() {

--- a/npa/tests/e2e/test_distill_pipeline_e2e.sh
+++ b/npa/tests/e2e/test_distill_pipeline_e2e.sh
@@ -395,7 +395,7 @@ destroy_genesis() {
   if [ "$GENESIS_CREATED" -eq 0 ] || [ "$GENESIS_DESTROYED" -eq 1 ]; then
     return 0
   fi
-  if run_npa_workbench_step "destroy Genesis workbench" genesis "$GENESIS_PROJECT" "$GENESIS_NAME" deploy --destroy --gpu-type "$GENESIS_GPU_TYPE" --gpu-preset "$GENESIS_GPU_PRESET"; then
+  if run_npa_workbench_step "destroy Genesis workbench" genesis "$GENESIS_PROJECT" "$GENESIS_NAME" deploy --destroy --yes --gpu-type "$GENESIS_GPU_TYPE" --gpu-preset "$GENESIS_GPU_PRESET"; then
     GENESIS_DESTROYED=1
     return 0
   fi
@@ -406,7 +406,7 @@ destroy_lerobot() {
   if [ "$LEROBOT_CREATED" -eq 0 ] || [ "$LEROBOT_DESTROYED" -eq 1 ]; then
     return 0
   fi
-  if run_npa_workbench_step "destroy LeRobot workbench" lerobot "$LEROBOT_PROJECT" "$LEROBOT_NAME" deploy --destroy --gpu-type "$LEROBOT_GPU_TYPE" --gpu-preset "$LEROBOT_GPU_PRESET"; then
+  if run_npa_workbench_step "destroy LeRobot workbench" lerobot "$LEROBOT_PROJECT" "$LEROBOT_NAME" deploy --destroy --yes --gpu-type "$LEROBOT_GPU_TYPE" --gpu-preset "$LEROBOT_GPU_PRESET"; then
     LEROBOT_DESTROYED=1
     return 0
   fi

--- a/npa/tests/e2e/test_genesis_e2e.sh
+++ b/npa/tests/e2e/test_genesis_e2e.sh
@@ -100,7 +100,7 @@ run_teardown_step() {
     return 0
   fi
   TEARDOWN_DONE=1
-  run_npa_step "destroy workbench" deploy --destroy --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
+  run_npa_step "destroy workbench" deploy --destroy --yes --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
 }
 
 cleanup() {

--- a/npa/tests/e2e/test_groot_composition_e2e.sh
+++ b/npa/tests/e2e/test_groot_composition_e2e.sh
@@ -243,6 +243,7 @@ destroy_groot() {
   if [ "$GROOT_DEPLOYED" -eq 1 ] && [ "$GROOT_DESTROYED" -eq 0 ]; then
     "$CLI" workbench groot -p "$PROJECT" -n "$GROOT_NAME" deploy \
       --destroy \
+      --yes \
       --gpu-type "$GROOT_GPU_TYPE" \
       --gpu-preset "$GROOT_GPU_PRESET"
     GROOT_DESTROYED=1

--- a/npa/tests/e2e/test_groot_e2e.sh
+++ b/npa/tests/e2e/test_groot_e2e.sh
@@ -142,7 +142,7 @@ run_teardown_step() {
     return 0
   fi
   TEARDOWN_DONE=1
-  run_npa_step "destroy workbench" deploy --destroy --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
+  run_npa_step "destroy workbench" deploy --destroy --yes --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
 }
 
 cleanup_s3_prefix() {

--- a/npa/tests/e2e/test_isaac_lab_e2e.sh
+++ b/npa/tests/e2e/test_isaac_lab_e2e.sh
@@ -100,7 +100,7 @@ run_teardown_step() {
     return 0
   fi
   TEARDOWN_DONE=1
-  run_npa_step "destroy workbench" deploy --destroy --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
+  run_npa_step "destroy workbench" deploy --destroy --yes --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
 }
 
 cleanup() {

--- a/npa/tests/e2e/test_lancedb_e2e.py
+++ b/npa/tests/e2e/test_lancedb_e2e.py
@@ -121,6 +121,7 @@ def lancedb_service(test_id: str, lancedb_storage: dict[str, str]) -> Iterator[d
                 "--container-name",
                 container,
                 "--destroy",
+                "--yes",
                 "--output",
                 "json",
             ],

--- a/npa/tests/e2e/test_lerobot_e2e.sh
+++ b/npa/tests/e2e/test_lerobot_e2e.sh
@@ -100,7 +100,7 @@ run_teardown_step() {
     return 0
   fi
   TEARDOWN_DONE=1
-  run_npa_step "destroy workbench" deploy --destroy --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
+  run_npa_step "destroy workbench" deploy --destroy --yes --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
 }
 
 cleanup() {

--- a/npa/tests/e2e/test_serve_infer_e2e.sh
+++ b/npa/tests/e2e/test_serve_infer_e2e.sh
@@ -106,7 +106,7 @@ run_teardown_step() {
     return 0
   fi
   TEARDOWN_DONE=1
-  run_npa_step "destroy workbench" deploy --destroy --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
+  run_npa_step "destroy workbench" deploy --destroy --yes --gpu-type "$GPU_TYPE" --gpu-preset "$GPU_PRESET"
 }
 
 cleanup() {

--- a/npa/tests/test_deploy_confirm.py
+++ b/npa/tests/test_deploy_confirm.py
@@ -1,0 +1,65 @@
+"""Tests for destructive deploy confirmation helpers."""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+from npa.deploy.confirm import confirm_or_exit, confirm_vm_destroy
+
+
+def test_confirm_or_exit_aborts_when_declined(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(typer, "confirm", lambda *args, **kwargs: False)
+    with pytest.raises(typer.Exit) as exc:
+        confirm_or_exit("Destroy?")
+    assert exc.value.exit_code == 1
+
+
+def test_confirm_or_exit_continues_when_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(typer, "confirm", lambda *args, **kwargs: True)
+    confirm_or_exit("Destroy?")
+
+
+@pytest.mark.parametrize(
+    ("byovm", "dry_run", "yes", "should_prompt"),
+    [
+        (False, False, False, True),
+        (False, False, True, False),
+        (False, True, False, False),
+        (True, False, False, False),
+    ],
+)
+def test_confirm_vm_destroy_prompt_gates(
+    monkeypatch: pytest.MonkeyPatch,
+    byovm: bool,
+    dry_run: bool,
+    yes: bool,
+    should_prompt: bool,
+) -> None:
+    called: list[str] = []
+
+    def fake_confirm(prompt: str, default: bool = False) -> bool:
+        called.append(prompt)
+        return False
+
+    monkeypatch.setattr(typer, "confirm", fake_confirm)
+    if should_prompt:
+        with pytest.raises(typer.Exit):
+            confirm_vm_destroy(
+                "proj",
+                "alias",
+                byovm=byovm,
+                dry_run=dry_run,
+                yes=yes,
+            )
+        assert called
+        assert "proj/alias" in called[0]
+    else:
+        confirm_vm_destroy(
+            "proj",
+            "alias",
+            byovm=byovm,
+            dry_run=dry_run,
+            yes=yes,
+        )
+        assert called == []

--- a/npa/tests/workflows/test_isaac_lab_rl.py
+++ b/npa/tests/workflows/test_isaac_lab_rl.py
@@ -46,6 +46,28 @@ def test_isaac_lab_single_job_yaml_uses_rt_core_gpu_and_rsl_rl_entrypoint() -> N
     assert "--num_envs" in task["run"]
     assert "--max_iterations" in task["run"]
     assert "agent.save_interval=1" in task["envs"]["ISAAC_LAB_HYDRA_OVERRIDES"]
+    # SkyPilot does not interpolate ${VAR} in envs; ship a concrete endpoint.
+    assert task["envs"]["AWS_ENDPOINT_URL"] == "https://storage.eu-north1.nebius.cloud"
+    assert "${AWS_ENDPOINT_URL}" not in task["envs"]["AWS_ENDPOINT_URL"]
+
+
+def test_isaac_lab_yaml_files_have_no_literal_aws_endpoint_placeholders() -> None:
+    yaml_paths = [
+        SINGLE_YAML,
+        SWEEP_YAML,
+        ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "isaac-lab-rl-train-rtxpro.yaml",
+        ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "isaac-lab-rl-train-rtxpro-smoke.yaml",
+        ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "byof-datagen-rtxpro-smoke.yaml",
+        ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "byof-container-smoke-rtxpro.yaml",
+    ]
+    for path in yaml_paths:
+        text = path.read_text(encoding="utf-8")
+        assert 'AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"' not in text, path
+        docs = _docs(path)
+        for doc in docs[1:]:
+            envs = doc.get("envs") or {}
+            if "AWS_ENDPOINT_URL" in envs:
+                assert envs["AWS_ENDPOINT_URL"] == "https://storage.eu-north1.nebius.cloud"
 
 
 def test_isaac_lab_sweep_yaml_uses_parallel_group_and_distinct_variants() -> None:
@@ -110,6 +132,24 @@ def test_isaac_lab_runner_renders_and_submits(monkeypatch, tmp_path, capsys) -> 
     assert rendered_task["envs"]["ISAAC_LAB_ITERATIONS"] == "3"
     assert rendered_task["envs"]["S3_OUTPUT_PREFIX"] == "s3://bucket/isaac-lab-rl/isaac-test-run/"
     assert rendered_task["resources"]["image_id"] == "docker:registry.example/npa-isaac-lab:test"
+    assert rendered_task["envs"]["AWS_ENDPOINT_URL"] == "https://storage.eu-north1.nebius.cloud"
+    assert rendered_task["envs"]["NEBIUS_S3_ENDPOINT"] == "https://storage.eu-north1.nebius.cloud"
+
+
+def test_isaac_lab_runner_materializes_endpoint_from_env(monkeypatch, tmp_path) -> None:
+    wrapper = _load_wrapper_module()
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://storage.custom.example")
+    docs = wrapper.render_workflow(
+        SINGLE_YAML,
+        run_id="endpoint-env",
+        task="Isaac-Cartpole-v0",
+        iterations=1,
+        output_root="s3://bucket/isaac-lab-rl",
+    )
+    envs = docs[1]["envs"]
+    assert envs["AWS_ENDPOINT_URL"] == "https://storage.custom.example"
+    assert envs["NEBIUS_S3_ENDPOINT"] == "https://storage.custom.example"
+    assert envs["NPA_CHECKPOINT_S3_ENDPOINT_URL"] == "https://storage.custom.example"
 
 
 def test_isaac_lab_runner_render_only_keeps_rendered_yaml(capsys) -> None:

--- a/npa/tests/workflows/test_sim2real_registry_auth.py
+++ b/npa/tests/workflows/test_sim2real_registry_auth.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
+from npa.workflows.sim2real.models import Sim2RealLoopConfig
 from npa.workflows.sim2real.registry_auth import (
     docker_config_json,
     ensure_nebius_registry_pull_secret,
@@ -49,3 +51,154 @@ def test_ensure_nebius_registry_pull_secret_applies_secret(
     )
     payload = json.loads(captured["input"])
     assert payload["metadata"]["name"] == "npa-nebius-registry"
+
+
+def test_refresh_registry_pull_secret_helper_forwards_k8s_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from npa.workflows.sim2real import engine
+
+    captured: dict[str, object] = {}
+
+    def fake_ensure(*images, **kwargs):
+        captured["images"] = images
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        "npa.workflows.sim2real.registry_auth.ensure_registry_pull_secret_for_images",
+        fake_ensure,
+    )
+    config = Sim2RealLoopConfig(
+        run_id="run-registry-helper",
+        k8s_namespace="sim2real",
+        k8s_kubeconfig="/tmp/kubeconfig",
+        k8s_context="npa-rtxpro-mk8s",
+    )
+    engine._refresh_registry_pull_secret_for_sibling_job(
+        "cr.eu-north1.nebius.cloud/reg/npa-lerobot-vlm-rl:1.0",
+        config=config,
+        namespace="sim2real",
+    )
+    assert captured["images"] == (
+        "cr.eu-north1.nebius.cloud/reg/npa-lerobot-vlm-rl:1.0",
+    )
+    assert captured["kwargs"] == {
+        "namespace": "sim2real",
+        "kubeconfig": "/tmp/kubeconfig",
+        "k8s_context": "npa-rtxpro-mk8s",
+    }
+
+
+def test_sibling_kubernetes_job_refreshes_registry_pull_secret(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Long Sim2Real runs must re-mint pull secrets before each sibling Job."""
+    from npa.workflows.sim2real import engine
+
+    refresh_calls: list[tuple] = []
+
+    def fake_refresh(image, *, config, namespace):
+        refresh_calls.append((image, config.k8s_context, namespace))
+
+    monkeypatch.setattr(engine, "_refresh_registry_pull_secret_for_sibling_job", fake_refresh)
+    monkeypatch.setattr(engine, "_ensure_sibling_source_env", lambda config, env: env)
+    monkeypatch.setattr(
+        engine,
+        "_component_job_manifest",
+        lambda *args, **kwargs: {"kind": "Job", "metadata": {"name": "job"}},
+    )
+    monkeypatch.setattr(
+        engine,
+        "_kubectl",
+        lambda *args, **kwargs: MagicMock(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(engine, "_log_sibling_job_applied", lambda *args, **kwargs: "uid")
+    monkeypatch.setattr(engine, "_wait_kubernetes_job", lambda *args, **kwargs: "complete")
+    monkeypatch.setattr(
+        engine,
+        "_component_pod_info",
+        lambda *args, **kwargs: {"image_digests": []},
+    )
+    monkeypatch.setattr(engine, "_cleanup_component_job", lambda *args, **kwargs: MagicMock(stdout="", stderr=""))
+    monkeypatch.setattr(engine, "_download_component_output", lambda *args, **kwargs: None)
+
+    config = Sim2RealLoopConfig(
+        run_id="run-registry-refresh",
+        k8s_namespace="sim2real",
+        k8s_kubeconfig="/tmp/kubeconfig",
+        k8s_context="npa-rtxpro-mk8s",
+    )
+    output_json = tmp_path / "out.json"
+    output_json.write_text("{}", encoding="utf-8")
+
+    engine._run_kubernetes_image_component(
+        "cr.eu-north1.nebius.cloud/reg/npa-lerobot-vlm-rl:1.0",
+        component="train",
+        env={},
+        output_json=output_json,
+        output_uri="s3://bucket/out.json",
+        config=config,
+        timeout_s=30,
+    )
+
+    assert refresh_calls == [
+        (
+            "cr.eu-north1.nebius.cloud/reg/npa-lerobot-vlm-rl:1.0",
+            "npa-rtxpro-mk8s",
+            "sim2real",
+        )
+    ]
+
+
+def test_indexed_sibling_kubernetes_job_refreshes_registry_pull_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from npa.workflows.sim2real import engine
+
+    refresh_calls: list[tuple] = []
+
+    def fake_refresh(image, *, config, namespace):
+        refresh_calls.append((image, config.k8s_context, namespace))
+
+    monkeypatch.setattr(engine, "_refresh_registry_pull_secret_for_sibling_job", fake_refresh)
+    monkeypatch.setattr(engine, "_ensure_sibling_source_env", lambda config, env: env)
+    monkeypatch.setattr(
+        engine,
+        "_indexed_component_job_manifest",
+        lambda *args, **kwargs: {"kind": "Job", "metadata": {"name": "job"}},
+    )
+    monkeypatch.setattr(
+        engine,
+        "_kubectl",
+        lambda *args, **kwargs: MagicMock(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(engine, "_log_sibling_job_applied", lambda *args, **kwargs: "uid")
+    monkeypatch.setattr(engine, "_wait_kubernetes_job", lambda *args, **kwargs: "complete")
+    monkeypatch.setattr(
+        engine,
+        "_component_pod_info",
+        lambda *args, **kwargs: {"image_digests": []},
+    )
+    monkeypatch.setattr(engine, "_cleanup_component_job", lambda *args, **kwargs: MagicMock(stdout="", stderr=""))
+
+    config = Sim2RealLoopConfig(
+        run_id="run-indexed-refresh",
+        k8s_namespace="default",
+        k8s_context="ctx",
+    )
+    engine._run_kubernetes_indexed_image_component(
+        "cr.eu-north1.nebius.cloud/reg/npa-cosmos2-transfer:1.0",
+        component="augment",
+        env={},
+        config=config,
+        completions=2,
+        parallelism=2,
+        timeout_s=30,
+    )
+    assert refresh_calls == [
+        (
+            "cr.eu-north1.nebius.cloud/reg/npa-cosmos2-transfer:1.0",
+            "ctx",
+            "default",
+        )
+    ]

--- a/npa/workflows/workbench/skypilot/byof-container-smoke-rtxpro.yaml
+++ b/npa/workflows/workbench/skypilot/byof-container-smoke-rtxpro.yaml
@@ -12,7 +12,7 @@ envs:
   NPA_BYOF_RUN_ID: "<your-run-id>"
   BYOF_REPO_ROOT: "/opt/byof"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/byof/${NPA_BYOF_RUN_ID}/"
-  AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
 setup: |
   set -euo pipefail
   test -d "${BYOF_REPO_ROOT}"

--- a/npa/workflows/workbench/skypilot/byof-datagen-rtxpro-smoke.yaml
+++ b/npa/workflows/workbench/skypilot/byof-datagen-rtxpro-smoke.yaml
@@ -17,7 +17,7 @@ envs:
   BYOF_REPO_ROOT: "/opt/byof"
   BYOF_DATASET_FILE: "/workspace/byof-runs/${NPA_BYOF_RUN_ID}/dataset.hdf5"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/byof/${NPA_BYOF_RUN_ID}/"
-  AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
 setup: |
   set -euo pipefail
   PYTHON_BIN="${ISAAC_LAB_PYTHON:-/isaac-sim/python.sh}"

--- a/npa/workflows/workbench/skypilot/isaac-lab-rl-sweep.yaml
+++ b/npa/workflows/workbench/skypilot/isaac-lab-rl-sweep.yaml
@@ -21,7 +21,7 @@ envs:
   ISAAC_LAB_RUN_NAME: "${NPA_ISAAC_LAB_RUN_ID}-lr-1e-3"
   ISAAC_LAB_HYDRA_OVERRIDES: "agent.save_interval=1 agent.algorithm.learning_rate=1.0e-3"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/isaac-lab-rl/${NPA_ISAAC_LAB_RUN_ID}/lr-1e-3/"
-  AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
 setup: |
   set -euo pipefail
   PYTHON_BIN="${ISAAC_LAB_PYTHON:-/isaac-sim/python.sh}"
@@ -81,7 +81,7 @@ envs:
   ISAAC_LAB_RUN_NAME: "${NPA_ISAAC_LAB_RUN_ID}-lr-3e-4"
   ISAAC_LAB_HYDRA_OVERRIDES: "agent.save_interval=1 agent.algorithm.learning_rate=3.0e-4"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/isaac-lab-rl/${NPA_ISAAC_LAB_RUN_ID}/lr-3e-4/"
-  AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
 setup: |
   set -euo pipefail
   PYTHON_BIN="${ISAAC_LAB_PYTHON:-/isaac-sim/python.sh}"
@@ -141,7 +141,7 @@ envs:
   ISAAC_LAB_RUN_NAME: "${NPA_ISAAC_LAB_RUN_ID}-entropy-0"
   ISAAC_LAB_HYDRA_OVERRIDES: "agent.save_interval=1 agent.algorithm.entropy_coef=0.0"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/isaac-lab-rl/${NPA_ISAAC_LAB_RUN_ID}/entropy-0/"
-  AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
 setup: |
   set -euo pipefail
   PYTHON_BIN="${ISAAC_LAB_PYTHON:-/isaac-sim/python.sh}"
@@ -201,7 +201,7 @@ envs:
   ISAAC_LAB_RUN_NAME: "${NPA_ISAAC_LAB_RUN_ID}-entropy-0-01"
   ISAAC_LAB_HYDRA_OVERRIDES: "agent.save_interval=1 agent.algorithm.entropy_coef=0.01"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/isaac-lab-rl/${NPA_ISAAC_LAB_RUN_ID}/entropy-0-01/"
-  AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
 setup: |
   set -euo pipefail
   PYTHON_BIN="${ISAAC_LAB_PYTHON:-/isaac-sim/python.sh}"

--- a/npa/workflows/workbench/skypilot/isaac-lab-rl-train-rtxpro-smoke.yaml
+++ b/npa/workflows/workbench/skypilot/isaac-lab-rl-train-rtxpro-smoke.yaml
@@ -29,7 +29,7 @@ envs:
   NPA_CHECKPOINT_S3_ENDPOINT_URL: ""
   ISAAC_LAB_HYDRA_OVERRIDES: "agent.save_interval=1"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/isaac-lab-rl/${NPA_ISAAC_LAB_RUN_ID}/"
-  AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
 setup: |
   set -euo pipefail
   PYTHON_BIN="${ISAAC_LAB_PYTHON:-/isaac-sim/python.sh}"

--- a/npa/workflows/workbench/skypilot/isaac-lab-rl-train-rtxpro.yaml
+++ b/npa/workflows/workbench/skypilot/isaac-lab-rl-train-rtxpro.yaml
@@ -29,7 +29,7 @@ envs:
   NPA_CHECKPOINT_S3_ENDPOINT_URL: ""
   ISAAC_LAB_HYDRA_OVERRIDES: "agent.save_interval=1"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/isaac-lab-rl/${NPA_ISAAC_LAB_RUN_ID}/"
-  AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
 setup: |
   set -euo pipefail
   PYTHON_BIN="${ISAAC_LAB_PYTHON:-/isaac-sim/python.sh}"

--- a/npa/workflows/workbench/skypilot/isaac-lab-rl-train.yaml
+++ b/npa/workflows/workbench/skypilot/isaac-lab-rl-train.yaml
@@ -29,7 +29,7 @@ envs:
   NPA_CHECKPOINT_S3_ENDPOINT_URL: ""
   ISAAC_LAB_HYDRA_OVERRIDES: "agent.save_interval=1"
   S3_OUTPUT_PREFIX: "s3://${NPA_S3_BUCKET}/isaac-lab-rl/${NPA_ISAAC_LAB_RUN_ID}/"
-  AWS_ENDPOINT_URL: "${AWS_ENDPOINT_URL}"
+  AWS_ENDPOINT_URL: "https://storage.eu-north1.nebius.cloud"
 setup: |
   set -euo pipefail
   PYTHON_BIN="${ISAAC_LAB_PYTHON:-/isaac-sim/python.sh}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Four high-value operational fixes for Workbench / Sim2Real reliability and safety:

1. **Sim2Real sibling Jobs refresh Nebius registry pull secrets** before each `kubectl apply`, preventing mid-pipeline `ImagePullBackOff` / `401` when IAM tokens expire.
2. **Isaac Lab / BYOF SkyPilot YAMLs materialize `AWS_ENDPOINT_URL`** to `https://storage.eu-north1.nebius.cloud` (SkyPilot 0.12.x does not interpolate `${VAR}` in `envs`); runner always materializes endpoints too.
3. **GR00T inherits project/host S3 credentials** on BYOVM deploy + `reload-env` (Cosmos parity via `apply_storage_env_vars` / `_shared_groot_env_or_fail(cfg, ...)`). Closes FIXME **[H]**.
4. **Confirm before Terraform `deploy --destroy`** across cosmos/groot/isaac-lab/fiftyone/genesis/lerobot unless `--yes` / `--dry-run` / BYOVM. Closes FIXME **[L]** (high ops risk). E2E destroy scripts pass `--yes`.

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks.
- [x] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`. *(N/A — no skill behavior change; known-footguns docs updated.)*
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

### DEV VM validation (SSH)

- Registry + Isaac tests: **12 passed**; live `npa-nebius-registry` secret `resourceVersion` advanced after sibling helper refresh.
- GR00T storage + destroy confirm tests: **16 passed**; live CLI decline → `Aborted.`; `--yes --dry-run` → would destroy; storage token merge includes `NEBIUS_S3_BUCKET`.
- CI fix: `test_groot_reload_env_requires_shared_credentials` updated for empty-storage fixture and revalidated on DEV VM.

## Skill Maintenance

- [x] I updated the relevant root `skills/` entry and `skills/index.yaml`, or this PR does not change behavior that needs skill guidance.

## What to merge

Merge **this entire branch** (`cursor/fix-registry-secret-isaac-endpoint`) into `main` as one PR. All commits are intentional operational hardening:

| Commit | Contents |
|--------|----------|
| `17b5aba` | Registry pull-secret refresh + Isaac/BYOF endpoint materialization |
| `9f4a7d1` | GR00T S3 credential inheritance + VM destroy confirmation |
| follow-up | Fix reload-env empty-credentials unit test for storage-merge behavior |

Do **not** cherry-pick only one commit — e2e scripts and FIXME updates assume the full branch lands together.

**Merge target:** `main` ← `cursor/fix-registry-secret-isaac-endpoint` (#188)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f9ddd1a-e9e9-4778-bdb8-7296d06bb225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f9ddd1a-e9e9-4778-bdb8-7296d06bb225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

