### PR TITLE
LeRobot S3 fail-fast, configure alias prompt, and health-preflight docs

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -13,55 +13,7 @@ work lives).
 
 ## Active
 
-### High
-
-#### [H] Parameterize Isaac Lab -> LeRobot formatter
-
-- **Surfaced by**: CC review of commit `2956b72` on 2026-05-10.
-- **Status**: Fixed.
-- **Current issue**: `npa/src/npa/adapter/isaac_lab_lerobot.py` remains G1-bound
-  through hardcoded state names, dimensions, schema shape, and robot type.
-- **Next step**: Introduce a `LeRobotFeatureSpec` dataclass and split
-  sim-specific extraction from shared LeRobot parquet/schema/metadata writing.
-
-#### [H] Isaac Lab train does not export trajectories or list registered tasks
-
-- **Surfaced by**: 2026-05-09 physical AI demo investigation.
-- **Status**: Fixed.
-- **Current issue**: `npa workbench isaac-lab train` writes summaries and a
-  random-policy checkpoint but not synced observation/action/state episodes;
-  the CLI also lacks a public `list-tasks` command.
-- **Next step**: Add opt-in trajectory export with the numpy episode contract and
-  add a task listing command with tests or documented runtime limitations.
-
-#### [H] GR00T BYOVM env omits inherited S3 credentials
-
-- **Surfaced by**: 2026-05-09 8x H200 validation.
-- **Status**: Fixed.
-- **Current issue**: GR00T BYOVM env files inherited HF/GPU values but omitted
-  project storage credentials present in Cosmos and FiftyOne env files.
-- **Next step**: Write merged project storage credentials into
-  `/etc/npa-groot-server/env` and include those keys in deploy env audit.
-
-#### [H] Cosmos infer surfaces S3 upload AccessDenied as an uncaught traceback
-
-- **Surfaced by**: 2026-05-09 8x H200 rerun.
-- **Status**: Fixed.
-- **Current issue**: Cosmos generation can complete successfully, then local S3
-  upload failure prints a Python traceback instead of a clean command error.
-- **Next step**: Catch upload failures, report the generated VM-local file path,
-  and return an actionable storage-credentials error.
-
 ### Medium
-
-#### [M] Cosmos requires manual serve after deploy/restart with no auto-load
-
-- **Surfaced by**: 2026-05-09 demo runbook dry-run.
-- **Status**: Fixed.
-- **Current issue**: `cosmos status` reports unloaded after deploy or service
-  restart until the operator manually runs `cosmos serve`.
-- **Next step**: Add an explicit deploy auto-serve option or make the post-deploy
-  `serve` requirement prominent in CLI help and standard runbooks.
 
 #### [M] Add standalone LeRobot library validation test
 
@@ -90,32 +42,18 @@ work lives).
 - **Next step**: Decide public versus internal methods, add re-exports,
   document the API, and cover imports/behavior in tests.
 
-#### [M] `<tool> status` without `-p`/`-n` hits an unconfigured default endpoint
-
-- **Surfaced by**: 2026-05-09 validation.
-- **Status**: Fixed.
-- **Current issue**: Omitted project/name flags can silently hit a stale or
-  computed endpoint, producing misleading failure output.
-- **Next step**: Error and prompt for an alias, or track and use the most recent
-  alias explicitly.
-
-### Low
-
-#### [L] VM `deploy --destroy` runs Terraform destroy with no confirmation
-
-- **Surfaced by**: 2026-06-11 Cosmos VM teardown.
-- **Status**: Fixed.
-- **Current issue**: For Terraform-managed (`--runtime vm`) aliases,
-  `cosmos deploy --destroy` proceeds straight to `terraform destroy` with no
-  confirmation prompt; `--yes` only gates `--replace`, so a mistyped `-n` alias
-  is destroyed immediately. BYOVM destroy is non-destructive (it only
-  unregisters the alias). The same unguarded VM-destroy path likely exists in the
-  other workbench deploy commands (groot, fiftyone, isaac-lab).
-- **Next step**: Prompt before VM destroy unless `--yes` (or `--dry-run`) is
-  passed, and apply the same guard consistently across the workbench tools.
-
 ## Resolved (recent)
 
+- 2026-07-22 - FIXME Active bookkeeping: removed seven stale `Status: Fixed`
+  entries that were already covered under Resolved (Isaac Lab→LeRobot
+  formatter, Isaac Lab train trajectories/`list-tasks`, GR00T BYOVM S3
+  inheritance, Cosmos infer S3 AccessDenied, Cosmos auto-serve after deploy,
+  `<tool> status` without `-p`/`-n`, VM `deploy --destroy` confirmation).
+- 2026-07-22 - LeRobot serverless train/profile-train fail fast on empty S3
+  credentials via `require_s3_credentials` before `create_job` (parity with
+  Cosmos/FiftyOne/Genesis/GR00T/Isaac Lab/SONIC).
+- 2026-07-22 - `npa configure` prompts for a project alias (default = region)
+  and echoes `-p <alias>` usage after writing `~/.npa/config.yaml`.
 - 2026-07-21 - FiftyOne BYOVM auto health fallback now spends a short public
   budget (`FIFTYONE_AUTO_PUBLIC_HEALTH_RETRIES = 3`, ~21s) before falling back
   to SSH-local readiness (`npa/src/npa/cli/fiftyone/__init__.py`).
@@ -143,13 +81,13 @@ work lives).
   `sha256:9ae0ca513a7cf03af3562c91a6e811cd2b68abe168e36899d37f7cb4cb4ebaaa`). The
   superseded broken `0.1.1-genuine-sm120` tag was deleted from the registry.
 - 2026-07-19 - Remote install/SSH failures now surface a compact, actionable
-  error (step label + exit code + stderr tail) with the full command and output
-  behind `NPA_DEBUG=1`. Root-caused in `SSHClient.run_or_raise`
-  (`npa.clients.ssh.format_remote_failure`) and the FiftyOne clone; retires the
-  full-script dumps across Cosmos install/serve, FiftyOne, GR00T, Isaac Lab,
-  LeRobot, and Genesis. Hiding the command by default also stops leaking the
-  inlined docker-login `registry_token`. Original FIXME entry: `[M] Cosmos deploy
-  install failure dumps the full install script and traceback`.
+  error (step label + exit code + stderr tail) with the full remote stderr
+  behind `NPA_DEBUG=1` (the failing command is never echoed, so inlined
+  registry tokens stay out of operator logs). Root-caused in
+  `SSHClient.run_or_raise` (`npa.clients.ssh.format_remote_failure`) and the
+  FiftyOne clone; retires the full-script dumps across Cosmos install/serve,
+  FiftyOne, GR00T, Isaac Lab, LeRobot, and Genesis. Original FIXME entry:
+  `[M] Cosmos deploy install failure dumps the full install script and traceback`.
 - 2026-07-19 - Isaac Lab -> LeRobot formatter parameterized via
   `LeRobotFeatureSpec` with a G1 default spec (decoupled state/action dims).
 - 2026-07-19 - `npa workbench isaac-lab list-tasks` (remote gym registry) and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -231,8 +231,9 @@ create one first; see the README **Nebius AI Cloud account** section,
 Run interactive setup in a terminal. `npa configure` creates or reuses your
 Nebius CLI profile first, then prompts for your project id and tenant id (in
 that order, no defaults shown), your region and container registry (defaults are
-discovered from the project), and guides you to reuse an existing bucket or
-create a default `npa-bucket` (standard storage, size limit in GB). It then
+discovered from the project), guides you to reuse an existing bucket or create a
+default `npa-bucket` (standard storage, size limit in GB), and asks for a local
+**project alias** (default = region; used later as `-p <alias>`). It then
 writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`:
 
 ```bash
@@ -256,10 +257,10 @@ Keep these non-secret values handy for later workbench deploys:
   <https://docs.nebius.com/iam/get-tenants>.
 - `<NEBIUS_REGION>`: the region where the project exists, for example
   `eu-north1`.
-- `<PROJECT_ALIAS>`: the local profile key `npa configure` writes for this
-  project. It is set automatically to your region (for example `eu-north1`) and
-  becomes `default_project` in `~/.npa/config.yaml`. Pass it as
-  `-p <PROJECT_ALIAS>` to workbench commands (or omit `-p` to use the default).
+- `<PROJECT_ALIAS>`: the local profile key `npa configure` prompts for (default
+  = region, for example `eu-north1`). It becomes `default_project` in
+  `~/.npa/config.yaml`. Pass it as `-p <PROJECT_ALIAS>` to workbench commands
+  (or omit `-p` to use the default).
 
 ### 4b. Required credential key names
 

--- a/docs/workbench/guides/sim2real-customer-assets.md
+++ b/docs/workbench/guides/sim2real-customer-assets.md
@@ -231,17 +231,16 @@ Stage 2 asset materialization + `POLICY_IMAGE` / augment placeholder fallbacks.
 
 ## Preflight
 
-Validate trigger path, optional asset URIs, and image seams before submit:
+Validate credentials before submit, then confirm trigger/asset URIs resolve in
+object storage:
 
 ```bash
-npa workbench health sim2real \
-  --s3-bucket <bucket> \
-  --s3-endpoint <your-s3-compatible-endpoint> \
-  --trigger-dataset-uri "s3://<bucket>/sim2real-triggers/<run-id>/lerobot-<task>/" \
-  --policy-image "<registry>/npa-reference-policy:0.1.2"
+npa workbench health preflight
+# Confirm the trigger dataset (and optional BYO asset URIs) exist under your bucket.
 ```
 
-Add `--assets-uri` and `--scene-spec-uri` when testing BYO scene wiring.
+See [sim2real-operate](../../../skills/workflows/sim2real-operate/SKILL.md) for
+cluster-side preflight (kube context, registry secret, gated HF models).
 
 ---
 

--- a/docs/workbench/guides/sim2real-demo-script-10min.md
+++ b/docs/workbench/guides/sim2real-demo-script-10min.md
@@ -45,7 +45,7 @@ s3://<bucket>/<prefix>/<run-id>/
    ```
 
 3. **Optional: pre-stage a loop-back run** — Second run where `eval/heldout/report.json` has `success_rate` below threshold and `outer_loop/loopback.json` exists (for held-out failure narrative).
-4. **Preflight** — `npa workbench health sim2real --checks all` (PASS on S3, tokens, GPU count).
+4. **Preflight** — `npa workbench health preflight` (PASS/WARN/FAIL on HF, NGC, S3, Token Factory).
 5. **Open tabs:** S3 browser (pre-staged root), terminal (`kubectl logs -f`), Rerun viewer with pre-staged `.rrd`.
 
 ---
@@ -215,18 +215,15 @@ jq '.components[] | select(.name=="stage_14_rerun_viz") | {tier, message}' \
 
 ### 9:30–10:00 — Close
 
-> "Thirteen stages, every artifact addressable on S3, three BYO seams for assets / real-world eval / retrigger, staged CLI for CI and human gates, one module behind runbook and direct K8s submit. Questions?"
+> "Fourteen stages, every artifact addressable on S3, three BYO seams for assets / real-world eval / retrigger, staged CLI for CI and human gates, one module behind runbook and direct K8s submit. Questions?"
 
 ---
 
 ## Demo commands (copy-paste)
 
 ```bash
-# Preflight
-npa workbench health sim2real \
-  --s3-bucket <bucket> \
-  --s3-endpoint https://storage.eu-north1.nebius.cloud \
-  --checks all
+# Preflight (credentials)
+npa workbench health preflight
 
 # Submit live run
 export KUBECONFIG=~/.npa/clusters/<cluster>/kubeconfig

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -91,15 +91,15 @@ SUCCESS_THRESHOLD=0.75
 
 **Before submit:** complete [Hugging Face model access](#hugging-face-model-access-self-hosted-workbench) — accept `nvidia/Cosmos-Reason2-8B`, `nvidia/Cosmos-Reason2-2B`, and `nvidia/Cosmos-Transfer2.5-2B`, put `HF_TOKEN` in `~/.npa/credentials.yaml`, and ensure cluster secret `hf-ngc-tokens` is present.
 
-Run preflight first (recommended):
+Run credential preflight first (recommended):
 
 ```bash
-npa workbench health sim2real \
-  --s3-bucket <your-bucket> \
-  --s3-endpoint <your-endpoint> \
-  --k8s-context <your-k8s-context> \
-  --k8s-kubeconfig ~/.npa/clusters/<your-k8s-context>/kubeconfig
+npa workbench health preflight
 ```
+
+For cluster/config coherence before a staged submit, follow the operator checks
+in [sim2real-operate](../../../skills/workflows/sim2real-operate/SKILL.md)
+(`kubectl` context, registry pull secret, HF gated-model access).
 
 Then submit:
 
@@ -195,7 +195,7 @@ that owns the token.
 huggingface-cli whoami
 # Optional: probe a repo you accepted
 python -c "from huggingface_hub import hf_hub_download; hf_hub_download('nvidia/Cosmos-Reason2-8B', 'config.json')"
-npa workbench health sim2real --checks tokens,registry,cluster
+npa workbench health preflight --checks hf,ngc,s3,token_factory
 ```
 
 If a sibling Job fails with `GatedRepoError` or `403`, re-open the repo page,
@@ -447,7 +447,7 @@ Asset handoff and scorecard: [sim2real-customer-assets.md](./sim2real-customer-a
 
 ```bash
 npa/.venv/bin/python -m pytest npa/tests/workflows/test_sim2real_loop.py -q
-npa workbench health sim2real --checks config,coherence
+npa workbench health preflight
 ```
 
 ## Upload behavior (`--upload-artifacts`)

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -536,13 +536,26 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
     }
     wrote_config = False
     if project_id or tenant_id:
-        alias = region or "default"
+        # Local name for later `-p <alias>` flags. Default to the region so a
+        # first-time configure without an explicit choice still resolves.
+        alias_default = region or "default"
+        alias = (
+            ask(
+                "Project alias (local name for -p)",
+                default=alias_default,
+            )
+            or alias_default
+        )
         write_config({"projects": {alias: project_stanza}, "default_project": alias})
         wrote_config = True
 
     typer.echo(f"\nWrote {credentials_path} (chmod 600).")
     if wrote_config:
-        typer.echo(f"Wrote {CONFIG_PATH}.")
+        typer.echo(
+            f"Wrote {CONFIG_PATH} (project alias: {alias}). "
+            f"Pass `-p {alias}` to workbench commands, or omit `-p` to use this "
+            "default."
+        )
     else:
         typer.echo(
             "Skipped ~/.npa/config.yaml: provide a Nebius project id to write a "

--- a/npa/src/npa/cli/workbench/lerobot.py
+++ b/npa/src/npa/cli/workbench/lerobot.py
@@ -42,7 +42,12 @@ from npa.clients.credentials import apply_shared_credential_env, shared_credenti
 from npa.clients.endpoint import EndpointError, service_endpoint
 from npa.clients.serverless import EndpointNotFoundError, JobInfo, ServerlessClient, ServerlessClientError
 from npa.deploy.images import container_image_for_tool, resolve_lerobot_image_tag, supported_tool_version
-from npa.serverless_common import SubnetResolutionError, resolve_subnet
+from npa.serverless_common import (
+    MissingS3CredentialsError,
+    SubnetResolutionError,
+    require_s3_credentials,
+    resolve_subnet,
+)
 from npa.workbench.lerobot.version_compat import (
     LeRobotVersionError,
     eval_checkpoint_arg,
@@ -1023,6 +1028,17 @@ def _train_serverless(
         resolved_access_key = s3_access_key or training_config.checkpoint_s3.aws_access_key_id
         resolved_secret_key = s3_secret_key or training_config.checkpoint_s3.aws_secret_access_key
         resolved_endpoint = s3_endpoint or training_config.checkpoint_s3.endpoint_url
+    try:
+        require_s3_credentials(
+            {
+                "aws_access_key_id": resolved_access_key,
+                "aws_secret_access_key": resolved_secret_key,
+                "endpoint_url": resolved_endpoint,
+            },
+            context="LeRobot serverless jobs",
+        )
+    except MissingS3CredentialsError as exc:
+        _fail(str(exc))
     env = _lerobot_serverless_job_env(
         credentials.hf_token,
         resolved_access_key,
@@ -1205,6 +1221,17 @@ def _profile_train_serverless(
     storage = resolve_project_storage(proj_alias)
     credentials = resolve_credentials()
     s3_access_key, s3_secret_key, s3_endpoint = _serverless_storage_env_values(storage, credentials, out)
+    try:
+        require_s3_credentials(
+            {
+                "aws_access_key_id": s3_access_key,
+                "aws_secret_access_key": s3_secret_key,
+                "endpoint_url": s3_endpoint,
+            },
+            context="LeRobot serverless jobs",
+        )
+    except MissingS3CredentialsError as exc:
+        _fail(str(exc))
     env = _lerobot_serverless_job_env(
         credentials.hf_token,
         s3_access_key,

--- a/npa/tests/cli/test_lerobot_cli.py
+++ b/npa/tests/cli/test_lerobot_cli.py
@@ -540,6 +540,39 @@ def test_lerobot_train_serverless_ner_error_json_mode(mocker) -> None:
     assert payload["platform"] == "gpu-h200-sxm"
 
 
+def test_lerobot_train_serverless_fails_fast_without_s3_credentials(mocker) -> None:
+    client, _update = _mock_serverless_train(mocker)
+    mocker.patch(
+        "npa.cli.workbench.lerobot.resolve_project_storage",
+        return_value=StorageConfig(
+            checkpoint_bucket="s3://bucket/checkpoints/",
+            endpoint_url="",
+            aws_access_key_id="",
+            aws_secret_access_key="",
+        ),
+    )
+    mocker.patch(
+        "npa.cli.workbench.lerobot.resolve_credentials",
+        return_value=SimpleNamespace(
+            hf_token="PLACEHOLDER_HF_TOKEN",
+            s3_access_key_id="",
+            s3_secret_access_key="",
+            s3_endpoint="",
+            s3_bucket="",
+        ),
+    )
+
+    result = runner.invoke(app, _serverless_train_args("--submit-only"))
+
+    assert result.exit_code != 0
+    # Rich may soft-wrap the message; match on the durable fragments.
+    compact = " ".join(result.output.split())
+    assert "Missing S3" in compact
+    assert "LeRobot serverless jobs" in compact
+    assert "npa configure" in compact
+    client.create_job.assert_not_called()
+
+
 def test_lerobot_train_serverless_existing_submit_is_idempotent(mocker) -> None:
     existing = JobInfo(id="job-1", name="train-1", project_id="project-1", status="succeeded")
     client, _update = _mock_serverless_train(mocker, existing=existing)
@@ -575,6 +608,42 @@ def test_lerobot_train_serverless_b300_diffusion_warning(mocker) -> None:
     assert "B300 is ~2.5x slower than H200 on Diffusion Policy" in result.output
     assert client.create_job.call_args.kwargs["gpu_type"] == "gpu-b300-sxm"
     assert client.create_job.call_args.kwargs["preset"] == "1gpu-24vcpu-346gb"
+
+
+def test_profile_train_serverless_fails_fast_without_s3_credentials(
+    tmp_path: Path, mocker
+) -> None:
+    script = tmp_path / "profile_train.py"
+    script.write_text("print('profile')\n")
+    client, _update = _mock_serverless_profile(mocker)
+    mocker.patch(
+        "npa.cli.workbench.lerobot.resolve_project_storage",
+        return_value=StorageConfig(
+            checkpoint_bucket="s3://bucket/checkpoints/",
+            endpoint_url="",
+            aws_access_key_id="",
+            aws_secret_access_key="",
+        ),
+    )
+    mocker.patch(
+        "npa.cli.workbench.lerobot.resolve_credentials",
+        return_value=SimpleNamespace(
+            hf_token="PLACEHOLDER_HF_TOKEN",
+            s3_access_key_id="",
+            s3_secret_access_key="",
+            s3_endpoint="",
+            s3_bucket="",
+        ),
+    )
+
+    result = runner.invoke(app, _serverless_profile_args(script, "--submit-only"))
+
+    assert result.exit_code != 0
+    compact = " ".join(result.output.split())
+    assert "Missing S3" in compact
+    assert "LeRobot serverless jobs" in compact
+    assert "npa configure" in compact
+    client.create_job.assert_not_called()
 
 
 def test_profile_train_serverless_requires_output_path(tmp_path: Path, mocker) -> None:

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -151,7 +151,8 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
     monkeypatch.setattr(nebius_module, "bootstrap_environment", fake_bootstrap)
 
     # Enter project/tenant + default region/registry; pick a custom
-    # bucket name and a custom size; then HF + AI Cloud + Token Factory + NGC.
+    # bucket name and a custom size; then HF + AI Cloud + Token Factory + NGC;
+    # accept the default project alias (region).
     answers = "\n".join(
         [
             "project-12345",     # project id
@@ -165,12 +166,15 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
             "aicloud_secret",    # AI Cloud API key
             "nebius_secret_key", # Nebius Token Factory API key
             "nvapi_secret",      # NGC API key
+            "",                  # project alias (default = region)
         ]
     ) + "\n"
 
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
     assert result.exit_code == 0, result.output
+    assert "project alias: eu-north1" in result.output
+    assert "-p eu-north1" in result.output
     assert len(bootstrap_calls) == 1
     call = bootstrap_calls[0]
     assert (call["project_id"], call["tenant_id"], call["region"]) == (
@@ -194,6 +198,7 @@ def test_configure_interactive_provisions_storage(monkeypatch, tmp_path) -> None
 
     cfg = yaml.safe_load(config_path.read_text())
     project = cfg["projects"]["eu-north1"]
+    assert cfg["default_project"] == "eu-north1"
     assert project["project_id"] == "project-12345"
     assert project["tenant_id"] == "tenant-abcde"
     assert project["container_registry"].startswith("cr.eu-north1.nebius.cloud/")
@@ -238,8 +243,9 @@ def test_configure_provision_reuses_existing_bucket_without_size_prompt(
 
     monkeypatch.setattr(nebius_module, "bootstrap_environment", fake_bootstrap)
 
-    # proj, tenant, region, registry, bucket name (Enter = default), hf, ai cloud, token factory, ngc
-    answers = "\n".join(["project-1", "tenant-1", "", "", "", "", "", "", ""]) + "\n"
+    # proj, tenant, region, registry, bucket name (Enter = default), hf, ai cloud,
+    # token factory, ngc, project alias (Enter = region default)
+    answers = "\n".join(["project-1", "tenant-1", "", "", "", "", "", "", "", ""]) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
 
     assert result.exit_code == 0, result.output
@@ -287,6 +293,7 @@ def test_configure_provision_falls_back_to_manual_on_error(monkeypatch, tmp_path
             "",                  # AI Cloud API key (skip)
             "",                  # Token Factory API key (skip)
             "",                  # NGC API key (skip)
+            "",                  # project alias (default = region)
         ]
     ) + "\n"
 
@@ -335,6 +342,7 @@ def test_configure_no_provision_uses_manual_entry(monkeypatch, tmp_path) -> None
             "",                  # AI Cloud API key
             "",                  # Token Factory API key
             "",                  # NGC API key
+            "lab",               # project alias (custom)
         ]
     ) + "\n"
 
@@ -343,10 +351,15 @@ def test_configure_no_provision_uses_manual_entry(monkeypatch, tmp_path) -> None
     )
 
     assert result.exit_code == 0, result.output
+    assert "project alias: lab" in result.output
+    assert "-p lab" in result.output
     creds = yaml.safe_load(creds_path.read_text())
     assert creds["storage"]["aws_access_key_id"] == "AKIAMANUAL"
     # Endpoint default tracks the entered region.
     assert creds["storage"]["endpoint_url"] == "https://storage.me-central1.nebius.cloud"
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["default_project"] == "lab"
+    assert cfg["projects"]["lab"]["region"] == "me-central1"
 
 
 def test_configure_interactive_skips_config_without_project(monkeypatch, tmp_path) -> None:
@@ -603,6 +616,7 @@ def test_configure_existing_profile_writes_config_with_explicit_ids(
             "",                  # AI Cloud API key (skip)
             "",                  # Token Factory API key (skip)
             "",                  # NGC API key (skip)
+            "",                  # project alias (default = region)
         ]
     ) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
@@ -791,6 +805,7 @@ def test_configure_full_interactive_bootstraps_profile_and_provisions(
             "",                  # AI Cloud API key (skip)
             "",                  # Token Factory API key (skip)
             "",                  # NGC API key (skip)
+            "",                  # project alias (default = region)
         ]
     ) + "\n"
     result = runner.invoke(app, ["configure", "--interactive"], input=answers)
@@ -799,6 +814,7 @@ def test_configure_full_interactive_bootstraps_profile_and_provisions(
     assert created == [True]
     assert "Nebius CLI profile is ready." in result.output
     assert "No bucket name provided" in result.output
+    assert "project alias: eu-north1" in result.output
     creds = yaml.safe_load(creds_path.read_text())
     assert creds["storage"]["aws_access_key_id"] == "AKIAPROVISIONED"
     assert creds["tokens"]["HF_TOKEN"] == "hf_secret_token"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small follow-up after #194–#200. Not a full “Top 5” delivery — most of that list already landed.

### Code
- **LeRobot serverless:** call `require_s3_credentials` before `create_job` in train and profile-train (parity with Cosmos/FiftyOne/Genesis/GR00T/Isaac Lab/SONIC). Tests for both paths.
- **`npa configure`:** prompt for project alias (default = region) and print `-p <alias>` after writing config. Main already used region silently; this makes the choice explicit.

### Docs / hygiene
- Replace advertised `health sim2real` (hidden/deprecated) with `health preflight` in the sim2real guides.
- Fix remaining “Thirteen stages” close line in the demo script.
- Move seven stale `Status: Fixed` FIXME Active entries to Resolved.

### Out of scope (already on main)
Error-surface hardening, Route C truthing, most stage-count / skill-link doc sweep (#200).

## Test plan
- [x] Unit: configure interactive tests + LeRobot train/profile-train empty-S3 fail-fast
- [x] Live (dev VM, earlier): empty-S3 rejected; real `gpu-rtx6000` submit then cancel; disposable agent fresh-setup → smoke → verify-live → destroy

## Note
Rebase onto latest `main` before merge if needed (`#196` landed after this branch).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8788-a6d5-7150-9faa-af6595eeb403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8788-a6d5-7150-9faa-af6595eeb403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

