### PR TITLE
fix(agent): run picker date reflects when the run started

### DIFF
--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -64,7 +64,7 @@ DEFAULT_LLM_MODELS = (
     DEFAULT_LLM_MODEL,
     "Qwen/Qwen2.5-VL-72B-Instruct",
 )
-AGENT_UI_VERSION = "2026072901"
+AGENT_UI_VERSION = "2026072902"
 DEFAULT_HTTPS_PORT = 443
 AGENT_SOURCE_ROOT = "/opt/npa-agent/npa-src"
 _AGENT_TERRAFORM_RUNTIME_ONLY_VARS = frozenset({"s3_prefix"})
@@ -6647,6 +6647,10 @@ def sim_viz_status(run_id: str = ""):
                 or item.get("submitted_at")
                 or ""
             ).strip(),
+            # When the run started (its submit time). Used for the displayed date;
+            # S3 discovery supplies started_at for runs it can see, and the client
+            # keeps the earliest of the two.
+            "started_at": str(item.get("submitted_at") or "").strip(),
             "last_modified": "",
             "stage": str(item.get("stage") or "").strip(),
         }}
@@ -6723,6 +6727,8 @@ def _sim_viz_load_response(state: dict, sim_viz: dict, *, run_id: str) -> dict:
                 or item.get("submitted_at")
                 or ""
             ).strip(),
+            # Run start (submit time) for the displayed date; see sim_viz_status.
+            "started_at": str(item.get("submitted_at") or "").strip(),
             "last_modified": "",
             "stage": str(item.get("stage") or "").strip(),
         }}

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -64,7 +64,7 @@ DEFAULT_LLM_MODELS = (
     DEFAULT_LLM_MODEL,
     "Qwen/Qwen2.5-VL-72B-Instruct",
 )
-AGENT_UI_VERSION = "2026072402"
+AGENT_UI_VERSION = "2026072901"
 DEFAULT_HTTPS_PORT = 443
 AGENT_SOURCE_ROOT = "/opt/npa-agent/npa-src"
 _AGENT_TERRAFORM_RUNTIME_ONLY_VARS = frozenset({"s3_prefix"})
@@ -6635,12 +6635,19 @@ def sim_viz_status(run_id: str = ""):
     payload["available_runs"] = [
         {{
             "run_id": str(item.get("run_id") or "").strip(),
-            "last_modified": str(
+            # activity_at is when this run was last loaded/visualized in the agent
+            # (rrd_updated_at), NOT when its artifacts were produced. It is exposed
+            # separately so the client never relabels a days-old run as recent just
+            # because it was opened today. Real recency (last_modified) is supplied
+            # by S3 artifact discovery; left blank here so viewer activity cannot
+            # override it in the merged, date-sorted run list.
+            "activity_at": str(
                 item.get("rrd_updated_at")
                 or item.get("updated_at")
                 or item.get("submitted_at")
                 or ""
             ).strip(),
+            "last_modified": "",
             "stage": str(item.get("stage") or "").strip(),
         }}
         for item in _sim_viz_runs(state)
@@ -6708,12 +6715,15 @@ def _sim_viz_load_response(state: dict, sim_viz: dict, *, run_id: str) -> dict:
     payload["available_runs"] = [
         {{
             "run_id": str(item.get("run_id") or "").strip(),
-            "last_modified": str(
+            # See sim_viz_status: activity_at is viewer-load time, not artifact
+            # recency; last_modified stays blank so S3 discovery owns the date.
+            "activity_at": str(
                 item.get("rrd_updated_at")
                 or item.get("updated_at")
                 or item.get("submitted_at")
                 or ""
             ).strip(),
+            "last_modified": "",
             "stage": str(item.get("stage") or "").strip(),
         }}
         for item in _sim_viz_runs(state)

--- a/npa/src/npa/cli/agent_ui.html
+++ b/npa/src/npa/cli/agent_ui.html
@@ -4818,13 +4818,12 @@
         // Allow loading a pasted id that is not yet in the cached list.
         return query;
       }
-      // Effective run timestamp for display + sort: prefer real artifact recency
-      // (last_modified from S3 discovery); fall back to viewer activity ONLY when
-      // a run has no artifact timestamp (e.g. seen in the viewer but not yet in
-      // S3 discovery). This keeps a days-old run that was merely opened today from
-      // being relabeled/sorted as if it were produced today.
+      // Effective run timestamp for display + sort: when the run STARTED
+      // (started_at). Falls back to artifact recency (last_modified), then viewer
+      // activity, only when no start time is known. This keeps the picker date on
+      // the run's start — not the newest artifact write or when it was last opened.
       function effectiveRunTs(run) {
-        return String((run && (run.last_modified || run.activity_at)) || "");
+        return String((run && (run.started_at || run.last_modified || run.activity_at)) || "");
       }
       function mergeRunsLatestFirst(knownRuns, discoveredRuns) {
         const map = new Map();
@@ -4833,12 +4832,17 @@
           if (!runId) return;
           const prev = map.get(runId) || {
             run_id: runId,
+            started_at: "",
             last_modified: "",
             activity_at: "",
             has_viewable: false,
             artifact_count: 0,
             source: source,
           };
+          // Run start: keep the EARLIEST across sources (submit time / earliest
+          // artifact write). This is the displayed date.
+          const startTs = String((run && (run.started_at || run.submitted_at)) || "");
+          if (startTs && (!prev.started_at || startTs < prev.started_at)) prev.started_at = startTs;
           // Artifact recency: when the run's objects were last written in S3.
           const artifactTs = String((run && run.last_modified) || "");
           if (artifactTs && artifactTs > String(prev.last_modified || "")) prev.last_modified = artifactTs;
@@ -5699,6 +5703,7 @@
         if (Array.isArray(simViz && simViz.available_runs) && simViz.available_runs.length) {
           knownAvailableRuns = simViz.available_runs.map((item) => ({
             run_id: String((item && item.run_id) || "").trim(),
+            started_at: String((item && (item.started_at || item.submitted_at)) || "").trim(),
             last_modified: String((item && item.last_modified) || "").trim(),
             activity_at: String((item && (item.activity_at || item.rrd_updated_at)) || "").trim(),
             stage: String((item && item.stage) || "").trim(),

--- a/npa/src/npa/cli/agent_ui.html
+++ b/npa/src/npa/cli/agent_ui.html
@@ -4818,6 +4818,14 @@
         // Allow loading a pasted id that is not yet in the cached list.
         return query;
       }
+      // Effective run timestamp for display + sort: prefer real artifact recency
+      // (last_modified from S3 discovery); fall back to viewer activity ONLY when
+      // a run has no artifact timestamp (e.g. seen in the viewer but not yet in
+      // S3 discovery). This keeps a days-old run that was merely opened today from
+      // being relabeled/sorted as if it were produced today.
+      function effectiveRunTs(run) {
+        return String((run && (run.last_modified || run.activity_at)) || "");
+      }
       function mergeRunsLatestFirst(knownRuns, discoveredRuns) {
         const map = new Map();
         const ingest = (run, source) => {
@@ -4826,12 +4834,18 @@
           const prev = map.get(runId) || {
             run_id: runId,
             last_modified: "",
+            activity_at: "",
             has_viewable: false,
             artifact_count: 0,
             source: source,
           };
-          const ts = String((run && (run.last_modified || run.rrd_updated_at || run.updated_at || run.submitted_at)) || "");
-          if (ts && ts > String(prev.last_modified || "")) prev.last_modified = ts;
+          // Artifact recency: when the run's objects were last written in S3.
+          const artifactTs = String((run && run.last_modified) || "");
+          if (artifactTs && artifactTs > String(prev.last_modified || "")) prev.last_modified = artifactTs;
+          // Viewer activity: when the run was last loaded/visualized in the agent.
+          // Tracked separately so it never inflates the run's displayed date.
+          const activityTs = String((run && (run.activity_at || run.rrd_updated_at || run.updated_at || run.submitted_at)) || "");
+          if (activityTs && activityTs > String(prev.activity_at || "")) prev.activity_at = activityTs;
           if (run && run.has_viewable) prev.has_viewable = true;
           if (run && run.artifact_count) prev.artifact_count = Number(run.artifact_count) || prev.artifact_count;
           if (run && run.stage) prev.stage = String(run.stage || "");
@@ -4841,7 +4855,7 @@
         for (const run of Array.isArray(knownRuns) ? knownRuns : []) ingest(run, "known");
         for (const run of Array.isArray(discoveredRuns) ? discoveredRuns : []) ingest(run, "discovered");
         return [...map.values()].sort((a, b) => {
-          const cmp = String(b.last_modified || "").localeCompare(String(a.last_modified || ""));
+          const cmp = effectiveRunTs(b).localeCompare(effectiveRunTs(a));
           if (cmp !== 0) return cmp;
           return String(b.run_id || "").localeCompare(String(a.run_id || ""));
         });
@@ -4861,7 +4875,8 @@
           const bits = [runId];
           if (run && run.has_viewable) bits.push("viewable");
           if (run && run.artifact_count) bits.push(String(run.artifact_count) + " artifacts");
-          if (run && run.last_modified) bits.push(String(run.last_modified).slice(0, 19));
+          const shownTs = effectiveRunTs(run);
+          if (shownTs) bits.push(shownTs.slice(0, 19));
           opt.textContent = bits.length > 1 ? (runId + " · " + bits.slice(1).join(" · ")) : runId;
           if (runId === current || (!current && runId === previous)) opt.selected = true;
           select.appendChild(opt);
@@ -5685,6 +5700,7 @@
           knownAvailableRuns = simViz.available_runs.map((item) => ({
             run_id: String((item && item.run_id) || "").trim(),
             last_modified: String((item && item.last_modified) || "").trim(),
+            activity_at: String((item && (item.activity_at || item.rrd_updated_at)) || "").trim(),
             stage: String((item && item.stage) || "").trim(),
           })).filter((item) => item.run_id);
         } else {

--- a/npa/src/npa/workflows/artifacts.py
+++ b/npa/src/npa/workflows/artifacts.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, replace as dataclass_replace
 from datetime import datetime, timezone
 import mimetypes
 from pathlib import Path
+import re
 import threading
 import time
 from typing import Any, Callable
@@ -101,11 +102,15 @@ class RunSummary:
     artifact_count: int
     has_viewable: bool
     bucket: str = ""
+    # When the run STARTED (its id-encoded submit time, or the earliest artifact
+    # write as a fallback) — distinct from last_modified (newest artifact write).
+    started_at: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "run_id": self.run_id,
             "last_modified": self.last_modified,
+            "started_at": self.started_at,
             "artifact_count": self.artifact_count,
             "has_viewable": self.has_viewable,
             "bucket": self.bucket,
@@ -262,13 +267,16 @@ def list_runs(
                 render = render_hint_for_object(key=key)
                 current = summary.setdefault(
                     run_id,
-                    {"artifact_count": 0, "last_modified": "", "has_viewable": False},
+                    {"artifact_count": 0, "last_modified": "", "earliest": "", "has_viewable": False},
                 )
                 current["artifact_count"] = int(current["artifact_count"]) + 1
                 current["has_viewable"] = bool(current["has_viewable"] or render != "download")
                 ts = _to_iso8601(item.get("LastModified"))
-                if ts and ts > str(current["last_modified"]):
-                    current["last_modified"] = ts
+                if ts:
+                    if ts > str(current["last_modified"]):
+                        current["last_modified"] = ts
+                    if not current["earliest"] or ts < str(current["earliest"]):
+                        current["earliest"] = ts
     except (ClientError, BotoCoreError) as exc:
         raise ArtifactDiscoveryError(f"failed to list runs from s3://{bucket}/{normalized_prefix}: {exc}") from exc
 
@@ -276,6 +284,7 @@ def list_runs(
         RunSummary(
             run_id=run_id,
             last_modified=str(payload["last_modified"]),
+            started_at=_run_started_at(run_id, str(payload.get("earliest") or "")),
             artifact_count=int(payload["artifact_count"]),
             has_viewable=bool(payload["has_viewable"]),
         )
@@ -862,6 +871,65 @@ def _run_id_for_key(key: str, normalized_prefix: str) -> str:
         return ""
     first_segment = remainder.split("/", 1)[0].strip()
     return first_segment
+
+
+# Run ids commonly embed the run's start time, e.g. ``s2r-real-0725t222636z``
+# (MMDD + t + HHMMSS + z, year omitted) or ``...20260725T222636Z`` (full date).
+# Match a date (8-digit YYYYMMDD or 4-digit MMDD) + 6-digit HHMMSS, with an
+# optional ``t``/``-``/``_`` separator, not glued to surrounding digits.
+_RUN_ID_TS_RE = re.compile(r"(?<![0-9])(\d{8}|\d{4})[tT_-]?(\d{6})(?![0-9])")
+
+
+def _parse_run_id_timestamp(run_id: str, *, year_hint: "int | None" = None) -> str:
+    """Best-effort extract the start time encoded in a run id.
+
+    Returns an ISO-8601 UTC string, or ``""`` when nothing plausible is found.
+    For the year-less ``MMDD`` form the year comes from ``year_hint`` (typically
+    the earliest artifact's year) or the current UTC year.
+    """
+    for match in _RUN_ID_TS_RE.finditer(str(run_id or "")):
+        date_part, time_part = match.group(1), match.group(2)
+        try:
+            if len(date_part) == 8:
+                year, month, day = int(date_part[0:4]), int(date_part[4:6]), int(date_part[6:8])
+            else:
+                year = int(year_hint or datetime.now(timezone.utc).year)
+                month, day = int(date_part[0:2]), int(date_part[2:4])
+            dt = datetime(
+                year, month, day,
+                int(time_part[0:2]), int(time_part[2:4]), int(time_part[4:6]),
+                tzinfo=timezone.utc,
+            )
+        except ValueError:
+            continue
+        return dt.isoformat()
+    return ""
+
+
+def _run_started_at(run_id: str, earliest_iso: str) -> str:
+    """Resolve when a run started: the id-encoded submit time when trustworthy,
+    else the earliest artifact write.
+
+    A run's start precedes its first artifact write, so the id-encoded time is
+    accepted only when it is at/just-before the earliest object (within a few
+    days). This guards against unrelated digit runs in an id parsing to a bogus
+    far-off date, while still yielding an exact start for delayed-upload runs.
+    """
+    earliest = str(earliest_iso or "")
+    year_hint = int(earliest[0:4]) if earliest[0:4].isdigit() else None
+    parsed = _parse_run_id_timestamp(run_id, year_hint=year_hint)
+    if not parsed:
+        return earliest
+    if not earliest:
+        return parsed
+    if parsed <= earliest:
+        try:
+            gap = datetime.fromisoformat(earliest) - datetime.fromisoformat(parsed)
+        except ValueError:
+            return parsed
+        if gap.total_seconds() <= 3 * 24 * 3600:
+            return parsed
+    return earliest
 
 
 def _to_iso8601(value: Any) -> str:

--- a/npa/src/npa/workflows/artifacts.py
+++ b/npa/src/npa/workflows/artifacts.py
@@ -880,56 +880,70 @@ def _run_id_for_key(key: str, normalized_prefix: str) -> str:
 _RUN_ID_TS_RE = re.compile(r"(?<![0-9])(\d{8}|\d{4})[tT_-]?(\d{6})(?![0-9])")
 
 
-def _parse_run_id_timestamp(run_id: str, *, year_hint: "int | None" = None) -> str:
-    """Best-effort extract the start time encoded in a run id.
+def _parse_run_id_timestamps(run_id: str, *, year_hint: int | None = None) -> list[str]:
+    """Best-effort extract every start time encoded in a run id.
 
-    Returns an ISO-8601 UTC string, or ``""`` when nothing plausible is found.
+    Returns ISO-8601 UTC strings (possibly several — a run id may contain more
+    than one timestamp-like token; :func:`_run_started_at` picks the right one).
     For the year-less ``MMDD`` form the year comes from ``year_hint`` (typically
-    the earliest artifact's year) or the current UTC year.
+    the earliest artifact's year) or the current UTC year; the prior year is also
+    offered so a run that started late in December with its first artifact in
+    January (or a hint one year off) still resolves.
     """
+    out: list[str] = []
     for match in _RUN_ID_TS_RE.finditer(str(run_id or "")):
         date_part, time_part = match.group(1), match.group(2)
         try:
+            hour, minute, second = int(time_part[0:2]), int(time_part[2:4]), int(time_part[4:6])
             if len(date_part) == 8:
-                year, month, day = int(date_part[0:4]), int(date_part[4:6]), int(date_part[6:8])
+                candidate_years = [int(date_part[0:4])]
+                month, day = int(date_part[4:6]), int(date_part[6:8])
             else:
-                year = int(year_hint or datetime.now(timezone.utc).year)
+                base_year = int(year_hint or datetime.now(timezone.utc).year)
+                candidate_years = [base_year, base_year - 1]
                 month, day = int(date_part[0:2]), int(date_part[2:4])
-            dt = datetime(
-                year, month, day,
-                int(time_part[0:2]), int(time_part[2:4]), int(time_part[4:6]),
-                tzinfo=timezone.utc,
-            )
         except ValueError:
             continue
-        return dt.isoformat()
-    return ""
+        for year in candidate_years:
+            try:
+                dt = datetime(year, month, day, hour, minute, second, tzinfo=timezone.utc)
+            except ValueError:
+                continue
+            out.append(dt.isoformat())
+    return out
 
 
 def _run_started_at(run_id: str, earliest_iso: str) -> str:
     """Resolve when a run started: the id-encoded submit time when trustworthy,
     else the earliest artifact write.
 
-    A run's start precedes its first artifact write, so the id-encoded time is
+    A run's start precedes its first artifact write, so an id-encoded time is
     accepted only when it is at/just-before the earliest object (within a few
-    days). This guards against unrelated digit runs in an id parsing to a bogus
-    far-off date, while still yielding an exact start for delayed-upload runs.
+    days). Among several id-encoded candidates, the latest one satisfying that
+    constraint is chosen — this ignores red-herring timestamps elsewhere in the
+    id and unrelated digit runs that would parse to a bogus far-off date, while
+    still yielding an exact start for delayed-upload runs.
     """
     earliest = str(earliest_iso or "")
     year_hint = int(earliest[0:4]) if earliest[0:4].isdigit() else None
-    parsed = _parse_run_id_timestamp(run_id, year_hint=year_hint)
-    if not parsed:
+    candidates = _parse_run_id_timestamps(run_id, year_hint=year_hint)
+    if not candidates:
         return earliest
     if not earliest:
-        return parsed
-    if parsed <= earliest:
+        # No artifact time to corroborate against; use the first-encoded time.
+        return candidates[0]
+    window_seconds = 3 * 24 * 3600
+    best = ""
+    for candidate in candidates:
+        if candidate > earliest:
+            continue
         try:
-            gap = datetime.fromisoformat(earliest) - datetime.fromisoformat(parsed)
+            gap = (datetime.fromisoformat(earliest) - datetime.fromisoformat(candidate)).total_seconds()
         except ValueError:
-            return parsed
-        if gap.total_seconds() <= 3 * 24 * 3600:
-            return parsed
-    return earliest
+            gap = 0.0
+        if gap <= window_seconds and candidate > best:
+            best = candidate
+    return best or earliest
 
 
 def _to_iso8601(value: Any) -> str:

--- a/npa/tests/cli/test_agent_runs_consolidated.py
+++ b/npa/tests/cli/test_agent_runs_consolidated.py
@@ -44,3 +44,43 @@ def test_available_run_ids_use_latest_first_helper() -> None:
     load_fn = source.split("def _sim_viz_load_response")[1].split("@app.post")[0]
     assert "_sim_viz_runs(state)" in load_fn
     assert "sorted(str(key) for key in runs.keys()" not in load_fn
+
+
+def test_available_runs_expose_viewer_activity_not_as_recency() -> None:
+    """Regression: opening a days-old run in the viewer must not relabel it as recent.
+
+    The run picker sorts/labels by artifact recency (S3 ``last_modified``). The
+    per-run viewer-load time (``rrd_updated_at``) is exposed as ``activity_at`` and
+    must NOT be surfaced as ``last_modified`` — otherwise ``mergeRunsLatestFirst``
+    (client) would take the max and float a run that was merely opened today to the
+    top, labeled with today's date even though it ran days ago.
+    """
+    source = AGENT_MODULE.read_text(encoding="utf-8")
+    for anchor, terminator in (
+        ('@app.get("/sim-viz/status")', '@app.get("/sim-viz/runs")'),
+        ("def _sim_viz_load_response", "@app.post"),
+    ):
+        block = source.split(anchor)[1].split(terminator)[0]
+        available = block.split('payload["available_runs"] = [')[1].split("]")[0]
+        # Viewer-load time is exposed under activity_at, and last_modified is blank
+        # so S3 discovery owns the displayed recency.
+        assert '"activity_at": str(' in available, anchor
+        assert '"last_modified": ""' in available, anchor
+        # The old bug: rrd_updated_at collapsed into last_modified.
+        assert '"last_modified": str(' not in available, anchor
+
+
+def test_client_merge_separates_artifact_recency_from_viewer_activity() -> None:
+    """The merged run list must date/sort by artifact recency, not viewer activity."""
+    source = AGENT_MODULE.read_text(encoding="utf-8")
+    ui = _embedded_ui_html(source)
+    assert "function effectiveRunTs(" in ui
+    # Effective timestamp prefers artifact recency, then viewer activity.
+    assert "run.last_modified || run.activity_at" in ui
+    merge_fn = ui.split("function mergeRunsLatestFirst")[1].split("function fillRunSelectOptionsRich")[0]
+    # Activity is tracked on its own field and never raises last_modified.
+    assert "prev.activity_at" in merge_fn
+    assert "prev.last_modified = artifactTs" in merge_fn
+    assert "effectiveRunTs(b).localeCompare(effectiveRunTs(a))" in merge_fn
+    # Known/available runs carry activity_at through to the merge.
+    assert "activity_at: String((item && (item.activity_at || item.rrd_updated_at))" in ui

--- a/npa/tests/cli/test_agent_runs_consolidated.py
+++ b/npa/tests/cli/test_agent_runs_consolidated.py
@@ -49,11 +49,11 @@ def test_available_run_ids_use_latest_first_helper() -> None:
 def test_available_runs_expose_viewer_activity_not_as_recency() -> None:
     """Regression: opening a days-old run in the viewer must not relabel it as recent.
 
-    The run picker sorts/labels by artifact recency (S3 ``last_modified``). The
-    per-run viewer-load time (``rrd_updated_at``) is exposed as ``activity_at`` and
-    must NOT be surfaced as ``last_modified`` — otherwise ``mergeRunsLatestFirst``
+    The per-run viewer-load time (``rrd_updated_at``) is exposed as ``activity_at``
+    and must NOT be surfaced as ``last_modified`` — otherwise ``mergeRunsLatestFirst``
     (client) would take the max and float a run that was merely opened today to the
-    top, labeled with today's date even though it ran days ago.
+    top, labeled with today's date even though it ran days ago. The run's start
+    time is exposed separately as ``started_at``.
     """
     source = AGENT_MODULE.read_text(encoding="utf-8")
     for anchor, terminator in (
@@ -62,25 +62,29 @@ def test_available_runs_expose_viewer_activity_not_as_recency() -> None:
     ):
         block = source.split(anchor)[1].split(terminator)[0]
         available = block.split('payload["available_runs"] = [')[1].split("]")[0]
-        # Viewer-load time is exposed under activity_at, and last_modified is blank
-        # so S3 discovery owns the displayed recency.
+        # Viewer-load time is exposed under activity_at, start under started_at,
+        # and last_modified is blank so S3 discovery owns the displayed recency.
         assert '"activity_at": str(' in available, anchor
+        assert '"started_at": str(item.get("submitted_at")' in available, anchor
         assert '"last_modified": ""' in available, anchor
         # The old bug: rrd_updated_at collapsed into last_modified.
         assert '"last_modified": str(' not in available, anchor
 
 
-def test_client_merge_separates_artifact_recency_from_viewer_activity() -> None:
-    """The merged run list must date/sort by artifact recency, not viewer activity."""
+def test_client_merge_dates_runs_by_start_not_recency_or_activity() -> None:
+    """The merged run list must date/sort by run start, then recency, then activity."""
     source = AGENT_MODULE.read_text(encoding="utf-8")
     ui = _embedded_ui_html(source)
     assert "function effectiveRunTs(" in ui
-    # Effective timestamp prefers artifact recency, then viewer activity.
-    assert "run.last_modified || run.activity_at" in ui
+    # Effective timestamp prefers run start, then artifact recency, then activity.
+    assert "run.started_at || run.last_modified || run.activity_at" in ui
     merge_fn = ui.split("function mergeRunsLatestFirst")[1].split("function fillRunSelectOptionsRich")[0]
-    # Activity is tracked on its own field and never raises last_modified.
+    # Start is kept as the earliest across sources; activity/recency stay separate.
+    assert "prev.started_at" in merge_fn
+    assert "startTs < prev.started_at" in merge_fn
     assert "prev.activity_at" in merge_fn
     assert "prev.last_modified = artifactTs" in merge_fn
     assert "effectiveRunTs(b).localeCompare(effectiveRunTs(a))" in merge_fn
-    # Known/available runs carry activity_at through to the merge.
+    # Known/available runs carry started_at + activity_at through to the merge.
+    assert "started_at: String((item && (item.started_at || item.submitted_at))" in ui
     assert "activity_at: String((item && (item.activity_at || item.rrd_updated_at))" in ui

--- a/npa/tests/workflows/test_workflow_artifacts.py
+++ b/npa/tests/workflows/test_workflow_artifacts.py
@@ -376,19 +376,46 @@ def test_list_runs_started_at_falls_back_to_earliest_write() -> None:
     assert run.started_at == "2026-05-10T08:00:00+00:00"
 
 
-def test_parse_run_id_timestamp_handles_full_and_yearless_forms() -> None:
-    from npa.workflows.artifacts import _parse_run_id_timestamp, _run_started_at
+def test_parse_run_id_timestamps_handles_full_and_yearless_forms() -> None:
+    from npa.workflows.artifacts import _parse_run_id_timestamps, _run_started_at
 
-    assert _parse_run_id_timestamp("job-20260725T222636Z") == "2026-07-25T22:26:36+00:00"
-    assert _parse_run_id_timestamp("s2r-real-0725t222636z", year_hint=2026) == "2026-07-25T22:26:36+00:00"
+    assert _parse_run_id_timestamps("job-20260725T222636Z") == ["2026-07-25T22:26:36+00:00"]
+    # Year-less: the hinted year plus the prior year are offered as candidates.
+    assert _parse_run_id_timestamps("s2r-real-0725t222636z", year_hint=2026) == [
+        "2026-07-25T22:26:36+00:00",
+        "2025-07-25T22:26:36+00:00",
+    ]
     # No embedded timestamp -> nothing parsed, fall back to the earliest write.
-    assert _parse_run_id_timestamp("free-form-run-name") == ""
+    assert _parse_run_id_timestamps("free-form-run-name") == []
     assert _run_started_at("free-form-run-name", "2026-05-10T08:00:00+00:00") == "2026-05-10T08:00:00+00:00"
+
+
+def test_run_started_at_distrusts_far_off_id_date() -> None:
+    from npa.workflows.artifacts import _run_started_at
+
     # A far-off id date (not just-before the first write) is distrusted.
     assert (
         _run_started_at("legacy-v20200101t000000-run", "2026-05-10T08:00:00+00:00")
         == "2026-05-10T08:00:00+00:00"
     )
+
+
+def test_run_started_at_picks_real_start_past_a_red_herring_timestamp() -> None:
+    from npa.workflows.artifacts import _run_started_at
+
+    # A leading red-herring timestamp (2020) plus the real year-less start; the
+    # latest candidate at/just-before the first write (2026-07-25) is chosen.
+    started = _run_started_at("legacy-v20200101t000000-s2r-0725t222636z", "2026-07-25T22:26:39+00:00")
+    assert started == "2026-07-25T22:26:36+00:00"
+
+
+def test_run_started_at_handles_year_boundary() -> None:
+    from npa.workflows.artifacts import _run_started_at
+
+    # Started 2025-12-31 23:59:00; first artifact 2026-01-01. The prior-year
+    # candidate is selected so the start isn't after the first write.
+    started = _run_started_at("run-1231t235900z", "2026-01-01T00:00:05+00:00")
+    assert started == "2025-12-31T23:59:00+00:00"
 
 
 class _PrefixAwareS3:

--- a/npa/tests/workflows/test_workflow_artifacts.py
+++ b/npa/tests/workflows/test_workflow_artifacts.py
@@ -337,6 +337,60 @@ def test_list_runs_requires_positive_limit() -> None:
         list_runs("bucket", limit=0, s3=_FakeS3([]))
 
 
+def test_list_runs_started_at_uses_run_start_not_newest_write() -> None:
+    """started_at reflects when the run started; last_modified the newest write."""
+    s3 = _FakeS3(
+        [
+            {
+                "Contents": [
+                    # Run started 2026-07-25 22:26:36Z (encoded in the id); first
+                    # artifact a few seconds later, newest artifact two days on.
+                    _obj("sim2real-b/s2r-real-0725t222636z/env/data.json", ts="2026-07-25T22:26:39+00:00"),
+                    _obj("sim2real-b/s2r-real-0725t222636z/reports/sim2real.rrd", ts="2026-07-27T02:17:31+00:00"),
+                ]
+            }
+        ]
+    )
+    page = list_runs("bucket", prefix="sim2real-b", limit=50, s3=s3)
+    run = next(r for r in page.runs if r.run_id == "s2r-real-0725t222636z")
+    # Newest write is July 27; the displayed start is July 25 (id-encoded time).
+    assert run.last_modified == "2026-07-27T02:17:31+00:00"
+    assert run.started_at == "2026-07-25T22:26:36+00:00"
+    assert run.to_dict()["started_at"] == "2026-07-25T22:26:36+00:00"
+
+
+def test_list_runs_started_at_falls_back_to_earliest_write() -> None:
+    """Runs whose id has no embedded timestamp start at the earliest artifact."""
+    s3 = _FakeS3(
+        [
+            {
+                "Contents": [
+                    _obj("cat/plain-run/a.json", ts="2026-05-10T08:00:00+00:00"),
+                    _obj("cat/plain-run/b.json", ts="2026-05-12T09:00:00+00:00"),
+                ]
+            }
+        ]
+    )
+    page = list_runs("bucket", prefix="cat", limit=50, s3=s3)
+    run = next(r for r in page.runs if r.run_id == "plain-run")
+    assert run.started_at == "2026-05-10T08:00:00+00:00"
+
+
+def test_parse_run_id_timestamp_handles_full_and_yearless_forms() -> None:
+    from npa.workflows.artifacts import _parse_run_id_timestamp, _run_started_at
+
+    assert _parse_run_id_timestamp("job-20260725T222636Z") == "2026-07-25T22:26:36+00:00"
+    assert _parse_run_id_timestamp("s2r-real-0725t222636z", year_hint=2026) == "2026-07-25T22:26:36+00:00"
+    # No embedded timestamp -> nothing parsed, fall back to the earliest write.
+    assert _parse_run_id_timestamp("free-form-run-name") == ""
+    assert _run_started_at("free-form-run-name", "2026-05-10T08:00:00+00:00") == "2026-05-10T08:00:00+00:00"
+    # A far-off id date (not just-before the first write) is distrusted.
+    assert (
+        _run_started_at("legacy-v20200101t000000-run", "2026-05-10T08:00:00+00:00")
+        == "2026-05-10T08:00:00+00:00"
+    )
+
+
 class _PrefixAwareS3:
     """Fake S3 that honors Prefix + Delimiter over an in-memory key store."""
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the NPA agent run picker showing run `s2r-real-0725t222636z` (started July 25) "as from today". Root-caused and fixed in two parts.

**Part 1 — the "today" bug (viewer activity leaked into the date):** The picker labeled/sorted each run by the **max** of its S3 artifact `last_modified` and a *viewer-activity* timestamp. The server put `rrd_updated_at` — stamped `now()` every time a run is loaded/visualized (`stage=artifact-loaded`) — into `available_runs[].last_modified`, and the client's `mergeRunsLatestFirst` took the max. So simply **opening a days-old run today relabeled it "today"** and floated it to the top. Verified on live data (read-only, over SSH): the persisted agent state had `sim_viz_runs["s2r-real-0725t222636z"].rrd_updated_at = 2026-07-29T…` (today), while the run's real artifacts span July 25 → July 27.

**Part 2 — the date now reflects when the run STARTED (requested):** Instead of the newest artifact write, the picker now dates and sorts runs by their start time.
- `artifacts.list_runs` computes a new `started_at` per run: the run-id-encoded submit time (e.g. `s2r-real-0725t222636z` → `2026-07-25T22:26:36Z`, handling both full `YYYYMMDD` and year-less `MMDD` forms) when it is at/just-before the earliest artifact write, otherwise the earliest write itself. This guards against unrelated digit runs in an id parsing to a bogus far-off date, while giving an exact start even for delayed-upload runs. `RunSummary` gains a `started_at` field carried through every discovery path.
- Server `available_runs` expose `started_at` (submit time) for viewer-only runs; `activity_at` (viewer-load time) stays separate and `last_modified` blank so S3 discovery owns recency.
- Client `effectiveRunTs` prefers `started_at` (then `last_modified`, then `activity_at`); `mergeRunsLatestFirst` keeps the earliest start across sources. Viewer activity can never inflate the displayed date.

For `s2r-real-0725t222636z` the picker now shows **2026-07-25 22:26:36** (its start) instead of July 27 (last artifact) or July 29 (last opened).

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks.
  - `tests/workflows/test_workflow_artifacts.py` (new `started_at` + run-id-timestamp parsing tests), `tests/cli/test_agent_runs_consolidated.py` (updated contract tests), `test_agent_stages_run_picker.py`, `test_agent.py`, `test_agent_chat.py`, `test_agent_backend_render.py` (confirms the generated `backend.py` still compiles), `tests/guardrails/test_hygiene_guards.py` (agent.py stays under the monolith ratchet) — all green.
- [x] For workflow/tool changes: N/A — behavior fix within the existing agent tool; no skill smoke changes needed.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Skill Maintenance

- [x] This PR fixes a UI/labeling bug and does not change behavior that needs skill guidance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf1316a2-f85d-43ca-bfbf-93c99c75f531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf1316a2-f85d-43ca-bfbf-93c99c75f531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

