### PR TITLE
fix(cli): force plain Rich output when FORCE_COLOR=0 corrupts non-color runs

### DIFF
--- a/npa/src/npa/cli/__init__.py
+++ b/npa/src/npa/cli/__init__.py
@@ -19,6 +19,17 @@ def _configure_rich_plain_output() -> None:
         return
 
     os.environ.setdefault("NO_COLOR", "1")
+
+    # Rich (>=13) treats FORCE_COLOR=0 as "force terminal on" (it only checks
+    # ``force_color != ""``), so on a host that exports FORCE_COLOR=0 with a
+    # non-dumb TERM, every ``Console`` still emits bold SGR escapes even though
+    # NO_COLOR is set -- NO_COLOR strips color but not bold. That corrupts the
+    # plain-substring output assertions across the CLI suite whenever it runs
+    # under tmux/CI (TERM != "dumb"). TTY_COMPATIBLE is evaluated before
+    # FORCE_COLOR in Rich's terminal detection, so pinning it to "0" forces
+    # every Rich console -- not just Typer's help renderer -- to plain output.
+    os.environ["TTY_COMPATIBLE"] = "0"
+
     try:
         import typer.rich_utils as typer_rich_utils
     except ImportError:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the intermittent `make test` failures (~30 CLI assertions) caused by Rich emitting bold ANSI escapes into supposedly plain output.

## Root cause

Rich (>=13, here 15.0.0) treats `FORCE_COLOR=0` as *"force terminal ON"* — its terminal detection only checks `force_color != ""`, and `"0" != ""` is `True`. On a host that exports `FORCE_COLOR=0` together with a **non-dumb** `TERM` (tmux sets `tmux-256color`, CI often sets `xterm`), every CLI `Console(stderr=True)` resolves `is_terminal=True` and `color_system=STANDARD`. `NO_COLOR=1` strips color codes but **not** bold, so status/error output gets `\x1b[1m…\x1b[0m` wrapped around numbers, brackets and `<...>` tokens (Rich's `ReprHighlighter`).

That corrupts plain-substring assertions like:

```
assert "num-workers must be -1" in output
# output was: "…must be \x1b[1m-1\x1b[0m …got \x1b[1m-2\x1b[0m"
```

It only reproduced in full `make test` runs under tmux/CI (`TERM != "dumb"`); in isolation the plain Shell environment has `TERM=dumb`, which disables color, so the tests passed — hence the apparent flakiness.

The existing `_configure_rich_plain_output()` only neutralized Typer's help renderer (`typer.rich_utils`), not the app's own status consoles.

## Fix

When plain output is requested, pin `TTY_COMPATIBLE=0`. Rich evaluates `TTY_COMPATIBLE` **before** `FORCE_COLOR` in terminal detection, so `"0"` forces every Rich console (not just Typer's) to plain output regardless of `FORCE_COLOR`/`TERM`. Real interactive TTY sessions (no `NO_COLOR`, no `CI`, a real tty) are unaffected and keep color.

## Verification

- Reproduced deterministically with `TERM=xterm-256color FORCE_COLOR=0 NO_COLOR=1` (2 representative tests failed pre-fix, pass post-fix).
- Full unit suite under the same env: **3037 passed, 15 skipped, 1 xpassed, 0 failed**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f878a-a204-772f-9e51-47d045f7240f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f878a-a204-772f-9e51-47d045f7240f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

