### PR TITLE
Harden PAIDF live GPU submit path

### DIFF
--- a/docs/workbench/cosmos3-generate.md
+++ b/docs/workbench/cosmos3-generate.md
@@ -145,8 +145,8 @@ is present, rather than discovering it after the pod is scheduled. Pass
 SkyPilot's Kubernetes bootstrap replaces the image entrypoint with its own shell
 and installs an SSH runtime as the pod user, so the image ships `sudo` and
 `openssh-server` for it. Without them a workbench image cannot host a SkyPilot
-k8s task (it dies with `sudo: command not found`) — that is what
-`NPA_E2E_CLEAR_WORKBENCH_IMAGES` works around for the images that still lack them.
+k8s task (it dies with `sudo: command not found`). Do not clear the workflow image
+pin as a workaround for Cosmos 3 submits; fix the image bootstrap contract instead.
 
 ### Declarative npa.workflow
 

--- a/docs/workbench/guides/physical-ai-data-factory-deploy.md
+++ b/docs/workbench/guides/physical-ai-data-factory-deploy.md
@@ -277,11 +277,11 @@ npa workbench workflow submit "$SPEC" --run-id preflight --plan-only \
   --var bucket=<your-artifact-bucket> | grep -E 'image_id|accelerators'
 ```
 
-> **If your shell sources `~/.npa/live-e2e.env`, `unset
-> NPA_E2E_CLEAR_WORKBENCH_IMAGES` first.** The submit CLI honors it by clearing
-> *every* image pin, which silently drops the Cosmos Transfer GPU image, the
-> evaluator, and the curator — the run then "succeeds" having done none of the real
-> work. The plan-only `image_id` check above catches this.
+> **Do not submit with cleared workbench images.** The submit CLI no longer treats
+> `NPA_E2E_CLEAR_WORKBENCH_IMAGES` as a global override; it only clears image pins
+> when you pass `--image none` explicitly. The plan-only `image_id` check above
+> catches accidental unpinned submits before a run silently skips the real Cosmos
+> Transfer, evaluator, or curator images.
 
 Also `unset NEBIUS_IAM_TOKEN NPA_NEBIUS_IAM_TOKEN`: the Nebius provider prefers an
 ambient (often expired) token over the fresh CLI one.

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -429,12 +429,6 @@ def submit_cmd(
         # ``none`` / ``default`` clears workbench image pins so tasks use the
         # SkyPilot default image (needed when registry images fail k8s apt-ssh).
         image_value = image.strip()
-        if not image_value and os.environ.get("NPA_E2E_CLEAR_WORKBENCH_IMAGES", "").strip() in {
-            "1",
-            "true",
-            "yes",
-        }:
-            image_value = "none"
         if image_value.lower() in {"none", "default", "-"}:
             image_overrides["*"] = ""
         elif image_value:

--- a/npa/src/npa/orchestration/npa_workflow/submit_matrix.py
+++ b/npa/src/npa/orchestration/npa_workflow/submit_matrix.py
@@ -554,15 +554,26 @@ SUBMIT_LIVE_MATRIX: tuple[SubmitLiveCase, ...] = (
 def selected_submit_cases() -> list[SubmitLiveCase]:
     """Filter SUBMIT_LIVE_MATRIX by env tier / spec allowlists."""
 
-    tiers_raw = os.environ.get("NPA_E2E_NPA_WORKFLOW_SUBMIT_TIERS", "cpu,gpu,multi")
+    tiers_env = "NPA_E2E_NPA_WORKFLOW_SUBMIT_TIERS"
+    specs_env = "NPA_E2E_NPA_WORKFLOW_SUBMIT_SPECS"
+    tiers_raw = os.environ.get(tiers_env, "cpu,gpu,multi")
     tiers = {t.strip().lower() for t in tiers_raw.split(",") if t.strip()}
-    specs_raw = os.environ.get("NPA_E2E_NPA_WORKFLOW_SUBMIT_SPECS", "")
+    specs_raw = os.environ.get(specs_env, "")
     specs = {s.strip() for s in specs_raw.split(",") if s.strip()}
-    return [
+    cases = [
         case
         for case in SUBMIT_LIVE_MATRIX
         if case.tier in tiers and (not specs or case.spec in specs)
     ]
+    if not cases and (tiers_env in os.environ or specs_raw.strip()):
+        known_specs = ", ".join(sorted({case.spec for case in SUBMIT_LIVE_MATRIX}))
+        known_tiers = ", ".join(sorted({case.tier for case in SUBMIT_LIVE_MATRIX}))
+        raise ValueError(
+            "live submit filters selected no npa.workflow cases: "
+            f"{tiers_env}={tiers_raw!r}, {specs_env}={specs_raw!r}. "
+            f"Known tiers: {known_tiers}. Known specs: {known_specs}."
+        )
+    return cases
 
 
 def gpu_submit_cases(

--- a/npa/tests/conftest.py
+++ b/npa/tests/conftest.py
@@ -70,8 +70,8 @@ _AMBIENT_CREDENTIAL_ENV_VARS = (
     "SKYPILOT_DOCKER_PASSWORD",
     # Operator knobs that product code reads and that therefore change render or
     # tool behavior. A dev VM sources these from ~/.npa/live-e2e.env for live
-    # submits; without scrubbing, e.g. NPA_E2E_CLEAR_WORKBENCH_IMAGES=1 clears
-    # every image pin and the render tests assert against an unpinned plan.
+    # submits; without scrubbing, e.g. GPU accelerator or source-overlay values
+    # make render tests assert against the operator's live profile.
     "NPA_E2E_CLEAR_WORKBENCH_IMAGES",
     "NPA_SRC_S3_URI",
     "NPA_SRC_OVERLAY",

--- a/npa/tests/e2e/test_npa_workflow_submit_live_e2e.py
+++ b/npa/tests/e2e/test_npa_workflow_submit_live_e2e.py
@@ -50,6 +50,7 @@ from .npa_workflow_live_helpers import (
     parse_runtime_json,
     seed_live_workflow_inputs,
     seed_trigger_inbox_later,
+    selected_submit_cases,
     write_runtime_evidence,
 )
 
@@ -594,7 +595,7 @@ def test_npa_workflow_runtime_gate_loop_early_exit_vs_full_budget(
     assert full_states[-1] == "escalate"
 
 
-@pytest.mark.parametrize("case", SUBMIT_LIVE_MATRIX, ids=lambda c: c.spec)
+@pytest.mark.parametrize("case", selected_submit_cases(), ids=lambda c: c.spec)
 def test_npa_workflow_submit_plan_only_matrix_no_leak(
     case: SubmitLiveCase,
     tmp_path: Path,
@@ -602,7 +603,7 @@ def test_npa_workflow_submit_plan_only_matrix_no_leak(
     e2e_registry: str,
     forbidden_markers: list[str],
 ) -> None:
-    """Always-safe preflight: every twin in the matrix must render cleanly."""
+    """Always-safe preflight: every selected matrix twin must render cleanly."""
 
     if os.environ.get("NPA_E2E_NPA_WORKFLOW_SUBMIT") != "1":
         pytest.skip("NPA_E2E_NPA_WORKFLOW_SUBMIT not set")

--- a/npa/tests/orchestration/npa_workflow/test_real_components.py
+++ b/npa/tests/orchestration/npa_workflow/test_real_components.py
@@ -47,6 +47,10 @@ def _states() -> dict:
     return spec["states"]
 
 
+def _spec() -> dict:
+    return yaml.safe_load(BLUEPRINT.read_text(encoding="utf-8"))
+
+
 def test_blueprint_uses_no_stub_toolrefs() -> None:
     for name, state in _states().items():
         tool_ref = state.get("toolRef")
@@ -120,6 +124,14 @@ def test_quality_gate_reads_the_evaluator_report() -> None:
     outputs = [output["uri"] for output in states["evaluate"]["outputs"]]
     assert any(uri.endswith(RESULT_FILENAME) for uri in outputs), (
         f"evaluate must publish {RESULT_FILENAME}, which grade_gate reads"
+    )
+
+
+def test_gpu_resource_has_headroom_for_multi_variant_fanout() -> None:
+    gpu = _spec()["resources"]["gpu"]
+    assert int(gpu["cpus"]) >= 16, "4-way Cosmos fan-out needs CPU headroom"
+    assert str(gpu["memory"]) == "128Gi", (
+        "4-way Cosmos fan-out OOMs with the old 16Gi profile"
     )
 
 

--- a/npa/tests/orchestration/npa_workflow/test_real_components.py
+++ b/npa/tests/orchestration/npa_workflow/test_real_components.py
@@ -51,6 +51,12 @@ def _spec() -> dict:
     return yaml.safe_load(BLUEPRINT.read_text(encoding="utf-8"))
 
 
+def _memory_gi(value: object) -> int:
+    match = re.fullmatch(r"(\d+)Gi", str(value))
+    assert match is not None, f"expected Gi memory value, got {value!r}"
+    return int(match.group(1))
+
+
 def test_blueprint_uses_no_stub_toolrefs() -> None:
     for name, state in _states().items():
         tool_ref = state.get("toolRef")
@@ -130,7 +136,7 @@ def test_quality_gate_reads_the_evaluator_report() -> None:
 def test_gpu_resource_has_headroom_for_multi_variant_fanout() -> None:
     gpu = _spec()["resources"]["gpu"]
     assert int(gpu["cpus"]) >= 16, "4-way Cosmos fan-out needs CPU headroom"
-    assert str(gpu["memory"]) == "128Gi", (
+    assert _memory_gi(gpu["memory"]) >= 128, (
         "4-way Cosmos fan-out OOMs with the old 16Gi profile"
     )
 

--- a/npa/tests/orchestration/npa_workflow/test_skypilot_render.py
+++ b/npa/tests/orchestration/npa_workflow/test_skypilot_render.py
@@ -533,6 +533,33 @@ def test_workbench_workflow_submit_plan_only_redacts_registry_password(
     assert "live-plan-only-token" not in result.output
 
 
+def test_e2e_clear_workbench_images_env_is_not_global_cli_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NPA_E2E_CLEAR_WORKBENCH_IMAGES", "1")
+    monkeypatch.delenv("NPA_SRC_S3_URI", raising=False)
+    monkeypatch.delenv("NPA_E2E_NPA_SRC_S3_URI", raising=False)
+
+    result = RUNNER.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(NPA_SPECS / "vlm-eval-single.yaml"),
+            "--run-id",
+            "env-clear-is-test-only",
+            "--plan-only",
+            "--registry",
+            "cr.example.invalid/reg",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "status: PLANNED" in result.output
+    assert "image_id: docker:cr.example.invalid/reg/npa-cosmos:" in result.output
+
+
 def test_workbench_workflow_submit_npa_var_merges_config(
     mocker, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/npa/tests/orchestration/npa_workflow/test_submit_live_matrix.py
+++ b/npa/tests/orchestration/npa_workflow/test_submit_live_matrix.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 from npa.orchestration.npa_workflow.blueprints import resolve_npa_workflow_spec
 from npa.orchestration.npa_workflow.spec import load_spec
 from npa.orchestration.npa_workflow.submit_matrix import (
@@ -105,6 +107,13 @@ def test_selected_submit_cases_spec_filter(monkeypatch) -> None:
         "vlm-eval-single.yaml",
         "token-factory-caption.yaml",
     }
+
+
+def test_selected_submit_cases_explicit_empty_filter_fails(monkeypatch) -> None:
+    monkeypatch.setenv("NPA_E2E_NPA_WORKFLOW_SUBMIT_TIERS", "cpu,gpu,multi")
+    monkeypatch.setenv("NPA_E2E_NPA_WORKFLOW_SUBMIT_SPECS", "typo.yaml")
+    with pytest.raises(ValueError, match="selected no npa\\.workflow cases"):
+        selected_submit_cases()
 
 
 def test_submit_live_matrix_has_cpu_gpu_and_multi() -> None:

--- a/npa/workflows/physical-ai-data-factory.yaml
+++ b/npa/workflows/physical-ai-data-factory.yaml
@@ -121,8 +121,11 @@ resources:
     # (auto-detected, or set NPA_COSMOS_VARIANT_PARALLELISM). N variants then run
     # in ~one variant's wall-clock instead of N x. Keep :1 for a single-GPU run.
     accelerators: RTXPRO6000:1
-    cpus: 4
-    memory: 16Gi
+    # Host-side model loading/checkpoint materialization scales with the
+    # multi-GPU variant fan-out. Keep enough CPU/RAM headroom for a 4-GPU
+    # override instead of OOM-killing four concurrent Cosmos workers.
+    cpus: 16
+    memory: 128Gi
   cpu:
     cloud: kubernetes
     cpus: 4

--- a/skills/workflows/cosmos3-npa-workflow/SKILL.md
+++ b/skills/workflows/cosmos3-npa-workflow/SKILL.md
@@ -104,8 +104,8 @@ npa workbench workflow submit <spec> --plan-only \
 
 Check the rendered output for:
 
-- `image_id: docker:<registry>/npa-cosmos3:<tag>` — if it is missing, see the
-  `NPA_E2E_CLEAR_WORKBENCH_IMAGES` note below.
+- `image_id: docker:<registry>/npa-cosmos3:<tag>` — if it is missing, inspect the
+  render/registry inputs before submitting.
 - `secret_env_hints: HF_TOKEN`.
 
 ## Submit
@@ -125,9 +125,9 @@ anything else.
 1. **Missing `--secret-env HF_TOKEN`.** The plan only *hints* the secret. The
    image bakes no weights, so the stage fails fast with "Cosmos 3 weights are
    not baked into this image". Always pass it explicitly.
-2. **`NPA_E2E_CLEAR_WORKBENCH_IMAGES=1` in the environment.** It strips the
-   workbench image pin and the stage then runs on a generic SkyPilot image with
-   no cosmos-framework. Unset it (or set `0`) for Cosmos 3 runs.
+2. **Cleared workbench image pins.** If a submit is rendered with `--image none`,
+   the stage runs on a generic SkyPilot image with no cosmos-framework. Use the
+   pinned `npa-cosmos3` image for Cosmos 3 runs.
 3. **Registry mismatch.** Submit refuses when the task image's registry differs
    from `SKYPILOT_DOCKER_SERVER`. Point the Docker credentials at the same
    registry the image was pushed to.

--- a/skills/workflows/physical-ai-data-factory/SKILL.md
+++ b/skills/workflows/physical-ai-data-factory/SKILL.md
@@ -208,8 +208,8 @@ the image and as the image's own user, `$(prefix_cmd) apt install openssh-server
 rsync -y` then `service ssh restart`, where `prefix_cmd` is `sudo` for a non-root
 user. An image missing `sudo` or those packages fails that script, the container
 exits, and SkyPilot reports `container not found ("ray-node")` — which reads like a
-scheduling fault and is the reason operators reached for
-`NPA_E2E_CLEAR_WORKBENCH_IMAGES=1`. All three Cosmos images install
+scheduling fault and is the reason operators historically reached for unpinned
+submits. All three Cosmos images install
 `openssh-server`, `rsync`, and `sudo` and grant their user passwordless sudo;
 `npa/tests/docker/test_cosmos_oss_images.py` fails if that regresses. The same test
 covers the entrypoint contract: a bare `ENTRYPOINT ["/bin/bash"]` swallows the args


### PR DESCRIPTION
## Summary
- Honor live-submit spec/tier filters in the plan-only PAIDF matrix test by using `selected_submit_cases()`.
- Keep `NPA_E2E_CLEAR_WORKBENCH_IMAGES` scoped to e2e rendering so normal workflow submits still pin required workbench images.
- Increase the PAIDF GPU resource profile to `16 CPU` / `128Gi` so the documented 4-GPU Cosmos fan-out has host-memory headroom.
- Address review follow-ups: stale docs no longer claim the submit CLI globally honors `NPA_E2E_CLEAR_WORKBENCH_IMAGES`, explicit empty live-submit filters now fail fast, and the PAIDF memory headroom test accepts future increases above `128Gi`.

## Validation
- `PYTHONPATH=/tmp/npa-pr220-merge-ready/npa/src npa/.venv/bin/python -m pytest npa/tests/orchestration/npa_workflow/test_submit_live_matrix.py npa/tests/orchestration/npa_workflow/test_real_components.py npa/tests/orchestration/npa_workflow/test_skypilot_render.py npa/tests/smoke/test_all_workflow_yamls.py -q`
  - `179 passed in 26.26s`
- `PYTHONPATH=/tmp/npa-pr220-merge-ready/npa/src npa/.venv/bin/python -m ruff check npa/src/npa/orchestration/npa_workflow/submit_matrix.py npa/tests/orchestration/npa_workflow/test_submit_live_matrix.py npa/tests/orchestration/npa_workflow/test_real_components.py npa/tests/conftest.py`
  - `All checks passed!`
- Filtered PAIDF plan-only live-submit matrix with explicit non-`lerobot-` validation storage:
  - `NPA_INTEGRATION_E2E=1 NPA_E2E_NPA_WORKFLOW_SUBMIT=1 NPA_E2E_NPA_WORKFLOW_SUBMIT_TIERS=multi NPA_E2E_NPA_WORKFLOW_SUBMIT_SPECS=physical-ai-data-factory.yaml ... pytest npa/tests/e2e/test_npa_workflow_submit_live_e2e.py::test_npa_workflow_submit_plan_only_matrix_no_leak -q --timeout=600 -s`
  - `1 passed in 0.84s`
- Live PAIDF submit on Kubernetes / RTX PRO:
  - Managed job `332`, run id `paidf-pr220-gpu-overlay-20260802T194317Z`
  - Workflow status: `SUCCEEDED`
  - GPU augment task: `SUCCEEDED` on `RTXPRO-6000-BLACKWELL-SERVER-EDITION:4`
  - Artifact manifest: `variant_count: 4`, `variant_parallelism: 4`, `status: executed`

## Storage
- The validation run used an explicit non-`lerobot-` bucket for source overlay, checkpoint override, and artifacts.
- The PR diff adds no `lerobot-` S3 bucket strings.

## Notes
- This PR was mechanically outdated against `main`; it has now been rebased onto `d3490b6d`.
- A local `scripts/build_docs.sh --check` attempt was not meaningful because this dev VM's installed `npa` entrypoint has a stale shebang. A wrapper confirmed the command walks the CLI tree, but generated help naturally used the wrapper path; the GitHub `docs-drift` check remains the authoritative gate.
- The first live submit without source overlay failed because the baked Cosmos image lacked the current `npa workbench cosmos2` command. The source-overlay submit above completed successfully and is the validation result for the workflow change.
