### PR TITLE
fix(agent): never serve the stock Franka .rrd as Sim2Real run data

### DIFF
--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -209,6 +209,17 @@ def _embedded_agent_actions_source() -> str:
     return raw
 
 
+def _embedded_agent_recordings_source() -> str:
+    """Return agent_recordings.py source embedded into the remote agent backend."""
+    import re
+
+    path = Path(__file__).with_name("agent_recordings.py")
+    raw = path.read_text(encoding="utf-8")
+    raw = re.sub(r'^""".*?"""\s*\n', "", raw, count=1, flags=re.DOTALL)
+    raw = re.sub(r"^from __future__ import annotations\s*\n", "", raw)
+    return raw
+
+
 def _embedded_agent_sim2real_loop_source() -> str:
     """Return agent_sim2real_loop.py source embedded into the remote agent backend."""
     import re
@@ -244,6 +255,7 @@ def _shipped_agent_backend_module_source(name: str) -> str:
 
 _AGENT_CHAT_EMBED = "__NPA_AGENT_CHAT_EMBED__"
 _AGENT_ACTIONS_EMBED = "__NPA_AGENT_ACTIONS_EMBED__"
+_AGENT_RECORDINGS_EMBED = "__NPA_AGENT_RECORDINGS_EMBED__"
 _AGENT_SIM2REAL_LOOP_EMBED = "__NPA_AGENT_SIM2REAL_LOOP_EMBED__"
 _AGENT_SEMANTIC_ROUTER_EMBED = "__NPA_AGENT_SEMANTIC_ROUTER_EMBED__"
 # Phase G: shipped (uploaded + imported) rather than embedded.
@@ -1792,6 +1804,7 @@ def _bootstrap_agent_stack(
     catalog_json = json.dumps(_tool_catalog_payload())
     agent_chat_source = _embedded_agent_chat_source()
     agent_actions_source = _embedded_agent_actions_source()
+    agent_recordings_source = _embedded_agent_recordings_source()
     agent_sim2real_loop_source = _embedded_agent_sim2real_loop_source()
     agent_semantic_router_source = _embedded_agent_semantic_router_source()
     agent_memory_ship_source = _shipped_agent_backend_module_source("memory")
@@ -3130,18 +3143,38 @@ def _wire_active_sim2real_recording(state: dict, *, camera: str = "workspace") -
     if not isinstance(latest, dict):
         latest = {{}}
     run_id = str(current.get("run_id") or latest.get("run_id") or "").strip()
-    if not run_id.startswith("sim2real-"):
+    if not run_id or run_id == "franka-demo":
         return None
-    candidates = [RECORDINGS_DIR / f"{{run_id}}.rrd", RECORDING_PATH, RRD_PATH]
-    source = next((item for item in candidates if item.is_file() and item.stat().st_size > 65536), None)
+    # Reattach the run's OWN recording by content (run-specific entities), not by
+    # a fragile size threshold — the stock demo is ~68KB and would pass a size
+    # check. Recognize any run id (agent-run-*, sim2real-*, …) and fall back to
+    # the run's local reports/ recording when the run-scoped copy is missing.
+    def _has_run_entities(item):
+        try:
+            return item.is_file() and recording_has_run_entities(item.read_bytes())
+        except Exception:
+            return False
+
+    run_rec = RECORDINGS_DIR / run_recording_basename(run_id)
+    candidates = [
+        run_rec,
+        Path("/opt/npa-agent/runs") / run_id / "reports" / "sim2real.rrd",
+    ]
+    source = next((item for item in candidates if _has_run_entities(item)), None)
     if source is None:
         return None
-    if source != RECORDING_PATH:
-        _publish_rrd_recording(source)
-    if source != RRD_PATH and RECORDING_PATH.is_file():
+    # Ensure a run-scoped copy exists, then publish it as the active recording.
+    if source != run_rec:
+        try:
+            RECORDINGS_DIR.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, run_rec)
+        except Exception:
+            pass
+    _publish_rrd_recording(run_rec if run_rec.is_file() else source)
+    if RECORDING_PATH.is_file():
         RRD_PATH.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(RECORDING_PATH, RRD_PATH)
-    _restart_rerun_serve(force=False)
+    _restart_rerun_serve(force=True)
     selection = _stock_franka_selection()
     state["selection"] = selection
     cam = (camera or "workspace").strip() or "workspace"
@@ -3540,6 +3573,8 @@ def _chat_with_resilience(
 {_AGENT_CHAT_EMBED}
 
 {_AGENT_ACTIONS_EMBED}
+
+{_AGENT_RECORDINGS_EMBED}
 
 {_AGENT_SIM2REAL_LOOP_EMBED}
 
@@ -4073,14 +4108,36 @@ def _run_sim2real_pipeline_background(run_id: str, selection: dict) -> None:
             details["result"] = "completed_missing_report"
             _append_run_log(details, "Runner completed but report file was not found.", level="warn")
         if rrd_path.is_file():
-            _publish_rrd_recording(rrd_path)
+            # Save a run-scoped copy so the run's recording is stable and cannot
+            # be clobbered by a later franka-demo load / bootstrap.
+            run_rec = RECORDINGS_DIR / run_recording_basename(run_id)
             try:
-                shutil.copy2(rrd_path, RRD_PATH)
+                RECORDINGS_DIR.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(rrd_path, run_rec)
             except Exception:
                 pass
-            _restart_rerun_serve(force=True)
-            _wait_rerun_web_viewer_healthy()
-            _append_run_log(details, f"Published Rerun recording: {{rrd_path}}")
+            # Only serve/claim the recording as run data when it actually holds
+            # run-specific entities — never let the stock franka demo masquerade.
+            try:
+                _run_specific = recording_has_run_entities(rrd_path.read_bytes())
+            except Exception:
+                _run_specific = False
+            if _run_specific:
+                _publish_rrd_recording(rrd_path)
+                try:
+                    shutil.copy2(rrd_path, RRD_PATH)
+                except Exception:
+                    pass
+                _restart_rerun_serve(force=True)
+                _wait_rerun_web_viewer_healthy()
+                _append_run_log(details, f"Published run-specific Rerun recording: {{run_rec}}")
+            else:
+                _append_run_log(
+                    details,
+                    "Run .rrd has no run-specific entities; not marking Rerun ready "
+                    "(refusing to serve the stock demo as run data).",
+                    level="warn",
+                )
         uploaded = []
         try:
             uploaded = _upload_output_tree()
@@ -4099,19 +4156,31 @@ def _run_sim2real_pipeline_background(run_id: str, selection: dict) -> None:
     if not isinstance(sim_viz, dict):
         sim_viz = {{}}
     if rrd_path.is_file():
+        try:
+            _run_specific = recording_has_run_entities(rrd_path.read_bytes())
+        except Exception:
+            _run_specific = False
+        run_rec = RECORDINGS_DIR / run_recording_basename(run_id)
+        recording_uri = f"file://{{run_rec}}" if run_rec.is_file() else ""
+        # rerun_ready / rrd_uri only when the recording is genuinely run-specific.
         sim_viz.update(
             {{
                 "run_id": run_id,
                 "stage": "completed",
-                "rrd_uri": f"file://{{RECORDING_PATH}}",
+                "rrd_uri": recording_uri if _run_specific else "",
+                "recording_uri": recording_uri,
                 "rrd_updated_at": _now_iso(),
-                "rerun_ready": RECORDING_PATH.is_file() and _rerun_web_viewer_healthy(),
-                "rerun_iframe_url": _rerun_iframe_url(str(sim_viz.get("camera") or "workspace")),
+                "rerun_ready": bool(_run_specific and RECORDING_PATH.is_file() and _rerun_web_viewer_healthy()),
+                "rerun_iframe_url": (
+                    _rerun_iframe_url(str(sim_viz.get("camera") or "workspace")) if _run_specific else ""
+                ),
                 "camera": str(sim_viz.get("camera") or "workspace"),
             }}
         )
     else:
-        sim_viz.update({{"run_id": run_id, "stage": "completed", "rrd_updated_at": _now_iso()}})
+        sim_viz.update(
+            {{"run_id": run_id, "stage": "completed", "rrd_updated_at": _now_iso(), "rerun_ready": False}}
+        )
     state["sim_viz"] = sim_viz
     _record_sim_viz_run(state, sim_viz)
     _save_state(state)
@@ -5504,9 +5573,28 @@ def tool(tool_ref: str):
         return {{"ok": False, "error": "unknown toolRef", "tool_ref": tool_ref}}
     return {{"ok": True, "tool_ref": tool_ref, **payload}}
 
+def _served_recording_is_run_specific() -> bool:
+    try:
+        return RECORDING_PATH.is_file() and recording_has_run_entities(RECORDING_PATH.read_bytes())
+    except Exception:
+        return False
+
 @app.get("/sim-viz/status")
 def sim_viz_status(run_id: str = ""):
     state = _load_state()
+    # Self-heal: if the active run is a real run but the served recording is the
+    # stock demo (clobbered by a later franka load / bootstrap), reattach the
+    # run's own recording so we never serve/claim the demo as run data.
+    _sv = state.get("sim_viz") if isinstance(state.get("sim_viz"), dict) else {{}}
+    _active_run = str(_sv.get("run_id") or "").strip()
+    _target_run = str(run_id or "").strip() or _active_run
+    if _target_run and _target_run != "franka-demo" and not _served_recording_is_run_specific():
+        _cam = str(_sv.get("camera") or "workspace") or "workspace"
+        try:
+            if _wire_active_sim2real_recording(state, camera=_cam) is not None:
+                state = _load_state()
+        except Exception:
+            pass
     payload = _sim_viz_for_run(state, run_id=run_id)
     requested_run = str(run_id or "").strip()
     # Prefer the live sim_viz snapshot when it matches — history can lag behind
@@ -5541,6 +5629,12 @@ def sim_viz_status(run_id: str = ""):
     # Read-only: do not _record/_save here. Concurrent GET status polls were
     # racing load-run and wiping artifact_render from sim_viz_runs.
     payload_run = str(payload.get("run_id") or "").strip()
+    # Honest gate: a real run must not report rerun_ready / a run rrd_uri unless
+    # the served recording actually holds run-specific entities (never the demo).
+    if payload_run and payload_run != "franka-demo" and not _served_recording_is_run_specific():
+        payload["rerun_ready"] = False
+        payload["rrd_uri"] = ""
+        payload["recording_status"] = "run_recording_unavailable"
     run_has_specific_rrd = bool(str(payload.get("rrd_uri") or "").strip())
     live_url = str(payload.get("live_grpc_url") or "").strip()
     may_use_default_recording = payload_run in {"", "franka-demo"} and not requested_run
@@ -6768,6 +6862,7 @@ sudo systemctl restart npa-agent-backend
     setup_script = (
         setup_script.replace(_AGENT_CHAT_EMBED, agent_chat_source)
         .replace(_AGENT_ACTIONS_EMBED, agent_actions_source)
+        .replace(_AGENT_RECORDINGS_EMBED, agent_recordings_source)
         .replace(_AGENT_SIM2REAL_LOOP_EMBED, agent_sim2real_loop_source)
         .replace(_AGENT_SEMANTIC_ROUTER_EMBED, agent_semantic_router_source)
         .replace(_AGENT_MEMORY_SHIP, agent_memory_ship_source)

--- a/npa/src/npa/cli/agent_recordings.py
+++ b/npa/src/npa/cli/agent_recordings.py
@@ -1,0 +1,69 @@
+"""Rerun recording identity helpers for the NPA agent backend.
+
+Enforces the "no stock Franka/demo `.rrd` as run data" rule
+(`skills/tools/npa-agent/SKILL.md`): a Sim2Real run may only be marked
+``rerun_ready`` — and its recording served/claimed as run data — when the
+recording actually contains run-specific entities (held-out eval, rollouts,
+training signal, per-env scores). The stock Franka demo recording contains only
+scene geometry (`world/franka/*`, `world/table`, `world/cube`) and must never
+masquerade as a run's artifact.
+
+Rerun `.rrd` files embed entity-path strings as UTF-8, so a byte scan is a cheap,
+dependency-free way to tell a real run recording from the stock demo. These
+helpers are pure/deterministic and unit-test without infra; the module is
+embedded verbatim into the agent VM backend (same mechanism as the other agent
+modules).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Entity-path markers that only appear in a real Sim2Real run recording.
+RUN_ENTITY_MARKERS: tuple[bytes, ...] = (
+    b"heldout",
+    b"rollout",
+    b"per_env",
+    b"success_rate",
+    b"training_signal",
+    b"/scores",
+    b"/signals",
+    b"outer_loop",
+)
+
+# Markers characteristic of the stock Franka/demo recording (scene geometry only).
+DEMO_MARKERS: tuple[bytes, ...] = (
+    b"world/franka",
+    b"/franka/base",
+    b"/franka/gripper",
+    b"world/table",
+    b"world/cube",
+    b"demo/active_camera",
+)
+
+_SAFE_RUN_ID_RE = re.compile(r"[^A-Za-z0-9._:-]")
+
+
+def recording_has_run_entities(data: bytes | None) -> bool:
+    """Return True when the recording bytes contain run-specific entity paths."""
+    if not data:
+        return False
+    return any(marker in data for marker in RUN_ENTITY_MARKERS)
+
+
+def is_stock_demo_recording(data: bytes | None) -> bool:
+    """Return True when bytes look like the stock demo (geometry only, no run data)."""
+    if not data:
+        return False
+    if recording_has_run_entities(data):
+        return False
+    return any(marker in data for marker in DEMO_MARKERS)
+
+
+def run_recording_basename(run_id: str) -> str:
+    """Return a filesystem-safe ``<run_id>.rrd`` basename for run-scoped recordings."""
+    token = _SAFE_RUN_ID_RE.sub("_", str(run_id or "").strip())
+    token = re.sub(r"\.{2,}", "_", token).strip("._")
+    if not token:
+        token = "run"
+    return f"{token}.rrd"

--- a/npa/tests/cli/test_agent_backend_render.py
+++ b/npa/tests/cli/test_agent_backend_render.py
@@ -81,6 +81,9 @@ def test_rendered_backend_wires_action_loop_and_route(monkeypatch) -> None:
     # Phase B: agent_actions is embedded and the /agent/act route is wired.
     assert "def run_action_loop" in body
     assert "TOOL_ALLOWLIST" in body
+    # Recording identity guard embedded + used to gate rerun_ready (no stock demo).
+    assert "def recording_has_run_entities" in body
+    assert "def _served_recording_is_run_specific" in body
     assert '@app.post("/agent/act")' in body
     # Phase C: sim2real drive orchestration embedded + route wired.
     assert "def drive_sim2real_loop" in body

--- a/npa/tests/cli/test_agent_recordings.py
+++ b/npa/tests/cli/test_agent_recordings.py
@@ -1,0 +1,41 @@
+"""Tier-0 tests for Rerun recording identity (no stock-demo-as-run-data rule)."""
+
+from __future__ import annotations
+
+from npa.cli import agent_recordings as R
+
+# Minimal byte fixtures mimicking the entity-path strings embedded in .rrd files.
+_RUN_RRD = b"RRF2\x00...world/table.../heldout/per_env/env-0000.../rollout/0.../scores..."
+_DEMO_RRD = b"RRF2\x00...world/franka/base.../franka/gripper...world/table...world/cube...demo/active_camera..."
+_EMPTY = b""
+
+
+def test_run_recording_detected_as_run_specific():
+    assert R.recording_has_run_entities(_RUN_RRD) is True
+    assert R.is_stock_demo_recording(_RUN_RRD) is False
+
+
+def test_stock_demo_detected_and_not_run_specific():
+    assert R.recording_has_run_entities(_DEMO_RRD) is False
+    assert R.is_stock_demo_recording(_DEMO_RRD) is True
+
+
+def test_empty_or_none_is_not_ready():
+    assert R.recording_has_run_entities(_EMPTY) is False
+    assert R.recording_has_run_entities(None) is False
+    assert R.is_stock_demo_recording(_EMPTY) is False
+
+
+def test_unknown_geometry_only_is_not_run_and_not_demo():
+    other = b"RRF2\x00...world/floor...world/lamp..."
+    assert R.recording_has_run_entities(other) is False
+    assert R.is_stock_demo_recording(other) is False
+
+
+def test_run_recording_basename_is_filesystem_safe():
+    assert R.run_recording_basename("agent-run-1843d1e8b64d") == "agent-run-1843d1e8b64d.rrd"
+    assert R.run_recording_basename("sim2real-2026:07") == "sim2real-2026:07.rrd"
+    # Traversal / odd input is sanitized.
+    assert "/" not in R.run_recording_basename("../../evil")
+    assert ".." not in R.run_recording_basename("../../evil")
+    assert R.run_recording_basename("") == "run.rrd"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the merged **Agent Enhancement (#207)**. A completed Sim2Real run's Rerun artifact was showing the **stock Franka demo `.rrd`** instead of the run's real recording — a violation of the "no stock Franka/demo `.rrd` as run data" rule (`skills/tools/npa-agent/SKILL.md`).

### Root cause
All recordings shared one mutable file (`/opt/npa-agent/recordings/sim2real.rrd`). The "reattach the real recording" guard only matched `sim2real-*` run ids (not `agent-run-*`) and used a size heuristic that the ~68 KB demo passes, so a later `load-franka-demo` / bootstrap **clobbered** the run's recording while `/api/sim-viz/status` still reported `rerun_ready: true`.

### Fix
New pure, unit-tested `npa/src/npa/cli/agent_recordings.py` (embedded into the VM backend):
- `recording_has_run_entities()` / `is_stock_demo_recording()` — identify a real run recording by content (byte-scan for `heldout`/`rollout`/`scores`/`per_env`/… vs `world/franka`/`table`/`cube`); `run_recording_basename()` for run-scoped files.
- **Finalize** saves a run-scoped `recordings/<run_id>.rrd` and only publishes + marks `rerun_ready` when the `.rrd` is genuinely run-specific (otherwise it warns and stays not-ready — never serves the demo as run data).
- `_wire_active_sim2real_recording` reattaches by **content** for **any** run id, falling back to `runs/<run_id>/reports/sim2real.rrd`, so a franka load restores the real run instead of clobbering it.
- `GET /api/sim-viz/status` self-heals (reattaches the run recording when the served file is the demo) and honestly gates `rerun_ready` / `rrd_uri` off served content.

## Verification

- [x] Local: `agent_recordings` unit tests + rendered-backend compile check + agent suite (135 passed in the focused sweep); lints clean.
- [x] **Live-validated on the agent VM:** the served `.rrd` went from franka-only (`heldout=0, rollout=0, franka=55`) to the real run recording (`heldout=20, rollout=38, per_env=10, scores=4`, 162 KB) after a single status call; an explicit `load-franka-demo` no longer clobbers the active run.
- [x] Public-repo hygiene: no customer names, VM IPs, project/tenant/registry IDs, bucket names, or secrets.

## Skill Maintenance

- [ ] No skill change needed — this enforces an existing documented rule in `skills/tools/npa-agent/SKILL.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b5fbd09-523a-4346-90e0-4d7882516903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b5fbd09-523a-4346-90e0-4d7882516903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

