### PR TITLE
Improve Sim2Real success visualization

### DIFF
--- a/npa/src/npa/workbench/cosmos/transfer.py
+++ b/npa/src/npa/workbench/cosmos/transfer.py
@@ -93,6 +93,9 @@ def _venv_has_torch(py: Path) -> bool:
     try:
         if not py.exists():
             return False
+    except OSError:
+        return False
+    try:
         proc = subprocess.run(
             [str(py), "-c", "import torch, flash_attn"],
             capture_output=True,

--- a/npa/src/npa/workflows/rerun_serve.py
+++ b/npa/src/npa/workflows/rerun_serve.py
@@ -330,8 +330,11 @@ def rerun_serve_sdk_version() -> str:
     return override or DEFAULT_RERUN_SERVE_SDK_VERSION
 
 
-def _rerun_remote_cors_flags() -> str:
+def _rerun_remote_cors_flags(image: str) -> str:
     # rerun 0.32+ only; allow remote viewer origins (no hardcoded host/IP ranges).
+    # The current prebuilt 0.31.x viewer rejects this flag and exits before serving.
+    if re.search(r"[:@]0\.31(?:[.\-+@]|$)", image.strip().lower()):
+        return ""
     return "--cors-allow-origin 'http://*:*' "
 
 
@@ -404,7 +407,7 @@ def _rerun_serve_command(config: RerunServeConfig) -> str:
     base_cmd = (
         "rerun /data/sim2real.rrd --serve-web --web-viewer "
         f"--web-viewer-port {RERUN_INTERNAL_WEB_PORT} --port {DEFAULT_GRPC_PORT} --bind 0.0.0.0 "
-        f"{_rerun_remote_cors_flags()}"
+        f"{_rerun_remote_cors_flags(config.rerun_image)}"
     )
     if _rerun_image_has_preinstalled_cli(config.rerun_image):
         return base_cmd

--- a/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
@@ -570,7 +570,19 @@ def build_isaac_eval_job_manifest(
     script = (
         "set -uo pipefail\n"
         'exec > >(tee -a /tmp/byo-eval.log) 2>&1\n'
-        'PY="/isaac-sim/python.sh"; [ -x "$PY" ] || PY="$(command -v python3 || command -v python)"\n'
+        'if [ -x /isaac-sim/python.sh ]; then\n'
+        '  PY=/isaac-sim/python.sh\n'
+        'elif [ -x /workspace/isaaclab/isaaclab.sh ]; then\n'
+        '  cat > /tmp/isaac-python <<\'ISPYEOF\'\n'
+        '#!/usr/bin/env bash\n'
+        'exec /workspace/isaaclab/isaaclab.sh -p "$@"\n'
+        'ISPYEOF\n'
+        '  chmod +x /tmp/isaac-python\n'
+        '  PY=/tmp/isaac-python\n'
+        'else\n'
+        '  PY="$(command -v python3 || command -v python || true)"\n'
+        'fi\n'
+        '[ -n "$PY" ] || { echo "NO_PYTHON_LAUNCHER"; exit 127; }\n'
         '"$PY" -m pip install --quiet boto3 pillow 2>/dev/null || true\n'
         "mkdir -p /tmp/evalwork/renders; cd /tmp/evalwork\n"
         f'export EVAL_TASK="{task}" EVAL_NUM_ENVS="{num_envs}" EVAL_SEED="{seed}" '
@@ -644,6 +656,10 @@ def build_isaac_eval_job_manifest(
                             "name": "eval",
                             "image": image,
                             "imagePullPolicy": "Always",
+                            # Isaac Lab images launch through /isaac-sim/isaaclab.sh and
+                            # write under the prebuilt workspace; current RTX PRO runtime
+                            # requires root for that path. Keep this scoped to BYO Isaac jobs.
+                            "securityContext": {"runAsUser": 0, "runAsGroup": 0},
                             "resources": {
                                 "limits": {gpu_resource: "1"},
                                 "requests": {gpu_resource: "1"},
@@ -702,7 +718,10 @@ def run_isaac_eval_job(
     gpu_product = _env("NPA_SIM2REAL_K8S_GPU_PRODUCT", DEFAULT_GPU_PRODUCT)
     success_dist = float(_env("NPA_BYO_ISAAC_SUCCESS_DIST_M", str(DEFAULT_SUCCESS_DIST_M)) or DEFAULT_SUCCESS_DIST_M)
     timeout_s = int(_env("NPA_BYO_ISAAC_JOB_TIMEOUT_S", "5400") or 5400)
-    job_name = f"s2r-byo-isaac-eval-{run_id}"[:63]
+    from npa.workflows.sim2real.byo_isaac_trainer import artifact_tag, k8s_job_name
+
+    eval_tag = artifact_tag(_env("NPA_SIM2REAL_EVAL_TAG"))
+    job_name = k8s_job_name("s2r-byo-isaac-eval", run_id, eval_tag)
     per_env_uri = f"s3://{bucket}/sim2real-b/{run_id}/byo-eval/{job_name}/per_env_distances.json"
 
     gen = generated_envs or []

--- a/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
@@ -357,7 +357,19 @@ def build_isaac_rollout_job_manifest(
     script = (
         "set -uo pipefail\n"
         'exec > >(tee -a /tmp/byo-rollout.log) 2>&1\n'
-        'PY="/isaac-sim/python.sh"; [ -x "$PY" ] || PY="$(command -v python3 || command -v python)"\n'
+        'if [ -x /isaac-sim/python.sh ]; then\n'
+        '  PY=/isaac-sim/python.sh\n'
+        'elif [ -x /workspace/isaaclab/isaaclab.sh ]; then\n'
+        '  cat > /tmp/isaac-python <<\'ISPYEOF\'\n'
+        '#!/usr/bin/env bash\n'
+        'exec /workspace/isaaclab/isaaclab.sh -p "$@"\n'
+        'ISPYEOF\n'
+        '  chmod +x /tmp/isaac-python\n'
+        '  PY=/tmp/isaac-python\n'
+        'else\n'
+        '  PY="$(command -v python3 || command -v python || true)"\n'
+        'fi\n'
+        '[ -n "$PY" ] || { echo "NO_PYTHON_LAUNCHER"; exit 127; }\n'
         '"$PY" -m pip install --quiet boto3 pillow 2>/dev/null || true\n'
         "mkdir -p /tmp/rollwork/frames; cd /tmp/rollwork\n"
         f'export ROLLOUT_TASK="{task}" ROLLOUT_COUNT="{rollout_count}" '
@@ -408,6 +420,10 @@ def build_isaac_rollout_job_manifest(
                             "name": "rollout",
                             "image": image,
                             "imagePullPolicy": "Always",
+                            # Isaac Lab images launch through /isaac-sim/isaaclab.sh and
+                            # write under the prebuilt workspace; current RTX PRO runtime
+                            # requires root for that path. Keep this scoped to BYO Isaac jobs.
+                            "securityContext": {"runAsUser": 0, "runAsGroup": 0},
                             "resources": {
                                 "limits": {gpu_resource: "1"},
                                 "requests": {gpu_resource: "1"},
@@ -493,14 +509,20 @@ def run_isaac_rollout_job(
     timeout_s = int(_env("NPA_BYO_ISAAC_JOB_TIMEOUT_S", "5400") or 5400)
     # Rollouts spawn the SAME manipuland as train/eval (default: the proven
     # rigid-ready USD, not the stock primitive cube).
-    from npa.workflows.sim2real.byo_isaac_trainer import resolve_object_usd
+    from npa.workflows.sim2real.byo_isaac_trainer import (
+        artifact_tag,
+        artifact_tag_from_output_dir,
+        k8s_job_name,
+        resolve_object_usd,
+    )
 
     object_usd = resolve_object_usd(_env("NPA_BYO_ISAAC_OBJECT_USD"))
 
     checkpoint_uri = latest_checkpoint_uri(bucket, run_id, s3_endpoint=endpoint)
-    # Unique per (run, outer, inner) — the engine sets a distinct OUTPUT_DIR name.
-    job_suffix = output_dir.name or "iter"
-    job_name = f"s2r-byo-isaac-roll-{run_id}-{job_suffix}"[:63]
+    # Unique per (run, outer, inner) so second-pass component artifacts do not
+    # overwrite first-pass rollouts.
+    job_suffix = artifact_tag(_env("NPA_SIM2REAL_ROLLOUT_TAG")) or artifact_tag_from_output_dir(output_dir)
+    job_name = k8s_job_name("s2r-byo-isaac-roll", run_id, job_suffix)
     out_s3 = f"s3://{bucket}/sim2real-b/{run_id}/byo-rollouts/{job_suffix}"
 
     manifest = build_isaac_rollout_job_manifest(

--- a/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
@@ -472,6 +472,22 @@ def build_isaac_job_manifest(
                 "print('STAGED_ROBOT_USD', dest)\n"
                 "ROBOTDLEOF\n"
             )
+        resume_block = ""
+        resume_local = ""
+        if resume_uri and not physics:
+            resume_local = "/tmp/npa_robot/resume_model.pt"
+            resume_block = (
+                f'echo "ROBOT_RESUME_FROM: {resume_uri}"\n'
+                f'RESUME_URI="{resume_uri}" '
+                f'RESUME_DST="{resume_local}" "$PY" - <<\'ROBOTRESEOF\'\n'
+                "import os, boto3\n"
+                "from urllib.parse import urlparse\n"
+                "u = urlparse(os.environ['RESUME_URI'])\n"
+                "s3 = boto3.client('s3', endpoint_url=os.environ.get('AWS_ENDPOINT_URL') or None)\n"
+                "s3.download_file(u.netloc, u.path.lstrip('/'), os.environ['RESUME_DST'])\n"
+                "print('ROBOT_RESUME_DOWNLOADED', os.environ['RESUME_DST'])\n"
+                "ROBOTRESEOF\n"
+            )
         train_block = (
             "mkdir -p /tmp/npa_robot\n"
             "cat > /tmp/npa_robot/isaac_byo_robot_task.py <<'ROBOTEOF'\n"
@@ -479,11 +495,13 @@ def build_isaac_job_manifest(
             "cat > /tmp/npa_robot/runner.py <<'ROBOTRUNEOF'\n"
             + wrapper_src + "\nROBOTRUNEOF\n"
             '"$PY" -m pip install --quiet boto3 2>/dev/null || true\n'
+            + resume_block
             + stage_block
             + f'echo "ROBOT_INJECTION: {robot_spec.get("robot_source")} '
             f'{robot_spec.get("name")} seed={int(seed)}"\n'
             f'export NPA_ROBOT_MODULE_DIR=/tmp/npa_robot ROBOT_OUT_DIR="$OUT" '
             f'ROBOT_NUM_ENVS={num_envs} ROBOT_ITERS={iterations} ROBOT_SEED={int(seed)}\n'
+            + "export ROBOT_RESUME_CKPT_LOCAL=" + shlex.quote(resume_local) + "\n"
             "export NPA_BYO_ROBOT_SPEC_JSON=" + shlex.quote(spec_json) + "\n"
             + task_cfg_block
             + ent_block
@@ -556,7 +574,19 @@ def build_isaac_job_manifest(
     script = (
         "set -uo pipefail\n"
         'exec > >(tee -a /tmp/byo-train.log) 2>&1\n'
-        'PY="/isaac-sim/python.sh"; [ -x "$PY" ] || PY="$(command -v python3 || command -v python)"\n'
+        'if [ -x /isaac-sim/python.sh ]; then\n'
+        '  PY=/isaac-sim/python.sh\n'
+        'elif [ -x /workspace/isaaclab/isaaclab.sh ]; then\n'
+        '  cat > /tmp/isaac-python <<\'ISPYEOF\'\n'
+        '#!/usr/bin/env bash\n'
+        'exec /workspace/isaaclab/isaaclab.sh -p "$@"\n'
+        'ISPYEOF\n'
+        '  chmod +x /tmp/isaac-python\n'
+        '  PY=/tmp/isaac-python\n'
+        'else\n'
+        '  PY="$(command -v python3 || command -v python || true)"\n'
+        'fi\n'
+        '[ -n "$PY" ] || { echo "NO_PYTHON_LAUNCHER"; exit 127; }\n'
         f'OUT=/workspace/isaaclab/npa-runs/{run_id}; mkdir -p "$OUT"; cd "$OUT"\n'
         "set +e\n"
         f'{train_block}'
@@ -634,6 +664,10 @@ def build_isaac_job_manifest(
                             "name": "trainer",
                             "image": image,
                             "imagePullPolicy": "Always",
+                            # Isaac Lab images launch through /isaac-sim/isaaclab.sh and
+                            # write under the prebuilt workspace; current RTX PRO runtime
+                            # requires root for that path. Keep this scoped to BYO Isaac jobs.
+                            "securityContext": {"runAsUser": 0, "runAsGroup": 0},
                             "resources": {
                                 "limits": {gpu_resource: "1"},
                                 "requests": {gpu_resource: "1"},
@@ -728,6 +762,68 @@ def _sanitize_tag(tag: str) -> str:
     return cleaned.strip("-")
 
 
+def k8s_job_name(*parts: str, max_length: int = 63) -> str:
+    """Return a Kubernetes-safe Job name from arbitrary run/component parts."""
+
+    raw = "-".join(str(part or "").strip() for part in parts if str(part or "").strip())
+    cleaned: list[str] = []
+    previous_dash = False
+    for char in raw.lower():
+        if char.isalnum():
+            cleaned.append(char)
+            previous_dash = False
+        elif not previous_dash:
+            cleaned.append("-")
+            previous_dash = True
+    name = "".join(cleaned).strip("-")[:max_length].strip("-")
+    return name or "s2r-job"
+
+
+def artifact_tag(value: str, *, default: str = "") -> str:
+    """Return a Kubernetes/S3-safe artifact tag, or ``default`` when empty."""
+
+    return _sanitize_tag(value) or default
+
+
+def artifact_tag_from_output_dir(output_dir: Path, *, default: str = "iter") -> str:
+    """Derive ``outer-XX-iter-YY`` from a component output directory when possible."""
+
+    path = Path(output_dir)
+    name = path.name or default
+    parent = path.parent.name
+    if parent.startswith("outer-") and name.startswith("iter-"):
+        return artifact_tag(f"{parent}-{name}", default=default)
+    return artifact_tag(name, default=default)
+
+
+def latest_byo_checkpoint_uri(bucket: str, run_id: str, *, s3_endpoint: str = "") -> str:
+    """Return the newest same-run BYO trainer model_latest.pt, if any."""
+
+    if not bucket or not run_id:
+        return ""
+    try:
+        import boto3
+
+        s3 = boto3.client("s3", endpoint_url=s3_endpoint or None)
+        prefix = f"sim2real-b/{run_id}/byo-trainer/"
+        paginator = s3.get_paginator("list_objects_v2")
+        newest_key = ""
+        newest_ts = None
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []) or []:
+                key = obj["Key"]
+                if not key.endswith("model_latest.pt"):
+                    continue
+                ts = obj.get("LastModified")
+                if newest_ts is None or (ts is not None and ts > newest_ts):
+                    newest_ts = ts
+                    newest_key = key
+        return f"s3://{bucket}/{newest_key}" if newest_key else ""
+    except Exception as exc:  # pragma: no cover - network/credentials
+        print(f"byo_isaac_trainer: checkpoint scan failed: {exc!r}", flush=True)
+        return ""
+
+
 def run_isaac_training_job(run_id: str, *, signal_json: str) -> dict[str, Any]:
     """Submit the Isaac sibling Job, wait, and return an update-result dict."""
 
@@ -742,7 +838,7 @@ def run_isaac_training_job(run_id: str, *, signal_json: str) -> dict[str, Any]:
     namespace = _env("NPA_SIM2REAL_K8S_NAMESPACE", "default")
     service_account = _env("NPA_SIM2REAL_K8S_SERVICE_ACCOUNT", "agent-sa")
     gpu_product = _env("NPA_SIM2REAL_K8S_GPU_PRODUCT", DEFAULT_GPU_PRODUCT)
-    job_name = f"s2r-byo-isaac-train-{run_id}"[:63]
+    job_name = k8s_job_name("s2r-byo-isaac-train", run_id)
     # Per-iteration tag (e.g. "outer-02-iter-01") keeps each outer/inner iteration's
     # checkpoint at a DISTINCT S3 path so the prior model survives for the next
     # iteration to resume from (and outer iterations don't overwrite each other).
@@ -847,6 +943,11 @@ def run_isaac_training_job(run_id: str, *, signal_json: str) -> dict[str, Any]:
     # so this run continues the SAME policy (stage 11B "more RL" compounds). Ignored on
     # the physics-variant path (different task) — log it so the skip is visible.
     resume_uri = _env("NPA_SIM2REAL_RESUME_CHECKPOINT_URI")
+    if not resume_uri and _env("NPA_BYO_ISAAC_AUTO_RESUME", "1") != "0":
+        resume_uri = latest_byo_checkpoint_uri(bucket, run_id, s3_endpoint=endpoint)
+        if resume_uri:
+            print(f"byo_isaac_trainer: AUTO-RESUME from latest same-run checkpoint {resume_uri}",
+                  flush=True)
     experiment_name = _env("NPA_BYO_ISAAC_EXPERIMENT_NAME", DEFAULT_EXPERIMENT_NAME)
     if resume_uri:
         if physics:

--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -1562,6 +1562,7 @@ def _run_policy_rollouts_via_command(
             "NPA_SIM2REAL_ROLLOUT_COUNT": str(config.rollout_count),
             "NPA_SIM2REAL_STEPS_PER_ROLLOUT": str(config.steps_per_rollout),
             "NPA_SIM2REAL_OUTPUT_DIR": str(actions_dir),
+            "NPA_SIM2REAL_ROLLOUT_TAG": f"outer-{outer_iteration:02d}-iter-{iteration:02d}",
         },
     )
     invocation = _run_component_command(
@@ -1887,6 +1888,9 @@ def _refresh_registry_pull_secret_for_sibling_job(
     later sibling Jobs (augment/train/eval/heldout). IAM registry tokens expire,
     so stale ``npa-nebius-registry`` secrets cause mid-pipeline ImagePullBackOff.
     """
+
+    if _bool_value(os.environ.get("NPA_SIM2REAL_SKIP_REGISTRY_REFRESH", "0")):
+        return
 
     from npa.workflows.sim2real.registry_auth import ensure_registry_pull_secret_for_images
 
@@ -3164,6 +3168,7 @@ def run_heldout_eval(
         "NPA_SIM2REAL_SCENE_SPEC_URI": config.scene_spec_uri,
         "NPA_SIM2REAL_ASSETS_URI": config.assets_uri,
         "NPA_SIM2REAL_CAMERAS_URI": config.cameras_uri,
+        "NPA_SIM2REAL_EVAL_TAG": f"outer-{outer_iteration:02d}",
     }
     # BYO robot: opt the held-out eval into the SAME robot-swapped Lift variant the
     # policy trained on. This sets NPA_BYO_ROBOT_TASK=1 (+ the robot uri/source/preset)
@@ -5511,5 +5516,3 @@ def _redacted_config(config: Sim2RealLoopConfig) -> dict[str, Any]:
     payload = asdict(config)
     payload["output_dir"] = str(config.output_dir) if config.output_dir else None
     return payload
-
-

--- a/npa/src/npa/workflows/sim2real/isaac_byo_robot_task.py
+++ b/npa/src/npa/workflows/sim2real/isaac_byo_robot_task.py
@@ -1218,6 +1218,10 @@ try:
         os._exit(44)
     env = RslRlVecEnvWrapper(env)
     runner = OnPolicyRunner(env, acfg, log_dir=OUT, device="cuda:0")
+    resume_ckpt = os.environ.get("ROBOT_RESUME_CKPT_LOCAL", "").strip()
+    if resume_ckpt and os.path.isfile(resume_ckpt):
+        runner.load(resume_ckpt)
+        print("ROBOT_RESUME_LOADED", resume_ckpt, flush=True)
     runner.learn(num_learning_iterations=ITERS, init_at_random_ep_len=True)
     # Defensive explicit save (learn saves at save_interval; ensure one exists).
     try:

--- a/npa/src/npa/workflows/sim2real_rerun_regen.py
+++ b/npa/src/npa/workflows/sim2real_rerun_regen.py
@@ -37,6 +37,7 @@ class RegenResult:
     local_mcap_path: str = ""
     mcap_upload_uri: str = ""
     mcap_status: str = ""
+    synthetic_frame_count: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -50,6 +51,7 @@ class RegenResult:
             "local_mcap_path": self.local_mcap_path,
             "mcap_upload_uri": self.mcap_upload_uri,
             "mcap_status": self.mcap_status,
+            "synthetic_frame_count": self.synthetic_frame_count,
         }
 
 
@@ -130,19 +132,36 @@ def sync_regen_inputs(
     local_dir = Path(local_dir)
     local_dir.mkdir(parents=True, exist_ok=True)
 
+    inner_evidence_rel = _latest_inner_evidence_rel(storage, prefix)
     singles = {
-        "inner_loop/outer-01/evidence.json": local_dir / "inner_loop/outer-01/evidence.json",
+        inner_evidence_rel: local_dir / inner_evidence_rel,
         "eval/heldout/report.json": local_dir / "eval/heldout/report.json",
+        "reports/sim2real-report.json": local_dir / "reports/sim2real-report.json",
+        "outer_loop/decision.json": local_dir / "outer_loop/decision.json",
+        "outer_loop/loopback.json": local_dir / "outer_loop/loopback.json",
+        "tokens/manifest.json": local_dir / "tokens/manifest.json",
+        "envs/train/envs.jsonl": local_dir / "envs/train/envs.jsonl",
+        "envs/heldout/envs.jsonl": local_dir / "envs/heldout/envs.jsonl",
+        "envs/manifest/split-manifest.json": local_dir / "envs/manifest/split-manifest.json",
+        "envs/split-manifest.json": local_dir / "envs/split-manifest.json",
+        "stage_01_trigger/trigger.json": local_dir / "stage_01_trigger/trigger.json",
+        "stage_02_assets/assets_manifest.json": local_dir / "stage_02_assets/assets_manifest.json",
+        "stage_02_assets/consumed_robot_spec.json": local_dir / "stage_02_assets/consumed_robot_spec.json",
+        "stage_02_assets/consumed_scene_spec.json": local_dir / "stage_02_assets/consumed_scene_spec.json",
+        "stage_12_external_validation/external_stub.json": local_dir / "stage_12_external_validation/external_stub.json",
+        "stage_13_retrigger/retrigger.json": local_dir / "stage_13_retrigger/retrigger.json",
     }
     for rel, dest in singles.items():
         dest.parent.mkdir(parents=True, exist_ok=True)
         _download_if_exists(storage, f"{prefix}{rel}", dest)
 
-    for rel in ("actions", "vlm_eval", "training_signal"):
+    for rel in ("actions", "vlm_eval", "training_signal", "augment", "envs/raw"):
         try:
             storage.download_directory(f"{prefix}{rel}/", str(local_dir / rel))
         except (StorageError, OSError):
             pass
+    for evidence_path in sorted((local_dir / "inner_loop").glob("outer-*/evidence.json")):
+        _rewrite_inner_evidence_paths(local_dir, evidence_path)
 
     heldout_report: dict[str, Any] = {}
     heldout_path = local_dir / "eval" / "heldout/report.json"
@@ -185,21 +204,129 @@ def sync_heldout_renders(
         if _has_camera_pngs(renders_dir):
             manifest_uri = f"s3://{bucket}/{component_prefix}output/render-manifest.json"
             manifest_path = Path(local_dir) / "eval" / "heldout" / "render-manifest.sibling.json"
-            if _download_if_exists(storage, manifest_uri, manifest_path) and heldout_report is not None:
-                report_path = Path(local_dir) / "eval" / "heldout/report.json"
-                if report_path.is_file():
-                    report = json.loads(report_path.read_text(encoding="utf-8"))
-                else:
-                    report = dict(heldout_report or {})
-                report["render_manifest"] = json.loads(manifest_path.read_text(encoding="utf-8"))
-                report_path.parent.mkdir(parents=True, exist_ok=True)
-                report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            if _download_if_exists(storage, manifest_uri, manifest_path):
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            else:
+                manifest = _render_manifest_from_png_tree(renders_dir)
+            _write_report_render_manifest(local_dir, heldout_report, manifest)
+            return True
+    byo_root = f"{prefix}byo-eval/"
+    bucket, _ = _parse_s3(byo_root)
+    prefixes = sorted(_list_common_prefixes(storage, byo_root))
+    for component_prefix in reversed(prefixes):
+        sibling_renders = f"s3://{bucket}/{component_prefix}renders/"
+        try:
+            storage.download_directory(sibling_renders, str(renders_dir))
+        except (StorageError, OSError):
+            continue
+        if _has_camera_pngs(renders_dir):
+            manifest_uri = f"s3://{bucket}/{component_prefix}render-manifest.json"
+            manifest_path = Path(local_dir) / "eval" / "heldout" / "render-manifest.byo.json"
+            if _download_if_exists(storage, manifest_uri, manifest_path):
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            else:
+                manifest = _render_manifest_from_png_tree(renders_dir)
+            _write_report_render_manifest(local_dir, heldout_report, manifest)
             return True
     return _has_camera_pngs(renders_dir)
 
 
 def _has_camera_pngs(renders_dir: Path) -> bool:
     return any(renders_dir.rglob("camera-*.png"))
+
+
+def _latest_inner_evidence_rel(client: StorageClient, prefix_uri: str) -> str:
+    """Return the latest inner_loop/outer-*/evidence.json relative to the run prefix."""
+
+    default = "inner_loop/outer-01/evidence.json"
+    _bucket, run_prefix = _parse_s3(prefix_uri)
+    if run_prefix and not run_prefix.endswith("/"):
+        run_prefix += "/"
+    candidates: list[tuple[int, str]] = []
+    for outer_prefix in _list_common_prefixes(client, f"{prefix_uri.rstrip('/')}/inner_loop/"):
+        outer_name = Path(outer_prefix.rstrip("/")).name
+        if not outer_name.startswith("outer-"):
+            continue
+        try:
+            outer_index = int(outer_name.removeprefix("outer-"))
+        except ValueError:
+            continue
+        key = f"{outer_prefix.rstrip('/')}/evidence.json"
+        candidates.append((outer_index, key[len(run_prefix) :] if key.startswith(run_prefix) else key))
+    if not candidates:
+        return default
+    return sorted(candidates)[-1][1]
+
+
+def _latest_local_inner_evidence(local_dir: Path) -> Path:
+    candidates: list[tuple[int, Path]] = []
+    for evidence_path in sorted((Path(local_dir) / "inner_loop").glob("outer-*/evidence.json")):
+        try:
+            outer_index = int(evidence_path.parent.name.removeprefix("outer-"))
+        except ValueError:
+            continue
+        candidates.append((outer_index, evidence_path))
+    if candidates:
+        return sorted(candidates)[-1][1]
+    return Path(local_dir) / "inner_loop/outer-01/evidence.json"
+
+
+def _rewrite_inner_evidence_paths(local_dir: Path, evidence_path: Path) -> None:
+    try:
+        payload = json.loads(Path(evidence_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    changed = False
+    markers = {
+        "actions_dir": "actions",
+        "vlm_eval_dir": "vlm_eval",
+        "signal_dir": "training_signal",
+    }
+    for record in payload.get("iterations") or []:
+        if not isinstance(record, dict):
+            continue
+        for key, marker in markers.items():
+            rewritten = _path_under_marker(local_dir, record.get(key), marker)
+            if rewritten is not None and str(record.get(key) or "") != str(rewritten):
+                record[key] = str(rewritten)
+                changed = True
+    if changed:
+        Path(evidence_path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _path_under_marker(local_dir: Path, value: Any, marker: str) -> Path | None:
+    if not value:
+        return None
+    parts = Path(str(value)).parts
+    try:
+        index = parts.index(marker)
+    except ValueError:
+        return None
+    return Path(local_dir) / Path(*parts[index:])
+
+
+def _render_manifest_from_png_tree(renders_dir: Path) -> dict[str, Any]:
+    episodes: list[dict[str, Any]] = []
+    for env_dir in sorted(path for path in Path(renders_dir).iterdir() if path.is_dir()):
+        frames = [path.name for path in sorted(env_dir.glob("camera-*.png"))]
+        if frames:
+            episodes.append({"env_id": env_dir.name, "frames": frames})
+    return {"schema": "npa.sim2real.heldout_renders.v1", "episodes": episodes}
+
+
+def _write_report_render_manifest(
+    local_dir: Path,
+    heldout_report: dict[str, Any] | None,
+    manifest: dict[str, Any],
+) -> None:
+    report_path = Path(local_dir) / "eval" / "heldout/report.json"
+    if report_path.is_file():
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    else:
+        report = dict(heldout_report or {})
+    report["render_manifest"] = manifest
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def download_rrd_from_s3(
@@ -242,6 +369,9 @@ def publish_regen_outputs(
     rrd_path = local_dir / "reports" / "sim2real.rrd"
     if not rrd_path.is_file():
         raise Sim2RealRerunRegenError(f"missing regenerated recording: {rrd_path}")
+    visual_index_path = local_dir / "reports" / "sim2real-visual-index.json"
+    if visual_index_path.is_file():
+        storage.upload_file(str(visual_index_path), f"{prefix}reports/sim2real-visual-index.json")
     upload_uri = storage.upload_file(str(rrd_path), f"{prefix}reports/sim2real.rrd")
     return upload_uri
 
@@ -284,7 +414,8 @@ def regen_sim2real_rrd(
     if sync_inputs:
         sync_regen_inputs(config, work_dir, client=storage)
 
-    inner_path = work_dir / "inner_loop/outer-01/evidence.json"
+    inner_path = _latest_local_inner_evidence(work_dir)
+    _rewrite_inner_evidence_paths(work_dir, inner_path)
     heldout_path = work_dir / "eval/heldout/report.json"
     if not inner_path.is_file():
         raise Sim2RealRerunRegenError(f"missing inner evidence: {inner_path}")
@@ -409,4 +540,5 @@ def _regen_result_from_viz(
         local_mcap_path=str(mcap.get("output_mcap_path") or ""),
         mcap_upload_uri=mcap_upload_uri,
         mcap_status=str(mcap.get("status") or ""),
+        synthetic_frame_count=int(getattr(result, "synthetic_frame_count", 0)),
     )

--- a/npa/src/npa/workflows/sim2real_stages.py
+++ b/npa/src/npa/workflows/sim2real_stages.py
@@ -6,6 +6,7 @@ import json
 import os
 import random
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
@@ -103,8 +104,16 @@ def run_augment_stage(config: Sim2RealLoopConfig, local_dir: Path) -> dict[str, 
         )
         manifest = result["manifest"]
         augmented_frames_uri = result["augmented_frames_uri"]
+        mirrored = _mirror_augment_frames(augmented_frames_uri, augment_dir)
         tier = "WORKS"
-        evidence = "Executed Cosmos Transfer 2.5 via sibling Kubernetes job."
+        evidence = (
+            "Executed Cosmos Transfer 2.5 via sibling Kubernetes job and mirrored frame descriptors locally."
+            if mirrored
+            else (
+                "Executed Cosmos Transfer 2.5 via sibling Kubernetes job; local frame mirror was unavailable, "
+                "so final visualization falls back to manifest descriptors."
+            )
+        )
     else:
         manifest, augmented_frames_uri = _reference_augment_local(
             config, local_dir, input_uri=input_uri
@@ -361,6 +370,39 @@ def _reference_augment_local(
     manifest["augmented_frames_uri"] = output_uri
     manifest["frame_count"] = frame_count
     return manifest, output_uri
+
+
+def _mirror_augment_frames(frames_uri: str, augment_dir: Path, *, attempts: int = 6) -> bool:
+    """Mirror remote augmentation descriptors/images into the orchestrator tree."""
+
+    uri = str(frames_uri or "").strip()
+    if not uri.startswith("s3://"):
+        return False
+    from npa.clients.storage import StorageClient, StorageError
+
+    frames_dir = Path(augment_dir) / "frames"
+    frames_dir.mkdir(parents=True, exist_ok=True)
+    last_error = ""
+    client = StorageClient.from_environment()
+    for attempt in range(attempts):
+        try:
+            client.download_directory(uri.rstrip("/") + "/", str(frames_dir))
+        except (OSError, StorageError) as exc:
+            last_error = repr(exc)
+        if (frames_dir / "index.json").is_file() or any(frames_dir.glob("frame-*.*")):
+            return True
+        if attempt + 1 < attempts:
+            time.sleep(2)
+    _write_json(
+        frames_dir / "mirror-warning.json",
+        {
+            "schema": "npa.sim2real.augment_mirror_warning.v1",
+            "status": "mirror_unavailable",
+            "frames_uri": uri,
+            "last_error": last_error,
+        },
+    )
+    return False
 
 
 def _mirror_env_manifests(

--- a/npa/src/npa/workflows/sim2real_viz.py
+++ b/npa/src/npa/workflows/sim2real_viz.py
@@ -16,6 +16,7 @@ but it MUST produce a non-empty ``.rrd`` whenever the SDK is available.
 from __future__ import annotations
 import logging
 
+import hashlib
 import json
 import math
 from dataclasses import dataclass, field
@@ -31,6 +32,9 @@ APPLICATION_ID = "npa_sim2real_loop"
 TIMELINE = "frame_time"
 ROLLOUT_FRAME_SECONDS = 0.5
 HELDOUT_STEP_SECONDS = 1.0
+SYNTHETIC_STEP_SECONDS = 1.0
+SYNTHETIC_DATASET_SAMPLE_LIMIT = 6
+SYNTHETIC_AUGMENT_SAMPLE_LIMIT = 12
 CRITIQUE_COLOR = (255, 136, 0, 255)
 FRANKA_HOME_JOINTS = (0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785)
 
@@ -104,6 +108,7 @@ class Sim2RealVizResult:
     heldout_env_count: int = 0
     heldout_frame_count: int = 0
     pointcloud_frame_count: int = 0
+    synthetic_frame_count: int = 0
     mp4_paths: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
@@ -116,6 +121,7 @@ class Sim2RealVizResult:
             "heldout_env_count": self.heldout_env_count,
             "heldout_frame_count": self.heldout_frame_count,
             "pointcloud_frame_count": self.pointcloud_frame_count,
+            "synthetic_frame_count": self.synthetic_frame_count,
             "mp4_paths": list(self.mp4_paths),
         }
 
@@ -167,10 +173,12 @@ def emit_sim2real_rerun(
 
     heldout_episodes = _heldout_render_episodes(local_dir, heldout_report)
     has_heldout_cameras = bool(heldout_episodes)
+    has_synthetic_data = _has_synthetic_visual_data(local_dir)
     blueprint = _build_blueprint(
         rrb,
         has_heldout_cameras=has_heldout_cameras,
         heldout_env_ids=[env_id for env_id, _frames in heldout_episodes],
+        has_synthetic_data=has_synthetic_data,
     )
     recording = rr.RecordingStream(APPLICATION_ID)
     rr.save(output_rrd, default_blueprint=blueprint, recording=recording)
@@ -181,9 +189,11 @@ def emit_sim2real_rerun(
     rollout_count = 0
     frame_count = 0
     heldout_frame_count = 0
+    synthetic_frame_count = 0
     mp4_paths: list[str] = []
     critique_panel_rows: list[str] = []
-    _log_scene_overview(rr, recording, inner_evidence, counts)
+    if not has_heldout_cameras:
+        _log_scene_overview(rr, recording, inner_evidence, counts)
 
     iterations = inner_evidence.get("iterations") or []
     for record in iterations:
@@ -219,14 +229,14 @@ def emit_sim2real_rerun(
                 if mp4_path is not None:
                     mp4_paths.append(str(mp4_path))
 
-    _log_vlm_critique_panel(rr, recording, critique_panel_rows, counts)
     _log_reward_trend(rr, recording, inner_evidence.get("reward_trend") or [], counts)
+    synthetic_frame_count = _log_synthetic_data(rr, recording, local_dir, counts)
     heldout_frame_count, heldout_seconds = _log_heldout_cameras(
         rr,
         recording,
         heldout_episodes,
         counts,
-        start_seconds=seconds,
+        start_seconds=0.0 if has_heldout_cameras else seconds,
     )
     seconds = max(seconds, heldout_seconds)
     pointcloud_frame_count = _log_heldout_pointclouds(
@@ -242,19 +252,25 @@ def emit_sim2real_rerun(
         (heldout_report or {}).get("success_rate"),
         counts,
     )
+    _log_vlm_critique_panel(rr, recording, critique_panel_rows, counts)
+    _log_summary_documents(
+        rr,
+        recording,
+        local_dir=local_dir,
+        inner_evidence=inner_evidence,
+        heldout_report=heldout_report,
+        critique_panel_rows=critique_panel_rows,
+        counts=counts,
+    )
 
     _disconnect(rr, recording)
 
     if not output_rrd.exists() or output_rrd.stat().st_size == 0:
         raise Sim2RealVizError(f"Rerun recording was not written: {output_rrd}")
-    if (
-        frame_count == 0
-        and rollout_count == 0
-        and heldout_env_count == 0
-        and heldout_frame_count == 0
-    ):
+    if frame_count == 0 and rollout_count == 0 and heldout_env_count == 0 and heldout_frame_count == 0:
         raise Sim2RealVizError(
-            "Sim2Real Rerun recording has no rollout frames, held-out cameras, signal, or held-out content"
+            "Sim2Real Rerun recording has no real rollout frames, held-out cameras, or held-out scores; "
+            f"synthetic descriptor previews logged={synthetic_frame_count}"
         )
 
     return Sim2RealVizResult(
@@ -266,6 +282,7 @@ def emit_sim2real_rerun(
         heldout_env_count=heldout_env_count,
         heldout_frame_count=heldout_frame_count,
         pointcloud_frame_count=pointcloud_frame_count,
+        synthetic_frame_count=synthetic_frame_count,
         mp4_paths=mp4_paths,
     )
 
@@ -357,12 +374,695 @@ def _log_vlm_critique_panel(
     if not entries:
         return
     _set_time(rr, recording, 0.0)
+    body = "# VLM critiques by rollout\n\n" + "\n\n---\n\n".join(entries)
     rr.log(
         "rollouts/summary/critique",
-        rr.TextDocument("# VLM critiques by rollout\n\n" + "\n\n---\n\n".join(entries), media_type="text/markdown"),
+        rr.TextDocument(body, media_type="text/markdown"),
         recording=recording,
     )
     _bump(counts, "rollouts/summary/critique")
+    rr.log(
+        "summary/vlm_critiques",
+        rr.TextDocument(body, media_type="text/markdown"),
+        recording=recording,
+    )
+    _bump(counts, "summary/vlm_critiques")
+
+
+def _log_summary_documents(
+    rr: Any,
+    recording: Any,
+    *,
+    local_dir: Path,
+    inner_evidence: dict[str, Any],
+    heldout_report: dict[str, Any] | None,
+    critique_panel_rows: list[str],
+    counts: dict[str, int],
+) -> None:
+    index = _build_visual_index(
+        local_dir=local_dir,
+        inner_evidence=inner_evidence,
+        heldout_report=heldout_report,
+        critique_panel_rows=critique_panel_rows,
+    )
+    reports_dir = Path(local_dir) / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    (reports_dir / "sim2real-visual-index.json").write_text(
+        json.dumps(index, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    documents = {
+        "summary/run_success": _run_success_markdown(index),
+        "summary/augmentation": _augmentation_markdown(index),
+        "summary/artifacts": _artifacts_markdown(index),
+    }
+    _set_time(rr, recording, 0.0)
+    for entity, body in documents.items():
+        if not body.strip():
+            continue
+        rr.log(entity, rr.TextDocument(body, media_type="text/markdown"), recording=recording)
+        _bump(counts, entity)
+
+
+def _build_visual_index(
+    *,
+    local_dir: Path,
+    inner_evidence: dict[str, Any],
+    heldout_report: dict[str, Any] | None,
+    critique_panel_rows: list[str],
+) -> dict[str, Any]:
+    report = _read_json(Path(local_dir) / "reports" / "sim2real-report.json")
+    decision = _read_json(Path(local_dir) / "outer_loop" / "decision.json")
+    augment = _read_json(Path(local_dir) / "augment" / "manifest.json")
+    augment_index = _read_json(Path(local_dir) / "augment" / "frames" / "index.json")
+    tokens = _read_json(Path(local_dir) / "tokens" / "manifest.json")
+    split = _read_json(Path(local_dir) / "envs" / "manifest" / "split-manifest.json")
+    if not split:
+        split = _read_json(Path(local_dir) / "envs" / "split-manifest.json")
+    full_heldout = dict(heldout_report or {})
+    if not full_heldout:
+        full_heldout = dict((report.get("outer_loop") or {}).get("latest_heldout_report") or {})
+
+    return {
+        "schema": "npa.sim2real.visual_index.v1",
+        "run_id": report.get("run_id") or decision.get("run_id") or "",
+        "success": {
+            "status": report.get("status") or "",
+            "decision": decision.get("decision") or "",
+            "success_rate": _first_present(decision.get("success_rate"), full_heldout.get("success_rate")),
+            "threshold": _first_present(decision.get("threshold"), report.get("threshold")),
+            "checkpoint_uri": decision.get("checkpoint_uri") or "",
+            "heldout_envs": [
+                {
+                    "env_id": item.get("env_id"),
+                    "score": item.get("score"),
+                    "success": item.get("success"),
+                    "distance_m": item.get("distance_m"),
+                }
+                for item in (full_heldout.get("per_env") or [])[:8]
+                if isinstance(item, dict)
+            ],
+        },
+        "augmentation": {
+            "status": augment.get("status") or "",
+            "mode": augment.get("mode") or "",
+            "stage": augment.get("stage") or "",
+            "frame_count": _first_present(augment.get("frame_count"), augment_index.get("frame_count")),
+            "image": augment.get("image") or "",
+            "input_uri": augment.get("input_uri") or "",
+            "output_uri": augment.get("output_uri") or "",
+            "sample_frames": (augment_index.get("frames") or [])[:8],
+        },
+        "dataset": {
+            "raw_count": split.get("raw_count"),
+            "train_count": _first_present(split.get("train_count"), tokens.get("train_env_count")),
+            "heldout_count": _first_present(split.get("heldout_count"), tokens.get("heldout_env_count")),
+            "disjoint": split.get("disjoint"),
+            "seed": split.get("seed"),
+            "train_samples": _jsonl_samples(Path(local_dir) / "envs" / "train" / "envs.jsonl"),
+            "heldout_samples": _jsonl_samples(Path(local_dir) / "envs" / "heldout" / "envs.jsonl"),
+        },
+        "vlm": {
+            "critique_count": len(critique_panel_rows),
+            "model": _first_sample_value(inner_evidence, "sample_vlm_eval", "model"),
+            "score": _first_sample_value(inner_evidence, "sample_vlm_eval", "score"),
+        },
+        "synthetic": _synthetic_visual_index(Path(local_dir)),
+        "artifact_counts": _artifact_counts(Path(local_dir)),
+        "key_artifacts": _key_artifacts(Path(local_dir)),
+    }
+
+
+def _run_success_markdown(index: dict[str, Any]) -> str:
+    success = index.get("success") or {}
+    rows = [
+        ("Run", index.get("run_id") or "unknown"),
+        ("Status", success.get("status") or "unknown"),
+        ("Decision", success.get("decision") or "unknown"),
+        ("Held-out success rate", _format_value(success.get("success_rate"))),
+        ("Threshold", _format_value(success.get("threshold"))),
+        ("Final checkpoint", success.get("checkpoint_uri") or "not recorded"),
+    ]
+    per_env = success.get("heldout_envs") or []
+    lines = ["# Sim2Real success", "", _markdown_table(["Metric", "Value"], rows)]
+    if per_env:
+        lines.extend(
+            [
+                "",
+                "## Held-out eval",
+                "",
+                _markdown_table(
+                    ["Env", "Success", "Score", "Distance m"],
+                    [
+                        (
+                            item.get("env_id") or "",
+                            _format_value(item.get("success")),
+                            _format_value(item.get("score")),
+                            _format_value(item.get("distance_m")),
+                        )
+                        for item in per_env
+                    ],
+                ),
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _augmentation_markdown(index: dict[str, Any]) -> str:
+    aug = index.get("augmentation") or {}
+    dataset = index.get("dataset") or {}
+    synthetic = index.get("synthetic") or {}
+    lines = [
+        "# Augmentation and dataset",
+        "",
+        "## Cosmos transfer augmentation",
+        "",
+        _markdown_table(
+            ["Field", "Value"],
+            [
+                ("Status", aug.get("status") or "unknown"),
+                ("Mode", aug.get("mode") or "unknown"),
+                ("Frame descriptors", _format_value(aug.get("frame_count"))),
+                ("Image", aug.get("image") or "not recorded"),
+                ("Input", aug.get("input_uri") or "not recorded"),
+                ("Output", aug.get("output_uri") or "not recorded"),
+            ],
+        ),
+        "",
+        "## Environment split",
+        "",
+        _markdown_table(
+            ["Field", "Value"],
+            [
+                ("Raw envs", _format_value(dataset.get("raw_count"))),
+                ("Train envs", _format_value(dataset.get("train_count"))),
+                ("Held-out envs", _format_value(dataset.get("heldout_count"))),
+                ("Disjoint split", _format_value(dataset.get("disjoint"))),
+                ("Seed", _format_value(dataset.get("seed"))),
+            ],
+        ),
+        "",
+        "## Rerun synthetic-data visuals",
+        "",
+        _markdown_table(
+            ["Field", "Value"],
+            [
+                ("Synthetic viewport", synthetic.get("view_origin") or "synthetic"),
+                ("Dataset samples visualized", _format_value(synthetic.get("dataset_sample_count"))),
+                ("Actual dataset camera PNGs", _format_value(synthetic.get("dataset_camera_image_count"))),
+                ("Dataset descriptor previews", _format_value(synthetic.get("dataset_descriptor_preview_count"))),
+                ("Augmentation samples visualized", _format_value(synthetic.get("augmentation_sample_count"))),
+                ("Actual augmentation PNGs", _format_value(synthetic.get("augmentation_image_count"))),
+                ("Augmentation descriptor previews", _format_value(synthetic.get("augmentation_descriptor_preview_count"))),
+            ],
+        ),
+    ]
+    samples = dataset.get("heldout_samples") or dataset.get("train_samples") or []
+    if samples:
+        lines.extend(["", "## Sample env descriptors", ""])
+        for sample in samples[:3]:
+            lines.append(
+                "- `{env_id}` `{asset}` friction `{friction}` lighting `{lighting}` augmented `{augmented}`".format(
+                    env_id=sample.get("env_id", "env"),
+                    asset=((sample.get("scene") or {}).get("simready_asset") or "asset"),
+                    friction=_format_value((sample.get("physics") or {}).get("friction")),
+                    lighting=_format_value((sample.get("physics") or {}).get("lighting_lux")),
+                    augmented=((sample.get("scene") or {}).get("augmented_frame_uri") or "not recorded"),
+                )
+            )
+    return "\n".join(lines)
+
+
+def _artifacts_markdown(index: dict[str, Any]) -> str:
+    counts = index.get("artifact_counts") or {}
+    artifacts = index.get("key_artifacts") or {}
+    vlm = index.get("vlm") or {}
+    lines = [
+        "# Visual artifact index",
+        "",
+        "## Counts",
+        "",
+        _markdown_table(["Artifact group", "Count"], sorted((key, value) for key, value in counts.items())),
+        "",
+        "## VLM signal",
+        "",
+        _markdown_table(
+            ["Field", "Value"],
+            [
+                ("Model", vlm.get("model") or "unknown"),
+                ("Sample score", _format_value(vlm.get("score"))),
+                ("Critique documents", _format_value(vlm.get("critique_count"))),
+            ],
+        ),
+        "",
+        "## Key artifacts",
+        "",
+        _markdown_table(["Name", "Path"], sorted((key, value) for key, value in artifacts.items())),
+    ]
+    return "\n".join(lines)
+
+
+def _synthetic_visual_index(local_dir: Path) -> dict[str, Any]:
+    dataset_samples = _synthetic_dataset_samples(local_dir)
+    dataset_camera_count = 0
+    dataset_view_count = 0
+    for _split, sample in dataset_samples:
+        for camera_name in _sample_camera_names(sample):
+            dataset_view_count += 1
+            if _local_camera_image_for_sample(local_dir, sample, camera_name) is not None:
+                dataset_camera_count += 1
+    augment_samples = _augmentation_visual_samples(local_dir)
+    augment_image_count = sum(1 for _frame_id, _payload, frame in augment_samples if frame is not None)
+    return {
+        "view_origin": "synthetic",
+        "dataset_sample_count": len(dataset_samples),
+        "dataset_camera_view_count": dataset_view_count,
+        "dataset_camera_image_count": dataset_camera_count,
+        "dataset_descriptor_preview_count": max(0, dataset_view_count - dataset_camera_count),
+        "augmentation_sample_count": len(augment_samples),
+        "augmentation_image_count": augment_image_count,
+        "augmentation_descriptor_preview_count": max(0, len(augment_samples) - augment_image_count),
+    }
+
+
+def _has_synthetic_visual_data(local_dir: Path) -> bool:
+    root = Path(local_dir)
+    return any(
+        path.is_file()
+        for path in (
+            root / "envs" / "train" / "envs.jsonl",
+            root / "envs" / "heldout" / "envs.jsonl",
+            root / "augment" / "frames" / "index.json",
+            root / "augment" / "manifest.json",
+        )
+    ) or any((root / "augment" / "frames").glob("frame-*.*"))
+
+
+def _log_synthetic_data(
+    rr: Any,
+    recording: Any,
+    local_dir: Path,
+    counts: dict[str, int],
+) -> int:
+    """Log synthetic dataset and augmentation samples as image streams.
+
+    If real RGB camera PNGs are present locally, those are logged. Current staged
+    runs often contain env/augment descriptors without persisted camera pixels;
+    those are rendered as labeled descriptor-preview tiles so the viewer exposes
+    the synthetic data surface without pretending descriptor metadata is footage.
+    """
+
+    logged = 0
+    dataset_samples = _synthetic_dataset_samples(Path(local_dir))
+    for sample_index, (split, sample) in enumerate(dataset_samples):
+        env_id = str(sample.get("env_id") or f"{split}-{sample_index:04d}")
+        cameras = _sample_camera_names(sample)
+        seconds = sample_index * SYNTHETIC_STEP_SECONDS
+        for camera_index, camera_name in enumerate(cameras):
+            frame = _local_camera_image_for_sample(Path(local_dir), sample, camera_name)
+            if frame is None:
+                frame = _synthetic_env_preview(sample, split=split, camera_name=camera_name, index=sample_index)
+            _set_time(rr, recording, seconds + camera_index * 0.01)
+            image = _rerun_image(rr, frame)
+            entity = f"synthetic/dataset/{split}/{env_id}/{camera_name}"
+            rr.log(entity, image, recording=recording)
+            _bump(counts, entity)
+            if logged == 0:
+                rr.log("synthetic/preview", image, recording=recording)
+                _bump(counts, "synthetic/preview")
+            logged += 1
+
+    for frame_index, (frame_id, payload, frame) in enumerate(_augmentation_visual_samples(Path(local_dir))):
+        if frame is None:
+            frame = _augmentation_preview(payload, index=frame_index)
+        _set_time(rr, recording, frame_index * SYNTHETIC_STEP_SECONDS)
+        image = _rerun_image(rr, frame)
+        entity = f"synthetic/augmentation/{frame_id}/image"
+        rr.log(entity, image, recording=recording)
+        _bump(counts, entity)
+        if logged == 0:
+            rr.log("synthetic/preview", image, recording=recording)
+            _bump(counts, "synthetic/preview")
+        logged += 1
+    return logged
+
+
+def _synthetic_dataset_samples(local_dir: Path, *, limit_per_split: int = SYNTHETIC_DATASET_SAMPLE_LIMIT) -> list[tuple[str, dict[str, Any]]]:
+    samples: list[tuple[str, dict[str, Any]]] = []
+    for split in ("train", "heldout"):
+        for sample in _jsonl_samples(Path(local_dir) / "envs" / split / "envs.jsonl", limit=limit_per_split):
+            samples.append((split, sample))
+    return samples
+
+
+def _sample_camera_names(sample: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for section in ("camera_obs", "cameras"):
+        values = sample.get(section)
+        if isinstance(values, dict):
+            names.extend(str(name) for name in values.keys() if str(name))
+    ordered = sorted(dict.fromkeys(names))
+    return ordered or ["workspace"]
+
+
+def _local_camera_image_for_sample(local_dir: Path, sample: dict[str, Any], camera_name: str) -> np.ndarray | None:
+    for section in ("camera_obs", "cameras"):
+        cameras = sample.get(section)
+        if not isinstance(cameras, dict):
+            continue
+        spec = cameras.get(camera_name)
+        if not isinstance(spec, dict):
+            continue
+        uri = str(spec.get("uri") or "")
+        if not uri:
+            continue
+        path = _local_artifact_path_from_uri(local_dir, uri)
+        if path is not None:
+            image = _read_image(path)
+            if image is not None:
+                return image
+    return None
+
+
+def _augmentation_visual_samples(
+    local_dir: Path,
+    *,
+    limit: int = SYNTHETIC_AUGMENT_SAMPLE_LIMIT,
+) -> list[tuple[str, dict[str, Any], np.ndarray | None]]:
+    frames_dir = Path(local_dir) / "augment" / "frames"
+    index = _read_json(frames_dir / "index.json")
+    manifest = _read_json(Path(local_dir) / "augment" / "manifest.json")
+    records: list[dict[str, Any]] = []
+    if isinstance(index.get("frames"), list):
+        records = [item for item in index["frames"] if isinstance(item, dict)]
+    if not records:
+        records = [{"frame_id": path.stem, "local": str(path)} for path in sorted(frames_dir.glob("frame-*.*"))]
+    if not records:
+        frame_count = int(_safe_float(manifest.get("frame_count"), 0.0))
+        frames_uri = str(manifest.get("augmented_frames_uri") or manifest.get("output_uri") or "").rstrip("/")
+        perturbations = ["lighting", "texture", "background", "contrast"]
+        records = [
+            {
+                "frame_id": f"frame-{index_no:05d}",
+                "uri": f"{frames_uri}/frame-{index_no:05d}.json" if frames_uri else "",
+                "source_dataset_uri": manifest.get("input_uri") or "",
+                "perturbation": perturbations[index_no % len(perturbations)],
+                "status": manifest.get("status") or "recorded",
+                "mode": manifest.get("mode") or "",
+                "image": manifest.get("image") or "",
+            }
+            for index_no in range(min(limit, frame_count))
+        ]
+
+    samples: list[tuple[str, dict[str, Any], np.ndarray | None]] = []
+    seen: set[str] = set()
+    for record in records:
+        if len(samples) >= limit:
+            break
+        frame_id = str(record.get("frame_id") or Path(str(record.get("local") or record.get("uri") or "")).stem)
+        if not frame_id or frame_id in seen:
+            continue
+        seen.add(frame_id)
+        json_path = frames_dir / f"{frame_id}.json"
+        payload_path = json_path if json_path.is_file() else _local_artifact_path_from_uri(local_dir, str(record.get("uri") or ""))
+        payload = _read_json(payload_path) if payload_path is not None else {}
+        if not payload:
+            payload = dict(record)
+        image_path = frames_dir / f"{frame_id}.png"
+        if not image_path.is_file():
+            image_path = _local_artifact_path_from_uri(local_dir, str(record.get("uri") or ""))
+        frame = _read_image(image_path) if image_path is not None else None
+        samples.append((frame_id, payload, frame))
+    return samples
+
+
+def _local_artifact_path_from_uri(local_dir: Path, uri: str) -> Path | None:
+    ref = str(uri or "").strip()
+    if not ref:
+        return None
+    if ref.startswith("file://"):
+        path = Path(ref.removeprefix("file://"))
+        return path if path.is_file() else None
+    path = Path(ref)
+    if not ref.startswith("s3://") and path.is_file():
+        return path
+    markers = ("/envs/", "/augment/", "/eval/", "/actions/", "/vlm_eval/", "/training_signal/", "/reports/")
+    for marker in markers:
+        if marker in ref:
+            rel = ref.split(marker, 1)[1]
+            candidate = Path(local_dir) / marker.strip("/") / rel
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def _synthetic_env_preview(
+    sample: dict[str, Any],
+    *,
+    split: str,
+    camera_name: str,
+    index: int,
+) -> np.ndarray:
+    physics = sample.get("physics") if isinstance(sample.get("physics"), dict) else {}
+    scene = sample.get("scene") if isinstance(sample.get("scene"), dict) else {}
+    env_id = str(sample.get("env_id") or f"{split}-{index:04d}")
+    friction = _safe_float(physics.get("friction"), 0.8)
+    lighting = _safe_float(physics.get("lighting_lux"), 650.0)
+    mass = _safe_float(physics.get("mass_scale"), 1.0)
+    asset = str(scene.get("simready_asset") or "simready://unknown")
+    augmented = str(scene.get("augmented_frame_uri") or "")
+    accent = _color_from_text(f"{env_id}:{camera_name}:{asset}")
+    rows = [
+        f"{split.upper()} {env_id}",
+        f"CAM {camera_name}",
+        f"ASSET {Path(asset).name or asset.rsplit('/', 1)[-1]}",
+        f"FRICTION {friction:.2f} MASS {mass:.2f}",
+        f"LIGHT {lighting:.0f} LUX",
+        "AUGMENTED REF" if augmented else "NO AUGMENT REF",
+    ]
+    image = _descriptor_preview_image(rows, accent=accent, seed_text=f"{env_id}:{asset}")
+    _draw_env_glyph(image, accent=accent, friction=friction, lighting=lighting, mass=mass, wrist=camera_name == "wrist")
+    return image
+
+
+def _augmentation_preview(payload: dict[str, Any], *, index: int) -> np.ndarray:
+    frame_id = str(payload.get("frame_id") or f"frame-{index:05d}")
+    perturbation = str(payload.get("perturbation") or payload.get("mode") or "augmentation")
+    status = str(payload.get("status") or "recorded")
+    source = str(payload.get("source_dataset_uri") or payload.get("input_uri") or "")
+    accent = _color_from_text(f"{frame_id}:{perturbation}:{status}")
+    rows = [
+        "COSMOS TRANSFER",
+        frame_id.upper(),
+        f"PERTURB {perturbation.upper()}",
+        f"STATUS {status.upper()}",
+        Path(source.rstrip("/")).name.upper() if source else "SOURCE RECORDED",
+    ]
+    image = _descriptor_preview_image(rows, accent=accent, seed_text=f"{frame_id}:{perturbation}")
+    _draw_augmentation_glyph(image, accent=accent, seed_text=f"{frame_id}:{perturbation}")
+    return image
+
+
+def _descriptor_preview_image(
+    rows: list[str],
+    *,
+    accent: tuple[int, int, int],
+    seed_text: str,
+    width: int = 320,
+    height: int = 240,
+) -> np.ndarray:
+    seed = int(hashlib.sha256(seed_text.encode("utf-8")).hexdigest()[:8], 16)
+    rng = np.random.default_rng(seed)
+    yy = np.linspace(0, 1, height, dtype=np.float32)[:, None]
+    xx = np.linspace(0, 1, width, dtype=np.float32)[None, :]
+    base = np.zeros((height, width, 3), dtype=np.uint8)
+    base[:, :, 0] = np.clip(34 + 42 * xx + accent[0] * 0.18, 0, 255).astype(np.uint8)
+    base[:, :, 1] = np.clip(38 + 52 * yy + accent[1] * 0.14, 0, 255).astype(np.uint8)
+    base[:, :, 2] = np.clip(46 + 28 * (1.0 - yy) + accent[2] * 0.18, 0, 255).astype(np.uint8)
+    for x in range(0, width, 32):
+        base[:, x : x + 1] = np.maximum(base[:, x : x + 1], 96)
+    for y in range(0, height, 32):
+        base[y : y + 1, :] = np.maximum(base[y : y + 1, :], 96)
+    for _ in range(18):
+        x0 = int(rng.integers(0, max(1, width - 24)))
+        y0 = int(rng.integers(64, max(65, height - 20)))
+        w = int(rng.integers(10, 34))
+        h = int(rng.integers(8, 26))
+        color = np.array(_mix_color(accent, int(rng.integers(50, 180))), dtype=np.uint8)
+        base[y0 : min(height, y0 + h), x0 : min(width, x0 + w)] = color
+
+    try:
+        from PIL import Image, ImageDraw
+
+        image = Image.fromarray(base, mode="RGB")
+        draw = ImageDraw.Draw(image)
+        draw.rectangle((0, 0, width, 46), fill=(12, 18, 28))
+        draw.rectangle((0, 46, width, 50), fill=accent)
+        for row_index, row in enumerate(rows):
+            y = 10 + row_index * 26
+            if row_index == 0:
+                draw.text((12, y), row[:32], fill=(255, 255, 255))
+            else:
+                draw.text((12, y + 36), row[:38], fill=(230, 236, 245))
+        return np.asarray(image, dtype=np.uint8).copy()
+    except Exception:
+        base[0:48, :] = np.array([12, 18, 28], dtype=np.uint8)
+        base[48:52, :] = np.array(accent, dtype=np.uint8)
+        return base
+
+
+def _draw_env_glyph(
+    image: np.ndarray,
+    *,
+    accent: tuple[int, int, int],
+    friction: float,
+    lighting: float,
+    mass: float,
+    wrist: bool,
+) -> None:
+    height, width = image.shape[:2]
+    left = int(width * 0.48)
+    right = width - 16
+    table_y0 = int(height * 0.54)
+    table_y1 = int(height * 0.86)
+    image[table_y0:table_y1, left:right] = np.array([96, 104, 116], dtype=np.uint8)
+    cx = int(width * (0.72 if wrist else 0.65))
+    cy = int(height * 0.66)
+    arm = np.array([236, 238, 240], dtype=np.uint8)
+    image[cy - 38 : cy + 38, cx - 8 : cx + 8] = arm
+    image[cy - 8 : cy + 8, max(left, cx - 36) : min(right, cx + 36)] = arm
+    block_size = int(14 + 10 * max(0.0, min(1.0, mass - 0.85)) / 0.3)
+    bx = int(width * 0.82)
+    by = int(height * 0.64)
+    image[by : by + block_size, bx : bx + block_size] = np.array(accent, dtype=np.uint8)
+    grip = int(10 + 20 * max(0.0, min(1.0, friction)))
+    image[cy + 34 : cy + 40, max(left, cx - grip) : min(right, cx + grip)] = np.array([30, 220, 140], dtype=np.uint8)
+    light_width = int(max(8, min(width - 24, lighting / 1200.0 * (width - 24))))
+    image[height - 18 : height - 10, 12 : 12 + light_width] = np.array([250, 204, 21], dtype=np.uint8)
+
+
+def _draw_augmentation_glyph(image: np.ndarray, *, accent: tuple[int, int, int], seed_text: str) -> None:
+    height, width = image.shape[:2]
+    seed = int(hashlib.sha256(seed_text.encode("utf-8")).hexdigest()[:8], 16)
+    rng = np.random.default_rng(seed)
+    for index in range(5):
+        x0 = int(width * 0.48) + index * 28
+        y0 = 145 + int(rng.integers(-16, 16))
+        image[y0 : y0 + 40, x0 : x0 + 22] = np.array(_mix_color(accent, 40 + index * 18), dtype=np.uint8)
+        image[y0 + 40 : y0 + 46, x0 - 2 : x0 + 24] = np.array([18, 24, 38], dtype=np.uint8)
+    for _ in range(30):
+        x = int(rng.integers(int(width * 0.45), width - 12))
+        y = int(rng.integers(82, height - 24))
+        image[y : y + 3, x : x + 3] = np.array([255, 255, 255], dtype=np.uint8)
+
+
+def _color_from_text(value: str) -> tuple[int, int, int]:
+    digest = hashlib.sha256(value.encode("utf-8")).digest()
+    return (72 + digest[0] % 152, 72 + digest[1] % 152, 72 + digest[2] % 152)
+
+
+def _mix_color(accent: tuple[int, int, int], amount: int) -> tuple[int, int, int]:
+    return tuple(int(max(0, min(255, channel + amount - 90))) for channel in accent)
+
+
+def _safe_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _markdown_table(headers: list[str], rows: list[Any]) -> str:
+    table = ["| " + " | ".join(headers) + " |", "| " + " | ".join(["---"] * len(headers)) + " |"]
+    for row in rows:
+        values = list(row if isinstance(row, (list, tuple)) else [row])
+        table.append("| " + " | ".join(_escape_markdown(_format_value(value)) for value in values) + " |")
+    return "\n".join(table)
+
+
+def _escape_markdown(value: str) -> str:
+    return value.replace("\n", " ").replace("|", "\\|")
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.4g}"
+    return str(value)
+
+
+def _first_present(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _first_sample_value(inner_evidence: dict[str, Any], sample_key: str, value_key: str) -> Any:
+    for record in inner_evidence.get("iterations") or []:
+        if not isinstance(record, dict):
+            continue
+        sample = record.get(sample_key)
+        if isinstance(sample, dict) and sample.get(value_key) is not None:
+            return sample.get(value_key)
+    return None
+
+
+def _jsonl_samples(path: Path, limit: int = 3) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    try:
+        with Path(path).open(encoding="utf-8") as handle:
+            for line in handle:
+                if len(samples) >= limit:
+                    break
+                try:
+                    item = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(item, dict):
+                    samples.append(item)
+    except OSError:
+        pass
+    return samples
+
+
+def _artifact_counts(local_dir: Path) -> dict[str, int]:
+    roots = {
+        "augment_frames": Path(local_dir) / "augment" / "frames",
+        "raw_env_shards": Path(local_dir) / "envs" / "raw",
+        "heldout_renders": Path(local_dir) / "eval" / "heldout" / "renders",
+        "rollout_dirs": Path(local_dir) / "actions" / "train",
+        "vlm_eval_json": Path(local_dir) / "vlm_eval" / "train",
+        "training_signal_json": Path(local_dir) / "training_signal" / "train",
+    }
+    counts: dict[str, int] = {}
+    for name, root in roots.items():
+        if not root.exists():
+            counts[name] = 0
+        elif name == "rollout_dirs":
+            counts[name] = sum(1 for path in root.rglob("rollout-*") if path.is_dir())
+        else:
+            counts[name] = sum(1 for path in root.rglob("*") if path.is_file())
+    return counts
+
+
+def _key_artifacts(local_dir: Path) -> dict[str, str]:
+    rels = [
+        "reports/sim2real-report.json",
+        "reports/sim2real-visual-index.json",
+        "outer_loop/decision.json",
+        "augment/manifest.json",
+        "augment/frames/index.json",
+        "envs/raw/raw-shard-00-of-16.jsonl",
+        "envs/raw/raw-shard-00-summary.json",
+        "envs/manifest/split-manifest.json",
+        "envs/train/envs.jsonl",
+        "envs/heldout/envs.jsonl",
+        "tokens/manifest.json",
+        "eval/heldout/report.json",
+    ]
+    return {rel: str(Path(local_dir) / rel) for rel in rels if (Path(local_dir) / rel).exists()}
 
 
 def _franka_joint_positions(joint_angles: tuple[float, ...]) -> list[list[float]]:
@@ -686,6 +1386,7 @@ def _build_blueprint(
     *,
     has_heldout_cameras: bool = False,
     heldout_env_ids: list[str] | None = None,
+    has_synthetic_data: bool = False,
 ) -> Any:
     env_ids = list(heldout_env_ids or [])
     has_heldout_cameras = has_heldout_cameras or bool(env_ids)
@@ -694,7 +1395,7 @@ def _build_blueprint(
         # single Spatial2DView, while the per-env grid remains available for
         # deeper inspection in the Streams tree.
         camera_view = rrb.Vertical(
-            rrb.Spatial2DView(origin="camera", name="Franka held-out sim camera"),
+            rrb.Spatial2DView(origin="camera", name="Isaac held-out simulation camera"),
             rrb.Grid(
                 *[
                     rrb.Spatial2DView(
@@ -733,17 +1434,65 @@ def _build_blueprint(
         if secondary_camera is not None
         else camera_view
     )
-    return rrb.Blueprint(
-        rrb.Horizontal(
+    synthetic_view = rrb.Vertical(
+        rrb.Spatial2DView(
+            origin="synthetic/preview",
+            name="Synthetic data preview",
+        ),
+        rrb.Grid(
+            rrb.Spatial2DView(
+                origin="synthetic/dataset/train",
+                contents="synthetic/dataset/train/**",
+                name="Train env samples",
+            ),
+            rrb.Spatial2DView(
+                origin="synthetic/dataset/heldout",
+                contents="synthetic/dataset/heldout/**",
+                name="Held-out env samples",
+            ),
+            rrb.Spatial2DView(
+                origin="synthetic/augmentation",
+                contents="synthetic/augmentation/**",
+                name="Augmentation samples",
+            ),
+            name="Synthetic dataset and augmentation",
+        ),
+        row_shares=[1.2, 2.0],
+    )
+    signal_view = rrb.Vertical(
+        rrb.TimeSeriesView(origin="signal", contents="signal/**", name="VLM->RL signal"),
+        rrb.TimeSeriesView(origin="heldout", contents="heldout/**", name="Held-out scores"),
+    )
+    summary_view = rrb.Vertical(
+        rrb.TextDocumentView(origin="summary/run_success", name="Success"),
+        rrb.TextDocumentView(origin="summary/augmentation", name="Augmented data"),
+        rrb.TextDocumentView(origin="summary/artifacts", name="Artifacts"),
+        rrb.TextDocumentView(origin="summary/vlm_critiques", name="VLM critiques"),
+        row_shares=[1.2, 1.1, 1.0, 1.0],
+    )
+    if has_heldout_cameras:
+        columns = [left_column]
+        shares = [2.4]
+        if has_synthetic_data:
+            columns.append(synthetic_view)
+            shares.append(2.1)
+        columns.extend([summary_view, signal_view])
+        shares.extend([1.5, 1.1])
+        layout = rrb.Horizontal(*columns, column_shares=shares)
+    else:
+        columns = [
             rrb.Spatial3DView(origin="world", contents="world/**", name="Scene overview"),
             left_column,
-            rrb.TextDocumentView(origin="rollouts", contents="rollouts/**/critique", name="VLM critiques"),
-            rrb.Vertical(
-                rrb.TimeSeriesView(origin="signal", contents="signal/**", name="VLM->RL signal"),
-                rrb.TimeSeriesView(origin="heldout", contents="heldout/**", name="Held-out scores"),
-            ),
-            column_shares=[2.0, 1.4, 1.2, 1.3],
-        ),
+        ]
+        shares = [2.0, 1.4]
+        if has_synthetic_data:
+            columns.append(synthetic_view)
+            shares.append(1.8)
+        columns.extend([summary_view, signal_view])
+        shares.extend([1.2, 1.3])
+        layout = rrb.Horizontal(*columns, column_shares=shares)
+    return rrb.Blueprint(
+        layout,
         rrb.TimePanel(state=rrb.PanelState.Expanded, timeline=TIMELINE),
         auto_layout=False,
     )
@@ -842,21 +1591,32 @@ def _decode_png_bytes(data: bytes) -> np.ndarray | None:
     import zlib
 
     index = 8
-    width = height = bit_depth = color_type = 0
+    width = height = 0
+    bit_depth = color_type = interlace = 0
     idat = bytearray()
     while index + 8 <= len(data):
         length = struct.unpack("!I", data[index : index + 4])[0]
         chunk_type = data[index + 4 : index + 8]
         chunk = data[index + 8 : index + 8 + length]
         index += 12 + length
-        if chunk_type == b"IHDR" and len(chunk) >= 10:
-            width, height, bit_depth, color_type = struct.unpack("!IIBB", chunk[:10])
+        if chunk_type == b"IHDR" and len(chunk) >= 13:
+            width, height = struct.unpack("!II", chunk[:8])
+            bit_depth = int(chunk[8])
+            color_type = int(chunk[9])
+            interlace = int(chunk[12])
         elif chunk_type == b"IDAT":
             idat.extend(chunk)
         elif chunk_type == b"IEND":
             break
     channels = {0: 1, 2: 3, 4: 2, 6: 4}.get(color_type)
-    if width <= 0 or height <= 0 or not idat or bit_depth != 8 or channels is None:
+    if (
+        width <= 0
+        or height <= 0
+        or not idat
+        or bit_depth != 8
+        or interlace != 0
+        or channels is None
+    ):
         return None
     try:
         raw = zlib.decompress(bytes(idat))

--- a/npa/tests/workflows/test_byo_isaac_eval.py
+++ b/npa/tests/workflows/test_byo_isaac_eval.py
@@ -49,6 +49,42 @@ def test_build_isaac_eval_job_manifest_shape():
     assert "per_env_distances.json" in args           # uploads measured distances
 
 
+def test_run_isaac_eval_job_uses_outer_iteration_artifact_tag(monkeypatch):
+    captured: dict[str, str] = {}
+
+    class _Proc:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_build(**kwargs):
+        captured["job_name"] = kwargs["job_name"]
+        captured["per_env_s3_uri"] = kwargs["per_env_s3_uri"]
+        captured["renders_s3_prefix"] = kwargs["renders_s3_prefix"]
+        return {"kind": "Job"}
+
+    monkeypatch.setattr(ev, "build_isaac_eval_job_manifest", fake_build)
+    monkeypatch.setattr(ev, "_kubectl", lambda *a, **k: _Proc())
+    monkeypatch.setattr(ev, "_download_json", lambda _uri: {"object_goal_distances": [0.01]})
+    monkeypatch.setenv("NPA_SIM2REAL_ISAAC_IMAGE", "reg/npa-isaac-lab:2.3.2.post1")
+    monkeypatch.setenv("NPA_SIM2REAL_BUCKET", "bkt")
+    monkeypatch.setenv("NPA_SIM2REAL_EVAL_TAG", "outer-02")
+
+    rows = ev.run_isaac_eval_job(
+        "myrun",
+        checkpoint_uri="s3://bkt/run/model_latest.pt",
+        num_envs=1,
+        generated_envs=[],
+    )
+
+    assert rows[0]["success"] is True
+    assert captured["job_name"].endswith("outer-02")
+    assert captured["per_env_s3_uri"].endswith(
+        "/byo-eval/s2r-byo-isaac-eval-myrun-outer-02/per_env_distances.json"
+    )
+    assert captured["renders_s3_prefix"].endswith("/byo-eval/s2r-byo-isaac-eval-myrun-outer-02/renders")
+
+
 def test_dryrun_main_writes_normalizable_report(tmp_path, monkeypatch):
     """Dry-run output must flow through the engine's _normalize_heldout_report."""
 

--- a/npa/tests/workflows/test_byo_isaac_policy_rollout.py
+++ b/npa/tests/workflows/test_byo_isaac_policy_rollout.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import sys
+from pathlib import Path
 
 from npa.workflows.sim2real import byo_isaac_policy_rollout as pr
 
@@ -108,3 +110,43 @@ def test_untrained_job_manifest_skips_download():
     script = m["spec"]["template"]["spec"]["containers"][0]["args"][0]
     assert "DOWNLOADED_CKPT" not in script  # no checkpoint -> untrained policy
     assert 'ROLLOUT_CKPT_LOCAL=""' in script
+
+
+def test_run_isaac_rollout_job_uses_outer_iteration_artifact_tag(tmp_path, monkeypatch):
+    captured: dict[str, str] = {}
+
+    class _Proc:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    class _FakeS3:
+        def download_file(self, _bucket: str, _key: str, local: str) -> None:
+            Path(local).write_text(json.dumps({"rollouts": []}), encoding="utf-8")
+
+    class _FakeBoto3:
+        def client(self, *_args, **_kwargs):
+            return _FakeS3()
+
+    def fake_build(**kwargs):
+        captured["job_name"] = kwargs["job_name"]
+        captured["out_s3_prefix"] = kwargs["out_s3_prefix"]
+        return {"kind": "Job"}
+
+    monkeypatch.setitem(sys.modules, "boto3", _FakeBoto3())
+    monkeypatch.setattr(pr, "_kubectl", lambda *a, **k: _Proc())
+    monkeypatch.setattr(pr, "build_isaac_rollout_job_manifest", fake_build)
+    monkeypatch.setattr(pr, "latest_checkpoint_uri", lambda *a, **k: "s3://b/run/model_latest.pt")
+    monkeypatch.setattr(pr, "materialize_rollout_dirs", lambda *a, **k: [])
+    monkeypatch.setenv("NPA_SIM2REAL_ISAAC_IMAGE", "reg/npa-isaac-lab:2.3.2.post1")
+    monkeypatch.setenv("NPA_SIM2REAL_BUCKET", "bkt")
+
+    pr.run_isaac_rollout_job(
+        tmp_path / "actions" / "train" / "outer-02" / "iter-01",
+        run_id="myrun",
+        rollout_count=1,
+        steps_per_rollout=1,
+    )
+
+    assert captured["job_name"].endswith("outer-02-iter-01")
+    assert captured["out_s3_prefix"].endswith("/byo-rollouts/outer-02-iter-01")

--- a/npa/tests/workflows/test_byo_isaac_trainer.py
+++ b/npa/tests/workflows/test_byo_isaac_trainer.py
@@ -380,6 +380,14 @@ def test_sanitize_tag():
     assert byo._sanitize_tag("") == ""
 
 
+def test_artifact_tag_from_output_dir_keeps_outer_iteration(tmp_path):
+    output_dir = tmp_path / "actions" / "train" / "outer-02" / "iter-01"
+
+    assert byo.artifact_tag_from_output_dir(output_dir) == "outer-02-iter-01"
+    assert byo.artifact_tag_from_output_dir(tmp_path / "iter-01") == "iter-01"
+    assert byo.artifact_tag("outer/02 iter 01") == "outer-02-iter-01"
+
+
 def test_run_isaac_training_job_tags_s3_path_per_iteration(monkeypatch):
     # NPA_SIM2REAL_TRAINER_TAG must make each iteration's checkpoint a DISTINCT S3
     # path (so the prior model survives for the next outer iteration to resume from

--- a/npa/tests/workflows/test_sim2real_rerun_regen.py
+++ b/npa/tests/workflows/test_sim2real_rerun_regen.py
@@ -10,6 +10,7 @@ from npa.workflows.sim2real_rerun_regen import (
     Sim2RealRerunRegenError,
     regen_sim2real_rrd,
     resolve_local_rrd_path,
+    sync_heldout_renders,
 )
 
 
@@ -182,3 +183,65 @@ def test_regen_mcap_failure_never_breaks_the_rrd_regen(
     assert result.mcap_status == "skipped"
     assert result.local_mcap_path == ""
     assert result.mcap_upload_uri == ""
+
+
+def test_sync_heldout_renders_falls_back_to_byo_eval_tree(tmp_path: Path) -> None:
+    run_id = "s2r-real-0725t222636z"
+    config = _config(run_id=run_id)
+    local_dir = tmp_path / "run"
+    report_path = local_dir / "eval" / "heldout" / "report.json"
+    report_path.parent.mkdir(parents=True)
+    report_path.write_text(json.dumps({"success_rate": 1.0}), encoding="utf-8")
+
+    class FakePaginator:
+        def paginate(self, *, Bucket: str, Prefix: str, Delimiter: str):
+            if Prefix.endswith(f"{run_id}/byo-eval/"):
+                return [
+                    {
+                        "CommonPrefixes": [
+                            {
+                                "Prefix": (
+                                    f"sim2real-b/{run_id}/byo-eval/"
+                                    f"s2r-byo-isaac-eval-{run_id}/"
+                                )
+                            }
+                        ]
+                    }
+                ]
+            return [{"CommonPrefixes": []}]
+
+    class FakeS3:
+        def get_paginator(self, name: str) -> FakePaginator:
+            assert name == "list_objects_v2"
+            return FakePaginator()
+
+    class FakeStorage:
+        _s3 = FakeS3()
+
+        def download_directory(self, uri: str, dest: str) -> None:
+            if uri.endswith(f"/byo-eval/s2r-byo-isaac-eval-{run_id}/renders/"):
+                env_dir = Path(dest) / "env-00006"
+                env_dir.mkdir(parents=True)
+                (env_dir / "camera-000.png").write_bytes(b"png")
+                return
+            raise OSError(uri)
+
+        def download_path(self, uri: str, local_path: str) -> None:
+            if uri.endswith(f"/byo-eval/s2r-byo-isaac-eval-{run_id}/render-manifest.json"):
+                Path(local_path).parent.mkdir(parents=True)
+                Path(local_path).write_text(
+                    json.dumps(
+                        {
+                            "schema": "npa.sim2real.heldout_renders.v1",
+                            "episodes": [{"env_id": "env-00006", "frames": ["camera-000.png"]}],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                return
+            raise OSError(uri)
+
+    assert sync_heldout_renders(config, local_dir, heldout_report={"success_rate": 1.0}, client=FakeStorage())
+    assert (local_dir / "eval" / "heldout" / "renders" / "env-00006" / "camera-000.png").is_file()
+    updated_report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert updated_report["render_manifest"]["episodes"][0]["env_id"] == "env-00006"

--- a/npa/tests/workflows/test_sim2real_rerun_serve.py
+++ b/npa/tests/workflows/test_sim2real_rerun_serve.py
@@ -228,6 +228,27 @@ def test_manifest_contains_init_sync_and_rerun_serve(mocker) -> None:
     assert service["spec"]["ports"][1]["port"] == DEFAULT_GRPC_PORT
 
 
+def test_manifest_omits_cors_flag_for_preinstalled_rerun_031_image(mocker) -> None:
+    mocker.patch(
+        "npa.workflows.rerun_serve.resolve_project_storage",
+        return_value=_storage(),
+    )
+    config = build_rerun_serve_config(
+        run_id="sim2real-staged-20260615t180818z",
+        rerun_image="registry.example/npa-rerun-viewer:0.31.4",
+        aws_access_key_id="ak",
+        aws_secret_access_key="sk",
+    )
+    manifest = build_rerun_serve_manifest(config)
+    deployment = next(item for item in manifest["items"] if item["kind"] == "Deployment")
+    rerun_container = next(
+        c for c in deployment["spec"]["template"]["spec"]["containers"] if c["name"] == "rerun"
+    )
+
+    assert "--cors-allow-origin" not in rerun_container["command"][-1]
+    assert "pip install" not in rerun_container["command"][-1]
+
+
 def test_public_viewer_url_points_at_external_grpc_proxy() -> None:
     url = public_viewer_url("203.0.113.10", http_port=9090, grpc_port=9876)
     assert url.startswith("http://203.0.113.10:9090/?url=")

--- a/npa/tests/workflows/test_sim2real_stages.py
+++ b/npa/tests/workflows/test_sim2real_stages.py
@@ -97,6 +97,110 @@ def test_augment_stage_uses_seam_reference_for_placeholder_image(tmp_path: Path)
     assert (tmp_path / "augment" / "frames" / "index.json").exists()
 
 
+def test_augment_stage_mirrors_k8s_frame_descriptors(monkeypatch, tmp_path: Path) -> None:
+    def fake_component(config, *, input_uri, output_uri, local_dir):
+        return {
+            "manifest": {
+                "status": "executed",
+                "mode": "descriptor_stub",
+                "frame_count": 2,
+                "augmented_frames_uri": f"{output_uri.rstrip('/')}/frames/",
+            },
+            "augmented_frames_uri": f"{output_uri.rstrip('/')}/frames/",
+        }
+
+    class FakeClient:
+        def download_directory(self, uri: str, local_dir: str) -> None:
+            frames_dir = Path(local_dir)
+            frames_dir.mkdir(parents=True, exist_ok=True)
+            (frames_dir / "index.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "npa.sim2real.augmented_frames.v1",
+                        "frame_count": 1,
+                        "frames": [{"frame_id": "frame-00000", "uri": f"{uri}frame-00000.json"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (frames_dir / "frame-00000.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "npa.sim2real.augmented_frame.v1",
+                        "frame_id": "frame-00000",
+                        "perturbation": "lighting",
+                        "status": "cosmos2_transfer_executed",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+    monkeypatch.setattr(
+        "npa.workflows.sim2real.engine.run_cosmos2_transfer_component",
+        fake_component,
+    )
+    monkeypatch.setattr(
+        "npa.clients.storage.StorageClient.from_environment",
+        lambda: FakeClient(),
+    )
+    config = Sim2RealLoopConfig(
+        run_id="k8s-augment",
+        output_dir=tmp_path,
+        s3_bucket="bucket",
+        s3_endpoint="https://storage.example.test",
+        trigger_dataset_uri="s3://bucket/triggers/pusht/",
+        augment_image="cr.eu-north1.nebius.cloud/example-registry-id/npa-cosmos2-transfer:2.5.0",
+    )
+
+    result = run_augment_stage(config, tmp_path)
+
+    assert result["component"]["tier"] == "WORKS"
+    assert (tmp_path / "augment" / "frames" / "index.json").is_file()
+    assert (tmp_path / "augment" / "frames" / "frame-00000.json").is_file()
+
+
+def test_augment_stage_keeps_working_when_frame_mirror_lags(monkeypatch, tmp_path: Path) -> None:
+    def fake_component(config, *, input_uri, output_uri, local_dir):
+        return {
+            "manifest": {
+                "status": "executed",
+                "mode": "descriptor_stub",
+                "frame_count": 2,
+                "augmented_frames_uri": f"{output_uri.rstrip('/')}/frames/",
+            },
+            "augmented_frames_uri": f"{output_uri.rstrip('/')}/frames/",
+        }
+
+    class FakeClient:
+        def download_directory(self, uri: str, local_dir: str) -> None:
+            raise OSError(f"not visible yet: {uri}")
+
+    monkeypatch.setattr(
+        "npa.workflows.sim2real.engine.run_cosmos2_transfer_component",
+        fake_component,
+    )
+    monkeypatch.setattr(
+        "npa.clients.storage.StorageClient.from_environment",
+        lambda: FakeClient(),
+    )
+    monkeypatch.setattr("npa.workflows.sim2real_stages.time.sleep", lambda _seconds: None)
+    config = Sim2RealLoopConfig(
+        run_id="k8s-augment-lag",
+        output_dir=tmp_path,
+        s3_bucket="bucket",
+        s3_endpoint="https://storage.example.test",
+        trigger_dataset_uri="s3://bucket/triggers/pusht/",
+        augment_image="cr.eu-north1.nebius.cloud/example-registry-id/npa-cosmos2-transfer:2.5.0",
+    )
+
+    result = run_augment_stage(config, tmp_path)
+
+    assert result["component"]["tier"] == "WORKS"
+    assert "falls back to manifest descriptors" in result["component"]["evidence"]
+    warning = json.loads((tmp_path / "augment" / "frames" / "mirror-warning.json").read_text())
+    assert warning["status"] == "mirror_unavailable"
+
+
 def test_envgen_split_stage_launches_indexed_shards_when_image_ready(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/npa/tests/workflows/test_sim2real_viz.py
+++ b/npa/tests/workflows/test_sim2real_viz.py
@@ -26,7 +26,9 @@ class _FakeRerun:
 
     def __init__(self) -> None:
         self.logged: list[tuple[str, str]] = []
+        self.logged_times: list[tuple[str, str, float]] = []
         self.times: list[float] = []
+        self.current_time = 0.0
         self.saved_path: Path | None = None
         self.disconnected = False
 
@@ -62,10 +64,13 @@ class _FakeRerun:
         return None
 
     def set_time_seconds(self, timeline: str, seconds: float, recording: Any = None) -> None:
+        self.current_time = float(seconds)
         self.times.append(float(seconds))
 
     def log(self, entity_path: str, archetype: dict[str, Any], recording: Any = None) -> None:
-        self.logged.append((entity_path, archetype.get("kind", "?")))
+        kind = archetype.get("kind", "?")
+        self.logged.append((entity_path, kind))
+        self.logged_times.append((entity_path, kind, self.current_time))
 
     def disconnect(self, recording: Any = None) -> None:
         self.disconnected = True
@@ -427,6 +432,22 @@ def test_emit_mcap_raises_when_no_content(tmp_path: Path) -> None:
         )
 
 
+def test_emit_rejects_synthetic_descriptor_only_recording(monkeypatch, tmp_path: Path) -> None:
+    _write_summary_artifacts(tmp_path)
+    fake = _FakeRerun()
+    monkeypatch.setattr(viz_module, "_import_rerun", lambda: (fake, MagicMock()))
+
+    with pytest.raises(Sim2RealVizError, match="no real rollout frames"):
+        emit_sim2real_rerun(
+            local_dir=tmp_path,
+            inner_evidence={"iterations": [], "reward_trend": []},
+            heldout_report={"per_env": []},
+            output_rrd=tmp_path / "reports" / "sim2real.rrd",
+        )
+
+    assert any(entity.startswith("synthetic/") for entity, _kind in fake.logged)
+
+
 def _write_test_png(path: Path, *, red: int, green: int, blue: int) -> None:
     import struct
     import zlib
@@ -453,6 +474,66 @@ def _write_test_png(path: Path, *, red: int, green: int, blue: int) -> None:
     png += _chunk(b"IEND", b"")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(png)
+
+
+def _write_summary_artifacts(tmp_path: Path) -> None:
+    (tmp_path / "reports").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "reports" / "sim2real-report.json").write_text(
+        json.dumps({"run_id": "s2r-test", "status": "completed"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "outer_loop").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "outer_loop" / "decision.json").write_text(
+        json.dumps(
+            {
+                "decision": "promote_checkpoint",
+                "success_rate": 1.0,
+                "threshold": 0.5,
+                "checkpoint_uri": "s3://bucket/run/model_latest.pt",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "augment" / "frames").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "augment" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "status": "executed",
+                "mode": "descriptor_stub",
+                "frame_count": 2,
+                "image": "npa-cosmos2-transfer:test",
+                "input_uri": "s3://bucket/input",
+                "output_uri": "s3://bucket/augment",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "augment" / "frames" / "index.json").write_text(
+        json.dumps({"frame_count": 2, "frames": [{"frame_id": "frame-00000"}]}),
+        encoding="utf-8",
+    )
+    (tmp_path / "envs" / "manifest").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "envs" / "manifest" / "split-manifest.json").write_text(
+        json.dumps({"raw_count": 10, "train_count": 8, "heldout_count": 2, "disjoint": True, "seed": 42}),
+        encoding="utf-8",
+    )
+    (tmp_path / "tokens").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "tokens" / "manifest.json").write_text(
+        json.dumps({"train_env_count": 8, "heldout_env_count": 2}),
+        encoding="utf-8",
+    )
+    env_sample = {
+        "env_id": "env-00006",
+        "physics": {"friction": 0.58, "lighting_lux": 700},
+        "scene": {
+            "simready_asset": "simready://warehouse/tabletop_v1",
+            "augmented_frame_uri": "s3://bucket/augment/frame-00006.png",
+        },
+    }
+    for rel in ("envs/train/envs.jsonl", "envs/heldout/envs.jsonl"):
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(env_sample) + "\n", encoding="utf-8")
 
 
 def _gradient_rgb(width: int = 48, height: int = 32) -> Any:
@@ -528,6 +609,7 @@ def _encode_png_with_filter(pixels, filter_type: int) -> bytes:
     import zlib
 
     height, width, channels = pixels.shape
+    assert channels == 3
     raw = bytearray()
     prev = [0] * (width * channels)
     for y in range(height):
@@ -566,6 +648,57 @@ def _encode_png_with_filter(pixels, filter_type: int) -> bytes:
         + _chunk(b"IDAT", zlib.compress(bytes(raw)))
         + _chunk(b"IEND", b"")
     )
+
+
+def _write_filtered_rgb_png(path: Path, pixels: Any, filter_types: list[int]) -> None:
+    import struct
+    import zlib
+
+    height, width, channels = pixels.shape
+    assert channels == 3
+    raw = bytearray()
+    previous = [0] * (width * channels)
+    for row_index in range(height):
+        row = [int(value) for value in pixels[row_index].reshape(-1)]
+        filter_type = filter_types[row_index % len(filter_types)]
+        encoded = bytearray()
+        for byte_index, value in enumerate(row):
+            left = row[byte_index - channels] if byte_index >= channels else 0
+            up = previous[byte_index]
+            upper_left = previous[byte_index - channels] if byte_index >= channels else 0
+            if filter_type == 0:
+                predictor = 0
+            elif filter_type == 1:
+                predictor = left
+            elif filter_type == 2:
+                predictor = up
+            elif filter_type == 3:
+                predictor = (left + up) // 2
+            elif filter_type == 4:
+                predictor = viz_module._paeth(left, up, upper_left)
+            else:
+                raise AssertionError(filter_type)
+            encoded.append((value - predictor) & 0xFF)
+        raw.append(filter_type)
+        raw.extend(encoded)
+        previous = row
+
+    def _chunk(tag: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack("!I", len(payload))
+            + tag
+            + payload
+            + struct.pack("!I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+        )
+
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", struct.pack("!IIBBBBB", width, height, 8, 2, 0, 0, 0))
+        + _chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+        + _chunk(b"IEND", b"")
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(png)
 
 
 def _noisy_rgb(width: int = 24, height: int = 18):
@@ -620,6 +753,29 @@ def test_decode_png_matches_pillow_on_filter0(tmp_path: Path) -> None:
     assert int(decoded.mean()) == int(np.array([12, 200, 77]).mean())
 
 
+def test_read_png_reconstructs_filtered_truecolor_rows(monkeypatch, tmp_path: Path) -> None:
+    import numpy as np
+
+    monkeypatch.setattr(viz_module, "_read_png_with_pillow", lambda _path: None)
+    pixels = np.array(
+        [
+            [[10, 20, 30], [40, 50, 60], [70, 80, 90], [100, 110, 120]],
+            [[11, 21, 31], [45, 55, 65], [76, 86, 96], [111, 121, 131]],
+            [[12, 22, 32], [47, 57, 67], [81, 91, 101], [118, 128, 138]],
+            [[13, 23, 33], [49, 59, 69], [88, 98, 108], [125, 135, 145]],
+            [[14, 24, 34], [51, 61, 71], [95, 105, 115], [132, 142, 152]],
+        ],
+        dtype=np.uint8,
+    )
+    path = tmp_path / "filtered.png"
+    _write_filtered_rgb_png(path, pixels, [0, 1, 2, 3, 4])
+
+    decoded = viz_module._read_png(path)
+
+    assert decoded is not None
+    assert np.array_equal(decoded, pixels)
+
+
 def test_is_reference_stub_rollout_detects_reference_fixture(tmp_path: Path) -> None:
     actions_dir = tmp_path / "actions"
     rollouts = generate_action_rollouts(actions_dir, count=1, steps_per_rollout=2, seed=3, quality=0.5)
@@ -642,6 +798,7 @@ def test_is_reference_stub_rollout_detects_reference_fixture(tmp_path: Path) -> 
 
 def test_emit_prefers_heldout_isaac_cameras_over_stub_rollouts(monkeypatch, tmp_path: Path) -> None:
     inner_evidence, heldout_report = _build_run_tree(tmp_path)
+    _write_summary_artifacts(tmp_path)
     renders_dir = tmp_path / "eval" / "heldout" / "renders" / "heldout-0000"
     _write_test_png(renders_dir / "camera-000.png", red=40, green=120, blue=200)
     _write_test_png(renders_dir / "camera-001.png", red=50, green=130, blue=210)
@@ -673,12 +830,56 @@ def test_emit_prefers_heldout_isaac_cameras_over_stub_rollouts(monkeypatch, tmp_
     assert result.frame_count == 0
     assert "heldout/camera/heldout-0000/camera" in entities
     assert kinds["heldout/camera/heldout-0000/camera"] == "image"
+    assert ("camera", "image", 0.0) in fake.logged_times
+    assert not any(entity.startswith("world/franka") for entity in entities)
     assert not any(
         entity.startswith("rollouts/iter_01/rollout-") and entity.endswith("/camera")
         for entity in entities
     )
     assert "signal/reward_trend" in entities
     assert "heldout/success_rate" in entities
+    assert "summary/run_success" in entities
+    assert "summary/augmentation" in entities
+    assert "summary/artifacts" in entities
+    assert result.synthetic_frame_count > 0
+    assert any(entity.startswith("synthetic/dataset/train/") for entity in entities)
+    assert any(entity.startswith("synthetic/dataset/heldout/") for entity in entities)
+    assert any(entity.startswith("synthetic/augmentation/") for entity in entities)
+    assert "synthetic/preview" in entities
+    visual_index = tmp_path / "reports" / "sim2real-visual-index.json"
+    assert visual_index.is_file()
+    index = json.loads(visual_index.read_text(encoding="utf-8"))
+    assert index["success"]["decision"] == "promote_checkpoint"
+    assert index["augmentation"]["frame_count"] == 2
+    assert index["dataset"]["heldout_count"] == 2
+    assert index["synthetic"]["dataset_sample_count"] == 2
+    assert index["synthetic"]["dataset_descriptor_preview_count"] >= 2
+    assert index["synthetic"]["augmentation_sample_count"] == 1
+
+
+def test_emit_logs_augmentation_previews_from_manifest_without_frame_index(
+    monkeypatch, tmp_path: Path
+) -> None:
+    inner_evidence, heldout_report = _build_run_tree(tmp_path)
+    _write_summary_artifacts(tmp_path)
+    (tmp_path / "augment" / "frames" / "index.json").unlink()
+
+    fake = _FakeRerun()
+    monkeypatch.setattr(viz_module, "_import_rerun", lambda: (fake, MagicMock()))
+    result = emit_sim2real_rerun(
+        local_dir=tmp_path,
+        inner_evidence=inner_evidence,
+        heldout_report=heldout_report,
+        output_rrd=tmp_path / "reports" / "sim2real.rrd",
+    )
+
+    entities = [entity for entity, _kind in fake.logged]
+    assert result.synthetic_frame_count > 0
+    assert any(entity.startswith("synthetic/augmentation/frame-") for entity in entities)
+    index = json.loads((tmp_path / "reports" / "sim2real-visual-index.json").read_text(encoding="utf-8"))
+    assert index["augmentation"]["frame_count"] == 2
+    assert index["synthetic"]["augmentation_sample_count"] == 2
+    assert index["synthetic"]["augmentation_descriptor_preview_count"] == 2
 
 
 def test_heldout_render_step_indices_samples_evenly() -> None:
@@ -780,7 +981,12 @@ def test_build_blueprint_one_2d_view_per_heldout_env() -> None:
     viz_module._build_blueprint(
         rrb, heldout_env_ids=["env-00006", "env-00009", "env-00018"]
     )
-    assert any(v["kind"] == "Spatial3DView" and v["origin"] == "world" for v in rrb.views)
+    assert rrb.views[0] == {
+        "kind": "Spatial2DView",
+        "origin": "camera",
+        "name": "Isaac held-out simulation camera",
+    }
+    assert not any(v["kind"] == "Spatial3DView" and v["origin"] == "world" for v in rrb.views)
     heldout_origins = [
         v["origin"] for v in rrb.views
         if v["kind"] == "Spatial2DView" and v["origin"].startswith("heldout/camera/")
@@ -799,6 +1005,20 @@ def test_build_blueprint_without_env_ids_keeps_single_camera_view() -> None:
     assert not any(
         v["origin"].startswith("heldout/camera/") for v in rrb.views
     )
+
+
+def test_build_blueprint_with_synthetic_view() -> None:
+    rrb = _RecordingRRB()
+    viz_module._build_blueprint(
+        rrb,
+        heldout_env_ids=["env-00006"],
+        has_synthetic_data=True,
+    )
+    origins = [view["origin"] for view in rrb.views if view["kind"] == "Spatial2DView"]
+    assert "synthetic/preview" in origins
+    assert "synthetic/dataset/train" in origins
+    assert "synthetic/dataset/heldout" in origins
+    assert "synthetic/augmentation" in origins
 
 
 def test_log_heldout_cameras_time_aligns_envs() -> None:

--- a/scripts/sim2real_real_success_tmux.sh
+++ b/scripts/sim2real_real_success_tmux.sh
@@ -1,0 +1,755 @@
+#!/usr/bin/env bash
+# Detached Sim2Real live run launcher.
+# Owns a single run end-to-end: preflight, source tarball staging, K8s Job,
+# status polling, final success validation, and Rerun serve deployment.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="${ROOT}/npa/.venv/bin/python"
+if [ ! -x "${PY}" ]; then
+  echo "Missing repo venv python: ${PY}" >&2
+  exit 2
+fi
+
+RUN_ID="${RUN_ID:-sim2real-real-success-$(date -u +%Y%m%dt%H%M%Sz)}"
+RUN_ID="$(printf '%s' "${RUN_ID}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9.-' '-')"
+RUN_ID="${RUN_ID%-}"
+if [ "${#RUN_ID}" -gt 52 ]; then
+  RUN_ID="${RUN_ID:0:52}"
+  RUN_ID="${RUN_ID%-}"
+fi
+
+OUT_ROOT="${OUT_ROOT:-/tmp/sim2real-real-success}"
+OUT="${OUT_ROOT}/${RUN_ID}"
+mkdir -p "${OUT}"
+ln -sfn "${OUT}" "${OUT_ROOT}/latest"
+LOG="${OUT}/launcher.log"
+exec > >(tee -a "${LOG}") 2>&1
+
+echo "=== sim2real real success launcher ==="
+echo "run_id=${RUN_ID}"
+echo "worktree=${ROOT}"
+echo "log=${LOG}"
+date -u +"started_at=%Y-%m-%dT%H:%M:%SZ"
+
+export PYTHONPATH="${ROOT}/npa/src:${PYTHONPATH:-}"
+export RUN_ID
+
+for env_file in "${HOME}/.npa/sim2real-operator.env" "${HOME}/.npa/live-e2e.env"; do
+  if [ -f "${env_file}" ]; then
+    echo "sourcing ${env_file}"
+    set -a
+    # shellcheck disable=SC1090
+    source "${env_file}"
+    set +a
+  fi
+done
+# Some local env files can carry a short-lived NEBIUS_IAM_TOKEN. If it is
+# stale, the Nebius CLI refuses to mint a fresh registry token. Let the CLI use
+# its durable configured profile instead.
+unset NEBIUS_IAM_TOKEN
+
+CONFIG_JSON="${OUT}/launcher-config.json"
+"${PY}" - "${ROOT}" "${RUN_ID}" "${CONFIG_JSON}" <<'PY'
+import json
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+
+from npa.clients.credentials import load_credentials
+from npa.clients.storage import StorageClient
+from npa.deploy.images import supported_tool_version
+from npa.workflows.sim2real.monitor import load_operator_config, resolve_kubeconfig
+
+root = Path(os.sys.argv[1]).resolve()
+run_id = os.sys.argv[2]
+config_path = Path(os.sys.argv[3])
+operator = load_operator_config()
+creds = load_credentials()
+
+bucket = operator.bucket
+endpoint = operator.endpoint_url
+registry = operator.registry.rstrip("/")
+context = operator.k8s_context
+kubeconfig = str(resolve_kubeconfig(context))
+
+if not registry:
+    raise SystemExit("storage.registry is not set in ~/.npa/config.yaml")
+
+trigger_uri = (
+    os.environ.get("NPA_SIM2REAL_TRIGGER_DATASET_URI")
+    or os.environ.get("TRIGGER_DATASET_URI")
+    or f"s3://{bucket}/sim2real-triggers/trigger-validate-20260611T154016Z/lerobot-pusht/"
+)
+if trigger_uri and not trigger_uri.endswith("/"):
+    trigger_uri += "/"
+trigger_id = (
+    os.environ.get("NPA_SIM2REAL_TRIGGER_DATASET_ID")
+    or os.environ.get("TRIGGER_DATASET_ID")
+    or "lerobot/pusht"
+)
+
+tags = {
+    "trainer": supported_tool_version("lerobot-vlm-rl"),
+    "eval": supported_tool_version("loop-eval"),
+    "vlm": supported_tool_version("cosmos3-reason"),
+    "augment": supported_tool_version("cosmos2-transfer"),
+    "isaac": supported_tool_version("isaac-lab"),
+    "rerun": supported_tool_version("rerun-viewer"),
+}
+images = {
+    "TRAINER_IMAGE": os.environ.get("TRAINER_IMAGE")
+    or f"{registry}/npa-lerobot-vlm-rl:{tags['trainer']}",
+    "EVAL_IMAGE": os.environ.get("EVAL_IMAGE")
+    or f"{registry}/npa-loop-eval:{tags['eval']}",
+    "VLM_IMAGE": os.environ.get("VLM_IMAGE")
+    or f"{registry}/npa-cosmos3-reason:{tags['vlm']}",
+    "AUGMENT_IMAGE": os.environ.get("AUGMENT_IMAGE")
+    or f"{registry}/npa-cosmos2-transfer:{tags['augment']}",
+    "ISAAC_IMAGE": os.environ.get("ISAAC_IMAGE")
+    or f"{registry}/npa-isaac-lab:{tags['isaac']}",
+    "RERUN_IMAGE": os.environ.get("RERUN_IMAGE")
+    or os.environ.get("NPA_RERUN_VIEWER_IMAGE")
+    or f"{registry}/npa-rerun-viewer:{tags['rerun']}",
+}
+images["POLICY_IMAGE"] = os.environ.get("POLICY_IMAGE") or images["TRAINER_IMAGE"]
+images["ORCHESTRATOR_IMAGE"] = os.environ.get("ORCHESTRATOR_IMAGE") or images["TRAINER_IMAGE"]
+
+access_key = os.environ.get("AWS_ACCESS_KEY_ID") or creds.s3_access_key_id
+secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY") or creds.s3_secret_access_key
+if not access_key or not secret_key:
+    raise SystemExit("S3 credentials missing; configure ~/.npa/credentials.yaml or AWS_*")
+
+def tar_filter(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo | None:
+    name = tarinfo.name
+    if "__pycache__" in name or name.endswith(".pyc"):
+        return None
+    return tarinfo
+
+with tempfile.TemporaryDirectory(prefix="npa-orchestrator-src-") as tmp:
+    tarball = Path(tmp) / "npa-source.tgz"
+    with tarfile.open(tarball, "w:gz") as archive:
+        archive.add(root / "npa" / "src", arcname="npa/src", filter=tar_filter)
+        archive.add(root / "npa" / "pyproject.toml", arcname="npa/pyproject.toml", filter=tar_filter)
+    destination = f"s3://{bucket}/sim2real-b/{run_id}/source/orchestrator-{run_id}.tgz"
+    client = StorageClient(
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+    )
+    source_uri = client.upload_file(str(tarball), destination)
+
+payload = {
+    "BUCKET": bucket,
+    "ENDPOINT": endpoint,
+    "REGISTRY": registry,
+    "CTX": context,
+    "KUBECONFIG_PATH": kubeconfig,
+    "TRIGGER_URI": trigger_uri,
+    "TRIGGER_ID": trigger_id,
+    "SOURCE_TARBALL_URI": source_uri,
+    **images,
+}
+config_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(config_path)
+PY
+
+eval "$("${PY}" - "${CONFIG_JSON}" <<'PY'
+import json
+import shlex
+import sys
+data = json.loads(open(sys.argv[1], encoding="utf-8").read())
+for key, value in data.items():
+    print(f"{key}={shlex.quote(str(value))}")
+PY
+)"
+
+export AWS_ENDPOINT_URL="${ENDPOINT}"
+export S3_ENDPOINT_URL="${ENDPOINT}"
+export S3_BUCKET="${BUCKET}"
+export NPA_SIM2REAL_BUCKET="${BUCKET}"
+export KUBECONFIG="${KUBECONFIG_PATH}"
+export BUCKET ENDPOINT REGISTRY CTX KUBECONFIG_PATH SOURCE_TARBALL_URI
+export TRIGGER_URI TRIGGER_ID
+
+echo "operator_context=${CTX}"
+echo "kubeconfig=${KUBECONFIG_PATH}"
+echo "bucket=${BUCKET}"
+echo "endpoint=${ENDPOINT}"
+echo "source_tarball=${SOURCE_TARBALL_URI}"
+echo "trigger_uri=${TRIGGER_URI}"
+echo "images:"
+echo "  orchestrator=${ORCHESTRATOR_IMAGE}"
+echo "  trainer=${TRAINER_IMAGE}"
+echo "  policy=${POLICY_IMAGE}"
+echo "  eval=${EVAL_IMAGE}"
+echo "  isaac=${ISAAC_IMAGE}"
+echo "  vlm=${VLM_IMAGE}"
+echo "  augment=${AUGMENT_IMAGE}"
+echo "  rerun=${RERUN_IMAGE}"
+
+refresh_registry_pull_secrets() {
+  local operator_registry_lib="/home/ubuntu/npa-sim2real-demo-walkthrough/operator/sim2real-rtxpro/lib/registry-pull-secret.sh"
+  if [ -f "${operator_registry_lib}" ]; then
+    export NEBIUS_REGISTRY_PROFILE="${NEBIUS_REGISTRY_PROFILE:-agent-sa}"
+    # shellcheck disable=SC1090
+    source "${operator_registry_lib}"
+    registry_refresh_for_images "${CTX}" \
+      "${ORCHESTRATOR_IMAGE}" "${TRAINER_IMAGE}" "${POLICY_IMAGE}" "${EVAL_IMAGE}" \
+      "${ISAAC_IMAGE}" "${VLM_IMAGE}" "${AUGMENT_IMAGE}" "${RERUN_IMAGE}"
+    return
+  fi
+  "${PY}" - "${KUBECONFIG_PATH}" "${CTX}" \
+    "${ORCHESTRATOR_IMAGE}" "${TRAINER_IMAGE}" "${POLICY_IMAGE}" "${EVAL_IMAGE}" \
+    "${ISAAC_IMAGE}" "${VLM_IMAGE}" "${AUGMENT_IMAGE}" "${RERUN_IMAGE}" <<'PY'
+import sys
+from npa.workflows.sim2real.registry_auth import ensure_registry_pull_secret_for_images
+
+kubeconfig, context, *images = sys.argv[1:]
+ensure_registry_pull_secret_for_images(
+    *images,
+    namespace="default",
+    kubeconfig=kubeconfig,
+    k8s_context=context,
+)
+print("registry_pull_secret_refreshed=true")
+PY
+}
+
+echo "=== preflight: refresh registry pull secrets ==="
+refresh_registry_pull_secrets
+
+echo "=== preflight: sim2real health ==="
+"${PY}" -m npa.cli.main workbench health sim2real \
+  --run-id "${RUN_ID}" \
+  --s3-bucket "${BUCKET}" \
+  --s3-prefix sim2real-b \
+  --s3-endpoint "${ENDPOINT}" \
+  --trigger-dataset-uri "${TRIGGER_URI}" \
+  --trigger-dataset-id "${TRIGGER_ID}" \
+  --augment-image "${AUGMENT_IMAGE}" \
+  --policy-image "${POLICY_IMAGE}" \
+  --trainer-image "${TRAINER_IMAGE}" \
+  --vlm-image "${VLM_IMAGE}" \
+  --eval-image "${EVAL_IMAGE}" \
+  --threshold "${SUCCESS_THRESHOLD:-0.50}" \
+  --inner-iterations "${INNER_ITERATIONS:-1}" \
+  --outer-iterations "${OUTER_ITERATIONS:-2}" \
+  --rollout-count "${ROLLOUT_COUNT:-8}" \
+  --steps-per-rollout "${STEPS_PER_ROLLOUT:-6}" \
+  --heldout-env-count "${HELDOUT_ENV_COUNT:-4}" \
+  --k8s-context "${CTX}" \
+  --k8s-kubeconfig "${KUBECONFIG_PATH}" \
+  --checks all \
+  --warn-only \
+  --json | tee "${OUT}/health.json"
+
+echo "=== preflight: refresh registry pull secrets again before submit ==="
+refresh_registry_pull_secrets
+
+echo "=== preflight: cluster quick view ==="
+kubectl --context "${CTX}" -n default get nodes -o wide | tee "${OUT}/nodes.txt"
+kubectl --context "${CTX}" -n default get secret npa-storage-credentials hf-ngc-tokens npa-nebius-registry | tee "${OUT}/required-secrets.txt"
+
+BYO_TRAINER_COMMAND="${BYO_TRAINER_COMMAND:-NPA_BYO_ISAAC_ITERATIONS=1000 NPA_BYO_ISAAC_NUM_ENVS=1024 python3 -m npa.workflows.sim2real.byo_isaac_trainer}"
+BYO_POLICY_COMMAND="${BYO_POLICY_COMMAND:-python3 -m npa.workflows.sim2real.byo_isaac_policy_rollout}"
+BYO_EVAL_COMMAND="${BYO_EVAL_COMMAND:-python3 -m npa.workflows.sim2real.byo_isaac_eval}"
+
+BYO_TRAINER_COMMAND_B64="$(printf '%s' "${BYO_TRAINER_COMMAND}" | base64 -w0 2>/dev/null || printf '%s' "${BYO_TRAINER_COMMAND}" | base64)"
+BYO_POLICY_COMMAND_B64="$(printf '%s' "${BYO_POLICY_COMMAND}" | base64 -w0 2>/dev/null || printf '%s' "${BYO_POLICY_COMMAND}" | base64)"
+BYO_EVAL_COMMAND_B64="$(printf '%s' "${BYO_EVAL_COMMAND}" | base64 -w0 2>/dev/null || printf '%s' "${BYO_EVAL_COMMAND}" | base64)"
+
+JOB="sim2real-${RUN_ID}"
+MANIFEST="${OUT}/${JOB}.json"
+export JOB MANIFEST SOURCE_TARBALL_URI
+export TRAINER_IMAGE POLICY_IMAGE EVAL_IMAGE ISAAC_IMAGE VLM_IMAGE AUGMENT_IMAGE ORCHESTRATOR_IMAGE
+export TRIGGER_URI TRIGGER_ID BYO_TRAINER_COMMAND_B64 BYO_POLICY_COMMAND_B64 BYO_EVAL_COMMAND_B64
+
+"${PY}" - "${MANIFEST}" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+env = os.environ
+job = env["JOB"]
+
+container_script = r'''set -euo pipefail
+exec > >(tee -a /tmp/run.log) 2>&1
+echo "orchestrator_started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+python3 -c "import boto3" 2>/dev/null || python3 -m pip install --quiet boto3 botocore
+rm -rf /tmp/npa-source && mkdir -p /tmp/npa-source
+python3 - "${NPA_SIM2REAL_SOURCE_TARBALL_URI}" <<'PYB'
+import os
+import sys
+import tarfile
+import urllib.parse
+
+import boto3
+
+uri = urllib.parse.urlparse(sys.argv[1])
+endpoint = os.environ.get("AWS_ENDPOINT_URL") or os.environ.get("S3_ENDPOINT_URL") or None
+boto3.client("s3", endpoint_url=endpoint).download_file(
+    uri.netloc,
+    uri.path.lstrip("/"),
+    "/tmp/npa-source.tgz",
+)
+with tarfile.open("/tmp/npa-source.tgz") as tar:
+    tar.extractall("/tmp/npa-source")
+PYB
+export PYTHONPATH="/tmp/npa-source/npa/src:${PYTHONPATH:-}"
+python3 -c "import npa.workflows.sim2real as m; print('npa_source=' + m.__file__)"
+
+if [[ -n "${BYO_TRAINER_COMMAND_B64:-}" ]]; then
+  export BYO_TRAINER_COMMAND="$(printf '%s' "${BYO_TRAINER_COMMAND_B64}" | base64 -d)"
+fi
+if [[ -n "${BYO_POLICY_COMMAND_B64:-}" ]]; then
+  export BYO_POLICY_COMMAND="$(printf '%s' "${BYO_POLICY_COMMAND_B64}" | base64 -d)"
+fi
+if [[ -n "${BYO_EVAL_COMMAND_B64:-}" ]]; then
+  export BYO_EVAL_COMMAND="$(printf '%s' "${BYO_EVAL_COMMAND_B64}" | base64 -d)"
+fi
+
+if ! command -v kubectl >/dev/null; then
+  curl -fsSL -o /tmp/kubectl https://dl.k8s.io/release/v1.33.7/bin/linux/amd64/kubectl
+  chmod +x /tmp/kubectl
+fi
+export PATH="/tmp:/usr/local/bin:${PATH}"
+
+run_id="${NPA_SIM2REAL_RUN_ID}"
+output_dir="/tmp/npa-sim2real-${run_id}"
+mkdir -p "${output_dir}"
+
+common_args=(
+  --run-id "${run_id}"
+  --output-dir "${output_dir}"
+  --s3-bucket "${NPA_SIM2REAL_BUCKET}"
+  --s3-prefix "${NPA_SIM2REAL_PREFIX:-sim2real-b}"
+  --s3-endpoint "${AWS_ENDPOINT_URL}"
+  --trigger-dataset-uri "${NPA_SIM2REAL_TRIGGER_DATASET_URI}"
+  --trigger-dataset-id "${NPA_SIM2REAL_TRIGGER_DATASET_ID:-lerobot/pusht}"
+  --augment-image "${AUGMENT_IMAGE}"
+  --policy-image "${POLICY_IMAGE}"
+  --trainer-image "${TRAINER_IMAGE}"
+  --vlm-image "${VLM_IMAGE}"
+  --eval-image "${EVAL_IMAGE}"
+  --isaac-image "${ISAAC_IMAGE}"
+  --sim-backend "${NPA_SIM2REAL_SIM_BACKEND:-isaac}"
+  --isaac-task "${NPA_SIM2REAL_ISAAC_TASK:-Isaac-Lift-Cube-Franka-v0}"
+  --threshold "${SUCCESS_THRESHOLD:-0.50}"
+  --inner-iterations "${INNER_ITERATIONS:-1}"
+  --outer-iterations "${OUTER_ITERATIONS:-2}"
+  --rollout-count "${ROLLOUT_COUNT:-8}"
+  --steps-per-rollout "${STEPS_PER_ROLLOUT:-6}"
+  --heldout-env-count "${HELDOUT_ENV_COUNT:-4}"
+  --heldout-eval-limit "${NPA_SIM2REAL_HELDOUT_EVAL_LIMIT:-4}"
+  --env-count "${NPA_ENV_COUNT:-10000}"
+  --train-fraction "${NPA_TRAIN_FRACTION:-0.8}"
+  --envgen-shard-count "${NPA_ENVGEN_SHARD_COUNT:-16}"
+  --k8s-max-parallel-gpus "${NPA_SIM2REAL_K8S_MAX_PARALLEL_GPUS:-16}"
+  --k8s-namespace "${NPA_SIM2REAL_K8S_NAMESPACE:-default}"
+  --k8s-service-account "${NPA_SIM2REAL_K8S_SERVICE_ACCOUNT:-agent-sa}"
+  --k8s-image-pull-secrets "${NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS:-agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry}"
+  --k8s-env-secret-names "${NPA_SIM2REAL_K8S_ENV_SECRET_NAMES:-hf-ngc-tokens,npa-storage-credentials}"
+  --k8s-gpu-resource "${NPA_SIM2REAL_K8S_GPU_RESOURCE:-nvidia.com/gpu}"
+  --k8s-gpu-product "${NPA_SIM2REAL_K8S_GPU_PRODUCT:-NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition}"
+  --k8s-job-timeout-s "${NPA_SIM2REAL_K8S_JOB_TIMEOUT_S:-28800}"
+  --learning-rate "${LEARNING_RATE:-0.08}"
+  --byo-trainer-command "${BYO_TRAINER_COMMAND:-}"
+  --byo-policy-command "${BYO_POLICY_COMMAND:-}"
+  --byo-eval-command "${BYO_EVAL_COMMAND:-}"
+  --source-repo "local-source-tarball"
+  --source-ref "${NPA_SIM2REAL_RUN_ID}"
+  --vlm-reason2-model "${VLM_REASON2_MODEL:-nvidia/Cosmos-Reason2-8B}"
+  --vlm-reason3-model "${VLM_REASON3_MODEL:-nvidia/Cosmos-Reason2-2B}"
+  --vlm-dual-reason
+  --rerun
+  --upload-artifacts
+)
+
+python3 -m npa.workflows.sim2real run "${common_args[@]}" \
+  --initial-quality "${INITIAL_QUALITY:-0.42}"
+
+python3 - "${output_dir}/reports/sim2real-report.json" <<'PYC'
+import json
+import sys
+from pathlib import Path
+report = json.loads(Path(sys.argv[1]).read_text())
+decision = (report.get("outer_loop") or {}).get("latest_decision") or {}
+heldout = (report.get("outer_loop") or {}).get("latest_heldout_report") or {}
+print("CLUSTER_METRICS", json.dumps({
+    "run_id": report.get("run_id"),
+    "status": report.get("status"),
+    "decision": decision.get("decision"),
+    "success_rate": decision.get("success_rate", heldout.get("success_rate")),
+    "threshold": decision.get("threshold", heldout.get("threshold")),
+    "checkpoint_uri": decision.get("checkpoint_uri"),
+}, sort_keys=True))
+PYC
+'''
+
+def env_entry(name: str, value: str) -> dict[str, str]:
+    return {"name": name, "value": str(value)}
+
+run_env = [
+    env_entry("NPA_SIM2REAL_RUN_ID", env["RUN_ID"]),
+    env_entry("NPA_SIM2REAL_BUCKET", env["BUCKET"]),
+    env_entry("NPA_SIM2REAL_PREFIX", "sim2real-b"),
+    env_entry("AWS_ENDPOINT_URL", env["ENDPOINT"]),
+    env_entry("S3_ENDPOINT_URL", env["ENDPOINT"]),
+    env_entry("NPA_SIM2REAL_SOURCE_TARBALL_URI", env["SOURCE_TARBALL_URI"]),
+    env_entry("TRAINER_IMAGE", env["TRAINER_IMAGE"]),
+    env_entry("POLICY_IMAGE", env["POLICY_IMAGE"]),
+    env_entry("EVAL_IMAGE", env["EVAL_IMAGE"]),
+    env_entry("VLM_IMAGE", env["VLM_IMAGE"]),
+    env_entry("AUGMENT_IMAGE", env["AUGMENT_IMAGE"]),
+    env_entry("ISAAC_IMAGE", env["ISAAC_IMAGE"]),
+    env_entry("NPA_SIM2REAL_ISAAC_IMAGE", env["ISAAC_IMAGE"]),
+    env_entry("NPA_REGISTRY", env["REGISTRY"]),
+    env_entry("BYO_TRAINER_COMMAND_B64", env["BYO_TRAINER_COMMAND_B64"]),
+    env_entry("BYO_POLICY_COMMAND_B64", env["BYO_POLICY_COMMAND_B64"]),
+    env_entry("BYO_EVAL_COMMAND_B64", env["BYO_EVAL_COMMAND_B64"]),
+    env_entry("NPA_SIM2REAL_ISAAC_TASK", env.get("NPA_SIM2REAL_ISAAC_TASK", "Isaac-Lift-Cube-Franka-v0")),
+    env_entry("NPA_SIM2REAL_SIM_BACKEND", env.get("NPA_SIM2REAL_SIM_BACKEND", "isaac")),
+    env_entry("INNER_ITERATIONS", env.get("INNER_ITERATIONS", "1")),
+    env_entry("OUTER_ITERATIONS", env.get("OUTER_ITERATIONS", "2")),
+    env_entry("NPA_ENV_COUNT", env.get("NPA_ENV_COUNT", "10000")),
+    env_entry("NPA_TRAIN_FRACTION", env.get("NPA_TRAIN_FRACTION", "0.8")),
+    env_entry("NPA_ENVGEN_SHARD_COUNT", env.get("NPA_ENVGEN_SHARD_COUNT", "16")),
+    env_entry("NPA_SIM2REAL_K8S_MAX_PARALLEL_GPUS", env.get("NPA_SIM2REAL_K8S_MAX_PARALLEL_GPUS", "16")),
+    env_entry("ROLLOUT_COUNT", env.get("ROLLOUT_COUNT", "8")),
+    env_entry("STEPS_PER_ROLLOUT", env.get("STEPS_PER_ROLLOUT", "6")),
+    env_entry("HELDOUT_ENV_COUNT", env.get("HELDOUT_ENV_COUNT", "4")),
+    env_entry("NPA_SIM2REAL_HELDOUT_EVAL_LIMIT", env.get("NPA_SIM2REAL_HELDOUT_EVAL_LIMIT", "4")),
+    env_entry("LEARNING_RATE", env.get("LEARNING_RATE", "0.08")),
+    env_entry("INITIAL_QUALITY", env.get("INITIAL_QUALITY", "0.42")),
+    env_entry("SUCCESS_THRESHOLD", env.get("SUCCESS_THRESHOLD", "0.50")),
+    env_entry("VLM_REASON2_MODEL", env.get("VLM_REASON2_MODEL", "nvidia/Cosmos-Reason2-8B")),
+    env_entry("VLM_REASON3_MODEL", env.get("VLM_REASON3_MODEL", "nvidia/Cosmos-Reason2-2B")),
+    env_entry("NPA_SIM2REAL_VLM_DUAL_REASON", env.get("NPA_SIM2REAL_VLM_DUAL_REASON", "1")),
+    env_entry("NPA_SIM2REAL_RERUN", "1"),
+    env_entry("NPA_SIM2REAL_RERUN_SERVE", "0"),
+    env_entry("NPA_SIM2REAL_SKIP_REGISTRY_REFRESH", "1"),
+    env_entry("NPA_SIM2REAL_COMPONENT_DOWNLOAD_RETRIES", env.get("NPA_SIM2REAL_COMPONENT_DOWNLOAD_RETRIES", "24")),
+    env_entry("NPA_SIM2REAL_HELDOUT_UPLOAD_GRACE_S", env.get("NPA_SIM2REAL_HELDOUT_UPLOAD_GRACE_S", "20")),
+    env_entry("NPA_BYO_ISAAC_JOB_TIMEOUT_S", env.get("NPA_BYO_ISAAC_JOB_TIMEOUT_S", "7200")),
+    env_entry("NPA_BYO_ISAAC_SUCCESS_DIST_M", env.get("NPA_BYO_ISAAC_SUCCESS_DIST_M", "0.10")),
+    env_entry("NPA_SIM2REAL_K8S_NAMESPACE", "default"),
+    env_entry("NPA_SIM2REAL_K8S_SERVICE_ACCOUNT", "agent-sa"),
+    env_entry("NPA_SIM2REAL_K8S_IMAGE_PULL_SECRETS", "agent-sa,ngc-nvcr-imagepullsecret,npa-nebius-registry"),
+    env_entry("NPA_SIM2REAL_K8S_ENV_SECRET_NAMES", "hf-ngc-tokens,npa-storage-credentials"),
+    env_entry("NPA_SIM2REAL_K8S_GPU_RESOURCE", "nvidia.com/gpu"),
+    env_entry("NPA_SIM2REAL_K8S_GPU_PRODUCT", env.get("NPA_SIM2REAL_K8S_GPU_PRODUCT", "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition")),
+    env_entry("NPA_SIM2REAL_K8S_JOB_TIMEOUT_S", env.get("NPA_SIM2REAL_K8S_JOB_TIMEOUT_S", "28800")),
+    env_entry("NPA_SIM2REAL_TRIGGER_DATASET_URI", env["TRIGGER_URI"]),
+    env_entry("NPA_SIM2REAL_TRIGGER_DATASET_ID", env["TRIGGER_ID"]),
+    env_entry("ASSETS_URI", env.get("ASSETS_URI", "")),
+    env_entry("SCENE_SPEC_URI", env.get("SCENE_SPEC_URI", "")),
+    env_entry("NPA_SIM2REAL_ROBOT_PRESET", env.get("NPA_SIM2REAL_ROBOT_PRESET", env.get("ROBOT_PRESET", ""))),
+    env_entry("NPA_SIM2REAL_ROBOT_SOURCE", env.get("NPA_SIM2REAL_ROBOT_SOURCE", env.get("ROBOT_SOURCE", ""))),
+    env_entry("NPA_SIM2REAL_ROBOT_SPEC_URI", env.get("NPA_SIM2REAL_ROBOT_SPEC_URI", env.get("ROBOT_SPEC_URI", ""))),
+]
+
+manifest = {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+        "name": job,
+        "namespace": "default",
+        "labels": {"app": "sim2real-staged-loop", "run-id": env["RUN_ID"]},
+    },
+    "spec": {
+        "backoffLimit": 0,
+        "ttlSecondsAfterFinished": 86400,
+        "activeDeadlineSeconds": 28800,
+        "template": {
+            "metadata": {
+                "labels": {"app": "sim2real-staged-loop", "run-id": env["RUN_ID"]},
+            },
+            "spec": {
+                "restartPolicy": "Never",
+                "serviceAccountName": "agent-sa",
+                "imagePullSecrets": [
+                    {"name": "agent-sa"},
+                    {"name": "ngc-nvcr-imagepullsecret"},
+                    {"name": "npa-nebius-registry"},
+                ],
+                "containers": [
+                    {
+                        "name": "orchestrator",
+                        "image": env["ORCHESTRATOR_IMAGE"],
+                        "imagePullPolicy": "Always",
+                        "resources": {
+                            "limits": {"nvidia.com/gpu": "1"},
+                            "requests": {"nvidia.com/gpu": "1"},
+                        },
+                        "env": run_env,
+                        "envFrom": [
+                            {"secretRef": {"name": "hf-ngc-tokens"}},
+                            {"secretRef": {"name": "npa-storage-credentials"}},
+                        ],
+                        "command": ["/bin/bash", "-lc"],
+                        "args": [container_script],
+                    }
+                ],
+                "nodeSelector": {
+                    "nvidia.com/gpu.product": env.get(
+                        "NPA_SIM2REAL_K8S_GPU_PRODUCT",
+                        "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition",
+                    )
+                },
+            },
+        },
+    },
+}
+Path(sys.argv[1]).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(sys.argv[1])
+PY
+
+chmod 600 "${MANIFEST}"
+echo "=== apply orchestrator job ==="
+kubectl --context "${CTX}" -n default apply -f "${MANIFEST}" | tee "${OUT}/kubectl-apply.txt"
+echo "job=${JOB}"
+echo "manifest=${MANIFEST}"
+echo "run_prefix=s3://${BUCKET}/sim2real-b/${RUN_ID}/"
+
+(
+  while true; do
+    sleep "${REGISTRY_REFRESH_INTERVAL_SECONDS:-2700}"
+    echo "periodic_registry_refresh started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    refresh_registry_pull_secrets || echo "periodic_registry_refresh_failed=true"
+  done
+) &
+REGISTRY_REFRESH_PID="$!"
+echo "${REGISTRY_REFRESH_PID}" > "${OUT}/registry-refresh.pid"
+cleanup_refresh_loop() {
+  kill "${REGISTRY_REFRESH_PID}" >/dev/null 2>&1 || true
+}
+trap cleanup_refresh_loop EXIT
+
+POD=""
+for _ in $(seq 1 90); do
+  POD="$(kubectl --context "${CTX}" -n default get pods -l "job-name=${JOB}" --sort-by=.metadata.creationTimestamp -o name 2>/dev/null | tail -1 | sed 's#^pod/##')"
+  if [ -n "${POD}" ]; then
+    break
+  fi
+  sleep 2
+done
+if [ -n "${POD}" ]; then
+  echo "orchestrator_pod=${POD}"
+  (kubectl --context "${CTX}" -n default logs -f "${POD}" > "${OUT}/orchestrator.log" 2>&1 & echo $! > "${OUT}/orchestrator-logs.pid") || true
+else
+  echo "orchestrator_pod=pending"
+fi
+
+echo "=== monitor job ==="
+DEADLINE_SECONDS="${DEADLINE_SECONDS:-28800}"
+start_epoch="$(date +%s)"
+while true; do
+  now="$(date +%s)"
+  elapsed=$((now - start_epoch))
+  succeeded="$(kubectl --context "${CTX}" -n default get job "${JOB}" -o jsonpath='{.status.succeeded}' 2>/dev/null || true)"
+  failed="$(kubectl --context "${CTX}" -n default get job "${JOB}" -o jsonpath='{.status.failed}' 2>/dev/null || true)"
+  active="$(kubectl --context "${CTX}" -n default get job "${JOB}" -o jsonpath='{.status.active}' 2>/dev/null || true)"
+  echo "job_status elapsed=${elapsed}s active=${active:-0} succeeded=${succeeded:-0} failed=${failed:-0}"
+  "${PY}" -m npa.cli.main workbench sim2real status \
+    --run-id "${RUN_ID}" \
+    --s3-bucket "${BUCKET}" \
+    --s3-prefix sim2real-b \
+    --s3-endpoint "${ENDPOINT}" \
+    --k8s-context "${CTX}" \
+    --k8s-namespace default \
+    --json > "${OUT}/status-current.json" 2>"${OUT}/status-current.err" || true
+  if [ "${succeeded:-0}" != "0" ]; then
+    echo "job_complete=true"
+    break
+  fi
+  if [ "${failed:-0}" != "0" ]; then
+    echo "job_failed=true"
+    kubectl --context "${CTX}" -n default describe job "${JOB}" > "${OUT}/job-describe.txt" 2>&1 || true
+    kubectl --context "${CTX}" -n default logs "job/${JOB}" --tail=300 > "${OUT}/job-failed-tail.log" 2>&1 || true
+    exit 1
+  fi
+  if [ "${elapsed}" -gt "${DEADLINE_SECONDS}" ]; then
+    echo "job_timeout=true"
+    kubectl --context "${CTX}" -n default describe job "${JOB}" > "${OUT}/job-timeout-describe.txt" 2>&1 || true
+    kubectl --context "${CTX}" -n default logs "job/${JOB}" --tail=300 > "${OUT}/job-timeout-tail.log" 2>&1 || true
+    exit 1
+  fi
+  sleep "${MONITOR_INTERVAL_SECONDS:-60}"
+done
+
+echo "=== download and validate final report ==="
+FINAL_REPORT="${OUT}/sim2real-report.json"
+"${PY}" - "${RUN_ID}" "${BUCKET}" "${ENDPOINT}" "${FINAL_REPORT}" <<'PY'
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from npa.clients.credentials import load_credentials
+from npa.clients.storage import StorageClient
+
+run_id, bucket, endpoint, dest = sys.argv[1:]
+creds = load_credentials()
+client = StorageClient(
+    endpoint_url=endpoint,
+    aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID") or creds.s3_access_key_id,
+    aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY") or creds.s3_secret_access_key,
+)
+uri = f"s3://{bucket}/sim2real-b/{run_id}/reports/sim2real-report.json"
+last_error = ""
+for _ in range(90):
+    try:
+        client.download_path(uri, dest)
+        break
+    except Exception as exc:
+        last_error = repr(exc)
+        time.sleep(10)
+else:
+    raise SystemExit(f"could not download final report {uri}: {last_error}")
+
+report = json.loads(Path(dest).read_text(encoding="utf-8"))
+outer = report.get("outer_loop") or {}
+decision = outer.get("latest_decision") or {}
+heldout = outer.get("latest_heldout_report") or {}
+success_rate = decision.get("success_rate", heldout.get("success_rate"))
+threshold = decision.get("threshold", heldout.get("threshold", 0.5))
+payload = {
+    "run_id": report.get("run_id"),
+    "status": report.get("status"),
+    "decision": decision.get("decision"),
+    "success_rate": success_rate,
+    "threshold": threshold,
+    "checkpoint_uri": decision.get("checkpoint_uri") or heldout.get("policy_checkpoint"),
+    "heldout_envs": heldout.get("generated_envs_tested"),
+    "report_uri": uri,
+}
+Path(str(dest) + ".summary.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print("FINAL_RESULT", json.dumps(payload, sort_keys=True))
+if report.get("status") != "completed":
+    raise SystemExit(f"report status is not completed: {report.get('status')!r}")
+if decision.get("decision") != "promote_checkpoint":
+    raise SystemExit(f"latest decision is not promote_checkpoint: {decision!r}")
+if success_rate is None or float(success_rate) < float(threshold):
+    raise SystemExit(f"success_rate {success_rate!r} is below threshold {threshold!r}")
+if not payload["checkpoint_uri"]:
+    raise SystemExit("missing promoted checkpoint URI")
+PY
+
+echo "=== download and validate final visual artifacts ==="
+mkdir -p "${OUT}/reports"
+FINAL_RRD="${OUT}/reports/sim2real.rrd"
+FINAL_VISUAL_INDEX="${OUT}/reports/sim2real-visual-index.json"
+"${PY}" - "${RUN_ID}" "${BUCKET}" "${ENDPOINT}" "${FINAL_RRD}" "${FINAL_VISUAL_INDEX}" <<'PY'
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from npa.clients.credentials import load_credentials
+from npa.clients.storage import StorageClient
+
+run_id, bucket, endpoint, rrd_dest, index_dest = sys.argv[1:]
+creds = load_credentials()
+client = StorageClient(
+    endpoint_url=endpoint,
+    aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID") or creds.s3_access_key_id,
+    aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY") or creds.s3_secret_access_key,
+)
+
+
+def _download_with_retry(uri: str, dest: str) -> None:
+    last_error = ""
+    for _ in range(90):
+        try:
+            client.download_path(uri, dest)
+            if Path(dest).is_file() and Path(dest).stat().st_size > 0:
+                return
+        except Exception as exc:
+            last_error = repr(exc)
+        time.sleep(10)
+    raise SystemExit(f"could not download non-empty artifact {uri}: {last_error}")
+
+
+rrd_uri = f"s3://{bucket}/sim2real-b/{run_id}/reports/sim2real.rrd"
+index_uri = f"s3://{bucket}/sim2real-b/{run_id}/reports/sim2real-visual-index.json"
+_download_with_retry(rrd_uri, rrd_dest)
+_download_with_retry(index_uri, index_dest)
+
+rrd_path = Path(rrd_dest)
+rrd_bytes = rrd_path.read_bytes()
+if rrd_path.stat().st_size < 1_000_000:
+    raise SystemExit(f"final RRD is unexpectedly small: {rrd_path.stat().st_size} bytes")
+required_rrd_tokens = [
+    b"synthetic",
+    b"heldout/camera",
+    b"summary",
+    b"signal",
+]
+missing_tokens = [token.decode("utf-8") for token in required_rrd_tokens if token not in rrd_bytes]
+if missing_tokens:
+    raise SystemExit(f"final RRD is missing broad visual tokens: {missing_tokens}")
+
+index = json.loads(Path(index_dest).read_text(encoding="utf-8"))
+success = index.get("success") or {}
+synthetic = index.get("synthetic") or {}
+dataset = index.get("dataset") or {}
+augmentation = index.get("augmentation") or {}
+success_rate = success.get("success_rate")
+threshold = success.get("threshold", 0.5)
+if success.get("decision") != "promote_checkpoint":
+    raise SystemExit(f"visual index decision is not promote_checkpoint: {success!r}")
+if success_rate is None or float(success_rate) < float(threshold):
+    raise SystemExit(f"visual index success_rate {success_rate!r} below threshold {threshold!r}")
+if int(synthetic.get("dataset_sample_count") or 0) <= 0:
+    raise SystemExit(f"visual index has no synthetic dataset samples: {synthetic!r}")
+if int(synthetic.get("augmentation_sample_count") or 0) <= 0:
+    raise SystemExit(f"visual index has no augmentation samples: {synthetic!r}")
+if int(dataset.get("train_count") or 0) <= 0 or int(dataset.get("heldout_count") or 0) <= 0:
+    raise SystemExit(f"visual index has an invalid train/heldout split: {dataset!r}")
+
+payload = {
+    "run_id": run_id,
+    "rrd_uri": rrd_uri,
+    "rrd_size_bytes": Path(rrd_dest).stat().st_size,
+    "visual_index_uri": index_uri,
+    "success_rate": success_rate,
+    "threshold": threshold,
+    "decision": success.get("decision"),
+    "train_envs": dataset.get("train_count"),
+    "heldout_envs": dataset.get("heldout_count"),
+    "augmentation_frames": augmentation.get("frame_count"),
+    "synthetic_dataset_samples": synthetic.get("dataset_sample_count"),
+    "synthetic_dataset_camera_pngs": synthetic.get("dataset_camera_image_count"),
+    "synthetic_dataset_descriptor_previews": synthetic.get("dataset_descriptor_preview_count"),
+    "synthetic_augmentation_samples": synthetic.get("augmentation_sample_count"),
+    "synthetic_augmentation_pngs": synthetic.get("augmentation_image_count"),
+    "synthetic_augmentation_descriptor_previews": synthetic.get("augmentation_descriptor_preview_count"),
+}
+Path(str(index_dest) + ".summary.json").write_text(
+    json.dumps(payload, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+print("FINAL_VISUALS", json.dumps(payload, sort_keys=True))
+PY
+
+echo "=== serve Rerun ==="
+"${PY}" -m npa.cli.main workbench sim2real rerun serve \
+  --run-id "${RUN_ID}" \
+  --kubeconfig "${KUBECONFIG_PATH}" \
+  --namespace default \
+  --s3-bucket "${BUCKET}" \
+  --s3-prefix sim2real-b \
+  --s3-endpoint "${ENDPOINT}" \
+  --rerun-image "${RERUN_IMAGE}" \
+  --local-record \
+  --local-rrd-path "${OUT}/reports/sim2real-served.rrd" \
+  --output json | tee "${OUT}/rerun-serve.json"
+
+date -u +"finished_at=%Y-%m-%dT%H:%M:%SZ"
+echo "DONE run_id=${RUN_ID} out=${OUT}"

--- a/scripts/sim2real_regen_real_visual_tmux.sh
+++ b/scripts/sim2real_regen_real_visual_tmux.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_ID="${RUN_ID:-s2r-real-0725t222636z}"
+S3_BUCKET="${S3_BUCKET:-}"
+S3_PREFIX="${S3_PREFIX:-sim2real-b}"
+S3_ENDPOINT="${S3_ENDPOINT:-https://storage.us-central1.nebius.cloud}"
+LOCAL_DIR="${LOCAL_DIR:-/tmp/sim2real-regen/${RUN_ID}-real-visual}"
+LOG_DIR="${LOG_DIR:-/tmp/sim2real-visual-audit/${RUN_ID}}"
+AGENT_URL="${AGENT_URL:-}"
+AGENT_USER="${AGENT_USER:-npa}"
+AGENT_PASSWORD="${AGENT_PASSWORD:-}"
+
+mkdir -p "$LOG_DIR"
+
+if [[ -f "$HOME/.npa/sim2real-operator.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$HOME/.npa/sim2real-operator.env"
+  set +a
+fi
+
+export PYTHONPATH="$PWD/npa/src${PYTHONPATH:+:$PYTHONPATH}"
+
+if [[ -z "$S3_BUCKET" ]]; then
+  S3_BUCKET="$(
+    npa/.venv/bin/python - <<'PY'
+from npa.workflows.sim2real.monitor import load_operator_config
+
+print(load_operator_config().bucket)
+PY
+  )"
+fi
+if [[ -z "$S3_BUCKET" ]]; then
+  echo "S3_BUCKET is required or must be configured in ~/.npa/config.yaml" >&2
+  exit 2
+fi
+
+echo "started_at=$(date -Iseconds)"
+echo "run_id=$RUN_ID"
+echo "local_dir=$LOCAL_DIR"
+echo "log_dir=$LOG_DIR"
+
+echo "== targeted tests =="
+npa/.venv/bin/python -m pytest \
+  npa/tests/workflows/test_sim2real_viz.py \
+  npa/tests/workflows/test_sim2real_stages.py \
+  npa/tests/workflows/test_sim2real_rerun_regen.py \
+  npa/tests/workflows/test_sim2real_rerun_serve.py \
+  -q
+
+echo "== regenerate and upload =="
+npa/.venv/bin/npa workbench sim2real rerun regen \
+  --run-id "$RUN_ID" \
+  --s3-bucket "$S3_BUCKET" \
+  --s3-prefix "$S3_PREFIX" \
+  --s3-endpoint "$S3_ENDPOINT" \
+  --local-dir "$LOCAL_DIR" \
+  --upload \
+  --output json | tee "$LOG_DIR/regen-real-visual.json"
+
+RRD_URI="$(
+  npa/.venv/bin/python - "$LOG_DIR/regen-real-visual.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload.get("upload_uri") or "")
+PY
+)"
+
+if [[ -z "$RRD_URI" ]]; then
+  echo "ERROR: regen did not return upload_uri" >&2
+  exit 1
+fi
+
+echo "rrd_uri=$RRD_URI"
+echo "== inspect regenerated evidence =="
+npa/.venv/bin/python - "$LOG_DIR/regen-real-visual.json" "$LOCAL_DIR" <<'PY' | tee "$LOG_DIR/regen-real-visual-summary.txt"
+import json
+import sys
+from pathlib import Path
+
+regen = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+local_dir = Path(sys.argv[2])
+report = json.loads((local_dir / "eval/heldout/report.json").read_text(encoding="utf-8"))
+evidence_paths = sorted((local_dir / "inner_loop").glob("outer-*/evidence.json"))
+latest = evidence_paths[-1] if evidence_paths else None
+evidence = json.loads(latest.read_text(encoding="utf-8")) if latest else {}
+print("local_rrd_path", regen.get("local_rrd_path"))
+print("heldout_frame_count", regen.get("heldout_frame_count"))
+print("synthetic_frame_count", regen.get("synthetic_frame_count"))
+print("rollout_count", regen.get("rollout_count"))
+print("frame_count", regen.get("frame_count"))
+print("rrd_size_bytes", Path(regen["local_rrd_path"]).stat().st_size)
+print("success_rate", report.get("success_rate"))
+print("render_episodes", len((report.get("render_manifest") or {}).get("episodes") or []))
+print("latest_inner_evidence", latest)
+visual_index_path = local_dir / "reports/sim2real-visual-index.json"
+print("visual_index_path", visual_index_path)
+if visual_index_path.is_file():
+    visual_index = json.loads(visual_index_path.read_text(encoding="utf-8"))
+    print("visual_success_decision", (visual_index.get("success") or {}).get("decision"))
+    print("visual_augmentation_frames", (visual_index.get("augmentation") or {}).get("frame_count"))
+    print("visual_train_envs", (visual_index.get("dataset") or {}).get("train_count"))
+    print("visual_heldout_envs", (visual_index.get("dataset") or {}).get("heldout_count"))
+    synthetic = visual_index.get("synthetic") or {}
+    print("visual_synthetic_dataset_samples", synthetic.get("dataset_sample_count"))
+    print("visual_synthetic_dataset_camera_pngs", synthetic.get("dataset_camera_image_count"))
+    print("visual_synthetic_dataset_descriptor_previews", synthetic.get("dataset_descriptor_preview_count"))
+    print("visual_synthetic_augmentation_samples", synthetic.get("augmentation_sample_count"))
+    print("visual_synthetic_augmentation_pngs", synthetic.get("augmentation_image_count"))
+    print("visual_synthetic_augmentation_descriptor_previews", synthetic.get("augmentation_descriptor_preview_count"))
+for record in (evidence.get("iterations") or [])[:3]:
+    print("iteration", record.get("iteration"))
+    print("actions_dir", record.get("actions_dir"))
+    sample = record.get("sample_vlm_eval") or {}
+    print("vlm_model", sample.get("model"))
+    print("vlm_score", sample.get("score"))
+    print("trainer_status", (record.get("update") or {}).get("status"))
+PY
+
+RRD_LOCAL="$(
+  npa/.venv/bin/python - "$LOG_DIR/regen-real-visual.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(payload["local_rrd_path"])
+PY
+)"
+for needle in \
+  "synthetic" \
+  "heldout/camera" \
+  "summary" \
+  "signal"; do
+  if ! grep -a -q "$needle" "$RRD_LOCAL"; then
+    echo "ERROR: regenerated RRD missing broad visual token $needle" >&2
+    exit 1
+  fi
+done
+
+npa/.venv/bin/python - "$LOCAL_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+local_dir = Path(sys.argv[1])
+index = json.loads((local_dir / "reports/sim2real-visual-index.json").read_text(encoding="utf-8"))
+success = index.get("success") or {}
+synthetic = index.get("synthetic") or {}
+dataset = index.get("dataset") or {}
+success_rate = success.get("success_rate")
+threshold = success.get("threshold", 0.5)
+if success.get("decision") != "promote_checkpoint":
+    raise SystemExit(f"visual index decision is not promote_checkpoint: {success!r}")
+if success_rate is None or float(success_rate) < float(threshold):
+    raise SystemExit(f"visual index success_rate {success_rate!r} below threshold {threshold!r}")
+if int(dataset.get("train_count") or 0) <= 0 or int(dataset.get("heldout_count") or 0) <= 0:
+    raise SystemExit(f"visual index has invalid train/heldout split: {dataset!r}")
+if int(synthetic.get("dataset_sample_count") or 0) <= 0:
+    raise SystemExit(f"visual index has no synthetic dataset samples: {synthetic!r}")
+if int(synthetic.get("augmentation_sample_count") or 0) <= 0:
+    raise SystemExit(f"visual index has no synthetic augmentation samples: {synthetic!r}")
+PY
+
+if [[ -n "$AGENT_URL" && -n "$AGENT_PASSWORD" ]]; then
+  echo "== reload agent viewer =="
+  curl -fsS \
+    -u "${AGENT_USER}:${AGENT_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    "${AGENT_URL%/}/api/sim-viz/load-run" \
+    -d "{\"run_id\":\"${RUN_ID}\",\"rrd_uri\":\"${RRD_URI}\",\"camera\":\"heldout-sim\"}" \
+    | tee "$LOG_DIR/agent-load-run.json"
+  echo
+  curl -fsS \
+    -u "${AGENT_USER}:${AGENT_PASSWORD}" \
+    "${AGENT_URL%/}/api/sim-viz/status?run_id=${RUN_ID}" \
+    | tee "$LOG_DIR/agent-status.json"
+  echo
+else
+  echo "agent_reload=skipped"
+fi
+
+echo "completed_at=$(date -Iseconds)"

--- a/scripts/sim2real_visual_wait_and_serve.sh
+++ b/scripts/sim2real_visual_wait_and_serve.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Wait for a Sim2Real run to produce reports/sim2real.rrd, then deploy a Rerun
+# viewer and keep a local .rrd copy for direct inspection.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="${ROOT}/npa/.venv/bin/python"
+export PYTHONPATH="${ROOT}/npa/src:${PYTHONPATH:-}"
+
+RUN_ID="${1:-${RUN_ID:-}}"
+if [ -z "${RUN_ID}" ]; then
+  RUN_ID="$(basename "$(readlink -f /tmp/sim2real-real-success/latest)")"
+fi
+if [ -z "${RUN_ID}" ]; then
+  echo "RUN_ID is required" >&2
+  exit 2
+fi
+
+OUT_ROOT="${OUT_ROOT:-/tmp/sim2real-real-success}"
+OUT="${OUT_ROOT}/${RUN_ID}"
+mkdir -p "${OUT}/reports"
+LOG="${OUT}/visual-serve.log"
+exec > >(tee -a "${LOG}") 2>&1
+
+echo "=== sim2real visual wait-and-serve ==="
+echo "run_id=${RUN_ID}"
+echo "log=${LOG}"
+date -u +"started_at=%Y-%m-%dT%H:%M:%SZ"
+
+for env_file in "${HOME}/.npa/sim2real-operator.env" "${HOME}/.npa/live-e2e.env"; do
+  if [ -f "${env_file}" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${env_file}"
+    set +a
+  fi
+done
+unset NEBIUS_IAM_TOKEN
+
+CONFIG_JSON="${OUT}/visual-config.json"
+"${PY}" - "${CONFIG_JSON}" <<'PY'
+import json
+import os
+from pathlib import Path
+
+from npa.deploy.images import supported_tool_version
+from npa.workflows.sim2real.monitor import load_operator_config, resolve_kubeconfig
+
+operator = load_operator_config()
+registry = operator.registry.rstrip("/")
+payload = {
+    "BUCKET": operator.bucket,
+    "ENDPOINT": operator.endpoint_url,
+    "CTX": operator.k8s_context,
+    "KUBECONFIG_PATH": str(resolve_kubeconfig(operator.k8s_context)),
+    "RERUN_IMAGE": os.environ.get("RERUN_IMAGE")
+    or os.environ.get("NPA_RERUN_VIEWER_IMAGE")
+    or f"{registry}/npa-rerun-viewer:{supported_tool_version('rerun-viewer')}",
+}
+Path(os.sys.argv[1]).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+eval "$("${PY}" - "${CONFIG_JSON}" <<'PY'
+import json
+import shlex
+import sys
+data = json.loads(open(sys.argv[1], encoding="utf-8").read())
+for key, value in data.items():
+    print(f"{key}={shlex.quote(str(value))}")
+PY
+)"
+export AWS_ENDPOINT_URL="${ENDPOINT}"
+export S3_ENDPOINT_URL="${ENDPOINT}"
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+RRD_URI="s3://${BUCKET}/sim2real-b/${RUN_ID}/reports/sim2real.rrd"
+LOCAL_RRD="${OUT}/reports/sim2real.rrd"
+echo "rrd_uri=${RRD_URI}"
+echo "local_rrd=${LOCAL_RRD}"
+
+deadline_seconds="${VISUAL_DEADLINE_SECONDS:-28800}"
+start_epoch="$(date +%s)"
+while true; do
+  now="$(date +%s)"
+  elapsed=$((now - start_epoch))
+  echo "visual_wait elapsed=${elapsed}s"
+  if "${PY}" -m npa.cli.main workbench sim2real rerun serve \
+      --run-id "${RUN_ID}" \
+      --kubeconfig "${KUBECONFIG_PATH}" \
+      --namespace default \
+      --s3-bucket "${BUCKET}" \
+      --s3-prefix sim2real-b \
+      --s3-endpoint "${ENDPOINT}" \
+      --rrd-uri "${RRD_URI}" \
+      --rerun-image "${RERUN_IMAGE}" \
+      --local-record \
+      --local-rrd-path "${LOCAL_RRD}" \
+      --output json > "${OUT}/visual-rerun-serve.json" 2>"${OUT}/visual-rerun-serve.err"; then
+    cat "${OUT}/visual-rerun-serve.json"
+    date -u +"finished_at=%Y-%m-%dT%H:%M:%SZ"
+    echo "VISUAL_READY run_id=${RUN_ID} local_rrd=${LOCAL_RRD}"
+    exit 0
+  fi
+  tail -20 "${OUT}/visual-rerun-serve.err" || true
+  if [ "${elapsed}" -gt "${deadline_seconds}" ]; then
+    echo "visual_timeout=true"
+    exit 1
+  fi
+  sleep "${VISUAL_POLL_SECONDS:-60}"
+done


### PR DESCRIPTION
## Summary
- add success, augmentation, artifact, and VLM summary documents to Sim2Real Rerun recordings
- visualize synthetic train/held-out descriptors and augmentation samples alongside held-out Isaac camera renders
- harden Rerun regeneration/serve paths and Isaac BYO sibling jobs for live E2E runs
- add tmux launch/audit scripts with final report, RRD, and visual-index gates

## Validation
- PYTHONPATH=$PWD/npa/src npa/.venv/bin/python -m pytest npa/tests/workflows/test_sim2real_viz.py npa/tests/workflows/test_sim2real_rerun_regen.py npa/tests/workflows/test_sim2real_rerun_serve.py -q
- PYTHONPATH=$PWD/npa/src npa/.venv/bin/ruff check <touched Python files>
- bash -n scripts/sim2real_real_success_tmux.sh scripts/sim2real_regen_real_visual_tmux.sh scripts/sim2real_visual_wait_and_serve.sh

## Live E2E
- Fresh tmux run will be started from the isolated worktree and monitored before marking ready for review.