### PR TITLE
Fix FTUE cold-start gaps: configure silent-exit, generic preflight, Route C prereqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ a versioned heading when a release is cut.
 
 ## Unreleased
 
+### First-time-user cold-start fixes
+
+- `npa configure --interactive` no longer exits 0 having written nothing. When it
+  cannot proceed (no authenticated Nebius CLI profile for provisioning) or is
+  cancelled mid-flow (EOF/Ctrl-C), it now exits **non-zero** with actionable
+  guidance. **Behavior change:** wrappers/CI that treated a cancelled or aborted
+  `npa configure` as success will now see a failure. Setup guidance and the
+  interactive prompts also link where to obtain the Hugging Face and NGC keys.
+- Added `npa workbench health preflight`: a PASS/WARN/FAIL/SKIP check over
+  Hugging Face, NVIDIA NGC, Nebius object storage (S3), and Token Factory
+  credentials (`--checks`, `--offline`, `--warn-only`, `--json`). Replaces the
+  deprecated hidden `npa workbench health sim2real` in the README preflight
+  guidance.
+- Added `npa agent preflight` and moved the terraform-binary and SSH-key-pair
+  checks (plus the Token Factory 503 warning) ahead of any cloud IAM side effects
+  in `npa agent deploy`, so Route C prerequisites fail fast instead of mid-run.
+
 ### Repo hardening
 
 - Shipped SkyPilot examples and cookbooks now use the `<your-registry-id>`

--- a/README.md
+++ b/README.md
@@ -205,9 +205,12 @@ teardown/reproduce loop: [skills/workflows/agent-fresh-operate/SKILL.md](skills/
 A short list of things that catch first-time users mid-run. Skim before your
 first GPU submit.
 
-- **Run preflight.** `npa workbench health sim2real` is a single
-  PASS/WARN/FAIL/SKIP check over config, coherence, S3, registry, tokens,
-  and cluster. See [FTUE-AUDIT.md § friction 1](FTUE-AUDIT.md#friction-points-ordered).
+- **Run preflight.** `npa workbench health preflight` is a single
+  PASS/WARN/FAIL/SKIP check over the credentials nearly every job needs —
+  Hugging Face, NVIDIA NGC, Nebius object storage (S3), and Token Factory.
+  Add `--offline` to check presence only (no network), or `--json` for
+  machine-readable output. See
+  [FTUE-AUDIT.md § friction 1](FTUE-AUDIT.md#friction-points-ordered).
 - **GPU routing matters.** Isaac Lab needs an **RT-core** GPU (L40S / RTX
   Pro 6000), not an H100. See [docs/workbench/troubleshooting/known-footguns.md § L40S Capacity](docs/workbench/troubleshooting/known-footguns.md#l40s-capacity-is-on-demand-zero).
 - **Registry pull secrets expire silently.** A `401` on image pull usually
@@ -257,7 +260,8 @@ Workbench is the main product surface. Every tool lives under `npa workbench`
   see [`vlm-eval-single.yaml`](npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml).
 - **`token-factory`** wraps Nebius Token Factory for zero-GPU inference,
   captioning, and reasoning against your own frames.
-- **`health`** runs preflight checks before a Sim2Real submit.
+- **`health preflight`** validates HF / NGC / S3 / Token Factory credentials
+  before a deploy or GPU job.
 - **`sonic export`** converts locomotion checkpoints to ONNX.
 - **`workflow validate-spec` / `plan-spec` / `run-spec` / `submit`** operate on
   customer-facing `npa.workflow/v0.0.1` specs — see
@@ -280,7 +284,7 @@ Workbench is the main product surface. Every tool lives under `npa workbench`
 | World models    | `npa workbench cosmos deploy`, `serve`, `infer`, `train`, `finetune`, `optimize`, `autoscale`, `status`, `system-info`                                                                                                                                                                                   |
 | Zero-GPU LLM    | `npa workbench token-factory caption`, `generate`, `reason`, `verify`, `models`, `workflow`, `status`                                                                                                                                                                                                    |
 | Workflows       | `npa workbench workflow validate-spec`, `plan-spec`, `run-spec`, `submit`; workbench workflows under [`npa-workflows/`](npa/workflows/workbench/npa-workflows/)                                                                                                                                           |
-| Observability   | Tool-level `status`, `list`, and `system-info` commands; `npa workbench workflow status`, `logs`; `npa workbench health sim2real`; `npa rerun host`, `share`, `list-shares`, `revoke`; `npa cluster status`, `list`                                                                                       |
+| Observability   | Tool-level `status`, `list`, and `system-info` commands; `npa workbench workflow status`, `logs`; `npa workbench health preflight`; `npa rerun host`, `share`, `list-shares`, `revoke`; `npa cluster status`, `list`                                                                                       |
 | Platform utils  | `npa configure` / `init`, `npa provision-if-absent`; `npa agent`, `npa skypilot bootstrap/status/verify`, `npa soperator`, `npa burst`, `npa cluster`, `npa network`, `npa adapter convert`, `npa convert lerobot-to-rrd/-mp4`, `npa viz`, `npa demo`                                                    |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ with the same install.
 | -------------------------------------------------- | ------------ | ---------------------------------------- | -------------------------------------------------------- |
 | **A. [60-second try-it](#a-60-second-try-it)**     | ~60 s        | Python 3.10+                             | A scored VLM benchmark report — no cloud, no GPU, no key |
 | **B. [First workload on Nebius](#b-first-workload-on-nebius)** | ~15 min | Nebius account · `nebius` CLI            | A configured project running managed Workbench tools     |
-| **C. [Self-hosted `npa agent`](#c-self-hosted-npa-agent)** | ~20 min | Nebius account · Terraform · SSH key    | A browser-based chat workbench VM with embedded Rerun    |
+| **C. [Self-hosted `npa agent`](#c-self-hosted-npa-agent)** | ~20 min | Authenticated `nebius` profile · Terraform · SSH key pair · Token Factory key · writable S3 creds | A browser-based chat workbench VM with embedded Rerun    |
 
 All three share the same one-time install:
 
@@ -186,6 +186,10 @@ embedded [Rerun](https://www.rerun.io) viewer for `.rrd` recordings, and
 draft/validate/plan/submit endpoints for `npa.workflow/v0.0.1` specs.
 
 ```bash
+# Check prerequisites first (terraform, SSH key pair, Nebius auth, Token Factory
+# key) — no cloud side effects, so late failures surface before any VM is built:
+npa agent preflight
+
 npa agent fresh-setup \
   --project my-agent --name agent \
   --project-id project-... --tenant-id tenant-... --region eu-north1

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -791,7 +791,9 @@ def _agent_hard_prereq_results(ssh_public_key_path: str) -> list[Any]:
         )
 
     # The deploy flow uses the private key alongside the public key (pub path
-    # minus the .pub suffix) to bootstrap the VM over SSH.
+    # minus the .pub suffix) to bootstrap the VM over SSH. If --ssh-public-key-path
+    # is given without a .pub suffix, this resolves to the same path as the public
+    # key check above, which at worst yields a slightly redundant message.
     priv_str = str(pub_path)[:-4] if str(pub_path).endswith(".pub") else str(pub_path)
     priv_path = Path(priv_str)
     if priv_path.is_file():

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -740,6 +740,141 @@ def _resolve_operator_credentials() -> tuple[str, str]:
     return creds.ai_cloud_api_key, creds.token_factory_api_key
 
 
+def _terraform_binary() -> str:
+    """Return the terraform binary path/name, honoring NPA_TERRAFORM_BIN."""
+    return (os.environ.get("NPA_TERRAFORM_BIN") or shutil.which("terraform") or "").strip()
+
+
+def _agent_hard_prereq_results(ssh_public_key_path: str) -> list[Any]:
+    """Cheap, side-effect-free Route C prerequisites (terraform + SSH keys).
+
+    These are checked before any cloud IAM side effects or Terraform apply so a
+    missing binary or key surfaces up front instead of mid-run (after which a
+    transient SSH failure would auto-roll-back a freshly provisioned VM).
+    """
+    from npa.workflows.sim2real_health import CheckResult, FAIL, PASS
+
+    results: list[Any] = []
+
+    terraform = _terraform_binary()
+    if terraform:
+        results.append(
+            CheckResult(name="terraform", status=PASS, summary=f"terraform found ({terraform}).")
+        )
+    else:
+        results.append(
+            CheckResult(
+                name="terraform",
+                status=FAIL,
+                summary="terraform binary not found on PATH.",
+                remedy="Install it: https://developer.hashicorp.com/terraform/install",
+            )
+        )
+
+    pub_path = Path(ssh_public_key_path).expanduser()
+    if pub_path.is_file():
+        results.append(
+            CheckResult(name="ssh_public_key", status=PASS, summary=f"SSH public key present ({pub_path}).")
+        )
+    else:
+        priv_hint = str(pub_path)[:-4] if str(pub_path).endswith(".pub") else str(pub_path)
+        results.append(
+            CheckResult(
+                name="ssh_public_key",
+                status=FAIL,
+                summary=f"SSH public key not found: {pub_path}",
+                remedy=(
+                    f"Generate a keypair (`ssh-keygen -t ed25519 -f {priv_hint}`) "
+                    "or pass --ssh-public-key-path to an existing key."
+                ),
+            )
+        )
+
+    # The deploy flow uses the private key alongside the public key (pub path
+    # minus the .pub suffix) to bootstrap the VM over SSH.
+    priv_str = str(pub_path)[:-4] if str(pub_path).endswith(".pub") else str(pub_path)
+    priv_path = Path(priv_str)
+    if priv_path.is_file():
+        results.append(
+            CheckResult(name="ssh_private_key", status=PASS, summary=f"SSH private key present ({priv_path}).")
+        )
+    else:
+        results.append(
+            CheckResult(
+                name="ssh_private_key",
+                status=FAIL,
+                summary=f"SSH private key not found: {priv_path}",
+                remedy="The private key next to the public key is required to bootstrap the VM over SSH.",
+            )
+        )
+
+    return results
+
+
+def _agent_token_factory_result() -> Any:
+    """Token Factory key check (WARN): the headline chat feature needs it."""
+    from npa.workflows.sim2real_health import CheckResult, PASS, WARN
+
+    tf_key, _ = _resolve_deploy_llm_credentials()
+    if tf_key:
+        return CheckResult(
+            name="token_factory", status=PASS, summary="Token Factory API key is configured."
+        )
+    return CheckResult(
+        name="token_factory",
+        status=WARN,
+        summary="Token Factory API key not found; agent chat will return 503 until it is set.",
+        remedy=(
+            "Get a key (starts with 'v1.') at https://tokenfactory.nebius.com/ and run "
+            "`npa configure --token-factory-key <key>`, then re-run `npa agent bootstrap`."
+        ),
+    )
+
+
+def _agent_nebius_auth_result() -> Any:
+    """Live Nebius auth check (FAIL): deploy needs an authenticated profile to provision."""
+    from npa.workflows.sim2real_health import CheckResult, FAIL, PASS
+
+    try:
+        from npa.clients.nebius import get_iam_token
+
+        token = get_iam_token()
+    except Exception as exc:  # noqa: BLE001 - any auth/CLI error means "not ready"
+        return CheckResult(
+            name="nebius_profile",
+            status=FAIL,
+            summary="No authenticated Nebius CLI profile.",
+            remedy="Install/authenticate the Nebius CLI and run `npa configure`.",
+            details=(str(exc),),
+        )
+    if token:
+        return CheckResult(
+            name="nebius_profile", status=PASS, summary="Nebius CLI profile is authenticated."
+        )
+    return CheckResult(
+        name="nebius_profile",
+        status=FAIL,
+        summary="Nebius IAM token unavailable.",
+        remedy="Run `npa configure` / `nebius profile create` to authenticate.",
+    )
+
+
+def _render_agent_checks(results: list[Any], *, output_json: bool) -> bool:
+    """Render agent preflight CheckResults; return True when any FAIL is present."""
+    has_fail = any(getattr(r, "status", "") == "FAIL" for r in results)
+    if output_json:
+        payload = {"checks": [r.as_dict() for r in results], "ok": not has_fail}
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return has_fail
+    for result in results:
+        typer.echo(f"[{result.status}] {result.name}: {result.summary}")
+        for detail in getattr(result, "details", ()):  # type: ignore[arg-type]
+            typer.echo(f"        - {detail}")
+        if result.remedy and result.status in {"WARN", "FAIL", "SKIP"}:
+            typer.echo(f"        fix: {result.remedy}")
+    return has_fail
+
+
 def _normalize_llm_models(models: list[str] | tuple[str, ...] | str) -> list[str]:
     """Return an ordered, unique model list from repeated or comma-separated values."""
     if isinstance(models, str):
@@ -6242,6 +6377,33 @@ def _health(
     return response.status_code == 200, response.status_code
 
 
+@app.command("preflight")
+def preflight_cmd(
+    ssh_public_key_path: str = typer.Option(
+        "~/.ssh/id_ed25519.pub",
+        "--ssh-public-key-path",
+        help="SSH public key path Terraform will read (its private key bootstraps the VM).",
+    ),
+    skip_nebius: bool = typer.Option(
+        False, "--skip-nebius", help="Skip the live Nebius authentication check."
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Print the report as JSON."),
+) -> None:
+    """Check Route C prerequisites before `npa agent deploy` / `fresh-setup`.
+
+    Validates terraform, the SSH key pair, Nebius authentication, and the Token
+    Factory key with no cloud side effects, so late failures (which auto-roll-back
+    a freshly provisioned VM) surface up front. Exits non-zero on any FAIL.
+    """
+    results = list(_agent_hard_prereq_results(ssh_public_key_path))
+    if not skip_nebius:
+        results.append(_agent_nebius_auth_result())
+    results.append(_agent_token_factory_result())
+    has_fail = _render_agent_checks(results, output_json=output_json)
+    if has_fail:
+        raise typer.Exit(code=1)
+
+
 @app.command("deploy")
 def deploy_cmd(
     project: str = typer.Option(DEFAULT_PROJECT_ALIAS, "--project", help="NPA project alias to store config under."),
@@ -6286,6 +6448,20 @@ def deploy_cmd(
     env_region = region or (saved_env.region if saved_env else "")
     if not env_project_id or not env_tenant_id or not env_region:
         _fail("--project-id, --tenant-id, and --region are required")
+
+    # Fail fast on cheap, side-effect-free prerequisites BEFORE any cloud IAM
+    # side effects or Terraform apply: a missing terraform binary or SSH key
+    # otherwise surfaces mid-run (as a raw Terraform file() error or a late
+    # provisioner failure) after infrastructure has already been touched. Surface
+    # the Token Factory warning here too, rather than only after the VM exists.
+    prereq_results = _agent_hard_prereq_results(ssh_public_key_path)
+    tf_key_result = _agent_token_factory_result()
+    for result in prereq_results:
+        if result.status == "FAIL":
+            _fail(f"{result.summary} {result.remedy}".strip())
+    if tf_key_result.status == "WARN":
+        typer.echo(f"  Warning: {tf_key_result.summary}", err=True)
+        typer.echo(f"           {tf_key_result.remedy}", err=True)
 
     from npa.clients.nebius import NebiusError, bootstrap_agent_environment, get_iam_token
 
@@ -6399,12 +6575,8 @@ def deploy_cmd(
     extra_llm_models = list(llm_models) if llm_models else list(DEFAULT_LLM_MODELS)
     configured_llm_models = _normalize_llm_models([configured_llm_model, *extra_llm_models])
     nebius_ai_key, _ = _resolve_operator_credentials()
-    if not tf_api_key:
-        typer.echo(
-            "Warning: Token Factory API key not found in credentials; "
-            "agent chat will return 503 until `npa agent bootstrap` with a configured key.",
-            err=True,
-        )
+    # A missing Token Factory key is already surfaced up front (before Terraform)
+    # by the deploy prerequisite check above.
     rollback_record = {
         "instance_id": instance_id,
         "project_id": env_project_id,

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -14,7 +14,10 @@ import tarfile
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from npa.workflows.sim2real_health import CheckResult
 
 import httpx
 import typer
@@ -745,7 +748,7 @@ def _terraform_binary() -> str:
     return (os.environ.get("NPA_TERRAFORM_BIN") or shutil.which("terraform") or "").strip()
 
 
-def _agent_hard_prereq_results(ssh_public_key_path: str) -> list[Any]:
+def _agent_hard_prereq_results(ssh_public_key_path: str) -> list[CheckResult]:
     """Cheap, side-effect-free Route C prerequisites (terraform + SSH keys).
 
     These are checked before any cloud IAM side effects or Terraform apply so a
@@ -813,11 +816,16 @@ def _agent_hard_prereq_results(ssh_public_key_path: str) -> list[Any]:
     return results
 
 
-def _agent_token_factory_result() -> Any:
-    """Token Factory key check (WARN): the headline chat feature needs it."""
+def _agent_token_factory_result(tf_key: str | None = None) -> CheckResult:
+    """Token Factory key check (WARN): the headline chat feature needs it.
+
+    Pass a pre-resolved ``tf_key`` to avoid re-reading credentials when the
+    caller already has them.
+    """
     from npa.workflows.sim2real_health import CheckResult, PASS, WARN
 
-    tf_key, _ = _resolve_deploy_llm_credentials()
+    if tf_key is None:
+        tf_key, _ = _resolve_deploy_llm_credentials()
     if tf_key:
         return CheckResult(
             name="token_factory", status=PASS, summary="Token Factory API key is configured."
@@ -833,7 +841,7 @@ def _agent_token_factory_result() -> Any:
     )
 
 
-def _agent_nebius_auth_result() -> Any:
+def _agent_nebius_auth_result() -> CheckResult:
     """Live Nebius auth check (FAIL): deploy needs an authenticated profile to provision."""
     from npa.workflows.sim2real_health import CheckResult, FAIL, PASS
 
@@ -861,20 +869,16 @@ def _agent_nebius_auth_result() -> Any:
     )
 
 
-def _render_agent_checks(results: list[Any], *, output_json: bool) -> bool:
-    """Render agent preflight CheckResults; return True when any FAIL is present."""
-    has_fail = any(getattr(r, "status", "") == "FAIL" for r in results)
-    if output_json:
-        payload = {"checks": [r.as_dict() for r in results], "ok": not has_fail}
-        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
-        return has_fail
-    for result in results:
-        typer.echo(f"[{result.status}] {result.name}: {result.summary}")
-        for detail in getattr(result, "details", ()):  # type: ignore[arg-type]
-            typer.echo(f"        - {detail}")
-        if result.remedy and result.status in {"WARN", "FAIL", "SKIP"}:
-            typer.echo(f"        fix: {result.remedy}")
-    return has_fail
+def _render_agent_checks(results: list[CheckResult], *, output_json: bool) -> bool:
+    """Render agent preflight CheckResults; return True when any FAIL is present.
+
+    Uses the shared report renderer so agent and workbench-health preflight
+    output stay aligned.
+    """
+    from npa.workflows.sim2real_health import format_check_report, has_failure
+
+    typer.echo(format_check_report(results, output_json=output_json))
+    return has_failure(results)
 
 
 def _normalize_llm_models(models: list[str] | tuple[str, ...] | str) -> list[str]:
@@ -6456,8 +6460,11 @@ def deploy_cmd(
     # otherwise surfaces mid-run (as a raw Terraform file() error or a late
     # provisioner failure) after infrastructure has already been touched. Surface
     # the Token Factory warning here too, rather than only after the VM exists.
+    # Resolve the deploy LLM creds once and thread them through to the VM
+    # bootstrap below.
+    tf_api_key, default_llm_model = _resolve_deploy_llm_credentials()
     prereq_results = _agent_hard_prereq_results(ssh_public_key_path)
-    tf_key_result = _agent_token_factory_result()
+    tf_key_result = _agent_token_factory_result(tf_api_key)
     for result in prereq_results:
         if result.status == "FAIL":
             _fail(f"{result.summary} {result.remedy}".strip())
@@ -6569,7 +6576,7 @@ def deploy_cmd(
         user=DEFAULT_AGENT_USER,
         password=auth_password,
     )
-    tf_api_key, default_llm_model = _resolve_deploy_llm_credentials()
+    # tf_api_key / default_llm_model were resolved once up front (before Terraform).
     configured_llm_model = str(llm_model or "").strip() or default_llm_model
     # With no explicit --llm-models, seed the cost-ordered default ladder so
     # per-turn routing can reach every tier (cheap/standard/reasoning/vision)

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -98,8 +98,8 @@ tokens:
 ngc:
   # NVIDIA NGC API key (for GR00T / Cosmos NVIDIA container + model pulls).
   # Get one at https://org.ngc.nvidia.com/setup/api-key -> "Generate API Key"
-  # (sign in / create a free NGC account first). The key starts with "nvapi_".
-  api_key: nvapi_REPLACE_ME
+  # (sign in / create a free NGC account first). The key starts with "nvapi-".
+  api_key: nvapi-REPLACE_ME
   # org: optional-ngc-org
   # team: optional-ngc-team
 storage:
@@ -497,7 +497,7 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
     typer.echo(
         "\nNVIDIA NGC API key (for GR00T / Cosmos NVIDIA assets): create one at "
         "https://org.ngc.nvidia.com/setup/api-key (sign in or make a free NGC "
-        "account first). The key starts with 'nvapi_'."
+        "account first). The key starts with 'nvapi-'."
     )
     ngc_api_key = ask(
         "NVIDIA NGC API key (NGC_API_KEY)",

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -84,6 +84,10 @@ existing S3 credentials instead, or create ~/.npa/credentials.yaml by hand for
 user-level tokens, object storage, and BYOVM SSH defaults:
 
 tokens:
+  # Hugging Face access token (for model + dataset downloads, incl. gated repos).
+  # Get one at https://huggingface.co/settings/tokens -> "Create new token"
+  # (a "Read" token is enough). For gated models (e.g. Llama, some GR00T assets),
+  # also click "Agree and access repository" on each model page while signed in.
   HF_TOKEN: hf_REPLACE_ME
   # Optional: Nebius AI Cloud API key (for Nebius AI Cloud APIs).
   NEBIUS_AI_CLOUD_KEY: <paste-your-nebius-ai-cloud-api-key>
@@ -92,6 +96,9 @@ tokens:
   # opaque token (it starts with "v1."); it is NOT your Nebius IAM/CLI token.
   NEBIUS_TOKEN_FACTORY_KEY: <paste-your-token-factory-api-key>  # e.g. v1.XXXXXXXX...
 ngc:
+  # NVIDIA NGC API key (for GR00T / Cosmos NVIDIA container + model pulls).
+  # Get one at https://org.ngc.nvidia.com/setup/api-key -> "Generate API Key"
+  # (sign in / create a free NGC account first). The key starts with "nvapi_".
   api_key: nvapi_REPLACE_ME
   # org: optional-ngc-org
   # team: optional-ngc-team
@@ -201,12 +208,18 @@ def _create_nebius_profile(*, runner: Callable[..., object] = subprocess.run) ->
     return getattr(result, "returncode", 1) == 0
 
 
-def _ensure_nebius_profile() -> None:
-    """Detect or interactively create a local Nebius CLI profile."""
+def _ensure_nebius_profile() -> bool:
+    """Detect or interactively create a local Nebius CLI profile.
+
+    Returns ``True`` when a usable, authenticated Nebius CLI profile is available
+    (either already present or created during this call), ``False`` otherwise.
+    Callers use the result to decide whether object-storage auto-provisioning,
+    which needs an authenticated profile, can proceed.
+    """
 
     if _nebius_profile_ready():
         typer.echo("Nebius CLI profile detected (`nebius iam get-access-token` works).")
-        return
+        return True
     if not shutil.which("nebius"):
         typer.echo(
             "Nebius CLI not found. Install the binary from "
@@ -214,7 +227,7 @@ def _ensure_nebius_profile() -> None:
             "`npa configure`; no separate profile CLI steps), then re-run "
             "`npa configure`."
         )
-        return
+        return False
     existing_profiles = _list_nebius_profiles()
     if existing_profiles:
         typer.echo(
@@ -231,14 +244,15 @@ def _ensure_nebius_profile() -> None:
             "Skipped Nebius profile creation. Re-run `npa configure` when ready "
             "to create or refresh a profile."
         )
-        return
+        return False
     if _create_nebius_profile() and _nebius_profile_ready():
         typer.echo("Nebius CLI profile is ready.")
-    else:
-        typer.echo(
-            "Could not verify a Nebius profile. Re-run `npa configure` in a "
-            "terminal to retry profile creation."
-        )
+        return True
+    typer.echo(
+        "Could not verify a Nebius profile. Re-run `npa configure` in a "
+        "terminal to retry profile creation."
+    )
+    return False
 
 
 def _endpoint_for_region(region: str) -> str:
@@ -382,8 +396,24 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
     from npa.deploy.images import DEFAULT_CONTAINER_REGISTRY
 
     typer.echo("Interactive npa setup. Press Enter to skip any optional field.\n")
-    _ensure_nebius_profile()
+    profile_ready = _ensure_nebius_profile()
     typer.echo("")
+
+    # Object-storage auto-provisioning needs an authenticated Nebius CLI profile.
+    # Without one, the flow used to fall through ~10 prompts (including a manual
+    # S3 access-key entry a brand-new user cannot answer) and then abort writing
+    # nothing. Stop up front with an actionable choice instead.
+    if provision and not profile_ready:
+        typer.echo(
+            "Object-storage auto-provisioning needs an authenticated Nebius CLI "
+            "profile, which is not available yet. Choose one of:\n"
+            "  - Install and authenticate the Nebius CLI "
+            "(https://docs.nebius.com/cli/install), then re-run `npa configure`.\n"
+            "  - Re-run `npa configure --no-provision` to enter existing S3 "
+            "credentials manually.\n"
+            "Nothing was written under ~/.npa."
+        )
+        raise typer.Exit(code=1)
 
     def ask(label: str, *, default: str = "", secret: bool = False) -> str:
         return str(
@@ -443,6 +473,12 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
             ),
         }
 
+    typer.echo(
+        "\nHugging Face token: create one at "
+        "https://huggingface.co/settings/tokens (a read token is enough). "
+        "For gated models, also click 'Agree and access repository' on each "
+        "model page while signed in."
+    )
     hf_token = ask(
         "Hugging Face token (HF_TOKEN)",
         default=existing_credentials.hf_token,
@@ -457,6 +493,11 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
         "Nebius Token Factory API key (NEBIUS_TOKEN_FACTORY_KEY, optional)",
         default=existing_credentials.token_factory_api_key,
         secret=True,
+    )
+    typer.echo(
+        "\nNVIDIA NGC API key (for GR00T / Cosmos NVIDIA assets): create one at "
+        "https://org.ngc.nvidia.com/setup/api-key (sign in or make a free NGC "
+        "account first). The key starts with 'nvapi_'."
     )
     ngc_api_key = ask(
         "NVIDIA NGC API key (NGC_API_KEY)",
@@ -539,8 +580,16 @@ def _configure_impl(
     try:
         _run_interactive_configure(provision=provision)
     except (EOFError, typer.Abort):
-        typer.echo("\n")
-        typer.echo(_SETUP_GUIDANCE)
+        # Cancelling mid-flow (Ctrl-C / Ctrl-D / no more input) previously exited
+        # 0 having written nothing under ~/.npa, so the next cloud command failed
+        # mysteriously. Fail loudly instead so the missing setup is obvious.
+        typer.echo("")
+        typer.echo(
+            "Setup was cancelled before anything was written under ~/.npa. "
+            "Re-run `npa configure` in a terminal to finish, or run "
+            "`npa configure --show` for the file layout to create it by hand."
+        )
+        raise typer.Exit(code=1)
 
 
 @app.command(

--- a/npa/src/npa/cli/workbench/health.py
+++ b/npa/src/npa/cli/workbench/health.py
@@ -32,6 +32,7 @@ from npa.workflows.sim2real_health import (
     PASS,
     SKIP,
     WARN,
+    format_check_report,
     has_failure,
     run_preflight,
 )
@@ -85,29 +86,7 @@ def _kube_runner_factory(context: str, kubeconfig: str):
 def _emit_results(results, *, output_json: bool) -> None:
     """Render a list of CheckResult objects as text or JSON."""
 
-    if output_json:
-        payload = {
-            "checks": [result.as_dict() for result in results],
-            "ok": not has_failure(results),
-        }
-        typer.echo(json_module.dumps(payload, indent=2, sort_keys=True))
-        return
-    for result in results:
-        typer.echo(
-            f"[{_STATUS_ICON.get(result.status, result.status)}] "
-            f"{result.name}: {result.summary}"
-        )
-        for detail in result.details:
-            typer.echo(f"        - {detail}")
-        if result.remedy and result.status in {FAIL, WARN, SKIP}:
-            typer.echo(f"        fix: {result.remedy}")
-    counts = {status: 0 for status in (PASS, WARN, FAIL, SKIP)}
-    for result in results:
-        counts[result.status] = counts.get(result.status, 0) + 1
-    typer.echo(
-        f"summary: {counts[PASS]} pass, {counts[WARN]} warn, "
-        f"{counts[FAIL]} fail, {counts[SKIP]} skip"
-    )
+    typer.echo(format_check_report(results, output_json=output_json))
 
 
 def _token_factory_verifier() -> list[str]:

--- a/npa/src/npa/cli/workbench/health.py
+++ b/npa/src/npa/cli/workbench/health.py
@@ -161,7 +161,13 @@ def preflight_command(
     else:
         probes = CredentialProbes(
             hf_validator=validate_hf_access,
-            s3_client_factory=lambda: StorageClient.from_environment(),
+            # Probe with the resolved credentials (endpoint/keys often live in
+            # ~/.npa rather than the process env), not env-only defaults.
+            s3_client_factory=lambda: StorageClient.from_environment(
+                endpoint_url=credentials.s3_endpoint,
+                aws_access_key_id=credentials.s3_access_key_id,
+                aws_secret_access_key=credentials.s3_secret_access_key,
+            ),
             token_factory_verifier=_token_factory_verifier,
         )
 

--- a/npa/src/npa/cli/workbench/health.py
+++ b/npa/src/npa/cli/workbench/health.py
@@ -15,9 +15,15 @@ from typing import Optional
 import typer
 
 from npa.clients.credentials import load_credentials
+from npa.clients.huggingface import validate_hf_access
 from npa.clients.kube import run_kubectl
 from npa.clients.storage import StorageClient
 from npa.guardrails.skypilot import inspect_image_exists
+from npa.workflows.credential_preflight import (
+    CREDENTIAL_CHECKS,
+    CredentialProbes,
+    run_credential_preflight,
+)
 from npa.workflows.sim2real_health import (
     ALL_CHECKS,
     DoctorProbes,
@@ -74,6 +80,96 @@ def _kube_runner_factory(context: str, kubeconfig: str):
         )
 
     return _run
+
+
+def _emit_results(results, *, output_json: bool) -> None:
+    """Render a list of CheckResult objects as text or JSON."""
+
+    if output_json:
+        payload = {
+            "checks": [result.as_dict() for result in results],
+            "ok": not has_failure(results),
+        }
+        typer.echo(json_module.dumps(payload, indent=2, sort_keys=True))
+        return
+    for result in results:
+        typer.echo(
+            f"[{_STATUS_ICON.get(result.status, result.status)}] "
+            f"{result.name}: {result.summary}"
+        )
+        for detail in result.details:
+            typer.echo(f"        - {detail}")
+        if result.remedy and result.status in {FAIL, WARN, SKIP}:
+            typer.echo(f"        fix: {result.remedy}")
+    counts = {status: 0 for status in (PASS, WARN, FAIL, SKIP)}
+    for result in results:
+        counts[result.status] = counts.get(result.status, 0) + 1
+    typer.echo(
+        f"summary: {counts[PASS]} pass, {counts[WARN]} warn, "
+        f"{counts[FAIL]} fail, {counts[SKIP]} skip"
+    )
+
+
+def _token_factory_verifier() -> list[str]:
+    """Live Token Factory auth probe: resolve the key and list models."""
+
+    from npa.clients.token_factory import TokenFactoryClient, resolve_config
+
+    config = resolve_config(require_api_key=True)
+    return TokenFactoryClient(config=config).list_models()
+
+
+@app.command("preflight")
+def preflight_command(
+    checks: str = typer.Option(
+        ",".join(CREDENTIAL_CHECKS),
+        "--checks",
+        help=(
+            "Comma-separated checks to run, or 'all'. "
+            f"Choices: all, {', '.join(CREDENTIAL_CHECKS)}."
+        ),
+    ),
+    offline: bool = typer.Option(
+        False,
+        "--offline",
+        help="Skip live network probes (HF/S3/Token Factory); only check presence.",
+    ),
+    warn_only: bool = typer.Option(
+        False, "--warn-only", help="Exit 0 even when a check fails."
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Print the report as JSON."),
+) -> None:
+    """Validate HF, NGC, S3, and Token Factory credentials before a deploy or GPU job.
+
+    A single PASS/WARN/FAIL/SKIP report over the credentials nearly every
+    workbench tool needs, so cold-start credential gaps surface here instead of
+    mid-run. Exits non-zero on any FAIL unless ``--warn-only`` is passed.
+    """
+
+    selected = [item.strip() for item in checks.split(",") if item.strip()]
+    if "all" in selected:
+        selected = list(CREDENTIAL_CHECKS)
+    unknown = [item for item in selected if item not in CREDENTIAL_CHECKS]
+    if unknown:
+        raise typer.BadParameter(
+            f"unknown check(s): {', '.join(unknown)}. Choices: {', '.join(CREDENTIAL_CHECKS)}."
+        )
+
+    credentials = load_credentials()
+    if offline:
+        probes = CredentialProbes()
+    else:
+        probes = CredentialProbes(
+            hf_validator=validate_hf_access,
+            s3_client_factory=lambda: StorageClient.from_environment(),
+            token_factory_verifier=_token_factory_verifier,
+        )
+
+    results = run_credential_preflight(credentials, probes=probes, checks=selected)
+    _emit_results(results, output_json=output_json)
+
+    if has_failure(results) and not warn_only:
+        raise typer.Exit(code=1)
 
 
 @app.command("sim2real", hidden=True)

--- a/npa/src/npa/deploy/provisioner.py
+++ b/npa/src/npa/deploy/provisioner.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +18,27 @@ class ProvisionerError(Exception):
 
 _BUNDLED_TF_DIR = Path(__file__).parent / "terraform"
 _WORKBENCH_BASE = Path.home() / ".npa" / "workbenches"
+# Shared Terraform plugin cache so every fresh per-deploy work dir reuses
+# already-downloaded providers instead of re-fetching them from
+# registry.terraform.io. This makes `terraform init` faster and resilient to
+# transient registry outages (a warm cache needs no network at all). Overridable
+# via the standard TF_PLUGIN_CACHE_DIR env var.
+_TF_PLUGIN_CACHE_DIR = Path.home() / ".npa" / "terraform-plugin-cache"
+# Substrings that identify a transient `terraform init` failure worth retrying
+# (registry/network hiccups) rather than a real configuration error.
+_TRANSIENT_INIT_MARKERS = (
+    "could not connect to registry",
+    "failed to request discovery document",
+    "timeout exceeded while awaiting headers",
+    "failed to retrieve",
+    "no such host",
+    "connection reset",
+    "connection refused",
+    "temporary failure in name resolution",
+    "i/o timeout",
+    "tls handshake timeout",
+    "eof",
+)
 DEFAULT_VM_BOOT_DISK_SIZE_GB = 100
 DEFAULT_CONTAINER_BOOT_DISK_SIZE_GB = 250
 
@@ -55,6 +78,19 @@ def _require_terraform() -> str:
     return tf
 
 
+def _tf_env() -> dict[str, str]:
+    """Return the subprocess env for terraform with a warm plugin cache."""
+    env = dict(os.environ)
+    if not env.get("TF_PLUGIN_CACHE_DIR"):
+        cache = _TF_PLUGIN_CACHE_DIR
+        try:
+            cache.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return env
+        env["TF_PLUGIN_CACHE_DIR"] = str(cache)
+    return env
+
+
 def _run(
     args: list[str],
     *,
@@ -64,7 +100,7 @@ def _run(
 ) -> subprocess.CompletedProcess[str]:
     tf = _require_terraform()
     cmd = [tf] + args
-    kwargs: dict[str, Any] = {"cwd": str(cwd), "text": True}
+    kwargs: dict[str, Any] = {"cwd": str(cwd), "text": True, "env": _tf_env()}
 
     if capture:
         kwargs["capture_output"] = True
@@ -210,15 +246,29 @@ def cleanup_working_dir(project: str, name: str) -> None:
 # ── Terraform commands ───────────────────────────────────────────────────
 
 
+def _looks_transient_init_failure(message: str) -> bool:
+    lowered = (message or "").lower()
+    return any(marker in lowered for marker in _TRANSIENT_INIT_MARKERS)
+
+
 def init(
     tf_dir: str | Path | None = None,
     backend_config: dict[str, str] | None = None,
+    *,
+    retries: int = 3,
+    backoff_seconds: float = 4.0,
+    sleep: Any = time.sleep,
 ) -> None:
     """Run terraform init.
 
     If *backend_config* is provided, each key/value pair is passed as a
     ``-backend-config`` flag.  Typically only ``access_key`` and
     ``secret_key`` are passed here — the rest is embedded in ``backend.tf``.
+
+    Provider installation from registry.terraform.io can fail transiently
+    (timeouts, DNS blips); those are retried with exponential backoff so a fresh
+    VM is not rolled back over a momentary registry hiccup. Non-transient
+    failures (e.g. a real config error) raise immediately.
     """
     tf_dir = Path(tf_dir) if tf_dir else _BUNDLED_TF_DIR
     args = ["init", "-input=false"]
@@ -226,7 +276,21 @@ def init(
         args.append("-reconfigure")
         for key, value in backend_config.items():
             args.extend(["-backend-config", f"{key}={value}"])
-    _run(args, cwd=tf_dir, capture=True)
+    delay = backoff_seconds
+    for attempt in range(1, max(1, retries) + 1):
+        try:
+            _run(args, cwd=tf_dir, capture=True)
+            return
+        except ProvisionerError as exc:
+            if attempt >= retries or not _looks_transient_init_failure(str(exc)):
+                raise
+            sys.stderr.write(
+                f"  terraform init attempt {attempt}/{retries} hit a transient "
+                f"registry/network error; retrying in {delay:.0f}s...\n"
+            )
+            sys.stderr.flush()
+            sleep(delay)
+            delay *= 2
 
 
 def plan(

--- a/npa/src/npa/workflows/credential_preflight.py
+++ b/npa/src/npa/workflows/credential_preflight.py
@@ -77,10 +77,14 @@ def check_hf(credentials: Any, probes: CredentialProbes) -> CheckResult:
         )
     result = probes.hf_validator(token, HF_PROBE_REPO)
     if getattr(result, "ok", False):
+        # The probe hits a public repo, which confirms presence + connectivity
+        # (and that the token is not outright rejected), but Hugging Face serves
+        # public metadata even for an expired token, so this is not full
+        # validation. Say "reachable", not "accepted".
         return CheckResult(
             name="hf",
             status=PASS,
-            summary="HF_TOKEN is set and accepted by Hugging Face.",
+            summary="HF_TOKEN is set and Hugging Face is reachable.",
         )
     status_code = getattr(result, "status_code", None)
     error = getattr(result, "error", "") or "unknown error"

--- a/npa/src/npa/workflows/credential_preflight.py
+++ b/npa/src/npa/workflows/credential_preflight.py
@@ -117,12 +117,14 @@ def check_ngc(credentials: Any, probes: CredentialProbes) -> CheckResult:
                 "at https://org.ngc.nvidia.com/setup/api-key and run `npa configure`."
             ),
         )
-    if not key.startswith("nvapi_"):
+    # Personal NGC API keys are prefixed 'nvapi-' (older docs sometimes show
+    # 'nvapi_'); accept either separator.
+    if not key.lower().startswith(("nvapi-", "nvapi_")):
         return CheckResult(
             name="ngc",
             status=WARN,
             summary="NGC_API_KEY is set but does not look like an NGC key.",
-            remedy="NGC keys start with 'nvapi_'. Re-check the value in ~/.npa/credentials.yaml.",
+            remedy="NGC keys start with 'nvapi-'. Re-check the value in ~/.npa/credentials.yaml.",
         )
     return CheckResult(name="ngc", status=PASS, summary="NGC_API_KEY is set.")
 

--- a/npa/src/npa/workflows/credential_preflight.py
+++ b/npa/src/npa/workflows/credential_preflight.py
@@ -1,0 +1,267 @@
+"""Generic credential preflight shared across workbench tools and deploys.
+
+Validates the credentials nearly every GPU job or deploy needs — Hugging Face,
+NVIDIA NGC, Nebius object storage (S3), and Nebius Token Factory — as explicit
+PASS/WARN/FAIL/SKIP checks, so a customer hits them as a clear preflight
+instead of a mid-pipeline failure.
+
+Every check is a pure function that takes the resolved credentials plus an
+injectable probe. The CLI wires real probes (Hugging Face HEAD, S3 list, Token
+Factory models); unit tests inject fakes. Nothing here imports GPU-heavy
+packages or touches infrastructure at import time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
+
+from npa.workflows.sim2real_health import (
+    FAIL,
+    PASS,
+    SKIP,
+    WARN,
+    CheckResult,
+    has_failure,
+)
+
+# A tiny, always-public HF repo used only to confirm a token is accepted (or
+# that anonymous access works). It never requires access to a gated repo.
+HF_PROBE_REPO = "hf-internal-testing/tiny-random-gpt2"
+
+# Canonical order a customer should reason about credentials in.
+CREDENTIAL_CHECKS: tuple[str, ...] = ("hf", "ngc", "s3", "token_factory")
+
+
+@dataclass
+class CredentialProbes:
+    """Injectable side-effecting dependencies for credential checks.
+
+    Defaults are ``None`` so the engine stays pure and import-safe. The CLI fills
+    these with real implementations; tests pass fakes. When a probe is ``None``
+    the corresponding live check is downgraded to a "present but unverified"
+    PASS/WARN rather than reaching the network.
+    """
+
+    hf_validator: Callable[[str, str], Any] | None = None
+    s3_client_factory: Callable[[], Any] | None = None
+    token_factory_verifier: Callable[[], list[str]] | None = None
+
+
+def _looks_like_auth_failure(text: str) -> bool:
+    lowered = (text or "").lower()
+    return any(
+        marker in lowered
+        for marker in ("401", "403", "unauthorized", "forbidden", "invalid api key", "authentication")
+    )
+
+
+def check_hf(credentials: Any, probes: CredentialProbes) -> CheckResult:
+    """Check the Hugging Face token is present and (optionally) accepted."""
+
+    token = getattr(credentials, "hf_token", "") or ""
+    if not token:
+        return CheckResult(
+            name="hf",
+            status=WARN,
+            summary="HF_TOKEN is not set.",
+            remedy=(
+                "Create a read token at https://huggingface.co/settings/tokens and "
+                "run `npa configure` (public models still download; gated repos fail)."
+            ),
+        )
+    if probes.hf_validator is None:
+        return CheckResult(
+            name="hf",
+            status=PASS,
+            summary="HF_TOKEN is set (not verified against Hugging Face).",
+        )
+    result = probes.hf_validator(token, HF_PROBE_REPO)
+    if getattr(result, "ok", False):
+        return CheckResult(
+            name="hf",
+            status=PASS,
+            summary="HF_TOKEN is set and accepted by Hugging Face.",
+        )
+    status_code = getattr(result, "status_code", None)
+    error = getattr(result, "error", "") or "unknown error"
+    if status_code in {401, 403}:
+        return CheckResult(
+            name="hf",
+            status=FAIL,
+            summary="HF_TOKEN was rejected by Hugging Face.",
+            remedy="Regenerate the token at https://huggingface.co/settings/tokens.",
+            details=(error,),
+        )
+    # Non-auth failure (e.g. transient network / rate limit): don't hard-fail.
+    return CheckResult(
+        name="hf",
+        status=WARN,
+        summary="HF_TOKEN is set but could not be verified against Hugging Face.",
+        remedy="Retry when the network is available; token presence looks fine.",
+        details=(error,),
+    )
+
+
+def check_ngc(credentials: Any, probes: CredentialProbes) -> CheckResult:
+    """Check the NVIDIA NGC API key is present and well-formed."""
+
+    key = getattr(credentials, "ngc_api_key", "") or ""
+    if not key:
+        return CheckResult(
+            name="ngc",
+            status=WARN,
+            summary="NGC_API_KEY is not set.",
+            remedy=(
+                "Needed for GR00T / Cosmos NVIDIA container + model pulls. Create one "
+                "at https://org.ngc.nvidia.com/setup/api-key and run `npa configure`."
+            ),
+        )
+    if not key.startswith("nvapi_"):
+        return CheckResult(
+            name="ngc",
+            status=WARN,
+            summary="NGC_API_KEY is set but does not look like an NGC key.",
+            remedy="NGC keys start with 'nvapi_'. Re-check the value in ~/.npa/credentials.yaml.",
+        )
+    return CheckResult(name="ngc", status=PASS, summary="NGC_API_KEY is set.")
+
+
+def check_s3(credentials: Any, probes: CredentialProbes) -> CheckResult:
+    """Check Nebius object storage credentials and (optionally) reachability."""
+
+    access = getattr(credentials, "s3_access_key_id", "") or ""
+    secret = getattr(credentials, "s3_secret_access_key", "") or ""
+    endpoint = getattr(credentials, "s3_endpoint", "") or ""
+    bucket = getattr(credentials, "s3_bucket", "") or ""
+
+    if not (access and secret):
+        return CheckResult(
+            name="s3",
+            status=WARN,
+            summary="No S3 access key configured.",
+            remedy=(
+                "Run `npa configure` (auto-provisions a bucket + key) or set "
+                "AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY."
+            ),
+        )
+    if not endpoint:
+        return CheckResult(
+            name="s3",
+            status=WARN,
+            summary="S3 credentials set but no endpoint configured.",
+            remedy="Set AWS_ENDPOINT_URL (e.g. https://storage.eu-north1.nebius.cloud).",
+        )
+    if not bucket:
+        return CheckResult(
+            name="s3",
+            status=WARN,
+            summary="S3 credentials set but no bucket configured.",
+            remedy="Set NEBIUS_S3_BUCKET / storage.bucket to an s3://... URI.",
+        )
+    if probes.s3_client_factory is None:
+        return CheckResult(
+            name="s3",
+            status=PASS,
+            summary="S3 credentials, endpoint, and bucket are set (not probed).",
+        )
+    try:
+        client = probes.s3_client_factory()
+        client.list_checkpoints(bucket)
+    except Exception as exc:  # noqa: BLE001 - surface any reachability/auth error
+        text = str(exc)
+        remedy = (
+            "Check the S3 access key/secret, endpoint region, and bucket name."
+            if _looks_like_auth_failure(text)
+            else "Confirm the endpoint is reachable and the bucket exists."
+        )
+        return CheckResult(
+            name="s3",
+            status=FAIL,
+            summary=f"S3 endpoint/bucket not reachable with these credentials ({bucket}).",
+            remedy=remedy,
+            details=(text,),
+        )
+    return CheckResult(
+        name="s3",
+        status=PASS,
+        summary=f"S3 endpoint reachable and bucket listable ({bucket}).",
+    )
+
+
+def check_token_factory(credentials: Any, probes: CredentialProbes) -> CheckResult:
+    """Check the Nebius Token Factory key is present and (optionally) authenticates."""
+
+    key = getattr(credentials, "token_factory_api_key", "") or ""
+    if not key:
+        return CheckResult(
+            name="token_factory",
+            status=WARN,
+            summary="NEBIUS_TOKEN_FACTORY_KEY is not set.",
+            remedy=(
+                "Required for `npa agent` chat and zero-GPU token-factory tools. Get a "
+                "key (starts with 'v1.') at https://tokenfactory.nebius.com/ and run "
+                "`npa configure --token-factory-key <key>`."
+            ),
+        )
+    if probes.token_factory_verifier is None:
+        return CheckResult(
+            name="token_factory",
+            status=PASS,
+            summary="NEBIUS_TOKEN_FACTORY_KEY is set (not verified).",
+        )
+    try:
+        models = probes.token_factory_verifier()
+    except Exception as exc:  # noqa: BLE001 - surface any auth/connectivity error
+        return CheckResult(
+            name="token_factory",
+            status=FAIL,
+            summary="Token Factory key did not authenticate.",
+            remedy="Confirm the key at https://tokenfactory.nebius.com/ -> API keys.",
+            details=(str(exc),),
+        )
+    return CheckResult(
+        name="token_factory",
+        status=PASS,
+        summary=f"Token Factory authenticated ({len(models)} models available).",
+    )
+
+
+_CHECK_FUNCS: dict[str, Callable[[Any, CredentialProbes], CheckResult]] = {
+    "hf": check_hf,
+    "ngc": check_ngc,
+    "s3": check_s3,
+    "token_factory": check_token_factory,
+}
+
+
+def run_credential_preflight(
+    credentials: Any,
+    *,
+    probes: CredentialProbes | None = None,
+    checks: Iterable[str] | None = None,
+) -> list[CheckResult]:
+    """Run the selected credential checks and return their results in order."""
+
+    active_probes = probes or CredentialProbes()
+    selected = list(checks) if checks is not None else list(CREDENTIAL_CHECKS)
+    unknown = [name for name in selected if name not in _CHECK_FUNCS]
+    if unknown:
+        raise ValueError(
+            f"unknown credential check(s): {', '.join(unknown)}. "
+            f"Choices: {', '.join(CREDENTIAL_CHECKS)}."
+        )
+    return [_CHECK_FUNCS[name](credentials, active_probes) for name in selected]
+
+
+__all__ = [
+    "CREDENTIAL_CHECKS",
+    "CredentialProbes",
+    "HF_PROBE_REPO",
+    "check_hf",
+    "check_ngc",
+    "check_s3",
+    "check_token_factory",
+    "has_failure",
+    "run_credential_preflight",
+]

--- a/npa/src/npa/workflows/credential_preflight.py
+++ b/npa/src/npa/workflows/credential_preflight.py
@@ -19,7 +19,6 @@ from typing import Any, Callable, Iterable
 from npa.workflows.sim2real_health import (
     FAIL,
     PASS,
-    SKIP,
     WARN,
     CheckResult,
     has_failure,

--- a/npa/src/npa/workflows/sim2real_health.py
+++ b/npa/src/npa/workflows/sim2real_health.py
@@ -564,6 +564,44 @@ def has_failure(results: list[CheckResult]) -> bool:
     return any(result.status == FAIL for result in results)
 
 
+_STATUS_ICON = {PASS: "PASS", WARN: "WARN", FAIL: "FAIL", SKIP: "SKIP"}
+
+
+def format_check_report(results: list[CheckResult], *, output_json: bool) -> str:
+    """Render a list of CheckResults as the shared preflight report.
+
+    Single source of truth for how ``npa`` preflight surfaces (workbench health
+    and agent) print their PASS/WARN/FAIL/SKIP output, so they stay aligned.
+    """
+
+    import json
+
+    if output_json:
+        return json.dumps(
+            {"checks": [result.as_dict() for result in results], "ok": not has_failure(results)},
+            indent=2,
+            sort_keys=True,
+        )
+    lines: list[str] = []
+    for result in results:
+        lines.append(
+            f"[{_STATUS_ICON.get(result.status, result.status)}] "
+            f"{result.name}: {result.summary}"
+        )
+        for detail in result.details:
+            lines.append(f"        - {detail}")
+        if result.remedy and result.status in {FAIL, WARN, SKIP}:
+            lines.append(f"        fix: {result.remedy}")
+    counts = {status: 0 for status in (PASS, WARN, FAIL, SKIP)}
+    for result in results:
+        counts[result.status] = counts.get(result.status, 0) + 1
+    lines.append(
+        f"summary: {counts[PASS]} pass, {counts[WARN]} warn, "
+        f"{counts[FAIL]} fail, {counts[SKIP]} skip"
+    )
+    return "\n".join(lines)
+
+
 def _short(text: str, limit: int = 240) -> str:
     collapsed = " ".join(str(text).split())
     if len(collapsed) > limit:
@@ -586,6 +624,7 @@ __all__ = [
     "check_s3",
     "check_tokens",
     "coherence_failures",
+    "format_check_report",
     "has_failure",
     "run_preflight",
 ]

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -1809,6 +1809,100 @@ def test_deploy_fails_fast_on_missing_ssh_key(monkeypatch, tmp_path) -> None:
     assert exc.value.exit_code == 1
 
 
+def test_deploy_fails_fast_on_missing_terraform(monkeypatch, tmp_path) -> None:
+    """Deploy aborts on a missing terraform binary BEFORE any cloud side effects."""
+    from npa.cli import agent as agent_module
+    from npa.cli.agent import deploy_cmd
+
+    (tmp_path / "id_ed25519.pub").write_text("ssh-ed25519 AAAA test\n")
+    (tmp_path / "id_ed25519").write_text("priv\n")
+    monkeypatch.delenv("NPA_TERRAFORM_BIN", raising=False)
+    monkeypatch.setattr(agent_module.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        "npa.cli.agent.resolve_environment",
+        lambda *a, **k: SimpleNamespace(
+            project_id=k.get("project_id"), tenant_id=k.get("tenant_id"), region=k.get("region")
+        ),
+    )
+    monkeypatch.setattr("npa.cli.agent._resolve_deploy_llm_credentials", lambda: ("tf-key", "m"))
+
+    def _must_not_run(*a, **k):
+        raise AssertionError("cloud bootstrap must not run when terraform is missing")
+
+    monkeypatch.setattr("npa.clients.nebius.bootstrap_agent_environment", _must_not_run)
+
+    with pytest.raises(Exit) as exc:
+        deploy_cmd(
+            project="fresh",
+            name="agent",
+            project_id="project-1",
+            tenant_id="tenant-1",
+            region="us-central1",
+            ssh_user="ubuntu",
+            ssh_public_key_path=str(tmp_path / "id_ed25519.pub"),
+            tf_var=[],
+            agent_port=8088,
+            backend_port=8787,
+            rerun_port=9090,
+            llm_model="model-a",
+            llm_models=[],
+            no_public_https=False,
+        )
+    assert exc.value.exit_code == 1
+
+
+def test_deploy_warns_on_missing_token_factory_key(monkeypatch, tmp_path, capsys) -> None:
+    """Deploy surfaces the Token Factory 503 warning up front (before Terraform)."""
+    from npa.cli.agent import deploy_cmd
+    from npa.clients.nebius import NebiusError
+
+    (tmp_path / "id_ed25519.pub").write_text("ssh-ed25519 AAAA test\n")
+    (tmp_path / "id_ed25519").write_text("priv\n")
+    monkeypatch.setenv("NPA_TERRAFORM_BIN", "/usr/bin/terraform")
+    monkeypatch.setattr(
+        "npa.cli.agent.resolve_environment",
+        lambda *a, **k: SimpleNamespace(
+            project_id=k.get("project_id"), tenant_id=k.get("tenant_id"), region=k.get("region")
+        ),
+    )
+    # No Token Factory key configured.
+    monkeypatch.setattr("npa.cli.agent._resolve_deploy_llm_credentials", lambda: ("", "m"))
+    # Stop the flow right after the warning, before any real provisioning.
+    monkeypatch.setattr(
+        "npa.clients.nebius.bootstrap_agent_environment",
+        lambda *a, **k: (_ for _ in ()).throw(NebiusError("stop after warning")),
+    )
+
+    with pytest.raises(Exit):
+        deploy_cmd(
+            project="fresh",
+            name="agent",
+            project_id="project-1",
+            tenant_id="tenant-1",
+            region="us-central1",
+            ssh_user="ubuntu",
+            ssh_public_key_path=str(tmp_path / "id_ed25519.pub"),
+            tf_var=[],
+            agent_port=8088,
+            backend_port=8787,
+            rerun_port=9090,
+            llm_model="model-a",
+            llm_models=[],
+            no_public_https=False,
+        )
+    err = capsys.readouterr().err
+    assert "503" in err
+
+
+def test_agent_nebius_auth_result_pass(monkeypatch) -> None:
+    from npa.cli import agent as agent_module
+
+    monkeypatch.setattr("npa.clients.nebius.get_iam_token", lambda: "iam-token")
+    result = agent_module._agent_nebius_auth_result()
+    assert result.status == "PASS"
+    assert result.name == "nebius_profile"
+
+
 def test_resolve_agent_service_account_id_from_nebius(mocker) -> None:
     from npa.cli.agent import _resolve_agent_service_account_id
 

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -308,6 +308,12 @@ def test_deploy_persists_terraform_state_before_apply(monkeypatch, tmp_path) -> 
     monkeypatch.setattr("npa.cli.agent.ensure_ingress", lambda **_kwargs: None)
     monkeypatch.setattr("npa.cli.agent.write_config", _write_config)
 
+    # Satisfy the fail-fast deploy prerequisites (terraform + SSH key pair) that
+    # now run before any cloud side effects.
+    (tmp_path / "id_ed25519.pub").write_text("ssh-ed25519 AAAA test\n")
+    (tmp_path / "id_ed25519").write_text("-----BEGIN OPENSSH PRIVATE KEY-----\n")
+    monkeypatch.setenv("NPA_TERRAFORM_BIN", "/usr/bin/terraform")
+
     deploy_cmd(
         project="fresh",
         name="agent",
@@ -1637,6 +1643,11 @@ def test_deploy_seeds_cost_ordered_ladder_without_explicit_models(monkeypatch, t
     monkeypatch.setattr("npa.cli.agent.ensure_ingress", lambda **k: None)
     monkeypatch.setattr("npa.cli.agent._store_agent_record", lambda project, name, rec: captured.update(rec))
 
+    # Satisfy the fail-fast deploy prerequisites (terraform + SSH key pair).
+    (tmp_path / "id_ed25519.pub").write_text("ssh-ed25519 AAAA test\n")
+    (tmp_path / "id_ed25519").write_text("-----BEGIN OPENSSH PRIVATE KEY-----\n")
+    monkeypatch.setenv("NPA_TERRAFORM_BIN", "/usr/bin/terraform")
+
     deploy_cmd(
         project="agent-live",
         name="agent",
@@ -1663,6 +1674,139 @@ def test_deploy_seeds_cost_ordered_ladder_without_explicit_models(monkeypatch, t
         "Qwen/Qwen2.5-VL-72B-Instruct",
     ):
         assert expected in configured, f"{expected} missing from {configured}"
+
+
+def test_agent_preflight_all_pass(monkeypatch, tmp_path) -> None:
+    from npa.cli import agent as agent_module
+
+    (tmp_path / "id_ed25519.pub").write_text("ssh-ed25519 AAAA test\n")
+    (tmp_path / "id_ed25519").write_text("-----BEGIN OPENSSH PRIVATE KEY-----\n")
+    monkeypatch.setenv("NPA_TERRAFORM_BIN", "/usr/bin/terraform")
+    monkeypatch.setattr(agent_module, "_resolve_deploy_llm_credentials", lambda: ("tf-key", "m"))
+
+    result = runner.invoke(
+        app,
+        [
+            "preflight",
+            "--skip-nebius",
+            "--ssh-public-key-path",
+            str(tmp_path / "id_ed25519.pub"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "[PASS] terraform" in result.output
+    assert "[PASS] ssh_public_key" in result.output
+    assert "[PASS] token_factory" in result.output
+
+
+def test_agent_preflight_fails_on_missing_terraform_and_keys(monkeypatch, tmp_path) -> None:
+    from npa.cli import agent as agent_module
+
+    monkeypatch.delenv("NPA_TERRAFORM_BIN", raising=False)
+    monkeypatch.setattr(agent_module.shutil, "which", lambda name: None)
+    monkeypatch.setattr(agent_module, "_resolve_deploy_llm_credentials", lambda: ("", "m"))
+
+    result = runner.invoke(
+        app,
+        [
+            "preflight",
+            "--skip-nebius",
+            "--ssh-public-key-path",
+            str(tmp_path / "missing.pub"),
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "[FAIL] terraform" in result.output
+    assert "[FAIL] ssh_public_key" in result.output
+    assert "[WARN] token_factory" in result.output
+
+
+def test_agent_preflight_json_output(monkeypatch, tmp_path) -> None:
+    from npa.cli import agent as agent_module
+
+    (tmp_path / "id_ed25519.pub").write_text("ssh-ed25519 AAAA test\n")
+    (tmp_path / "id_ed25519").write_text("priv\n")
+    monkeypatch.setenv("NPA_TERRAFORM_BIN", "/usr/bin/terraform")
+    monkeypatch.setattr(agent_module, "_resolve_deploy_llm_credentials", lambda: ("tf-key", "m"))
+
+    result = runner.invoke(
+        app,
+        [
+            "preflight",
+            "--skip-nebius",
+            "--json",
+            "--ssh-public-key-path",
+            str(tmp_path / "id_ed25519.pub"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert {c["name"] for c in payload["checks"]} == {
+        "terraform",
+        "ssh_public_key",
+        "ssh_private_key",
+        "token_factory",
+    }
+
+
+def test_agent_preflight_nebius_fail(monkeypatch, tmp_path) -> None:
+    from npa.cli import agent as agent_module
+
+    (tmp_path / "id_ed25519.pub").write_text("ssh-ed25519 AAAA test\n")
+    (tmp_path / "id_ed25519").write_text("priv\n")
+    monkeypatch.setenv("NPA_TERRAFORM_BIN", "/usr/bin/terraform")
+    monkeypatch.setattr(agent_module, "_resolve_deploy_llm_credentials", lambda: ("tf-key", "m"))
+
+    def _boom() -> str:
+        raise RuntimeError("no profile")
+
+    monkeypatch.setattr("npa.clients.nebius.get_iam_token", _boom)
+
+    result = runner.invoke(
+        app,
+        ["preflight", "--ssh-public-key-path", str(tmp_path / "id_ed25519.pub")],
+    )
+    assert result.exit_code == 1, result.output
+    assert "[FAIL] nebius_profile" in result.output
+
+
+def test_deploy_fails_fast_on_missing_ssh_key(monkeypatch, tmp_path) -> None:
+    """Deploy aborts on a missing SSH key BEFORE any cloud IAM side effects."""
+    from npa.cli.agent import deploy_cmd
+
+    monkeypatch.setenv("NPA_TERRAFORM_BIN", "/usr/bin/terraform")
+    monkeypatch.setattr(
+        "npa.cli.agent.resolve_environment",
+        lambda *a, **k: SimpleNamespace(
+            project_id=k.get("project_id"), tenant_id=k.get("tenant_id"), region=k.get("region")
+        ),
+    )
+    monkeypatch.setattr("npa.cli.agent._resolve_deploy_llm_credentials", lambda: ("tf-key", "m"))
+
+    def _must_not_run(*a, **k):
+        raise AssertionError("cloud bootstrap must not run when prerequisites fail")
+
+    monkeypatch.setattr("npa.clients.nebius.bootstrap_agent_environment", _must_not_run)
+
+    with pytest.raises(Exit) as exc:
+        deploy_cmd(
+            project="fresh",
+            name="agent",
+            project_id="project-1",
+            tenant_id="tenant-1",
+            region="us-central1",
+            ssh_user="ubuntu",
+            ssh_public_key_path=str(tmp_path / "missing.pub"),
+            tf_var=[],
+            agent_port=8088,
+            backend_port=8787,
+            rerun_port=9090,
+            llm_model="model-a",
+            llm_models=[],
+            no_public_https=False,
+        )
+    assert exc.value.exit_code == 1
 
 
 def test_resolve_agent_service_account_id_from_nebius(mocker) -> None:

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -110,7 +110,7 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
     config_path = tmp_path / "config.yaml"
     monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
     monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
     _stub_nebius_defaults(
         monkeypatch, project="project-12345", tenant="tenant-abcde"
     )
@@ -212,7 +212,7 @@ def test_configure_provision_reuses_existing_bucket_without_size_prompt(
     creds_path = tmp_path / "credentials.yaml"
     monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
     monkeypatch.setattr(config_module, "CONFIG_PATH", tmp_path / "config.yaml")
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
     _stub_nebius_defaults(monkeypatch, project="project-1", tenant="tenant-1")
     monkeypatch.setattr(nebius_module, "bucket_exists", lambda *_a, **_k: True)
 
@@ -261,7 +261,7 @@ def test_configure_provision_falls_back_to_manual_on_error(monkeypatch, tmp_path
     config_path = tmp_path / "config.yaml"
     monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
     monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
     _stub_nebius_defaults(monkeypatch, project="project-1", tenant="tenant-1")
     monkeypatch.setattr(nebius_module, "bucket_exists", lambda *_a, **_k: False)
 
@@ -313,7 +313,7 @@ def test_configure_no_provision_uses_manual_entry(monkeypatch, tmp_path) -> None
     config_path = tmp_path / "config.yaml"
     monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
     monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
     _stub_nebius_defaults(monkeypatch, project="project-1", tenant="tenant-1")
 
     def must_not_call(*_args, **_kwargs):
@@ -359,7 +359,7 @@ def test_configure_interactive_skips_config_without_project(monkeypatch, tmp_pat
     config_path = tmp_path / "config.yaml"
     monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
     monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
     _stub_nebius_defaults(monkeypatch)
 
     # Skip every field. With no project/tenant, provisioning is skipped and the
@@ -425,7 +425,7 @@ def test_configure_interactive_does_not_migrate_legacy_token_factory_key(
     )
     monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
     monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
     _stub_nebius_defaults(monkeypatch)
 
     answers = "\n".join([""] * 12) + "\n"
@@ -471,7 +471,7 @@ def test_configure_interactive_updates_selected_token_and_preserves_skipped_toke
     )
     monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
     monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
     _stub_nebius_defaults(monkeypatch)
 
     # Skip everything except HF token.
@@ -525,8 +525,9 @@ def test_configure_creates_nebius_profile_when_missing(monkeypatch, tmp_path) ->
     monkeypatch.setattr(cli_main, "_create_nebius_profile", fake_create)
     _stub_nebius_defaults(monkeypatch)
 
-    # confirm profile, then skip all interactive fields.
-    answers = "y\n" + "\n".join([""] * 11) + "\n"
+    # confirm profile, then skip all interactive fields (empty project => the
+    # manual object-storage prompts run, so 12 fields follow the confirm).
+    answers = "y\n" + "\n".join([""] * 12) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
     assert result.exit_code == 0, result.output
@@ -548,8 +549,10 @@ def test_configure_detects_existing_nebius_profile(monkeypatch, tmp_path) -> Non
     monkeypatch.setattr(cli_main, "_create_nebius_profile", fail_create)
     _stub_nebius_defaults(monkeypatch)
 
+    # Empty project => provisioning is skipped and the manual object-storage
+    # prompts run, so 12 fields are prompted for.
     result = runner.invoke(
-        app, ["configure", "--interactive"], input="\n".join([""] * 11) + "\n"
+        app, ["configure", "--interactive"], input="\n".join([""] * 12) + "\n"
     )
 
     assert result.exit_code == 0, result.output
@@ -627,10 +630,14 @@ def test_configure_stale_profile_shows_activate_guidance(monkeypatch, tmp_path) 
     answers = "n\n" + "\n".join([""] * 11) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
-    assert result.exit_code == 0, result.output
+    # Without an authenticated profile, default (provisioning) configure aborts
+    # up front instead of falling through unanswerable prompts.
+    assert result.exit_code == 1, result.output
     assert "profiles exist but" in result.output
     assert "nebius profile activate" in result.output
     assert "Skipped Nebius profile creation" in result.output
+    assert "auto-provisioning needs an authenticated Nebius CLI profile" in result.output
+    assert "--no-provision" in result.output
 
 
 def test_list_nebius_profiles_parses_profile_names(monkeypatch) -> None:
@@ -682,9 +689,10 @@ def test_configure_user_declines_profile_creation(monkeypatch, tmp_path) -> None
     answers = "n\n" + "\n".join([""] * 11) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1, result.output
     assert "Skipped Nebius profile creation" in result.output
     assert "Re-run `npa configure`" in result.output
+    assert "auto-provisioning needs an authenticated Nebius CLI profile" in result.output
 
 
 def test_configure_profile_creation_fails_verification(monkeypatch, tmp_path) -> None:
@@ -703,9 +711,10 @@ def test_configure_profile_creation_fails_verification(monkeypatch, tmp_path) ->
     answers = "y\n" + "\n".join([""] * 11) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1, result.output
     assert "Could not verify a Nebius profile" in result.output
     assert "Re-run `npa configure`" in result.output
+    assert "auto-provisioning needs an authenticated Nebius CLI profile" in result.output
 
 
 def test_configure_profile_create_subprocess_fails(monkeypatch, tmp_path) -> None:
@@ -723,8 +732,9 @@ def test_configure_profile_create_subprocess_fails(monkeypatch, tmp_path) -> Non
     answers = "y\n" + "\n".join([""] * 11) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1, result.output
     assert "Could not verify a Nebius profile" in result.output
+    assert "auto-provisioning needs an authenticated Nebius CLI profile" in result.output
 
 
 def test_configure_full_interactive_bootstraps_profile_and_provisions(
@@ -809,9 +819,38 @@ def test_configure_missing_nebius_cli_shows_install_guidance(
     answers = "\n".join([""] * 11) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
-    assert result.exit_code == 0, result.output
+    # No Nebius CLI => provisioning cannot proceed => abort up front (non-zero)
+    # with install guidance and the --no-provision escape hatch, rather than
+    # dropping into prompts a new user cannot answer and exiting 0 empty-handed.
+    assert result.exit_code == 1, result.output
     assert "Nebius CLI not found" in result.output
     assert "re-run `npa configure`" in result.output.lower()
+    assert "--no-provision" in result.output
+
+
+def test_configure_interactive_abort_exits_nonzero_and_writes_nothing(
+    monkeypatch, tmp_path
+) -> None:
+    from npa.clients import config as config_module
+    from npa.clients import credentials as credentials_module
+
+    creds_path = tmp_path / "credentials.yaml"
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
+    _stub_nebius_defaults(monkeypatch)
+
+    # Only one answer then EOF: typer aborts on the next prompt. This used to
+    # exit 0 having written nothing; it must now fail loudly.
+    result = runner.invoke(
+        app, ["configure", "--interactive", "--no-provision"], input="project-1\n"
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "cancelled before anything was written" in result.output
+    assert not creds_path.exists()
+    assert not config_path.exists()
 
 
 def test_nebius_profile_ready_uses_get_access_token(monkeypatch) -> None:

--- a/npa/tests/cli/test_workbench_health_cli.py
+++ b/npa/tests/cli/test_workbench_health_cli.py
@@ -97,3 +97,116 @@ def test_health_rejects_unknown_check() -> None:
     result = runner.invoke(app, ["workbench", "health", "sim2real", "--checks", "bogus"])
     assert result.exit_code != 0
     assert "unknown check" in result.output.lower()
+
+
+def test_health_help_lists_preflight_not_deprecated_sim2real() -> None:
+    result = runner.invoke(app, ["workbench", "health", "--help"])
+    assert result.exit_code == 0
+    # The generic credential preflight is the advertised command; the sim2real
+    # one is hidden/deprecated in favor of `workbench workflow submit`.
+    assert "preflight" in result.output
+    assert "sim2real" not in result.output
+
+
+class _EmptyCreds:
+    hf_token = ""
+    ngc_api_key = ""
+    token_factory_api_key = ""
+    s3_access_key_id = ""
+    s3_secret_access_key = ""
+    s3_endpoint = ""
+    s3_bucket = ""
+
+
+def test_preflight_offline_all_warn_exit_zero(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    result = runner.invoke(app, ["workbench", "health", "preflight", "--offline"])
+    assert result.exit_code == 0
+    for name in ("hf", "ngc", "s3", "token_factory"):
+        assert name in result.output
+    assert "0 fail" in result.output
+
+
+def test_preflight_json_offline(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    result = runner.invoke(
+        app, ["workbench", "health", "preflight", "--offline", "--json"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert {c["name"] for c in payload["checks"]} == {"hf", "ngc", "s3", "token_factory"}
+
+
+def test_preflight_selected_check(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    result = runner.invoke(
+        app, ["workbench", "health", "preflight", "--offline", "--checks", "hf"]
+    )
+    assert result.exit_code == 0
+    assert "hf:" in result.output
+    assert "token_factory:" not in result.output
+
+
+def test_preflight_rejects_unknown_check(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    result = runner.invoke(
+        app, ["workbench", "health", "preflight", "--checks", "bogus"]
+    )
+    assert result.exit_code != 0
+    assert "unknown check" in result.output.lower()
+
+
+def test_preflight_fails_on_bad_s3(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    class _Creds(_EmptyCreds):
+        s3_access_key_id = "AK"
+        s3_secret_access_key = "SK"
+        s3_endpoint = "https://storage.eu-north1.nebius.cloud"
+        s3_bucket = "s3://bkt/"
+
+    class _Client:
+        def list_checkpoints(self, uri):
+            raise RuntimeError("403 Forbidden")
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _Creds())
+    monkeypatch.setattr(
+        health_module.StorageClient, "from_environment", classmethod(lambda cls, **k: _Client())
+    )
+    result = runner.invoke(
+        app, ["workbench", "health", "preflight", "--checks", "s3"]
+    )
+    assert result.exit_code == 1
+    assert "FAIL" in result.output
+
+
+def test_preflight_warn_only_suppresses_exit(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    class _Creds(_EmptyCreds):
+        s3_access_key_id = "AK"
+        s3_secret_access_key = "SK"
+        s3_endpoint = "https://storage.eu-north1.nebius.cloud"
+        s3_bucket = "s3://bkt/"
+
+    class _Client:
+        def list_checkpoints(self, uri):
+            raise RuntimeError("403 Forbidden")
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _Creds())
+    monkeypatch.setattr(
+        health_module.StorageClient, "from_environment", classmethod(lambda cls, **k: _Client())
+    )
+    result = runner.invoke(
+        app, ["workbench", "health", "preflight", "--checks", "s3", "--warn-only"]
+    )
+    assert result.exit_code == 0

--- a/npa/tests/cli/test_workbench_health_cli.py
+++ b/npa/tests/cli/test_workbench_health_cli.py
@@ -103,9 +103,17 @@ def test_health_help_lists_preflight_not_deprecated_sim2real() -> None:
     result = runner.invoke(app, ["workbench", "health", "--help"])
     assert result.exit_code == 0
     # The generic credential preflight is the advertised command; the sim2real
-    # one is hidden/deprecated in favor of `workbench workflow submit`.
+    # one is hidden/deprecated in favor of `workbench workflow submit`. Assert on
+    # the command *rows* (Typer renders each listed command as "│ <name> ...")
+    # rather than a broad substring, so help copy mentioning "sim2real" elsewhere
+    # can't silently break this.
     assert "preflight" in result.output
-    assert "sim2real" not in result.output
+    command_rows = [
+        line for line in result.output.splitlines() if line.strip().startswith("│ ")
+    ]
+    listed_commands = {line.split()[1] for line in command_rows if len(line.split()) > 1}
+    assert "preflight" in listed_commands
+    assert "sim2real" not in listed_commands
 
 
 class _EmptyCreds:
@@ -178,15 +186,26 @@ def test_preflight_fails_on_bad_s3(monkeypatch) -> None:
         def list_checkpoints(self, uri):
             raise RuntimeError("403 Forbidden")
 
+    captured_kwargs: dict = {}
+
+    def _from_environment(cls, **kwargs):
+        captured_kwargs.update(kwargs)
+        return _Client()
+
     monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _Creds())
     monkeypatch.setattr(
-        health_module.StorageClient, "from_environment", classmethod(lambda cls, **k: _Client())
+        health_module.StorageClient, "from_environment", classmethod(_from_environment)
     )
     result = runner.invoke(
         app, ["workbench", "health", "preflight", "--checks", "s3"]
     )
     assert result.exit_code == 1
     assert "FAIL" in result.output
+    # The probe must be built from the resolved credentials (endpoint/keys often
+    # live in ~/.npa, not the process env), not env-only defaults.
+    assert captured_kwargs["endpoint_url"] == "https://storage.eu-north1.nebius.cloud"
+    assert captured_kwargs["aws_access_key_id"] == "AK"
+    assert captured_kwargs["aws_secret_access_key"] == "SK"
 
 
 def test_preflight_warn_only_suppresses_exit(monkeypatch) -> None:

--- a/npa/tests/conftest.py
+++ b/npa/tests/conftest.py
@@ -108,6 +108,9 @@ def isolate_home_config(monkeypatch, tmp_path_factory, request):
     monkeypatch.setattr(npa.clients.credentials, "CREDENTIALS_PATH", npa_dir / "credentials.yaml")
     monkeypatch.setattr(npa.orchestration.skypilot._bin, "CONFIG_PATH", npa_dir / "config.yaml")
     monkeypatch.setattr(npa.deploy.provisioner, "_WORKBENCH_BASE", npa_dir / "workbenches")
+    monkeypatch.setattr(
+        npa.deploy.provisioner, "_TF_PLUGIN_CACHE_DIR", npa_dir / "terraform-plugin-cache"
+    )
     monkeypatch.setattr(npa.cluster.state, "CLUSTERS_DIR", npa_dir / "clusters")
     monkeypatch.setattr(npa.cli.skypilot, "DEFAULT_VENV_PATH", npa_dir / "skypilot-venv")
     monkeypatch.setattr(

--- a/npa/tests/e2e/test_configure_bucket_e2e.py
+++ b/npa/tests/e2e/test_configure_bucket_e2e.py
@@ -73,7 +73,10 @@ def configure_paths(monkeypatch, tmp_path):
     config_path = tmp_path / "config.yaml"
     monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
     monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: None)
+    # Represent a ready, authenticated profile (the live env is authenticated per
+    # live_configure_env): _ensure_nebius_profile() returns True so provisioning
+    # proceeds instead of aborting on the "no profile" gate.
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
     return creds_path, config_path
 
 

--- a/npa/tests/e2e/test_configure_bucket_e2e.py
+++ b/npa/tests/e2e/test_configure_bucket_e2e.py
@@ -33,6 +33,12 @@ from npa.clients import nebius
 runner = CliRunner()
 GB = 1024**3
 
+# Mark as a live e2e module so the autouse HOME-isolation fixture in the root
+# conftest exempts these tests: they must see the operator's real ~/.nebius
+# profile to reach Nebius APIs (the npa dotfiles are still redirected to tmp by
+# the configure_paths fixture). Also gated at runtime by NPA_CONFIGURE_E2E=1.
+pytestmark = pytest.mark.e2e
+
 
 @dataclass(frozen=True)
 class LiveConfigureEnv:

--- a/npa/tests/test_deploy.py
+++ b/npa/tests/test_deploy.py
@@ -246,6 +246,87 @@ def test_terraform_command_wrappers_delegate_to_run(tmp_path: Path, mocker) -> N
     assert run.call_args.args[0][0] == "destroy"
 
 
+def test_run_sets_terraform_plugin_cache_dir(tmp_path: Path, monkeypatch, mocker) -> None:
+    monkeypatch.delenv("TF_PLUGIN_CACHE_DIR", raising=False)
+    monkeypatch.setattr(provisioner, "_TF_PLUGIN_CACHE_DIR", tmp_path / "tf-cache")
+    mocker.patch("shutil.which", return_value="/usr/bin/terraform")
+    run = mocker.patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["terraform"], returncode=0, stdout="ok", stderr=""
+        ),
+    )
+
+    provisioner._run(["init"], cwd=tmp_path, capture=True)
+
+    env = run.call_args.kwargs["env"]
+    assert env["TF_PLUGIN_CACHE_DIR"] == str(tmp_path / "tf-cache")
+    assert (tmp_path / "tf-cache").is_dir()
+
+
+def test_run_respects_preexisting_plugin_cache_env(tmp_path: Path, monkeypatch, mocker) -> None:
+    monkeypatch.setenv("TF_PLUGIN_CACHE_DIR", "/custom/cache")
+    mocker.patch("shutil.which", return_value="/usr/bin/terraform")
+    run = mocker.patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["terraform"], returncode=0, stdout="ok", stderr=""
+        ),
+    )
+
+    provisioner._run(["init"], cwd=tmp_path, capture=True)
+
+    assert run.call_args.kwargs["env"]["TF_PLUGIN_CACHE_DIR"] == "/custom/cache"
+
+
+def test_init_retries_transient_registry_failure(tmp_path: Path, mocker) -> None:
+    calls = {"n": 0}
+
+    def fake_run(args, *, cwd, capture=False, stream=False):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ProvisionerError(
+                "terraform init failed (exit 1):\ncould not connect to registry.terraform.io: "
+                "net/http: request canceled while waiting for connection (Client.Timeout exceeded "
+                "while awaiting headers)"
+            )
+        return subprocess.CompletedProcess(args=["terraform"], returncode=0, stdout="", stderr="")
+
+    mocker.patch("npa.deploy.provisioner._run", side_effect=fake_run)
+    slept: list[float] = []
+
+    provisioner.init(tmp_path, retries=3, backoff_seconds=0.01, sleep=slept.append)
+
+    assert calls["n"] == 2  # failed once, succeeded on retry
+    assert slept == [0.01]
+
+
+def test_init_does_not_retry_config_error(tmp_path: Path, mocker) -> None:
+    def fake_run(args, *, cwd, capture=False, stream=False):
+        raise ProvisionerError("terraform init failed (exit 1):\nInvalid provider configuration")
+
+    mocker.patch("npa.deploy.provisioner._run", side_effect=fake_run)
+    slept: list[float] = []
+
+    with pytest.raises(ProvisionerError, match="Invalid provider configuration"):
+        provisioner.init(tmp_path, retries=3, backoff_seconds=0.01, sleep=slept.append)
+
+    assert slept == []  # non-transient => no retry
+
+
+def test_init_gives_up_after_retries(tmp_path: Path, mocker) -> None:
+    def fake_run(args, *, cwd, capture=False, stream=False):
+        raise ProvisionerError("could not connect to registry.terraform.io: i/o timeout")
+
+    mocker.patch("npa.deploy.provisioner._run", side_effect=fake_run)
+    slept: list[float] = []
+
+    with pytest.raises(ProvisionerError, match="registry.terraform.io"):
+        provisioner.init(tmp_path, retries=3, backoff_seconds=0.01, sleep=slept.append)
+
+    assert len(slept) == 2  # retried after attempts 1 and 2, then raised on 3
+
+
 def test_apply_and_destroy_raise_on_nonzero(tmp_path: Path, mocker) -> None:
     mocker.patch(
         "npa.deploy.provisioner._run",

--- a/npa/tests/workflows/test_credential_preflight.py
+++ b/npa/tests/workflows/test_credential_preflight.py
@@ -77,10 +77,16 @@ def test_ngc_warns_when_missing() -> None:
 def test_ngc_warns_on_bad_prefix() -> None:
     result = check_ngc(_Creds(ngc_api_key="not-a-key"), CredentialProbes())
     assert result.status == WARN
-    assert "nvapi_" in result.remedy
+    assert "nvapi-" in result.remedy
 
 
-def test_ngc_pass_with_valid_key() -> None:
+def test_ngc_pass_with_hyphen_key() -> None:
+    # Real personal NGC keys are prefixed 'nvapi-'.
+    assert check_ngc(_Creds(ngc_api_key="nvapi-abc123"), CredentialProbes()).status == PASS
+
+
+def test_ngc_pass_with_underscore_key() -> None:
+    # Older docs sometimes show 'nvapi_'; accept it too.
     assert check_ngc(_Creds(ngc_api_key="nvapi_abc"), CredentialProbes()).status == PASS
 
 

--- a/npa/tests/workflows/test_credential_preflight.py
+++ b/npa/tests/workflows/test_credential_preflight.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from npa.workflows.credential_preflight import (
+    CREDENTIAL_CHECKS,
+    CredentialProbes,
+    check_hf,
+    check_ngc,
+    check_s3,
+    check_token_factory,
+    has_failure,
+    run_credential_preflight,
+)
+from npa.workflows.sim2real_health import FAIL, PASS, WARN
+
+
+@dataclass
+class _Creds:
+    hf_token: str = ""
+    ngc_api_key: str = ""
+    token_factory_api_key: str = ""
+    s3_access_key_id: str = ""
+    s3_secret_access_key: str = ""
+    s3_endpoint: str = ""
+    s3_bucket: str = ""
+
+
+@dataclass
+class _HFResult:
+    ok: bool
+    status_code: int | None = None
+    error: str = ""
+
+
+def test_hf_warns_when_missing() -> None:
+    result = check_hf(_Creds(), CredentialProbes())
+    assert result.status == WARN
+    assert "HF_TOKEN" in result.summary
+
+
+def test_hf_present_unverified_when_no_probe() -> None:
+    result = check_hf(_Creds(hf_token="hf_x"), CredentialProbes())
+    assert result.status == PASS
+    assert "not verified" in result.summary
+
+
+def test_hf_pass_when_validator_ok() -> None:
+    probes = CredentialProbes(hf_validator=lambda token, repo: _HFResult(ok=True))
+    result = check_hf(_Creds(hf_token="hf_x"), probes)
+    assert result.status == PASS
+
+
+def test_hf_fail_on_auth_rejection() -> None:
+    probes = CredentialProbes(
+        hf_validator=lambda token, repo: _HFResult(ok=False, status_code=401, error="denied")
+    )
+    result = check_hf(_Creds(hf_token="hf_bad"), probes)
+    assert result.status == FAIL
+    assert "denied" in result.details[0]
+
+
+def test_hf_warn_on_network_error_not_fail() -> None:
+    probes = CredentialProbes(
+        hf_validator=lambda token, repo: _HFResult(ok=False, status_code=None, error="conn reset")
+    )
+    result = check_hf(_Creds(hf_token="hf_x"), probes)
+    assert result.status == WARN
+
+
+def test_ngc_warns_when_missing() -> None:
+    assert check_ngc(_Creds(), CredentialProbes()).status == WARN
+
+
+def test_ngc_warns_on_bad_prefix() -> None:
+    result = check_ngc(_Creds(ngc_api_key="not-a-key"), CredentialProbes())
+    assert result.status == WARN
+    assert "nvapi_" in result.remedy
+
+
+def test_ngc_pass_with_valid_key() -> None:
+    assert check_ngc(_Creds(ngc_api_key="nvapi_abc"), CredentialProbes()).status == PASS
+
+
+def test_s3_warns_without_keys() -> None:
+    assert check_s3(_Creds(), CredentialProbes()).status == WARN
+
+
+def test_s3_present_unverified_without_probe() -> None:
+    creds = _Creds(
+        s3_access_key_id="AK",
+        s3_secret_access_key="SK",
+        s3_endpoint="https://storage.eu-north1.nebius.cloud",
+        s3_bucket="s3://bkt/",
+    )
+    result = check_s3(creds, CredentialProbes())
+    assert result.status == PASS
+    assert "not probed" in result.summary
+
+
+def test_s3_pass_when_reachable() -> None:
+    class _Client:
+        def list_checkpoints(self, uri):
+            return []
+
+    creds = _Creds(
+        s3_access_key_id="AK",
+        s3_secret_access_key="SK",
+        s3_endpoint="https://storage.eu-north1.nebius.cloud",
+        s3_bucket="s3://bkt/",
+    )
+    probes = CredentialProbes(s3_client_factory=lambda: _Client())
+    assert check_s3(creds, probes).status == PASS
+
+
+def test_s3_fail_on_auth_error() -> None:
+    class _Client:
+        def list_checkpoints(self, uri):
+            raise RuntimeError("403 Forbidden AccessDenied")
+
+    creds = _Creds(
+        s3_access_key_id="AK",
+        s3_secret_access_key="SK",
+        s3_endpoint="https://storage.eu-north1.nebius.cloud",
+        s3_bucket="s3://bkt/",
+    )
+    probes = CredentialProbes(s3_client_factory=lambda: _Client())
+    result = check_s3(creds, probes)
+    assert result.status == FAIL
+    assert "access key" in result.remedy.lower()
+
+
+def test_token_factory_warns_when_missing() -> None:
+    result = check_token_factory(_Creds(), CredentialProbes())
+    assert result.status == WARN
+    assert "TOKEN_FACTORY" in result.summary
+
+
+def test_token_factory_pass_when_authenticated() -> None:
+    probes = CredentialProbes(token_factory_verifier=lambda: ["m1", "m2"])
+    result = check_token_factory(_Creds(token_factory_api_key="v1.abc"), probes)
+    assert result.status == PASS
+    assert "2 models" in result.summary
+
+
+def test_token_factory_fail_when_verifier_raises() -> None:
+    def _boom() -> list[str]:
+        raise RuntimeError("401 unauthorized")
+
+    probes = CredentialProbes(token_factory_verifier=_boom)
+    result = check_token_factory(_Creds(token_factory_api_key="v1.bad"), probes)
+    assert result.status == FAIL
+
+
+def test_run_credential_preflight_default_order() -> None:
+    results = run_credential_preflight(_Creds(), probes=CredentialProbes())
+    assert [r.name for r in results] == list(CREDENTIAL_CHECKS)
+
+
+def test_run_credential_preflight_rejects_unknown_check() -> None:
+    with pytest.raises(ValueError):
+        run_credential_preflight(_Creds(), checks=["bogus"])
+
+
+def test_has_failure_true_when_any_fail() -> None:
+    class _Client:
+        def list_checkpoints(self, uri):
+            raise RuntimeError("403")
+
+    creds = _Creds(
+        s3_access_key_id="AK",
+        s3_secret_access_key="SK",
+        s3_endpoint="https://x",
+        s3_bucket="s3://bkt/",
+    )
+    results = run_credential_preflight(
+        creds,
+        probes=CredentialProbes(s3_client_factory=lambda: _Client()),
+        checks=["s3"],
+    )
+    assert has_failure(results) is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three first-time-user cold-start hazards (FTUE items #6, #7, #8), makes `npa agent deploy` resilient to Terraform registry outages, and adds credential-gathering guidance to `npa configure`. Validated against **real Nebius infrastructure** on the dev VM.

**#6 — `npa configure --interactive` silently exited 0 having written nothing.**
`_ensure_nebius_profile()` now returns a readiness bool; provisioning aborts up front (exit 1) with an actionable choice when no profile is ready; EOF/Abort exits non-zero with a "nothing was written" message; guidance + prompts show where to get the HF token and NGC API key; NGC placeholder corrected to `nvapi-`.

**#7 — No working generic preflight; README pointed at a deprecated hidden one.**
Added `npa workbench health preflight`: PASS/WARN/FAIL/SKIP over Hugging Face, NVIDIA NGC, Nebius S3, and Token Factory, reusing `validate_hf_access`, `StorageClient`, and Token Factory `list_models`. Supports `--checks`, `--offline`, `--warn-only`, `--json`. README repointed here.

**#8 — Route C prerequisites failed late.**
`npa agent deploy` now checks terraform + the SSH key pair **before** any cloud IAM side effects and surfaces the Token Factory warning up front. Added `npa agent preflight` (terraform, SSH key pair, Nebius auth, Token Factory key; `--skip-nebius`, `--json`). README Route C "Needs" column corrected.

**`npa agent deploy` Terraform reliability fix.**
A fresh per-deploy work dir ran `terraform init`, which re-downloaded providers from `registry.terraform.io` every time; a transient (or blocked) registry hiccup aborted the whole deploy and rolled back a just-provisioned VM. Now:
- Every terraform invocation runs with `TF_PLUGIN_CACHE_DIR` (`~/.npa/terraform-plugin-cache`, overridable), so providers are downloaded once and reused across deploys — faster inits and no registry round-trip once the cache is warm.
- `terraform init` retries transient registry/network failures with exponential backoff; non-transient config errors fail immediately.

**Fixes found by running against real infra:**
- S3 preflight probe now built from resolved credentials (was env-only).
- Real NGC keys are prefixed `nvapi-`; check + docs accept `nvapi-`/`nvapi_`.
- The live configure-bucket e2e stubbed `_ensure_nebius_profile` to `None` (would abort under the new gate) and lacked `@pytest.mark.e2e`, so the autouse HOME-isolation fixture hid the real `~/.nebius` profile. Both fixed.

**Review feedback incorporated (two rounds):** removed an unused `SKIP` import (ruff F401); shared `format_check_report()` renderer across preflight surfaces; honest HF wording ("reachable"); typed agent helpers as `CheckResult`; resolve deploy LLM creds once; extra deploy/nebius-auth tests; CHANGELOG entry.

## Verification

- [x] Unit/smoke: full touched suites pass locally; `ruff check src tests` clean; skills-index guardrail smoke passes.
- [x] **Live Nebius infra (dev VM):**
  - `npa workbench health preflight` → 4/4 PASS (live probes); `npa agent preflight` → 5/5 PASS (real Nebius auth); `npa configure` abort → exit 1, nothing written.
  - **Live configure-bucket e2e** → **5/5 PASS** (real bucket create/reuse/enhanced + token persistence + S3 round-trips + teardown).
  - **`npa agent deploy` end-to-end**: with the plugin-cache fix, `terraform init` succeeded offline and `terraform apply` provisioned real resources (network, security group, rules, boot disk) up to VM creation; it stopped only on the tenant's public-IP quota (10/10), and the auto-rollback cleanly destroyed all 7 partial resources. No resources orphaned (verified + cleaned up).
- [x] Public-repo hygiene: no customer names, VM IPs, private endpoints, project/tenant/registry IDs, bucket names, or secrets in the diff.

## Skill Maintenance

- [x] No skill behavior guidance needs updating; `skills/index.yaml` unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03b5a3b9-cb26-4f4c-b5cf-68eff3b663d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03b5a3b9-cb26-4f4c-b5cf-68eff3b663d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

