### PR TITLE
fix(agent/configure): robust Typer list-option defaults + ambient-token-proof profile probe

### DIFF
--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -8239,6 +8239,29 @@ def preflight_cmd(
         raise typer.Exit(code=1)
 
 
+def _coerce_cli_list(value: Any) -> list[str]:
+    """Return a real list for a possibly-unresolved Typer option default.
+
+    ``deploy_cmd`` is a Typer command but is also invoked programmatically (e.g.
+    ``fresh-setup`` and thin wrappers like ``agent setup`` call it directly).
+    When such a caller omits a list-valued option, the Typer default leaks
+    through as a ``typer.models.OptionInfo``, which is not iterable — later code
+    like ``for item in tf_var`` then blew up with
+    ``'OptionInfo' object is not iterable``. Coerce anything unset / non-iterable
+    to an empty list so those code paths are robust regardless of caller.
+    """
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if type(value).__name__ == "OptionInfo":  # unresolved typer.Option default
+        return []
+    try:
+        return list(value)
+    except TypeError:
+        return []
+
+
 @app.command("deploy")
 def deploy_cmd(
     project: str = typer.Option(DEFAULT_PROJECT_ALIAS, "--project", help="NPA project alias to store config under."),
@@ -8269,6 +8292,11 @@ def deploy_cmd(
     ),
 ) -> None:
     """Provision VM + bootstrap the public NPA agent stack."""
+    # deploy_cmd is also called programmatically (fresh-setup, `agent setup`
+    # wrappers). Coerce list-valued options so an unresolved Typer default
+    # (OptionInfo) can never crash `for item in tf_var` / `list(llm_models)`.
+    tf_var = _coerce_cli_list(tf_var)
+    llm_models = _coerce_cli_list(llm_models)
     profile = os.environ.get("NPA_NEBIUS_PROFILE", "").strip()
     if profile and shutil.which("nebius"):
         subprocess.run(["nebius", "profile", "activate", profile], check=False)

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -152,6 +152,14 @@ def _nebius_profile_ready(*, runner: Callable[..., object] = subprocess.run) -> 
 
     if not shutil.which("nebius"):
         return False
+    # Strip any ambient NEBIUS_IAM_TOKEN / NEBIUS_IAM_TOKEN_FILE so the probe
+    # reflects whether the configured *profile* can mint a token, not whether a
+    # (possibly stale) inherited token is present. A stale ambient token makes
+    # `nebius iam get-access-token` skip a real exchange, so the bare probe
+    # could report "not ready" even though the profile is fine (and the same
+    # command works when the operator runs it in a clean shell).
+    ambient_token_envs = ("NEBIUS_IAM_TOKEN", "NEBIUS_IAM_TOKEN_FILE")
+    clean_env = {k: v for k, v in os.environ.items() if k not in ambient_token_envs}
     try:
         result = runner(
             ["nebius", "iam", "get-access-token"],
@@ -159,6 +167,7 @@ def _nebius_profile_ready(*, runner: Callable[..., object] = subprocess.run) -> 
             stderr=subprocess.DEVNULL,
             timeout=30,
             check=False,
+            env=clean_env,
         )
     except (OSError, subprocess.SubprocessError):
         return False
@@ -235,7 +244,10 @@ def _ensure_nebius_profile() -> bool:
     if existing_profiles:
         typer.echo(
             "Nebius CLI profiles exist but `nebius iam get-access-token` failed. "
-            "Try `nebius profile activate <profile>` or recreate the active profile."
+            "Run `nebius iam get-access-token` in this shell to see the error. "
+            "Common causes: no active profile (`nebius profile activate "
+            "<profile>`), or a stale ambient token — `unset NEBIUS_IAM_TOKEN "
+            "NEBIUS_IAM_TOKEN_FILE` and retry. Otherwise recreate the profile."
         )
         create_prompt = "Create a new Nebius CLI profile now?"
         create_default = False

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -13,16 +13,37 @@ import pytest
 from typer import Exit
 from typer.testing import CliRunner
 
+import typer
+
 from npa.cli.agent import (
     AGENT_MEDIA_PREVIEW_CONTRACT,
     AGENT_RERUN_NO_BUNDLE_SPLASH_CONTRACT,
     AGENT_UI_VERSION,
+    _coerce_cli_list,
     _normalize_llm_models,
     app,
     build_agent_urls,
 )
 
 runner = CliRunner()
+
+
+def test_coerce_cli_list_handles_unresolved_typer_option() -> None:
+    """deploy_cmd is called programmatically; an omitted list Option leaks an
+    OptionInfo that used to crash `for item in tf_var` with
+    'OptionInfo' object is not iterable. _coerce_cli_list must neutralize it."""
+    leaked = typer.Option([], "--tf-var")  # unresolved default -> OptionInfo
+    assert type(leaked).__name__ == "OptionInfo"
+    coerced = _coerce_cli_list(leaked)
+    assert coerced == []
+    # The whole point: the result is iterable without raising.
+    assert list(coerced) == []
+
+
+def test_coerce_cli_list_passthrough_and_none() -> None:
+    assert _coerce_cli_list(None) == []
+    assert _coerce_cli_list(["a", "b"]) == ["a", "b"]
+    assert _coerce_cli_list(("a", "b")) == ["a", "b"]
 
 
 def _agent_ui_bundle() -> str:

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -1185,6 +1185,27 @@ def test_nebius_profile_ready_uses_get_access_token(monkeypatch) -> None:
     assert calls == [["nebius", "iam", "get-access-token"]]
 
 
+def test_nebius_profile_ready_strips_ambient_token(monkeypatch) -> None:
+    """A stale ambient NEBIUS_IAM_TOKEN must not be inherited by the probe, so
+    the check reflects whether the profile can mint a token (matches the CLI's
+    behavior in a clean shell)."""
+    monkeypatch.setattr(cli_main.shutil, "which", lambda name: "/usr/bin/nebius")
+    monkeypatch.setenv("NEBIUS_IAM_TOKEN", "stale-token")
+    monkeypatch.setenv("NEBIUS_IAM_TOKEN_FILE", "/tmp/stale")
+    seen_env: dict[str, str] = {}
+
+    class _Result:
+        returncode = 0
+
+    def fake_runner(cmd, **kwargs):
+        seen_env.update(kwargs.get("env") or {})
+        return _Result()
+
+    assert cli_main._nebius_profile_ready(runner=fake_runner) is True
+    assert "NEBIUS_IAM_TOKEN" not in seen_env
+    assert "NEBIUS_IAM_TOKEN_FILE" not in seen_env
+
+
 def test_nebius_profile_not_ready_without_binary(monkeypatch) -> None:
     monkeypatch.setattr(cli_main.shutil, "which", lambda name: None)
     assert cli_main._nebius_profile_ready() is False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a crash in `npa agent setup`/`deploy` and hardens the `npa configure` Nebius profile probe.

- **`'OptionInfo' object is not iterable` in agent deploy.** `deploy_cmd` is a Typer command but is also invoked *programmatically* (`fresh-setup`, and thin `agent setup` wrappers call it directly). When such a caller omits a list-valued option, the unresolved `typer.Option` default leaks through as a `typer.models.OptionInfo`, which is not iterable — so `for item in tf_var:` (and `list(llm_models)`) blew up mid-deploy, right after the S3/service-account setup. Added `_coerce_cli_list()` and normalize `tf_var` / `llm_models` at the top of `deploy_cmd`, so the crash can't happen regardless of how the command is reached.

- **`npa configure` false "profile failed".** `_nebius_profile_ready` ran `nebius iam get-access-token` with the *inherited* environment. A stale/ambient `NEBIUS_IAM_TOKEN` / `NEBIUS_IAM_TOKEN_FILE` (e.g. from a sourced env file) makes the CLI skip a real token exchange, so the probe could report "not ready" even when the profile is fine — while the same command works in a clean shell. The probe now strips those ambient vars before running, so it reflects whether the configured *profile* can mint a token. The failure message now names the real causes (no active profile / stale ambient token) and tells the operator to run `nebius iam get-access-token` to see the actual error.

Notes / scoped out:
- The `configure --provision` up-front requirement of an authenticated profile (for object-storage auto-provisioning) is intentional and test-covered; `--no-provision` already lets you configure with just a project. That is a design choice, so it's left as-is here (separate discussion).

## Verification

- [x] Ran the relevant unit checks: `npa/tests/cli/test_agent.py` and `npa/tests/cli/test_main.py` pass (139 + main-suite green). Added regression tests: `test_coerce_cli_list_*` (an unresolved `typer.Option` default coerces to an iterable empty list) and `test_nebius_profile_ready_strips_ambient_token` (ambient `NEBIUS_IAM_TOKEN*` is not inherited by the probe).
- [x] For workflow/tool changes: n/a — CLI-only bug fix, no skill smoke affected.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Skill Maintenance

- [x] No skill guidance change needed — this is a CLI robustness fix, not a behavior/workflow change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8aaf4b8d-6469-485c-be5a-9ee053561772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aaf4b8d-6469-485c-be5a-9ee053561772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

