### PR TITLE
Add LeRobot 0.6.0 support alongside default 0.5.1

### DIFF
--- a/docs/security/container-golden-evals.md
+++ b/docs/security/container-golden-evals.md
@@ -93,7 +93,8 @@ flowchart TB
 | --- | --- | --- | --- | --- | --- |
 | `base-cuda13-b300` | *(foundation)* | build-import | torch+CUDA; flash_attn import | required | blocked-on-upstream |
 | `groot` | `0.1.0` | container-smoke | GR00T repo; uv; standalone inference | required | gpu-gated |
-| `lerobot` | `0.5.1` | container-smoke | version; 50-step PushT train; checkpoint; eval; output | required | gpu-gated |
+| `lerobot` | `0.5.1` (default) | container-smoke | version; 50-step PushT train; checkpoint; eval; output | required | gpu-gated |
+| `lerobot` | `0.6.0` (additional) | container-smoke | same suite with `NPA_LEROBOT_VERSION=0.6.0` / `npa-lerobot:0.6.0` | optional | gpu-gated |
 | `lerobot-policy` | `0.1.1` | container-smoke | short train; short eval on checkpoint | optional | gpu-gated |
 | `lerobot-vlm-rl` | `0.1.1` | container-smoke | CUDA; VLM signal parse + RL step | required | gpu-gated |
 | `genesis` | `0.4.6` | container-smoke | import; Franka scene; step; body state | required | gpu-gated |

--- a/docs/workbench/oss-solution-catalog.md
+++ b/docs/workbench/oss-solution-catalog.md
@@ -86,6 +86,20 @@ unique and must be tested with its own upstream-named capabilities.
 | `droid_100_download` | accepted (live) | HTTPS metadata pull of `droid_100/1.0.0/dataset_info.json` |
 | `droid_100_config_gen` | accepted (live) | Documented `EXP_NAMES` debug subset wiring |
 
+## First-class Workbench tools (not BYOF)
+
+LeRobot is already a first-class `npa workbench lerobot` tool. Supported
+package/image tags:
+
+| Version | Status | Notes |
+| --- | --- | --- |
+| `0.5.1` | default | `npa-lerobot:0.5.1` |
+| `0.6.0` | additional | `npa-lerobot:0.6.0`; lean extras + `env_eval_freq` |
+
+Select with `--lerobot-version`. Manifest:
+`npa/src/npa/deploy/lerobot_version_manifest.json`. Upstream:
+https://huggingface.co/blog/lerobot-release-v060
+
 ## Capability Testing In The Onboarding Skill
 
 When creating or onboarding solutions, agents must follow

--- a/npa/docker/workbench/lerobot/Dockerfile
+++ b/npa/docker/workbench/lerobot/Dockerfile
@@ -16,7 +16,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     NPA_SERVER_PORT=8080 \
     NPA_CHECKPOINT_DIR=/opt/lerobot/checkpoints \
     NPA_JOB_STATUS_DIR=/opt/lerobot/job_status \
-    NPA_LOG_DIR=/var/log/npa-lerobot
+    NPA_LOG_DIR=/var/log/npa-lerobot \
+    NPA_LEROBOT_VERSION=${LEROBOT_VERSION}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates \
@@ -73,19 +74,31 @@ RUN useradd -m -s /bin/bash -u 1000 ubuntu \
 USER ubuntu
 WORKDIR /opt/lerobot
 
+# 0.5.1 keeps the historic [pusht,libero] extra bundle + pinned torch upgrades.
+# 0.6.0 uses lean feature extras and must NOT force torch>=2.12 (upstream ceiling).
 RUN python3.12 -m venv /opt/lerobot/venv \
     && /opt/lerobot/venv/bin/python -m pip install --upgrade pip setuptools wheel \
-    && /opt/lerobot/venv/bin/pip install \
-      "lerobot[pusht,libero]==${LEROBOT_VERSION}" \
-      boto3 \
-      fastapi~=0.136.1 \
-      num2words \
-      tensorboard \
-      "uvicorn[standard]" \
-    && /opt/lerobot/venv/bin/pip install --no-cache-dir --upgrade \
-      "torch==2.12.1" \
-      "torchvision==0.27.1" \
-      "diffusers>=0.38.0" \
+    && if [ "${LEROBOT_VERSION}" = "0.6.0" ]; then \
+         /opt/lerobot/venv/bin/pip install \
+           "lerobot[training,evaluation,pusht,libero]==${LEROBOT_VERSION}" \
+           boto3 \
+           fastapi~=0.136.1 \
+           num2words \
+           tensorboard \
+           "uvicorn[standard]"; \
+       else \
+         /opt/lerobot/venv/bin/pip install \
+           "lerobot[pusht,libero]==${LEROBOT_VERSION}" \
+           boto3 \
+           fastapi~=0.136.1 \
+           num2words \
+           tensorboard \
+           "uvicorn[standard]" \
+         && /opt/lerobot/venv/bin/pip install --no-cache-dir --upgrade \
+           "torch==2.12.1" \
+           "torchvision==0.27.1" \
+           "diffusers>=0.38.0"; \
+       fi \
     && /opt/lerobot/venv/bin/pip uninstall -y wandb
 
 ENV PATH=/opt/lerobot/venv/bin:$PATH \

--- a/npa/docker/workbench/lerobot/build.sh
+++ b/npa/docker/workbench/lerobot/build.sh
@@ -6,12 +6,16 @@ NPA_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 REGISTRY=""
 PUSH=0
+VERSION=""
+ALL_VERSIONS=0
 
 usage() {
   cat <<'EOF'
-Usage: build.sh [--registry REGISTRY] [--push]
+Usage: build.sh [--registry REGISTRY] [--push] [--version VERSION | --all-versions]
 
 Builds the LeRobot container image as npa-lerobot:<version>.
+Default VERSION is the [tool.npa.supported-tools].lerobot pin (0.5.1).
+Supported versions: 0.5.1 (default) and 0.6.0.
 When --registry is provided, also tags REGISTRY/npa-lerobot:<version>.
 EOF
 }
@@ -28,6 +32,18 @@ while [ "$#" -gt 0 ]; do
       ;;
     --push)
       PUSH=1
+      shift
+      ;;
+    --version)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --version requires a value" >&2
+        exit 2
+      fi
+      VERSION="$2"
+      shift 2
+      ;;
+    --all-versions)
+      ALL_VERSIONS=1
       shift
       ;;
     --help|-h)
@@ -47,7 +63,12 @@ if [ "$PUSH" -eq 1 ] && [ -z "$REGISTRY" ]; then
   exit 2
 fi
 
-VERSION="$(
+if [ "$ALL_VERSIONS" -eq 1 ] && [ -n "$VERSION" ]; then
+  echo "ERROR: --version and --all-versions are mutually exclusive" >&2
+  exit 2
+fi
+
+default_version() {
   cd "$NPA_ROOT"
   python3 - <<'PY'
 from pathlib import Path
@@ -67,37 +88,67 @@ else:
         data = tomllib.load(handle)
     print(data["tool"]["npa"]["supported-tools"]["lerobot"])
 PY
-)"
+}
 
-LOCAL_IMAGE="npa-lerobot:${VERSION}"
-BUILD_ARGS=(
-  -f "$SCRIPT_DIR/Dockerfile"
-  --build-arg "LEROBOT_VERSION=${VERSION}"
-  -t "$LOCAL_IMAGE"
-)
+supported_versions() {
+  cd "$NPA_ROOT"
+  python3 - <<'PY'
+import json
+from pathlib import Path
 
-if [ -n "$REGISTRY" ]; then
-  REGISTRY_IMAGE="${REGISTRY}/npa-lerobot:${VERSION}"
-  BUILD_ARGS+=(-t "$REGISTRY_IMAGE")
+manifest = Path("src/npa/deploy/lerobot_version_manifest.json")
+data = json.loads(manifest.read_text())
+print("\n".join(data["supported_versions"]))
+PY
+}
+
+build_one() {
+  local version="$1"
+  local local_image="npa-lerobot:${version}"
+  local build_args=(
+    -f "$SCRIPT_DIR/Dockerfile"
+    --build-arg "LEROBOT_VERSION=${version}"
+    -t "$local_image"
+  )
+  local registry_image=""
+
+  if [ -n "$REGISTRY" ]; then
+    registry_image="${REGISTRY}/npa-lerobot:${version}"
+    build_args+=(-t "$registry_image")
+  fi
+
+  docker build "${build_args[@]}" "$NPA_ROOT"
+
+  local size_bytes
+  size_bytes="$(docker image inspect "$local_image" --format '{{.Size}}')"
+  if command -v numfmt >/dev/null 2>&1; then
+    echo "Built: $local_image ($(numfmt --to=iec-i --suffix=B "$size_bytes"))"
+  else
+    echo "Built: $local_image (${size_bytes} bytes)"
+  fi
+  if [ -n "$registry_image" ]; then
+    echo "Tagged: $registry_image"
+  fi
+  if [ "$PUSH" -eq 1 ]; then
+    docker push "$registry_image"
+  fi
+}
+
+if [ "$ALL_VERSIONS" -eq 1 ]; then
+  while IFS= read -r version; do
+    [ -n "$version" ] || continue
+    build_one "$version"
+  done < <(supported_versions)
 else
-  REGISTRY_IMAGE=""
-fi
-
-docker build "${BUILD_ARGS[@]}" "$NPA_ROOT"
-
-SIZE_BYTES="$(docker image inspect "$LOCAL_IMAGE" --format '{{.Size}}')"
-if command -v numfmt >/dev/null 2>&1; then
-  SIZE="$(numfmt --to=iec-i --suffix=B "$SIZE_BYTES")"
-else
-  SIZE="${SIZE_BYTES} bytes"
-fi
-
-echo "Built: $LOCAL_IMAGE"
-if [ -n "$REGISTRY_IMAGE" ]; then
-  echo "Tagged: $REGISTRY_IMAGE"
-fi
-echo "Image size: $SIZE"
-
-if [ "$PUSH" -eq 1 ]; then
-  docker push "$REGISTRY_IMAGE"
+  if [ -z "$VERSION" ]; then
+    VERSION="$(default_version)"
+  fi
+  case "$VERSION" in
+    0.5.1|0.6.0) ;;
+    *)
+      echo "ERROR: unsupported LeRobot version: $VERSION (supported: 0.5.1, 0.6.0)" >&2
+      exit 2
+      ;;
+  esac
+  build_one "$VERSION"
 fi

--- a/npa/pyproject.toml
+++ b/npa/pyproject.toml
@@ -79,6 +79,8 @@ dev = [
 npa = "npa.cli.main:app_entry"
 
 [tool.npa.supported-tools]
+# Default LeRobot pin. Additional supported tags live in
+# npa/src/npa/deploy/lerobot_version_manifest.json (currently 0.5.1 + 0.6.0).
 lerobot = "0.5.1"
 lerobot-policy = "0.1.1"
 genesis = "0.4.6"
@@ -110,6 +112,7 @@ packages = ["src/npa"]
 [tool.hatch.build.targets.wheel.force-include]
 "src/npa/solutions/solutions.toml" = "npa/solutions/solutions.toml"
 "src/npa/deploy/sonic_image_manifest.json" = "npa/deploy/sonic_image_manifest.json"
+"src/npa/deploy/lerobot_version_manifest.json" = "npa/deploy/lerobot_version_manifest.json"
 "src/npa/smoke/golden_evals.yaml" = "npa/smoke/golden_evals.yaml"
 
 [tool.pytest.ini_options]

--- a/npa/src/npa/cli/workbench/lerobot.py
+++ b/npa/src/npa/cli/workbench/lerobot.py
@@ -40,8 +40,15 @@ from npa.clients.config import (
 from npa.clients.credentials import apply_shared_credential_env, shared_credential_env
 from npa.clients.endpoint import EndpointError, service_endpoint
 from npa.clients.serverless import EndpointNotFoundError, JobInfo, ServerlessClient, ServerlessClientError
-from npa.deploy.images import container_image_for_tool, supported_tool_version
+from npa.deploy.images import container_image_for_tool, resolve_lerobot_image_tag, supported_tool_version
 from npa.serverless_common import SubnetResolutionError, resolve_subnet
+from npa.workbench.lerobot.version_compat import (
+    LeRobotVersionError,
+    eval_checkpoint_arg,
+    resolve_lerobot_version,
+    supported_lerobot_versions,
+    train_env_eval_arg,
+)
 from npa.workbench.training_config import (
     TrainingConfig,
     TrainingConfigError,
@@ -266,6 +273,34 @@ def _runtime_exec_cmd(cfg: Any, command: str) -> str:
     if runtime_uses_container(getattr(cfg, "runtime", "vm")):
         return f"sudo docker exec npa-lerobot bash -lc {shlex.quote(command)}"
     return command
+
+
+def _probe_remote_lerobot_version(ssh: Any, cfg: Any) -> str:
+    """Best-effort remote LeRobot version for CLI flag compatibility."""
+
+    probe = (
+        "source /opt/lerobot/venv/bin/activate 2>/dev/null || true; "
+        "python -c \"import lerobot; print(lerobot.__version__)\""
+    )
+    try:
+        code, stdout, _stderr = ssh.run(_runtime_exec_cmd(cfg, probe), stream=False)
+    except Exception:
+        return resolve_lerobot_version(None)
+    if code != 0:
+        return resolve_lerobot_version(None)
+    version = (stdout or "").strip().splitlines()[-1].strip() if stdout else ""
+    try:
+        return resolve_lerobot_version(version)
+    except LeRobotVersionError:
+        # Unknown patch/build still maps by major.minor when possible.
+        parts = version.split(".")
+        if len(parts) >= 2:
+            candidate = f"{parts[0]}.{parts[1]}.0"
+            try:
+                return resolve_lerobot_version(candidate)
+            except LeRobotVersionError:
+                pass
+        return resolve_lerobot_version(None)
 
 
 def _effective_gpu_count(cfg: Any, requested: int | None = None) -> tuple[int, str]:
@@ -719,6 +754,7 @@ def _lerobot_train_container_command(
     device: str = "cuda",
     smoke: bool = False,
     training_config: TrainingConfig | None = None,
+    lerobot_version: str | None = None,
 ) -> str:
     config = training_config or TrainingConfig()
     effective_steps = 50 if smoke else steps
@@ -765,7 +801,7 @@ def _lerobot_train_container_command(
         f"--output_dir={output_dir} "
         f"--steps={effective_steps} "
         f"--save_freq={effective_steps} "
-        f"--eval_freq=1000000 "
+        f"{train_env_eval_arg(1_000_000, version=lerobot_version)} "
         f"--batch_size={effective_batch} "
         f"--policy.device={shlex.quote(device)} "
         f"--eval.batch_size=1 "
@@ -912,6 +948,7 @@ def _train_serverless(
     output: OutputFormat,
     training_config: TrainingConfig,
     checkpoint_s3_explicit: bool = False,
+    lerobot_version: str = "",
 ) -> None:
     if num_workers < -1:
         _fail(f"--num-workers must be -1 (omit) or >= 0, got {num_workers}")
@@ -937,7 +974,16 @@ def _train_serverless(
     except EndpointNotFoundError:
         existing = None
     platform = _lerobot_gpu_platform(gpu_type)
-    resolved_image = image or container_image_for_tool("lerobot", registry=resolve_container_registry(proj_alias))
+    try:
+        image_tag = resolve_lerobot_image_tag(lerobot_version or None)
+    except LeRobotVersionError as exc:
+        _fail(str(exc))
+        return
+    resolved_image = image or container_image_for_tool(
+        "lerobot",
+        registry=resolve_container_registry(proj_alias),
+        tag=image_tag,
+    )
     if existing is not None:
         info = existing
         if not submit_only and existing.status not in {"succeeded", "failed", "cancelled"}:
@@ -1010,6 +1056,7 @@ def _train_serverless(
                 device=device,
                 smoke=smoke,
                 training_config=training_config,
+                lerobot_version=image_tag,
             ),
             gpu_type=platform,
             gpu_count=gpu_count or 1,
@@ -1278,6 +1325,15 @@ def train(
     smoke: bool = typer.Option(False, "--smoke", help="Use smoke training settings for serverless Jobs."),
     poll_interval: float = typer.Option(30.0, "--poll-interval", help="Seconds between serverless Job status checks."),
     wait_timeout: int = typer.Option(3600, "--wait-timeout", help="Max seconds to wait for Job completion when not --submit-only."),
+    lerobot_version: str = typer.Option(
+        "",
+        "--lerobot-version",
+        help=(
+            "LeRobot package/image version for serverless Jobs when --image is omitted. "
+            f"Supported: {', '.join(supported_lerobot_versions())}. "
+            f"Default: {supported_tool_version('lerobot')}."
+        ),
+    ),
     output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
 ) -> None:
     """Run lerobot-train on the VM via SSH, stream logs."""
@@ -1364,6 +1420,7 @@ def train(
             output=output,
             training_config=training_config,
             checkpoint_s3_explicit=checkpoint_s3_explicit,
+            lerobot_version=lerobot_version,
         )
         return
 
@@ -1373,6 +1430,7 @@ def train(
 
     ssh = _ssh_client_for_training(cfg, training_config)
     stream_logs = output != OutputFormat.json
+    remote_version = _probe_remote_lerobot_version(ssh, cfg)
 
     output_is_s3 = _is_s3_uri(checkpoint_output_path)
     checkpoint_dir = (
@@ -1442,7 +1500,7 @@ def train(
         f"--output_dir={checkpoint_dir} "
         f"--steps={steps} "
         f"--save_freq={steps} "
-        f"--eval_freq=1000000 "
+        f"{train_env_eval_arg(1_000_000, version=remote_version)} "
         f"--batch_size={batch_size} "
         f"--policy.device={device} "
         f"--eval.batch_size=1 "
@@ -1583,6 +1641,7 @@ def eval_cmd(
 
     ssh = SSHClient(cfg.ssh)
     stream_logs = output != OutputFormat.json
+    remote_version = _probe_remote_lerobot_version(ssh, cfg)
 
     # Resolve checkpoint: if s3://, download on the VM first
     resolved_checkpoint = checkpoint_ref
@@ -1609,7 +1668,7 @@ def eval_cmd(
         f"source /opt/lerobot/venv/bin/activate && "
         f"set -a && source /opt/lerobot/.env && set +a && "
         f"lerobot-eval "
-        f"--policy.path={resolved_checkpoint} "
+        f"{eval_checkpoint_arg(resolved_checkpoint, version=remote_version)} "
         f"--env.type={env} "
         f"{env_task_arg} "
         f"--eval.n_episodes={episodes} "
@@ -1923,6 +1982,15 @@ def deploy(
     disk_size: int | None = typer.Option(None, "--disk-size", help="Boot disk size in GiB. Defaults to 250 for container runtime; VM runtime keeps the Terraform default."),
     preemptible: bool = typer.Option(True, "--preemptible/--no-preemptible", help="Preemptible (spot) instance. Pass --no-preemptible for regular VMs."),
     default: bool = typer.Option(False, "--default", help="Set this workbench as the default."),
+    lerobot_version: str = typer.Option(
+        "",
+        "--lerobot-version",
+        help=(
+            "LeRobot package/image version to deploy. "
+            f"Supported: {', '.join(supported_lerobot_versions())}. "
+            f"Default: {supported_tool_version('lerobot')}."
+        ),
+    ),
     output: OutputFormat = typer.Option(OutputFormat.text, "--output", help="Output format."),
 ) -> None:
     """Deploy or update LeRobot infrastructure and application.
@@ -1937,7 +2005,11 @@ def deploy(
     wb_name = _workbench_name or "b200"
     byovm = is_byovm_runtime(runtime)
     use_remote_state = not tf_dir and not byovm
-    lerobot_version = supported_tool_version("lerobot")
+    try:
+        resolved_lerobot_version = resolve_lerobot_version(lerobot_version or None)
+    except LeRobotVersionError as exc:
+        _fail(str(exc))
+        return
     if byovm:
         skip_infra = True
 
@@ -1971,7 +2043,7 @@ def deploy(
     container_image = container_image_for_tool(
         "lerobot",
         registry=container_registry,
-        tag=lerobot_version,
+        tag=resolved_lerobot_version,
     )
     cloud_init_workbench_type = (
         "lerobot-container"
@@ -2036,7 +2108,7 @@ def deploy(
     ):
         if key in nebius_creds:
             merged_vars[key] = nebius_creds[key]
-    merged_vars.setdefault("lerobot_version", lerobot_version)
+    merged_vars.setdefault("lerobot_version", resolved_lerobot_version)
     if use_remote_state and (destroy or skip_infra):
         _apply_saved_terraform_state(
             merged_vars,
@@ -2474,7 +2546,7 @@ def deploy(
         console.print(f"  [{step}/{total_steps}] Writing deployment manifest...")
         if not dry_run:
             try:
-                write_manifest(ssh, tool="lerobot", version=lerobot_version, deployed_by=f"npa deploy --runtime {runtime.value}")
+                write_manifest(ssh, tool="lerobot", version=resolved_lerobot_version, deployed_by=f"npa deploy --runtime {runtime.value}")
             except SSHError:
                 pass
         mark_app_status(APP_STATUS_HEALTHY)
@@ -2593,6 +2665,7 @@ def benchmark_cmd(
 
     ssh = SSHClient(cfg.ssh)
     stream = output != OutputFormat.json
+    remote_version = _probe_remote_lerobot_version(ssh, cfg)
 
     # Parse run specs
     specs: list[dict[str, Any]] = []
@@ -2736,7 +2809,7 @@ def benchmark_cmd(
                 f"--output_dir={output_dir} "
                 f"--steps={steps} "
                 f"--save_freq={steps} "
-                f"--eval_freq=1000000 "
+                f"{train_env_eval_arg(1_000_000, version=remote_version)} "
                 f"--batch_size={batch_size} "
                 f"--num_workers={nw} "
                 f"--policy.device=cuda "

--- a/npa/src/npa/deploy/images.py
+++ b/npa/src/npa/deploy/images.py
@@ -44,6 +44,8 @@ CONTAINER_IMAGE_NAMES = {
 }
 
 SUPPORTED_TOOL_VERSIONS = {
+    # Default LeRobot pin. Selectable additional versions: see
+    # lerobot_version_manifest.json (0.5.1 default + 0.6.0).
     "lerobot": "0.5.1",
     "lerobot-policy": "0.1.1",
     "genesis": "0.4.6",
@@ -118,6 +120,22 @@ def supported_tool_version(tool: str) -> str:
         return SUPPORTED_TOOL_VERSIONS[tool]
     except KeyError as exc:
         raise RuntimeError(f"Could not find supported version for tool: {tool}") from exc
+
+
+def supported_lerobot_versions() -> tuple[str, ...]:
+    """Return LeRobot versions supported by the workbench (default first)."""
+
+    from npa.workbench.lerobot.version_compat import supported_lerobot_versions as _versions
+
+    return _versions()
+
+
+def resolve_lerobot_image_tag(version: str | None = None) -> str:
+    """Resolve a validated LeRobot image tag (equals the LeRobot package version)."""
+
+    from npa.workbench.lerobot.version_compat import resolve_lerobot_version
+
+    return resolve_lerobot_version(version)
 
 
 def sonic_image_variant_for_gpu(gpu_target: str | None = None) -> str:

--- a/npa/src/npa/deploy/lerobot_version_manifest.json
+++ b/npa/src/npa/deploy/lerobot_version_manifest.json
@@ -1,0 +1,28 @@
+{
+  "format": "npa_lerobot_version_manifest_v1",
+  "tool": "lerobot",
+  "default_version": "0.5.1",
+  "supported_versions": ["0.5.1", "0.6.0"],
+  "versions": {
+    "0.5.1": {
+      "pip_extras": "pusht,libero",
+      "train_env_eval_flag": "eval_freq",
+      "eval_checkpoint_flag": "policy.path",
+      "policy_eval_checkpoint_flag": "policy.pretrained_path",
+      "torch_pin": "torch==2.12.1",
+      "torchvision_pin": "torchvision==0.27.1",
+      "diffusers_pin": "diffusers>=0.38.0",
+      "notes": "Default workbench pin. Keep for GR00T N1.5 and sim2real policy image parity."
+    },
+    "0.6.0": {
+      "pip_extras": "training,evaluation,pusht,libero",
+      "train_env_eval_flag": "env_eval_freq",
+      "eval_checkpoint_flag": "policy.path",
+      "policy_eval_checkpoint_flag": "policy.pretrained_path",
+      "torch_pin": null,
+      "torchvision_pin": null,
+      "diffusers_pin": null,
+      "notes": "Lean install extras; torch must stay <2.12 per upstream. Do not force-upgrade torch after install."
+    }
+  }
+}

--- a/npa/src/npa/deploy/terraform/cloud_init.yaml.tpl
+++ b/npa/src/npa/deploy/terraform/cloud_init.yaml.tpl
@@ -474,7 +474,14 @@ runcmd:
     "$LEROBOT_VENV/bin/pip" install --upgrade pip setuptools wheel || { echo "ERROR: Failed to upgrade pip"; exit 1; }
 
     echo "Installing LeRobot ${lerobot_version}..."
-    "$LEROBOT_VENV/bin/pip" install "lerobot[pusht,libero]==${lerobot_version}" boto3 wandb tensorboard num2words || { echo "ERROR: Failed to install packages"; exit 1; }
+    # 0.6.0 ships a lean base install; workbench needs training/eval + PushT/LIBERO extras.
+    # 0.5.1 (default) keeps the historic [pusht,libero] bundle.
+    if [ "${lerobot_version}" = "0.6.0" ]; then
+      LEROBOT_PIP_SPEC="lerobot[training,evaluation,pusht,libero]==${lerobot_version}"
+    else
+      LEROBOT_PIP_SPEC="lerobot[pusht,libero]==${lerobot_version}"
+    fi
+    "$LEROBOT_VENV/bin/pip" install "$LEROBOT_PIP_SPEC" boto3 wandb tensorboard num2words || { echo "ERROR: Failed to install packages"; exit 1; }
 
     # Verify installation
     echo "Verifying LeRobot installation..."

--- a/npa/src/npa/deploy/terraform/variables.tf
+++ b/npa/src/npa/deploy/terraform/variables.tf
@@ -119,9 +119,14 @@ variable "ssh_cidr_block" {
 # ── LeRobot ────────────────────────────────────────────────────────────────
 
 variable "lerobot_version" {
-  description = "LeRobot PyPI version to install on the instance"
+  description = "LeRobot PyPI version to install on the instance (supported: 0.5.1 default, 0.6.0)"
   type        = string
   default     = "0.5.1"
+
+  validation {
+    condition     = contains(["0.5.1", "0.6.0"], var.lerobot_version)
+    error_message = "lerobot_version must be one of: 0.5.1, 0.6.0."
+  }
 }
 
 # ── S3 credentials (from environment.sh) ──────────────────────────────────

--- a/npa/src/npa/lerobot/train_student.py
+++ b/npa/src/npa/lerobot/train_student.py
@@ -5,12 +5,13 @@ student policy (ACT, diffusion, etc.) on a dataset produced by the
 SimToLeRobot adapter. The student only sees camera observations and joint
 state — never privileged simulator state.
 
-LeRobot API notes (v0.5.x):
+LeRobot API notes (v0.5.x / v0.6.0):
     - Training is step-based (--steps), not epoch-based.
     - Local datasets use --dataset.repo_id=<name> --dataset.root=<path>.
       There is no local:// prefix.
     - lerobot-train rejects an existing output_dir unless --resume=true.
     - Flag names are flattened dataclass paths via draccus.
+    - v0.6.0 renames --eval_freq to --env_eval_freq (handled via version_compat).
 """
 
 from __future__ import annotations
@@ -21,6 +22,8 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+
+from npa.workbench.lerobot.version_compat import train_env_eval_arg
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +105,7 @@ def build_train_command(
         f"--num_workers={num_workers}",
         f"--save_freq={save_freq}",
         # Disable eval during distillation (eval is done in Genesis separately)
-        "--eval_freq=1000000",
+        train_env_eval_arg(1_000_000),
         "--wandb.enable=false",
     ]
 

--- a/npa/src/npa/setup/install_lerobot.sh
+++ b/npa/src/npa/setup/install_lerobot.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
 set -e
 
+# Optional override. Default matches [tool.npa.supported-tools].lerobot.
+LEROBOT_VERSION="${LEROBOT_VERSION:-0.5.1}"
+
 echo "=== LeRobot Training Environment Setup ==="
 echo "Target: GPU VM with CUDA 12.4+"
+echo "LeRobot version: ${LEROBOT_VERSION}"
+
+case "$LEROBOT_VERSION" in
+  0.5.1)
+    LEROBOT_PIP_SPEC="lerobot[pusht]==${LEROBOT_VERSION}"
+    ;;
+  0.6.0)
+    # Lean 0.6.0 base needs training + PushT extras for workbench train/eval.
+    LEROBOT_PIP_SPEC="lerobot[training,evaluation,pusht]==${LEROBOT_VERSION}"
+    ;;
+  *)
+    echo "ERROR: unsupported LEROBOT_VERSION=${LEROBOT_VERSION} (supported: 0.5.1, 0.6.0)" >&2
+    exit 2
+    ;;
+esac
 
 # Create conda environment (skip if it already exists)
 echo "[1/5] Creating conda environment..."
@@ -15,12 +33,17 @@ eval "$(conda shell.bash hook)"
 conda activate lerobot
 
 # Install PyTorch with CUDA 12.4
+# For 0.6.0, upstream caps torch < 2.12; let the lerobot resolver pick a compatible wheel.
 echo "[2/5] Installing PyTorch (CUDA 12.4)..."
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
+if [ "$LEROBOT_VERSION" = "0.6.0" ]; then
+    echo "  Skipping standalone torch pin for 0.6.0 (installed via lerobot deps)."
+else
+    pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
+fi
 
-# Install LeRobot (pin to 0.5.1 to match cloud-init and npa adapter expectations)
-echo "[3/5] Installing LeRobot 0.5.1..."
-pip install "lerobot[pusht]==0.5.1"
+# Install LeRobot
+echo "[3/5] Installing LeRobot ${LEROBOT_VERSION}..."
+pip install "$LEROBOT_PIP_SPEC"
 
 # Install NPA CLI (provides npa entrypoint for remote workflow commands)
 echo "[4/6] Installing NPA CLI..."
@@ -46,7 +69,7 @@ fi
 echo "[6/6] Verifying installation..."
 
 echo "--- LeRobot import test ---"
-python -c "from lerobot.datasets import LeRobotDataset; print('LeRobot imported OK')"
+python -c "from lerobot.datasets import LeRobotDataset; import lerobot; print(f'LeRobot {lerobot.__version__} imported OK')"
 
 echo "--- PyTorch CUDA test ---"
 python -c "import torch; print(f'CUDA available: {torch.cuda.is_available()}, devices: {torch.cuda.device_count()}')"
@@ -54,3 +77,4 @@ python -c "import torch; print(f'CUDA available: {torch.cuda.is_available()}, de
 echo ""
 echo "=== LeRobot setup complete ==="
 echo "Activate with: conda activate lerobot"
+echo "Selected version: ${LEROBOT_VERSION}"

--- a/npa/src/npa/smoke/_versions.py
+++ b/npa/src/npa/smoke/_versions.py
@@ -65,3 +65,31 @@ def supported_tool_version(tool: str, start_file: str) -> str:
         raise KeyError(
             f"Missing [tool.npa.supported-tools].{tool} in {pyproject}"
         ) from exc
+
+
+def expected_lerobot_version(start_file: str) -> str:
+    """Return the LeRobot version this image/smoke should assert.
+
+    Prefer ``NPA_LEROBOT_VERSION`` (set in multi-version container images) so
+    ``npa-lerobot:0.6.0`` can pass env smoke while the pyproject default remains
+    ``0.5.1``.
+    """
+
+    import os
+
+    override = os.environ.get("NPA_LEROBOT_VERSION", "").strip()
+    if override:
+        return override
+    return supported_tool_version("lerobot", start_file)
+
+
+def train_env_eval_arg_for_version(version: str, value: int = 1_000_000) -> str:
+    """Return the train env-eval cadence CLI arg for a LeRobot version.
+
+    Kept dependency-free for container smokes that do not ship the full
+    ``npa.workbench`` package tree.
+    """
+
+    flag = "env_eval_freq" if str(version).startswith("0.6") else "eval_freq"
+    return f"--{flag}={int(value)}"
+

--- a/npa/src/npa/smoke/golden_evals.yaml
+++ b/npa/src/npa/smoke/golden_evals.yaml
@@ -88,11 +88,14 @@ containers:
   lerobot:
     image: npa-lerobot
     dockerfile: npa/docker/workbench/lerobot/Dockerfile
+    # Default tag = pyproject supported-tools pin (0.5.1). Additional supported
+    # tag: 0.6.0 via build.sh --version 0.6.0 / --lerobot-version 0.6.0.
     physical_ai:
       useful: true
       role: >-
         LeRobot policy training/eval/serving (ACT, pusht, libero) — core robot
-        manipulation policy workflow.
+        manipulation policy workflow. Supported package tags: 0.5.1 (default)
+        and 0.6.0 (additional).
     safety:
       runs_as: ubuntu
       base_image: nvidia/cuda:12.4.1-devel-ubuntu22.04
@@ -100,6 +103,7 @@ containers:
       external_fetch: [pypi, huggingface-datasets]
       notes: >-
         Build-time env smoke baked in (RUN python -m npa.smoke.test_lerobot_env).
+        NPA_LEROBOT_VERSION labels the image tag for multi-version smokes.
         Telemetry disabled (HF_HUB_DISABLE_TELEMETRY, WANDB_DISABLED) in smokes.
     golden_eval:
       kind: container-smoke

--- a/npa/src/npa/smoke/test_lerobot_env.py
+++ b/npa/src/npa/smoke/test_lerobot_env.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from importlib import metadata
 from typing import Callable
 
-from npa.smoke._versions import supported_tool_version
+from npa.smoke._versions import expected_lerobot_version
 
 
 @dataclass
@@ -40,7 +40,7 @@ def _format_exception(exc: BaseException) -> str:
 
 def check_import_lerobot() -> CheckResult:
     try:
-        expected = supported_tool_version("lerobot", __file__)
+        expected = expected_lerobot_version(__file__)
         lerobot = importlib.import_module("lerobot")
         version = _package_version(lerobot, "lerobot")
         if version != expected:

--- a/npa/src/npa/smoke/test_lerobot_functional.py
+++ b/npa/src/npa/smoke/test_lerobot_functional.py
@@ -20,7 +20,7 @@ from importlib import metadata
 from pathlib import Path
 from typing import Callable
 
-from npa.smoke._versions import supported_tool_version
+from npa.smoke._versions import expected_lerobot_version, train_env_eval_arg_for_version
 
 
 @dataclass
@@ -107,7 +107,7 @@ def _find_checkpoint(train_dir: Path) -> Path | None:
 
 def check_lerobot_version(state: SmokeState) -> CheckResult:
     try:
-        expected = supported_tool_version("lerobot", __file__)
+        expected = expected_lerobot_version(__file__)
         version = metadata.version("lerobot")
     except Exception as exc:
         return CheckResult("check lerobot version", False, _format_exception(exc))
@@ -123,6 +123,7 @@ def check_lerobot_version(state: SmokeState) -> CheckResult:
 
 def check_lerobot_train(state: SmokeState) -> CheckResult:
     state.train_log = state.root / "lerobot_train.log"
+    version = expected_lerobot_version(__file__)
     command = [
         "lerobot-train",
         "--policy.type=act",
@@ -130,7 +131,7 @@ def check_lerobot_train(state: SmokeState) -> CheckResult:
         f"--output_dir={state.train_dir}",
         "--steps=50",
         "--save_freq=50",
-        "--eval_freq=1000000",
+        train_env_eval_arg_for_version(version, 1_000_000),
         "--log_freq=10",
         "--batch_size=8",
         "--num_workers=4",

--- a/npa/src/npa/smoke/test_lerobot_policy_functional.py
+++ b/npa/src/npa/smoke/test_lerobot_policy_functional.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Callable
 
 from npa.workbench.lerobot.policy_container import build_lerobot_eval_command
+from npa.smoke._versions import expected_lerobot_version, train_env_eval_arg_for_version
 
 
 @dataclass
@@ -60,7 +61,7 @@ def check_short_train(state: Path) -> CheckResult:
         "--batch_size=8",
         "--num_workers=0",
         "--save_freq=20",
-        "--eval_freq=1000000",
+        train_env_eval_arg_for_version(expected_lerobot_version(__file__), 1_000_000),
         "--log_freq=10",
     ]
     code, output = _run(command, log_path=log_path, timeout=900)

--- a/npa/src/npa/workbench/lerobot/policy_container.py
+++ b/npa/src/npa/workbench/lerobot/policy_container.py
@@ -22,6 +22,10 @@ from npa.workbench.training_config import (
     upload_checkpoint_path,
     wandb_overrides,
 )
+from npa.workbench.lerobot.version_compat import (
+    eval_checkpoint_arg,
+    train_env_eval_arg,
+)
 
 
 DEFAULT_POLICY_CHECKPOINT = "lerobot/diffusion_pusht"
@@ -356,7 +360,7 @@ def build_lerobot_train_command(
         f"--output_dir={output_dir}",
         f"--steps={steps}",
         f"--save_freq={save_freq}",
-        f"--eval_freq={eval_freq}",
+        train_env_eval_arg(eval_freq),
         f"--log_freq={log_freq}",
         f"--batch_size={batch_size}",
         f"--num_workers={num_workers}",
@@ -469,7 +473,7 @@ def build_lerobot_eval_command(
     cmd = [
         "lerobot-eval",
         f"--policy.type={policy_type}",
-        f"--policy.pretrained_path={checkpoint_path}",
+        eval_checkpoint_arg(str(checkpoint_path), style="policy"),
         f"--env.type={env_type}",
         f"--output_dir={output_dir}",
         "--eval.batch_size=1",

--- a/npa/src/npa/workbench/lerobot/version_compat.py
+++ b/npa/src/npa/workbench/lerobot/version_compat.py
@@ -1,0 +1,129 @@
+"""LeRobot version resolution and CLI flag compatibility helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+LEROBOT_VERSION_MANIFEST_RESOURCE = "lerobot_version_manifest.json"
+LEROBOT_VERSION_ENV = "NPA_LEROBOT_VERSION"
+
+
+class LeRobotVersionError(ValueError):
+    """Raised when a LeRobot version is unsupported or misconfigured."""
+
+
+@lru_cache(maxsize=1)
+def lerobot_version_manifest() -> dict[str, Any]:
+    """Return the packaged LeRobot version compatibility manifest."""
+
+    text = resources.files("npa.deploy").joinpath(LEROBOT_VERSION_MANIFEST_RESOURCE).read_text(
+        encoding="utf-8"
+    )
+    payload = json.loads(text)
+    if payload.get("format") != "npa_lerobot_version_manifest_v1":
+        raise RuntimeError("Unsupported LeRobot version manifest format")
+    return payload
+
+
+def default_lerobot_version() -> str:
+    """Return the default LeRobot version (pyproject / supported-tools pin)."""
+
+    from npa.deploy.images import supported_tool_version
+
+    return supported_tool_version("lerobot")
+
+
+def supported_lerobot_versions() -> tuple[str, ...]:
+    """Return supported LeRobot versions in declared order."""
+
+    versions = lerobot_version_manifest().get("supported_versions") or []
+    return tuple(str(item) for item in versions)
+
+
+def resolve_lerobot_version(version: str | None = None) -> str:
+    """Resolve a LeRobot version from explicit arg, env, or default."""
+
+    candidates = (
+        (version or "").strip(),
+        os.environ.get(LEROBOT_VERSION_ENV, "").strip(),
+        default_lerobot_version(),
+    )
+    resolved = next((item for item in candidates if item), "")
+    if not resolved:
+        raise LeRobotVersionError("Could not resolve a LeRobot version")
+    supported = supported_lerobot_versions()
+    if resolved not in supported:
+        choices = ", ".join(supported)
+        raise LeRobotVersionError(
+            f"Unsupported LeRobot version {resolved!r}; choose one of: {choices}"
+        )
+    return resolved
+
+
+def lerobot_version_entry(version: str | None = None) -> dict[str, Any]:
+    """Return the manifest entry for a resolved LeRobot version."""
+
+    resolved = resolve_lerobot_version(version)
+    versions = lerobot_version_manifest().get("versions") or {}
+    try:
+        entry = versions[resolved]
+    except KeyError as exc:
+        raise LeRobotVersionError(f"Missing LeRobot version entry for {resolved!r}") from exc
+    if not isinstance(entry, dict):
+        raise LeRobotVersionError(f"Invalid LeRobot version entry for {resolved!r}")
+    return {"version": resolved, **entry}
+
+
+def lerobot_pip_spec(version: str | None = None) -> str:
+    """Return the pinned pip install spec for a LeRobot version."""
+
+    entry = lerobot_version_entry(version)
+    extras = str(entry.get("pip_extras") or "").strip()
+    resolved = str(entry["version"])
+    if extras:
+        return f"lerobot[{extras}]=={resolved}"
+    return f"lerobot=={resolved}"
+
+
+def train_env_eval_flag(version: str | None = None) -> str:
+    """Return the train-time env-eval cadence flag name for this version."""
+
+    return str(lerobot_version_entry(version)["train_env_eval_flag"])
+
+
+def train_env_eval_arg(value: int = 1_000_000, *, version: str | None = None) -> str:
+    """Return ``--eval_freq=...`` or ``--env_eval_freq=...`` for this version."""
+
+    return f"--{train_env_eval_flag(version)}={int(value)}"
+
+
+def eval_checkpoint_arg(
+    checkpoint: str,
+    *,
+    version: str | None = None,
+    style: str = "cli",
+) -> str:
+    """Return the eval checkpoint flag for workbench CLI-style invocations."""
+
+    entry = lerobot_version_entry(version)
+    if style == "policy":
+        flag = str(entry["policy_eval_checkpoint_flag"])
+    else:
+        flag = str(entry["eval_checkpoint_flag"])
+    return f"--{flag}={checkpoint}"
+
+
+def torch_install_pins(version: str | None = None) -> list[str]:
+    """Return optional torch/torchvision/diffusers pins after lerobot install."""
+
+    entry = lerobot_version_entry(version)
+    pins: list[str] = []
+    for key in ("torch_pin", "torchvision_pin", "diffusers_pin"):
+        value = entry.get(key)
+        if value:
+            pins.append(str(value))
+    return pins

--- a/npa/tests/cli/test_lerobot_cli.py
+++ b/npa/tests/cli/test_lerobot_cli.py
@@ -391,6 +391,23 @@ def test_lerobot_train_container_command_does_not_pre_create_output_dir() -> Non
 
     assert "mkdir -p /tmp/lerobot_output" not in command
     assert "mkdir -p /tmp/hf_home" in command
+    assert "--eval_freq=1000000" in command
+
+
+def test_lerobot_train_container_command_uses_env_eval_freq_for_060() -> None:
+    command = lerobot._lerobot_train_container_command(
+        "act",
+        "lerobot/pusht",
+        "",
+        50,
+        4,
+        2,
+        smoke=True,
+        lerobot_version="0.6.0",
+    )
+
+    assert "--env_eval_freq=1000000" in command
+    assert "--eval_freq=" not in command
 
 
 def test_lerobot_train_container_command_supports_s3_input() -> None:
@@ -428,6 +445,21 @@ def test_lerobot_train_serverless_submit_only_creates_job(mocker) -> None:
     client.subnet_resolver.assert_called_once_with(project_id="project-1", explicit_subnet_id="")
     client.poll_job.assert_not_called()
     update.assert_called_once()
+
+
+def test_lerobot_train_serverless_lerobot_version_060_selects_image(mocker) -> None:
+    client, _update = _mock_serverless_train(mocker)
+
+    result = runner.invoke(
+        app,
+        _serverless_train_args("--submit-only", "--lerobot-version", "0.6.0"),
+    )
+
+    assert result.exit_code == 0, result.output
+    kwargs = client.create_job.call_args.kwargs
+    assert kwargs["image"] == "registry.example/npa/npa-lerobot:0.6.0"
+    assert "--env_eval_freq=1000000" in kwargs["command"]
+    assert "--eval_freq=" not in kwargs["command"]
 
 
 def test_lerobot_train_serverless_prefers_credentials_endpoint_for_matching_bucket(mocker) -> None:
@@ -705,5 +737,5 @@ def test_lerobot_train_default_runtime_still_uses_ssh(mocker) -> None:
     )
 
     assert result.exit_code == 0
-    assert "lerobot-train" in ssh.run.call_args.args[0]
+    assert any("lerobot-train" in call.args[0] for call in ssh.run.call_args_list)
     client_cls.assert_not_called()

--- a/npa/tests/cli/test_workbench_cli.py
+++ b/npa/tests/cli/test_workbench_cli.py
@@ -148,7 +148,7 @@ def test_lerobot_train_runs_ssh_command(mocker) -> None:
 
     assert result.exit_code == 0
     assert "status: success" in result.output
-    assert "lerobot-train" in ssh.run.call_args.args[0]
+    assert any("lerobot-train" in call.args[0] for call in ssh.run.call_args_list)
 
 
 def test_lerobot_train_rejects_local_input_output_paths(mocker) -> None:
@@ -207,8 +207,9 @@ def test_lerobot_train_s3_input_and_output_syncs(mocker) -> None:
     )
 
     assert result.exit_code == 0
-    train_cmd = ssh.run.call_args_list[0].args[0]
-    upload_cmd = ssh.run.call_args_list[1].args[0]
+    run_cmds = [call.args[0] for call in ssh.run.call_args_list]
+    train_cmd = next(cmd for cmd in run_cmds if "lerobot-train" in cmd)
+    upload_cmd = next(cmd for cmd in run_cmds if "upload_file" in cmd)
     assert "download_file" in train_cmd
     assert "--dataset.root=/opt/lerobot/dataset_cache/bucket_datasets_pick-place" in train_cmd
     assert "upload_file" in upload_cmd
@@ -292,10 +293,11 @@ def test_lerobot_eval_uses_input_and_output_path(mocker) -> None:
     )
 
     assert result.exit_code == 0
-    cmd = ssh.run.call_args_list[0].args[0]
+    run_cmds = [call.args[0] for call in ssh.run.call_args_list]
+    cmd = next(c for c in run_cmds if "lerobot-eval" in c)
     assert "--policy.path=repo/model" in cmd
     assert "--output_dir=/tmp/npa-eval-" in cmd
-    assert "upload_file" in ssh.run.call_args_list[1].args[0]
+    assert any("upload_file" in c for c in run_cmds)
     assert "output_path: s3://bucket/eval-results/" in result.output
 
 
@@ -327,7 +329,8 @@ def test_lerobot_eval_s3_input_and_output_syncs(mocker) -> None:
 
     assert result.exit_code == 0
     assert "download_file" in ssh.run_or_raise.call_args.args[0]
-    assert "upload_file" in ssh.run.call_args_list[1].args[0]
+    run_cmds = [call.args[0] for call in ssh.run.call_args_list]
+    assert any("upload_file" in c for c in run_cmds)
     assert "output_path: s3://bucket/evals/job/" in result.output
 
 
@@ -589,6 +592,67 @@ def test_lerobot_deploy_runtime_vm_preserves_existing_behavior(tmp_path: Path, m
     deploy_container.assert_not_called()
     wb_cfg = write_config.call_args.args[0]["projects"]["proj"]["workbenches"]["wb"]
     assert wb_cfg["runtime"] == "vm"
+
+
+def test_lerobot_deploy_accepts_lerobot_version_060(tmp_path: Path, mocker) -> None:
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (0, "connected", "")
+
+    mocker.patch("npa.deploy.provisioner.init")
+    apply = mocker.patch(
+        "npa.deploy.provisioner.apply",
+        return_value={
+            "vm_ip": "10.0.0.8",
+            "ssh_user": "ubuntu",
+            "ssh_key_path": "~/.ssh/id",
+            "storage_bucket": "bucket",
+            "storage_endpoint": "https://storage.example",
+        },
+    )
+    mocker.patch("npa.clients.config.resolve_environment", return_value=None)
+    mocker.patch("npa.clients.config.list_projects", return_value={})
+    mocker.patch("npa.clients.config.write_config")
+    mocker.patch("npa.cli.workbench.lerobot.update_workbench_app_status")
+    mocker.patch("npa.clients.ssh.SSHClient", return_value=ssh)
+    mocker.patch("npa.deploy.configurator.install_lerobot", return_value=True)
+    mocker.patch("npa.deploy.configurator.deploy_server")
+    mocker.patch("npa.deploy.configurator.deploy_lerobot_container")
+    mocker.patch("npa.deploy.configurator.health_check", return_value=True)
+    mocker.patch("npa.deploy.configurator.write_manifest")
+    mocker.patch(
+        "npa.cli.workbench.lerobot.resolve_container_registry",
+        return_value=DEFAULT_CONTAINER_REGISTRY,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "lerobot",
+            "-p",
+            "proj",
+            "-n",
+            "wb",
+            "deploy",
+            "--project-id",
+            "project",
+            "--tenant-id",
+            "tenant",
+            "--region",
+            "eu-north1",
+            "--tf-dir",
+            str(tmp_path),
+            "--runtime",
+            "vm",
+            "--lerobot-version",
+            "0.6.0",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    tf_vars = apply.call_args.kwargs["tf_vars"]
+    assert tf_vars["lerobot_version"] == "0.6.0"
 
 
 def test_lerobot_deploy_runtime_container_uses_default_registry(tmp_path: Path, mocker) -> None:

--- a/npa/tests/test_deploy.py
+++ b/npa/tests/test_deploy.py
@@ -80,7 +80,10 @@ def test_cloud_init_branches_bootstrap_by_workbench_type() -> None:
 
     assert "/opt/lerobot/.env" in lerobot_branch
     assert "Installing LeRobot ${lerobot_version}" in lerobot_branch
-    assert "lerobot[pusht,libero]==${lerobot_version}" in lerobot_branch
+    assert 'LEROBOT_PIP_SPEC="lerobot[pusht,libero]==${lerobot_version}"' in lerobot_branch
+    assert 'LEROBOT_PIP_SPEC="lerobot[training,evaluation,pusht,libero]==${lerobot_version}"' in lerobot_branch
+    assert 'if [ "${lerobot_version}" = "0.6.0" ]' in lerobot_branch
+    assert '"$LEROBOT_VENV/bin/pip" install "$LEROBOT_PIP_SPEC"' in lerobot_branch
 
     assert "LeRobot container VM setup" in container_branch
     assert "$DEPLOY_ROOT/checkpoints" in container_branch

--- a/npa/tests/test_lerobot_version_compat.py
+++ b/npa/tests/test_lerobot_version_compat.py
@@ -1,0 +1,53 @@
+"""Unit tests for LeRobot multi-version compatibility helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from npa.workbench.lerobot.version_compat import (
+    LeRobotVersionError,
+    eval_checkpoint_arg,
+    lerobot_pip_spec,
+    resolve_lerobot_version,
+    supported_lerobot_versions,
+    torch_install_pins,
+    train_env_eval_arg,
+    train_env_eval_flag,
+)
+
+
+def test_supported_versions_include_default_and_060() -> None:
+    versions = supported_lerobot_versions()
+    assert "0.5.1" in versions
+    assert "0.6.0" in versions
+    assert resolve_lerobot_version(None) == "0.5.1"
+
+
+def test_pip_spec_and_train_flags_differ_by_version() -> None:
+    assert lerobot_pip_spec("0.5.1") == "lerobot[pusht,libero]==0.5.1"
+    assert lerobot_pip_spec("0.6.0") == "lerobot[training,evaluation,pusht,libero]==0.6.0"
+    assert train_env_eval_flag("0.5.1") == "eval_freq"
+    assert train_env_eval_flag("0.6.0") == "env_eval_freq"
+    assert train_env_eval_arg(100, version="0.5.1") == "--eval_freq=100"
+    assert train_env_eval_arg(100, version="0.6.0") == "--env_eval_freq=100"
+
+
+def test_eval_checkpoint_and_torch_pins() -> None:
+    assert eval_checkpoint_arg("/ckpt", version="0.5.1") == "--policy.path=/ckpt"
+    assert (
+        eval_checkpoint_arg("/ckpt", version="0.6.0", style="policy")
+        == "--policy.pretrained_path=/ckpt"
+    )
+    assert "torch==2.12.1" in torch_install_pins("0.5.1")
+    assert torch_install_pins("0.6.0") == []
+
+
+def test_unsupported_version_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NPA_LEROBOT_VERSION", raising=False)
+    with pytest.raises(LeRobotVersionError, match="Unsupported"):
+        resolve_lerobot_version("9.9.9")
+
+
+def test_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NPA_LEROBOT_VERSION", "0.6.0")
+    assert resolve_lerobot_version(None) == "0.6.0"

--- a/skills/tools/lerobot/SKILL.md
+++ b/skills/tools/lerobot/SKILL.md
@@ -5,9 +5,22 @@ description: Use when working on LeRobot workbench training, evaluation, serving
 
 # LeRobot
 
-LeRobot is the default robot policy training framework. It supports ACT, Diffusion Policy, and SmolVLA.
+LeRobot is the default robot policy training framework. It supports ACT, Diffusion Policy, and SmolVLA (and additional VLAs / world models in 0.6.0).
 
 Use it as the data standard and policy interface layer, not as a managed-service competitor to Hugging Face.
+
+## Supported versions
+
+| Version | Role | Image tag | Notes |
+| --- | --- | --- | --- |
+| **0.5.1** | **Default** | `npa-lerobot:0.5.1` | Current golden-eval pin; keep for GR00T N1.5 / sim2real policy image parity |
+| **0.6.0** | Additional | `npa-lerobot:0.6.0` | Lean extras (`training,evaluation,pusht,libero`); `--eval_freq` → `--env_eval_freq` |
+
+Select with `--lerobot-version` on deploy / serverless train, or override the image with `--image .../npa-lerobot:0.6.0`.
+
+Canonical manifest: `npa/src/npa/deploy/lerobot_version_manifest.json`.
+
+Upstream release notes: https://huggingface.co/blog/lerobot-release-v060
 
 ## Interfaces
 
@@ -23,11 +36,21 @@ CLI:
 
 ```bash
 npa workbench lerobot deploy
+npa workbench lerobot deploy --lerobot-version 0.6.0
 npa workbench lerobot train
+npa workbench lerobot train --runtime serverless --lerobot-version 0.6.0 ...
 npa workbench lerobot eval
 npa workbench lerobot serve
 npa workbench lerobot infer
 npa workbench lerobot list-checkpoints
+```
+
+Build both image tags:
+
+```bash
+npa/docker/workbench/lerobot/build.sh --all-versions
+# or
+npa/docker/workbench/lerobot/build.sh --version 0.6.0
 ```
 
 ## Data Contract
@@ -38,5 +61,6 @@ Output is a policy checkpoint on S3.
 
 ## Validation
 
-- 9/9 E2E serverless tests pass on Nebius.
+- 9/9 E2E serverless tests pass on Nebius (default 0.5.1 image).
 - Tier 1 validated on B300.
+- 0.6.0: build `npa-lerobot:0.6.0` and run the same golden env/functional smokes with `NPA_LEROBOT_VERSION=0.6.0`.

--- a/skills/workflows/byof-onboard/SKILL.md
+++ b/skills/workflows/byof-onboard/SKILL.md
@@ -75,6 +75,20 @@ Workloads:
 
 Container layout: OSS repo cloned to `/opt/byof` + `npa_source_metadata.json`.
 
+### LeRobot-dependent solutions
+
+If the OSS repo installs or imports Hugging Face LeRobot, pin a workbench-
+supported version explicitly:
+
+| Version | Install sketch | When |
+| --- | --- | --- |
+| `0.5.1` (default) | `pip install 'lerobot[pusht]==0.5.1'` | Match current golden evals / GR00T N1.5 |
+| `0.6.0` (additional) | `pip install 'lerobot[training,evaluation,pusht]==0.6.0'` | New VLAs, reward models, `lerobot-rollout` |
+
+See `skills/tools/lerobot/SKILL.md`. Prefer the first-class
+`npa workbench lerobot --lerobot-version …` path when the workload is policy
+train/eval rather than wrapping LeRobot inside a BYOF image.
+
 ## Agent Chat Flow (`onboard_solution`)
 
 1. **Contract** — register `workbench.byof.repo` (already in catalog); draft `byof` workflow via chat or:

--- a/skills/workflows/oss-solution-registry-onboard/SKILL.md
+++ b/skills/workflows/oss-solution-registry-onboard/SKILL.md
@@ -44,6 +44,14 @@ Load these as needed before making decisions:
   `cosmos`, `groot`, `sonic`, `fiftyone`, `lancedb`, `mjlab`, or
   `retargeting`) when the upstream repo depends on that stack.
 
+When the solution depends on Hugging Face LeRobot, pin an explicit supported
+workbench version (`0.5.1` default or `0.6.0` additional) via
+`skills/tools/lerobot/SKILL.md` and
+`npa/src/npa/deploy/lerobot_version_manifest.json`. Do not assume
+`pip install lerobot` without extras on 0.6.0 — use
+`lerobot[training,evaluation,...]==0.6.0`. Record the chosen pin in the
+capability table (`gpu_or_assets` / runtime notes).
+
 ## Non-Negotiable Agent Contract
 
 Do not invent capabilities from repo names, README badges, or marketing copy.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **LeRobot 0.6.0** as a selectable workbench version while keeping **0.5.1 as the default** (golden evals, sim2real policy image, GR00T N1.5 unchanged).

- Version manifest + `version_compat` helpers (`eval_freq` → `env_eval_freq` for 0.6.0; torch stays &lt;2.12)
- CLI: `--lerobot-version` on deploy / serverless train
- Image tag: `npa-lerobot:0.6.0` via Dockerfile/`build.sh`
- Docs/skills/onboarding updates

## Live Nebius validation (merge gate)

Ran on real Nebius infra (not mocked):

| Item | Value |
| --- | --- |
| Cluster | `npa-workbench-eu-north1` |
| Job | `npa-lr060-gpu-1784254256` |
| Node / GPU | `computeinstance-e00as19y90nd9vy1cg` / **NVIDIA H100 80GB HBM3** |
| Image | `cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lerobot:0.6.0` |
| Runtime | lerobot **0.6.0**, torch **2.11.0+cu130**, CUDA **True** |
| Smokes | `python -m npa.smoke.test_lerobot_env` → **4/4** |
|  | `python -m npa.smoke.test_lerobot_functional` → **5/5** (50-step train + eval) |
| Marker | `LIVE_K8S_LEROBOT_060_OK` |

Pull secret note: registry pull from this cluster requires an **eu-north1** IAM token (`nebius --profile agent-sa iam get-access-token`). The default `npa-mk8s` (us-central1) token OAuth-succeeds but gets **403 DENIED** on eu-north1 manifests.

Serverless create_job from the us-central1 e2e project still hits `ImageAccessDenied` for this private eu-north1 image (cross-region); live proof is the K8s H100 path above.

## Test plan

- [x] Unit/CLI tests (CI)
- [x] Build + push `npa-lerobot:0.6.0` to Nebius registry
- [x] Live K8s H100 env + functional smokes
- [ ] Optional follow-up: serverless train once a same-region project/registry pair can pull the image
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5c935c6-c7f8-4fd7-9d03-308d231a6759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5c935c6-c7f8-4fd7-9d03-308d231a6759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

