### PR TITLE
feat(health): gated model access preflight for HF + NGC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ observability, and cluster orchestration.**
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
-[![Platforms: macOS · Linux · Windows](https://img.shields.io/badge/platforms-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)](docs/install.md)
+[![Platforms: macOS · Linux · WSL2](https://img.shields.io/badge/platforms-macOS%20%7C%20Linux%20%7C%20WSL2-lightgrey.svg)](docs/install.md)
 [![Test](https://github.com/nebius/nebius-physical-ai/actions/workflows/test.yml/badge.svg)](https://github.com/nebius/nebius-physical-ai/actions/workflows/test.yml)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
@@ -41,24 +41,23 @@ RTX6000).
 | --------------------------------- | ------------------------------------------------------------------------------------- |
 | **What you can do**               | Curate datasets · train and evaluate policies · render synthetic data · run sim-to-real loops · serve models |
 | **Who it's for**                  | Robotics teams, physical-AI researchers, and partners shipping on Nebius              |
-| **Where it runs**                 | Nebius S3, managed Kubernetes, GPU clusters; local for stubs and unit tests           |
+| **Where it runs**                 | Nebius S3, managed Kubernetes, and GPU clusters                                        |
 | **How you extend it**             | Declarative `npa.workflow/v0.0.1` YAML specs and reusable Workbench tool refs         |
 
 ---
 
 ## Pick your path
 
-Three onboarding routes, in ascending order of setup effort. Every one starts
-with the same install.
+Two onboarding routes, in ascending order of setup effort. Both start with the
+same install and a Nebius account.
 
 | Route                                              | Time         | Needs                                    | You end up with                                          |
 | -------------------------------------------------- | ------------ | ---------------------------------------- | -------------------------------------------------------- |
-| **A. [60-second try-it](#a-60-second-try-it)**     | ~60 s        | Python 3.10+                             | A scored VLM benchmark report — no cloud, no GPU, no key |
-| **B. [First workload on Nebius](#b-first-workload-on-nebius)** | ~15 min | Nebius account · `nebius` CLI            | A configured project running managed Workbench tools     |
-| **C. [Self-hosted `npa agent`](#c-self-hosted-npa-agent)** | ~20 min | Authenticated `nebius` profile · Terraform · SSH key pair · Token Factory key · writable S3 creds | A browser-based chat workbench VM with embedded Rerun    |
+| **A. [First workload on Nebius](#a-first-workload-on-nebius)** | ~15 min | Nebius account · `nebius` CLI            | A configured project running managed Workbench tools     |
+| **B. [Self-hosted `npa agent`](#b-self-hosted-npa-agent)** | ~20 min | Authenticated `nebius` profile · Terraform · SSH key pair · Token Factory key · writable S3 creds | A browser-based chat workbench VM with embedded Rerun    |
 
-All three share the same one-time install. `npa` works with **Python 3.10+** and
-installs editable from the clone (it is not on PyPI):
+Both routes share the same one-time install. `npa` works with **Python 3.10+**
+and installs editable from the clone (it is not on PyPI):
 
 ```bash
 git clone https://github.com/nebius/nebius-physical-ai.git
@@ -70,91 +69,20 @@ pip install -e npa
 
 Verify: `npa --version`.
 
-> The base install is deliberately lightweight — it covers the offline paths
-> (Route A) with no GPU or database wheels. Before running cloud workloads
-> (Routes B and C), add the remaining workbench dependencies with
+> The base install is the core CLI, with no GPU or database wheels. Before
+> running cloud workloads, add the remaining workbench dependencies with
 > `pip install -e "npa[full]"`.
 
-> **Windows:** native works for install and the offline try-it (Route A); S3,
-> SkyPilot, and Kubernetes workflows (Routes B–C) need **WSL2 Ubuntu**. Full
-> per-platform steps (venv/uv, Nebius CLI, WSL2): [docs/install.md](docs/install.md).
+> **Windows:** use **WSL2 Ubuntu**. Full per-platform steps (venv, Nebius CLI,
+> WSL2): [docs/install.md](docs/install.md).
 
 ---
 
-### A. 60-second try-it
-
-Score a shipped sample rollout set with the offline stub backend — no
-credentials of any kind. Run these from the repository root; the `--dataset`
-and spec paths are relative to it:
-
-```bash
-npa workbench vlm-eval benchmark \
-  --dataset npa/src/npa/workbench/vlm_eval/fixtures/sample_benchmark/benchmark.json \
-  --output /tmp/vlm-eval-benchmark.json \
-  --backend stub \
-  --thresholds 0.5,0.8,0.9 \
-  --rubrics default,strict \
-  --models Qwen/Qwen2-VL-7B-Instruct \
-  --format json
-```
-
-You should see a ranked report with `accuracy: 1.0`.
-
-Want to see the **declarative authoring layer** without any cloud either?
-`npa.workflow/v0.0.1` is the customer-facing spec for chaining Workbench
-tools; validate and plan a real one offline:
-
-```bash
-npa workbench workflow validate-spec \
-  npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
-npa workbench workflow plan-spec \
-  npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml --run-id demo
-```
-
-The spec is 33 lines and looks like this — every Workbench tool has a
-`toolRef` you can chain, loop, or gate on:
-
-```yaml
-apiVersion: npa.workflow/v0.0.1
-kind: Workflow
-metadata:
-  name: vlm-eval-single
-config:
-  bucket: example-bucket
-  prefix: "runs/{{run.id}}/vlm-eval"
-  rollouts_uri: "s3://{{config.bucket}}/{{config.prefix}}/rollouts/"
-  scores_uri: "s3://{{config.bucket}}/{{config.prefix}}/scores/"
-resources:
-  gpu:
-    cloud: kubernetes
-    accelerators: H100:1
-initial: score-rollouts
-states:
-  score-rollouts:
-    toolRef: workbench.vlm_eval.run
-    resources: gpu
-    outputs:
-      - uri: "{{config.scores_uri}}report.json"
-    terminal: true
-```
-
-Author, validate, plan, and submit guide:
-[docs/workbench/npa-workflow-guide.md](docs/workbench/npa-workflow-guide.md).
-Workbench workflows: [`npa/workflows/workbench/npa-workflows/`](npa/workflows/workbench/npa-workflows/).
-Composable `toolRef` steps: [`npa.workflow` tool catalog](docs/workbench/npa-workflow-tool-catalog.md).
-
-> **Submit the same YAML to the cluster.** After configure, launch with
-> `npa workbench workflow submit <npa.workflow.yaml> --run-id demo`. Use
-> `--plan-only` to inspect the plan without launching. See
-> [Author and submit workflows](#author-and-submit-workflows) below.
-
----
-
-### B. First workload on Nebius
+### A. First workload on Nebius
 
 1. [Sign up](https://docs.nebius.com/signup-billing/sign-up) and create a
    [tenant and project](https://docs.nebius.com/iam/manage-projects).
-2. Install the Nebius CLI (only needed for cloud steps):
+2. Install the Nebius CLI:
 
    ```bash
    curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
@@ -182,7 +110,7 @@ the cheapest way to try large models against your own data.
 
 ---
 
-### C. Self-hosted `npa agent`
+### B. Self-hosted `npa agent`
 
 `npa agent` is a self-hosted **browser workbench VM**: HTTPS UI with
 basic-auth login, grounded chat over Nebius Token Factory
@@ -242,13 +170,11 @@ and the active operational backlog in [FIXME.md](FIXME.md).
 
 ## Learn by doing — pick a robot
 
-Short copy-paste walkthroughs. Start with the no-GPU guide, then pick any
-robot or simulator. Full index:
+Short copy-paste walkthroughs — pick any robot or simulator. Full index:
 [docs/workbench/guides/README.md](docs/workbench/guides/README.md).
 
 | Guide                                                                                             | Robot                | Sim / engine     | Public dataset                     |
 | ------------------------------------------------------------------------------------------------- | -------------------- | ---------------- | ---------------------------------- |
-| [Score a robot in 60 seconds (no GPU)](docs/workbench/guides/score-a-robot-no-gpu.md)             | any                  | offline          | shipped sample rollouts            |
 | [Pick-and-place with a Franka arm](docs/workbench/guides/franka-pick-and-place-genesis.md)        | Franka Emika Panda   | Genesis          | DROID (Franka)                     |
 | [Teach a robot to push a T](docs/workbench/guides/pusht-sim-to-real.md)                           | sim pusher           | sim-to-real loop | `lerobot/pusht`                    |
 | [Train a Reachy 2 humanoid policy](docs/workbench/guides/reachy2-lerobot-policy.md)               | Reachy 2             | LeRobot          | Pollen Robotics / LeRobot Hub      |
@@ -265,7 +191,7 @@ benchmarks): [docs/workbench/cookbooks/README.md](docs/workbench/cookbooks/READM
 Workbench is the main product surface. Every tool lives under `npa workbench`
 (there is no `solutions` CLI namespace). Highlights:
 
-- **`vlm-eval`** scores rollouts with stub, API, or self-hosted vLLM backends —
+- **`vlm-eval`** scores rollouts with API or self-hosted vLLM backends —
   see [`vlm-eval-single.yaml`](npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml).
 - **`token-factory`** wraps Nebius Token Factory for zero-GPU inference,
   captioning, and reasoning against your own frames.
@@ -306,10 +232,10 @@ Full CLI reference: [docs/cli/README.md](docs/cli/README.md).
 
 Author pipelines as declarative `npa.workflow/v0.0.1` specs — a state graph of
 Workbench `toolRef` steps with S3 handoffs, gates, and loops. The same YAML is
-what you validate offline and submit to the cluster.
+what you validate, plan, and submit to the cluster.
 
 ```bash
-# Offline
+# Validate and plan (no submit)
 npa workbench workflow validate-spec npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
 npa workbench workflow plan-spec     npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml --run-id demo
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ observability, and cluster orchestration.**
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
-[![Platforms: macOS · Linux · WSL2](https://img.shields.io/badge/platforms-macOS%20%7C%20Linux%20%7C%20WSL2-lightgrey.svg)](docs/quickstart.md#fast-install-by-platform)
+[![Platforms: macOS · Linux · Windows](https://img.shields.io/badge/platforms-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)](docs/install.md)
 [![Test](https://github.com/nebius/nebius-physical-ai/actions/workflows/test.yml/badge.svg)](https://github.com/nebius/nebius-physical-ai/actions/workflows/test.yml)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
@@ -57,24 +57,27 @@ with the same install.
 | **B. [First workload on Nebius](#b-first-workload-on-nebius)** | ~15 min | Nebius account · `nebius` CLI            | A configured project running managed Workbench tools     |
 | **C. [Self-hosted `npa agent`](#c-self-hosted-npa-agent)** | ~20 min | Authenticated `nebius` profile · Terraform · SSH key pair · Token Factory key · writable S3 creds | A browser-based chat workbench VM with embedded Rerun    |
 
-All three share the same one-time install:
+All three share the same one-time install. `npa` works with **Python 3.10+** and
+installs editable from the clone (it is not on PyPI):
 
 ```bash
 git clone https://github.com/nebius/nebius-physical-ai.git
 cd nebius-physical-ai
-python3 -m venv .venv && source .venv/bin/activate
-pip install --upgrade pip && pip install -e npa
-npa --version
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e npa
 ```
+
+Verify: `npa --version`.
 
 > The base install is deliberately lightweight — it covers the offline paths
 > (Route A) with no GPU or database wheels. Before running cloud workloads
 > (Routes B and C), add the remaining workbench dependencies with
 > `pip install -e "npa[full]"`.
 
-> **Windows:** use **WSL2 Ubuntu**. Native PowerShell / `cmd` are not
-> supported. Platform-specific install blocks:
-> [docs/quickstart.md § Fast install](docs/quickstart.md#fast-install-by-platform).
+> **Windows:** native works for install and the offline try-it (Route A); S3,
+> SkyPilot, and Kubernetes workflows (Routes B–C) need **WSL2 Ubuntu**. Full
+> per-platform steps (venv/uv, Nebius CLI, WSL2): [docs/install.md](docs/install.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,18 +46,15 @@ RTX6000).
 
 ---
 
-## Pick your path
+## Setup
 
-Two onboarding routes, in ascending order of setup effort. Both start with the
-same install and a Nebius account.
+Three steps take you from a clone to a real result on Nebius: install `npa`,
+configure Nebius, then run your first cloud workload.
 
-| Route                                              | Time         | Needs                                    | You end up with                                          |
-| -------------------------------------------------- | ------------ | ---------------------------------------- | -------------------------------------------------------- |
-| **A. [First workload on Nebius](#a-first-workload-on-nebius)** | ~15 min | Nebius account · `nebius` CLI            | A configured project running managed Workbench tools     |
-| **B. [Self-hosted `npa agent`](#b-self-hosted-npa-agent)** | ~20 min | Authenticated `nebius` profile · Terraform · SSH key pair · Token Factory key · writable S3 creds | A browser-based chat workbench VM with embedded Rerun    |
+### 1. Install npa
 
-Both routes share the same one-time install. `npa` works with **Python 3.10+**
-and installs editable from the clone (it is not on PyPI):
+`npa` works with **Python 3.10+** and installs editable from the clone (it is
+not on PyPI):
 
 ```bash
 git clone https://github.com/nebius/nebius-physical-ai.git
@@ -76,41 +73,50 @@ Verify: `npa --version`.
 > **Windows:** use **WSL2 Ubuntu**. Full per-platform steps (venv, Nebius CLI,
 > WSL2): [docs/install.md](docs/install.md).
 
----
+### 2. Configure Nebius
 
-### A. First workload on Nebius
+[Sign up](https://docs.nebius.com/signup-billing/sign-up) and create a
+[tenant and project](https://docs.nebius.com/iam/manage-projects), install the
+Nebius CLI, then run `npa configure` — it creates or reuses your Nebius CLI
+profile and writes `~/.npa/credentials.yaml` + `~/.npa/config.yaml`:
 
-1. [Sign up](https://docs.nebius.com/signup-billing/sign-up) and create a
-   [tenant and project](https://docs.nebius.com/iam/manage-projects).
-2. Install the Nebius CLI:
+```bash
+curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
+export PATH="${HOME}/.nebius/bin:${PATH}"   # add to ~/.zshrc or ~/.bashrc
+npa configure
+```
 
-   ```bash
-   curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
-   export PATH="${HOME}/.nebius/bin:${PATH}"   # add to ~/.zshrc or ~/.bashrc
-   ```
-
-3. Interactive setup — creates or reuses your Nebius CLI profile and prompts
-   for project, tenant, region, container registry, bucket, and optional API
-   keys (in that order):
-
-   ```bash
-   npa configure --interactive
-   ```
-
-Now you're ready for [docs/workbench/getting-started.md](docs/workbench/getting-started.md).
 Full account/credential detail: [docs/quickstart.md](docs/quickstart.md).
 
-**Zero-GPU inference:** [Nebius Token Factory](https://tokenfactory.nebius.com/)
-needs only a `NEBIUS_TOKEN_FACTORY_KEY` — see
-[docs/workbench/token-factory.md](docs/workbench/token-factory.md). This is
-the cheapest way to try large models against your own data.
+### 3. Your first cloud result
 
-**Flagship GPU workload:** NVIDIA Cosmos (`npa workbench cosmos deploy/infer`)
-— see [docs/quickstart.md § Cosmos](docs/quickstart.md#7-flagship-gpu-workload-nvidia-cosmos).
+[Nebius Token Factory](https://tokenfactory.nebius.com/) zero-GPU inference is
+the cheapest way to get a real result — it needs only a
+`NEBIUS_TOKEN_FACTORY_KEY` (add it during `npa configure`), no cluster or GPU:
+
+```bash
+npa workbench token-factory verify        # confirm the key authenticates
+printf 'Explain sim-to-real transfer in one sentence.\n' > /tmp/prompts.txt
+npa workbench token-factory generate \
+  --input-path /tmp/prompts.txt --output-path /tmp/tf-generations.jsonl --output json
+```
+
+See [docs/workbench/token-factory.md](docs/workbench/token-factory.md).
 
 ---
 
-### B. Self-hosted `npa agent`
+## Do more with npa
+
+- **Run workbench workloads** — NVIDIA Cosmos, vlm-eval, sim2real, and more.
+  Start with the [robot guides](docs/workbench/guides/README.md) and
+  [Workbench Getting Started](docs/workbench/getting-started.md); the flagship
+  GPU workload is
+  [NVIDIA Cosmos](docs/quickstart.md#7-flagship-gpu-workload-nvidia-cosmos).
+- **Deploy the self-hosted agent** — `npa agent` is a browser workbench VM. It
+  builds on the setup above and additionally needs **Terraform**, an **SSH key
+  pair**, a **Token Factory key**, and **writable S3** (~20 min).
+
+### Deploy the self-hosted `npa` agent
 
 `npa agent` is a self-hosted **browser workbench VM**: HTTPS UI with
 basic-auth login, grounded chat over Nebius Token Factory

--- a/docs/cli/health.md
+++ b/docs/cli/health.md
@@ -11,6 +11,7 @@ Options
 --help  Show this message and exit.
 Commands
 preflight  Validate HF, NGC, S3, and Token Factory credentials before a deploy or GPU job.
+access  Check HF + NGC access to every gated model the workbench capabilities need.
 ```
 
 ## Options
@@ -24,6 +25,7 @@ preflight  Validate HF, NGC, S3, and Token Factory credentials before a deploy o
 | Command | Description |
 | --- | --- |
 | `preflight` | Validate HF, NGC, S3, and Token Factory credentials before a deploy or GPU job. |
+| `access` | Check HF + NGC access to every gated model the workbench capabilities need. |
 
 ## Examples
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,136 @@
+# Installing npa on every platform
+
+`npa` runs on **macOS**, **Linux**, and **Windows**, and works with
+**Python 3.10+**. It is not published to PyPI, so you always install it editable
+from a clone of this repository.
+
+The [quickstart install](quickstart.md#3-install-npa) has the short,
+copy-paste path. This page collects the full per-platform detail — Python setup,
+the Nebius CLI, WSL2, and optional operator tools — for when the default needs a
+little more.
+
+## Platform support at a glance
+
+| Platform | Install + offline quickstart | Cloud (S3 / SkyPilot / Kubernetes) |
+| --- | --- | --- |
+| macOS (Intel / Apple Silicon) | native | native |
+| Linux (Debian/Ubuntu, ...) | native | native |
+| Windows | native (PowerShell / cmd) | use **WSL2 Ubuntu** |
+
+Native Windows is fine for installing `npa` and running the offline paths
+(`npa --version`, the vlm-eval stub benchmark, `npa workbench workflow
+validate-spec`). Cloud workflows that shell out to S3, SkyPilot, and Kubernetes
+tooling assume a POSIX environment — run those from **WSL2 Ubuntu**.
+
+## 1. Get Python 3.10+
+
+Check what you have:
+
+```bash
+python3 --version
+```
+
+If it is older than 3.10 (or missing):
+
+- **macOS:** `brew install python@3.12`, or download from
+  [python.org](https://www.python.org/downloads/), or use
+  [pyenv](https://github.com/pyenv/pyenv).
+- **Debian/Ubuntu:** the interpreter is usually current; also install the venv
+  module (shipped separately): `sudo apt-get install -y python3 python3-venv`.
+- **Windows:** install from [python.org](https://www.python.org/downloads/)
+  (check "Add python.exe to PATH"), or from the Microsoft Store.
+
+## 2. Create a virtual environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+On native **Windows** PowerShell, activate with `.venv\Scripts\Activate.ps1`
+(or `.venv\Scripts\activate.bat` in cmd) instead of `source .venv/bin/activate`.
+
+## 3. Install npa (editable, from the clone)
+
+```bash
+git clone https://github.com/nebius/nebius-physical-ai.git
+cd nebius-physical-ai
+pip install -e npa
+```
+
+Verify:
+
+```bash
+npa --version
+```
+
+Prefer [`uv`](https://docs.astral.sh/uv/)? It can install Python and create the
+env in one go: `uv venv .venv && source .venv/bin/activate && uv pip install -e npa`.
+
+The base install is lightweight — it carries only what the offline paths need.
+Add extras when a workload requires them:
+
+```bash
+pip install -e "npa[full]"      # everything below except the GPU extras
+pip install -e "npa[data]"      # pandas/scipy/matplotlib curation + reports
+pip install -e "npa[lancedb]"   # LanceDB workbench tool
+pip install -e "npa[viz]"       # Rerun viewer/recording integration
+pip install -e "npa[server]"    # FastAPI policy/eval server
+pip install -e "npa[adapter]"   # dataset conversion
+pip install -e "npa[genesis]"   # Genesis + distillation stages (GPU)
+pip install -e "npa[groot]"     # GR00T SDK (GPU)
+pip install -e "npa[dev]"       # tests, lint (pytest, ruff)
+```
+
+Activate the venv in every new shell (`source .venv/bin/activate`), or call the
+interpreter directly with `./.venv/bin/npa` without activating.
+
+## 4. Nebius CLI (cloud steps only)
+
+The offline quickstart needs no cloud tooling. For managed workbench deploys and
+`npa configure`, install the Nebius AI Cloud CLI:
+
+```bash
+# macOS / Linux (and inside WSL2)
+curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
+export PATH="${HOME}/.nebius/bin:${PATH}"   # add to ~/.zshrc or ~/.bashrc to persist
+```
+
+`npa configure` creates or reuses a local profile for you (no manual
+`nebius profile create` step). See <https://docs.nebius.com/cli/install> for
+details.
+
+## 5. Optional operator tools
+
+- **macOS:** `brew install jq`, plus `kubectl` and `terraform` from their
+  official installers (Terraform is no longer in Homebrew core:
+  `brew install hashicorp/tap/terraform`).
+- **Debian/Ubuntu:** `sudo apt-get install -y jq`. `kubectl` and `terraform` are
+  **not** in the stock apt repositories — install `kubectl` from the
+  [Kubernetes docs](https://kubernetes.io/docs/tasks/tools/) and `terraform`
+  from [HashiCorp's apt repo](https://developer.hashicorp.com/terraform/install#linux).
+
+## 6. Windows via WSL2 (for cloud workflows)
+
+Native Windows covers install and the offline quickstart. For S3 / SkyPilot /
+Kubernetes workflows, use WSL2 Ubuntu. In PowerShell (admin), install WSL once:
+
+```powershell
+wsl --install -d Ubuntu
+```
+
+Restart if prompted, open **Ubuntu** from the Start menu, then follow the
+Debian/Ubuntu steps above inside WSL. Keep the repo under your Linux home (for
+example `~/nebius-physical-ai`), not under `/mnt/c/…`, for faster I/O and fewer
+path issues.
+
+## Out of scope (extra steps needed)
+
+These work but are not covered by the copy-paste path:
+
+- **Alpine / musl** distros: some wheels are glibc-only; expect to build from
+  source or use a glibc base image.
+- **Brand-new Python** (a release so new that dependency wheels do not exist
+  yet): pin to the latest Python that has wheels, or build from source.
+- **Air-gapped machines:** pre-mirror the repo and a wheelhouse; `pip install -e`
+  still needs the transitive dependencies available offline.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Installing npa on every platform
 
-`npa` runs on **macOS**, **Linux**, and **Windows**, and works with
+`npa` targets **macOS**, **Linux**, and **Windows via WSL2**, and works with
 **Python 3.10+**. It is not published to PyPI, so you always install it editable
 from a clone of this repository.
 
@@ -11,16 +11,14 @@ little more.
 
 ## Platform support at a glance
 
-| Platform | Install + offline quickstart | Cloud (S3 / SkyPilot / Kubernetes) |
-| --- | --- | --- |
-| macOS (Intel / Apple Silicon) | native | native |
-| Linux (Debian/Ubuntu, ...) | native | native |
-| Windows | native (PowerShell / cmd) | use **WSL2 Ubuntu** |
+| Platform | Supported |
+| --- | --- |
+| macOS (Intel / Apple Silicon) | native |
+| Linux (Debian/Ubuntu, ...) | native |
+| Windows | via **WSL2 Ubuntu** |
 
-Native Windows is fine for installing `npa` and running the offline paths
-(`npa --version`, the vlm-eval stub benchmark, `npa workbench workflow
-validate-spec`). Cloud workflows that shell out to S3, SkyPilot, and Kubernetes
-tooling assume a POSIX environment — run those from **WSL2 Ubuntu**.
+`npa` runs cloud workloads (S3, SkyPilot, Kubernetes) that assume a POSIX
+environment, so on Windows do all `npa` work from **WSL2 Ubuntu**.
 
 ## 1. Get Python 3.10+
 
@@ -47,8 +45,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 ```
 
-On native **Windows** PowerShell, activate with `.venv\Scripts\Activate.ps1`
-(or `.venv\Scripts\activate.bat` in cmd) instead of `source .venv/bin/activate`.
+On Windows, do this inside **WSL2 Ubuntu** (see [§6](#6-windows-via-wsl2)).
 
 ## 3. Install npa (editable, from the clone)
 
@@ -67,8 +64,8 @@ npa --version
 Prefer [`uv`](https://docs.astral.sh/uv/)? It can install Python and create the
 env in one go: `uv venv .venv && source .venv/bin/activate && uv pip install -e npa`.
 
-The base install is lightweight — it carries only what the offline paths need.
-Add extras when a workload requires them:
+The base install is the core CLI, with no GPU or database wheels. Add extras
+when a workload requires them:
 
 ```bash
 pip install -e "npa[full]"      # everything below except the GPU extras
@@ -85,10 +82,10 @@ pip install -e "npa[dev]"       # tests, lint (pytest, ruff)
 Activate the venv in every new shell (`source .venv/bin/activate`), or call the
 interpreter directly with `./.venv/bin/npa` without activating.
 
-## 4. Nebius CLI (cloud steps only)
+## 4. Nebius CLI (required)
 
-The offline quickstart needs no cloud tooling. For managed workbench deploys and
-`npa configure`, install the Nebius AI Cloud CLI:
+`npa` runs on Nebius, so the Nebius AI Cloud CLI is part of the standard setup —
+`npa configure` and every managed workbench deploy use it. Install it:
 
 ```bash
 # macOS / Linux (and inside WSL2)
@@ -110,10 +107,10 @@ details.
   [Kubernetes docs](https://kubernetes.io/docs/tasks/tools/) and `terraform`
   from [HashiCorp's apt repo](https://developer.hashicorp.com/terraform/install#linux).
 
-## 6. Windows via WSL2 (for cloud workflows)
+## 6. Windows via WSL2
 
-Native Windows covers install and the offline quickstart. For S3 / SkyPilot /
-Kubernetes workflows, use WSL2 Ubuntu. In PowerShell (admin), install WSL once:
+On Windows, run all `npa` work from WSL2 Ubuntu. In PowerShell (admin), install
+WSL once:
 
 ```powershell
 wsl --install -d Ubuntu

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -353,6 +353,36 @@ npa demo stage --source-project project-a --target-project project-b \
   --target-bucket s3://customer-bucket/demo-artifacts/ --allow-host-creds
 ```
 
+### 4e. Accept and verify gated model access
+
+Several workbench capabilities (GR00T, Cosmos, sim2real) pull **gated** models
+from Hugging Face and NVIDIA NGC. Hugging Face gated models require you to accept
+the license once per model — click **"Agree and access repository"** on each
+model page while signed in. There is no API that accepts these licenses for you.
+
+Once your `HF_TOKEN` and `NGC_API_KEY` are set, verify access to every gated
+model the workbench needs (the command prints the exact page to accept for any
+model you have not yet unlocked):
+
+```bash
+npa workbench health access
+# or pass keys explicitly / persist them:
+npa workbench health access --hf-token hf_xxx --ngc-key nvapi-xxx --set-credentials
+# scope to one capability, or run offline (presence-only):
+npa workbench health access --capability groot
+```
+
+A convenience wrapper is also available:
+
+```bash
+HF_TOKEN=hf_xxx NGC_API_KEY=nvapi-xxx scripts/accept-model-access.sh
+```
+
+The report is PASS/WARN/FAIL per model; it exits non-zero if a required gated
+model is still inaccessible, so it fits a CI or cold-start preflight. For the
+broader credential preflight (HF/NGC/S3/Token Factory presence and
+reachability), use `npa workbench health preflight`.
+
 ## 5. First platform checks
 
 These commands should not provision cloud resources:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -234,7 +234,9 @@ that order, no defaults shown), your region and container registry (defaults are
 discovered from the project), guides you to reuse an existing bucket or create a
 default `npa-bucket` (standard storage, size limit in GB), and asks for a local
 **project alias** (default = region; used later as `-p <alias>`). It then
-writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`:
+writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`, and prints a one-line
+`[NOTE]` summarizing which gated workbench models your HF and NGC tokens can (or
+cannot) access — see [§4e](#4e-accept-and-verify-gated-model-access):
 
 ```bash
 npa configure

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -220,9 +220,11 @@ long-lived `NEBIUS_TOKEN` in `~/.npa/credentials.yaml`.
 
 Before running `npa configure`, sign up for Nebius AI Cloud, note your tenant
 id, and create a project in the target region. An Object Storage bucket is
-optional — `npa configure` creates a default `npa-bucket` with **standard**
-storage and a size cap when you press Enter at the bucket prompt (you can choose
-`enhanced` storage or a custom size for new buckets). To reuse your own bucket,
+optional — `npa configure` creates a default bucket named `npa-bucket-<hash>`
+(a short hash of your tenant and project ids, e.g. `npa-bucket-1a2b3c4d`) with
+**standard** storage and a size cap when you press Enter at the bucket prompt
+(you can choose `enhanced` storage or a custom size for new buckets). To reuse
+your own bucket,
 create one first; see the README **Nebius AI Cloud account** section,
 [Creating a tenant](https://docs.nebius.com/iam/create-tenants),
 [Manage projects](https://docs.nebius.com/iam/manage-projects), and
@@ -231,9 +233,9 @@ create one first; see the README **Nebius AI Cloud account** section,
 Run interactive setup in a terminal. `npa configure` creates or reuses your
 Nebius CLI profile first, then prompts for your project id and tenant id, your
 region and container registry (defaults are discovered from the project), guides
-you to reuse an existing bucket or create a default `npa-bucket` (standard
-storage, size limit in GB), and asks for a local **project alias** (default =
-region; used later as `-p <alias>`).
+you to reuse an existing bucket or create a default `npa-bucket-<hash>` bucket
+(standard storage, size limit in GB), and asks for a local **project alias**
+(default = region; used later as `-p <alias>`).
 
 `npa configure` is idempotent: re-run it any time to update keys or properties.
 On a re-run every prompt is pre-filled with the value already saved in
@@ -279,6 +281,8 @@ Use these canonical keys in `~/.npa/credentials.yaml`.
 | Need | `credentials.yaml` key | Environment override | Required when |
 |---|---|---|---|
 | Hugging Face token | `tokens.HF_TOKEN` | `HF_TOKEN` | Downloading gated Hugging Face models, datasets, or weights |
+| Nebius Token Factory key | `tokens.NEBIUS_TOKEN_FACTORY_KEY` | `NEBIUS_TOKEN_FACTORY_KEY` | Zero-GPU hosted inference (Token Factory / OpenAI-compatible) paths |
+| Nebius AI Cloud key | `tokens.NEBIUS_AI_CLOUD_KEY` | `NEBIUS_AI_CLOUD_KEY` | Calling Nebius AI Cloud APIs |
 | NGC API key | `ngc.api_key` | `NGC_API_KEY` | Using NGC-backed GR00T model references |
 | NGC organization | `ngc.org` | `NGC_ORG` | Your NGC key is organization-scoped |
 | NGC team | `ngc.team` | `NGC_TEAM` | Your NGC key is team-scoped |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -484,10 +484,21 @@ and [the workflows guide](workbench-yaml-guide.md) for routing, backend
 selection, and known limits. Isaac Lab is the simulation counterpart but is
 RT-core-only (L40S / RTX Pro 6000); see its guide before choosing GPU type.
 
-## 8. Where to next
+## 8. Do more with npa
 
-- [Workbench Getting Started](workbench/getting-started.md): Kubernetes,
-  SkyPilot, registry, S3, and first workload setup.
+With install → `npa configure` → a first cloud result done, build outward:
+
+- **Run workbench workloads** — NVIDIA Cosmos (Section 7), vlm-eval, sim2real,
+  and more. See [Workbench Getting Started](workbench/getting-started.md) for
+  Kubernetes, SkyPilot, registry, and S3 setup, and the
+  [robot guides](workbench/guides/README.md).
+- **Deploy the self-hosted agent** — `npa agent` is a browser workbench VM. It
+  builds on the setup above and additionally needs Terraform, an SSH key pair, a
+  Token Factory key, and writable S3. Operator docs:
+  [skills/tools/npa-agent/SKILL.md](../skills/tools/npa-agent/SKILL.md).
+
+Reference:
+
 - [CLI and package overview](../npa/README.md): package-level command and
   development notes.
 - [Repository overview](../README.md): project map and current workbench list.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,8 +25,9 @@ the package overview in [npa/README.md](../npa/README.md).
 
 - Python 3.10 or newer. The package metadata requires `>=3.10`.
 - Git, `python3 -m venv`, and `pip`.
-- **macOS**, **Linux**, or **Windows via WSL2** (Ubuntu). Native Windows shells
-  (PowerShell, cmd) are not supported for `npa` workflows — use WSL2.
+- **macOS**, **Linux**, or **Windows**. Native Windows works for install and the
+  offline quickstart; S3 / SkyPilot / Kubernetes workflows require **WSL2 Ubuntu**
+  (see [docs/install.md](install.md)).
 - A Nebius AI Cloud account with billing enabled. Start with the Nebius signup
   guide: <https://docs.nebius.com/signup-billing/sign-up>.
 - The Nebius AI Cloud CLI binary on `PATH`. Install it from
@@ -54,117 +55,45 @@ nebius profile list
 terraform version
 ```
 
-### Fast install by platform
-
-Copy-paste once per machine. All paths install the Nebius CLI, clone NPA, create
-a venv, and verify `npa`. Then set up credentials in Section 4 with
-`npa configure`, which creates or reuses your Nebius CLI profile for you (no
-manual `nebius profile create` step). Run `npa configure` only after you have a
-Nebius project and tenant id ready (Section 4a).
-
-| Platform | Shell | Nebius CLI |
-| --- | --- | --- |
-| macOS (Intel or Apple Silicon) | Terminal / zsh | Official install script (see below) |
-| Linux (Debian/Ubuntu) | bash | `curl …/cli/install.sh \| bash` |
-| Windows | **WSL2 Ubuntu** only | same curl one-liner inside WSL |
-
-**macOS**
-
-```bash
-curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
-export PATH="${HOME}/.nebius/bin:${PATH}"   # add to ~/.zshrc to persist
-git clone https://github.com/nebius/nebius-physical-ai.git
-cd nebius-physical-ai
-python3 -m venv .venv
-source .venv/bin/activate
-pip install --upgrade pip
-pip install -e npa
-npa --version
-```
-
-Then continue with credential setup in Section 4 (`npa configure`).
-
-Optional operator tools: `brew install python@3.12 jq`, plus `kubectl` and
-`terraform` from their official installers (Terraform is no longer in
-Homebrew core: `brew install hashicorp/tap/terraform`).
-
-**Linux (Debian/Ubuntu)**
-
-```bash
-sudo apt-get update
-sudo apt-get install -y git python3 python3-venv python3-pip curl
-curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
-export PATH="${HOME}/.nebius/bin:${PATH}"   # add to ~/.bashrc to persist
-git clone https://github.com/nebius/nebius-physical-ai.git
-cd nebius-physical-ai
-python3 -m venv .venv
-source .venv/bin/activate
-pip install --upgrade pip
-pip install -e npa
-npa --version
-```
-
-Then continue with credential setup in Section 4 (`npa configure`).
-
-Optional operator tools: `sudo apt-get install -y jq`. `kubectl` and
-`terraform` are **not** in the stock Ubuntu apt repositories — install
-`kubectl` from the [Kubernetes docs](https://kubernetes.io/docs/tasks/tools/)
-and `terraform` from
-[HashiCorp's apt repo](https://developer.hashicorp.com/terraform/install#linux).
-
-**Windows (WSL2)**
-
-In PowerShell (admin), install WSL once:
-
-```powershell
-wsl --install -d Ubuntu
-```
-
-Restart if prompted, open **Ubuntu** from the Start menu, then run the **Linux**
-block above inside WSL. Keep the repo under your Linux home (for example
-`~/nebius-physical-ai`), not under `/mnt/c/…`, for faster I/O and fewer path
-issues.
-
-**Windows (native)** — not supported. Use WSL2 Ubuntu; do not run `npa` from
-PowerShell or Git Bash for cluster/S3 workflows.
-
-After install, activate the venv in every new shell:
-
-```bash
-cd nebius-physical-ai
-source .venv/bin/activate
-```
-
 ## 3. Install npa
 
-Clone the repository and install the Python package into a fresh virtual
-environment. The venv can live anywhere (for example `.venv` in the repo, or
-`~/.venvs/npa`); activating it puts `npa` on your `PATH`:
+`npa` works with **Python 3.10+**. It installs editable from a clone (it is not
+on PyPI):
 
 ```bash
-git clone <REPO_URL> nebius-physical-ai
+git clone https://github.com/nebius/nebius-physical-ai.git
 cd nebius-physical-ai
-
 python3 -m venv .venv
 source .venv/bin/activate
-pip install --upgrade pip
 pip install -e npa
 ```
 
-If you prefer not to activate the venv, call its interpreter directly
-(`./.venv/bin/python -m pip install -e npa`) and use `./.venv/bin/npa` instead
-of `npa`. The rest of this guide assumes the venv is activated.
+Verify: `npa --version`.
 
-Verify the install:
+`npa --version` prints `npa <version>`, and `npa --help` prints the command tree
+without requiring Nebius, Hugging Face, NGC, Kubernetes, or S3 credentials.
 
-```bash
-npa --version
-npa --help
-```
+<details>
+<summary>Platform notes</summary>
 
-Gate: `npa --version` prints `npa <version>`, and `npa --help` prints the
-command tree without requiring Nebius, Hugging Face, NGC, Kubernetes, or S3
-credentials.
+- **Windows:** run inside **WSL2 Ubuntu** for cloud (S3 / SkyPilot / Kubernetes)
+  workflows; native Windows works for install and the offline quickstart. On
+  PowerShell activate with `.venv\Scripts\Activate.ps1` instead of
+  `source .venv/bin/activate`.
+- **Debian/Ubuntu:** install the venv module first —
+  `sudo apt-get install -y python3-venv`.
+- **Need Python 3.10+, or a faster installer?** [`uv`](https://docs.astral.sh/uv/)
+  can install Python and create the env:
+  `uv venv .venv && source .venv/bin/activate && uv pip install -e npa`.
+- **Out of scope (needs extra steps):** Alpine/musl, brand-new Python before
+  wheels exist, and air-gapped machines.
+
+Full per-platform steps — Nebius CLI, WSL2 setup, operator tools:
+[docs/install.md](install.md).
+</details>
+
+If you prefer not to activate the venv, call its interpreter directly with
+`./.venv/bin/npa`. The rest of this guide assumes the venv is activated.
 
 The base install is lightweight: it carries only what the offline paths need.
 Optional extras are available when you need them:
@@ -182,7 +111,8 @@ pip install -e "npa[dev]"       # tests, lint (pytest, ruff); see Section 6
 ```
 
 Before running cloud workloads (Sections 5+), install `npa[full]` so every
-workbench tool has its dependencies.
+workbench tool has its dependencies. Cloud steps also need the Nebius CLI —
+see [docs/install.md § Nebius CLI](install.md#4-nebius-cli-cloud-steps-only).
 
 ## 4. Configure credentials
 
@@ -224,8 +154,8 @@ optional — `npa configure` creates a default bucket named `npa-bucket-<hash>`
 (a short hash of your tenant and project ids, e.g. `npa-bucket-1a2b3c4d`) with
 **standard** storage and a size cap when you press Enter at the bucket prompt
 (you can choose `enhanced` storage or a custom size for new buckets). To reuse
-your own bucket,
-create one first; see the README **Nebius AI Cloud account** section,
+your own bucket, create one first; see the README **Nebius AI Cloud account**
+section,
 [Creating a tenant](https://docs.nebius.com/iam/create-tenants),
 [Manage projects](https://docs.nebius.com/iam/manage-projects), and
 [Manage buckets](https://docs.nebius.com/object-storage/buckets/manage).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -229,11 +229,19 @@ create one first; see the README **Nebius AI Cloud account** section,
 [Manage buckets](https://docs.nebius.com/object-storage/buckets/manage).
 
 Run interactive setup in a terminal. `npa configure` creates or reuses your
-Nebius CLI profile first, then prompts for your project id and tenant id (in
-that order, no defaults shown), your region and container registry (defaults are
-discovered from the project), guides you to reuse an existing bucket or create a
-default `npa-bucket` (standard storage, size limit in GB), and asks for a local
-**project alias** (default = region; used later as `-p <alias>`). It then
+Nebius CLI profile first, then prompts for your project id and tenant id, your
+region and container registry (defaults are discovered from the project), guides
+you to reuse an existing bucket or create a default `npa-bucket` (standard
+storage, size limit in GB), and asks for a local **project alias** (default =
+region; used later as `-p <alias>`).
+
+`npa configure` is idempotent: re-run it any time to update keys or properties.
+On a re-run every prompt is pre-filled with the value already saved in
+`~/.npa/config.yaml` / `~/.npa/credentials.yaml`, so pressing Enter through the
+flow keeps your current setup unchanged, and typing a new value updates just
+that field. When object storage is already configured it defaults to keeping the
+existing bucket and S3 key (so a re-run does not mint a new access key); decline
+that prompt to re-provision. It then
 writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`, and prints a one-line
 `[NOTE]` summarizing which gated workbench models your HF and NGC tokens can (or
 cannot) access — see [§4e](#4e-accept-and-verify-gated-model-access):

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,14 +23,17 @@ the package overview in [npa/README.md](../npa/README.md).
 
 ## 2. Prerequisites
 
+`npa` runs cloud workloads on Nebius, so a Nebius account and the `nebius` CLI
+are required.
+
 - Python 3.10 or newer. The package metadata requires `>=3.10`.
 - Git, `python3 -m venv`, and `pip`.
-- **macOS**, **Linux**, or **Windows**. Native Windows works for install and the
-  offline quickstart; S3 / SkyPilot / Kubernetes workflows require **WSL2 Ubuntu**
-  (see [docs/install.md](install.md)).
-- A Nebius AI Cloud account with billing enabled. Start with the Nebius signup
-  guide: <https://docs.nebius.com/signup-billing/sign-up>.
-- The Nebius AI Cloud CLI binary on `PATH`. Install it from
+- **macOS**, **Linux**, or **Windows via WSL2** (Ubuntu). `npa` cloud workflows
+  (S3 / SkyPilot / Kubernetes) assume a POSIX environment — on Windows run
+  everything from WSL2 (see [docs/install.md](install.md)).
+- **Required:** a Nebius AI Cloud account with billing enabled. Start with the
+  Nebius signup guide: <https://docs.nebius.com/signup-billing/sign-up>.
+- **Required:** the Nebius AI Cloud CLI binary on `PATH`. Install it from
   <https://docs.nebius.com/cli/install>; `npa configure` creates or reuses a
   local profile for you (no manual `nebius profile create` step).
 - Terraform on `PATH` for later managed `deploy` and `--destroy` commands.
@@ -76,10 +79,8 @@ without requiring Nebius, Hugging Face, NGC, Kubernetes, or S3 credentials.
 <details>
 <summary>Platform notes</summary>
 
-- **Windows:** run inside **WSL2 Ubuntu** for cloud (S3 / SkyPilot / Kubernetes)
-  workflows; native Windows works for install and the offline quickstart. On
-  PowerShell activate with `.venv\Scripts\Activate.ps1` instead of
-  `source .venv/bin/activate`.
+- **Windows:** use **WSL2 Ubuntu**. `npa` cloud workflows (S3 / SkyPilot /
+  Kubernetes) assume a POSIX environment; run everything from WSL2.
 - **Debian/Ubuntu:** install the venv module first —
   `sudo apt-get install -y python3-venv`.
 - **Need Python 3.10+, or a faster installer?** [`uv`](https://docs.astral.sh/uv/)
@@ -95,8 +96,8 @@ Full per-platform steps — Nebius CLI, WSL2 setup, operator tools:
 If you prefer not to activate the venv, call its interpreter directly with
 `./.venv/bin/npa`. The rest of this guide assumes the venv is activated.
 
-The base install is lightweight: it carries only what the offline paths need.
-Optional extras are available when you need them:
+The base install is the core CLI, with no GPU or database wheels. Add extras
+when a workload requires them:
 
 ```bash
 pip install -e "npa[full]"      # everything below except the GPU extras
@@ -111,8 +112,8 @@ pip install -e "npa[dev]"       # tests, lint (pytest, ruff); see Section 6
 ```
 
 Before running cloud workloads (Sections 5+), install `npa[full]` so every
-workbench tool has its dependencies. Cloud steps also need the Nebius CLI —
-see [docs/install.md § Nebius CLI](install.md#4-nebius-cli-cloud-steps-only).
+workbench tool has its dependencies. You also need the Nebius CLI —
+see [docs/install.md § Nebius CLI](install.md#4-nebius-cli-required).
 
 ## 4. Configure credentials
 
@@ -343,112 +344,63 @@ S3 bucket and access key); use `npa configure --show` for a read-only view of
 the file layout, or `npa configure --no-provision` to enter existing S3
 credentials by hand.
 
-### 5a. Your first real result (offline)
+### 5a. Your first result: zero-GPU inference (Nebius Token Factory)
 
-You can produce a real eval result with no cloud, GPU, or credentials. The
-`vlm-eval benchmark` command scores a shipped, labeled rollout set with the
-offline `stub` backend. Run it from the repository root — the `--dataset` path
-is relative to it (or pass an absolute path):
+The cheapest way to get a real result on Nebius is
+[Token Factory](https://tokenfactory.nebius.com/) hosted inference —
+OpenAI-compatible, zero-GPU, and it needs only a `NEBIUS_TOKEN_FACTORY_KEY`
+(no cluster, registry, or S3). Add the key with `npa configure` (or
+`export NEBIUS_TOKEN_FACTORY_KEY=v1...`), then confirm it authenticates:
 
 ```bash
-npa workbench vlm-eval benchmark \
-  --dataset npa/src/npa/workbench/vlm_eval/fixtures/sample_benchmark/benchmark.json \
-  --output /tmp/vlm-eval-benchmark.json \
-  --backend stub \
-  --thresholds 0.5,0.8,0.9 \
-  --rubrics default,strict \
-  --models Qwen/Qwen2-VL-7B-Instruct \
-  --format json
+npa workbench token-factory verify
 ```
 
-Gate: the report ranks configurations and reports `accuracy: 1.0` over four
-labeled rollouts, and writes `/tmp/vlm-eval-benchmark.json`.
+Generate a completion against a hosted model — write a prompt and run:
 
-### 5b. The same eval, three coherent ways
+```bash
+printf 'Explain sim-to-real transfer in one sentence.\n' > /tmp/prompts.txt
+npa workbench token-factory generate \
+  --input-path /tmp/prompts.txt \
+  --output-path /tmp/tf-generations.jsonl \
+  --output json
+```
 
-Every Workbench capability is usable as a `npa` CLI command, a Python SDK call,
-and a parameterizable SkyPilot YAML you can run with raw `sky`. The three stay
-coherent; pick whichever fits your workflow.
+Gate: `verify` reports `authenticated: true` with a non-zero model count, and
+`generate` writes `/tmp/tf-generations.jsonl` with a completion for the prompt.
+
+More Token Factory capabilities (image captioning, physical-scene reasoning) and
+the checked-in SkyPilot templates:
+[docs/workbench/token-factory.md](workbench/token-factory.md).
+
+### 5b. The same capability, three coherent ways
+
+Every Workbench capability is usable as an `npa` CLI command, a Python SDK call,
+and a parameterizable SkyPilot YAML. The three stay coherent; pick whichever
+fits your workflow.
 
 **CLI** (shown above):
 
 ```bash
-npa workbench vlm-eval benchmark --dataset <benchmark.json> --backend stub --format json
+npa workbench token-factory generate --input-path /tmp/prompts.txt \
+  --output-path /tmp/tf-generations.jsonl --output json
 ```
 
 **Python SDK:**
 
 ```python
-from npa.sdk.workbench import vlm_eval
-from npa.workbench.vlm_eval import DEFAULT_MODEL, DEFAULT_SAMPLE_BENCHMARK_PATH
+from npa.workbench.token_factory import generate_text
 
-report = vlm_eval.benchmark(
-    dataset=str(DEFAULT_SAMPLE_BENCHMARK_PATH),
-    backend="stub",
-    thresholds=[0.5, 0.8, 0.9],
-    rubrics=["default", "strict"],
-    models=[DEFAULT_MODEL],
+result = generate_text(
+    input_path="/tmp/prompts.txt",
+    output_path="/tmp/tf-generations.jsonl",
 )
-print(report.best_config.metrics.accuracy)  # 1.0
+print(result.generations[0].completion)
 ```
 
-**Standalone SkyPilot YAML (raw `sky`, BYO S3 endpoint + image).** Save this at
-the repo root as `vlm-eval-benchmark.sky.yaml` and run it with plain `sky
-launch` — no `npa` CLI or SDK orchestrating it. `workdir: .` uploads your
-cloned checkout so the job installs `npa` from the synced source (there is no
-public PyPI/registry dependency). Run as-is to score the in-repo fixture with
-the offline `stub` backend, or override the `--env` values to use your own
-image and object storage:
-
-```yaml
-name: vlm-eval-benchmark
-# Upload the cloned repo so the job can `pip install -e ./npa` without needing
-# npa on PyPI or a prebuilt image. Launch this file from the repo root.
-workdir: .
-resources:
-  cloud: kubernetes
-  cpus: 4
-  # Generic CPU Python image; npa installs from the synced workdir in `setup`.
-  # SkyPilot does not expand env vars in `image_id`, so bring your own image by
-  # overriding it at launch:
-  #   sky launch ... --image-id docker:cr.<region>.nebius.cloud/<registry-id>/<image>:<tag>
-  image_id: docker:python:3.11-slim
-envs:
-  # Defaults read the in-repo fixture (uploaded via workdir) and write a local
-  # report — no object storage required. Point these at s3:// URIs plus an
-  # endpoint to bring your own storage.
-  BENCHMARK_URI: "npa/src/npa/workbench/vlm_eval/fixtures/sample_benchmark/benchmark.json"
-  OUTPUT_URI: "vlm-eval-benchmark-report.json"
-  AWS_ENDPOINT_URL: ""
-  VLM_BACKEND: "stub"
-setup: |
-  set -euo pipefail
-  pip install --upgrade pip
-  pip install -e ./npa
-run: |
-  set -euo pipefail
-  npa workbench vlm-eval benchmark \
-    --dataset "${BENCHMARK_URI}" \
-    --output "${OUTPUT_URI}" \
-    --backend "${VLM_BACKEND}" \
-    --format json
-```
-
-```bash
-# Run from the repo root. As written it scores the in-repo fixture with the
-# offline stub backend and tears the cluster down when done (--down). Override
-# any value at launch; nothing is hardcoded to a specific account. Use
-# --image-id for a BYO image and matching s3:// URIs for BYO storage.
-sky launch -y --down -c vlm-eval vlm-eval-benchmark.sky.yaml \
-  --image-id docker:cr.<your-region>.nebius.cloud/<your-registry-id>/<image>:<tag> \
-  --env BENCHMARK_URI=s3://<your-bucket>/vlm-eval/benchmark.json \
-  --env OUTPUT_URI=s3://<your-bucket>/vlm-eval/benchmark-report.json \
-  --env AWS_ENDPOINT_URL=https://storage.<your-region>.nebius.cloud
-```
-
-For maintained, checked-in workflow YAMLs (including a self-hosted GPU VLM
-variant), see `npa/src/npa/workflows/skypilot/` and
-[the workflows guide](workbench-yaml-guide.md).
+**SkyPilot:** the checked-in, parameterizable templates run the same tools on the
+cluster — see `npa/src/npa/workflows/skypilot/` (for example
+`token-factory-generate.yaml`) and [the workflows guide](workbench-yaml-guide.md).
 
 ## 6. Developing and testing npa
 
@@ -474,7 +426,7 @@ conventions (branch → PR → squash, one approval, never self-approve).
 
 ## 7. Flagship GPU workload: NVIDIA Cosmos
 
-Once the offline loop above works, the headline Workbench workload is **NVIDIA
+With your project configured (Section 4), the headline GPU workload is **NVIDIA
 Cosmos** — a world-foundation model for synthetic data and world generation.
 Cosmos is the recommended first GPU workload because it runs across **multiple
 NVIDIA GPU platforms** (for example `gpu-h100-sxm`, `gpu-h200-sxm`,
@@ -628,9 +580,9 @@ managing AI Jobs on the project, or switch to a profile whose principal has it
 
 `credentials.yaml` is missing or tokens are not loading
 
-Offline commands tolerate a missing credentials file, but token-dependent
-commands will behave as if no token exists. Create the file under your home
-directory and secure it:
+Commands that need no tokens tolerate a missing credentials file, but
+token-dependent commands will behave as if no token exists. Create the file
+under your home directory and secure it:
 
 ```bash
 mkdir -p ~/.npa

--- a/docs/workbench/getting-started.md
+++ b/docs/workbench/getting-started.md
@@ -2,8 +2,8 @@
 
 > Prerequisites: complete docs/quickstart.md first
 > ([open quickstart](../quickstart.md), including
-> [Fast install by platform](../quickstart.md#fast-install-by-platform) for
-> macOS, Linux, or WSL2).
+> [Install npa](../quickstart.md#3-install-npa); full per-platform steps for
+> macOS, Linux, and Windows are in [docs/install.md](../install.md)).
 
 This guide assumes `npa` is already installed, the Nebius CLI is authenticated,
 and user-level credentials are already configured in

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
 import sys
 import traceback
 from importlib.metadata import version as package_version
-from typing import Callable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 import typer
 
@@ -28,6 +29,8 @@ from npa.cli.soperator import app as soperator_app
 from npa.cli.viz import app as viz_app
 from npa.cli.workflow_shim import workflow_shim_app
 from npa.clients.serverless import ServerlessClientError
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(
     name="npa",
@@ -455,11 +458,13 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
 
     project_id = ask("Nebius project id", default=str(existing_stanza.get("project_id", "")))
     tenant_id = ask("Nebius tenant id", default=str(existing_stanza.get("tenant_id", "")))
-    discovered_registry = (
+    existing_registry = str(existing_stanza.get("container_registry", ""))
+    # Only hit Nebius for registry discovery when we don't already have one saved
+    # (an idempotent re-run should not make an avoidable CLI call).
+    registry_default = existing_registry or (
         nebius_client.discover_container_registry(project_id)
         or DEFAULT_CONTAINER_REGISTRY
     )
-    registry_default = str(existing_stanza.get("container_registry", "")) or discovered_registry
     region_default = (
         str(existing_stanza.get("region", ""))
         or _region_from_registry_host(registry_default)
@@ -625,27 +630,84 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
     typer.echo("Setup complete. Run `npa configure --show` to see the file layout.")
 
 
+def _probe_hf_repos_parallel(
+    validator: Callable[..., Any],
+    token: str,
+    repos: Iterable[str],
+    *,
+    per_probe_timeout: float = 3.0,
+    total_budget: float = 8.0,
+) -> dict[str, Any]:
+    """Probe HF access for *repos* concurrently within a wall-clock budget.
+
+    Returns ``{repo: result}``. Repos that do not finish inside ``total_budget``
+    (or whose probe raises) are omitted, so the caller treats them as unverified
+    rather than stalling the primary onboarding command.
+    """
+
+    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import TimeoutError as FuturesTimeout
+    from concurrent.futures import as_completed
+
+    repo_list = list(repos)
+    results: dict[str, Any] = {}
+    if not repo_list:
+        return results
+    pool = ThreadPoolExecutor(max_workers=min(8, len(repo_list)))
+    try:
+        futures = {
+            pool.submit(validator, token, repo, timeout=per_probe_timeout): repo
+            for repo in repo_list
+        }
+        try:
+            for fut in as_completed(futures, timeout=total_budget):
+                repo = futures[fut]
+                try:
+                    results[repo] = fut.result()
+                except Exception:  # noqa: BLE001 - a failed probe -> unverified
+                    logger.debug("HF access probe failed for %s", repo, exc_info=True)
+        except FuturesTimeout:
+            # Budget exceeded: keep whatever finished; the rest stay unverified.
+            logger.debug("HF access probe budget of %.1fs exceeded", total_budget)
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+    return results
+
+
 def _model_access_note(hf_token: str, ngc_key: str) -> str:
     """Return a one-line ``[NOTE]`` on which gated workbench models the tokens can access.
 
     Runs a live Hugging Face access check for each license-gated model the
     workbench uses and a presence/format check for the NGC key, then summarizes
-    the models without access on a single line. Any failure here is swallowed so
-    a preflight note can never break `npa configure`.
+    the models without access on a single line. HF probes run in parallel under a
+    total wall-clock budget, and any failure is swallowed, so a preflight note
+    can never stall or break `npa configure`.
     """
 
     try:
         from npa.clients import huggingface
-        from npa.workbench.model_access import access_note, check_workbench_access
+        from npa.clients.huggingface import HFAccessResult
+        from npa.workbench.model_access import (
+            access_note,
+            check_workbench_access,
+            gated_hf_repos,
+        )
 
-        # Bound each HF probe so a slow/unreachable network cannot stall setup.
+        cache: dict[str, Any] = {}
+        if hf_token:
+            cache = _probe_hf_repos_parallel(
+                huggingface.validate_hf_access, hf_token, gated_hf_repos()
+            )
+
         def _validator(token: str, repo: str):
-            return huggingface.validate_hf_access(token, repo, timeout=5.0)
+            return cache.get(repo) or HFAccessResult(
+                repo=repo, ok=False, error="not verified (timed out)"
+            )
 
         results = check_workbench_access(
             hf_token=hf_token,
             ngc_key=ngc_key,
-            hf_validator=_validator,
+            hf_validator=_validator if hf_token else None,
             gated_only=True,
         )
         return access_note(results)

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -313,6 +313,16 @@ def _prompt_new_bucket_settings(
     return storage_class, max_size_bytes
 
 
+def _bucket_name_from_uri(bucket: str) -> str:
+    """Extract the bare bucket name from an ``s3://bucket/prefix`` URI."""
+    value = (bucket or "").strip()
+    if not value:
+        return ""
+    if "://" in value:
+        value = value.split("://", 1)[1]
+    return value.strip("/").split("/", 1)[0]
+
+
 def _provision_object_storage(
     nebius_client,
     ask: Callable[..., str],
@@ -320,6 +330,7 @@ def _provision_object_storage(
     project_id: str,
     tenant_id: str,
     region: str,
+    existing_bucket: str = "",
 ) -> dict[str, str] | None:
     """Auto-create the S3 bucket + access key for the project."""
     if not (project_id and tenant_id):
@@ -329,7 +340,7 @@ def _provision_object_storage(
         "\nObject storage: enter an existing bucket name to reuse it, "
         "or press Enter to have npa create a default npa-bucket for this project."
     )
-    bucket_name = ask("Object-storage bucket name")
+    bucket_name = ask("Object-storage bucket name", default=existing_bucket)
     if not bucket_name:
         bucket_name = nebius_client.bucket_name_for(tenant_id, project_id)
         typer.echo("  No bucket name provided; npa will create a default bucket.")
@@ -390,12 +401,20 @@ def _provision_object_storage(
 def _run_interactive_configure(*, provision: bool = True) -> None:
     """Prompt for credentials/config and write the NPA dotfiles."""
 
-    from npa.clients.config import CONFIG_PATH, write_config
+    from npa.clients.config import (
+        CONFIG_PATH,
+        default_project_name,
+        list_projects,
+        write_config,
+    )
     from npa.clients.credentials import load_credentials, write_credentials_file
     from npa.clients import nebius as nebius_client
     from npa.deploy.images import DEFAULT_CONTAINER_REGISTRY
 
-    typer.echo("Interactive npa setup. Press Enter to skip any optional field.\n")
+    typer.echo(
+        "Interactive npa setup. Existing values are shown as defaults — press "
+        "Enter to keep them, or type a new value to update.\n"
+    )
     profile_ready = _ensure_nebius_profile()
     typer.echo("")
 
@@ -427,25 +446,60 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
 
     existing_credentials = load_credentials(environ={})
 
-    project_id = ask("Nebius project id")
-    tenant_id = ask("Nebius tenant id")
-    registry_default = (
+    # Re-running configure should be idempotent: default every prompt to the
+    # values already saved so pressing Enter keeps the current setup, while
+    # typing a new value updates it. Config is deep-merged on write.
+    existing_projects = list_projects()
+    existing_default_alias = default_project_name()
+    existing_stanza = existing_projects.get(existing_default_alias, {}) or {}
+
+    project_id = ask("Nebius project id", default=str(existing_stanza.get("project_id", "")))
+    tenant_id = ask("Nebius tenant id", default=str(existing_stanza.get("tenant_id", "")))
+    discovered_registry = (
         nebius_client.discover_container_registry(project_id)
         or DEFAULT_CONTAINER_REGISTRY
     )
-    region_default = _region_from_registry_host(registry_default) or DEFAULT_REGION
+    registry_default = str(existing_stanza.get("container_registry", "")) or discovered_registry
+    region_default = (
+        str(existing_stanza.get("region", ""))
+        or _region_from_registry_host(registry_default)
+        or DEFAULT_REGION
+    )
     region = ask("Region", default=region_default)
     registry = ask("Container registry", default=registry_default)
 
     storage: dict[str, str] | None = None
+    existing_has_storage = bool(
+        existing_credentials.s3_access_key_id
+        and existing_credentials.s3_secret_access_key
+        and existing_credentials.s3_bucket
+    )
     if provision and project_id and tenant_id:
-        storage = _provision_object_storage(
-            nebius_client,
-            ask,
-            project_id=project_id,
-            tenant_id=tenant_id,
-            region=region,
-        )
+        if existing_has_storage:
+            # Reuse already-provisioned storage by default so a re-run does not
+            # mint a fresh S3 access key each time.
+            keep = ask(
+                f"Keep existing object storage ({existing_credentials.s3_bucket})? [Y/n]",
+                default="Y",
+            )
+            if keep.lower() in ("", "y", "yes"):
+                storage = {
+                    "aws_access_key_id": existing_credentials.s3_access_key_id,
+                    "aws_secret_access_key": existing_credentials.s3_secret_access_key,
+                    "endpoint_url": existing_credentials.s3_endpoint
+                    or _endpoint_for_region(region),
+                    "bucket": existing_credentials.s3_bucket,
+                }
+                typer.echo("  Keeping existing object-storage credentials.")
+        if storage is None:
+            storage = _provision_object_storage(
+                nebius_client,
+                ask,
+                project_id=project_id,
+                tenant_id=tenant_id,
+                region=region,
+                existing_bucket=_bucket_name_from_uri(existing_credentials.s3_bucket),
+            )
         if storage is None:
             typer.echo(
                 "\nFalling back to manual object-storage entry. "
@@ -536,9 +590,14 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
     }
     wrote_config = False
     if project_id or tenant_id:
-        # Local name for later `-p <alias>` flags. Default to the region so a
-        # first-time configure without an explicit choice still resolves.
-        alias_default = region or "default"
+        # Local name for later `-p <alias>` flags. Prefer the existing default
+        # alias so a re-run updates the same project stanza; otherwise default to
+        # the region so a first-time configure still resolves.
+        alias_default = (
+            existing_default_alias
+            if existing_default_alias and existing_default_alias != "default"
+            else (region or "default")
+        )
         alias = (
             ask(
                 "Project alias (local name for -p)",

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -561,7 +561,37 @@ def _run_interactive_configure(*, provision: bool = True) -> None:
             "Skipped ~/.npa/config.yaml: provide a Nebius project id to write a "
             "project profile."
         )
+
+    typer.echo(_model_access_note(hf_token, ngc_api_key))
     typer.echo("Setup complete. Run `npa configure --show` to see the file layout.")
+
+
+def _model_access_note(hf_token: str, ngc_key: str) -> str:
+    """Return a one-line ``[NOTE]`` on which gated workbench models the tokens can access.
+
+    Runs a live Hugging Face access check for each license-gated model the
+    workbench uses and a presence/format check for the NGC key, then summarizes
+    the models without access on a single line. Any failure here is swallowed so
+    a preflight note can never break `npa configure`.
+    """
+
+    try:
+        from npa.clients import huggingface
+        from npa.workbench.model_access import access_note, check_workbench_access
+
+        # Bound each HF probe so a slow/unreachable network cannot stall setup.
+        def _validator(token: str, repo: str):
+            return huggingface.validate_hf_access(token, repo, timeout=5.0)
+
+        results = check_workbench_access(
+            hf_token=hf_token,
+            ngc_key=ngc_key,
+            hf_validator=_validator,
+            gated_only=True,
+        )
+        return access_note(results)
+    except Exception:  # noqa: BLE001 - a preflight note must never break configure
+        return "[NOTE] Skipped model-access check (verify later with `npa workbench health access`)."
 
 
 def _store_token_factory_key(api_key: str) -> None:

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -635,8 +635,8 @@ def _probe_hf_repos_parallel(
     token: str,
     repos: Iterable[str],
     *,
-    per_probe_timeout: float = 3.0,
-    total_budget: float = 8.0,
+    per_probe_timeout: float = 2.0,
+    total_budget: float = 5.0,
 ) -> dict[str, Any]:
     """Probe HF access for *repos* concurrently within a wall-clock budget.
 

--- a/npa/src/npa/cli/workbench/health.py
+++ b/npa/src/npa/cli/workbench/health.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 import typer
 
-from npa.clients.credentials import load_credentials
+from npa.clients.credentials import load_credentials, write_credentials_file
 from npa.clients.huggingface import validate_hf_access
 from npa.clients.kube import run_kubectl
 from npa.clients.storage import StorageClient
@@ -37,6 +37,10 @@ from npa.workflows.sim2real_health import (
     run_preflight,
 )
 from npa.workflows.sim2real_loop import build_config_from_env
+from npa.workbench.model_access import (
+    all_capabilities,
+    check_workbench_access,
+)
 
 app = typer.Typer(
     name="health",
@@ -151,6 +155,96 @@ def preflight_command(
         )
 
     results = run_credential_preflight(credentials, probes=probes, checks=selected)
+    _emit_results(results, output_json=output_json)
+
+    if has_failure(results) and not warn_only:
+        raise typer.Exit(code=1)
+
+
+@app.command("access")
+def access_command(
+    hf_token: str = typer.Option(
+        "",
+        "--hf-token",
+        help="Hugging Face token (default: ~/.npa/credentials.yaml or HF_TOKEN).",
+    ),
+    ngc_key: str = typer.Option(
+        "",
+        "--ngc-key",
+        help="NVIDIA NGC API key (default: ~/.npa/credentials.yaml or NGC_API_KEY).",
+    ),
+    capability: str = typer.Option(
+        "all",
+        "--capability",
+        help=(
+            "Comma-separated capabilities to check, or 'all'. "
+            f"Choices: all, {', '.join(all_capabilities())}."
+        ),
+    ),
+    offline: bool = typer.Option(
+        False,
+        "--offline",
+        help="Skip live Hugging Face probes; only check that a token is present.",
+    ),
+    set_credentials: bool = typer.Option(
+        False,
+        "--set-credentials",
+        help="Persist the provided --hf-token / --ngc-key to ~/.npa/credentials.yaml.",
+    ),
+    warn_only: bool = typer.Option(
+        False, "--warn-only", help="Exit 0 even when an access check fails."
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Print the report as JSON."),
+) -> None:
+    """Check HF + NGC access to every gated model the workbench capabilities need.
+
+    Given a Hugging Face token and an NGC API key, this reports whether the token
+    already has access to each gated model and prints the exact 'Agree and access
+    repository' URL for anything still gated. Hugging Face gated licenses must be
+    accepted interactively on the model page — there is no API to accept them for
+    you — so this command automates the check and the guidance, not the click.
+
+    Pass ``--set-credentials`` to also persist the provided keys to
+    ~/.npa/credentials.yaml. Exits non-zero on any FAIL unless ``--warn-only``.
+    """
+
+    credentials = load_credentials()
+    resolved_hf = hf_token or getattr(credentials, "hf_token", "") or ""
+    resolved_ngc = ngc_key or getattr(credentials, "ngc_api_key", "") or ""
+
+    if set_credentials:
+        payload: dict[str, object] = {}
+        if hf_token:
+            payload["tokens"] = {"HF_TOKEN": hf_token}
+        if ngc_key:
+            payload["ngc"] = {"api_key": ngc_key}
+        if payload:
+            path = write_credentials_file(payload)
+            typer.echo(f"Persisted provided keys to {path} (chmod 600).\n")
+        else:
+            typer.echo(
+                "--set-credentials was passed but no --hf-token/--ngc-key given; "
+                "nothing persisted.\n"
+            )
+
+    if capability.strip().lower() in {"all", ""}:
+        selected: list[str] | None = None
+    else:
+        selected = [item.strip() for item in capability.split(",") if item.strip()]
+        known = set(all_capabilities())
+        unknown = [item for item in selected if item not in known]
+        if unknown:
+            raise typer.BadParameter(
+                f"unknown capability(ies): {', '.join(unknown)}. "
+                f"Choices: all, {', '.join(all_capabilities())}."
+            )
+
+    results = check_workbench_access(
+        hf_token=resolved_hf,
+        ngc_key=resolved_ngc,
+        hf_validator=None if offline else validate_hf_access,
+        capabilities=selected,
+    )
     _emit_results(results, output_json=output_json)
 
     if has_failure(results) and not warn_only:

--- a/npa/src/npa/workbench/model_access.py
+++ b/npa/src/npa/workbench/model_access.py
@@ -98,6 +98,15 @@ def assets_for(capabilities: Iterable[str] | None) -> tuple[GatedAsset, ...]:
     )
 
 
+def gated_hf_repos(capabilities: Iterable[str] | None = None) -> tuple[str, ...]:
+    """Return the license-gated Hugging Face repos for *capabilities*."""
+    return tuple(
+        asset.repo
+        for asset in assets_for(capabilities)
+        if asset.provider == HF and asset.gated
+    )
+
+
 def _ngc_needed(capabilities: Iterable[str] | None) -> bool:
     if capabilities is None:
         return True
@@ -261,13 +270,13 @@ def access_note(results: list[CheckResult]) -> str:
     if hf_no:
         parts.append("HF has no access to: " + ", ".join(hf_no))
     if not ngc_ok:
-        ngc_models = [
-            r.name for r in results if r.name != "ngc" and r.name.startswith("nvidia/")
-        ]
-        if ngc_models:
-            parts.append("NGC has no access to: " + ", ".join(ngc_models))
-        else:
-            parts.append("NGC key not set (blocks GR00T/Cosmos NVIDIA pulls)")
+        # NGC gates NVIDIA *container/model pulls* for whole capabilities, not
+        # individual HF repos — name the affected capabilities, not repo IDs.
+        parts.append(
+            "NGC not configured (blocks NVIDIA pulls for: "
+            + ", ".join(NGC_CAPABILITIES)
+            + ")"
+        )
     if hf_unverified:
         parts.append(f"{len(hf_unverified)} model(s) unverified")
 
@@ -289,6 +298,7 @@ __all__ = [
     "check_hf_asset",
     "check_ngc_key",
     "check_workbench_access",
+    "gated_hf_repos",
     "has_failure",
     "hf_model_url",
 ]

--- a/npa/src/npa/workbench/model_access.py
+++ b/npa/src/npa/workbench/model_access.py
@@ -1,0 +1,251 @@
+"""Access preflight for the gated models the workbench capabilities depend on.
+
+Given a Hugging Face token and an NVIDIA NGC API key, this module reports
+whether the token already has access to every gated model the workbench uses and
+points at the exact page to accept for anything still gated.
+
+Important: Hugging Face gated repositories require *interactive* license
+acceptance ("Agree and access repository" on each model page). There is no
+public API to accept a license on a user's behalf, so this module does not (and
+cannot honestly) auto-accept. It checks access and surfaces the acceptance URLs,
+which is the part that can be automated. NGC access is a valid, well-formed key
+plus (for org/team-scoped keys) the matching org/team.
+
+Every check is a pure function that takes the resolved tokens plus an injectable
+Hugging Face validator; the CLI wires the real probe, tests inject fakes.
+Nothing here imports GPU-heavy packages or touches infrastructure at import
+time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
+
+from npa.workflows.sim2real_health import FAIL, PASS, WARN, CheckResult, has_failure
+
+HF = "huggingface"
+NGC = "ngc"
+
+
+@dataclass(frozen=True)
+class GatedAsset:
+    """A model/asset a workbench capability needs and how it is gated."""
+
+    repo: str
+    provider: str
+    capabilities: tuple[str, ...]
+    gated: bool
+    note: str = ""
+
+
+# Curated from the tool default-model constants. Keep in sync with:
+#   - npa/src/npa/cli/groot/__init__.py         DEFAULT_MODEL, COSMOS_REASON_MODEL
+#   - npa/src/npa/cli/cosmos/__init__.py        DEFAULT_MODEL
+#   - npa/src/npa/workflows/sim2real/constants.py
+#   - npa/src/npa/clients/token_factory.py
+#   - npa/src/npa/workbench/vlm_eval/__init__.py
+# `gated=True` marks repos that require accepting the license on Hugging Face
+# before the token can download them.
+WORKBENCH_ASSETS: tuple[GatedAsset, ...] = (
+    GatedAsset("nvidia/GR00T-N1.7-3B", HF, ("groot",), True),
+    GatedAsset("nvidia/Cosmos-Reason2-2B", HF, ("groot", "sim2real"), True),
+    GatedAsset("nvidia/Cosmos-Reason2-8B", HF, ("sim2real",), True),
+    GatedAsset("nvidia/Cosmos-Reason1-7B", HF, ("cosmos",), True),
+    GatedAsset("nvidia/Cosmos-1.0-Diffusion-7B-Text2World", HF, ("cosmos",), True),
+    GatedAsset(
+        "meta-llama/Llama-3.3-70B-Instruct",
+        HF,
+        ("token_factory",),
+        True,
+        note="Only needed to self-host; Token Factory serves it hosted (no HF gating).",
+    ),
+    GatedAsset("Qwen/Qwen2-VL-7B-Instruct", HF, ("vlm_eval",), False),
+    GatedAsset("Qwen/Qwen2.5-VL-72B-Instruct", HF, ("vlm_eval", "token_factory"), False),
+    GatedAsset("lerobot/pusht", HF, ("lerobot", "sim2real"), False),
+)
+
+# Capabilities whose NVIDIA containers/models are pulled from NGC and therefore
+# need a valid NGC API key in addition to Hugging Face access.
+NGC_CAPABILITIES: tuple[str, ...] = ("groot", "cosmos")
+
+
+def hf_model_url(repo: str) -> str:
+    """Return the Hugging Face page where a gated repo's license is accepted."""
+    return f"https://huggingface.co/{repo}"
+
+
+def all_capabilities() -> tuple[str, ...]:
+    """Return every capability referenced by the catalog, sorted."""
+    seen: set[str] = set()
+    for asset in WORKBENCH_ASSETS:
+        seen.update(asset.capabilities)
+    seen.update(NGC_CAPABILITIES)
+    return tuple(sorted(seen))
+
+
+def assets_for(capabilities: Iterable[str] | None) -> tuple[GatedAsset, ...]:
+    """Return the assets needed for *capabilities* (all when ``None``)."""
+    if capabilities is None:
+        return WORKBENCH_ASSETS
+    wanted = {item.strip() for item in capabilities if item and item.strip()}
+    if not wanted:
+        return WORKBENCH_ASSETS
+    return tuple(
+        asset
+        for asset in WORKBENCH_ASSETS
+        if wanted.intersection(asset.capabilities)
+    )
+
+
+def _ngc_needed(capabilities: Iterable[str] | None) -> bool:
+    if capabilities is None:
+        return True
+    wanted = {item.strip() for item in capabilities if item and item.strip()}
+    if not wanted:
+        return True
+    return bool(wanted.intersection(NGC_CAPABILITIES))
+
+
+def _cap_suffix(asset: GatedAsset) -> str:
+    return f" [{', '.join(asset.capabilities)}]"
+
+
+def check_hf_asset(
+    asset: GatedAsset,
+    token: str,
+    hf_validator: Callable[[str, str], Any] | None,
+) -> CheckResult:
+    """Check whether *token* can access one gated Hugging Face repo."""
+
+    name = asset.repo
+    caps = _cap_suffix(asset)
+    if not token:
+        if asset.gated:
+            return CheckResult(
+                name=name,
+                status=WARN,
+                summary=f"No HF token; cannot verify gated access to {asset.repo}.{caps}",
+                remedy=(
+                    f"Accept the license at {hf_model_url(asset.repo)} while signed in, "
+                    "then run `npa configure` (or pass --hf-token)."
+                ),
+            )
+        return CheckResult(
+            name=name,
+            status=WARN,
+            summary=f"No HF token; {asset.repo} is public but downloads may be rate-limited.{caps}",
+            remedy="Set HF_TOKEN via `npa configure` for authenticated downloads.",
+        )
+    if hf_validator is None:
+        return CheckResult(
+            name=name,
+            status=PASS,
+            summary=f"HF token present; {asset.repo} access not verified (offline).{caps}",
+        )
+    result = hf_validator(token, asset.repo)
+    if getattr(result, "ok", False):
+        return CheckResult(
+            name=name,
+            status=PASS,
+            summary=f"HF access ok: {asset.repo}.{caps}",
+        )
+    status_code = getattr(result, "status_code", None)
+    error = getattr(result, "error", "") or "unknown error"
+    if status_code in {401, 403}:
+        if asset.gated:
+            return CheckResult(
+                name=name,
+                status=FAIL,
+                summary=f"HF token cannot access gated repo {asset.repo}.{caps}",
+                remedy=(
+                    f"Open {hf_model_url(asset.repo)} while signed in and click "
+                    "'Agree and access repository', then re-run this check."
+                ),
+                details=(error,),
+            )
+        return CheckResult(
+            name=name,
+            status=FAIL,
+            summary=f"HF token rejected for {asset.repo}.{caps}",
+            remedy="Regenerate the token at https://huggingface.co/settings/tokens.",
+            details=(error,),
+        )
+    return CheckResult(
+        name=name,
+        status=WARN,
+        summary=f"Could not verify HF access to {asset.repo} (transient).{caps}",
+        remedy="Retry when the network is available.",
+        details=(error,),
+    )
+
+
+def check_ngc_key(ngc_key: str, *, needed: bool) -> CheckResult:
+    """Check the NGC API key is present and well-formed for NVIDIA asset pulls."""
+
+    if not needed:
+        return CheckResult(
+            name="ngc",
+            status=PASS,
+            summary="NGC not required for the selected capabilities.",
+        )
+    key = ngc_key or ""
+    if not key:
+        return CheckResult(
+            name="ngc",
+            status=WARN,
+            summary="NGC_API_KEY is not set (needed for GR00T / Cosmos NVIDIA pulls).",
+            remedy=(
+                "Create one at https://org.ngc.nvidia.com/setup/api-key and run "
+                "`npa configure` (or pass --ngc-key)."
+            ),
+        )
+    if not key.lower().startswith(("nvapi-", "nvapi_")):
+        return CheckResult(
+            name="ngc",
+            status=WARN,
+            summary="NGC_API_KEY is set but does not look like an NGC key.",
+            remedy="NGC keys start with 'nvapi-'. Re-check the value.",
+        )
+    return CheckResult(name="ngc", status=PASS, summary="NGC_API_KEY is set.")
+
+
+def check_workbench_access(
+    *,
+    hf_token: str,
+    ngc_key: str,
+    hf_validator: Callable[[str, str], Any] | None = None,
+    capabilities: Iterable[str] | None = None,
+) -> list[CheckResult]:
+    """Return access checks for every gated asset the capabilities require.
+
+    The NGC key check comes first, then one result per Hugging Face asset in
+    catalog order. When *hf_validator* is ``None`` the HF checks report presence
+    only (offline mode).
+    """
+
+    selected = list(capabilities) if capabilities is not None else None
+    results: list[CheckResult] = [
+        check_ngc_key(ngc_key, needed=_ngc_needed(selected))
+    ]
+    for asset in assets_for(selected):
+        if asset.provider != HF:
+            continue
+        results.append(check_hf_asset(asset, hf_token, hf_validator))
+    return results
+
+
+__all__ = [
+    "GatedAsset",
+    "HF",
+    "NGC",
+    "NGC_CAPABILITIES",
+    "WORKBENCH_ASSETS",
+    "all_capabilities",
+    "assets_for",
+    "check_hf_asset",
+    "check_ngc_key",
+    "check_workbench_access",
+    "has_failure",
+    "hf_model_url",
+]

--- a/npa/src/npa/workbench/model_access.py
+++ b/npa/src/npa/workbench/model_access.py
@@ -216,12 +216,15 @@ def check_workbench_access(
     ngc_key: str,
     hf_validator: Callable[[str, str], Any] | None = None,
     capabilities: Iterable[str] | None = None,
+    gated_only: bool = False,
 ) -> list[CheckResult]:
     """Return access checks for every gated asset the capabilities require.
 
     The NGC key check comes first, then one result per Hugging Face asset in
     catalog order. When *hf_validator* is ``None`` the HF checks report presence
-    only (offline mode).
+    only (offline mode). Pass ``gated_only=True`` to check just the license-gated
+    repos (skips always-public repos) — useful to keep an interactive preflight
+    fast.
     """
 
     selected = list(capabilities) if capabilities is not None else None
@@ -231,8 +234,47 @@ def check_workbench_access(
     for asset in assets_for(selected):
         if asset.provider != HF:
             continue
+        if gated_only and not asset.gated:
+            continue
         results.append(check_hf_asset(asset, hf_token, hf_validator))
     return results
+
+
+def access_note(results: list[CheckResult]) -> str:
+    """Return a one-line ``[NOTE]`` naming the models HF/NGC cannot access.
+
+    HF entries with a definitive rejection (401/403) are listed as "no access";
+    entries that could not be reached are counted as "unverified". NGC access is
+    a key presence/format check (there is no offline NGC probe), so a missing or
+    malformed key lists the NVIDIA models its absence blocks.
+    """
+
+    hf_no = [r.name for r in results if r.name != "ngc" and r.status == FAIL]
+    hf_unverified = [r.name for r in results if r.name != "ngc" and r.status == WARN]
+    ngc = next((r for r in results if r.name == "ngc"), None)
+    ngc_ok = ngc is None or ngc.status == PASS
+
+    if not hf_no and ngc_ok and not hf_unverified:
+        return "[NOTE] HF and NGC tokens can access all checked workbench models."
+
+    parts: list[str] = []
+    if hf_no:
+        parts.append("HF has no access to: " + ", ".join(hf_no))
+    if not ngc_ok:
+        ngc_models = [
+            r.name for r in results if r.name != "ngc" and r.name.startswith("nvidia/")
+        ]
+        if ngc_models:
+            parts.append("NGC has no access to: " + ", ".join(ngc_models))
+        else:
+            parts.append("NGC key not set (blocks GR00T/Cosmos NVIDIA pulls)")
+    if hf_unverified:
+        parts.append(f"{len(hf_unverified)} model(s) unverified")
+
+    note = "[NOTE] " + "; ".join(parts) + "."
+    if hf_no:
+        note += " Accept gated licenses at https://huggingface.co/<model>."
+    return note
 
 
 __all__ = [
@@ -241,6 +283,7 @@ __all__ = [
     "NGC",
     "NGC_CAPABILITIES",
     "WORKBENCH_ASSETS",
+    "access_note",
     "all_capabilities",
     "assets_for",
     "check_hf_asset",

--- a/npa/src/npa/workbench/model_access.py
+++ b/npa/src/npa/workbench/model_access.py
@@ -39,14 +39,22 @@ class GatedAsset:
     note: str = ""
 
 
-# Curated from the tool default-model constants. Keep in sync with:
+# This tuple is the single source of truth for the models the access check
+# covers. To support or remove a workbench HF/NGC model, edit this list only —
+# `npa configure`'s model-access NOTE, `npa workbench health access`, and
+# `gated_hf_repos()` / `check_workbench_access()` all derive from it, so no other
+# file needs to change.
+#
+# The entries mirror the tool default-model constants in:
 #   - npa/src/npa/cli/groot/__init__.py         DEFAULT_MODEL, COSMOS_REASON_MODEL
 #   - npa/src/npa/cli/cosmos/__init__.py        DEFAULT_MODEL
 #   - npa/src/npa/workflows/sim2real/constants.py
 #   - npa/src/npa/clients/token_factory.py
 #   - npa/src/npa/workbench/vlm_eval/__init__.py
-# `gated=True` marks repos that require accepting the license on Hugging Face
-# before the token can download them.
+# `tests/workbench/test_model_access.py` imports those real constants and asserts
+# each still appears here, so a default-model change fails CI until this list is
+# updated. `gated=True` marks repos that require accepting the license on Hugging
+# Face before the token can download them.
 WORKBENCH_ASSETS: tuple[GatedAsset, ...] = (
     GatedAsset("nvidia/GR00T-N1.7-3B", HF, ("groot",), True),
     GatedAsset("nvidia/Cosmos-Reason2-2B", HF, ("groot", "sim2real"), True),

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -15,6 +15,24 @@ from npa.clients.serverless import NotEnoughResourcesError
 runner = CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def _stub_hf_model_access(monkeypatch):
+    """Keep `npa configure`'s model-access NOTE off the real Hugging Face API.
+
+    `configure` runs a live HF access check for the gated workbench models after
+    collecting tokens. Default every probe to "accessible" so unrelated tests
+    stay hermetic; individual tests override this to exercise the NOTE.
+    """
+
+    from npa.clients import huggingface
+    from npa.clients.huggingface import HFAccessResult
+
+    def _ok(token, repo, *, timeout=10.0):
+        return HFAccessResult(repo=repo, ok=True, status_code=200)
+
+    monkeypatch.setattr(huggingface, "validate_hf_access", _ok)
+
+
 @pytest.mark.parametrize(
     ("args", "expected"),
     [
@@ -254,6 +272,110 @@ def test_configure_provision_reuses_existing_bucket_without_size_prompt(
     assert sizes == [0]
     creds = yaml.safe_load(creds_path.read_text())
     assert creds["storage"]["bucket"].startswith("s3://npa-bucket-")
+
+
+def _run_reuse_bucket_configure(monkeypatch, tmp_path, *, hf_token: str, ngc_key: str):
+    """Drive a successful reuse-existing-bucket `npa configure` and return output.
+
+    Uses the reuse path (bucket_exists=True) so there are no storage-class/size
+    prompts; answers are: project, tenant, region, registry, bucket-name(reuse),
+    HF, AI Cloud, Token Factory, NGC, alias.
+    """
+
+    from npa.clients import config as config_module
+    from npa.clients import credentials as credentials_module
+    import npa.clients.nebius as nebius_module
+
+    creds_path = tmp_path / "credentials.yaml"
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", tmp_path / "config.yaml")
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
+    _stub_nebius_defaults(monkeypatch, project="project-1", tenant="tenant-1")
+    monkeypatch.setattr(nebius_module, "bucket_exists", lambda *_a, **_k: True)
+
+    def fake_bootstrap(project_id, tenant_id, region, *, bucket_name=None,
+                       bucket_max_size_bytes=0, bucket_storage_class="standard",
+                       on_status=None):
+        return {
+            "nebius_api_key": "AKIA",
+            "nebius_secret_key": "secret",
+            "s3_bucket": bucket_name,
+            "s3_endpoint": "https://storage.eu-north1.nebius.cloud",
+        }
+
+    monkeypatch.setattr(nebius_module, "bootstrap_environment", fake_bootstrap)
+
+    answers = "\n".join(
+        ["project-1", "tenant-1", "", "", "", hf_token, "", "", ngc_key, ""]
+    ) + "\n"
+    return runner.invoke(app, ["configure", "--interactive"], input=answers)
+
+
+def _note_line(output: str) -> str:
+    lines = [line for line in output.splitlines() if line.startswith("[NOTE]")]
+    assert lines, f"expected a [NOTE] line in output:\n{output}"
+    assert len(lines) == 1, f"expected exactly one [NOTE] line, got: {lines}"
+    return lines[0]
+
+
+def test_configure_prints_model_access_note_all_ok(monkeypatch, tmp_path) -> None:
+    # Autouse fixture makes every HF probe succeed; NGC key is well-formed.
+    result = _run_reuse_bucket_configure(
+        monkeypatch, tmp_path, hf_token="hf_good", ngc_key="nvapi-good"
+    )
+    assert result.exit_code == 0, result.output
+    note = _note_line(result.output)
+    assert note == "[NOTE] HF and NGC tokens can access all checked workbench models."
+
+
+def test_configure_note_lists_inaccessible_hf_models(monkeypatch, tmp_path) -> None:
+    from npa.clients import huggingface
+    from npa.clients.huggingface import HFAccessResult
+
+    denied = "nvidia/GR00T-N1.7-3B"
+
+    def _deny_one(token, repo, *, timeout=10.0):
+        if repo == denied:
+            return HFAccessResult(repo=repo, ok=False, status_code=403, error="no access")
+        return HFAccessResult(repo=repo, ok=True, status_code=200)
+
+    monkeypatch.setattr(huggingface, "validate_hf_access", _deny_one)
+
+    result = _run_reuse_bucket_configure(
+        monkeypatch, tmp_path, hf_token="hf_partial", ngc_key="nvapi-good"
+    )
+    assert result.exit_code == 0, result.output
+    note = _note_line(result.output)
+    assert "HF has no access to:" in note
+    assert denied in note
+    assert "huggingface.co" in note
+
+
+def test_configure_note_lists_ngc_blocked_when_key_missing(monkeypatch, tmp_path) -> None:
+    # HF probes all succeed (autouse); NGC key omitted -> NVIDIA pulls blocked.
+    result = _run_reuse_bucket_configure(
+        monkeypatch, tmp_path, hf_token="hf_good", ngc_key=""
+    )
+    assert result.exit_code == 0, result.output
+    note = _note_line(result.output)
+    assert "NGC has no access to:" in note
+    assert "nvidia/GR00T-N1.7-3B" in note
+
+
+def test_configure_note_never_breaks_on_probe_error(monkeypatch, tmp_path) -> None:
+    from npa.clients import huggingface
+
+    def _boom(token, repo, *, timeout=10.0):
+        raise RuntimeError("network exploded")
+
+    monkeypatch.setattr(huggingface, "validate_hf_access", _boom)
+
+    result = _run_reuse_bucket_configure(
+        monkeypatch, tmp_path, hf_token="hf_good", ngc_key="nvapi-good"
+    )
+    assert result.exit_code == 0, result.output
+    note = _note_line(result.output)
+    assert "Skipped model-access check" in note
 
 
 def test_configure_provision_falls_back_to_manual_on_error(monkeypatch, tmp_path) -> None:

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -358,8 +358,8 @@ def test_configure_note_lists_ngc_blocked_when_key_missing(monkeypatch, tmp_path
     )
     assert result.exit_code == 0, result.output
     note = _note_line(result.output)
-    assert "NGC has no access to:" in note
-    assert "nvidia/GR00T-N1.7-3B" in note
+    assert "NGC not configured" in note
+    assert "groot" in note and "cosmos" in note
 
 
 def test_configure_note_never_breaks_on_probe_error(monkeypatch, tmp_path) -> None:
@@ -373,9 +373,12 @@ def test_configure_note_never_breaks_on_probe_error(monkeypatch, tmp_path) -> No
     result = _run_reuse_bucket_configure(
         monkeypatch, tmp_path, hf_token="hf_good", ngc_key="nvapi-good"
     )
+    # A probe blowing up must not break configure; each affected model is simply
+    # reported as unverified on the single NOTE line.
     assert result.exit_code == 0, result.output
     note = _note_line(result.output)
-    assert "Skipped model-access check" in note
+    assert note.startswith("[NOTE]")
+    assert "unverified" in note
 
 
 def _prepopulate_config(monkeypatch, tmp_path):

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -378,6 +378,182 @@ def test_configure_note_never_breaks_on_probe_error(monkeypatch, tmp_path) -> No
     assert "Skipped model-access check" in note
 
 
+def _prepopulate_config(monkeypatch, tmp_path):
+    """Write an existing config + credentials and point configure at them."""
+    import yaml
+
+    from npa.clients import config as config_module
+    from npa.clients import credentials as credentials_module
+    import npa.clients.nebius as nebius_module
+
+    creds_path = tmp_path / "credentials.yaml"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "default_project": "prod",
+                "projects": {
+                    "prod": {
+                        "project_id": "project-existing",
+                        "tenant_id": "tenant-existing",
+                        "region": "eu-north1",
+                        "container_registry": "cr.eu-north1.nebius.cloud/registry-existing",
+                    }
+                },
+            }
+        )
+    )
+    creds_path.write_text(
+        yaml.safe_dump(
+            {
+                "tokens": {
+                    "HF_TOKEN": "hf_existing",
+                    "NEBIUS_AI_CLOUD_KEY": "aicloud_existing",
+                    "NEBIUS_TOKEN_FACTORY_KEY": "tf_existing",
+                },
+                "ngc": {"api_key": "nvapi-existing"},
+                "storage": {
+                    "aws_access_key_id": "AK_existing",
+                    "aws_secret_access_key": "SK_existing",
+                    "endpoint_url": "https://storage.eu-north1.nebius.cloud",
+                    "bucket": "s3://npa-bucket-existing/",
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(credentials_module, "CREDENTIALS_PATH", creds_path)
+    monkeypatch.setattr(config_module, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli_main, "_ensure_nebius_profile", lambda: True)
+    _stub_nebius_defaults(
+        monkeypatch, project="project-existing", tenant="tenant-existing"
+    )
+    monkeypatch.setattr(nebius_module, "bucket_exists", lambda *_a, **_k: True)
+    return creds_path, config_path, nebius_module
+
+
+def test_configure_rerun_all_defaults_is_idempotent(monkeypatch, tmp_path) -> None:
+    import yaml
+
+    creds_path, config_path, nebius_module = _prepopulate_config(monkeypatch, tmp_path)
+
+    def _must_not_provision(*_a, **_k):
+        raise AssertionError("bootstrap_environment should not run on an all-defaults re-run")
+
+    monkeypatch.setattr(nebius_module, "bootstrap_environment", _must_not_provision)
+
+    # project, tenant, region, registry, keep-storage, HF, AI cloud, TF, NGC, alias
+    answers = "\n".join([""] * 10) + "\n"
+    result = runner.invoke(app, ["configure", "--interactive"], input=answers)
+
+    assert result.exit_code == 0, result.output
+
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["default_project"] == "prod"
+    prod = cfg["projects"]["prod"]
+    assert prod["project_id"] == "project-existing"
+    assert prod["tenant_id"] == "tenant-existing"
+    assert prod["region"] == "eu-north1"
+    assert prod["container_registry"] == "cr.eu-north1.nebius.cloud/registry-existing"
+
+    creds = yaml.safe_load(creds_path.read_text())
+    assert creds["tokens"]["HF_TOKEN"] == "hf_existing"
+    assert creds["tokens"]["NEBIUS_AI_CLOUD_KEY"] == "aicloud_existing"
+    assert creds["tokens"]["NEBIUS_TOKEN_FACTORY_KEY"] == "tf_existing"
+    assert creds["ngc"]["api_key"] == "nvapi-existing"
+    # Storage preserved verbatim — no new access key minted.
+    assert creds["storage"]["aws_access_key_id"] == "AK_existing"
+    assert creds["storage"]["aws_secret_access_key"] == "SK_existing"
+    assert creds["storage"]["bucket"] == "s3://npa-bucket-existing/"
+
+
+def test_configure_rerun_updates_selected_values(monkeypatch, tmp_path) -> None:
+    import yaml
+
+    creds_path, config_path, nebius_module = _prepopulate_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        nebius_module,
+        "bootstrap_environment",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("should keep storage")),
+    )
+
+    # Update project id and HF token; keep everything else (incl. storage).
+    answers = "\n".join(
+        [
+            "project-new",  # project id (update)
+            "",             # tenant id (keep)
+            "",             # region (keep)
+            "",             # registry (keep)
+            "",             # keep existing storage? -> Y
+            "hf_new",       # HF token (update)
+            "",             # AI cloud (keep)
+            "",             # token factory (keep)
+            "",             # NGC (keep)
+            "",             # alias (keep prod)
+        ]
+    ) + "\n"
+    result = runner.invoke(app, ["configure", "--interactive"], input=answers)
+
+    assert result.exit_code == 0, result.output
+
+    cfg = yaml.safe_load(config_path.read_text())
+    # Updated stanza lives under the preserved alias.
+    prod = cfg["projects"]["prod"]
+    assert cfg["default_project"] == "prod"
+    assert prod["project_id"] == "project-new"
+    assert prod["tenant_id"] == "tenant-existing"
+
+    creds = yaml.safe_load(creds_path.read_text())
+    assert creds["tokens"]["HF_TOKEN"] == "hf_new"
+    assert creds["tokens"]["NEBIUS_AI_CLOUD_KEY"] == "aicloud_existing"
+    assert creds["storage"]["aws_access_key_id"] == "AK_existing"
+
+
+def test_configure_rerun_can_reprovision_storage_when_declined(monkeypatch, tmp_path) -> None:
+    import yaml
+
+    creds_path, config_path, nebius_module = _prepopulate_config(monkeypatch, tmp_path)
+
+    calls: list[dict] = []
+
+    def fake_bootstrap(project_id, tenant_id, region, *, bucket_name=None,
+                       bucket_max_size_bytes=0, bucket_storage_class="standard",
+                       on_status=None):
+        calls.append({"bucket_name": bucket_name})
+        return {
+            "nebius_api_key": "AK_new",
+            "nebius_secret_key": "SK_new",
+            "s3_bucket": bucket_name,
+            "s3_endpoint": "https://storage.eu-north1.nebius.cloud",
+        }
+
+    monkeypatch.setattr(nebius_module, "bootstrap_environment", fake_bootstrap)
+
+    # Decline keep-existing storage -> provision; bucket name Enter reuses the
+    # existing bucket name default (bucket_exists=True -> no size prompts).
+    answers = "\n".join(
+        [
+            "",     # project id (keep)
+            "",     # tenant id (keep)
+            "",     # region (keep)
+            "",     # registry (keep)
+            "n",    # keep existing storage? -> no
+            "",     # bucket name (default = npa-bucket-existing)
+            "",     # HF (keep)
+            "",     # AI cloud (keep)
+            "",     # token factory (keep)
+            "",     # NGC (keep)
+            "",     # alias (keep)
+        ]
+    ) + "\n"
+    result = runner.invoke(app, ["configure", "--interactive"], input=answers)
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    assert calls[0]["bucket_name"] == "npa-bucket-existing"
+    creds = yaml.safe_load(creds_path.read_text())
+    assert creds["storage"]["aws_access_key_id"] == "AK_new"
+
+
 def test_configure_provision_falls_back_to_manual_on_error(monkeypatch, tmp_path) -> None:
     import yaml
 

--- a/npa/tests/cli/test_workbench_health_cli.py
+++ b/npa/tests/cli/test_workbench_health_cli.py
@@ -229,3 +229,119 @@ def test_preflight_warn_only_suppresses_exit(monkeypatch) -> None:
         app, ["workbench", "health", "preflight", "--checks", "s3", "--warn-only"]
     )
     assert result.exit_code == 0
+
+
+class _HFOK:
+    def __init__(self, ok=True, status_code=None, error=""):
+        self.ok = ok
+        self.status_code = status_code
+        self.error = error
+
+
+def test_access_registered_and_help() -> None:
+    result = runner.invoke(app, ["workbench", "health", "access", "--help"])
+    assert result.exit_code == 0
+    assert "--hf-token" in result.output
+    assert "--ngc-key" in result.output
+
+
+def test_access_offline_reports_gated_models(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    result = runner.invoke(
+        app,
+        ["workbench", "health", "access", "--offline", "--hf-token", "hf_x", "--ngc-key", "nvapi-x"],
+    )
+    assert result.exit_code == 0
+    assert "nvidia/GR00T-N1.7-3B" in result.output
+    assert "ngc" in result.output
+
+
+def test_access_fails_on_gated_denial(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    monkeypatch.setattr(
+        health_module,
+        "validate_hf_access",
+        lambda token, repo: _HFOK(ok=False, status_code=403, error="no access"),
+    )
+    result = runner.invoke(
+        app,
+        ["workbench", "health", "access", "--hf-token", "hf_x", "--ngc-key", "nvapi-x", "--capability", "groot"],
+    )
+    assert result.exit_code == 1
+    assert "FAIL" in result.output
+    assert "Agree and access repository" in result.output
+
+
+def test_access_warn_only_suppresses_exit(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    monkeypatch.setattr(
+        health_module,
+        "validate_hf_access",
+        lambda token, repo: _HFOK(ok=False, status_code=403, error="no access"),
+    )
+    result = runner.invoke(
+        app,
+        [
+            "workbench", "health", "access",
+            "--hf-token", "hf_x", "--ngc-key", "nvapi-x",
+            "--capability", "groot", "--warn-only",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+def test_access_pass_when_validator_ok(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    monkeypatch.setattr(
+        health_module, "validate_hf_access", lambda token, repo: _HFOK(ok=True)
+    )
+    result = runner.invoke(
+        app,
+        ["workbench", "health", "access", "--hf-token", "hf_x", "--ngc-key", "nvapi-x", "--json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert "ngc" in {c["name"] for c in payload["checks"]}
+
+
+def test_access_rejects_unknown_capability(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    result = runner.invoke(
+        app, ["workbench", "health", "access", "--offline", "--capability", "bogus"]
+    )
+    assert result.exit_code != 0
+    assert "unknown capability" in result.output.lower()
+
+
+def test_access_set_credentials_persists(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _EmptyCreds())
+    captured: dict = {}
+
+    def _fake_write(data, *, path=None):
+        captured.update(data)
+        return "/tmp/fake-credentials.yaml"
+
+    monkeypatch.setattr(health_module, "write_credentials_file", _fake_write)
+    result = runner.invoke(
+        app,
+        [
+            "workbench", "health", "access", "--offline",
+            "--hf-token", "hf_new", "--ngc-key", "nvapi-new", "--set-credentials",
+        ],
+    )
+    assert result.exit_code == 0
+    assert captured["tokens"]["HF_TOKEN"] == "hf_new"
+    assert captured["ngc"]["api_key"] == "nvapi-new"

--- a/npa/tests/workbench/test_model_access.py
+++ b/npa/tests/workbench/test_model_access.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from npa.workbench.model_access import (
+    WORKBENCH_ASSETS,
+    all_capabilities,
+    assets_for,
+    check_hf_asset,
+    check_ngc_key,
+    check_workbench_access,
+    has_failure,
+    hf_model_url,
+)
+from npa.workflows.sim2real_health import FAIL, PASS, WARN
+
+
+@dataclass
+class _HFResult:
+    ok: bool
+    status_code: int | None = None
+    error: str = ""
+
+
+def _gated_asset():
+    return next(a for a in WORKBENCH_ASSETS if a.gated)
+
+
+def _public_asset():
+    return next(a for a in WORKBENCH_ASSETS if not a.gated)
+
+
+def test_catalog_has_known_gated_nvidia_models() -> None:
+    repos = {a.repo for a in WORKBENCH_ASSETS}
+    assert "nvidia/GR00T-N1.7-3B" in repos
+    assert "nvidia/Cosmos-Reason2-8B" in repos
+    # GR00T + Cosmos NVIDIA repos are gated.
+    gated = {a.repo for a in WORKBENCH_ASSETS if a.gated}
+    assert "nvidia/GR00T-N1.7-3B" in gated
+
+
+def test_hf_model_url() -> None:
+    assert hf_model_url("nvidia/GR00T-N1.7-3B") == "https://huggingface.co/nvidia/GR00T-N1.7-3B"
+
+
+def test_all_capabilities_includes_core_tools() -> None:
+    caps = all_capabilities()
+    for expected in ("groot", "cosmos", "sim2real", "vlm_eval"):
+        assert expected in caps
+
+
+def test_assets_for_filters_by_capability() -> None:
+    groot_assets = assets_for(["groot"])
+    assert groot_assets, "expected at least one groot asset"
+    assert all("groot" in a.capabilities for a in groot_assets)
+    # 'all' / None returns the full catalog.
+    assert assets_for(None) == WORKBENCH_ASSETS
+    assert assets_for([]) == WORKBENCH_ASSETS
+
+
+def test_hf_gated_warns_without_token() -> None:
+    result = check_hf_asset(_gated_asset(), "", hf_validator=None)
+    assert result.status == WARN
+    assert "Agree and access" in result.remedy or "Accept the license" in result.remedy
+
+
+def test_hf_present_unverified_offline() -> None:
+    result = check_hf_asset(_gated_asset(), "hf_x", hf_validator=None)
+    assert result.status == PASS
+    assert "not verified" in result.summary
+
+
+def test_hf_pass_when_validator_ok() -> None:
+    result = check_hf_asset(
+        _gated_asset(), "hf_x", hf_validator=lambda t, r: _HFResult(ok=True)
+    )
+    assert result.status == PASS
+    assert "access ok" in result.summary.lower()
+
+
+def test_hf_gated_fail_points_at_acceptance_url() -> None:
+    asset = _gated_asset()
+    result = check_hf_asset(
+        asset, "hf_x", hf_validator=lambda t, r: _HFResult(ok=False, status_code=403, error="no access")
+    )
+    assert result.status == FAIL
+    assert hf_model_url(asset.repo) in result.remedy
+    assert "Agree and access repository" in result.remedy
+
+
+def test_hf_public_401_is_token_problem_not_gating() -> None:
+    result = check_hf_asset(
+        _public_asset(), "hf_bad", hf_validator=lambda t, r: _HFResult(ok=False, status_code=401, error="bad")
+    )
+    assert result.status == FAIL
+    assert "settings/tokens" in result.remedy
+
+
+def test_hf_transient_error_warns() -> None:
+    result = check_hf_asset(
+        _gated_asset(), "hf_x", hf_validator=lambda t, r: _HFResult(ok=False, status_code=None, error="timeout")
+    )
+    assert result.status == WARN
+
+
+def test_ngc_warns_when_needed_and_missing() -> None:
+    assert check_ngc_key("", needed=True).status == WARN
+
+
+def test_ngc_skipped_when_not_needed() -> None:
+    result = check_ngc_key("", needed=False)
+    assert result.status == PASS
+    assert "not required" in result.summary
+
+
+def test_ngc_pass_with_valid_prefix() -> None:
+    assert check_ngc_key("nvapi-abc", needed=True).status == PASS
+    assert check_ngc_key("nvapi_abc", needed=True).status == PASS
+
+
+def test_ngc_warns_on_bad_prefix() -> None:
+    assert check_ngc_key("bogus", needed=True).status == WARN
+
+
+def test_check_workbench_access_ngc_first_then_hf() -> None:
+    results = check_workbench_access(hf_token="hf_x", ngc_key="nvapi-x", hf_validator=None)
+    assert results[0].name == "ngc"
+    hf_names = {r.name for r in results[1:]}
+    assert "nvidia/GR00T-N1.7-3B" in hf_names
+
+
+def test_check_workbench_access_capability_scope_drops_ngc_when_not_needed() -> None:
+    results = check_workbench_access(
+        hf_token="hf_x", ngc_key="", hf_validator=None, capabilities=["vlm_eval"]
+    )
+    ngc = next(r for r in results if r.name == "ngc")
+    assert ngc.status == PASS
+    assert "not required" in ngc.summary
+    # Only vlm_eval assets present.
+    repos = {r.name for r in results if r.name != "ngc"}
+    assert repos <= {a.repo for a in assets_for(["vlm_eval"])}
+
+
+def test_check_workbench_access_flags_failure_on_gated_denial() -> None:
+    results = check_workbench_access(
+        hf_token="hf_x",
+        ngc_key="nvapi-x",
+        hf_validator=lambda t, r: _HFResult(ok=False, status_code=403, error="denied"),
+        capabilities=["groot"],
+    )
+    assert has_failure(results) is True

--- a/npa/tests/workbench/test_model_access.py
+++ b/npa/tests/workbench/test_model_access.py
@@ -10,6 +10,7 @@ from npa.workbench.model_access import (
     check_hf_asset,
     check_ngc_key,
     check_workbench_access,
+    gated_hf_repos,
     has_failure,
     hf_model_url,
 )
@@ -152,6 +153,17 @@ def test_check_workbench_access_flags_failure_on_gated_denial() -> None:
     assert has_failure(results) is True
 
 
+def test_gated_hf_repos_returns_only_gated_hf() -> None:
+    repos = gated_hf_repos()
+    assert "nvidia/GR00T-N1.7-3B" in repos
+    public = {a.repo for a in WORKBENCH_ASSETS if not a.gated}
+    assert set(repos).isdisjoint(public)
+    # Scoped to a capability, only that capability's gated repos come back.
+    groot = gated_hf_repos(["groot"])
+    assert "nvidia/GR00T-N1.7-3B" in groot
+    assert all("groot" in a.capabilities for a in WORKBENCH_ASSETS if a.repo in groot)
+
+
 def test_check_workbench_access_gated_only_skips_public() -> None:
     results = check_workbench_access(
         hf_token="hf_x", ngc_key="nvapi-x", hf_validator=None, gated_only=True
@@ -191,7 +203,7 @@ def test_access_note_lists_hf_failures_on_one_line() -> None:
     assert "huggingface.co" in note
 
 
-def test_access_note_ngc_missing_lists_nvidia_models() -> None:
+def test_access_note_ngc_missing_names_capabilities() -> None:
     results = check_workbench_access(
         hf_token="hf_x",
         ngc_key="",
@@ -199,8 +211,10 @@ def test_access_note_ngc_missing_lists_nvidia_models() -> None:
         gated_only=True,
     )
     note = access_note(results)
-    assert "NGC has no access to:" in note
-    assert "nvidia/" in note
+    assert "NGC not configured" in note
+    assert "groot" in note and "cosmos" in note
+    # NGC line must not conflate HF repo IDs with NGC container access.
+    assert "nvidia/" not in note
 
 
 def test_access_note_counts_unverified() -> None:

--- a/npa/tests/workbench/test_model_access.py
+++ b/npa/tests/workbench/test_model_access.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import pytest
+
 from npa.workbench.model_access import (
     WORKBENCH_ASSETS,
     access_note,
@@ -224,3 +226,49 @@ def test_access_note_counts_unverified() -> None:
     )
     note = access_note(results)
     assert "unverified" in note
+
+
+# --- Drift guards: the catalog must stay in sync with the real tool defaults ---
+# If a tool changes its default model constant, one of these fails until
+# WORKBENCH_ASSETS is updated, so the access check never silently goes stale.
+
+def _catalog_repos() -> set[str]:
+    return {asset.repo for asset in WORKBENCH_ASSETS}
+
+
+def test_catalog_covers_light_default_constants() -> None:
+    tf = pytest.importorskip("npa.clients.token_factory")
+    constants = pytest.importorskip("npa.workflows.sim2real.constants")
+    repos = _catalog_repos()
+    expected = {
+        tf.DEFAULT_TEXT_MODEL,
+        tf.DEFAULT_VISION_MODEL,
+        constants.DEFAULT_REASON2_MODEL,
+        constants.DEFAULT_REASON3_MODEL,
+        constants.DEFAULT_REFERENCE_VLM_MODEL,
+        constants.DEFAULT_LEROBOT_DATASET_ID,
+    }
+    missing = expected - repos
+    assert not missing, f"WORKBENCH_ASSETS is missing tool default models: {sorted(missing)}"
+
+
+def test_catalog_covers_groot_and_cosmos_cli_defaults() -> None:
+    groot = pytest.importorskip("npa.cli.groot")
+    cosmos = pytest.importorskip("npa.cli.cosmos")
+    repos = _catalog_repos()
+    for const in (groot.DEFAULT_MODEL, groot.COSMOS_REASON_MODEL, cosmos.DEFAULT_MODEL):
+        assert const in repos, f"{const} missing from WORKBENCH_ASSETS"
+
+
+def test_catalog_covers_vlm_eval_default_model() -> None:
+    vlm_eval = pytest.importorskip("npa.workbench.vlm_eval")
+    assert vlm_eval.DEFAULT_MODEL in _catalog_repos()
+
+
+def test_gated_nvidia_defaults_are_marked_gated() -> None:
+    # nvidia/* and meta-llama/* defaults are license-gated; make sure the catalog
+    # marks them so, otherwise the access check would skip their live probe.
+    gated = {a.repo for a in WORKBENCH_ASSETS if a.gated}
+    for repo in _catalog_repos():
+        if repo.startswith(("nvidia/", "meta-llama/")):
+            assert repo in gated, f"{repo} should be marked gated=True"

--- a/npa/tests/workbench/test_model_access.py
+++ b/npa/tests/workbench/test_model_access.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from npa.workbench.model_access import (
     WORKBENCH_ASSETS,
+    access_note,
     all_capabilities,
     assets_for,
     check_hf_asset,
@@ -149,3 +150,63 @@ def test_check_workbench_access_flags_failure_on_gated_denial() -> None:
         capabilities=["groot"],
     )
     assert has_failure(results) is True
+
+
+def test_check_workbench_access_gated_only_skips_public() -> None:
+    results = check_workbench_access(
+        hf_token="hf_x", ngc_key="nvapi-x", hf_validator=None, gated_only=True
+    )
+    repos = {r.name for r in results if r.name != "ngc"}
+    public = {a.repo for a in WORKBENCH_ASSETS if not a.gated}
+    assert repos.isdisjoint(public)
+    assert "nvidia/GR00T-N1.7-3B" in repos
+
+
+def test_access_note_all_ok_is_one_positive_line() -> None:
+    results = check_workbench_access(
+        hf_token="hf_x",
+        ngc_key="nvapi-x",
+        hf_validator=lambda t, r: _HFResult(ok=True),
+        gated_only=True,
+    )
+    note = access_note(results)
+    assert "\n" not in note
+    assert note.startswith("[NOTE]")
+    assert "can access all checked workbench models" in note
+
+
+def test_access_note_lists_hf_failures_on_one_line() -> None:
+    denied = {"nvidia/GR00T-N1.7-3B"}
+
+    def _validator(token, repo):
+        return _HFResult(ok=repo not in denied, status_code=403 if repo in denied else 200)
+
+    results = check_workbench_access(
+        hf_token="hf_x", ngc_key="nvapi-x", hf_validator=_validator, gated_only=True
+    )
+    note = access_note(results)
+    assert "\n" not in note
+    assert "HF has no access to:" in note
+    assert "nvidia/GR00T-N1.7-3B" in note
+    assert "huggingface.co" in note
+
+
+def test_access_note_ngc_missing_lists_nvidia_models() -> None:
+    results = check_workbench_access(
+        hf_token="hf_x",
+        ngc_key="",
+        hf_validator=lambda t, r: _HFResult(ok=True),
+        gated_only=True,
+    )
+    note = access_note(results)
+    assert "NGC has no access to:" in note
+    assert "nvidia/" in note
+
+
+def test_access_note_counts_unverified() -> None:
+    # No token + gated => WARN (unverified) for each gated model, NGC present.
+    results = check_workbench_access(
+        hf_token="", ngc_key="nvapi-x", hf_validator=None, gated_only=True
+    )
+    note = access_note(results)
+    assert "unverified" in note

--- a/scripts/accept-model-access.sh
+++ b/scripts/accept-model-access.sh
@@ -33,4 +33,6 @@ if [ -n "${NGC_API_KEY:-}" ]; then
   args+=(--ngc-key "${NGC_API_KEY}")
 fi
 
-exec "${NPA_BIN}" workbench health access "${args[@]}" "$@"
+# Expand args safely even when empty under `set -u` (bash 3.2 on stock macOS
+# errors on a bare "${args[@]}" when the array is empty).
+exec "${NPA_BIN}" workbench health access ${args[@]+"${args[@]}"} "$@"

--- a/scripts/accept-model-access.sh
+++ b/scripts/accept-model-access.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Accept / verify access to every gated model the workbench needs.
+#
+# Given a Hugging Face token and an NVIDIA NGC API key, this reports whether the
+# token already has access to each gated model the workbench uses and prints the
+# exact "Agree and access repository" URL for anything still gated.
+#
+# NOTE: Hugging Face gated licenses must be accepted interactively on each model
+# page — there is no API to accept them on your behalf — so this script automates
+# the check + guidance and (optionally) persists your keys; it does not click the
+# license button for you.
+#
+# Usage:
+#   scripts/accept-model-access.sh                       # use ~/.npa/credentials.yaml
+#   HF_TOKEN=hf_xxx NGC_API_KEY=nvapi-xxx scripts/accept-model-access.sh
+#   scripts/accept-model-access.sh --hf-token hf_xxx --ngc-key nvapi-xxx --set-credentials
+#   scripts/accept-model-access.sh --capability groot,cosmos
+#
+# Any extra arguments are forwarded to `npa workbench health access`
+# (e.g. --json, --offline, --warn-only, --capability, --set-credentials).
+set -euo pipefail
+
+NPA_BIN="${NPA_BIN:-npa}"
+
+args=()
+# Promote HF_TOKEN / NGC_API_KEY from the environment to explicit flags so the
+# same invocation works with or without ~/.npa/credentials.yaml.
+if [ -n "${HF_TOKEN:-}" ]; then
+  args+=(--hf-token "${HF_TOKEN}")
+fi
+if [ -n "${NGC_API_KEY:-}" ]; then
+  args+=(--ngc-key "${NGC_API_KEY}")
+fi
+
+exec "${NPA_BIN}" workbench health access "${args[@]}" "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud-first onboarding for `npa`, a gated-model access preflight (HF + NGC), and an idempotent `npa configure`.

Note on the headline question ("given an NGC key + HF token, accept permissions for all workbench models"): you **cannot** auto-accept Hugging Face gated licenses — HF requires clicking **"Agree and access repository"** per model page with no API to accept for you. This PR automates the checkable/guidable part.

### 1. Gated-model access preflight (nimble, single-source, drift-guarded)
- `npa workbench health access` — PASS/WARN/FAIL per gated model with the exact acceptance URL; `--capability`, `--offline`, `--set-credentials`, `--warn-only`, `--json`. `scripts/accept-model-access.sh` wrapper.
- `npa/src/npa/workbench/model_access.py` — `WORKBENCH_ASSETS` is the **single source of truth**: supporting/removing an HF or NGC model is a one-line edit that automatically updates `npa configure`'s NOTE, `npa workbench health access`, and `gated_hf_repos()`/`check_workbench_access()`. Pure/import-safe (no heavy imports).
- **Drift guards** (`tests/workbench/test_model_access.py`): import the real tool default-model constants (`token_factory`, `sim2real.constants`, `cli.groot`, `cli.cosmos`, `vlm_eval`) and assert each still appears in the catalog, so a default-model change fails CI until the catalog is updated; also assert `nvidia/*` and `meta-llama/*` defaults are marked gated.

### 2. `npa configure`
- Idempotent + update-capable: prompts pre-fill from saved config/credentials; existing storage kept by default (no new S3 key); deep-merged writes.
- Prints a one-line model-access `[NOTE]`; HF probes run in parallel under a 5s budget and are fully swallowed.

### 3. Onboarding is one linear path, not a menu
- README "Pick your path" A/B/C table → a single **Setup** trunk (**1. Install npa** → **2. Configure Nebius** → **3. Your first cloud result** via Token Factory) + a **Do more with npa** branch. The self-hosted agent is a *later layer* listing only its added prereqs (Terraform, SSH key pair, Token Factory key, writable S3). quickstart §8 mirrors it.

### 4. Cloud-first + single clean install
- Offline / no-cloud / `--backend stub` usage route removed from docs (stub code, fixtures, tests unchanged — internal CI infra). First result is real Nebius via Token Factory.
- One `venv`-only install path (README + quickstart §3); `uv` as a one-line fallback; full per-platform detail in `docs/install.md`. Windows → **WSL2 Ubuntu**.

## Verification
- `make test` green (3398 passed + new drift guards); changed source files `ruff`-clean; drift guards run in CI (not skipped); all HF/NGC/Nebius probes mocked (no real infra).
- `scripts/build_docs.sh --check` → no drift.
- All relative links + `#anchor` fragments in README/quickstart/install/getting-started resolve; repo-wide grep finds no surviving `pick your path`, route, or `60-second` anchors.
- `npa --version` verified from a fresh venv built with the documented steps.

> Pre-existing (not from this PR): `make lint` reports 4 `F401`s in `npa/docker/.../mujoco_eval.py`, `npa/examples/…`, `npa/scripts/…` — present on `main`, in files this PR does not touch.

## Skill Maintenance
- [x] This PR does not change behavior that needs skill guidance (additive preflight + onboarding IA/docs); the skills-index guardrail passes unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c5ca480-60b9-4423-8027-833cede0b806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c5ca480-60b9-4423-8027-833cede0b806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

