### PR TITLE
docs: add npa uninstall steps and venv setup to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,10 @@ Composable `toolRef` steps: [`npa.workflow` tool catalog](docs/workbench/npa-wor
    export PATH="${HOME}/.nebius/bin:${PATH}"   # add to ~/.zshrc or ~/.bashrc
    ```
 
-3. Interactive setup — creates or reuses your Nebius CLI profile and prompts
-   for project, tenant, region, container registry, bucket, and optional API
-   keys (in that order):
+3. Interactive setup — creates or reuses your Nebius CLI profile, then prompts
+   in order for project id, tenant id, region, container registry, bucket, the
+   optional API keys (Hugging Face, Nebius AI Cloud, Nebius Token Factory, NGC),
+   and finally a local project alias:
 
    ```bash
    npa configure --interactive

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ npa --version
 > supported. Platform-specific install blocks:
 > [docs/quickstart.md § Fast install](docs/quickstart.md#fast-install-by-platform).
 
+To uninstall, run `pip uninstall npa`, or delete the virtualenv entirely with
+`deactivate && rm -rf .venv`. User config and credentials live under `~/.npa`
+and are removed separately with `rm -rf ~/.npa`. Full steps:
+[docs/quickstart.md § Uninstall](docs/quickstart.md#3a-uninstall-npa).
+
 ---
 
 ### A. 60-second try-it

--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -13,8 +13,9 @@ Options
 TTY).
 --provision  --no-provision  Auto-create a Nebius S3 bucket (when missing) and an access key
 (default). Reuse an existing bucket by name, or press Enter to
-create a default npa-bucket with standard storage and a size cap.
-Use --no-provision to enter existing S3 credentials.
+create a default npa-bucket-<hash> bucket with standard storage
+and a size cap. Use --no-provision to enter existing S3
+credentials.
 [default: provision]
 --token-factory-key  <str>  Store a Nebius Token Factory API key in ~/.npa/credentials.yaml
 under tokens.NEBIUS_TOKEN_FACTORY_KEY (skips interactive setup).

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -13,8 +13,9 @@ Options
 TTY).
 --provision  --no-provision  Auto-create a Nebius S3 bucket (when missing) and an access key
 (default). Reuse an existing bucket by name, or press Enter to
-create a default npa-bucket with standard storage and a size cap.
-Use --no-provision to enter existing S3 credentials.
+create a default npa-bucket-<hash> bucket with standard storage
+and a size cap. Use --no-provision to enter existing S3
+credentials.
 [default: provision]
 --token-factory-key  <str>  Store a Nebius Token Factory API key in ~/.npa/credentials.yaml
 under tokens.NEBIUS_TOKEN_FACTORY_KEY (skips interactive setup).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -142,7 +142,7 @@ environment. The venv can live anywhere (for example `.venv` in the repo, or
 `~/.venvs/npa`); activating it puts `npa` on your `PATH`:
 
 ```bash
-git clone <REPO_URL> nebius-physical-ai
+git clone https://github.com/nebius/nebius-physical-ai.git
 cd nebius-physical-ai
 
 python3 -m venv .venv
@@ -245,21 +245,33 @@ long-lived `NEBIUS_TOKEN` in `~/.npa/credentials.yaml`.
 
 Before running `npa configure`, sign up for Nebius AI Cloud, note your tenant
 id, and create a project in the target region. An Object Storage bucket is
-optional — `npa configure` creates a default `npa-bucket` with **standard**
-storage and a size cap when you press Enter at the bucket prompt (you can choose
-`enhanced` storage or a custom size for new buckets). To reuse your own bucket,
+optional — `npa configure` creates a default bucket named
+`npa-bucket-<hash>` (a short hash derived from your tenant and project ids, for
+example `npa-bucket-1a2b3c4d`) with **standard** storage and a size cap when you
+press Enter at the bucket prompt (you can choose `enhanced` storage or a custom
+size for new buckets). To reuse your own bucket,
 create one first; see the README **Nebius AI Cloud account** section,
 [Creating a tenant](https://docs.nebius.com/iam/create-tenants),
 [Manage projects](https://docs.nebius.com/iam/manage-projects), and
 [Manage buckets](https://docs.nebius.com/object-storage/buckets/manage).
 
-Run interactive setup in a terminal. `npa configure` creates or reuses your
-Nebius CLI profile first, then prompts for your project id and tenant id (in
-that order, no defaults shown), your region and container registry (defaults are
-discovered from the project), guides you to reuse an existing bucket or create a
-default `npa-bucket` (standard storage, size limit in GB), and asks for a local
-**project alias** (default = region; used later as `-p <alias>`). It then
-writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`:
+Run interactive setup in a terminal. `npa configure` prompts in this order:
+
+1. **Nebius CLI profile** — created or reused first; no manual
+   `nebius profile create` step.
+2. **Project id**, then **tenant id** (no defaults shown).
+3. **Region**, then **container registry** (defaults discovered from the
+   project).
+4. **Object storage** — reuse an existing bucket, or press Enter to create a
+   default `npa-bucket-<hash>` bucket (choose standard/enhanced storage and a
+   size limit in GB for new buckets).
+5. Four secret prompts, each optional and hidden as you type:
+   **Hugging Face token** (`HF_TOKEN`), **Nebius AI Cloud API key**
+   (`NEBIUS_AI_CLOUD_KEY`), **Nebius Token Factory API key**
+   (`NEBIUS_TOKEN_FACTORY_KEY`), and **NVIDIA NGC API key** (`NGC_API_KEY`).
+6. **Project alias** (default = region; used later as `-p <alias>`).
+
+It then writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`:
 
 ```bash
 npa configure
@@ -294,6 +306,8 @@ Use these canonical keys in `~/.npa/credentials.yaml`.
 | Need | `credentials.yaml` key | Environment override | Required when |
 |---|---|---|---|
 | Hugging Face token | `tokens.HF_TOKEN` | `HF_TOKEN` | Downloading gated Hugging Face models, datasets, or weights |
+| Nebius Token Factory key | `tokens.NEBIUS_TOKEN_FACTORY_KEY` | `NEBIUS_TOKEN_FACTORY_KEY` | Zero-GPU hosted inference (Token Factory / OpenAI-compatible) paths |
+| Nebius AI Cloud key | `tokens.NEBIUS_AI_CLOUD_KEY` | `NEBIUS_AI_CLOUD_KEY` | Calling Nebius AI Cloud APIs |
 | NGC API key | `ngc.api_key` | `NGC_API_KEY` | Using NGC-backed GR00T model references |
 | NGC organization | `ngc.org` | `NGC_ORG` | Your NGC key is organization-scoped |
 | NGC team | `ngc.team` | `NGC_TEAM` | Your NGC key is team-scoped |
@@ -317,11 +331,19 @@ export NPA_STORAGE_ENDPOINT=storage.eu-north1.nebius.cloud
 
 ### 4c. Populate `~/.npa/credentials.yaml`
 
+If you completed the interactive `npa configure` flow above, these keys are
+already written for you — edit this file by hand only to add keys you skipped or
+to set up credentials without running `npa configure`.
+
 Use this complete template and delete keys you do not need yet:
 
 ```yaml
 tokens:
   HF_TOKEN: <YOUR_HUGGING_FACE_TOKEN>
+  # Optional: Nebius Token Factory API key (zero-GPU hosted inference; starts with "v1.").
+  NEBIUS_TOKEN_FACTORY_KEY: <YOUR_TOKEN_FACTORY_KEY>
+  # Optional: Nebius AI Cloud API key.
+  NEBIUS_AI_CLOUD_KEY: <YOUR_NEBIUS_AI_CLOUD_KEY>
 
 ngc:
   api_key: <YOUR_NGC_API_KEY>
@@ -392,7 +414,10 @@ NGC, or Hugging Face network access. Note that a bare `npa configure` in a
 terminal is interactive and provisions object storage by default (it creates an
 S3 bucket and access key); use `npa configure --show` for a read-only view of
 the file layout, or `npa configure --no-provision` to enter existing S3
-credentials by hand.
+credentials by hand. Because auto-provisioning needs an authenticated Nebius CLI
+profile, a bare `npa configure` exits immediately (code 1, writing nothing under
+`~/.npa`) if no profile is available yet — install and authenticate the Nebius
+CLI first, or re-run with `--no-provision`.
 
 ### 5a. Your first real result (offline)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -184,6 +184,31 @@ pip install -e "npa[dev]"       # tests, lint (pytest, ruff); see Section 6
 Before running cloud workloads (Sections 5+), install `npa[full]` so every
 workbench tool has its dependencies.
 
+### 3a. Uninstall npa
+
+To remove the package from your active virtual environment:
+
+```bash
+pip uninstall npa
+```
+
+Because the recommended install uses a dedicated virtualenv, the cleanest
+removal is to deactivate and delete the environment directory — this drops
+`npa` and every dependency it pulled in:
+
+```bash
+deactivate            # leave the virtual environment
+rm -rf .venv          # or the path you chose, e.g. ~/.venvs/npa
+```
+
+User-level configuration and credentials live outside the package under
+`~/.npa` and are not touched by `pip uninstall`. Remove them only if you no
+longer need your saved projects, workbenches, and tokens:
+
+```bash
+rm -rf ~/.npa         # config.yaml, credentials.yaml, and cached state
+```
+
 ## 4. Configure credentials
 
 For credential setup, `npa` has one user-authored file:

--- a/npa/README.md
+++ b/npa/README.md
@@ -16,12 +16,21 @@ The Python package exposes the same building blocks as importable modules: Nebiu
 
 ## Install
 
+Install into a dedicated virtual environment so `npa` and its dependencies stay
+isolated from other Python projects. From the repository root:
+
 ```bash
+python3 -m venv .venv          # create a virtual environment (Python 3.10+)
+source .venv/bin/activate      # Windows: use WSL2 Ubuntu and this same command
+pip install --upgrade pip
 pip install -e .
 pip install -e ".[server]"   # policy server
 pip install -e ".[adapter]"  # dataset conversion
 pip install -e ".[genesis]"  # Genesis + distillation stages
 ```
+
+Activate the venv (`source .venv/bin/activate`) in every new shell before
+running `npa`, or call the interpreter directly with `./.venv/bin/npa`.
 
 Extra tools required by specific commands:
 
@@ -30,6 +39,29 @@ Extra tools required by specific commands:
 - `ffmpeg` for `npa adapter convert`
 - `ffmpeg` and Chrome/Chromium for `npa convert lerobot-to-mp4 --renderer rerun`
   (`NPA_RERUN_FFMPEG` and `NPA_RERUN_CHROME` may point to explicit executables)
+
+## Uninstall
+
+Remove the package from your active virtual environment:
+
+```bash
+pip uninstall npa
+```
+
+To remove the environment entirely, deactivate and delete the venv directory:
+
+```bash
+deactivate            # leave the virtual environment
+rm -rf .venv          # delete the venv created during install
+```
+
+User-level configuration and credentials live outside the package. Delete them
+only if you no longer need them (this removes saved projects, workbenches, and
+tokens):
+
+```bash
+rm -rf ~/.npa         # config.yaml, credentials.yaml, and cached state
+```
 
 ## CLI layout
 

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -327,7 +327,8 @@ def _provision_object_storage(
 
     typer.echo(
         "\nObject storage: enter an existing bucket name to reuse it, "
-        "or press Enter to have npa create a default npa-bucket for this project."
+        "or press Enter to have npa create a default npa-bucket-<hash> bucket "
+        "for this project (the hash is derived from your tenant and project ids)."
     )
     bucket_name = ask("Object-storage bucket name")
     if not bucket_name:
@@ -627,7 +628,8 @@ def configure(
         help=(
             "Auto-create a Nebius S3 bucket (when missing) and an access key "
             "(default). Reuse an existing bucket by name, or press Enter to "
-            "create a default npa-bucket with standard storage and a size cap. "
+            "create a default npa-bucket-<hash> bucket with standard storage and "
+            "a size cap. "
             "Use --no-provision to enter existing S3 credentials."
         ),
     ),
@@ -671,7 +673,8 @@ def init(
         help=(
             "Auto-create a Nebius S3 bucket (when missing) and an access key "
             "(default). Reuse an existing bucket by name, or press Enter to "
-            "create a default npa-bucket with standard storage and a size cap. "
+            "create a default npa-bucket-<hash> bucket with standard storage and "
+            "a size cap. "
             "Use --no-provision to enter existing S3 credentials."
         ),
     ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documentation accuracy pass for `npa` onboarding, plus a way to uninstall.

### Uninstall + virtualenv install
- Added a way to uninstall `npa` and made virtual-environment setup explicit in the install instructions.
- `npa/README.md`: `## Install` now creates/activates a dedicated venv before `pip install -e .`; new `## Uninstall` section covers `pip uninstall npa`, `deactivate && rm -rf .venv`, and optional `rm -rf ~/.npa`.
- `docs/quickstart.md`: new `3a. Uninstall npa` section (install already used a venv).
- `README.md`: short uninstall note under the shared install block linking to the quickstart.

### `npa configure` audit fixes (verified against source)
Traced `npa configure` end-to-end (`npa/src/npa/cli/main.py`, `clients/credentials.py`, `clients/nebius.py`) and corrected doc/CLI mismatches:
- **Token keys**: added `tokens.NEBIUS_TOKEN_FACTORY_KEY` (zero-GPU Token Factory) and `tokens.NEBIUS_AI_CLOUD_KEY` to the §4b credential-key table and the §4c `credentials.yaml` template — previously omitted even though `configure` prompts for and writes both.
- **Prompt order**: rewrote §4a to list the real prompt sequence (profile → project id → tenant id → region → registry → storage → HF / Nebius AI Cloud / Token Factory / NGC secrets → project alias). `README.md` Route B updated similarly (now includes the alias prompt).
- **Default bucket name**: corrected `npa-bucket` → `npa-bucket-<hash>` (derived from tenant+project ids, e.g. `npa-bucket-1a2b3c4d`) in `docs/quickstart.md`, and in the `configure`/`init` `--help` strings in `main.py` (regenerated `docs/cli/configure.md` and `docs/cli/init.md`).
- **No-profile exit**: §5 now notes a bare `npa configure` exits (code 1, writes nothing under `~/.npa`) when no authenticated Nebius CLI profile exists.
- **Placeholder**: replaced §3's `<REPO_URL>` with the real clone URL.
- **Overlap note**: §4c now clarifies interactive `configure` already writes these keys.

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks. — Tested the documented install/uninstall commands end-to-end (venv create, `pip install -e npa`, `npa --version`/`--help`, `./.venv/bin/npa`, `pip uninstall npa`, `deactivate && rm -rf .venv`). Ran `npa/tests/cli/test_main.py` (49 passed). Ran `scripts/build_docs.sh --check` (`docs/cli is up to date`). Verified live `npa configure --help` / `--show` output.
- [x] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`. — N/A, no workflow/tool changes.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Skill Maintenance

- [x] I updated the relevant root `skills/` entry and `skills/index.yaml`, or this PR does not change behavior that needs skill guidance. — Docs/help-text-only change; no behavior change requiring skill updates.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c5ca480-60b9-4423-8027-833cede0b806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c5ca480-60b9-4423-8027-833cede0b806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

