### PR TITLE
fix(deploy): point BACKUP_CONTAINER_REGISTRY at the live us-central1 mirror

### DIFF
--- a/npa/src/npa/deploy/images.py
+++ b/npa/src/npa/deploy/images.py
@@ -16,8 +16,11 @@ from typing import Any
 DEFAULT_CONTAINER_REGISTRY_ID = "e00cm0vc6t09m0z5gw"
 DEFAULT_CONTAINER_REGISTRY = f"cr.eu-north1.nebius.cloud/{DEFAULT_CONTAINER_REGISTRY_ID}"
 # Backup registry (us-central1) used for failover when the primary is
-# unavailable. Override with NPA_BACKUP_REGISTRY.
-BACKUP_CONTAINER_REGISTRY = "cr.us-central1.nebius.cloud/registry-u00gwj4vqcp98k7ph6"
+# unavailable. Override with NPA_BACKUP_REGISTRY. The Docker path uses the bare
+# registry id (no "registry-" prefix); the previous value pointed at a
+# non-existent registry id and included the API-only "registry-" prefix, so
+# failover pulls to us-central1 always 404'd.
+BACKUP_CONTAINER_REGISTRY = "cr.us-central1.nebius.cloud/u00j7q4jjkahvsx0jy"
 DEFAULT_VLM_IMAGE_ENV = "NPA_VLM_IMAGE"
 DEFAULT_WORKBENCH_IMAGE_ENV = "NPA_WORKBENCH_IMAGE"
 SONIC_IMAGE_MANIFEST_RESOURCE = "sonic_image_manifest.json"

--- a/npa/tests/test_deploy_images.py
+++ b/npa/tests/test_deploy_images.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from npa.deploy.images import (
+    BACKUP_CONTAINER_REGISTRY,
     DEFAULT_CONTAINER_REGISTRY,
     SUPPORTED_TOOL_VERSIONS,
+    backup_container_registry,
+    container_image_candidates,
     container_image_for_tool,
     default_vlm_image,
     default_workbench_image,
@@ -52,6 +55,32 @@ def test_primary_container_registry_defaults_when_unset(monkeypatch) -> None:
 
 def test_default_registry_is_real_first_party_registry() -> None:
     assert DEFAULT_CONTAINER_REGISTRY == "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw"
+
+
+def test_backup_registry_is_real_us_central1_registry() -> None:
+    # The backup path must be the live us-central1 mirror, addressed by its bare
+    # registry id. A "registry-" prefix is the API resource id, not a valid
+    # Docker repository path, so it must never appear here.
+    assert BACKUP_CONTAINER_REGISTRY == "cr.us-central1.nebius.cloud/u00j7q4jjkahvsx0jy"
+    assert "/registry-" not in BACKUP_CONTAINER_REGISTRY
+
+
+def test_backup_registry_honors_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("NPA_BACKUP_REGISTRY", "registry.example/backup")
+    assert backup_container_registry() == "registry.example/backup"
+    monkeypatch.delenv("NPA_BACKUP_REGISTRY", raising=False)
+    assert backup_container_registry() == BACKUP_CONTAINER_REGISTRY
+
+
+def test_container_image_candidates_include_primary_then_backup(monkeypatch) -> None:
+    monkeypatch.delenv("NPA_REGISTRY", raising=False)
+    monkeypatch.delenv("NPA_REGISTRY_ID", raising=False)
+    monkeypatch.delenv("NPA_BACKUP_REGISTRY", raising=False)
+    candidates = container_image_candidates("lancedb")
+    assert candidates == [
+        "cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw/npa-lancedb:0.30.3",
+        "cr.us-central1.nebius.cloud/u00j7q4jjkahvsx0jy/npa-lancedb:0.30.3",
+    ]
 
 
 def test_non_sonic_workbench_images_resolve_from_supported_tools() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`BACKUP_CONTAINER_REGISTRY` in `npa/src/npa/deploy/images.py` pointed at a **non-existent** us-central1 registry id and used the API-only `registry-` prefix, which is not a valid Docker repository path:

```
cr.us-central1.nebius.cloud/registry-u00gwj4vqcp98k7ph6   # dead id + wrong prefix
```

As a result, every failover pull to us-central1 (via `container_image_candidates()` / `backup_container_registry()`) resolved to a repository path that does not exist, so the cross-region redundancy the constant exists to provide never worked.

This changes it to the live us-central1 mirror, addressed by its **bare** registry id:

```
cr.us-central1.nebius.cloud/u00j7q4jjkahvsx0jy   # registry "npa-workbench"
```

## Why this id

Verified live against Nebius Container Registry:

- `registry-u00j7q4jjkahvsx0jy` (name `npa-workbench`, `cr.us-central1.nebius.cloud`) is the **only** active us-central1 registry in the workbench project (`project-u00zhx4tpr00xh99b28n52`, `workbench-poc`). It currently mirrors the canonical workbench tool set with **digests matching eu-north1**.
- The old `registry-u00gwj4vqcp98k7ph6` id is not resolvable as a usable registry.

## Registry parity note

An audit of the two workbench registries (eu-north1 primary + us-central1 backup) found the canonical tool set matches with identical digests (17/18 tool `name:tag` refs + the SONIC default). The remaining us-central1 gaps (`npa-lerobot:0.6.0`, `npa-sonic:0.1.2-k8s-runtime`, `npa-sonic-mujoco:0.1.3-mvp`) are being mirrored eu→us so the backup registry this constant points at is a true parity mirror.

## Tests

- `test_backup_registry_is_real_us_central1_registry` — locks the corrected path and forbids a `/registry-` prefix.
- `test_backup_registry_honors_env_override` — `NPA_BACKUP_REGISTRY` override still wins.
- `test_container_image_candidates_include_primary_then_backup` — failover list is eu-north1 primary then us-central1 backup.

All 14 tests in `npa/tests/test_deploy_images.py` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f2e09f4-d9d1-4d99-98c6-18bd0affb482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f2e09f4-d9d1-4d99-98c6-18bd0affb482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

