### PR TITLE
repo hardening priorities s3gd0y

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,12 +1,39 @@
-# GPU e2e tests — requires infrastructure credentials, run manually.
-name: GPU e2e
+# GPU e2e tests require real Nebius infrastructure credentials and run from an
+# operator machine (see docs/testing/e2e-serverless.md). This workflow cannot
+# reach GPUs from GitHub-hosted runners; what it CAN honestly verify is that
+# the e2e suite still collects and the e2e shell entrypoints still parse.
+name: GPU e2e preflight
 
 on:
   workflow_dispatch:
 
 jobs:
-  e2e:
+  preflight:
     runs-on: ubuntu-latest
     steps:
-      - name: Placeholder
-        run: ':'
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install npa
+        run: cd npa && pip install -e ".[dev,adapter]"
+
+      - name: Collect e2e test suite (no execution)
+        run: cd npa && python -m pytest tests/e2e/ --collect-only -q
+
+      - name: Syntax-check e2e shell entrypoints
+        run: |
+          cd npa
+          for script in tests/e2e/*.sh; do
+            bash -n "${script}"
+          done
+
+      - name: Explain how real GPU e2e runs work
+        run: |
+          echo "Real GPU e2e runs need Nebius credentials and are gated on"
+          echo "NPA_INTEGRATION_E2E=1 from an operator machine; see"
+          echo "docs/testing/e2e-serverless.md."

--- a/.github/workflows/harness-guardrails.yml
+++ b/.github/workflows/harness-guardrails.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Create repository venv
         run: |
           python -m venv npa/.venv
-          npa/.venv/bin/python -m pip install -e "npa[server]" pytest pytest-mock PyYAML
+          npa/.venv/bin/python -m pip install -e "npa[dev]"
 
       - name: Run guardrail tests
         run: npa/.venv/bin/python -m pytest npa/tests/guardrails -q

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Mypy (advisory, non-blocking)
         continue-on-error: true
-        run: cd npa && mypy src/npa --ignore-missing-imports --no-error-summary || true
+        run: cd npa && mypy src/npa --ignore-missing-imports --no-error-summary

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,43 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install "ruff>=0.4.0"
+
+      - name: Ruff check (blocking)
+        run: cd npa && ruff check src tests
+
+  mypy:
+    # Advisory only for now: the tree has no type-checking history. Flip
+    # continue-on-error to false once the baseline is clean.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install npa and mypy
+        run: cd npa && pip install -e ".[full]" mypy
+
+      - name: Mypy (advisory, non-blocking)
+        continue-on-error: true
+        run: cd npa && mypy src/npa --ignore-missing-imports --no-error-summary || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           pip install build twine
           cd npa && python -m build
-          twine check npa/dist/*
+          twine check dist/*
 
       - name: Smoke-install the wheel
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+# Builds and publishes release artifacts when a version tag is pushed.
+#
+# Cut a release with:
+#   1. Bump `version` in npa/pyproject.toml and move the CHANGELOG "Unreleased"
+#      entries under a new versioned heading (see docs/releasing.md).
+#   2. git tag vX.Y.Z && git push origin vX.Y.Z
+#
+# The workflow builds the sdist + wheel, smoke-installs the wheel, and attaches
+# both to a GitHub Release. PyPI publishing is documented in docs/releasing.md
+# and can be enabled by adding a `pypi` environment with trusted publishing.
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches package version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version="$(python -c "import tomllib; print(tomllib.load(open('npa/pyproject.toml','rb'))['project']['version'])")"
+          if [ "${tag_version}" != "${pkg_version}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match npa/pyproject.toml version ${pkg_version}" >&2
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: |
+          pip install build twine
+          cd npa && python -m build
+          twine check npa/dist/*
+
+      - name: Smoke-install the wheel
+        run: |
+          python -m venv /tmp/wheel-venv
+          /tmp/wheel-venv/bin/pip install npa/dist/*.whl
+          /tmp/wheel-venv/bin/npa --version
+
+      - name: Create GitHub Release with artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: npa/dist/*
+          generate_release_notes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Cover the supported floor (3.10), a common current version, and the
+        # latest release so requires-python = ">=3.10" is actually tested.
+        python-version: ["3.10", "3.12", "3.14"]
     env:
       NPA_PROJECT_ID: project-test-00000000
       NPA_S3_BUCKET: test-bucket-00000000
@@ -17,16 +23,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Set up Python 3.14
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install npa
-        run: cd npa && pip install -e ".[server]" && pip install pytest pytest-cov pytest-mock
-
-      - name: Install adapter test dependencies
-        run: cd npa && pip install -e ".[adapter]"
+        run: cd npa && pip install -e ".[dev,adapter]"
 
       - name: Verify checked-out CLI flags
         run: |
@@ -66,7 +69,9 @@ jobs:
           PY
 
       - name: Run pytest with coverage
-        run: cd npa && python -m pytest tests/ -v --tb=short --cov=npa --cov-report=term-missing
+        # The floor sits below the current ~66% so version-dependent skips
+        # don't flake the gate; raise it as coverage grows, never lower it.
+        run: cd npa && python -m pytest tests/ -v --tb=short --cov=npa --cov-report=term-missing --cov-fail-under=60
 
       - name: Run CLI install test
         run: cd npa && bash tests/integration/test_cli_install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
+Releases are git tags `vX.Y.Z` matching `npa/pyproject.toml`; artifacts are
+built and attached by `.github/workflows/release.yml`. See `docs/releasing.md`
+for the release process. Entries accumulate under "Unreleased" and move under
+a versioned heading when a release is cut.
+
 ## Unreleased
+
+### Repo hardening
+
+- Shipped SkyPilot examples and cookbooks now use the `<your-registry-id>`
+  placeholder instead of the first-party registry ID; a guardrail test keeps
+  concrete registry IDs out of shipped examples.
+- The base `pip install npa` is now lightweight (offline paths only); heavy
+  dependencies moved to `npa[data]`, `npa[lancedb]`, `npa[viz]`, with
+  `npa[full]` covering the previous monolithic install. Over-narrow version
+  pins were relaxed and the previously undeclared `pydantic` dependency is
+  declared.
+- Added `npa.__version__`, a tag-driven Release workflow that builds and
+  attaches sdist/wheel artifacts, and `docs/releasing.md`.
 
 ### Cosmos e2e
 

--- a/FIXME.md
+++ b/FIXME.md
@@ -18,7 +18,7 @@ work lives).
 #### [H] Parameterize Isaac Lab -> LeRobot formatter
 
 - **Surfaced by**: CC review of commit `2956b72` on 2026-05-10.
-- **Status**: Still active.
+- **Status**: Fixed.
 - **Current issue**: `npa/src/npa/adapter/isaac_lab_lerobot.py` remains G1-bound
   through hardcoded state names, dimensions, schema shape, and robot type.
 - **Next step**: Introduce a `LeRobotFeatureSpec` dataclass and split
@@ -27,7 +27,7 @@ work lives).
 #### [H] Isaac Lab train does not export trajectories or list registered tasks
 
 - **Surfaced by**: 2026-05-09 physical AI demo investigation.
-- **Status**: Still active.
+- **Status**: Fixed.
 - **Current issue**: `npa workbench isaac-lab train` writes summaries and a
   random-policy checkpoint but not synced observation/action/state episodes;
   the CLI also lacks a public `list-tasks` command.
@@ -141,7 +141,7 @@ work lives).
 #### [M] `<tool> status` without `-p`/`-n` hits an unconfigured default endpoint
 
 - **Surfaced by**: 2026-05-09 validation.
-- **Status**: Still active.
+- **Status**: Fixed.
 - **Current issue**: Omitted project/name flags can silently hit a stale or
   computed endpoint, producing misleading failure output.
 - **Next step**: Error and prompt for an alias, or track and use the most recent
@@ -172,6 +172,15 @@ work lives).
   passed, and apply the same guard consistently across the workbench tools.
 
 ## Resolved (recent)
+
+- 2026-07-19 - Isaac Lab -> LeRobot formatter parameterized via
+  `LeRobotFeatureSpec` with a G1 default spec (decoupled state/action dims).
+- 2026-07-19 - `npa workbench isaac-lab list-tasks` (remote gym registry) and
+  opt-in `train --export-trajectories` (trained-policy rollout, numpy episode
+  contract, `npa_isaac_lab_rollout_v2` meta).
+- 2026-07-19 - Omitted `-p`/`-n` now errors with available aliases when no
+  unambiguous default exists (`npa.clients.config` shared resolvers) instead
+  of silently hitting a stale or arbitrary endpoint.
 
 - 2026-07-09 - GR00T BYOVM/project storage credential inheritance + reload-env
   parity with Cosmos (`apply_storage_env_vars`, `_shared_groot_env_or_fail(cfg, ...)`).

--- a/FTUE-AUDIT.md
+++ b/FTUE-AUDIT.md
@@ -62,20 +62,26 @@ a "non-default S3-compatible endpoint."
 
 ## Deferred gaps (follow-up)
 
-- **Three-tier → GPU launch gap.** All three tiers reach GPUs only via the
+- **Three-tier → GPU launch gap.** ~~All three tiers reach GPUs only via the
   materialized-runbook / direct-Kubernetes path today, because raw
   `sky jobs launch` is blocked by the SkyPilot 0.12.2 pre-setup `getcwd()` bug.
   Closing this needs an upstream SkyPilot fix or a thin in-repo materializer that
-  renders the runbook to a Kubernetes Job. Out of scope for this pass.
+  renders the runbook to a Kubernetes Job. Out of scope for this pass.~~
+  **Closed:** `npa workbench sim2real materialize` renders the committed
+  runbook to a plain Kubernetes Job
+  (`npa/src/npa/workflows/sim2real/materialize.py`), no operator pack needed.
 - **SDK seam discoverability.** `sim2real.run(**overrides)` forwards seams by
   keyword into `build_config_from_env`, so the seams are real and coherent but
   not discoverable from the function signature (and cannot use the inspect-based
   `CapabilityContract`). Promoting the seams to explicit keyword parameters would
   change the public SDK signature; deferred.
-- **`sim2real` name collision.** Two surfaces share the "sim2real" name: the
+- **`sim2real` name collision.** ~~Two surfaces share the "sim2real" name: the
   13-stage VLM-to-RL loop (`npa workbench workflow submit` on the sim2real runbook) and the separate
   sim-to-real H100 quickstart/pipeline. A first-time user cannot tell which is
-  canonical. Naming reconciliation is deferred.
+  canonical. Naming reconciliation is deferred.~~ **Closed:** the spelling is
+  now the documented disambiguator (`sim2real` = staged VLM-to-RL loop,
+  `sim-to-real` = older H100 pipeline) with a naming note in
+  `npa/workflows/workbench/sim2real/README.md`.
 - **Deeper GPU gate.** The cluster check counts schedulable `nvidia.com/gpu`; it
   does not yet match the requested GPU product node-selector label against
   available node products. A product-aware gate is a follow-up.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ pip install --upgrade pip && pip install -e npa
 npa --version
 ```
 
+> The base install is deliberately lightweight — it covers the offline paths
+> (Route A) with no GPU or database wheels. Before running cloud workloads
+> (Routes B and C), add the remaining workbench dependencies with
+> `pip install -e "npa[full]"`.
+
 > **Windows:** use **WSL2 Ubuntu**. Native PowerShell / `cmd` are not
 > supported. Platform-specific install blocks:
 > [docs/quickstart.md § Fast install](docs/quickstart.md#fast-install-by-platform).

--- a/docs/cli/isaac-lab.md
+++ b/docs/cli/isaac-lab.md
@@ -16,6 +16,7 @@ list  List configured Isaac Lab workbenches.
 cleanup-partial  Clean up orphaned Terraform resources from an interrupted Isaac Lab deploy.
 deploy  Deploy or destroy an Isaac Lab workbench.
 status  Check Isaac Lab VM status via SSH.
+list-tasks  List registered Isaac Lab tasks on the workbench VM.
 system-info  Collect and display system hardware information from the Isaac Lab VM.
 train  Run Isaac Lab training on the VM via SSH.
 eval  Run Isaac Lab evaluation on the VM via SSH.
@@ -38,8 +39,9 @@ export-lerobot  Generate Isaac Lab G1 rollouts and export them as a standard LeR
 | `cleanup-partial` | Clean up orphaned Terraform resources from an interrupted Isaac Lab deploy. |
 | `deploy` | Deploy or destroy an Isaac Lab workbench. |
 | `status` | Check Isaac Lab VM status via SSH. |
+| `list-tasks` | List registered Isaac Lab tasks on the workbench VM. |
 | `system-info` | Collect and display system hardware information from the Isaac Lab VM. |
-| `train` | Run Isaac Lab training on the VM via SSH. |
+| `train` | Run Isaac Lab training on the VM via SSH (`--export-trajectories` rolls out the trained checkpoint to numpy episodes). |
 | `eval` | Run Isaac Lab evaluation on the VM via SSH. |
 | `export-lerobot` | Generate Isaac Lab G1 rollouts and export them as a standard LeRobotDataset. |
 

--- a/docs/demos/bdd100k-lancedb-demo.md
+++ b/docs/demos/bdd100k-lancedb-demo.md
@@ -41,7 +41,7 @@ resources:
   cpus: 4
   memory: 16
   # Pinned first-party LanceDB image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.2"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.2"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -159,15 +159,23 @@ Gate: `npa --version` prints `npa <version>`, and `npa --help` prints the
 command tree without requiring Nebius, Hugging Face, NGC, Kubernetes, or S3
 credentials.
 
+The base install is lightweight: it carries only what the offline paths need.
 Optional extras are available when you need them:
 
 ```bash
+pip install -e "npa[full]"      # everything below except the GPU extras
+pip install -e "npa[data]"      # pandas/scipy/matplotlib curation + reports
+pip install -e "npa[lancedb]"   # LanceDB workbench tool
+pip install -e "npa[viz]"       # Rerun viewer/recording integration
 pip install -e "npa[server]"    # FastAPI policy/eval server
 pip install -e "npa[adapter]"   # dataset conversion
 pip install -e "npa[genesis]"   # Genesis + distillation stages (GPU)
 pip install -e "npa[groot]"     # GR00T SDK (GPU)
 pip install -e "npa[dev]"       # tests, lint (pytest, ruff); see Section 6
 ```
+
+Before running cloud workloads (Sections 5+), install `npa[full]` so every
+workbench tool has its dependencies.
 
 ## 4. Configure credentials
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,63 @@
+# Releasing `npa`
+
+`npa` is distributed as a source checkout plus tagged releases with built
+artifacts. Every release is a git tag `vX.Y.Z` that matches the `version`
+field in `npa/pyproject.toml`; the `Release` workflow
+(`.github/workflows/release.yml`) builds the sdist and wheel, smoke-installs
+the wheel, and attaches both to a GitHub Release.
+
+## Cutting a release
+
+1. **Bump the version** in `npa/pyproject.toml` (`[project] version`).
+   Pre-1.0, breaking CLI/SDK changes bump the minor version and fixes bump the
+   patch version.
+2. **Update `CHANGELOG.md`**: move the relevant `## Unreleased` entries under a
+   new `## vX.Y.Z - YYYY-MM-DD` heading. Keep `## Unreleased` at the top for
+   the next cycle.
+3. **Merge to `main`** through the normal PR flow (CI must be green).
+4. **Tag and push**:
+
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+5. The `Release` workflow refuses tags whose version does not match
+   `npa/pyproject.toml`, so a mismatched tag fails fast instead of shipping a
+   mislabeled artifact.
+
+## Installing a release
+
+Consumers who do not want a source checkout can pin a released artifact:
+
+```bash
+pip install "npa @ https://github.com/nebius/nebius-physical-ai/releases/download/vX.Y.Z/npa-X.Y.Z-py3-none-any.whl"
+```
+
+The base wheel is lightweight; add extras as needed
+(`npa[full]`, `npa[data]`, `npa[lancedb]`, `npa[viz]`, `npa[server]`, ...).
+
+## Enabling PyPI publishing (optional, not yet enabled)
+
+When the project is ready to publish to PyPI:
+
+1. Create the `npa` project on PyPI and configure a
+   [trusted publisher](https://docs.pypi.org/trusted-publishers/) pointing at
+   this repository and the `release.yml` workflow.
+2. Add a `pypi` environment in the repository settings.
+3. Append a publish job to `release.yml`:
+
+   ```yaml
+   publish:
+     needs: build
+     runs-on: ubuntu-latest
+     environment: pypi
+     permissions:
+       id-token: write
+     steps:
+       - uses: actions/download-artifact@v4
+       - uses: pypa/gh-action-pypi-publish@release/v1
+   ```
+
+Until then, GitHub Releases are the canonical distribution channel.

--- a/docs/workbench/cookbooks/bdd100k-pipeline.md
+++ b/docs/workbench/cookbooks/bdd100k-pipeline.md
@@ -273,8 +273,8 @@ configured S3 credentials to list and read this prefix.
 
 The committed YAML pins the first-party LanceDB and detection-training images:
 
-- `cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3`
-- `cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z`
+- `cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3`
+- `cr.eu-north1.nebius.cloud/<your-registry-id>/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z`
 
 The optional final FiftyOne app can still be replaced with a BYO registry image:
 

--- a/docs/workbench/cookbooks/lancedb-deploy-runbook.md
+++ b/docs/workbench/cookbooks/lancedb-deploy-runbook.md
@@ -24,7 +24,7 @@ npa/docker/workbench/lancedb/build.sh
 ```
 
 The pushed first-party default is
-`cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3`.
+`cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3`.
 
 Deploy:
 
@@ -35,7 +35,7 @@ npa workbench lancedb deploy \
   --port 8686 \
   --auth-mode none \
   --replace \
-  --image cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3
+  --image cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3
 ```
 
 Check status:

--- a/docs/workbench/cookbooks/lancedb-vector-search.md
+++ b/docs/workbench/cookbooks/lancedb-vector-search.md
@@ -14,7 +14,7 @@ npa/docker/workbench/lancedb/build.sh
 ```
 
 The first-party registry default is
-`cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3`.
+`cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3`.
 
 Start a local container-backed service:
 
@@ -24,7 +24,7 @@ npa workbench lancedb deploy \
   --storage-path /tmp/npa-lancedb \
   --port 8686 \
   --auth-mode none \
-  --image cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3
+  --image cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3
 ```
 
 Create a table from local JSON, JSONL, parquet, or a directory of parquet

--- a/docs/workbench/cookbooks/sim-to-real-pipeline.md
+++ b/docs/workbench/cookbooks/sim-to-real-pipeline.md
@@ -303,7 +303,7 @@ Both should show no in-progress clusters or managed jobs for the run.
 | `--gpu` / `NPA_GPU_TYPE` / `gpu` | `H100:1` | Primary SkyPilot accelerator. Nebius VM examples: `H100:1`, `H200:1`, `L40S:1`, or explicit multi-GPU `B200:8` when present in the live catalog |
 | `--gpu-failover` / `NPA_GPU_FAILOVER` / `gpu_failover` | `H200:1,L40S:1` | Ordered fallback accelerator list, validated against the live Nebius VM catalog before VM submission |
 | `--vlm-eval-backend` | `stub` | Live VLM backend |
-| `NPA_VLM_IMAGE` / `npa workbench vlm-eval workflow --image` / `workflow(image=...)` | `cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-cosmos:1.0.9` | BYO prebuilt VLM/vLLM serving image |
+| `NPA_VLM_IMAGE` / `npa workbench vlm-eval workflow --image` / `workflow(image=...)` | `cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9` | BYO prebuilt VLM/vLLM serving image |
 | `--task-cloud` | `nebius` | Task backend for acceptance runs when Kubernetes GPU capacity is occupied |
 | `--controller-backend` | `nebius` | Managed-jobs controller fallback for clusters that cannot validate the Kubernetes controller pod |
 | `--rerun-max-frames-per-episode` | `32` | Lower for smoke, higher for inspection |

--- a/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
+++ b/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
@@ -37,7 +37,7 @@ Retargeting uses `NPA_RETARGETING_IMAGE`, which defaults to the CPU
 CPU Python dependencies, and the pinned upstream
 `NVlabs/GR00T-WholeBodyControl` data-process scripts. MJLab still uses
 `NPA_WORKBENCH_IMAGE`, which defaults to the pushed generic Workbench image
-`cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-genesis:0.4.6`.
+`cr.eu-north1.nebius.cloud/<your-registry-id>/npa-genesis:0.4.6`.
 
 ## Tool Templates
 

--- a/docs/workbench/cookbooks/vlm-eval-loop-runbook.md
+++ b/docs/workbench/cookbooks/vlm-eval-loop-runbook.md
@@ -24,7 +24,7 @@ export RUN_ID="vlm-eval-loop-smoke"
 export NPA_S3_BUCKET="<your-bucket-name>"
 export ROLLOUTS="s3://${NPA_S3_BUCKET}/sim-to-real/${RUN_ID}/rollouts/"
 export OUTPUT_DIR="s3://${NPA_S3_BUCKET}/sim-to-real/${RUN_ID}/vlm-eval-loop/"
-export NPA_VLM_IMAGE="cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-cosmos:1.0.9"
+export NPA_VLM_IMAGE="cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
 # For production BYO, set NPA_VLM_IMAGE to a prebuilt VLM/vLLM serving image.
 
 npa/.venv/bin/python - <<'PY'

--- a/npa/pyproject.toml
+++ b/npa/pyproject.toml
@@ -7,29 +7,44 @@ name = "npa"
 version = "0.1.0"
 description = "Nebius Physical AI platform CLI/SDK"
 requires-python = ">=3.10"
+# Core keeps only what `import npa.cli.main` needs so the offline paths
+# (`npa --version`, vlm-eval stub, workflow validate/plan) install fast on a
+# clean index. Heavy or tool-specific packages live in extras; lower bounds are
+# deliberately wide so a stale mirror does not break the first install.
 dependencies = [
-    "typer~=0.24.1",
-    "httpx~=0.28.1",
-    "paramiko~=5.0.0",
-    "pyyaml~=6.0.3",
-    "rich~=15.0.0",
-    "boto3~=1.42.91",
-    "jinja2~=3.1.6",
-    "joblib>=1.3",
-    "matplotlib>=3.8",
+    "typer>=0.24",
+    "httpx>=0.27",
+    "paramiko>=4.0",
+    "pyyaml>=6.0",
+    "rich>=13.0",
+    "boto3>=1.34",
+    "jinja2>=3.1",
     "numpy>=1.24",
-    "pandas>=2.0",
     "pyarrow>=14.0",
     "pillow>=10.0",
-    "scipy>=1.10",
-    "lancedb==0.30.2",
-    "rerun-sdk==0.31.4",
+    "pydantic>=2.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]
 # SkyPilot is installed in an isolated venv outside NPA's package environment; see docs/orchestration/skypilot-setup.md.
 orchestration = []
+# Dataframe/plotting helpers used by curation, benchmarks, and reports.
+data = [
+    "pandas>=2.0",
+    "joblib>=1.3",
+    "matplotlib>=3.8",
+    "scipy>=1.10",
+]
+# LanceDB workbench tool (local server, BDD100K import, materialized views).
+lancedb = [
+    "lancedb==0.30.2",
+    "pandas>=2.0",
+]
+# Rerun viewer/recording integration (`npa rerun`, sim-viz adapters).
+viz = ["rerun-sdk==0.31.4"]
+# Everything the previous monolithic install provided, minus GPU extras.
+full = ["npa[data,lancedb,viz,server]"]
 server = ["fastapi~=0.136.1"]
 genesis = [
     "genesis-world",
@@ -54,10 +69,10 @@ sonic = [
     "onnxruntime>=1.18",
 ]
 # Development and test tooling. Install with: pip install -e "npa[dev]"
-# Includes the server extra so the standard (non-e2e) test suite collects
+# Includes the full extra so the standard (non-e2e) test suite collects
 # without pulling in GPU-heavy extras (genesis, groot, sonic).
 dev = [
-    "npa[server]",
+    "npa[full]",
     "pytest>=8.0",
     "pytest-mock>=3.14",
     "pytest-cov>=5.0",
@@ -114,6 +129,16 @@ packages = ["src/npa"]
 "src/npa/deploy/sonic_image_manifest.json" = "npa/deploy/sonic_image_manifest.json"
 "src/npa/deploy/lerobot_version_manifest.json" = "npa/deploy/lerobot_version_manifest.json"
 "src/npa/smoke/golden_evals.yaml" = "npa/smoke/golden_evals.yaml"
+
+[tool.ruff]
+target-version = "py310"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+# Pyflakes + the default pycodestyle errors. The tree is clean under this set
+# and CI enforces it (.github/workflows/lint.yml); widen deliberately, not by
+# accident.
+select = ["E4", "E7", "E9", "F"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/npa/pyproject.toml
+++ b/npa/pyproject.toml
@@ -13,6 +13,9 @@ requires-python = ">=3.10"
 # deliberately wide so a stale mirror does not break the first install.
 dependencies = [
     "typer>=0.24",
+    # Imported directly (npa.cli.workflow_shim); typer >= 0.27 no longer
+    # depends on click, so it must be declared here.
+    "click>=8.0",
     "httpx>=0.27",
     "paramiko>=4.0",
     "pyyaml>=6.0",

--- a/npa/src/npa/__init__.py
+++ b/npa/src/npa/__init__.py
@@ -8,8 +8,16 @@ the public API reaches v1 stability.
 from __future__ import annotations
 
 import os as _os
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _package_version
+
+try:
+    __version__ = _package_version("npa")
+except _PackageNotFoundError:  # pragma: no cover - source tree without install
+    __version__ = "0.0.0.dev0"
 
 __all__ = [
+    "__version__",
     "convert",
     "demo",
     "errors",

--- a/npa/src/npa/adapter/isaac_lab_lerobot.py
+++ b/npa/src/npa/adapter/isaac_lab_lerobot.py
@@ -1,9 +1,16 @@
-"""Convert Isaac Lab G1 rollouts into standard LeRobotDataset v3 layout."""
+"""Convert Isaac Lab numpy rollouts into standard LeRobotDataset v3 layout.
+
+The writer half is robot-agnostic and driven by a ``LeRobotFeatureSpec``
+(joint names, dimensions, robot type). The module ships a Unitree G1 default
+spec so existing G1 callers keep working unchanged; other robots pass their
+own spec to ``convert``.
+"""
 
 from __future__ import annotations
 
 import json
 import subprocess
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -124,6 +131,37 @@ class IsaacLabLeRobotError(Exception):
     """Raised when an Isaac Lab rollout cannot be represented as LeRobot data."""
 
 
+@dataclass(frozen=True)
+class LeRobotFeatureSpec:
+    """Robot-specific feature layout for the LeRobot writer.
+
+    ``state_dim``/``action_dim`` default to the length of the corresponding
+    name lists; pass them explicitly only when the arrays are wider than the
+    named joints.
+    """
+
+    state_names: list[str]
+    action_names: list[str]
+    robot_type: str
+    state_dim: int = field(default=0)
+    action_dim: int = field(default=0)
+
+    def __post_init__(self) -> None:
+        if not self.state_names or not self.action_names:
+            raise IsaacLabLeRobotError("LeRobotFeatureSpec requires state and action names")
+        if self.state_dim <= 0:
+            object.__setattr__(self, "state_dim", len(self.state_names))
+        if self.action_dim <= 0:
+            object.__setattr__(self, "action_dim", len(self.action_names))
+
+
+G1_FEATURE_SPEC = LeRobotFeatureSpec(
+    state_names=list(G1_STATE_NAMES_43),
+    action_names=list(G1_STATE_NAMES_43),
+    robot_type="unitree_g1",
+)
+
+
 def discover_episodes(input_dir: Path) -> list[Path]:
     episodes = sorted(
         path
@@ -144,11 +182,13 @@ def convert(
     task: str = "",
     include_placeholder_video: bool = False,
     video_size: int = 64,
+    spec: LeRobotFeatureSpec | None = None,
 ) -> Path:
-    """Convert raw Isaac Lab G1 numpy rollouts to standard LeRobotDataset v3.
+    """Convert raw Isaac Lab numpy rollouts to standard LeRobotDataset v3.
 
     Raw input is a directory containing ``episode_*`` subdirectories, each with
-    ``state.npy`` and ``actions.npy`` arrays in the canonical 43D G1 layout.
+    ``state.npy`` and ``actions.npy`` arrays matching ``spec`` (default: the
+    canonical 43D Unitree G1 layout).
     """
     if fps <= 0:
         raise IsaacLabLeRobotError(f"fps must be positive, got {fps}")
@@ -156,10 +196,23 @@ def convert(
     output_dir = Path(output_dir)
     episodes = discover_episodes(input_dir)
     top_meta = _load_optional_json(input_dir / "meta.json")
-    task_text = task or str(top_meta.get("task") or top_meta.get("task_id") or "Isaac Lab G1 rollout")
-    robot = robot_type or str(top_meta.get("robot_type") or "unitree_g1")
-    state_names = _names_from_meta(top_meta, "state_names")
-    action_names = _names_from_meta(top_meta, "action_names")
+    resolved_spec = spec or G1_FEATURE_SPEC
+    default_task = (
+        "Isaac Lab G1 rollout"
+        if resolved_spec.robot_type == "unitree_g1"
+        else f"Isaac Lab {resolved_spec.robot_type} rollout"
+    )
+    task_text = task or str(top_meta.get("task") or top_meta.get("task_id") or default_task)
+    if spec is not None and robot_type == "unitree_g1":
+        robot = spec.robot_type
+    else:
+        robot = robot_type or str(top_meta.get("robot_type") or resolved_spec.robot_type)
+    state_names = _names_from_meta(
+        top_meta, "state_names", expected_dim=resolved_spec.state_dim, fallback=resolved_spec.state_names
+    )
+    action_names = _names_from_meta(
+        top_meta, "action_names", expected_dim=resolved_spec.action_dim, fallback=resolved_spec.action_names
+    )
 
     _reset_dir(output_dir)
     (output_dir / "data" / "chunk-000").mkdir(parents=True, exist_ok=True)
@@ -181,7 +234,7 @@ def convert(
 
     global_index = 0
     for episode_index, episode_dir in enumerate(episodes):
-        state, actions = _load_episode_arrays(episode_dir)
+        state, actions = _load_episode_arrays(episode_dir, spec=resolved_spec)
         ep_len = int(state.shape[0])
         dataset_from_index = global_index
 
@@ -240,7 +293,11 @@ def convert(
         episode_rows.append(episode_row)
 
     total_frames = len(all_rows)
-    _write_data_parquet(all_rows, output_dir / "data" / "chunk-000" / "file-000.parquet")
+    _write_data_parquet(
+        all_rows,
+        output_dir / "data" / "chunk-000" / "file-000.parquet",
+        spec=resolved_spec,
+    )
     _write_episodes_parquet(
         episode_rows,
         output_dir / "meta" / "episodes" / "chunk-000" / "file-000.parquet",
@@ -258,6 +315,7 @@ def convert(
         action_names=action_names,
         include_video=include_placeholder_video,
         video_size=video_size,
+        spec=resolved_spec,
     )
     return output_dir
 
@@ -277,14 +335,22 @@ def _load_optional_json(path: Path) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-def _names_from_meta(meta: dict[str, Any], key: str) -> list[str]:
+def _names_from_meta(
+    meta: dict[str, Any],
+    key: str,
+    *,
+    expected_dim: int = G1_STATE_DIM,
+    fallback: list[str] | None = None,
+) -> list[str]:
     raw = meta.get(key)
-    if isinstance(raw, list) and len(raw) == G1_STATE_DIM and all(isinstance(v, str) for v in raw):
+    if isinstance(raw, list) and len(raw) == expected_dim and all(isinstance(v, str) for v in raw):
         return [str(v) for v in raw]
-    return list(G1_STATE_NAMES_43)
+    return list(fallback if fallback is not None else G1_STATE_NAMES_43)
 
 
-def _load_episode_arrays(episode_dir: Path) -> tuple[np.ndarray, np.ndarray]:
+def _load_episode_arrays(
+    episode_dir: Path, *, spec: LeRobotFeatureSpec | None = None
+) -> tuple[np.ndarray, np.ndarray]:
     state_path = episode_dir / "state.npy"
     action_path = episode_dir / "actions.npy"
     if not state_path.exists():
@@ -303,9 +369,11 @@ def _load_episode_arrays(episode_dir: Path) -> tuple[np.ndarray, np.ndarray]:
             f"{episode_dir.name}: state/action length mismatch "
             f"({state.shape[0]} != {actions.shape[0]})"
         )
-    if state.shape[1] != G1_STATE_DIM or actions.shape[1] != G1_STATE_DIM:
+    resolved = spec or G1_FEATURE_SPEC
+    if state.shape[1] != resolved.state_dim or actions.shape[1] != resolved.action_dim:
         raise IsaacLabLeRobotError(
-            f"{episode_dir.name}: expected 43D G1 state/action arrays, "
+            f"{episode_dir.name}: expected {resolved.state_dim}D state / "
+            f"{resolved.action_dim}D action arrays for {resolved.robot_type}, "
             f"got state={state.shape[1]} action={actions.shape[1]}"
         )
     if state.shape[0] == 0:
@@ -313,11 +381,14 @@ def _load_episode_arrays(episode_dir: Path) -> tuple[np.ndarray, np.ndarray]:
     return state, actions
 
 
-def _write_data_parquet(rows: list[dict[str, Any]], output_path: Path) -> None:
+def _write_data_parquet(
+    rows: list[dict[str, Any]], output_path: Path, *, spec: LeRobotFeatureSpec | None = None
+) -> None:
+    resolved = spec or G1_FEATURE_SPEC
     schema = pa.schema(
         [
-            ("observation.state", pa.list_(pa.float32(), G1_STATE_DIM)),
-            ("action", pa.list_(pa.float32(), G1_STATE_DIM)),
+            ("observation.state", pa.list_(pa.float32(), resolved.state_dim)),
+            ("action", pa.list_(pa.float32(), resolved.action_dim)),
             ("episode_index", pa.int64()),
             ("frame_index", pa.int64()),
             ("timestamp", pa.float32()),
@@ -329,11 +400,11 @@ def _write_data_parquet(rows: list[dict[str, Any]], output_path: Path) -> None:
         {
             "observation.state": pa.array(
                 [row["observation.state"] for row in rows],
-                type=pa.list_(pa.float32(), G1_STATE_DIM),
+                type=pa.list_(pa.float32(), resolved.state_dim),
             ),
             "action": pa.array(
                 [row["action"] for row in rows],
-                type=pa.list_(pa.float32(), G1_STATE_DIM),
+                type=pa.list_(pa.float32(), resolved.action_dim),
             ),
             "episode_index": pa.array([row["episode_index"] for row in rows], type=pa.int64()),
             "frame_index": pa.array([row["frame_index"] for row in rows], type=pa.int64()),
@@ -428,16 +499,18 @@ def _write_info(
     action_names: list[str],
     include_video: bool,
     video_size: int,
+    spec: LeRobotFeatureSpec | None = None,
 ) -> None:
+    resolved = spec or G1_FEATURE_SPEC
     features: dict[str, Any] = {
         "observation.state": {
             "dtype": "float32",
-            "shape": [G1_STATE_DIM],
+            "shape": [resolved.state_dim],
             "names": [state_names],
         },
         "action": {
             "dtype": "float32",
-            "shape": [G1_STATE_DIM],
+            "shape": [resolved.action_dim],
             "names": [action_names],
         },
         "timestamp": {"dtype": "float32", "shape": [1], "names": None},

--- a/npa/src/npa/cli/agent_chat.py
+++ b/npa/src/npa/cli/agent_chat.py
@@ -332,7 +332,6 @@ INTENT_APIS: dict[str, list[str]] = {
     "load_franka": ["sim-viz/load-franka-demo", "sim-viz/status"],
 }
 
-_DEFAULT_REGISTRY = "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw"
 _DEFAULT_TOOL_IMAGE_TAGS: dict[str, tuple[str, str]] = {
     "cosmos": ("npa-cosmos", "1.0.9"),
     "lancedb": ("npa-lancedb", "0.30.3"),
@@ -649,7 +648,9 @@ def format_tools_catalog(tool_refs: list[str], *, sample_size: int = 8) -> str:
 
 
 def _image_for_tool(tool: str) -> str:
-    registry = os.environ.get("NPA_REGISTRY", "").strip() or _DEFAULT_REGISTRY
+    from npa.deploy.images import primary_container_registry
+
+    registry = primary_container_registry()
     image_name, tag = _DEFAULT_TOOL_IMAGE_TAGS.get(tool, (f"npa-{tool}", "<tag>"))
     return f"{registry.rstrip('/')}/{image_name}:{tag}"
 

--- a/npa/src/npa/cli/fiftyone/__init__.py
+++ b/npa/src/npa/cli/fiftyone/__init__.py
@@ -1,6 +1,7 @@
 """npa workbench fiftyone - Voxel51 FiftyOne dataset curation app."""
 
 from __future__ import annotations
+import logging
 
 import json
 import os
@@ -3926,7 +3927,7 @@ def open_app_cmd(
     try:
         webbrowser.open(url)
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
     try:
         proc = subprocess.Popen(cmd)
     except FileNotFoundError:

--- a/npa/src/npa/cli/isaac_lab/__init__.py
+++ b/npa/src/npa/cli/isaac_lab/__init__.py
@@ -1436,6 +1436,208 @@ finally:
 """
 
 
+def _build_list_tasks_script() -> str:
+    return """\
+import json
+
+from isaaclab.app import AppLauncher
+
+app_launcher = AppLauncher(headless=True)
+simulation_app = app_launcher.app
+
+try:
+    import gymnasium as gym
+    import isaaclab_tasks  # noqa: F401  (import registers Isaac Lab tasks)
+
+    tasks = sorted(env_id for env_id in gym.registry.keys() if env_id.startswith("Isaac"))
+    print("ISAAC_LAB_LIST_TASKS_JSON " + json.dumps({"tasks": tasks, "count": len(tasks)}))
+finally:
+    simulation_app.close()
+"""
+
+
+def _build_train_trajectory_export_script(
+    task: str,
+    num_episodes: int,
+    steps_per_episode: int,
+    checkpoint: str,
+    output_dir: str,
+) -> str:
+    """Roll out the trained checkpoint and write the numpy episode contract.
+
+    Unlike ``_build_export_lerobot_script`` (random actions, G1 joint
+    canonicalization), this drives the freshly trained rsl_rl policy and
+    records raw env joint names so any robot converts via a
+    ``LeRobotFeatureSpec`` built from ``meta.json``. ``policy_loaded`` is
+    recorded so a random fallback is never silently presented as the trained
+    policy.
+    """
+    return f"""\
+import json
+import time
+from pathlib import Path
+
+from isaaclab.app import AppLauncher
+
+app_launcher = AppLauncher(headless=True)
+simulation_app = app_launcher.app
+
+import gymnasium as gym
+import numpy as np
+import torch
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils import parse_env_cfg
+
+task = {task!r}
+num_episodes = {num_episodes}
+steps_per_episode = {steps_per_episode}
+checkpoint_path = Path({checkpoint!r})
+output_dir = Path({output_dir!r})
+output_dir.mkdir(parents=True, exist_ok=True)
+device = "cuda:0" if torch.cuda.is_available() else "cpu"
+started = time.time()
+env = None
+
+
+def _to_numpy(value):
+    tensor = torch.as_tensor(value)
+    return tensor.detach().cpu().numpy()
+
+
+def _robot(env):
+    try:
+        return env.unwrapped.scene["robot"]
+    except Exception:
+        return None
+
+
+try:
+    print(
+        f"ISAAC_LAB_TRAJ_EXPORT_START task={{task}} episodes={{num_episodes}} "
+        f"steps_per_episode={{steps_per_episode}} device={{device}}",
+        flush=True,
+    )
+    env_cfg = parse_env_cfg(task, device=device, num_envs=1)
+    env = gym.make(task, cfg=env_cfg)
+
+    policy = None
+    policy_loaded = False
+    try:
+        try:
+            from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
+        except Exception:
+            from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper
+        from rsl_rl.runners import OnPolicyRunner
+        wrapped = RslRlVecEnvWrapper(env)
+        agent_cfg = None
+        for loader in ("isaaclab_tasks.utils", "omni.isaac.lab_tasks.utils"):
+            try:
+                mod = __import__(loader, fromlist=["load_cfg_from_registry"])
+                agent_cfg = mod.load_cfg_from_registry(task, "rsl_rl_cfg_entry_point")
+                break
+            except Exception:
+                pass
+        acfg = agent_cfg.to_dict() if hasattr(agent_cfg, "to_dict") else dict(agent_cfg)
+        runner = OnPolicyRunner(wrapped, acfg, log_dir=None, device=device)
+        runner.load(str(checkpoint_path))
+        policy = runner.get_inference_policy(device=device)
+        env = wrapped
+        policy_loaded = True
+        print("ISAAC_LAB_TRAJ_EXPORT_POLICY_LOADED", flush=True)
+    except Exception as exc:
+        print(f"ISAAC_LAB_TRAJ_EXPORT_POLICY_LOAD_FAILED {{exc!r}} -- random fallback", flush=True)
+
+    def _act(obs):
+        if policy_loaded and policy is not None and obs is not None:
+            with torch.inference_mode():
+                return policy(obs)
+        return torch.as_tensor(env.action_space.sample(), device=device, dtype=torch.float32)
+
+    robot = _robot(env)
+    joint_names = list(getattr(getattr(robot, "data", None), "joint_names", []) or [])
+
+    total_frames = 0
+    episode_lengths = []
+    action_dim = None
+    for episode_index in range(num_episodes):
+        reset_out = env.reset()
+        obs = reset_out[0] if isinstance(reset_out, tuple) else reset_out
+        states = []
+        actions_out = []
+        for step in range(steps_per_episode):
+            robot = _robot(env)
+            if robot is not None and joint_names:
+                state_values = _to_numpy(robot.data.joint_pos)[0]
+            else:
+                obs_np = _to_numpy(obs)
+                state_values = obs_np[0] if obs_np.ndim > 1 else obs_np
+            actions = _act(obs)
+            actions_np = _to_numpy(actions)
+            action_values = actions_np[0] if actions_np.ndim > 1 else actions_np
+            action_dim = int(action_values.shape[-1])
+
+            states.append(np.asarray(state_values, dtype=np.float32))
+            actions_out.append(np.asarray(action_values, dtype=np.float32))
+
+            obs, _rewards, terminated, truncated, _info = env.step(actions)
+            done = bool(torch.as_tensor(terminated).any().item()) or bool(torch.as_tensor(truncated).any().item())
+            if done:
+                break
+
+        if not states:
+            raise RuntimeError(f"episode {{episode_index}} produced no frames")
+        episode_dir = output_dir / f"episode_{{episode_index:06d}}"
+        episode_dir.mkdir(parents=True, exist_ok=True)
+        np.save(episode_dir / "state.npy", np.stack(states))
+        np.save(episode_dir / "actions.npy", np.stack(actions_out))
+        (episode_dir / "episode_meta.json").write_text(json.dumps({{
+            "episode_index": episode_index,
+            "length": len(states),
+            "task": task,
+            "policy_loaded": policy_loaded,
+        }}, indent=2))
+        total_frames += len(states)
+        episode_lengths.append(len(states))
+        print(
+            f"ISAAC_LAB_TRAJ_EXPORT_EPISODE episode={{episode_index + 1}}/{{num_episodes}} "
+            f"frames={{len(states)}}",
+            flush=True,
+        )
+
+    state_dim = int(np.load(output_dir / "episode_000000" / "state.npy").shape[1])
+    state_names = joint_names if len(joint_names) == state_dim else [f"state_{{i}}" for i in range(state_dim)]
+    action_names = (
+        joint_names
+        if action_dim is not None and len(joint_names) == action_dim
+        else [f"action_{{i}}" for i in range(int(action_dim or 0))]
+    )
+    meta = {{
+        "format": "npa_isaac_lab_rollout_v2",
+        "task": task,
+        "checkpoint": str(checkpoint_path),
+        "policy_loaded": policy_loaded,
+        "fps": 50,
+        "state_names": state_names,
+        "action_names": action_names,
+        "source_joint_names": joint_names,
+        "num_episodes": num_episodes,
+        "steps_per_episode": steps_per_episode,
+        "episode_lengths": episode_lengths,
+        "total_frames": total_frames,
+        "created_unix": round(time.time(), 3),
+        "duration_seconds": round(time.time() - started, 3),
+    }}
+    (output_dir / "meta.json").write_text(json.dumps(meta, indent=2))
+    print("ISAAC_LAB_TRAJ_EXPORT_COMPLETE")
+    print(json.dumps(meta, indent=2), flush=True)
+finally:
+    if env is not None:
+        env.close()
+    simulation_app.close()
+"""
+
+
 def _is_isaac_lab_workbench(name: str, wb_cfg: dict) -> bool:
     """True when the workbench is an Isaac Lab VM."""
     wtype = wb_cfg.get("workbench_type")
@@ -2332,6 +2534,61 @@ def status_cmd(
             console.print(f"[red]stderr:[/red]\n{err.strip()[-500:]}")
 
 
+@app.command("list-tasks")
+def list_tasks_cmd(
+    contains: str = typer.Option(
+        "", "--contains", help="Case-insensitive substring filter, e.g. 'franka'."
+    ),
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.text, "--output-format", help="Output format."
+    ),
+) -> None:
+    """List registered Isaac Lab tasks on the workbench VM.
+
+    Tasks come from the gymnasium registry after importing isaaclab_tasks,
+    which only exists inside the Isaac Lab runtime — so this runs on the VM
+    via SSH, like `status` and `train`.
+    """
+    cfg = _get_ssh_config()
+    ssh = SSHClient(cfg.ssh)
+    prefix = _container_prefix() if _is_container_runtime(cfg) else _activate_prefix()
+    python_bin = "/isaac-sim/python.sh" if _is_container_runtime(cfg) else "python"
+    cmd = _runtime_bash(
+        cfg,
+        prefix + f"{python_bin} - <<'PY'\n{_build_list_tasks_script()}PY\n",
+    )
+    try:
+        exit_code, stdout, stderr = ssh.run(cmd)
+    except SSHError as exc:
+        _fail(f"SSH error: {exc}")
+        return
+
+    payload: dict = {}
+    for line in stdout.splitlines():
+        if line.startswith("ISAAC_LAB_LIST_TASKS_JSON "):
+            try:
+                payload = json.loads(line.split(" ", 1)[1])
+            except json.JSONDecodeError:
+                payload = {}
+    if exit_code != 0 or not payload:
+        _fail(
+            "Failed to list Isaac Lab tasks on the VM"
+            + (f": {stderr.strip()[-300:]}" if stderr else "")
+        )
+        return
+
+    tasks = [str(item) for item in payload.get("tasks", [])]
+    if contains:
+        needle = contains.lower()
+        tasks = [item for item in tasks if needle in item.lower()]
+    if output_format == OutputFormat.json:
+        typer.echo(json.dumps({"tasks": tasks, "count": len(tasks)}, indent=2))
+    else:
+        for item in tasks:
+            typer.echo(item)
+        typer.echo(f"({len(tasks)} tasks)")
+
+
 @app.command("system-info")
 def system_info_cmd(
     output_format: OutputFormat = typer.Option(
@@ -2419,6 +2676,17 @@ def train_cmd(
     submit_only: bool = typer.Option(False, "--submit-only", help="Submit serverless Job and return before polling."),
     poll_interval: float = typer.Option(30.0, "--poll-interval", help="Seconds between serverless status checks."),
     timeout: float = typer.Option(3600.0, "--timeout", help="Seconds to wait for serverless completion."),
+    export_trajectories: bool = typer.Option(
+        False,
+        "--export-trajectories/--no-export-trajectories",
+        help="After training, roll out the trained checkpoint and export numpy episodes (VM runtime only).",
+    ),
+    export_episodes: int = typer.Option(
+        3, "--export-episodes", help="Episodes to export when --export-trajectories is set."
+    ),
+    export_steps_per_episode: int = typer.Option(
+        50, "--export-steps-per-episode", help="Max steps per exported episode."
+    ),
     output_format: OutputFormat = typer.Option(
         OutputFormat.text, "--output-format", help="Output format."
     ),
@@ -2443,8 +2711,12 @@ def train_cmd(
         _fail(f"--num-envs must be positive, got {num_envs}")
     if steps <= 0:
         _fail(f"--steps must be positive, got {steps}")
+    if export_trajectories and (export_episodes <= 0 or export_steps_per_episode <= 0):
+        _fail("--export-episodes and --export-steps-per-episode must be positive")
     checkpoint_output_path = resolve_checkpoint_s3_uri(training_config, output_path)
     if _is_serverless_runtime(runtime):
+        if export_trajectories:
+            _fail("--export-trajectories is only supported on the VM runtime, not serverless")
         _isaac_lab_serverless_train(
             task=task,
             num_envs=num_envs,
@@ -2528,6 +2800,33 @@ def train_cmd(
     if exit_code != 0:
         result["stderr"] = stderr.strip()[-500:] if stderr else ""
     else:
+        if export_trajectories:
+            trajectories_dir = f"{remote_output_dir}/trajectories"
+            traj_cmd = _runtime_bash(
+                cfg,
+                prefix
+                + f"{python_bin} - <<'PY'\n"
+                + _build_train_trajectory_export_script(
+                    task,
+                    export_episodes,
+                    export_steps_per_episode,
+                    f"{remote_output_dir}/npa_isaac_lab_checkpoint.pt",
+                    trajectories_dir,
+                )
+                + "PY\n",
+            )
+            if stream_logs:
+                console.print("[bold]Exporting trained-policy trajectories[/bold]")
+            try:
+                traj_exit, traj_stdout, traj_stderr = ssh.run(traj_cmd, stream=stream_logs)
+            except SSHError as exc:
+                traj_exit, traj_stdout, traj_stderr = 1, "", str(exc)
+            result["trajectories_dir"] = trajectories_dir
+            result["trajectory_export"] = "success" if traj_exit == 0 else "failed"
+            if traj_exit != 0:
+                # The checkpoint is still good; report the export failure
+                # without failing the training run.
+                result["trajectory_export_error"] = (traj_stderr or traj_stdout).strip()[-500:]
         if output_is_s3:
             try:
                 try:

--- a/npa/src/npa/cli/isaac_lab/__init__.py
+++ b/npa/src/npa/cli/isaac_lab/__init__.py
@@ -1182,6 +1182,18 @@ try:
                 return policy(obs)
         return torch.as_tensor(env.action_space.sample(), device=device, dtype=torch.float32)
 
+    def _step_env(env, actions):
+        # Gymnasium envs return 5 values; the rsl_rl VecEnv wrapper installed
+        # when a trained policy loads returns 4: (obs, rewards, dones, extras).
+        out = env.step(actions)
+        if len(out) == 5:
+            s_obs, s_rew, terminated, truncated, s_info = out
+            s_done = bool(torch.as_tensor(terminated).any().item()) or bool(torch.as_tensor(truncated).any().item())
+        else:
+            s_obs, s_rew, dones, s_info = out
+            s_done = bool(torch.as_tensor(dones).any().item())
+        return s_obs, s_rew, s_done, s_info
+
     def _goal_dist():
         try:
             u = env.unwrapped
@@ -1201,13 +1213,12 @@ try:
         min_dist = None
         for step in range(max_steps_per_episode):
             actions = _act(obs)
-            obs, rewards, terminated, truncated, _ = env.step(actions)
+            obs, rewards, done, _ = _step_env(env, actions)
             episode_reward += float(torch.as_tensor(rewards).mean().item())
             steps_ran = step + 1
             d = _goal_dist()
             if d is not None:
                 min_dist = d if min_dist is None else min(min_dist, d)
-            done = bool(torch.as_tensor(terminated).any().item()) or bool(torch.as_tensor(truncated).any().item())
             if done:
                 break
 
@@ -1554,6 +1565,18 @@ try:
                 return policy(obs)
         return torch.as_tensor(env.action_space.sample(), device=device, dtype=torch.float32)
 
+    def _step_env(env, actions):
+        # Gymnasium envs return 5 values; the rsl_rl VecEnv wrapper installed
+        # when a trained policy loads returns 4: (obs, rewards, dones, extras).
+        out = env.step(actions)
+        if len(out) == 5:
+            s_obs, s_rew, terminated, truncated, s_info = out
+            s_done = bool(torch.as_tensor(terminated).any().item()) or bool(torch.as_tensor(truncated).any().item())
+        else:
+            s_obs, s_rew, dones, s_info = out
+            s_done = bool(torch.as_tensor(dones).any().item())
+        return s_obs, s_rew, s_done, s_info
+
     robot = _robot(env)
     joint_names = list(getattr(getattr(robot, "data", None), "joint_names", []) or [])
 
@@ -1580,8 +1603,7 @@ try:
             states.append(np.asarray(state_values, dtype=np.float32))
             actions_out.append(np.asarray(action_values, dtype=np.float32))
 
-            obs, _rewards, terminated, truncated, _info = env.step(actions)
-            done = bool(torch.as_tensor(terminated).any().item()) or bool(torch.as_tensor(truncated).any().item())
+            obs, _rewards, done, _info = _step_env(env, actions)
             if done:
                 break
 
@@ -2822,8 +2844,15 @@ def train_cmd(
             except SSHError as exc:
                 traj_exit, traj_stdout, traj_stderr = 1, "", str(exc)
             result["trajectories_dir"] = trajectories_dir
-            result["trajectory_export"] = "success" if traj_exit == 0 else "failed"
-            if traj_exit != 0:
+            # Isaac Sim's kit app can exit 0 even when the Python rollout raised
+            # (the same reason the training path checks ISAAC_LAB_TRAIN_COMPLETE
+            # above), so a clean exit code alone is not proof the export ran.
+            # Require the completion marker the script prints right before it
+            # writes meta.json, otherwise an empty trajectories dir would be
+            # reported as success.
+            traj_ok = traj_exit == 0 and "ISAAC_LAB_TRAJ_EXPORT_COMPLETE" in (traj_stdout or "")
+            result["trajectory_export"] = "success" if traj_ok else "failed"
+            if not traj_ok:
                 # The checkpoint is still good; report the export failure
                 # without failing the training run.
                 result["trajectory_export_error"] = (traj_stderr or traj_stdout).strip()[-500:]

--- a/npa/src/npa/cli/workbench/lerobot.py
+++ b/npa/src/npa/cli/workbench/lerobot.py
@@ -1,6 +1,7 @@
 """npa workbench lerobot — LeRobot training, evaluation, serving, and inference."""
 
 from __future__ import annotations
+import logging
 
 import json
 import os
@@ -1588,7 +1589,7 @@ def train(
             if "uploaded" in up_out:
                 result["storage_uri"] = f"s3://{bucket_name}/{s3_dest_prefix}/"
         except Exception:
-            pass  # non-fatal; checkpoint is still on the VM
+            logging.getLogger(__name__).debug("suppressed exception", exc_info=True)  # non-fatal; checkpoint is still on the VM
 
     _output(result, output)
     if exit_code != 0:
@@ -1656,7 +1657,7 @@ def eval_cmd(
             ssh.run_or_raise(_runtime_exec_cmd(cfg, resolve_cmd))
             resolved_checkpoint = local_cache
         except Exception:
-            pass  # try using the URI directly
+            logging.getLogger(__name__).debug("suppressed exception", exc_info=True)  # try using the URI directly
 
     output_is_s3 = _is_s3_uri(output_path)
     eval_output_dir = (

--- a/npa/src/npa/cli/workbench/sim2real.py
+++ b/npa/src/npa/cli/workbench/sim2real.py
@@ -26,7 +26,6 @@ from npa.workflows.sim2real_loop import (
     run_full_loop,
     run_inner_loop,
 )
-from npa.workflows.sim2real_loop import build_config_from_env
 from npa.workflows.sim2real_rerun_regen import (
     Sim2RealRerunRegenError,
     default_regen_local_dir,
@@ -296,6 +295,72 @@ def run_command(
         typer.echo(text)
     else:
         typer.echo(text)
+
+
+@app.command("materialize")
+def materialize_command(
+    runbook: Optional[Path] = typer.Argument(
+        None,
+        help="SkyPilot runbook to render (default: the committed sim2real runbook).",
+    ),
+    run_id: str = typer.Option("", "--run-id", help="Run id; also sets NPA_SIM2REAL_RUN_ID."),
+    image: str = typer.Option(
+        "", "--image", help="Registry-qualified trainer image (required while the runbook ships a placeholder)."
+    ),
+    env: list[str] = typer.Option(
+        [], "--env", help="KEY=VALUE override for a runbook env (repeatable)."
+    ),
+    namespace: str = typer.Option("", "--namespace", help="Kubernetes namespace override."),
+    skip_setup: bool = typer.Option(
+        False, "--skip-setup", help="Omit the runbook setup block (image already carries npa)."
+    ),
+    output: Optional[Path] = typer.Option(
+        None, "--output", "-o", help="Write the Job manifest YAML here instead of stdout."
+    ),
+) -> None:
+    """Render the sim2real runbook to a Kubernetes Job (no SkyPilot, no operator pack).
+
+    This is the in-repo GPU-reaching path while raw `sky jobs launch` is blocked
+    by the SkyPilot 0.12.2 pre-setup getcwd() bug: materialize, then
+    `kubectl apply -f <manifest>` and follow with `npa workbench sim2real status`.
+    """
+
+    from npa.workflows.sim2real.materialize import (
+        Sim2RealMaterializeError,
+        materialize_k8s_job,
+    )
+
+    overrides: dict[str, str] = {}
+    for item in env:
+        key, separator, value = item.partition("=")
+        if not separator or not key:
+            raise typer.BadParameter(f"--env expects KEY=VALUE, got {item!r}")
+        overrides[key] = value
+
+    try:
+        job = materialize_k8s_job(
+            runbook,
+            run_id=run_id,
+            image=image,
+            env_overrides=overrides,
+            namespace=namespace,
+            include_setup=not skip_setup,
+        )
+    except (Sim2RealMaterializeError, FileNotFoundError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    if output is not None:
+        output.write_text(job.to_yaml(), encoding="utf-8")
+        typer.echo(f"wrote {output}")
+        typer.echo(
+            f"apply with: kubectl apply -f {output} "
+            f"(job {job.job_name} in namespace {job.namespace}, image {job.image})"
+        )
+    else:
+        typer.echo(job.to_yaml())
+    for warning in job.warnings:
+        typer.echo(f"note: {warning}", err=True)
 
 
 @app.command("status")

--- a/npa/src/npa/clients/config.py
+++ b/npa/src/npa/clients/config.py
@@ -243,7 +243,17 @@ def _resolve_project_section(
                 )
             return proj
         default_name = yml.get("default_project", "default")
-        return projects.get(default_name, {})
+        if default_name in projects:
+            return projects[default_name]
+        if len(projects) == 1:
+            return next(iter(projects.values()))
+        # No usable default and several candidates: guessing here sends
+        # commands at a stale or arbitrary endpoint, so ask for the alias.
+        raise ConfigError(
+            "No project selected and no default_project configured. "
+            f"Pass -p/--project (available: {', '.join(projects.keys())}) "
+            "or set default_project in ~/.npa/config.yaml."
+        )
 
     # ── Legacy compat: flat workbenches → synthetic project ──────────
     workbenches = yml.get("workbenches")
@@ -282,12 +292,18 @@ def _resolve_workbench_in_project(
             )
         return wb
 
-    # Fall back to default_workbench, then first entry.
+    # Fall back to default_workbench, then a sole unambiguous entry.
     default_name = (yml or {}).get("default_workbench", "default")
     if default_name in workbenches:
         return workbenches[default_name]
-    if workbenches:
+    if len(workbenches) == 1:
         return next(iter(workbenches.values()))
+    if workbenches:
+        raise ConfigError(
+            "No workbench selected and no default_workbench configured. "
+            f"Pass -n/--name (available: {', '.join(workbenches.keys())}) "
+            "or set default_workbench in ~/.npa/config.yaml."
+        )
     return {}
 
 

--- a/npa/src/npa/deploy/images.py
+++ b/npa/src/npa/deploy/images.py
@@ -197,7 +197,7 @@ def container_image_for_tool(
     return f"{resolved_registry.rstrip('/')}/{image_name}:{resolved_tag}"
 
 
-def _primary_registry() -> str:
+def primary_container_registry() -> str:
     """Resolve the primary registry: NPA_REGISTRY, then NPA_REGISTRY_ID, then default."""
     explicit = os.environ.get("NPA_REGISTRY", "").strip()
     if explicit:
@@ -206,6 +206,9 @@ def _primary_registry() -> str:
     if registry_id:
         return f"cr.eu-north1.nebius.cloud/{registry_id}"
     return DEFAULT_CONTAINER_REGISTRY
+
+
+_primary_registry = primary_container_registry
 
 
 def backup_container_registry() -> str:

--- a/npa/src/npa/fiftyone_lerobot.py
+++ b/npa/src/npa/fiftyone_lerobot.py
@@ -6,6 +6,7 @@ the CLI and executed inside the FiftyOne virtualenv.
 """
 
 from __future__ import annotations
+import logging
 
 import json
 import os
@@ -601,7 +602,7 @@ def _resolve_video_path(
         if candidate.exists():
             return candidate
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
 
     feature_dir = root / "videos" / video_key
     media = _sorted_media(feature_dir, VIDEO_EXTENSIONS)

--- a/npa/src/npa/genesis/env_pick_place.py
+++ b/npa/src/npa/genesis/env_pick_place.py
@@ -12,6 +12,7 @@ Based on: examples/manipulation/grasp_env.py, examples/locomotion/go2_env.py
 """
 
 from __future__ import annotations
+import logging
 
 from dataclasses import dataclass
 from typing import Any
@@ -503,7 +504,7 @@ class FrankaPickPlaceEnv:
             try:
                 kwargs["material"] = gs.materials.Rigid(friction=float(obj.friction))
             except Exception:  # noqa: BLE001 - material is best-effort physics
-                pass
+                logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
         entity = self._scene.add_entity(morph, **kwargs)
         obj.loaded = True
         return entity

--- a/npa/src/npa/genesis/env_pick_place.py
+++ b/npa/src/npa/genesis/env_pick_place.py
@@ -34,7 +34,6 @@ from npa.genesis.scene_assets import (
     PRIMITIVE_CYLINDER,
     PRIMITIVE_SPHERE,
     ROLE_MANIPULAND,
-    CameraSpec,
     ObjectSpec,
     SceneSpec,
     SceneSpecError,

--- a/npa/src/npa/genesis/eval_student.py
+++ b/npa/src/npa/genesis/eval_student.py
@@ -426,6 +426,6 @@ def _classify_failure(env, env_idx: int, step: int) -> str:
         if np.any(np.abs(joint_pos[:7]) > 2.8):
             return "collision"
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
 
     return "timeout"

--- a/npa/src/npa/orchestration/npa_workflow/scheduler.py
+++ b/npa/src/npa/orchestration/npa_workflow/scheduler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any
 
 from npa.orchestration.npa_workflow.interpreter import PlanStep
 from npa.orchestration.npa_workflow.spec import NpaWorkflowSpec

--- a/npa/src/npa/orchestration/skypilot/workflow_state.py
+++ b/npa/src/npa/orchestration/skypilot/workflow_state.py
@@ -13,14 +13,14 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 from urllib.parse import urlparse
 
-UTC = timezone.utc
-
 import boto3
 import yaml
 from botocore.config import Config as BotoConfig
 
 from npa.clients.config import resolve_project_storage
 from npa.clients.credentials import load_credentials, storage_endpoint_url
+
+UTC = timezone.utc
 
 
 DEFAULT_WORKFLOW_MOUNT_PATH = "/mnt/npa-workflow-state"

--- a/npa/src/npa/smoke/test_fiftyone_functional.py
+++ b/npa/src/npa/smoke/test_fiftyone_functional.py
@@ -8,6 +8,7 @@ Run with:
 """
 
 from __future__ import annotations
+import logging
 
 import atexit
 import base64
@@ -194,12 +195,12 @@ def _cleanup(state: SmokeState) -> None:
         try:
             state.session.close()
         except Exception:
-            pass
+            logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
     if state.dataset is not None:
         try:
             state.dataset.delete()
         except Exception:
-            pass
+            logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
     shutil.rmtree(state.root, ignore_errors=True)
 
 

--- a/npa/src/npa/workbench/sonic/__init__.py
+++ b/npa/src/npa/workbench/sonic/__init__.py
@@ -861,7 +861,7 @@ def _jsonable(value: Any) -> Any:
 
 from npa.workbench.sonic.eval import evaluate_onnx_policy  # noqa: E402
 from npa.workbench.sonic.routing import (  # noqa: E402
-    SonicRoutingError,
+    SonicRoutingError as SonicRoutingError,
     classify_gpu_target,
     is_datacenter_headless_target,
     is_rt_core_target,

--- a/npa/src/npa/workflows/rerun_serve.py
+++ b/npa/src/npa/workflows/rerun_serve.py
@@ -1,6 +1,7 @@
 """Deploy a hosted Rerun web viewer for workflow recordings on Kubernetes."""
 
 from __future__ import annotations
+import logging
 
 import base64
 import json
@@ -1144,7 +1145,7 @@ def resolve_rerun_serve_credentials() -> tuple[str, str]:
         access_key = access_key or (creds.s3_access_key_id or "").strip()
         secret_key = secret_key or (creds.s3_secret_access_key or "").strip()
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
     if not access_key or not secret_key:
         raise RerunServeError(
             "S3 credentials are required for auto rerun serve. Configure ~/.npa/credentials.yaml "

--- a/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
@@ -26,7 +26,6 @@ import json
 import os
 import subprocess
 import sys
-import time
 from pathlib import Path
 from typing import Any
 

--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -35,7 +35,6 @@ import hashlib
 import json
 import os
 import random
-import re
 import shlex
 import subprocess
 import sys
@@ -64,14 +63,12 @@ from npa.workbench.cosmos.reason import (
 from npa.workflows.sim2real.config import artifact_uris, byo_seams
 from npa.workflows.sim2real.constants import (
     CORRECTIVE_TARGETS,
-    DEFAULT_COSMOS_REASON_CACHE,
     DEFAULT_ISAAC_TASK,
     DEFAULT_REFERENCE_VLM_MODEL,
     DEFAULT_SIM_BACKEND,
     DEFAULT_THRESHOLD,
     DEFAULT_VLM_SEAM_EVIDENCE,
     ERROR_SEVERITY,
-    REFERENCE_VLM_ALIASES,
     SCHEMA_E2E_REPORT,
     SCHEMA_HELDOUT_REPORT,
     SCHEMA_RL_SIGNAL,
@@ -1359,13 +1356,6 @@ def run_cosmos2_transfer_component(
 
     if not config.s3_bucket:
         raise Sim2RealLoopError("s3_bucket is required for Cosmos Transfer sibling jobs")
-    attempt_id = _component_attempt_id(config, "cosmos2_transfer", "preamble")
-    manifest_uri = _component_output_uri(
-        config,
-        component="cosmos2_transfer",
-        attempt_id=attempt_id,
-        filename="transfer.json",
-    )
     frames_uri = _normalized_s3_prefix(f"{output_uri.rstrip('/')}/frames/")
     augment_prefix = output_uri.rstrip("/") + "/"
     result_uri = f"{augment_prefix}cosmos2-transfer-result.json"
@@ -1472,9 +1462,6 @@ def run_policy_rollout_component(
             iteration=iteration,
             train_envs_uri=train_envs_uri,
         )
-    attempt_id = _component_attempt_id(
-        config, "policy_actions", f"outer-{outer_iteration:02d}-iter-{iteration:02d}"
-    )
     output_uri = _normalized_s3_prefix(
         f"{_artifact_root_uri(config)}/actions/train/"
         f"outer-{outer_iteration:02d}/iter-{iteration:02d}/"
@@ -2660,7 +2647,6 @@ def _apply_reference_adapter_heldout_gate(
     base = _inner_loop_progress_score(inner_evidence)
     for index, (item, env) in enumerate(zip(per_env, envs, strict=False)):
         cal_score = _reference_adapter_env_score(base, env, index)
-        cal_success = cal_score >= threshold
         sim_success = bool(item.get("success"))
         sim_score = float(item.get("score", 0.0))
         details = dict(item.get("details") or {})

--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -30,6 +30,7 @@ Phase boundaries:
 """
 
 from __future__ import annotations
+import logging
 
 import hashlib
 import json
@@ -4899,7 +4900,7 @@ def _close_isaac_app() -> None:
         try:
             app.close()
         except Exception:  # noqa: BLE001
-            pass
+            logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
 
 
 def _policy_adapter_from_inner_evidence(inner_evidence: dict[str, Any]) -> dict[str, Any]:

--- a/npa/src/npa/workflows/sim2real/k8s_submit.py
+++ b/npa/src/npa/workflows/sim2real/k8s_submit.py
@@ -12,7 +12,6 @@ from npa.workflows.sim2real.constants import DEFAULT_PREFIX
 from npa.workflows.sim2real.monitor import (
     load_operator_config,
     normalize_staged_run_id,
-    orchestrator_job_name,
     parse_submit_job,
     parse_submit_run_id,
 )

--- a/npa/src/npa/workflows/sim2real/materialize.py
+++ b/npa/src/npa/workflows/sim2real/materialize.py
@@ -1,0 +1,217 @@
+"""Render the sim2real SkyPilot runbook into a plain Kubernetes Job manifest.
+
+Raw ``sky jobs launch`` against the runbook is blocked by the SkyPilot 0.12.2
+pre-setup ``getcwd()`` bug, and the previous direct-Kubernetes route required a
+private operator pack. This module closes that gap in-repo: it reads the
+committed runbook (a single SkyPilot task document), applies operator
+overrides, and emits a Job manifest that ``kubectl apply -f`` can run on any
+cluster with GPUs — no SkyPilot controller and no operator pack required.
+
+The runbook stays the single source of truth: envs, resources, and the
+setup/run scripts are taken from the YAML, never duplicated here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class Sim2RealMaterializeError(RuntimeError):
+    """Raised when the runbook cannot be rendered into a runnable Job."""
+
+
+_PLACEHOLDER_IMAGE_MARKERS = ("example.invalid", "<your-registry-id>")
+_DNS1123_SANITIZE = re.compile(r"[^a-z0-9-]+")
+
+
+@dataclass(frozen=True)
+class MaterializedJob:
+    manifest: dict[str, Any]
+    job_name: str
+    namespace: str
+    image: str
+    warnings: list[str] = field(default_factory=list)
+
+    def to_yaml(self) -> str:
+        return yaml.safe_dump(self.manifest, sort_keys=False, default_flow_style=False)
+
+
+def default_runbook_path() -> Path:
+    """Locate the committed runbook relative to this source tree."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "npa" / "workflows" / "workbench" / "sim2real" / "runbook.yaml"
+        if candidate.is_file():
+            return candidate
+        candidate = parent / "workflows" / "workbench" / "sim2real" / "runbook.yaml"
+        if candidate.is_file():
+            return candidate
+    raise Sim2RealMaterializeError(
+        "could not locate the committed sim2real runbook; pass an explicit path"
+    )
+
+
+def load_runbook_task(path: Path) -> dict[str, Any]:
+    """Load the SkyPilot task document (name/resources/envs/setup/run) from the runbook."""
+    documents = [doc for doc in yaml.safe_load_all(path.read_text(encoding="utf-8")) if doc]
+    tasks = [doc for doc in documents if isinstance(doc, dict) and "run" in doc]
+    if not tasks:
+        raise Sim2RealMaterializeError(f"no SkyPilot task document with a run block in {path}")
+    if len(tasks) > 1:
+        raise Sim2RealMaterializeError(
+            f"{path} contains {len(tasks)} task documents; the materializer supports exactly one"
+        )
+    return tasks[0]
+
+
+def _job_name(run_id: str, task_name: str) -> str:
+    base = run_id or task_name or "sim2real"
+    slug = _DNS1123_SANITIZE.sub("-", base.lower()).strip("-") or "sim2real"
+    name = slug if slug.startswith("sim2real") else f"sim2real-{slug}"
+    return name[:63].rstrip("-")
+
+
+def _gpu_count(accelerators: Any) -> int:
+    if not accelerators:
+        return 0
+    text = str(accelerators)
+    if ":" in text:
+        try:
+            return int(text.rsplit(":", 1)[1])
+        except ValueError as exc:
+            raise Sim2RealMaterializeError(f"unparseable accelerators value: {text!r}") from exc
+    return 1
+
+
+def _numeric_prefix(value: Any) -> str:
+    match = re.match(r"\d+", str(value or ""))
+    return match.group(0) if match else ""
+
+
+def _split_csv(value: str) -> list[str]:
+    return [item.strip() for item in str(value or "").split(",") if item.strip()]
+
+
+def materialize_k8s_job(
+    runbook_path: Path | None = None,
+    *,
+    run_id: str = "",
+    image: str = "",
+    env_overrides: dict[str, str] | None = None,
+    namespace: str = "",
+    include_setup: bool = True,
+) -> MaterializedJob:
+    """Render the runbook into a Kubernetes Job manifest dict.
+
+    ``env_overrides`` wins over the runbook's materialized literals, mirroring
+    the ``--env KEY=VALUE`` contract of ``sky jobs launch``. The runbook ships
+    a placeholder ``image_id``, so ``image`` (or an override of the relevant
+    env) is required unless the runbook was edited to a concrete registry.
+    """
+    path = runbook_path or default_runbook_path()
+    task = load_runbook_task(path)
+    resources = task.get("resources") or {}
+    warnings: list[str] = []
+
+    envs: dict[str, str] = {
+        str(key): str(value) for key, value in (task.get("envs") or {}).items()
+    }
+    for key, value in (env_overrides or {}).items():
+        envs[str(key)] = str(value)
+    if run_id:
+        envs["NPA_SIM2REAL_RUN_ID"] = run_id
+
+    unresolved = sorted(key for key, value in envs.items() if "${" in value)
+    if unresolved:
+        raise Sim2RealMaterializeError(
+            "runbook envs contain unexpanded ${VAR} references (SkyPilot does not "
+            f"interpolate them and neither does Kubernetes): {', '.join(unresolved)}"
+        )
+
+    resolved_image = image.strip()
+    if not resolved_image:
+        image_id = str(resources.get("image_id") or "")
+        resolved_image = image_id.removeprefix("docker:").strip()
+    if not resolved_image or any(marker in resolved_image for marker in _PLACEHOLDER_IMAGE_MARKERS):
+        raise Sim2RealMaterializeError(
+            "the runbook ships a placeholder image; pass a registry-qualified trainer "
+            f"image (got {resolved_image!r}). Example: --image cr.<region>.nebius.cloud/"
+            "<your-registry-id>/npa-lerobot-vlm-rl:<tag>"
+        )
+
+    scripts = []
+    if include_setup and task.get("setup"):
+        scripts.append(str(task["setup"]))
+    scripts.append(str(task["run"]))
+    command_script = "\n".join(scripts)
+
+    gpu_resource = envs.get("NPA_SIM2REAL_K8S_GPU_RESOURCE", "nvidia.com/gpu")
+    gpu_count = _gpu_count(resources.get("accelerators"))
+    limits: dict[str, Any] = {}
+    if gpu_count:
+        limits[gpu_resource] = gpu_count
+    cpu = _numeric_prefix(resources.get("cpus"))
+    if cpu:
+        limits["cpu"] = cpu
+    memory = _numeric_prefix(resources.get("memory"))
+    if memory:
+        limits["memory"] = f"{memory}Gi"
+
+    container: dict[str, Any] = {
+        "name": "sim2real",
+        "image": resolved_image,
+        "command": ["/bin/bash", "-c", command_script],
+        "env": [{"name": key, "value": value} for key, value in sorted(envs.items())],
+    }
+    if limits:
+        container["resources"] = {"limits": limits}
+    secret_names = _split_csv(envs.get("NPA_SIM2REAL_K8S_ENV_SECRET_NAMES", ""))
+    if secret_names:
+        container["envFrom"] = [{"secretRef": {"name": name}} for name in secret_names]
+        warnings.append(
+            "the Job references secrets "
+            f"({', '.join(secret_names)}); create them in the namespace before applying"
+        )
+
+    pod_spec: dict[str, Any] = {"restartPolicy": "Never", "containers": [container]}
+    service_account = envs.get("NPA_SIM2REAL_K8S_SERVICE_ACCOUNT", "").strip()
+    if service_account:
+        pod_spec["serviceAccountName"] = service_account
+    pull_secrets = _split_csv(envs.get("NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS", ""))
+    if pull_secrets:
+        pod_spec["imagePullSecrets"] = [{"name": name} for name in pull_secrets]
+    gpu_product = envs.get("NPA_SIM2REAL_K8S_GPU_PRODUCT", "").strip()
+    if gpu_count and gpu_product:
+        pod_spec["nodeSelector"] = {"nvidia.com/gpu.product": gpu_product}
+
+    job_spec: dict[str, Any] = {"backoffLimit": 0, "template": {"spec": pod_spec}}
+    timeout = _numeric_prefix(envs.get("NPA_SIM2REAL_K8S_JOB_TIMEOUT_S"))
+    if timeout:
+        job_spec["activeDeadlineSeconds"] = int(timeout)
+
+    resolved_namespace = (
+        namespace.strip() or envs.get("NPA_SIM2REAL_K8S_NAMESPACE", "").strip() or "default"
+    )
+    job_name = _job_name(run_id, str(task.get("name") or ""))
+    manifest = {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {
+            "name": job_name,
+            "namespace": resolved_namespace,
+            "labels": {"app.kubernetes.io/part-of": "npa-sim2real"},
+        },
+        "spec": job_spec,
+    }
+    return MaterializedJob(
+        manifest=manifest,
+        job_name=job_name,
+        namespace=resolved_namespace,
+        image=resolved_image,
+        warnings=warnings,
+    )

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -7,7 +7,6 @@ import hashlib
 import json
 import os
 import random
-import re
 import shlex
 import subprocess
 import sys
@@ -1828,13 +1827,6 @@ def run_cosmos2_transfer_component(
 
     if not config.s3_bucket:
         raise Sim2RealLoopError("s3_bucket is required for Cosmos Transfer sibling jobs")
-    attempt_id = _component_attempt_id(config, "cosmos2_transfer", "preamble")
-    manifest_uri = _component_output_uri(
-        config,
-        component="cosmos2_transfer",
-        attempt_id=attempt_id,
-        filename="transfer.json",
-    )
     frames_uri = _normalized_s3_prefix(f"{output_uri.rstrip('/')}/frames/")
     env = {
         "NPA_SIM2REAL_INPUT_URI": input_uri,
@@ -1886,9 +1878,6 @@ def run_policy_rollout_component(
             iteration=iteration,
             train_envs_uri=train_envs_uri,
         )
-    attempt_id = _component_attempt_id(
-        config, "policy_actions", f"outer-{outer_iteration:02d}-iter-{iteration:02d}"
-    )
     output_uri = _normalized_s3_prefix(
         f"{_artifact_root_uri(config)}/actions/train/"
         f"outer-{outer_iteration:02d}/iter-{iteration:02d}/"
@@ -2871,7 +2860,6 @@ def _apply_reference_adapter_heldout_gate(
     base = _inner_loop_progress_score(inner_evidence)
     for index, (item, env) in enumerate(zip(per_env, envs, strict=False)):
         cal_score = _reference_adapter_env_score(base, env, index)
-        cal_success = cal_score >= threshold
         sim_success = bool(item.get("success"))
         sim_score = float(item.get("score", 0.0))
         details = dict(item.get("details") or {})

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -1,6 +1,7 @@
 """Concrete Sim2Real VLM-to-RL loop and end-to-end runbook runtime."""
 
 from __future__ import annotations
+import logging
 
 import argparse
 import hashlib
@@ -4645,7 +4646,7 @@ def _close_isaac_app() -> None:
         try:
             app.close()
         except Exception:  # noqa: BLE001
-            pass
+            logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
 
 
 def _policy_adapter_from_inner_evidence(inner_evidence: dict[str, Any]) -> dict[str, Any]:

--- a/npa/src/npa/workflows/sim2real_viz.py
+++ b/npa/src/npa/workflows/sim2real_viz.py
@@ -14,6 +14,7 @@ but it MUST produce a non-empty ``.rrd`` whenever the SDK is available.
 """
 
 from __future__ import annotations
+import logging
 
 import json
 import math
@@ -800,7 +801,7 @@ def _disconnect(rr: Any, recording: Any) -> None:
         try:
             disconnect(recording=recording)
         except Exception:
-            pass
+            logging.getLogger(__name__).debug("suppressed exception", exc_info=True)
 
 
 def _bump(counts: dict[str, int], entity: str) -> None:

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -1459,7 +1459,6 @@ def test_default_llm_models_are_cost_ordered() -> None:
 def test_deploy_seeds_cost_ordered_ladder_without_explicit_models(monkeypatch, tmp_path) -> None:
     """A bare `npa agent deploy` (no --llm-models) configures the full tier
     ladder on the VM, so routing works without the operator listing models."""
-    from npa.cli import agent as agent_module
     from npa.cli.agent import deploy_cmd
 
     captured: dict[str, object] = {}

--- a/npa/tests/cli/test_isaac_lab_cli.py
+++ b/npa/tests/cli/test_isaac_lab_cli.py
@@ -1414,7 +1414,13 @@ def test_isaac_lab_list_tasks_fails_cleanly_without_registry(mocker) -> None:
 
 def test_isaac_lab_train_export_trajectories_runs_second_remote_script(mocker) -> None:
     ssh = mocker.MagicMock()
-    ssh.run.return_value = (0, "", "")
+    # Training call, then the trajectory-export call. The export must emit its
+    # completion marker for the CLI to treat it as a real success (Isaac Sim's
+    # kit app can exit 0 even when the rollout raised).
+    ssh.run.side_effect = [
+        (0, "", ""),
+        (0, "ISAAC_LAB_TRAJ_EXPORT_COMPLETE\n", ""),
+    ]
     mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
     mocker.patch("npa.cli.isaac_lab.SSHClient", return_value=ssh)
 
@@ -1449,6 +1455,46 @@ def test_isaac_lab_train_export_trajectories_runs_second_remote_script(mocker) -
     payload = json.loads(result.output)
     assert payload["trajectory_export"] == "success"
     assert payload["trajectories_dir"] == "/tmp/isaac-out/trajectories"
+
+
+def test_isaac_lab_train_export_trajectories_marks_masked_failure(mocker) -> None:
+    """A zero exit without the completion marker must not be reported as success.
+
+    Isaac Sim's kit app can exit 0 even when the Python rollout raised (e.g. the
+    env.step tuple mismatch that produced an empty trajectories dir), so the CLI
+    must key success off the ISAAC_LAB_TRAJ_EXPORT_COMPLETE marker, not the exit
+    code alone.
+    """
+    ssh = mocker.MagicMock()
+    ssh.run.side_effect = [
+        (0, "", ""),
+        (0, "ISAAC_LAB_TRAJ_EXPORT_START ...\nISAAC_LAB_TRAJ_EXPORT_POLICY_LOADED\n", ""),
+    ]
+    mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
+    mocker.patch("npa.cli.isaac_lab.SSHClient", return_value=ssh)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "train",
+            "--task",
+            "Isaac-Reach-Franka-v0",
+            "--steps",
+            "5",
+            "--output-dir",
+            "/tmp/isaac-out",
+            "--export-trajectories",
+            "--output-format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["trajectory_export"] == "failed"
+    assert "trajectory_export_error" in payload
 
 
 def test_isaac_lab_train_without_export_flag_runs_single_command(mocker) -> None:

--- a/npa/tests/cli/test_isaac_lab_cli.py
+++ b/npa/tests/cli/test_isaac_lab_cli.py
@@ -1357,3 +1357,138 @@ def test_isaac_lab_export_onnx_rejects_missing_local_checkpoint(tmp_path: Path) 
     )
     assert result.exit_code == 1
     assert "local checkpoint not found" in result.output
+
+
+def test_isaac_lab_list_tasks_parses_remote_registry(mocker) -> None:
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (
+        0,
+        'ISAAC_LAB_LIST_TASKS_JSON {"tasks": ["Isaac-Lift-Cube-Franka-v0", "Isaac-Reach-Franka-v0", "Isaac-Velocity-Flat-G1-v0"], "count": 3}\n',
+        "",
+    )
+    mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
+    mocker.patch("npa.cli.isaac_lab.SSHClient", return_value=ssh)
+
+    result = runner.invoke(app, ["workbench", "isaac-lab", "list-tasks"])
+
+    assert result.exit_code == 0
+    cmd = ssh.run.call_args.args[0]
+    assert "import isaaclab_tasks" in cmd
+    assert "gym.registry" in cmd
+    assert "Isaac-Lift-Cube-Franka-v0" in result.output
+    assert "(3 tasks)" in result.output
+
+
+def test_isaac_lab_list_tasks_contains_filter_and_json(mocker) -> None:
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (
+        0,
+        'ISAAC_LAB_LIST_TASKS_JSON {"tasks": ["Isaac-Lift-Cube-Franka-v0", "Isaac-Velocity-Flat-G1-v0"], "count": 2}\n',
+        "",
+    )
+    mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
+    mocker.patch("npa.cli.isaac_lab.SSHClient", return_value=ssh)
+
+    result = runner.invoke(
+        app,
+        ["workbench", "isaac-lab", "list-tasks", "--contains", "franka", "--output-format", "json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["tasks"] == ["Isaac-Lift-Cube-Franka-v0"]
+    assert payload["count"] == 1
+
+
+def test_isaac_lab_list_tasks_fails_cleanly_without_registry(mocker) -> None:
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (3, "", "ModuleNotFoundError: isaaclab_tasks")
+    mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
+    mocker.patch("npa.cli.isaac_lab.SSHClient", return_value=ssh)
+
+    result = runner.invoke(app, ["workbench", "isaac-lab", "list-tasks"])
+
+    assert result.exit_code != 0
+    assert "Failed to list Isaac Lab tasks" in result.output
+
+
+def test_isaac_lab_train_export_trajectories_runs_second_remote_script(mocker) -> None:
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (0, "", "")
+    mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
+    mocker.patch("npa.cli.isaac_lab.SSHClient", return_value=ssh)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "train",
+            "--task",
+            "Isaac-Reach-Franka-v0",
+            "--steps",
+            "5",
+            "--output-dir",
+            "/tmp/isaac-out",
+            "--export-trajectories",
+            "--export-episodes",
+            "2",
+            "--export-steps-per-episode",
+            "10",
+            "--output-format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ssh.run.call_count == 2
+    traj_cmd = ssh.run.call_args_list[1].args[0]
+    assert "ISAAC_LAB_TRAJ_EXPORT_START" in traj_cmd
+    assert "npa_isaac_lab_checkpoint.pt" in traj_cmd
+    assert "/tmp/isaac-out/trajectories" in traj_cmd
+    payload = json.loads(result.output)
+    assert payload["trajectory_export"] == "success"
+    assert payload["trajectories_dir"] == "/tmp/isaac-out/trajectories"
+
+
+def test_isaac_lab_train_without_export_flag_runs_single_command(mocker) -> None:
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (0, "", "")
+    mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
+    mocker.patch("npa.cli.isaac_lab.SSHClient", return_value=ssh)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "train",
+            "--task",
+            "Isaac-Reach-Franka-v0",
+            "--steps",
+            "5",
+            "--output-dir",
+            "/tmp/isaac-out",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert ssh.run.call_count == 1
+
+
+def test_isaac_lab_train_export_trajectories_rejected_on_serverless(mocker) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "train",
+            "--task",
+            "Isaac-Reach-Franka-v0",
+            "--runtime",
+            "serverless",
+            "--export-trajectories",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "only supported on the VM runtime" in result.output

--- a/npa/tests/conftest.py
+++ b/npa/tests/conftest.py
@@ -78,6 +78,45 @@ def scrub_ambient_credential_env(monkeypatch, request):
         monkeypatch.delenv(env_var, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def isolate_home_config(monkeypatch, tmp_path_factory, request):
+    """Isolate non-live tests from the operator's real ~/.npa, ~/.aws, ~/.ssh.
+
+    A dev machine or workbench VM carries a real ~/.npa/config.yaml and
+    credentials.yaml; the unit suite must behave identically there and on a
+    pristine CI runner, so every non-live test gets an empty HOME. Several
+    modules capture home-derived paths in module-level constants at import
+    time, so those are repointed as well — new home-derived constants belong
+    in this list.
+    """
+    if any(request.node.get_closest_marker(marker) for marker in _LIVE_MARKERS):
+        return
+    home = tmp_path_factory.mktemp("home")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    import npa.cli.cluster.terraform_lifecycle
+    import npa.cli.skypilot
+    import npa.clients.config
+    import npa.clients.credentials
+    import npa.cluster.state
+    import npa.deploy.provisioner
+    import npa.orchestration.skypilot._bin
+
+    npa_dir = home / ".npa"
+    monkeypatch.setattr(npa.clients.config, "CONFIG_PATH", npa_dir / "config.yaml")
+    monkeypatch.setattr(npa.clients.credentials, "CREDENTIALS_PATH", npa_dir / "credentials.yaml")
+    monkeypatch.setattr(npa.orchestration.skypilot._bin, "CONFIG_PATH", npa_dir / "config.yaml")
+    monkeypatch.setattr(npa.deploy.provisioner, "_WORKBENCH_BASE", npa_dir / "workbenches")
+    monkeypatch.setattr(npa.cluster.state, "CLUSTERS_DIR", npa_dir / "clusters")
+    monkeypatch.setattr(npa.cli.skypilot, "DEFAULT_VENV_PATH", npa_dir / "skypilot-venv")
+    monkeypatch.setattr(
+        npa.cli.cluster.terraform_lifecycle,
+        "_DEFAULT_SKYPILOT_BIN",
+        npa_dir / "skypilot-venv" / "bin" / "sky",
+    )
+
+
 def _is_huggingface_url(url: object) -> bool:
     host = urlparse(str(url)).hostname or ""
     return host == "huggingface.co" or host.endswith(".huggingface.co")

--- a/npa/tests/e2e/test_byof_onboarding_live_e2e.py
+++ b/npa/tests/e2e/test_byof_onboarding_live_e2e.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -88,7 +87,6 @@ def _parse_last_json_blob(text: str) -> dict[str, object]:
 def _maybe_refresh_byof_registry_pull_secret(registry: str, e2e_project: str | None) -> None:
     if os.environ.get("NPA_BYOF_SKIP_REGISTRY_REFRESH") == "1":
         return
-    profile = os.environ.get("NPA_NEBIUS_PROFILE", "agent-sa").strip()
     _activate_nebius_profile()
     server = registry.split("/", 1)[0]
     if not server.startswith("cr.") or ".nebius.cloud" not in server:

--- a/npa/tests/e2e/test_npa_workflow_live_e2e.py
+++ b/npa/tests/e2e/test_npa_workflow_live_e2e.py
@@ -14,7 +14,6 @@ from npa.orchestration.npa_workflow import build_plan, load_spec, validate_spec
 from .npa_workflow_live_helpers import (
     ALL_GOLDEN_SPECS,
     DYNAMIC_SPECS,
-    assert_cli_ok,
     assert_no_credential_leakage,
     assume_decision_for,
     live_bucket,

--- a/npa/tests/guardrails/test_hygiene_guards.py
+++ b/npa/tests/guardrails/test_hygiene_guards.py
@@ -122,3 +122,32 @@ def _is_pytest_skip(node: ast.Call) -> bool:
 def _mentions_local_cuda(node: ast.AST, source: str) -> bool:
     segment = ast.get_source_segment(source, node) or ""
     return "cuda.is_available" in segment or "torch.cuda" in segment
+
+
+def test_shipped_examples_use_registry_placeholder_not_first_party_id() -> None:
+    """Shipped BYO examples must not bake in the first-party registry ID.
+
+    Resolver-owned defaults (npa.deploy.images, the image manifests, and ops
+    scripts) may reference the concrete `npa-workbench` registry; committed
+    example YAMLs and cookbooks must use the `<your-registry-id>` placeholder
+    so external users never pull against a registry they cannot access.
+    """
+    from npa.deploy.images import DEFAULT_CONTAINER_REGISTRY_ID
+
+    example_roots = [
+        REPO_ROOT / "npa" / "workflows",
+        REPO_ROOT / "docs" / "workbench" / "cookbooks",
+        REPO_ROOT / "docs" / "demos",
+    ]
+    offenders: list[str] = []
+    for root in example_roots:
+        for path in sorted(root.rglob("*")):
+            if path.suffix not in {".yaml", ".yml", ".md", ".json"}:
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            if DEFAULT_CONTAINER_REGISTRY_ID in text:
+                offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert not offenders, (
+        "Concrete first-party registry ID found in shipped examples; "
+        "use the <your-registry-id> placeholder instead: " + ", ".join(offenders)
+    )

--- a/npa/tests/guardrails/test_hygiene_guards.py
+++ b/npa/tests/guardrails/test_hygiene_guards.py
@@ -151,3 +151,51 @@ def test_shipped_examples_use_registry_placeholder_not_first_party_id() -> None:
         "Concrete first-party registry ID found in shipped examples; "
         "use the <your-registry-id> placeholder instead: " + ", ".join(offenders)
     )
+
+
+def test_monolith_modules_do_not_grow() -> None:
+    """Size ratchet for the largest modules.
+
+    These files are already big enough to resist review; new functionality
+    belongs in new modules, not appended here. If a change legitimately grows
+    one (e.g. mechanical refactor prep), lower other entries or split the file
+    and tighten the cap — never raise a cap to make room for features.
+    """
+    caps = {
+        "npa/src/npa/cli/agent.py": 10_100,
+        "npa/src/npa/workflows/sim2real_loop.py": 5_800,
+        "npa/src/npa/workflows/sim2real/engine.py": 5_600,
+        "npa/src/npa/cli/groot/__init__.py": 4_400,
+        "npa/src/npa/cli/fiftyone/__init__.py": 4_250,
+        "npa/src/npa/cli/cosmos/__init__.py": 4_050,
+        "npa/src/npa/cli/isaac_lab/__init__.py": 3_500,
+    }
+    over = []
+    for rel_path, cap in caps.items():
+        lines = sum(1 for _ in (REPO_ROOT / rel_path).open())
+        if lines > cap:
+            over.append(f"{rel_path}: {lines} lines > cap {cap}")
+    assert not over, "Monolith size ratchet exceeded — split, don't grow:\n" + "\n".join(over)
+
+
+def test_no_silent_except_exception_pass() -> None:
+    """`except Exception: pass` hides real failures; log at debug or narrow it."""
+    offenders = []
+    for path in sorted((REPO_ROOT / "npa" / "src").rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ExceptHandler)
+                and isinstance(node.type, ast.Name)
+                and node.type.id == "Exception"
+                and len(node.body) == 1
+                and isinstance(node.body[0], ast.Pass)
+            ):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+    assert not offenders, (
+        "Silent `except Exception: pass` found; log the exception at debug "
+        "level or narrow the except type:\n" + "\n".join(offenders)
+    )

--- a/npa/tests/smoke/test_agent_chat_smoke.py
+++ b/npa/tests/smoke/test_agent_chat_smoke.py
@@ -4,7 +4,6 @@ import stat
 import subprocess
 from pathlib import Path
 
-import pytest
 
 from npa.cli import agent as agent_module
 from npa.cli.agent_chat import (

--- a/npa/tests/smoke/test_golden_eval_capabilities.py
+++ b/npa/tests/smoke/test_golden_eval_capabilities.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from npa.deploy.images import CONTAINER_IMAGE_NAMES, supported_tool_version
+from npa.deploy.images import CONTAINER_IMAGE_NAMES
 from npa.smoke.capabilities import GOLDEN_EVAL_CAPABILITIES
 from npa.smoke.manifest import load_manifest
 

--- a/npa/tests/test_isaac_lab_lerobot.py
+++ b/npa/tests/test_isaac_lab_lerobot.py
@@ -79,3 +79,55 @@ def test_convert_rejects_state_action_length_mismatch(tmp_path: Path) -> None:
 def test_discover_episodes_rejects_empty_input(tmp_path: Path) -> None:
     with pytest.raises(IsaacLabLeRobotError, match="No episode_"):
         discover_episodes(tmp_path)
+
+
+def test_convert_with_custom_feature_spec(tmp_path):
+    from npa.adapter.isaac_lab_lerobot import LeRobotFeatureSpec
+
+    spec = LeRobotFeatureSpec(
+        state_names=[f"joint_{i}" for i in range(9)],
+        action_names=[f"act_{i}" for i in range(7)],
+        robot_type="franka_panda",
+    )
+    assert spec.state_dim == 9
+    assert spec.action_dim == 7
+
+    input_dir = tmp_path / "raw"
+    episode = input_dir / "episode_000000"
+    episode.mkdir(parents=True)
+    frames = 4
+    np.save(episode / "state.npy", np.zeros((frames, 9), dtype=np.float32))
+    np.save(episode / "actions.npy", np.ones((frames, 7), dtype=np.float32))
+
+    output_dir = tmp_path / "lerobot"
+    convert(input_dir, output_dir, spec=spec)
+
+    info = json.loads((output_dir / "meta" / "info.json").read_text())
+    assert info["robot_type"] == "franka_panda"
+    assert info["features"]["observation.state"]["shape"] == [9]
+    assert info["features"]["action"]["shape"] == [7]
+    assert info["features"]["observation.state"]["names"] == [spec.state_names]
+
+    import pyarrow.parquet as pq
+
+    data = pq.read_table(output_dir / "data" / "chunk-000" / "file-000.parquet")
+    assert data.schema.field("observation.state").type.list_size == 9
+    assert data.schema.field("action").type.list_size == 7
+
+
+def test_convert_with_spec_rejects_mismatched_dims(tmp_path):
+    from npa.adapter.isaac_lab_lerobot import LeRobotFeatureSpec
+
+    spec = LeRobotFeatureSpec(
+        state_names=["a", "b", "c"],
+        action_names=["a", "b", "c"],
+        robot_type="tiny_bot",
+    )
+    input_dir = tmp_path / "raw"
+    episode = input_dir / "episode_000000"
+    episode.mkdir(parents=True)
+    np.save(episode / "state.npy", np.zeros((2, 5), dtype=np.float32))
+    np.save(episode / "actions.npy", np.zeros((2, 5), dtype=np.float32))
+
+    with pytest.raises(IsaacLabLeRobotError, match="tiny_bot"):
+        convert(input_dir, tmp_path / "lerobot", spec=spec)

--- a/npa/tests/unit/test_config_resolution.py
+++ b/npa/tests/unit/test_config_resolution.py
@@ -1,0 +1,35 @@
+"""Unit tests for shared project/workbench config resolution guards."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_ambiguous_project_without_default_errors_with_aliases():
+    from npa.clients.config import ConfigError, _resolve_project_section
+
+    yml = {"projects": {"proj-a": {"workbenches": {}}, "proj-b": {"workbenches": {}}}}
+    with pytest.raises(ConfigError, match="-p/--project"):
+        _resolve_project_section(yml, None)
+
+
+def test_single_project_without_default_resolves_unambiguously():
+    from npa.clients.config import _resolve_project_section
+
+    yml = {"projects": {"only": {"workbenches": {"wb": {"x": 1}}}}}
+    assert _resolve_project_section(yml, None) == {"workbenches": {"wb": {"x": 1}}}
+
+
+def test_ambiguous_workbench_without_default_errors_with_aliases():
+    from npa.clients.config import ConfigError, _resolve_workbench_in_project
+
+    proj = {"workbenches": {"wb-a": {"x": 1}, "wb-b": {"x": 2}}}
+    with pytest.raises(ConfigError, match="-n/--name"):
+        _resolve_workbench_in_project(proj, None, {})
+
+
+def test_single_workbench_without_default_resolves_unambiguously():
+    from npa.clients.config import _resolve_workbench_in_project
+
+    proj = {"workbenches": {"only": {"x": 1}}}
+    assert _resolve_workbench_in_project(proj, None, {}) == {"x": 1}

--- a/npa/tests/unit/test_soperator_cli.py
+++ b/npa/tests/unit/test_soperator_cli.py
@@ -418,7 +418,6 @@ def test_install_monitoring_crds_raises_when_crd_absent(monkeypatch) -> None:
 
 def _write_recipe_locals(tmp_path, essential_body: str):
     """Write a minimal locals_active_checks.tf with an ``essential`` scope."""
-    from pathlib import Path
 
     locals_tf = tmp_path / "modules" / "slurm" / "locals_active_checks.tf"
     locals_tf.parent.mkdir(parents=True, exist_ok=True)

--- a/npa/tests/workbench/test_cosmos_reason.py
+++ b/npa/tests/workbench/test_cosmos_reason.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 
 from npa.workbench.cosmos.reason import (
-    DEFAULT_REASON1_CACHE,
     DEFAULT_REASON2_CACHE,
     DEFAULT_REASON2_MODEL,
     DEFAULT_REASON3_CACHE,

--- a/npa/tests/workflows/test_bdd100k_pipeline.py
+++ b/npa/tests/workflows/test_bdd100k_pipeline.py
@@ -29,10 +29,10 @@ EXPECTED_TASK_ORDER = [
     "bdd100k-eval-distant",
     "bdd100k-fiftyone-app",
 ]
-EXPECTED_YAML_SHA256 = "3659d8e3d6ec8f46c3c0263d5e7c42d2c680e6862fc3207d9e45abcbf95f42c5"
-EXPECTED_LANCEDB_IMAGE = "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3"
+EXPECTED_YAML_SHA256 = "2defa822d68d398f6b25569c6e6faad741786da6fb2f7f2690a8f2bd5fe79e56"
+EXPECTED_LANCEDB_IMAGE = "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3"
 EXPECTED_DETECTION_IMAGE = (
-    "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/"
+    "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/"
     "npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
 )
 SYNTHETIC_BDD100K_LABEL_MAP = {

--- a/npa/tests/workflows/test_byo_isaac_eval.py
+++ b/npa/tests/workflows/test_byo_isaac_eval.py
@@ -89,7 +89,8 @@ def test_dryrun_refuses_without_checkpoint(tmp_path, monkeypatch):
 
 
 def test_read_generated_envs(tmp_path):
-    d = tmp_path / "heldout"; d.mkdir()
+    d = tmp_path / "heldout"
+    d.mkdir()
     (d / "envs.jsonl").write_text(
         '{"env_id":"env-00000","seed":111,"scene":{"simready_asset":"a"}}\n'
         '{"env_id":"env-00001","seed":222}\n', encoding="utf-8")

--- a/npa/tests/workflows/test_sim2real_materialize.py
+++ b/npa/tests/workflows/test_sim2real_materialize.py
@@ -1,0 +1,129 @@
+"""Tests for the in-repo sim2real runbook -> Kubernetes Job materializer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.workflows.sim2real.materialize import (
+    Sim2RealMaterializeError,
+    default_runbook_path,
+    materialize_k8s_job,
+)
+
+RUNBOOK = default_runbook_path()
+IMAGE = "cr.eu-north1.nebius.cloud/test-registry/npa-lerobot-vlm-rl:0.1.1"
+
+
+def _materialize(**kwargs):
+    kwargs.setdefault("image", IMAGE)
+    kwargs.setdefault("run_id", "unit-run")
+    return materialize_k8s_job(RUNBOOK, **kwargs)
+
+
+def test_default_runbook_path_is_the_committed_runbook() -> None:
+    assert RUNBOOK.is_file()
+    assert RUNBOOK.name == "runbook.yaml"
+
+
+def test_placeholder_image_is_rejected_with_actionable_error() -> None:
+    with pytest.raises(Sim2RealMaterializeError, match="placeholder image"):
+        materialize_k8s_job(RUNBOOK, run_id="unit-run")
+
+
+def test_manifest_is_a_runnable_job() -> None:
+    job = _materialize()
+    manifest = job.manifest
+    assert manifest["apiVersion"] == "batch/v1"
+    assert manifest["kind"] == "Job"
+    assert manifest["metadata"]["name"] == "sim2real-unit-run"
+    pod = manifest["spec"]["template"]["spec"]
+    container = pod["containers"][0]
+    assert container["image"] == IMAGE
+    assert container["command"][0] == "/bin/bash"
+    # setup + run travel together so the pod bootstraps npa before the loop.
+    assert "pip install -e ./npa" in container["command"][2]
+    assert "npa.workflows.sim2real run" in container["command"][2]
+    assert pod["restartPolicy"] == "Never"
+    assert manifest["spec"]["backoffLimit"] == 0
+
+
+def test_runbook_resources_map_to_k8s_limits_and_node_selector() -> None:
+    job = _materialize()
+    pod = job.manifest["spec"]["template"]["spec"]
+    limits = pod["containers"][0]["resources"]["limits"]
+    assert limits["nvidia.com/gpu"] == 1
+    assert limits["cpu"] == "16"
+    assert limits["memory"] == "64Gi"
+    assert pod["nodeSelector"]["nvidia.com/gpu.product"]
+    assert pod["serviceAccountName"]
+    assert {entry["name"] for entry in pod["imagePullSecrets"]}
+    assert job.manifest["spec"]["activeDeadlineSeconds"] > 0
+
+
+def test_envs_carry_no_unexpanded_variables_and_overrides_win() -> None:
+    job = _materialize(env_overrides={"NPA_SIM2REAL_BUCKET": "my-real-bucket"})
+    env = {item["name"]: item["value"] for item in job.manifest["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert all("${" not in value for value in env.values())
+    assert env["NPA_SIM2REAL_BUCKET"] == "my-real-bucket"
+    assert env["NPA_SIM2REAL_RUN_ID"] == "unit-run"
+    secret_sources = {
+        ref["secretRef"]["name"]
+        for ref in job.manifest["spec"]["template"]["spec"]["containers"][0]["envFrom"]
+    }
+    assert secret_sources
+
+
+def test_skip_setup_omits_bootstrap() -> None:
+    job = _materialize(include_setup=False)
+    script = job.manifest["spec"]["template"]["spec"]["containers"][0]["command"][2]
+    assert "pip install -e ./npa" not in script
+    assert "npa.workflows.sim2real run" in script
+
+
+def test_job_name_is_dns1123_sanitized_and_bounded() -> None:
+    job = _materialize(run_id="My_Run/With Bad*Chars-" + "x" * 80)
+    name = job.manifest["metadata"]["name"]
+    assert len(name) <= 63
+    assert name.startswith("sim2real-my-run-with-bad-chars")
+
+
+def test_cli_materialize_writes_applyable_manifest(tmp_path: Path) -> None:
+    out = tmp_path / "job.yaml"
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "sim2real",
+            "materialize",
+            "--run-id",
+            "cli-run",
+            "--image",
+            IMAGE,
+            "--env",
+            "NPA_SIM2REAL_BUCKET=my-real-bucket",
+            "--namespace",
+            "robots",
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    manifest = yaml.safe_load(out.read_text())
+    assert manifest["kind"] == "Job"
+    assert manifest["metadata"]["namespace"] == "robots"
+    assert "kubectl apply -f" in result.output
+
+
+def test_cli_materialize_rejects_malformed_env() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["workbench", "sim2real", "materialize", "--image", IMAGE, "--env", "NOVALUE"],
+    )
+    assert result.exit_code != 0

--- a/npa/tests/workflows/test_sim2real_monitor.py
+++ b/npa/tests/workflows/test_sim2real_monitor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/npa/tests/workflows/test_sim2real_rerun_regen.py
+++ b/npa/tests/workflows/test_sim2real_rerun_regen.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 

--- a/npa/tests/workflows/test_sim2real_rerun_serve.py
+++ b/npa/tests/workflows/test_sim2real_rerun_serve.py
@@ -10,7 +10,6 @@ from npa.workflows.rerun_serve import (
     DEFAULT_NGINX_IMAGE,
     DEFAULT_PORT,
     DEFAULT_RERUN_IMAGE,
-    DEFAULT_S3_PREFIX,
     RERUN_INTERNAL_WEB_PORT,
     RERUN_STATIC_CACHE_CONTROL,
     Sim2RealRerunServeError,
@@ -33,7 +32,6 @@ from npa.workflows.rerun_serve import (
     should_auto_rerun_serve,
     validate_run_id,
     validate_staged_run_id,
-    verify_rrd_exists_on_s3,
 )
 
 

--- a/npa/tests/workflows/test_sim2real_resume.py
+++ b/npa/tests/workflows/test_sim2real_resume.py
@@ -8,7 +8,6 @@ command's environment, and the runner state that carries it across iterations.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import npa.workflows.sim2real.engine as engine
 from npa.workflows.sim2real.models import Sim2RealLoopConfig

--- a/npa/tests/workflows/test_sonic_locomotion_finetuning.py
+++ b/npa/tests/workflows/test_sonic_locomotion_finetuning.py
@@ -6,8 +6,8 @@ import yaml
 
 
 ROOT = Path(__file__).resolve().parents[3]
-EXPECTED_WORKBENCH_IMAGE = "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-genesis:0.4.6"
-EXPECTED_RETARGETING_IMAGE = "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-retargeting:0.1.1"
+EXPECTED_WORKBENCH_IMAGE = "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-genesis:0.4.6"
+EXPECTED_RETARGETING_IMAGE = "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-retargeting:0.1.1"
 PIPELINE_YAML = (
     ROOT
     / "npa"

--- a/npa/tests/workflows/test_vlm_eval_workflow.py
+++ b/npa/tests/workflows/test_vlm_eval_workflow.py
@@ -8,7 +8,7 @@ from npa.workbench.vlm_eval import DEFAULT_MODEL
 
 
 ROOT = Path(__file__).resolve().parents[3]
-EXPECTED_VLM_IMAGE = "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-cosmos:1.0.9"
+EXPECTED_VLM_IMAGE = "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
 VLM_EVAL_YAML = ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "vlm-eval.yaml"
 VLM_EVAL_BENCHMARK_YAML = (
     ROOT / "npa" / "workflows" / "workbench" / "skypilot" / "vlm-eval-benchmark.yaml"

--- a/npa/workflows/workbench/sim2real/README.md
+++ b/npa/workflows/workbench/sim2real/README.md
@@ -13,6 +13,14 @@ Steps 12 and 13 are documented external seams. Stage 2 materializes stock or BYO
 scene and robot specs. Every step writes local artifacts and, when
 `--upload-artifacts` is set, uploads the run tree to S3.
 
+> **Naming: `sim2real` vs `sim-to-real`.** Two related surfaces exist and the
+> spelling is the disambiguator. **`sim2real`** (this directory,
+> `npa workbench sim2real …`, `runbook.yaml`) is the canonical staged
+> VLM-to-RL loop described above. **`sim-to-real`** (hyphenated:
+> `skypilot/sim-to-real-loop.yaml`, `skypilot/sim-to-real-pipeline.yaml`, the
+> H100 quickstart cookbook) is the older standalone training pipeline. If you
+> are unsure which you want, start here — this is the maintained loop.
+
 Canonical operator routing after CLI namespace cleanup: use
 `npa workbench workflow submit npa/workflows/workbench/sim2real/runbook.yaml`
 for cluster execution (auto-routes to the direct K8s staged Job when SkyPilot is
@@ -255,9 +263,18 @@ YAML
 
 # Reaching GPUs: raw `sky jobs launch` against this YAML is currently blocked by
 # the SkyPilot 0.12.2 pre-setup getcwd() bug. Until that is fixed upstream, reach
-# GPUs through the materialized-runbook / direct-Kubernetes route: render the
-# run-block command (literal endpoint, bucket, and images already in place) into
-# a Kubernetes Job that uses the agent-sa pull path and the hf-ngc-tokens secret.
+# GPUs through the in-repo materializer — it renders this runbook (envs, GPU
+# resources, service account, pull/env secrets, setup+run script) into a plain
+# Kubernetes Job that needs no SkyPilot controller and no operator pack:
+#
+#   npa workbench sim2real materialize \
+#     --run-id my-run \
+#     --image cr.<region>.nebius.cloud/<your-registry-id>/npa-lerobot-vlm-rl:0.1.1 \
+#     --env NPA_SIM2REAL_BUCKET=<bucket> \
+#     --env AWS_ENDPOINT_URL=<your-s3-compatible-endpoint> \
+#     -o /tmp/sim2real-job.yaml
+#   kubectl apply -f /tmp/sim2real-job.yaml
+#   npa workbench sim2real status --run-id my-run --watch
 sky jobs launch \
   --config /tmp/sim2real-skypilot-k8s.yaml \
   --infra k8s/<cluster-name> \

--- a/npa/workflows/workbench/sim2real/runbook.yaml
+++ b/npa/workflows/workbench/sim2real/runbook.yaml
@@ -67,9 +67,10 @@
 # edit `image_id` to point at their own registry.
 #
 # GPU-reaching path: raw `sky jobs launch` against this file is currently blocked
-# by the SkyPilot 0.12.2 pre-setup getcwd() bug. Reach GPUs through the
-# materialized-runbook / direct-Kubernetes route documented in README.md until
-# that is fixed upstream.
+# by the SkyPilot 0.12.2 pre-setup getcwd() bug. Reach GPUs with the in-repo
+# materializer until that is fixed upstream:
+#   npa workbench sim2real materialize --run-id <id> --image <trainer-image> \
+#     --env NPA_SIM2REAL_BUCKET=<bucket> -o job.yaml && kubectl apply -f job.yaml
 #
 # For Kubernetes clusters that require a service account, pass a SkyPilot config:
 #

--- a/npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml
+++ b/npa/workflows/workbench/skypilot/bdd100k-pipeline.yaml
@@ -19,7 +19,7 @@ resources:
   cpus: 4
   memory: 16
   # Pinned first-party LanceDB image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
@@ -99,7 +99,7 @@ resources:
   cpus: 4
   memory: 16
   # Pinned first-party LanceDB image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
@@ -172,7 +172,7 @@ resources:
   cpus: 8
   memory: 32
   # Pinned first-party LanceDB image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
@@ -243,7 +243,7 @@ resources:
   cpus: 4
   memory: 16
   # Pinned first-party LanceDB image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
@@ -323,7 +323,7 @@ resources:
   cpus: 16
   memory: 64
   # Pinned first-party detection-training image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
@@ -447,7 +447,7 @@ resources:
   cpus: 16
   memory: 64
   # Pinned first-party detection-training image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
@@ -571,7 +571,7 @@ resources:
   cpus: 16
   memory: 64
   # Pinned first-party detection-training image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
@@ -695,7 +695,7 @@ resources:
   cpus: 8
   memory: 32
   # Pinned first-party detection-training image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
@@ -794,7 +794,7 @@ resources:
   cpus: 8
   memory: 32
   # Pinned first-party detection-training image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name
@@ -893,7 +893,7 @@ resources:
   cpus: 8
   memory: 32
   # Pinned first-party detection-training image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-detection-training:bdd100k-golden-eval-smoke-20260614T210000Z"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"  # set NPA_S3_BUCKET=your-bucket-name

--- a/npa/workflows/workbench/skypilot/mjlab-eval.yaml
+++ b/npa/workflows/workbench/skypilot/mjlab-eval.yaml
@@ -12,7 +12,7 @@ resources:
   # image that installs the npa CLI and this repository's Workbench package.
   image_id: "docker:${NPA_WORKBENCH_IMAGE}"
 envs:
-  NPA_WORKBENCH_IMAGE: "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-genesis:0.4.6"
+  NPA_WORKBENCH_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-genesis:0.4.6"
   EVAL_INPUT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/"
   SONIC_CHECKPOINT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/training/checkpoint_smoke.json"
   MJLAB_OUTPUT_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/mjlab/"

--- a/npa/workflows/workbench/skypilot/retargeting.yaml
+++ b/npa/workflows/workbench/skypilot/retargeting.yaml
@@ -11,7 +11,7 @@ resources:
   # image with npa plus upstream SONIC data_process scripts.
   image_id: "docker:${NPA_RETARGETING_IMAGE}"
 envs:
-  NPA_RETARGETING_IMAGE: "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-retargeting:0.1.1"
+  NPA_RETARGETING_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-retargeting:0.1.1"
   NPA_RETARGETING_UPSTREAM_REF: "a9d20b2ac0949244d94461a1a3263f38c5027c4a"
   INPUT_MOTION_URI: "s3://<your-bucket-name>/motions/source/"
   RETARGETED_MOTION_URI: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/"

--- a/npa/workflows/workbench/skypilot/sim-to-real-loop.yaml
+++ b/npa/workflows/workbench/skypilot/sim-to-real-loop.yaml
@@ -21,7 +21,7 @@ resources:
   # when you need pinned serving dependencies.
   image_id: "docker:${NPA_VLM_IMAGE}"
 envs:
-  NPA_VLM_IMAGE: "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-cosmos:1.0.9"
+  NPA_VLM_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
   # Rollout set. Use an S3 prefix or a local path in the image; child
   # directories are treated as independent rollouts.
   ROLLOUTS: "s3://<your-bucket-name>/sim-to-real/<run-id>/rollouts/"

--- a/npa/workflows/workbench/skypilot/sonic-eval.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-eval.yaml
@@ -12,7 +12,7 @@ resources:
   # image that installs the npa CLI and this repository's Workbench package.
   image_id: "docker:${NPA_WORKBENCH_IMAGE}"
 envs:
-  NPA_WORKBENCH_IMAGE: "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-genesis:0.4.6"
+  NPA_WORKBENCH_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-genesis:0.4.6"
   NPA_PIPELINE_RUN_ID: "<run-id>"
   SONIC_ONNX: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/export/sonic_policy.onnx"
   SONIC_METADATA: "s3://<your-bucket-name>/sonic-locomotion/<run-id>/export/sonic_policy.metadata.json"

--- a/npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml
+++ b/npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml
@@ -14,7 +14,7 @@ resources:
   # image with npa plus upstream SONIC data_process scripts.
   image_id: "docker:${NPA_RETARGETING_IMAGE}"
 envs:
-  NPA_RETARGETING_IMAGE: "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-retargeting:0.1.1"
+  NPA_RETARGETING_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-retargeting:0.1.1"
   NPA_RETARGETING_UPSTREAM_REF: "a9d20b2ac0949244d94461a1a3263f38c5027c4a"
   NPA_PIPELINE_RUN_ID: "<run-id>"
   INPUT_MOTION_URI: "s3://<your-bucket-name>/motions/source/"

--- a/npa/workflows/workbench/skypilot/vlm-eval-benchmark.yaml
+++ b/npa/workflows/workbench/skypilot/vlm-eval-benchmark.yaml
@@ -13,7 +13,7 @@ resources:
   # when you need pinned serving dependencies.
   image_id: "docker:${NPA_VLM_IMAGE}"
 envs:
-  NPA_VLM_IMAGE: "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-cosmos:1.0.9"
+  NPA_VLM_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
   VLM_BENCHMARK_DATASET_URI: "s3://<your-bucket-name>/vlm-eval/benchmark/benchmark.json"
   VLM_EVAL_BENCHMARK_OUTPUT_URI: "s3://<your-bucket-name>/vlm-eval/benchmark/results/"
   VLM_BACKEND: "self-hosted"

--- a/npa/workflows/workbench/skypilot/vlm-eval.yaml
+++ b/npa/workflows/workbench/skypilot/vlm-eval.yaml
@@ -18,7 +18,7 @@ resources:
   # when you need pinned serving dependencies.
   image_id: "docker:${NPA_VLM_IMAGE}"
 envs:
-  NPA_VLM_IMAGE: "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-cosmos:1.0.9"
+  NPA_VLM_IMAGE: "cr.eu-north1.nebius.cloud/<your-registry-id>/npa-cosmos:1.0.9"
   EVAL_INPUT_URI: "s3://<your-bucket-name>/sim-to-real/<run-id>/rollouts/"
   VLM_EVAL_OUTPUT_URI: "s3://<your-bucket-name>/sim-to-real/<run-id>/vlm-eval/"
   VLM_EVAL_TASK: "sim-to-real"

--- a/scripts/check-source-drift.sh
+++ b/scripts/check-source-drift.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
+# Fails when the test run left uncommitted modifications under npa/src/ —
+# tests must not mutate checked-in source.
 set -euo pipefail
 
 changed="$(git diff --name-only -- npa/src/ || true)"
 if [[ -n "${changed}" ]]; then
-  echo "Warning: uncommitted source changes under npa/src/:" >&2
+  echo "Error: test run modified checked-in source under npa/src/:" >&2
   echo "${changed}" >&2
+  git diff --stat -- npa/src/ >&2
+  exit 1
 fi
-


### PR DESCRIPTION
Hardens the repo against the top external-adoption blockers, validated by the full unit suite (2,876 passed), a clean-venv install matrix, and live validation on the dev VM.

- Shipped examples no longer leak internal infra: SkyPilot YAMLs/cookbooks use the <your-registry-id> placeholder; agent registry default single-sourced through npa.deploy.images; guardrail test prevents regression.
- Lightweight base install: heavy deps split into npa[data|lancedb|viz|full]; over-narrow pins relaxed; previously undeclared direct deps (pydantic, click) declared — the click gap was caught by live validation on the VM (typer ≥ 0.27 dropped its click dependency).
- Release story: npa.__version__, tag-driven Release workflow (build + wheel smoke-install + GitHub Release artifacts), [docs/releasing.md](https://github.com/nebius/nebius-physical-ai/blob/claude/repo-hardening-priorities-s3gd0y/docs/releasing.md).
- CI: blocking ruff gate (+ config; tree made clean), advisory mypy, Python 3.10/3.12/3.14 matrix, --cov-fail-under=60 (current 66%), source-drift check now fails on drift, honest GPU-e2e preflight instead of a no-op.
- GPU path: npa workbench sim2real materialize renders the runbook to a plain K8s Job (no operator pack); sim2real vs sim-to-real naming documented; FTUE deferred gaps closed.
- FIXME burn-down: LeRobot writer parameterized via LeRobotFeatureSpec (G1 default preserved); isaac-lab list-tasks; opt-in train --export-trajectories (trained-policy rollout, numpy episode contract); omitted -p/-n now errors with available aliases instead of hitting a stale endpoint.
- Monolith risk: silent except Exception: pass sites log at debug; size-ratchet + silent-except guardrail tests.
- Test hermeticity (found by live validation): non-live unit tests get an isolated HOME so a machine with a real ~/.npa behaves like a pristine CI runner.
🤖 Generated with [Claude Code](https://claude.com/claude-code)