### PR TITLE
Fix beginner-funnel doc rot, stage-count drift, and image-pin drift

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1,5 +1,10 @@
 # NPA CLI Reference
 
+> **Legacy / unmaintained.** This root-level file is an older CLI snapshot and
+> can drift from the shipped commands. The canonical CLI references are
+> [docs/cli/README.md](docs/cli/README.md) and [npa/README.md](npa/README.md);
+> `npa --help` is always authoritative. Kept for historical context only.
+
 Complete reference for the `npa` command-line tool. Use this to generate correct commands.
 
 ## Command Hierarchy

--- a/FTUE-AUDIT.md
+++ b/FTUE-AUDIT.md
@@ -76,7 +76,7 @@ a "non-default S3-compatible endpoint."
   `CapabilityContract`). Promoting the seams to explicit keyword parameters would
   change the public SDK signature; deferred.
 - **`sim2real` name collision.** ~~Two surfaces share the "sim2real" name: the
-  13-stage VLM-to-RL loop (`npa workbench workflow submit` on the sim2real runbook) and the separate
+  14-stage VLM-to-RL loop (`npa workbench workflow submit` on the sim2real runbook) and the separate
   sim-to-real H100 quickstart/pipeline. A first-time user cannot tell which is
   canonical. Naming reconciliation is deferred.~~ **Closed:** the spelling is
   now the documented disambiguator (`sim2real` = staged VLM-to-RL loop,

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ npa --version
 ### A. 60-second try-it
 
 Score a shipped sample rollout set with the offline stub backend — no
-credentials of any kind:
+credentials of any kind. Run these from the repository root; the `--dataset`
+and spec paths are relative to it:
 
 ```bash
 npa workbench vlm-eval benchmark \
@@ -158,7 +159,8 @@ Composable `toolRef` steps: [`npa.workflow` tool catalog](docs/workbench/npa-wor
    ```
 
 3. Interactive setup — creates or reuses your Nebius CLI profile and prompts
-   for tenant, project, region, bucket, and optional API keys:
+   for project, tenant, region, container registry, bucket, and optional API
+   keys (in that order):
 
    ```bash
    npa configure --interactive

--- a/demo-script-final.md
+++ b/demo-script-final.md
@@ -1,5 +1,11 @@
 # Nebius Physical AI Workbench Demo Script
 
+> **Legacy / unmaintained.** This root-level demo script predates the current
+> workbench flow and references retired commands. For the maintained
+> walkthrough see
+> [docs/workbench/guides/sim2real-demo-script-10min.md](docs/workbench/guides/sim2real-demo-script-10min.md)
+> and [docs/quickstart.md](docs/quickstart.md). Kept for historical context only.
+
 ## Pre-demo setup
 
 ### Option A: One command (default teacher)

--- a/docs/demos/bdd100k-lancedb-demo.md
+++ b/docs/demos/bdd100k-lancedb-demo.md
@@ -41,7 +41,7 @@ resources:
   cpus: 4
   memory: 16
   # Pinned first-party LanceDB image; override image_id only for BYO registries.
-  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.2"
+  image_id: "docker:cr.eu-north1.nebius.cloud/<your-registry-id>/npa-lancedb:0.30.3"
 envs:
   NPA_PIPELINE_RUN_ID: "<your-run-id>"
   S3_BUCKET: "${NPA_S3_BUCKET}"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,8 +57,10 @@ terraform version
 ### Fast install by platform
 
 Copy-paste once per machine. All paths install the Nebius CLI, clone NPA, create
-a venv, and verify `npa`. Finish with `nebius profile create` and
-`npa configure` (Section 4).
+a venv, and verify `npa`. Then set up credentials in Section 4 with
+`npa configure`, which creates or reuses your Nebius CLI profile for you (no
+manual `nebius profile create` step). Run `npa configure` only after you have a
+Nebius project and tenant id ready (Section 4a).
 
 | Platform | Shell | Nebius CLI |
 | --- | --- | --- |
@@ -78,11 +80,13 @@ source .venv/bin/activate
 pip install --upgrade pip
 pip install -e npa
 npa --version
-nebius profile create
-npa configure
 ```
 
-Optional operator tools: `brew install python@3.12 kubectl terraform jq`.
+Then continue with credential setup in Section 4 (`npa configure`).
+
+Optional operator tools: `brew install python@3.12 jq`, plus `kubectl` and
+`terraform` from their official installers (Terraform is no longer in
+Homebrew core: `brew install hashicorp/tap/terraform`).
 
 **Linux (Debian/Ubuntu)**
 
@@ -98,12 +102,15 @@ source .venv/bin/activate
 pip install --upgrade pip
 pip install -e npa
 npa --version
-nebius profile create
-npa configure
 ```
 
-Optional: `sudo apt-get install -y kubectl terraform jq` (or install kubectl
-from the [Kubernetes docs](https://kubernetes.io/docs/tasks/tools/)).
+Then continue with credential setup in Section 4 (`npa configure`).
+
+Optional operator tools: `sudo apt-get install -y jq`. `kubectl` and
+`terraform` are **not** in the stock Ubuntu apt repositories — install
+`kubectl` from the [Kubernetes docs](https://kubernetes.io/docs/tasks/tools/)
+and `terraform` from
+[HashiCorp's apt repo](https://developer.hashicorp.com/terraform/install#linux).
 
 **Windows (WSL2)**
 
@@ -221,12 +228,12 @@ create one first; see the README **Nebius AI Cloud account** section,
 [Manage projects](https://docs.nebius.com/iam/manage-projects), and
 [Manage buckets](https://docs.nebius.com/object-storage/buckets/manage).
 
-Run interactive setup in a terminal. `npa configure` detects an existing
-authenticated Nebius CLI profile (via `nebius iam get-access-token`), prompts
-for your tenant id and project id (no defaults are shown), guides you to reuse
-an existing bucket or create a default `npa-bucket` (standard storage, size
-limit in GB), and only runs profile creation when none is authenticated. It
-then writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`:
+Run interactive setup in a terminal. `npa configure` creates or reuses your
+Nebius CLI profile first, then prompts for your project id and tenant id (in
+that order, no defaults shown), your region and container registry (defaults are
+discovered from the project), and guides you to reuse an existing bucket or
+create a default `npa-bucket` (standard storage, size limit in GB). It then
+writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`:
 
 ```bash
 npa configure
@@ -249,8 +256,10 @@ Keep these non-secret values handy for later workbench deploys:
   <https://docs.nebius.com/iam/get-tenants>.
 - `<NEBIUS_REGION>`: the region where the project exists, for example
   `eu-north1`.
-- `<PROJECT_ALIAS>`: a local alias you choose for `npa`, for example
-  `quickstart`.
+- `<PROJECT_ALIAS>`: the local profile key `npa configure` writes for this
+  project. It is set automatically to your region (for example `eu-north1`) and
+  becomes `default_project` in `~/.npa/config.yaml`. Pass it as
+  `-p <PROJECT_ALIAS>` to workbench commands (or omit `-p` to use the default).
 
 ### 4b. Required credential key names
 
@@ -349,17 +358,22 @@ These commands should not provision cloud resources:
 
 ```bash
 npa --help
-npa configure
+npa configure --show
 ```
 
 Gate: both commands render local CLI output without requiring Kubernetes, S3,
-NGC, or Hugging Face network access.
+NGC, or Hugging Face network access. Note that a bare `npa configure` in a
+terminal is interactive and provisions object storage by default (it creates an
+S3 bucket and access key); use `npa configure --show` for a read-only view of
+the file layout, or `npa configure --no-provision` to enter existing S3
+credentials by hand.
 
 ### 5a. Your first real result (offline)
 
 You can produce a real eval result with no cloud, GPU, or credentials. The
 `vlm-eval benchmark` command scores a shipped, labeled rollout set with the
-offline `stub` backend:
+offline `stub` backend. Run it from the repository root — the `--dataset` path
+is relative to it (or pass an absolute path):
 
 ```bash
 npa workbench vlm-eval benchmark \
@@ -523,7 +537,7 @@ This same serverless job is available three coherent ways:
 
 Because this launches a real, potentially long GPU job, run it from a durable
 launcher (your job queue / SkyPilot-managed job) rather than an interactive
-session you might close. See [the Cosmos guide](../.agents/skills/workbench/cosmos/SKILL.md)
+session you might close. See [the Cosmos guide](../skills/tools/cosmos/SKILL.md)
 and [the workflows guide](workbench-yaml-guide.md) for routing, backend
 selection, and known limits. Isaac Lab is the simulation counterpart but is
 RT-core-only (L40S / RTX Pro 6000); see its guide before choosing GPU type.

--- a/docs/testing/e2e-serverless.md
+++ b/docs/testing/e2e-serverless.md
@@ -317,7 +317,7 @@ CPU-only service. Validate it with the local container smoke before any VM
 smoke:
 
 ```bash
-docker build -f npa/docker/workbench/lancedb/Dockerfile -t npa-lancedb:0.30.2 npa/
+docker build -f npa/docker/workbench/lancedb/Dockerfile -t npa-lancedb:0.30.3 npa/
 
 npa workbench lancedb deploy \
   --runtime container \
@@ -325,7 +325,7 @@ npa workbench lancedb deploy \
   --port 8686 \
   --auth-mode none \
   --replace \
-  --image npa-lancedb:0.30.2
+  --image npa-lancedb:0.30.3
 
 npa workbench lancedb create-table \
   --endpoint http://localhost:8686 \
@@ -400,7 +400,7 @@ npa/.venv/bin/pytest npa/tests/e2e/test_lancedb_e2e.py -m e2e_serverless -k lanc
 Resources used:
 
 - Project: `<YOUR_PROJECT_ID>` (`eu-north1`)
-- Runtime: local Docker container, image `npa-lancedb:0.30.2`
+- Runtime: local Docker container, image `npa-lancedb:0.30.3`
 - S3 bucket: `<your-bucket>`
 - Storage prefix: `s3://${NPA_S3_BUCKET}/w7lancedb-e2e-<timestamp>-<id>/db/`
 - Test duration: about 20 seconds when the image is already built

--- a/docs/workbench/cookbooks/sim-to-real-pipeline.md
+++ b/docs/workbench/cookbooks/sim-to-real-pipeline.md
@@ -1,6 +1,6 @@
 # Sim-To-Real Pipeline Runbook
 
-> **Production loop:** For the 13-stage VLM→RL sim-to-real runbook (Isaac held-out,
+> **Production loop:** For the 14-stage VLM→RL sim-to-real runbook (Isaac held-out,
 > Cosmos augment, envgen, policy K8s jobs), use
 > [../guides/sim2real-workflow.md](../guides/sim2real-workflow.md) and
 > [../guides/sim2real-data-contracts.md](../guides/sim2real-data-contracts.md).

--- a/docs/workbench/guides/README.md
+++ b/docs/workbench/guides/README.md
@@ -85,7 +85,7 @@ them, but the workbench is built to be swapped:
 When you're ready for the production recipes, head to the
 [cookbooks](../cookbooks/README.md).
 
-## Sim-to-real (13-stage production loop)
+## Sim-to-real (14-stage production loop)
 
 These guides are separate from the easy PushT walkthrough above. They document the
 full VLM→RL loop, data contracts, and cluster operations:

--- a/docs/workbench/guides/franka-pick-and-place-genesis.md
+++ b/docs/workbench/guides/franka-pick-and-place-genesis.md
@@ -115,10 +115,10 @@ real:
 - Genesis **training** works headless on Nebius. **Visual demo rendering at
   scale** is currently limited by EGL/DRI device access in containers; 480x640
   targeted renders work via the Mesa fallback. See
-  `.agents/skills/workbench/genesis/SKILL.md` for the current state.
+  `skills/tools/genesis/SKILL.md` for the current state.
 
 ## Dig deeper
 
 - Env source: `npa/src/npa/genesis/env_pick_place.py`
 - Commands: `npa workbench genesis train-teacher | generate-demos | eval-teacher | eval-student | diagnose | tune`
-- Skill: `.agents/skills/workbench/genesis/SKILL.md`
+- Skill: `skills/tools/genesis/SKILL.md`

--- a/docs/workbench/guides/g1-humanoid-walk-sonic.md
+++ b/docs/workbench/guides/g1-humanoid-walk-sonic.md
@@ -113,4 +113,4 @@ plan = sonic.materialize_workflow(
 
 - Cookbook: [SONIC G1 Fine-Tune to MuJoCo MVP](../cookbooks/sonic-mvp-g1-mujoco.md)
 - Workflow YAML: `npa/workflows/workbench/skypilot/sonic-locomotion-finetuning.yaml`
-- Skill: `.agents/skills/workbench/sonic/SKILL.md`
+- Skill: `skills/tools/sonic/SKILL.md`

--- a/docs/workbench/guides/pusht-sim-to-real.md
+++ b/docs/workbench/guides/pusht-sim-to-real.md
@@ -110,8 +110,8 @@ you recorded in Genesis, or a [Reachy 2](reachy2-lerobot-policy.md) dataset.
 
 ## Dig deeper
 
-- **13-stage production loop:** [Sim-to-real workflow](../sim2real-workflow.md) · [Data contracts](../sim2real-data-contracts.md)
+- **14-stage production loop:** [Sim-to-real workflow](sim2real-workflow.md) · [Data contracts](sim2real-data-contracts.md)
 - Cookbook (legacy module): [Sim-To-Real Pipeline Runbook](../cookbooks/sim-to-real-pipeline.md)
 - Quickstart (legacy H100 proof): [../sim-to-real-quickstart.md](../sim-to-real-quickstart.md)
 - Workflow YAML: `npa/workflows/workbench/skypilot/sim-to-real-pipeline.yaml`
-- Skill: `.agents/skills/workbench/sim-to-real/SKILL.md`
+- Skill: `skills/workflows/sim-to-real/SKILL.md`

--- a/docs/workbench/guides/quadruped-isaac-lab.md
+++ b/docs/workbench/guides/quadruped-isaac-lab.md
@@ -96,4 +96,4 @@ npa workbench isaac-lab eval \
 - Cookbook: [Isaac Lab BYOF](../cookbooks/byof-isaac-lab/README.md)
 - Workflows: `npa/workflows/workbench/skypilot/isaac-lab-rl-train.yaml`,
   `isaac-lab-rl-sweep.yaml`; runner `npa/scripts/run_isaac_lab_rl.py`
-- Skill: `.agents/skills/workbench/isaac-lab/SKILL.md`
+- Skill: `skills/tools/isaac-lab/SKILL.md`

--- a/docs/workbench/guides/reachy2-lerobot-policy.md
+++ b/docs/workbench/guides/reachy2-lerobot-policy.md
@@ -103,4 +103,4 @@ the data came from a real robot, a teleop session, or a simulator.
 
 - LeRobot CLI: `npa workbench lerobot train | eval | serve | infer | list-checkpoints | benchmark`
 - Reachy 2 in LeRobot: https://huggingface.co/docs/lerobot/main/en/reachy2
-- Skill: `.agents/skills/workbench/lerobot/SKILL.md`
+- Skill: `skills/tools/lerobot/SKILL.md`

--- a/docs/workbench/guides/score-a-robot-no-gpu.md
+++ b/docs/workbench/guides/score-a-robot-no-gpu.md
@@ -19,7 +19,7 @@ command you'll later point at a real VLM backend.
 ## Fast path
 
 Run the benchmark against the shipped sample set with the offline `stub`
-backend:
+backend (from the repository root — the `--dataset` path is relative to it):
 
 ```bash
 npa workbench vlm-eval benchmark \
@@ -75,4 +75,4 @@ credentials — the report shape never changes.
 
 - Cookbook: [VLM-Eval Loop Runbook](../cookbooks/vlm-eval-loop-runbook.md)
 - Workflow YAML: `npa/workflows/workbench/skypilot/vlm-eval.yaml`
-- Skill: `.agents/skills/workbench/vlm-eval/SKILL.md`
+- Used as the scorer inside the sim-to-real loop: `skills/workflows/sim-to-real/SKILL.md`

--- a/docs/workbench/guides/sim2real-customer-assets.md
+++ b/docs/workbench/guides/sim2real-customer-assets.md
@@ -193,7 +193,7 @@ registry-qualified Cosmos Transfer image.
 
 ## S3 layout
 
-See [sim2real-data-contracts.md § S3 layout](./sim2real-data-contracts.md#artifact-paths).
+See [sim2real-data-contracts.md § S3 layout](./sim2real-data-contracts.md#s3-layout).
 
 ---
 

--- a/docs/workbench/guides/sim2real-data-contracts.md
+++ b/docs/workbench/guides/sim2real-data-contracts.md
@@ -1,6 +1,6 @@
 # Sim-to-Real — Data types & artifact contracts
 
-**Canonical reference** for formats, schemas, and S3 layout in the 13-stage sim-to-real
+**Canonical reference** for formats, schemas, and S3 layout in the 14-stage sim-to-real
 loop. Other guides link here instead of duplicating tables.
 
 ---
@@ -20,7 +20,7 @@ loop. Other guides link here instead of duplicating tables.
 
 ---
 
-## Not everything is LeRobot {#not-everything-is-lerobot}
+## Not everything is LeRobot
 
 The loop uses **four format families**. Only Stage 1 input is LeRobot-native.
 
@@ -37,7 +37,7 @@ policy rollouts.
 
 ---
 
-## Customer input vs workflow output {#customer-input-vs-workflow-output}
+## Customer input vs workflow output
 
 | URI / artifact | Provider | Format | Stage |
 | --- | --- | --- | --- |
@@ -139,7 +139,7 @@ schemas above on stdout files:
 
 ---
 
-## S3 layout {#artifact-paths}
+## S3 layout
 
 ```text
 # INPUT (customer)

--- a/docs/workbench/guides/sim2real-demo-script-10min.md
+++ b/docs/workbench/guides/sim2real-demo-script-10min.md
@@ -50,7 +50,7 @@ s3://<bucket>/<prefix>/<run-id>/
 
 ---
 
-## Stage → artifact map (13 stages)
+## Stage → artifact map (14 stages)
 
 Use this table as the backbone of the demo. Every row is a file or prefix you can open live or from pre-staged S3.
 
@@ -69,6 +69,7 @@ Use this table as the backbone of the demo. Every row is a file or prefix you ca
 | 11 | **Threshold gate** | Compare `success_rate` to threshold (demo: 0.45) | `outer_loop/decision.json`; promote → `checkpoints/candidate/candidate.json`; fail → `outer_loop/loopback.json` | **Fallback story** (below) |
 | 12 | **Real-world validation (BYO seam)** | Documented external stub | `stage_12_external_validation/external_stub.json` | Always SEAM; customer hook point |
 | 13 | **Retrigger** | Next dataset batch → back to Stage 1 | `stage_13_retrigger/retrigger.json` | Loop-of-loops metadata |
+| 14 | **Rerun visualization** | Local `.rrd` timeline of rollouts, critiques, and held-out scores | `reports/sim2real.rrd` | Uploaded with the run tree when the `stage_14_rerun_viz` tier is **WORKS** |
 
 **Cross-cutting artifacts** (show at end):
 
@@ -92,7 +93,7 @@ Canonical URI is in `artifact_uris()` as `stage_14_rerun_viz_rrd`. The full run 
 
 ### 0:00–0:45 — Hook
 
-> "This is a **13-stage, inspectable sim-to-real loop**: real robot data triggers the run, simulation generates environments, a VLM critiques rollouts, we convert critique into RL signal, train, evaluate on held-out sim, and either promote a checkpoint or loop back. Every stage writes JSON to object storage — no black box."
+> "This is a **14-stage, inspectable sim-to-real loop**: real robot data triggers the run, simulation generates environments, a VLM critiques rollouts, we convert critique into RL signal, train, evaluate on held-out sim, and either promote a checkpoint or loop back. Every stage writes JSON to object storage — no black box."
 
 Show one slide or browser tab: pipeline diagram from [sim2real-architecture.md](./sim2real-architecture.md) (preamble → outer loop → finalize).
 

--- a/docs/workbench/sim-to-real-quickstart.md
+++ b/docs/workbench/sim-to-real-quickstart.md
@@ -1,6 +1,6 @@
 # Sim-To-Real H100 Quickstart
 
-> **Production loop:** The maintained 13-stage VLM→RL pipeline is documented under
+> **Production loop:** The maintained 14-stage VLM→RL pipeline is documented under
 > [guides/sim2real-workflow.md](guides/sim2real-workflow.md) with data types in
 > [guides/sim2real-data-contracts.md](guides/sim2real-data-contracts.md).
 > This page covers the **legacy** `sim_to_real` H100 proof path only.

--- a/npa/src/npa/cli/genesis/__init__.py
+++ b/npa/src/npa/cli/genesis/__init__.py
@@ -126,6 +126,9 @@ def _genesis_local_import(module: str, *names: str) -> tuple[Any, ...]:
     ``pip install -e npa`` (no GPU extra) raises a bare
     ``ModuleNotFoundError: No module named 'torch'``. Turn that into an
     actionable hint that also points at the remote and serverless paths.
+
+    A missing ``npa`` / ``npa.genesis`` submodule is an internal bug rather than
+    a missing GPU extra, so it is re-raised unchanged and stays debuggable.
     """
 
     import importlib
@@ -134,6 +137,12 @@ def _genesis_local_import(module: str, *names: str) -> tuple[Any, ...]:
         mod = importlib.import_module(f"npa.genesis.{module}")
     except ModuleNotFoundError as exc:
         missing = exc.name or "torch"
+        # A missing npa.genesis submodule (or npa itself) is an internal bug, not
+        # a missing GPU extra — re-raise it so it surfaces honestly instead of
+        # being masked by the install hint. Only a missing third-party dependency
+        # (torch and the rest of the Genesis stack) gets the actionable hint.
+        if missing == "npa" or missing.startswith("npa."):
+            raise
         # Escape the extras bracket so rich markup does not treat "[genesis]" as
         # a style tag and drop it from the rendered message.
         _fail(

--- a/npa/src/npa/cli/genesis/__init__.py
+++ b/npa/src/npa/cli/genesis/__init__.py
@@ -119,6 +119,31 @@ def _fail(msg: str, code: int = 1) -> None:
     raise typer.Exit(code)
 
 
+def _genesis_local_import(module: str, *names: str) -> tuple[Any, ...]:
+    """Import names from ``npa.genesis.<module>`` for local execution.
+
+    Genesis submodules import ``torch`` at module load, so a plain
+    ``pip install -e npa`` (no GPU extra) raises a bare
+    ``ModuleNotFoundError: No module named 'torch'``. Turn that into an
+    actionable hint that also points at the remote and serverless paths.
+    """
+
+    import importlib
+
+    try:
+        mod = importlib.import_module(f"npa.genesis.{module}")
+    except ModuleNotFoundError as exc:
+        missing = exc.name or "torch"
+        _fail(
+            f"Genesis local commands need the GPU extra (missing '{missing}'). "
+            'Install it with: pip install -e "npa[genesis]" (adds torch + Genesis). '
+            "To run on a remote workbench VM instead, pass -p <project> -n <workbench>; "
+            "for a no-GPU serverless smoke, add --runtime serverless --project-id <id>."
+        )
+        raise  # unreachable: _fail raises typer.Exit
+    return tuple(getattr(mod, name) for name in names)
+
+
 def _output(data: dict[str, Any], fmt: OutputFormat) -> None:
     if fmt == OutputFormat.json:
         typer.echo(json.dumps(data, indent=2))
@@ -866,7 +891,7 @@ def _split_genesis_training_overrides(
 def _ppo_config_from_overrides(overrides: dict[str, Any]):
     if not overrides:
         return None
-    from npa.genesis.train_teacher import PPOConfig
+    (PPOConfig,) = _genesis_local_import("train_teacher", "PPOConfig")
 
     config = PPOConfig()
     for key, value in overrides.items():
@@ -998,7 +1023,9 @@ def train_teacher_cmd(
     console.print(f"  output: {output}")
     console.print(f"  device: {device}")
 
-    from npa.genesis.train_teacher import TrainingError, train_teacher
+    TrainingError, train_teacher = _genesis_local_import(
+        "train_teacher", "TrainingError", "train_teacher"
+    )
 
     try:
         result = train_teacher(
@@ -1091,7 +1118,9 @@ def generate_demos_cmd(
         console.print(f"  gpu_count={configured_gpu_count}  mode=multiprocess")
     console.print(f"  output: {target_output}")
 
-    from npa.genesis.generate_demos import DemoGenerationError, generate_demos
+    DemoGenerationError, generate_demos = _genesis_local_import(
+        "generate_demos", "DemoGenerationError", "generate_demos"
+    )
 
     temp_dir: tempfile.TemporaryDirectory[str] | None = None
     local_output = Path(target_output)
@@ -1192,7 +1221,9 @@ def eval_teacher_cmd(
     console.print(f"  checkpoint: {ckpt}")
     console.print(f"  n_envs={n_envs}  seed={seed}")
 
-    from npa.genesis.generate_demos import DemoGenerationError, eval_teacher
+    DemoGenerationError, eval_teacher = _genesis_local_import(
+        "generate_demos", "DemoGenerationError", "eval_teacher"
+    )
 
     try:
         rate = eval_teacher(
@@ -1276,7 +1307,9 @@ def eval_student_cmd(
     console.print(f"  n_envs={n_envs}  n_episodes={n_episodes}")
     console.print(f"  output: {output}")
 
-    from npa.genesis.eval_student import EvalError, eval_student
+    EvalError, eval_student = _genesis_local_import(
+        "eval_student", "EvalError", "eval_student"
+    )
 
     tsr = teacher_success_rate if teacher_success_rate >= 0.0 else None
     try:
@@ -1359,7 +1392,9 @@ def diagnose_cmd(
     if env_overrides:
         console.print(f"  overrides: {env_overrides}")
 
-    from npa.genesis.diagnose import DiagnoseError, diagnose_teacher, save_diagnosis
+    DiagnoseError, diagnose_teacher, save_diagnosis = _genesis_local_import(
+        "diagnose", "DiagnoseError", "diagnose_teacher", "save_diagnosis"
+    )
 
     try:
         result = diagnose_teacher(
@@ -1536,7 +1571,9 @@ def tune_cmd(
         console.print(f"  overrides: {env_overrides}")
     console.print(f"  output: {output}")
 
-    from npa.genesis.tune import TuneError, tune_teacher
+    TuneError, tune_teacher = _genesis_local_import(
+        "tune", "TuneError", "tune_teacher"
+    )
 
     try:
         result = tune_teacher(

--- a/npa/src/npa/cli/genesis/__init__.py
+++ b/npa/src/npa/cli/genesis/__init__.py
@@ -134,9 +134,11 @@ def _genesis_local_import(module: str, *names: str) -> tuple[Any, ...]:
         mod = importlib.import_module(f"npa.genesis.{module}")
     except ModuleNotFoundError as exc:
         missing = exc.name or "torch"
+        # Escape the extras bracket so rich markup does not treat "[genesis]" as
+        # a style tag and drop it from the rendered message.
         _fail(
             f"Genesis local commands need the GPU extra (missing '{missing}'). "
-            'Install it with: pip install -e "npa[genesis]" (adds torch + Genesis). '
+            'Install it with: pip install -e "npa\\[genesis]" (adds torch + Genesis). '
             "To run on a remote workbench VM instead, pass -p <project> -n <workbench>; "
             "for a no-GPU serverless smoke, add --runtime serverless --project-id <id>."
         )

--- a/npa/src/npa/cli/workbench/lancedb/deploy.py
+++ b/npa/src/npa/cli/workbench/lancedb/deploy.py
@@ -271,7 +271,12 @@ def deploy_cmd(
             "status": "blocked",
             "storage_path": resolved_storage,
             "image": image_ref,
-            "reason": "VM/BYOVM app deploy needs Workbench parent registration outside this run allowlist.",
+            "reason": (
+                "LanceDB VM/BYOVM app deploy is not available from this command yet: "
+                "the wrapper must be registered through the shared Workbench deploy "
+                "path. Use --runtime container for a local server, --runtime cloud for "
+                "LanceDB Cloud, or pass --dry-run to preview the plan."
+            ),
             "skip_infra": skip_infra,
             "skip_app": skip_app,
             "dry_run": dry_run,

--- a/npa/src/npa/cli/workbench/sim2real.py
+++ b/npa/src/npa/cli/workbench/sim2real.py
@@ -234,7 +234,7 @@ def run_command(
     ),
     output_json: bool = typer.Option(False, "--output-json", help="Print only JSON."),
 ) -> None:
-    """Run the full 13-stage Sim2Real workflow."""
+    """Run the full 14-stage Sim2Real workflow."""
 
     config = build_config_from_env(
         run_id=run_id,

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -1469,7 +1469,8 @@ def plan_spec_cmd(
         typer.echo(json.dumps(plan.to_dict(), indent=2, sort_keys=True))
         return
     typer.echo(f"workflow: {plan.workflow}")
-    typer.echo(f"assume_decision: {plan.assume_decision}")
+    if plan.assume_decision:
+        typer.echo(f"assume_decision: {plan.assume_decision}")
     for index, step in enumerate(plan.steps, start=1):
         label = step.state
         if step.iteration is not None:

--- a/npa/src/npa/orchestration/npa_workflow/interpreter.py
+++ b/npa/src/npa/orchestration/npa_workflow/interpreter.py
@@ -86,14 +86,29 @@ class RunContext:
         }
 
 
+def _resolve_assume(spec: NpaWorkflowSpec, assume_decision: str | None) -> str:
+    """Normalize the planning branch assumption.
+
+    Only loop-free specs get an empty assumption. Specs with dynamic transitions
+    still default to ``loop_back`` so their loops expand; loop-free specs no
+    longer report a spurious ``loop_back_to_inner_loop``.
+    """
+
+    raw_assume = (assume_decision or "").strip() or str(
+        spec.config.get("plan_assume_decision") or ""
+    )
+    if not raw_assume and any(state.transitions for state in spec.states.values()):
+        raw_assume = "loop_back"
+    return normalize_decision(raw_assume)
+
+
 def build_plan(
     spec: NpaWorkflowSpec,
     *,
     run_id: str = "plan-run",
     assume_decision: str = "",
 ) -> ExecutionPlan:
-    raw_assume = assume_decision or str(spec.config.get("plan_assume_decision") or "loop_back")
-    assume = normalize_decision(raw_assume)
+    assume = _resolve_assume(spec, assume_decision)
     ctx = _make_context(spec, run_id=run_id)
     plan = ExecutionPlan(
         workflow=spec.name,
@@ -118,8 +133,7 @@ def run_workflow(
     artifact_checker: Any | None = None,
     state_store: RunStateStore | None = None,
 ) -> dict[str, Any]:
-    raw_assume = assume_decision or str(spec.config.get("plan_assume_decision") or "loop_back")
-    assume = normalize_decision(raw_assume)
+    assume = _resolve_assume(spec, assume_decision)
     ctx = _make_context(spec, run_id=run_id)
     store = state_store
     if store is None and persist_state:

--- a/npa/src/npa/workflows/sim2real/config.py
+++ b/npa/src/npa/workflows/sim2real/config.py
@@ -402,7 +402,7 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
 
 
 def artifact_uris(config: Sim2RealLoopConfig) -> dict[str, str]:
-    """Return canonical S3 artifact URIs for the full 13-stage workflow."""
+    """Return canonical S3 artifact URIs for the full 14-stage workflow."""
 
     if not config.s3_bucket:
         return {}

--- a/npa/src/npa/workflows/sim2real/constants.py
+++ b/npa/src/npa/workflows/sim2real/constants.py
@@ -13,9 +13,13 @@ DEFAULT_BUCKET = ""
 DEFAULT_PREFIX = "sim2real-b"
 DEFAULT_COSMOS2_TRANSFER_TAG = "2.5.1-golden-eval-smoke-20260616T033000Z"
 DEFAULT_VLM_IMAGE_TAG = "3.0.1-genuine-sm120"
-DEFAULT_ENVGEN_TAG = "0.1.1"
-DEFAULT_REFERENCE_POLICY_TAG = "0.1.1"
-DEFAULT_TRAINER_TAG = "0.1.0"
+# Reference-image pins. Canonical source of truth is pyproject.toml
+# ([tool.npa.supported-tools], mirrored in npa/src/npa/deploy/images.py); keep
+# these no-registry fallbacks in sync so the staged engine (models.py) and the
+# legacy loop (sim2real_loop.py) resolve identical defaults.
+DEFAULT_ENVGEN_TAG = "0.1.2"
+DEFAULT_REFERENCE_POLICY_TAG = "0.1.2"
+DEFAULT_TRAINER_TAG = "0.1.1"
 DEFAULT_EVAL_TAG = "0.1.3-genuine-sm120"
 DEFAULT_ISAAC_TAG = "2.3.2.post1"
 # Pluggable held-out sim backend. Genesis remains fully supported; Isaac Lab

--- a/npa/src/npa/workflows/sim2real/runner.py
+++ b/npa/src/npa/workflows/sim2real/runner.py
@@ -11,7 +11,7 @@ from npa.workflows.sim2real.state import WorkflowState
 
 
 class Sim2RealWorkflow:
-    """Run the 13-stage VLM→RL loop with explicit stage boundaries.
+    """Run the 14-stage VLM→RL loop with explicit stage boundaries.
 
     This is the canonical orchestrator. SkyPilot runbooks, SDK helpers, and
     legacy CLIs should delegate here instead of re-implementing bash loops or

--- a/npa/src/npa/workflows/sim2real_loop.py
+++ b/npa/src/npa/workflows/sim2real_loop.py
@@ -715,7 +715,7 @@ def build_config_from_env(**overrides: Any) -> Sim2RealLoopConfig:
 
 
 def artifact_uris(config: Sim2RealLoopConfig) -> dict[str, str]:
-    """Return canonical S3 artifact URIs for the full 13-stage workflow."""
+    """Return canonical S3 artifact URIs for the full 14-stage workflow."""
 
     if not config.s3_bucket:
         return {}

--- a/npa/tests/cli/test_genesis_cli.py
+++ b/npa/tests/cli/test_genesis_cli.py
@@ -145,6 +145,33 @@ def test_train_teacher_dispatches(monkeypatch: pytest.MonkeyPatch, mocker) -> No
     train_teacher.assert_called_once()
 
 
+def test_train_teacher_missing_torch_shows_actionable_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+
+    real_import = importlib.import_module
+
+    def fake_import(name, *args, **kwargs):
+        if name == "npa.genesis.train_teacher":
+            raise ModuleNotFoundError("No module named 'torch'", name="torch")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    result = runner.invoke(
+        app,
+        ["workbench", "genesis", "train-teacher", "--n-envs", "1", "--max-iterations", "1"],
+    )
+
+    assert result.exit_code == 1, result.output
+    normalized = " ".join(result.output.split())
+    # Rendered (rich-escaped) extra, not a bare ModuleNotFoundError.
+    assert 'npa[genesis]' in normalized
+    assert "-p <project> -n <workbench>" in normalized
+    assert "serverless" in normalized
+
+
 def test_train_teacher_rejects_bad_n_envs() -> None:
     result = runner.invoke(
         app,

--- a/npa/tests/cli/test_genesis_cli.py
+++ b/npa/tests/cli/test_genesis_cli.py
@@ -172,6 +172,35 @@ def test_train_teacher_missing_torch_shows_actionable_hint(
     assert "serverless" in normalized
 
 
+def test_train_teacher_internal_import_error_is_not_masked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A genuine missing npa.genesis submodule is an internal bug and must
+    # surface as-is, not be reported as a missing GPU extra.
+    import importlib
+
+    real_import = importlib.import_module
+
+    def fake_import(name, *args, **kwargs):
+        if name == "npa.genesis.train_teacher":
+            raise ModuleNotFoundError(
+                "No module named 'npa.genesis.train_teacher'",
+                name="npa.genesis.train_teacher",
+            )
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    result = runner.invoke(
+        app,
+        ["workbench", "genesis", "train-teacher", "--n-envs", "1", "--max-iterations", "1"],
+    )
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ModuleNotFoundError)
+    assert "npa[genesis]" not in " ".join(result.output.split())
+
+
 def test_train_teacher_rejects_bad_n_envs() -> None:
     result = runner.invoke(
         app,

--- a/npa/tests/cli/test_lancedb_cli.py
+++ b/npa/tests/cli/test_lancedb_cli.py
@@ -55,6 +55,20 @@ def test_lancedb_deploy_vm_requires_storage_path() -> None:
     assert "--storage-path is required" in result.output
 
 
+def test_lancedb_deploy_vm_blocked_message_is_actionable() -> None:
+    result = runner.invoke(
+        lancedb_app,
+        ["deploy", "--runtime", "vm", "--storage-path", "/tmp/lancedb-smoke"],
+    )
+
+    assert result.exit_code == 1
+    normalized = " ".join(result.output.split())
+    assert "not available from this command yet" in normalized
+    assert "--runtime container" in normalized
+    # No internal jargon leaks to users.
+    assert "run allowlist" not in normalized
+
+
 def test_lancedb_deploy_cloud_requires_endpoint_and_api_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LANCEDB_API_KEY", raising=False)
 

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -101,6 +101,22 @@ def test_bdd100k_pipeline_plan_expands_eleven_stages() -> None:
     ]
 
 
+def test_build_plan_omits_assume_decision_for_loop_free_spec() -> None:
+    # Loop-free specs (no state transitions) must not carry a spurious
+    # loop_back_to_inner_loop assumption; the plan-spec CLI hides the line.
+    spec = load_spec(SPECS / "vlm-eval-single.yaml")
+    plan = build_plan(spec, run_id="loop-free")
+    assert plan.assume_decision == ""
+
+
+def test_build_plan_defaults_loop_back_for_specs_with_transitions() -> None:
+    # Specs with dynamic transitions still default to loop_back so their loops
+    # expand when no explicit assumption is passed.
+    spec = load_spec(SPECS / "tokenfactory-cosmos-gate.yaml")
+    plan = build_plan(spec, run_id="loop-default")
+    assert plan.assume_decision == "loop_back_to_inner_loop"
+
+
 def test_tokenfactory_cosmos_gate_plan_expands_refinement_loop() -> None:
     spec = load_spec(SPECS / "tokenfactory-cosmos-gate.yaml")
     plan = build_plan(spec, run_id="gate-plan", assume_decision="loop_back")

--- a/npa/tests/smoke/test_npa_workflow_smoke.py
+++ b/npa/tests/smoke/test_npa_workflow_smoke.py
@@ -53,3 +53,39 @@ def test_cli_plan_spec_json() -> None:
     payload = json.loads(result.output)
     assert payload["workflow"] == "tokenfactory-rollout-judge"
     assert len(payload["steps"]) == 2
+
+
+def test_cli_plan_spec_omits_assume_decision_for_loop_free_spec() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "plan-spec",
+            str(SPECS / "vlm-eval-single.yaml"),
+            "--run-id",
+            "smoke-loopfree",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "assume_decision:" not in result.output
+
+
+def test_cli_plan_spec_shows_assume_decision_for_loop_spec() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "plan-spec",
+            str(SPECS / "tokenfactory-cosmos-gate.yaml"),
+            "--run-id",
+            "smoke-loop",
+            "--assume-decision",
+            "loop_back",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "assume_decision: loop_back_to_inner_loop" in result.output

--- a/npa/tests/workflows/test_sim2real_image_pins.py
+++ b/npa/tests/workflows/test_sim2real_image_pins.py
@@ -1,0 +1,34 @@
+"""Guard the sim2real no-registry image-pin fallbacks against drift.
+
+``sim2real/constants.py`` carries no-registry fallback tags that must stay in
+sync with the canonical ``[tool.npa.supported-tools]`` pins in ``pyproject.toml``
+(mirrored by ``deploy/images.py``). The tag-audit script only matches
+fully-qualified ``npa-<tool>:<tag>`` references, so it cannot catch drift in
+these bare constants — this test closes that gap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from npa.deploy.images import supported_tool_version
+from npa.workflows.sim2real import constants
+
+
+@pytest.mark.parametrize(
+    ("constant_name", "tool"),
+    [
+        ("DEFAULT_ENVGEN_TAG", "envgen"),
+        ("DEFAULT_REFERENCE_POLICY_TAG", "reference-policy"),
+        ("DEFAULT_TRAINER_TAG", "lerobot-vlm-rl"),
+        ("DEFAULT_EVAL_TAG", "loop-eval"),
+    ],
+)
+def test_sim2real_constant_matches_supported_tool_version(
+    constant_name: str, tool: str
+) -> None:
+    constant_value = getattr(constants, constant_name)
+    assert constant_value == supported_tool_version(tool), (
+        f"{constant_name}={constant_value!r} drifted from canonical "
+        f"{tool}={supported_tool_version(tool)!r} (pyproject supported-tools)"
+    )

--- a/two_vm.md
+++ b/two_vm.md
@@ -1,5 +1,11 @@
 # Genesis Distillation Pipeline — Session State
 
+> **Legacy / unmaintained.** This root-level file captures a one-off two-VM
+> session state and is not a current setup guide. For platform setup see
+> [docs/quickstart.md](docs/quickstart.md) and
+> [docs/workbench/getting-started.md](docs/workbench/getting-started.md). Kept
+> for historical context only.
+
 ## VMs
 
 | Alias | GPU | IP | SSH | Status |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the audited first-time-user friction across the beginner funnel plus the code/doc drift it surfaced.

- **Dead skill links.** `quickstart.md` and all six robot guides pointed at `.agents/skills/workbench/<tool>/SKILL.md`, which does not exist. Repointed to the real homes (`skills/tools/...`, `skills/workflows/sim-to-real/...`), replaced the nonexistent `vlm-eval` skill link in `score-a-robot-no-gpu.md`, and fixed the `../` sibling links in `pusht-sim-to-real.md` that 404'd.
- **13- vs 14-stage drift.** The engine is canonically 14 stages (`skills/workbench/sim2real-engine`, `README`, `index.yaml`). Updated the 7 doc locations plus code docstrings, and added the missing stage-14 (Rerun viz) row to the demo-script stage map.
- **Sim2real image-pin drift.** `sim2real/constants.py` pinned `envgen`/`reference-policy` `0.1.1` and `trainer` `0.1.0` while `pyproject` supported-tools, `deploy/images.py`, and `sim2real_loop.py` use `0.1.2/0.1.2/0.1.1`. The staged engine built defaults from the stale constants; aligned them to the canonical tags (source of truth: `pyproject.toml`).
- **Quickstart fast-install.** Dropped `kubectl`/`terraform` from stock-Ubuntu apt (not in the repos) and pointed at official installers; removed the manual `nebius profile create` and the premature `npa configure` from the copy-paste blocks; the §5 gate now uses `npa configure --show` since bare `configure` provisions object storage by default.
- **PROJECT_ALIAS.** Documented it as region-derived (matches `main.py` `alias = region or "default"`) instead of user-chosen, and corrected the configure prompt order in quickstart §4a and README Route B (project → tenant → region → registry → bucket).
- **Polish.** Genesis local commands now give an actionable hint instead of a bare `No module named 'torch'`; LanceDB VM deploy drops the "run allowlist" jargon; `plan-spec` no longer prints `assume_decision: loop_back_to_inner_loop` for loop-free specs; Route A commands note they are repo-root-relative; root-level `two_vm.md`/`demo-script-final.md`/`CLI.md` are marked legacy; Pandoc `{#anchor}` headings removed (with the cross-link repointed); stale `npa-lancedb:0.30.2` tags bumped to `0.30.3`.

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks. `ruff` clean on all touched modules; `npa/scripts/audit_workbench_image_tags.py` OK; `pytest` green for `orchestration/npa_workflow`, `cli/test_genesis_cli`, `cli/test_lancedb_cli`, `cli/test_agent_workflow`, `smoke/`, and the full `workflows/` suite.
- [x] **Regression tests added for the new behaviors** (from review):
  - `build_plan` / `plan-spec` omit `assume_decision` for loop-free specs and still default `loop_back` for specs with transitions (`test_spec.py`, `test_npa_workflow_smoke.py`).
  - `sim2real` constants stay pinned to `pyproject` supported-tools — closes the drift class the tag audit structurally can't catch (`test_sim2real_image_pins.py`).
  - Genesis local run without torch surfaces the `npa[genesis]` hint; LanceDB VM deploy shows the actionable, jargon-free message (`test_genesis_cli.py`, `test_lancedb_cli.py`).
- [x] **Live infra tests on the Nebius dev VM** (checked out this branch, restored `main` after):
  - `npa workbench health preflight` → 4 PASS / 0 fail (HF reachable, NGC set, S3 bucket listable, Token Factory 26 models) — live wiring intact.
  - Offline Route A `vlm-eval benchmark` → `accuracy: 1.0` (matches the documented gate).
  - `plan-spec` loop-free spec prints **no** `assume_decision`; loop spec still prints `loop_back_to_inner_loop`.
  - Genesis local run without torch shows the friendly `pip install -e "npa[genesis]"` hint (fixed a rich-markup escaping bug found during live test).
  - LanceDB VM deploy shows the new actionable message (dry-run + blocked paths).
  - `sim2real` default image pins resolve to canonical `0.1.2/0.1.2/0.1.1`.
- [x] For workflow/tool changes: existing skill smokes still pass; no skill behavior added.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Skill Maintenance

- [x] No skill guidance changes needed; the canonical `skills/` content (14-stage engine, tool homes) was already correct — this PR fixes docs/code to match it.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43ba4b72-48d4-46fa-a80d-9c916217d62a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43ba4b72-48d4-46fa-a80d-9c916217d62a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

