### PR TITLE
Fix the teardown gaps: the cancel/down race, zombie PENDING jobs, silent drains, and no single cleanup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ first GPU submit.
   hit a stale endpoint — see the `[M] <tool> status without -p/-n` entry in
   [FIXME.md](FIXME.md).
 
+### Tearing it back down
+
+Teardown is an ordered sequence (cancel managed jobs → destroy the agent →
+destroy the cluster → delete the bucket → drop the project entry → clear local
+caches), and missing a step leaves a hung job or a stale cache behind. Run
+`npa cleanup` for a report of what is still there plus the runbook, and
+`npa cleanup --yes` to clear the local caches. It never deletes cloud resources,
+and it reports rather than removes the `lerobot-training` service account
+`npa configure` creates, since that account is often shared with unrelated work.
+
 For the full known-issues surface: [docs/workbench/troubleshooting/known-footguns.md](docs/workbench/troubleshooting/known-footguns.md)
 and the active operational backlog in [FIXME.md](FIXME.md).
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -6,6 +6,7 @@ Generated from `npa --help`. Run `bash scripts/build_docs.sh` after CLI changes.
 - [npa agent](agent.md)
 - [npa burst](burst.md)
 - [npa workbench byof](byof.md)
+- [npa cleanup](cleanup.md)
 - [npa cluster](cluster.md)
 - [npa configure](configure.md)
 - [npa convert](convert.md)

--- a/docs/cli/cleanup.md
+++ b/docs/cli/cleanup.md
@@ -1,0 +1,40 @@
+# `npa cleanup`
+
+## Command Tree
+
+```text
+Usage: npa cleanup [OPTIONS] COMMAND [ARGS]...
+
+Report and remove NPA teardown leftovers.
+
+Options
+--yes  Remove the local caches listed in the report. Never touches cloud resources.
+--keep-sky  With --yes, keep ~/.sky (SkyPilot's own state) in place.
+--skip-jobs  Do not query the SkyPilot managed-job queue.
+--sky-bin  <str>  SkyPilot executable path. Defaults to NPA_SKYPILOT_BIN or PATH resolution.
+--json  Emit a JSON report.
+--help  Show this message and exit.
+```
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `--yes` | Remove the local caches listed in the report. Never touches cloud resources. |
+| `--keep-sky` | With --yes, keep ~/.sky (SkyPilot's own state) in place. |
+| `--skip-jobs` | Do not query the SkyPilot managed-job queue. |
+| `--sky-bin` | <str>  SkyPilot executable path. Defaults to NPA_SKYPILOT_BIN or PATH resolution. |
+| `--json` | Emit a JSON report. |
+| `--help` | Show this message and exit. |
+
+## Subcommands
+
+No subcommands are listed by `--help`.
+
+## Examples
+
+```bash
+npa cleanup --help
+```
+
+Regenerate this page with `bash scripts/build_docs.sh` after changing `cleanup`.

--- a/docs/workbench/troubleshooting/known-footguns.md
+++ b/docs/workbench/troubleshooting/known-footguns.md
@@ -46,6 +46,77 @@ image pull secret in the SkyPilot namespace, normally `default`.
 
 Category for follow-up: security.
 
+## `sky down` Refuses Right After `sky jobs cancel`
+
+Symptom: `sky jobs cancel -a` succeeds, and an immediate `sky down` of the jobs
+controller fails with `NotSupportedError: In-progress managed jobs found. To avoid
+resource leakage, cancel all jobs first` — telling the operator to do what they
+just did.
+
+Root cause: `sky jobs cancel` returns as soon as cancellation is *scheduled*. The
+controller keeps reporting the job as `CANCELLING` for a while, and `sky down`
+refuses while any managed job is non-terminal.
+
+Mitigation: NPA's teardown now waits for cancelled jobs to reach a terminal state
+before running `sky down`, recognizes this specific error, and retries once the
+queue drains. If a job genuinely will not drain, teardown names the job ids and
+says to wait for `sky jobs queue --all` to show them terminal.
+
+Category for follow-up: platform.
+
+## A Managed Job Sits In PENDING Forever
+
+Symptom: a managed job stays `PENDING` for hours and never becomes `FAILED`,
+burning wall-clock until somebody cancels it by hand.
+
+Root cause: Kubernetes retries image pulls and pod scheduling indefinitely, so a
+worker pod that cannot start never fails — and SkyPilot keeps reporting the job as
+`PENDING`. There is no signal distinguishing "slow to start" from "will never
+start".
+
+Mitigation: `npa workbench workflow status` inspects the pods behind a `PENDING`
+job (via SkyPilot's own `skypilot-cluster-name` label) and reports the container's
+waiting reason — `ImagePullBackOff`, `Unschedulable`, `CreateContainerConfigError`
+— with a remedy. `npa cleanup` also lists non-terminal managed jobs, since one of
+them will block controller teardown.
+
+Category for follow-up: platform.
+
+## Cluster Teardown Goes Quiet For Several Minutes
+
+Symptom: `npa cluster down` appears to hang while draining a node, then completes
+after roughly five to seven minutes.
+
+Root cause: draining respects PodDisruptionBudgets. Single-replica platform add-ons
+(`coredns`, `cilium-operator`, `metrics-server`) declare budgets that allow zero
+disruptions on a small node pool, so eviction retries until their pods reschedule.
+It is expected, but indistinguishable from a hang.
+
+Mitigation: `npa cluster down` now previews the budgets that currently allow no
+evictions and says the wait is expected, so the silence is bounded and explained.
+
+Category for follow-up: platform.
+
+## Teardown Is Six Ordered Steps With No Single Entry Point
+
+Symptom: an environment looks torn down but still has a hung managed job, a local
+SkyPilot venv, empty `~/.npa/agents` / `~/.npa/clusters` directories, or an IAM
+service account nothing removed.
+
+Root cause: teardown spans cancel → agent destroy → cluster down → bucket delete →
+forget project → remove local caches, and nothing checks the order or reports what
+is left.
+
+Mitigation: `npa cleanup` reports residual local state, configured project entries,
+non-terminal managed jobs, and the service accounts `npa configure` creates, then
+prints the ordered runbook. `npa cleanup --yes` removes the purely-local caches
+(`--keep-sky` keeps `~/.sky`). It never deletes cloud resources, and it never
+deletes service accounts — `lerobot-training` in particular is frequently shared
+with unrelated work in the same project, so it is reported for you to remove with
+the Nebius CLI if it really is unused.
+
+Category for follow-up: platform.
+
 ## Literal AWS Endpoint In SkyPilot YAML
 
 Symptom: S3 uploads fail and logs show the literal string `${AWS_ENDPOINT_URL}`

--- a/npa/src/npa/cli/cleanup.py
+++ b/npa/src/npa/cli/cleanup.py
@@ -1,0 +1,239 @@
+"""Report and remove what a full NPA teardown leaves behind.
+
+Tearing an environment down takes six commands in a specific order (cancel the
+managed jobs, destroy the agent, destroy the cluster, delete the bucket, forget
+the project, remove the SkyPilot venv). Nothing checks the order, and two things
+are easy to miss: a managed job still holding the jobs controller, and the IAM
+service account `npa configure` creates, which no destroy path removes.
+
+This command is the missing overview. It reports residual state, prints the
+ordered runbook, and can wipe the purely-local caches. It never deletes cloud
+resources -- particularly not service accounts, which are frequently shared with
+work that has nothing to do with this environment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import shutil
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+app = typer.Typer(name="cleanup", help="Report and remove NPA teardown leftovers.")
+console = Console(stderr=True)
+
+# Service accounts NPA creates. They are reported, never deleted: `lerobot-training`
+# in particular is shared with other work in the same project.
+REPORTED_SERVICE_ACCOUNTS = ("lerobot-training", "npa-agent")
+
+TEARDOWN_RUNBOOK = (
+    "sky jobs cancel -a  (and wait for `sky jobs queue --all` to show them terminal)",
+    "npa agent destroy --project <alias> --name <name> --yes",
+    "npa cluster down --force",
+    "delete the object-storage bucket",
+    "remove the project entry from ~/.npa/config.yaml",
+    "npa cleanup --yes  (local caches)",
+)
+
+
+@dataclass
+class Residue:
+    """Local and cloud state left over after a teardown."""
+
+    local_paths: list[Path] = field(default_factory=list)
+    projects: list[str] = field(default_factory=list)
+    live_jobs: list[str] = field(default_factory=list)
+    service_accounts: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def clean(self) -> bool:
+        return not (self.local_paths or self.projects or self.live_jobs)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "local_paths": [str(path) for path in self.local_paths],
+            "projects": list(self.projects),
+            "live_jobs": list(self.live_jobs),
+            "service_accounts": list(self.service_accounts),
+            "notes": list(self.notes),
+            "clean": self.clean,
+        }
+
+
+def _npa_home() -> Path:
+    return Path.home() / ".npa"
+
+
+def _local_cache_paths() -> list[Path]:
+    home = _npa_home()
+    return [
+        home / "skypilot-venv",
+        home / "terraform-plugin-cache",
+        Path.home() / ".sky",
+    ]
+
+
+def _empty_dirs(parent: Path) -> list[Path]:
+    """Return alias directories under ``parent`` that hold nothing."""
+
+    if not parent.is_dir():
+        return []
+    empty: list[Path] = []
+    for child in sorted(parent.iterdir()):
+        if not child.is_dir():
+            continue
+        if not any(child.iterdir()):
+            empty.append(child)
+    return empty
+
+
+def _configured_projects() -> tuple[list[str], str]:
+    config_path = _npa_home() / "config.yaml"
+    if not config_path.is_file():
+        return [], ""
+    try:
+        import yaml
+
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except (OSError, ValueError) as exc:
+        return [], f"could not read {config_path}: {exc}"
+    projects = data.get("projects") if isinstance(data, dict) else None
+    if not isinstance(projects, dict):
+        return [], ""
+    return sorted(str(name) for name in projects), ""
+
+
+def _nonterminal_jobs(sky_bin: str) -> tuple[list[str], str]:
+    from npa.orchestration.skypilot._bin import SkyPilotNotInstalledError
+    from npa.orchestration.skypilot.cleanup import _nonterminal_job_ids
+
+    try:
+        return (
+            _nonterminal_job_ids(
+                isolated_config_dir=None, config_path=None, sky_bin=sky_bin or None
+            ),
+            "",
+        )
+    except SkyPilotNotInstalledError:
+        return [], "SkyPilot is not installed, so managed jobs were not checked"
+    except (OSError, ValueError) as exc:
+        return [], f"could not read the managed-job queue: {exc}"
+
+
+def collect_residue(*, sky_bin: str = "", include_jobs: bool = True) -> Residue:
+    """Gather what a teardown has left behind, without changing anything."""
+
+    residue = Residue()
+    residue.local_paths = [path for path in _local_cache_paths() if path.exists()]
+    home = _npa_home()
+    for parent in (home / "agents", home / "clusters", home / "workbenches"):
+        residue.local_paths.extend(_empty_dirs(parent))
+
+    projects, project_note = _configured_projects()
+    residue.projects = projects
+    if project_note:
+        residue.notes.append(project_note)
+
+    if include_jobs:
+        jobs, job_note = _nonterminal_jobs(sky_bin)
+        residue.live_jobs = jobs
+        if job_note:
+            residue.notes.append(job_note)
+        if jobs:
+            residue.notes.append(
+                "A non-terminal managed job blocks `sky down` of the jobs controller. "
+                "A job whose pod cannot start stays PENDING forever rather than failing, "
+                "so check it before assuming it is still doing work."
+            )
+
+    residue.service_accounts = list(REPORTED_SERVICE_ACCOUNTS)
+    residue.notes.append(
+        "Service accounts are reported, never deleted: "
+        f"{', '.join(REPORTED_SERVICE_ACCOUNTS)} may be shared with other work in the "
+        "same project. Remove them yourself with the Nebius CLI if they are genuinely unused."
+    )
+    return residue
+
+
+def remove_local_caches(residue: Residue, *, keep_sky: bool = False) -> list[Path]:
+    """Delete the purely-local caches in ``residue``. No cloud state is touched."""
+
+    removed: list[Path] = []
+    sky_home = Path.home() / ".sky"
+    for path in residue.local_paths:
+        if keep_sky and path == sky_home:
+            continue
+        try:
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+        except OSError as exc:
+            console.print(f"[yellow]warning:[/yellow] could not remove {path}: {exc}")
+            continue
+        removed.append(path)
+    return removed
+
+
+@app.callback(invoke_without_command=True)
+def cleanup_cmd(
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Remove the local caches listed in the report. Never touches cloud resources.",
+    ),
+    keep_sky: bool = typer.Option(
+        False,
+        "--keep-sky",
+        help="With --yes, keep ~/.sky (SkyPilot's own state) in place.",
+    ),
+    skip_jobs: bool = typer.Option(
+        False,
+        "--skip-jobs",
+        help="Do not query the SkyPilot managed-job queue.",
+    ),
+    sky_bin: str = typer.Option(
+        "",
+        "--sky-bin",
+        help="SkyPilot executable path. Defaults to NPA_SKYPILOT_BIN or PATH resolution.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit a JSON report."),
+) -> None:
+    """Report NPA teardown leftovers, and optionally wipe the local caches."""
+
+    residue = collect_residue(sky_bin=sky_bin, include_jobs=not skip_jobs)
+    removed: list[Path] = []
+    if yes:
+        removed = remove_local_caches(residue, keep_sky=keep_sky)
+
+    if json_output:
+        payload = residue.to_dict()
+        payload["removed"] = [str(path) for path in removed]
+        payload["runbook"] = list(TEARDOWN_RUNBOOK)
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    if residue.live_jobs:
+        typer.echo(f"managed jobs still non-terminal: {', '.join(residue.live_jobs)}")
+    if residue.projects:
+        typer.echo(f"configured projects: {', '.join(residue.projects)}")
+    if residue.local_paths:
+        typer.echo("local leftovers:")
+        for path in residue.local_paths:
+            marker = "removed" if path in removed else "present"
+            typer.echo(f"  {path} ({marker})")
+    if residue.clean and not removed:
+        typer.echo("no local leftovers found")
+    typer.echo(f"service accounts (reported, not deleted): {', '.join(residue.service_accounts)}")
+    for note in residue.notes:
+        typer.echo(f"note: {note}")
+    if not yes:
+        typer.echo("")
+        typer.echo("Full teardown order:")
+        for index, step in enumerate(TEARDOWN_RUNBOOK, start=1):
+            typer.echo(f"  {index}. {step}")
+        typer.echo("Rerun with --yes to remove the local caches above.")

--- a/npa/src/npa/cli/cluster/terraform_lifecycle.py
+++ b/npa/src/npa/cli/cluster/terraform_lifecycle.py
@@ -125,6 +125,14 @@ def down_cmd(
     ),
     force: bool = typer.Option(False, "--force", help="Skip confirmation."),
     timeout: int = typer.Option(120, "--timeout", help="Terraform destroy timeout in minutes."),
+    kubeconfig: Path | None = typer.Option(
+        None,
+        "--kubeconfig",
+        help=(
+            "Kubeconfig used to report which PodDisruptionBudgets will hold up the "
+            "node drain. Defaults to the ambient KUBECONFIG."
+        ),
+    ),
 ) -> None:
     """Destroy the Terraform-managed NPA Kubernetes cluster."""
 
@@ -134,6 +142,7 @@ def down_cmd(
     env = _terraform_env(nebius_bin)
     if not force and not typer.confirm(f"Destroy Terraform-managed cluster in {tf_dir}?"):
         raise typer.Exit(1)
+    _report_drain_blockers(kubeconfig)
     _run_stream([terraform_bin, "init"], cwd=tf_dir, env=env, timeout=600)
     _run_stream(
         [terraform_bin, "destroy", "-auto-approve"],
@@ -141,6 +150,26 @@ def down_cmd(
         env=env,
         timeout=timeout * 60,
     )
+
+
+def _report_drain_blockers(kubeconfig: Path | None) -> None:
+    """Warn, before destroy, about budgets that will make the drain look hung.
+
+    Best-effort: a cluster that cannot be reached is simply not described, since
+    the destroy itself does not depend on this.
+    """
+
+    from npa.cluster.drain import blocking_pod_disruption_budgets, describe_drain_expectation
+
+    blockers, error = blocking_pod_disruption_budgets(
+        kubeconfig=str(kubeconfig) if kubeconfig else "",
+    )
+    if error:
+        typer.echo(f"drain-preview: skipped ({error})", err=True)
+        return
+    guidance = describe_drain_expectation(blockers)
+    if guidance:
+        typer.echo(f"drain-preview: {guidance}", err=True)
 
 
 def terraform_status(terraform_dir: Path | None = None) -> dict[str, Any] | None:

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -22,6 +22,7 @@ from npa.cli.cluster import app as cluster_app
 from npa.cli.convert import app as convert_app
 from npa.cli.demo import app as demo_app
 from npa.cli.network import app as network_app
+from npa.cli.cleanup import app as cleanup_app
 from npa.cli.provision import app as provision_app
 from npa.cli.rerun import app as rerun_app
 from npa.cli.skypilot import app as skypilot_app
@@ -55,6 +56,7 @@ app.add_typer(
 app.add_typer(adapter_app, name="adapter", rich_help_panel="Platform utilities")
 app.add_typer(agent_app, name="agent", rich_help_panel="Platform utilities")
 app.add_typer(burst_app, name="burst", rich_help_panel="Platform utilities")
+app.add_typer(cleanup_app, name="cleanup", rich_help_panel="Platform utilities")
 app.add_typer(cluster_app, name="cluster", rich_help_panel="Platform utilities")
 app.add_typer(convert_app, name="convert", rich_help_panel="Platform utilities")
 app.add_typer(demo_app, name="demo", rich_help_panel="Platform utilities")

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -972,7 +972,7 @@ def _durable_workflow_status(
         except Exception:
             live_status = ""
     status = _aggregate_stage_status(stages, live_status)
-    return {
+    payload: dict[str, object] = {
         "run_id": manifest.get("run_id") or _display_run_id(run_id),
         "workflow_name": manifest.get("workflow_name", ""),
         "status": status,
@@ -982,6 +982,49 @@ def _durable_workflow_status(
         "manifest_uri": f"{state.uri.rstrip('/')}/manifest.json",
         "stages": stages,
     }
+    blockers = _stalled_job_blockers(job_id, live_status, sky_bin=sky_bin)
+    if blockers:
+        payload["blockers"] = blockers
+    return payload
+
+
+def _stalled_job_blockers(
+    job_id: str, live_status: str, *, sky_bin: str = ""
+) -> list[dict[str, str]]:
+    """Explain a managed job that is not progressing, from its own pods.
+
+    A job whose pod cannot start never becomes FAILED -- Kubernetes retries image
+    pulls and scheduling forever -- so the only way to tell a slow start from a
+    dead one is to ask the pods.
+    """
+
+    if not job_id or live_status.upper() not in {"PENDING", "STARTING"}:
+        return []
+    from npa.orchestration.skypilot.job_blockers import inspect_job_blockers
+    from npa.orchestration.skypilot.workflow import workflow_task_statuses
+
+    try:
+        rows = workflow_task_statuses(job_id, sky_bin=_resolve_sky_bin(sky_bin))
+    except Exception:
+        return []
+    reported: list[dict[str, str]] = []
+    seen_clusters: set[str] = set()
+    for row in rows:
+        cluster = str(row.get("cluster_name") or "").strip()
+        if not cluster or cluster in seen_clusters:
+            continue
+        seen_clusters.add(cluster)
+        report = inspect_job_blockers(job_id=job_id, cluster_name=cluster)
+        for blocker in report.blockers:
+            reported.append(
+                {
+                    "pod": blocker.pod,
+                    "reason": blocker.reason,
+                    "message": blocker.message,
+                    "remedy": report.remedy(),
+                }
+            )
+    return reported
 
 
 def _aggregate_stage_status(stages: dict[str, dict[str, object]], live_status: str) -> str:
@@ -1017,6 +1060,21 @@ def _emit_workflow_status(result: dict[str, object], output_format: OutputFormat
         typer.echo(f"pod_reason: {result.get('pod_reason')}")
     if result.get("sky_job_id"):
         typer.echo(f"sky_job_id: {result.get('sky_job_id')}")
+    blockers = result.get("blockers")
+    if isinstance(blockers, list) and blockers:
+        # A managed job whose pod cannot start never becomes FAILED, so say why
+        # it is stuck rather than letting PENDING look like slow progress.
+        typer.echo(f"blocked: {len(blockers)} pod(s) cannot start")
+        for blocker in blockers:
+            if not isinstance(blocker, dict):
+                continue
+            detail = f"  {blocker.get('pod')}: {blocker.get('reason')}"
+            if blocker.get("message"):
+                detail = f"{detail} - {blocker.get('message')}"
+            typer.echo(detail)
+        remedy = str((blockers[0] or {}).get("remedy") or "")
+        if remedy:
+            typer.echo(f"  Suggested action: {remedy}")
     typer.echo(f"run_prefix_uri: {result.get('run_prefix_uri')}")
     eval_metrics = result.get("eval_metrics")
     if isinstance(eval_metrics, dict) and eval_metrics:

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -1006,15 +1006,19 @@ def _stalled_job_blockers(
     try:
         rows = workflow_task_statuses(job_id, sky_bin=_resolve_sky_bin(sky_bin))
     except Exception:
-        return []
+        rows = []
+    clusters = sorted(
+        {str(row.get("cluster_name") or "").strip() for row in rows} - {""}
+    )
+    # `sky jobs queue` reports a null cluster for a job that never provisioned --
+    # exactly the case worth diagnosing -- so fall back to the job id.
+    reports = (
+        [inspect_job_blockers(job_id=job_id, cluster_name=cluster) for cluster in clusters]
+        if clusters
+        else [inspect_job_blockers(job_id=job_id)]
+    )
     reported: list[dict[str, str]] = []
-    seen_clusters: set[str] = set()
-    for row in rows:
-        cluster = str(row.get("cluster_name") or "").strip()
-        if not cluster or cluster in seen_clusters:
-            continue
-        seen_clusters.add(cluster)
-        report = inspect_job_blockers(job_id=job_id, cluster_name=cluster)
+    for report in reports:
         for blocker in report.blockers:
             reported.append(
                 {

--- a/npa/src/npa/clients/config.py
+++ b/npa/src/npa/clients/config.py
@@ -277,6 +277,17 @@ def _resolve_project_section(
     ``workbench``.
     """
     projects = yml.get("projects")
+    if project and not (isinstance(projects, dict) and projects):
+        # An explicit alias against an empty/absent `projects` map used to fall
+        # through to the legacy branches, which silently ignored it: the command
+        # then failed downstream complaining it could not tell which Nebius
+        # project to use, never mentioning the alias the operator had passed.
+        # This is what an alias removed by teardown looks like.
+        raise ConfigError(
+            f"Project '{project}' is not configured in ~/.npa/config.yaml "
+            "(no projects are). Pass an explicit --project-id, or run "
+            "`npa configure` to recreate the project entry."
+        )
     if isinstance(projects, dict) and projects:
         if project:
             proj = projects.get(project, {})

--- a/npa/src/npa/cluster/drain.py
+++ b/npa/src/npa/cluster/drain.py
@@ -1,0 +1,132 @@
+"""Report the PodDisruptionBudgets that will hold up a cluster teardown.
+
+Destroying a managed-Kubernetes cluster drains its nodes, and eviction respects
+PodDisruptionBudgets. The platform add-ons that ship with every cluster
+(``coredns``, ``cilium-operator``, ``metrics-server``) declare budgets that allow
+zero disruptions while they are running a single replica, so a drain sits and
+retries -- around six minutes on a one-node CPU pool -- printing nothing an
+operator can act on. It is normal, but indistinguishable from a hang.
+
+Naming the budgets up front turns "terraform destroy has been quiet for five
+minutes" into an expected, bounded wait.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import json
+import subprocess
+
+DEFAULT_TIMEOUT_SECONDS = 60
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class DisruptionBlocker:
+    """A PodDisruptionBudget that currently permits no evictions."""
+
+    namespace: str
+    name: str
+    desired_healthy: int = 0
+    current_healthy: int = 0
+
+    def render(self) -> str:
+        return (
+            f"{self.namespace}/{self.name} "
+            f"(allows 0 disruptions; {self.current_healthy}/{self.desired_healthy} healthy)"
+        )
+
+
+def blocking_pod_disruption_budgets(
+    *,
+    kubeconfig: str = "",
+    context: str = "",
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    runner: Runner | None = None,
+) -> tuple[list[DisruptionBlocker], str]:
+    """Return the budgets that currently allow zero disruptions.
+
+    The second element is an error string; an unreachable cluster is reported
+    rather than treated as "nothing will block", so teardown guidance never
+    claims a clean drain it did not verify.
+    """
+
+    cmd = ["kubectl", "get", "poddisruptionbudgets", "--all-namespaces", "-o", "json"]
+    if context.strip():
+        cmd[1:1] = ["--context", context.strip()]
+    execute = runner or subprocess.run
+    env_kwargs: dict[str, object] = {}
+    if kubeconfig.strip():
+        import os
+
+        env = os.environ.copy()
+        env["KUBECONFIG"] = kubeconfig.strip()
+        env_kwargs["env"] = env
+    try:
+        result = execute(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+            check=False,
+            **env_kwargs,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return [], f"could not run kubectl: {exc}"
+    if result.returncode != 0:
+        return [], (result.stderr or result.stdout or f"exit {result.returncode}").strip()
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return [], "kubectl returned non-json output"
+
+    blockers: list[DisruptionBlocker] = []
+    for item in payload.get("items") or []:
+        if not isinstance(item, dict):
+            continue
+        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        status = item.get("status") if isinstance(item.get("status"), dict) else {}
+        allowed = status.get("disruptionsAllowed")
+        if allowed is None:
+            continue
+        try:
+            allowed_count = int(allowed)
+        except (TypeError, ValueError):
+            continue
+        if allowed_count > 0:
+            continue
+        blockers.append(
+            DisruptionBlocker(
+                namespace=str(metadata.get("namespace") or ""),
+                name=str(metadata.get("name") or ""),
+                desired_healthy=_as_int(status.get("desiredHealthy")),
+                current_healthy=_as_int(status.get("currentHealthy")),
+            )
+        )
+    blockers.sort(key=lambda blocker: (blocker.namespace, blocker.name))
+    return blockers, ""
+
+
+def _as_int(value: object) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+def describe_drain_expectation(blockers: list[DisruptionBlocker]) -> str:
+    """Return operator-facing guidance for a drain that will be held up."""
+
+    if not blockers:
+        return ""
+    names = ", ".join(blocker.render() for blocker in blockers)
+    return (
+        f"{len(blockers)} PodDisruptionBudget(s) currently allow no evictions: {names}. "
+        "Node drain will retry until their pods reschedule or the node pool is removed, "
+        "so teardown can look stalled for several minutes with no output. This is "
+        "expected for single-replica platform add-ons (CoreDNS, Cilium, metrics-server) "
+        "on a small node pool; let it run rather than interrupting it."
+    )

--- a/npa/src/npa/cluster/drain.py
+++ b/npa/src/npa/cluster/drain.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 import json
 import subprocess
+from typing import Any
 
 DEFAULT_TIMEOUT_SECONDS = 60
 
@@ -57,13 +58,12 @@ def blocking_pod_disruption_budgets(
     if context.strip():
         cmd[1:1] = ["--context", context.strip()]
     execute = runner or subprocess.run
-    env_kwargs: dict[str, object] = {}
+    env: dict[str, str] | None = None
     if kubeconfig.strip():
         import os
 
         env = os.environ.copy()
         env["KUBECONFIG"] = kubeconfig.strip()
-        env_kwargs["env"] = env
     try:
         result = execute(
             cmd,
@@ -72,7 +72,7 @@ def blocking_pod_disruption_budgets(
             text=True,
             timeout=timeout,
             check=False,
-            **env_kwargs,
+            env=env,
         )
     except (OSError, subprocess.SubprocessError) as exc:
         return [], f"could not run kubectl: {exc}"
@@ -87,8 +87,8 @@ def blocking_pod_disruption_budgets(
     for item in payload.get("items") or []:
         if not isinstance(item, dict):
             continue
-        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
-        status = item.get("status") if isinstance(item.get("status"), dict) else {}
+        metadata = _as_dict(item.get("metadata"))
+        status = _as_dict(item.get("status"))
         allowed = status.get("disruptionsAllowed")
         if allowed is None:
             continue
@@ -110,9 +110,13 @@ def blocking_pod_disruption_budgets(
     return blockers, ""
 
 
+def _as_dict(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
 def _as_int(value: object) -> int:
     try:
-        return int(value)  # type: ignore[arg-type]
+        return int(str(value))
     except (TypeError, ValueError):
         return 0
 

--- a/npa/src/npa/orchestration/skypilot/cleanup.py
+++ b/npa/src/npa/orchestration/skypilot/cleanup.py
@@ -7,7 +7,8 @@ import os
 import re
 import shutil
 import subprocess
-from collections.abc import Iterator
+import time
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -39,6 +40,15 @@ NONTERMINAL_JOB_STATUSES = {"PENDING", "STARTING", "RUNNING", "RECOVERING", "CAN
 JOBS_CONTROLLER_PATTERN = "sky-jobs-controller-*"
 RUN_ID_MIN_LENGTH = 12
 _RUN_ID_ALLOWED_RE = re.compile(r"^[A-Za-z0-9-]+$")
+
+# `sky jobs cancel` only *schedules* cancellation: the controller still reports the
+# job as CANCELLING for a while afterwards, and `sky down` on the controller refuses
+# to run while any managed job is non-terminal. Cancelling and immediately tearing
+# down therefore fails with the error below even though the operator did exactly
+# what the message asks for. Wait for the cancellation to land instead.
+DEFAULT_JOB_DRAIN_TIMEOUT_SECONDS = 300
+DEFAULT_JOB_DRAIN_INTERVAL_SECONDS = 5.0
+_IN_PROGRESS_JOBS_MARKERS = ("in-progress managed jobs", "in progress managed jobs")
 
 
 class InvalidRunIdError(ValueError):
@@ -80,8 +90,13 @@ def cleanup_jobs_controller(
     isolated_config_dir: Path | None = None,
     config_path: Path | None = None,
     sky_bin: SkyBin = None,
+    job_drain_timeout: int = DEFAULT_JOB_DRAIN_TIMEOUT_SECONDS,
 ) -> CleanupResult:
-    """Tear down the managed-jobs controller in the active SkyPilot state."""
+    """Tear down the managed-jobs controller in the active SkyPilot state.
+
+    ``sky down`` refuses while any managed job is non-terminal, and a job that was
+    only just cancelled still counts, so wait for the queue to drain first.
+    """
 
     cleanup = CleanupResult()
     controller_clusters, status_error = _jobs_controller_clusters(
@@ -92,6 +107,20 @@ def cleanup_jobs_controller(
     if status_error:
         cleanup.errors.append(status_error)
         return cleanup
+    if controller_clusters:
+        pending = _nonterminal_job_ids(
+            isolated_config_dir=isolated_config_dir,
+            config_path=config_path,
+            sky_bin=sky_bin,
+        )
+        if pending:
+            wait_for_jobs_terminal(
+                pending,
+                isolated_config_dir=isolated_config_dir,
+                config_path=config_path,
+                sky_bin=sky_bin,
+                timeout=job_drain_timeout,
+            )
     for controller_cluster in controller_clusters:
         controller_name = _cluster_name(controller_cluster)
         down_result = _down_jobs_controller(
@@ -99,6 +128,7 @@ def cleanup_jobs_controller(
             isolated_config_dir=isolated_config_dir,
             config_path=config_path,
             sky_bin=sky_bin,
+            job_drain_timeout=job_drain_timeout,
         )
         cleanup.extend(down_result)
         if down_result.ok and _is_kubernetes_controller(controller_cluster):
@@ -139,6 +169,7 @@ def cleanup_all_for_run(
     config_path: Path | None = None,
     sky_bin: SkyBin = None,
     also_teardown_controller: bool = False,
+    job_drain_timeout: int = DEFAULT_JOB_DRAIN_TIMEOUT_SECONDS,
 ) -> CleanupResult:
     """Cancel jobs and tear down this run's clusters.
 
@@ -149,6 +180,7 @@ def cleanup_all_for_run(
 
     _validate_run_id(run_id)
     cleanup = CleanupResult()
+    cancelled: list[str] = []
     for job in _matching_jobs(
         run_id,
         isolated_config_dir=isolated_config_dir,
@@ -156,13 +188,34 @@ def cleanup_all_for_run(
         sky_bin=sky_bin,
     ):
         if str(job.get("status", "")).upper() in NONTERMINAL_JOB_STATUSES:
+            job_id = str(job.get("job_id") or job.get("id"))
             cleanup.extend(
                 _cancel_job(
-                    str(job.get("job_id") or job.get("id")),
+                    job_id,
                     isolated_config_dir=isolated_config_dir,
                     config_path=config_path,
                     sky_bin=sky_bin,
                 )
+            )
+            cancelled.append(job_id)
+
+    # `sky jobs cancel` returns as soon as cancellation is scheduled, so tearing
+    # down immediately races the controller.
+    if cancelled:
+        drained, still_running = wait_for_jobs_terminal(
+            cancelled,
+            isolated_config_dir=isolated_config_dir,
+            config_path=config_path,
+            sky_bin=sky_bin,
+            timeout=job_drain_timeout,
+        )
+        if not drained:
+            cleanup.errors.append(
+                "managed job(s) "
+                + ", ".join(still_running)
+                + f" were still non-terminal {job_drain_timeout}s after cancel; "
+                "teardown continued, but `sky down` of the jobs controller may refuse "
+                "until they finish cancelling."
             )
 
     for pattern in cluster_name_patterns_for_run(run_id):
@@ -261,6 +314,126 @@ class _SkyPilotWorkflow:
             sky_bin=self.sky_bin,
         )
         return self.cleanup_result
+
+
+def looks_like_in_progress_jobs_error(detail: str) -> bool:
+    """Whether ``sky down`` refused because managed jobs are still non-terminal."""
+
+    lowered = str(detail or "").lower()
+    return any(marker in lowered for marker in _IN_PROGRESS_JOBS_MARKERS)
+
+
+def wait_for_jobs_terminal(
+    job_ids: Sequence[str],
+    *,
+    isolated_config_dir: Path | None = None,
+    config_path: Path | None = None,
+    sky_bin: SkyBin = None,
+    timeout: int = DEFAULT_JOB_DRAIN_TIMEOUT_SECONDS,
+    interval: float = DEFAULT_JOB_DRAIN_INTERVAL_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> tuple[bool, list[str]]:
+    """Block until the given managed jobs are terminal.
+
+    Returns ``(drained, still_running)``. A queue that cannot be read is treated
+    as drained: cleanup is best-effort and must not stall on a broken controller.
+    """
+
+    wanted = {str(job_id).strip() for job_id in job_ids if str(job_id).strip()}
+    if not wanted:
+        return True, []
+    deadline = time.monotonic() + max(timeout, 0)
+    still_running: list[str] = []
+    while True:
+        jobs, readable = _all_jobs(
+            isolated_config_dir=isolated_config_dir,
+            config_path=config_path,
+            sky_bin=sky_bin,
+        )
+        if not readable:
+            return True, []
+        still_running = [
+            job_id
+            for job_id, status in _job_statuses(jobs).items()
+            if job_id in wanted and status in NONTERMINAL_JOB_STATUSES
+        ]
+        if not still_running:
+            return True, []
+        if time.monotonic() >= deadline:
+            return False, sorted(still_running)
+        sleep(max(interval, 0.1))
+
+
+def _job_statuses(jobs: Sequence[dict[str, Any]]) -> dict[str, str]:
+    statuses: dict[str, str] = {}
+    for job in jobs or []:
+        if not isinstance(job, dict):
+            continue
+        job_id = str(job.get("job_id") or job.get("id") or "").strip()
+        if not job_id:
+            continue
+        status = str(job.get("status") or "").upper()
+        # A job group reports one row per task; the job is only terminal once
+        # every one of its rows is.
+        if job_id in statuses and statuses[job_id] in NONTERMINAL_JOB_STATUSES:
+            continue
+        statuses[job_id] = status
+    return statuses
+
+
+def _nonterminal_job_ids(
+    *,
+    isolated_config_dir: Path | None,
+    config_path: Path | None,
+    sky_bin: SkyBin,
+) -> list[str]:
+    jobs, readable = _all_jobs(
+        isolated_config_dir=isolated_config_dir,
+        config_path=config_path,
+        sky_bin=sky_bin,
+    )
+    if not readable:
+        return []
+    return sorted(
+        job_id
+        for job_id, status in _job_statuses(jobs).items()
+        if status in NONTERMINAL_JOB_STATUSES
+    )
+
+
+def _all_jobs(
+    *,
+    isolated_config_dir: Path | None,
+    config_path: Path | None,
+    sky_bin: SkyBin,
+) -> tuple[list[dict[str, Any]], bool]:
+    runtime_config = resolve_config(
+        sky_bin=sky_bin,
+        global_config_path=config_path,
+        isolated_config_dir=isolated_config_dir,
+    )
+    cmd = [
+        str(ensure_skypilot_version(runtime_config.sky_bin)),
+        "jobs",
+        "queue",
+        "--all",
+        "--output",
+        "json",
+    ]
+    result = _run(
+        cmd,
+        isolated_config_dir=runtime_config.isolated_config_dir,
+        config_path=runtime_config.global_config_path,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        return [], False
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return [], False
+    jobs = payload if isinstance(payload, list) else payload.get("jobs", [])
+    return [job for job in (jobs or []) if isinstance(job, dict)], True
 
 
 def _matching_jobs(
@@ -404,6 +577,7 @@ def _down_jobs_controller(
     isolated_config_dir: Path | None,
     config_path: Path | None,
     sky_bin: SkyBin,
+    job_drain_timeout: int = DEFAULT_JOB_DRAIN_TIMEOUT_SECONDS,
 ) -> CleanupResult:
     runtime_config = resolve_config(
         sky_bin=sky_bin,
@@ -411,6 +585,7 @@ def _down_jobs_controller(
         isolated_config_dir=isolated_config_dir,
     )
     cmd = [str(ensure_skypilot_version(runtime_config.sky_bin)), "down", "--yes", controller_name]
+    cleanup = CleanupResult(commands=[cmd])
     result = _run(
         cmd,
         isolated_config_dir=runtime_config.isolated_config_dir,
@@ -418,7 +593,42 @@ def _down_jobs_controller(
         timeout=900,
         input_text="delete\n",
     )
-    cleanup = CleanupResult(commands=[cmd])
+    if result.returncode != 0 and looks_like_in_progress_jobs_error(
+        _combined_output(result)
+    ):
+        # A job that finished cancelling between our poll and this call still
+        # trips the guard; drain once more and retry rather than reporting a
+        # failure the operator can only fix by waiting and rerunning.
+        pending = _nonterminal_job_ids(
+            isolated_config_dir=isolated_config_dir,
+            config_path=config_path,
+            sky_bin=sky_bin,
+        )
+        drained, still_running = wait_for_jobs_terminal(
+            pending,
+            isolated_config_dir=isolated_config_dir,
+            config_path=config_path,
+            sky_bin=sky_bin,
+            timeout=job_drain_timeout,
+        )
+        if drained:
+            cleanup.commands.append(cmd)
+            result = _run(
+                cmd,
+                isolated_config_dir=runtime_config.isolated_config_dir,
+                config_path=runtime_config.global_config_path,
+                timeout=900,
+                input_text="delete\n",
+            )
+        elif still_running:
+            cleanup.errors.append(
+                f"`sky down {controller_name}` refuses while managed job(s) "
+                + ", ".join(still_running)
+                + " are still non-terminal, and they did not finish cancelling within "
+                f"{job_drain_timeout}s. Suggested action: `sky jobs cancel -a`, wait for "
+                "`sky jobs queue --all` to show them terminal, then rerun teardown."
+            )
+            return cleanup
     if result.returncode == 0:
         cleanup.resources_removed.append(controller_name)
     else:
@@ -552,7 +762,9 @@ def _sanitize_name(value: str) -> str:
 
 
 def _format_command_error(cmd: list[str], result: subprocess.CompletedProcess[str]) -> str:
-    stderr = result.stderr.strip()
-    stdout = result.stdout.strip()
-    detail = stderr or stdout or f"exit {result.returncode}"
+    detail = _combined_output(result) or f"exit {result.returncode}"
     return f"{' '.join(cmd)} failed: {detail}"
+
+
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+    return (result.stderr or "").strip() or (result.stdout or "").strip()

--- a/npa/src/npa/orchestration/skypilot/job_blockers.py
+++ b/npa/src/npa/orchestration/skypilot/job_blockers.py
@@ -1,0 +1,222 @@
+"""Explain why a SkyPilot managed job is sitting in PENDING.
+
+A managed job whose worker pod cannot start never becomes FAILED: Kubernetes
+retries image pulls and rescheduling indefinitely, and SkyPilot keeps reporting
+the job as PENDING. A run blocked this way burns wall-clock until somebody
+notices and cancels it by hand -- 14 hours, in the case this module was written
+for.
+
+SkyPilot itself has nothing more to say, so the answer has to come from the pods
+it created. They carry ``skypilot-cluster-name=<cluster>``, which the managed-job
+queue already reports, so the blocked container's own waiting reason is one
+kubectl call away.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+import json
+import subprocess
+
+CLUSTER_LABEL = "skypilot-cluster-name"
+DEFAULT_TIMEOUT_SECONDS = 60
+
+# Container waiting reasons that Kubernetes will retry forever.
+_TERMINAL_INTENT_REASONS = {
+    "ImagePullBackOff": (
+        "the image could not be pulled. Kubernetes retries this forever, so the job "
+        "stays PENDING instead of failing. Confirm the run's identity is allowed to "
+        "pull that exact image reference -- being able to list a repository's tags is "
+        "a different permission from pulling it."
+    ),
+    "ErrImagePull": (
+        "the image pull failed. Check the image reference and the credentials the run "
+        "injects; Kubernetes will keep retrying rather than failing the job."
+    ),
+    "InvalidImageName": (
+        "the image reference is malformed. Fix the image pinned by the workflow spec "
+        "or the --image override."
+    ),
+    "CreateContainerConfigError": (
+        "the container config is invalid -- usually a missing Secret or ConfigMap "
+        "referenced by the pod."
+    ),
+    "CrashLoopBackOff": (
+        "the container starts and immediately exits. Read the pod logs for the real "
+        "error; the job will keep restarting."
+    ),
+}
+
+_UNSCHEDULABLE_REMEDY = (
+    "no node can satisfy the pod's resource request. Check the requested accelerator "
+    "name and per-node GPU count against what the cluster actually advertises -- "
+    "SkyPilot places all GPUs of one task on a single node."
+)
+
+
+@dataclass(frozen=True)
+class PodBlocker:
+    """One pod that cannot start, and why."""
+
+    pod: str
+    phase: str
+    reason: str
+    message: str = ""
+
+    def render(self) -> str:
+        detail = f"{self.pod}: {self.reason}"
+        if self.phase and self.phase.lower() != "pending":
+            detail = f"{detail} (phase {self.phase})"
+        if self.message:
+            detail = f"{detail} - {self.message}"
+        return detail
+
+
+@dataclass
+class JobBlockerReport:
+    """Why a managed job is not progressing, as seen from its pods."""
+
+    job_id: str = ""
+    cluster_name: str = ""
+    blockers: list[PodBlocker] = field(default_factory=list)
+    error: str = ""
+
+    @property
+    def blocked(self) -> bool:
+        return bool(self.blockers)
+
+    def remedy(self) -> str:
+        for blocker in self.blockers:
+            explanation = _TERMINAL_INTENT_REASONS.get(blocker.reason)
+            if explanation:
+                return explanation
+            if blocker.reason == "Unschedulable":
+                return _UNSCHEDULABLE_REMEDY
+        return ""
+
+    def render(self) -> str:
+        if self.error:
+            return f"blockers: unavailable ({self.error})"
+        if not self.blockers:
+            return "blockers: none found"
+        lines = [f"blockers ({len(self.blockers)}):"]
+        lines.extend(f"  {blocker.render()}" for blocker in self.blockers)
+        remedy = self.remedy()
+        if remedy:
+            lines.append(f"  Suggested action: {remedy}")
+        return "\n".join(lines)
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def inspect_job_blockers(
+    *,
+    job_id: str = "",
+    cluster_name: str = "",
+    namespace: str = "",
+    context: str = "",
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    runner: Runner | None = None,
+) -> JobBlockerReport:
+    """Return the pod-level reasons a managed job is not starting.
+
+    A cluster whose pods cannot be listed is reported as an error rather than as
+    "not blocked", so a missing kubectl is never mistaken for a healthy job.
+    """
+
+    report = JobBlockerReport(job_id=str(job_id), cluster_name=str(cluster_name))
+    if not cluster_name.strip():
+        report.error = "managed job has no cluster yet; nothing has been scheduled"
+        return report
+
+    cmd = ["kubectl", "get", "pods", "-l", f"{CLUSTER_LABEL}={cluster_name.strip()}", "-o", "json"]
+    if context.strip():
+        cmd[1:1] = ["--context", context.strip()]
+    if namespace.strip():
+        cmd.extend(["-n", namespace.strip()])
+    execute = runner or subprocess.run
+    try:
+        result = execute(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        report.error = f"could not run kubectl: {exc}"
+        return report
+    if result.returncode != 0:
+        report.error = (result.stderr or result.stdout or f"exit {result.returncode}").strip()
+        return report
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        report.error = "kubectl returned non-json output"
+        return report
+
+    report.blockers = _blockers_from_pods(payload.get("items") or [])
+    return report
+
+
+def _blockers_from_pods(items: list[object]) -> list[PodBlocker]:
+    blockers: list[PodBlocker] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(((item.get("metadata") or {}) if isinstance(item.get("metadata"), dict) else {}).get("name") or "")
+        status = item.get("status") if isinstance(item.get("status"), dict) else {}
+        phase = str(status.get("phase") or "")
+        if phase in {"Running", "Succeeded"}:
+            continue
+        blocker = _container_blocker(name, phase, status) or _scheduling_blocker(name, phase, status)
+        if blocker is not None:
+            blockers.append(blocker)
+    return blockers
+
+
+def _container_blocker(name: str, phase: str, status: dict) -> PodBlocker | None:
+    container_lists = (
+        status.get("containerStatuses") or [],
+        status.get("initContainerStatuses") or [],
+    )
+    for containers in container_lists:
+        if not isinstance(containers, list):
+            continue
+        for container in containers:
+            if not isinstance(container, dict):
+                continue
+            waiting = (container.get("state") or {}).get("waiting") or {}
+            reason = str(waiting.get("reason") or "")
+            # ContainerCreating is normal progress, not a blocker.
+            if reason and reason != "ContainerCreating":
+                return PodBlocker(
+                    pod=name,
+                    phase=phase,
+                    reason=reason,
+                    message=str(waiting.get("message") or "").strip(),
+                )
+    return None
+
+
+def _scheduling_blocker(name: str, phase: str, status: dict) -> PodBlocker | None:
+    conditions = status.get("conditions") or []
+    if not isinstance(conditions, list):
+        return None
+    for condition in conditions:
+        if not isinstance(condition, dict):
+            continue
+        if str(condition.get("type")) != "PodScheduled":
+            continue
+        if str(condition.get("status")) == "True":
+            continue
+        return PodBlocker(
+            pod=name,
+            phase=phase,
+            reason=str(condition.get("reason") or "Unschedulable"),
+            message=str(condition.get("message") or "").strip(),
+        )
+    return None

--- a/npa/src/npa/orchestration/skypilot/job_blockers.py
+++ b/npa/src/npa/orchestration/skypilot/job_blockers.py
@@ -123,16 +123,27 @@ def inspect_job_blockers(
 ) -> JobBlockerReport:
     """Return the pod-level reasons a managed job is not starting.
 
+    ``sky jobs queue`` frequently reports ``cluster_name_on_cloud`` as null -- a
+    job that never provisioned has no cluster recorded, which is exactly the case
+    worth diagnosing. SkyPilot names the pod label ``<task>-<job_id>-<hash>``, so
+    fall back to selecting on the job id when no cluster name is known.
+
     A cluster whose pods cannot be listed is reported as an error rather than as
     "not blocked", so a missing kubectl is never mistaken for a healthy job.
     """
 
     report = JobBlockerReport(job_id=str(job_id), cluster_name=str(cluster_name))
-    if not cluster_name.strip():
-        report.error = "managed job has no cluster yet; nothing has been scheduled"
+    by_job_id = not cluster_name.strip()
+    if by_job_id and not str(job_id).strip():
+        report.error = "no cluster name or job id to look up"
         return report
 
-    cmd = ["kubectl", "get", "pods", "-l", f"{CLUSTER_LABEL}={cluster_name.strip()}", "-o", "json"]
+    cmd = ["kubectl", "get", "pods", "-o", "json"]
+    if by_job_id:
+        # Every SkyPilot pod carries the label; the value is filtered below.
+        cmd[3:3] = ["-l", CLUSTER_LABEL]
+    else:
+        cmd[3:3] = ["-l", f"{CLUSTER_LABEL}={cluster_name.strip()}"]
     if context.strip():
         cmd[1:1] = ["--context", context.strip()]
     if namespace.strip():
@@ -159,12 +170,34 @@ def inspect_job_blockers(
         report.error = "kubectl returned non-json output"
         return report
 
-    report.blockers = _blockers_from_pods(payload.get("items") or [])
+    items = payload.get("items") or []
+    if by_job_id:
+        items = [item for item in items if _pod_belongs_to_job(item, str(job_id))]
+        if not items:
+            report.error = (
+                f"no pods found for managed job {job_id}; nothing has been scheduled yet"
+            )
+            return report
+    report.blockers = _blockers_from_pods(items)
     return report
 
 
 def _as_dict(value: object) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
+
+
+def _pod_belongs_to_job(item: object, job_id: str) -> bool:
+    """Whether a pod's SkyPilot cluster label names this managed job.
+
+    The label reads ``<task>-<job_id>-<user_hash>``, so the id must match a whole
+    dash-separated component -- job 3 must not match ``train-333-abc``.
+    """
+
+    if not isinstance(item, dict):
+        return False
+    labels = _as_dict(_as_dict(item.get("metadata")).get("labels"))
+    value = str(labels.get(CLUSTER_LABEL) or "")
+    return bool(value) and job_id in value.split("-")
 
 
 def _blockers_from_pods(items: list[object]) -> list[PodBlocker]:

--- a/npa/src/npa/orchestration/skypilot/job_blockers.py
+++ b/npa/src/npa/orchestration/skypilot/job_blockers.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import json
 import subprocess
+from typing import Any
 
 CLUSTER_LABEL = "skypilot-cluster-name"
 DEFAULT_TIMEOUT_SECONDS = 60
@@ -162,13 +163,17 @@ def inspect_job_blockers(
     return report
 
 
+def _as_dict(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
 def _blockers_from_pods(items: list[object]) -> list[PodBlocker]:
     blockers: list[PodBlocker] = []
     for item in items:
         if not isinstance(item, dict):
             continue
-        name = str(((item.get("metadata") or {}) if isinstance(item.get("metadata"), dict) else {}).get("name") or "")
-        status = item.get("status") if isinstance(item.get("status"), dict) else {}
+        name = str(_as_dict(item.get("metadata")).get("name") or "")
+        status = _as_dict(item.get("status"))
         phase = str(status.get("phase") or "")
         if phase in {"Running", "Succeeded"}:
             continue
@@ -178,7 +183,7 @@ def _blockers_from_pods(items: list[object]) -> list[PodBlocker]:
     return blockers
 
 
-def _container_blocker(name: str, phase: str, status: dict) -> PodBlocker | None:
+def _container_blocker(name: str, phase: str, status: dict[str, Any]) -> PodBlocker | None:
     container_lists = (
         status.get("containerStatuses") or [],
         status.get("initContainerStatuses") or [],
@@ -189,7 +194,7 @@ def _container_blocker(name: str, phase: str, status: dict) -> PodBlocker | None
         for container in containers:
             if not isinstance(container, dict):
                 continue
-            waiting = (container.get("state") or {}).get("waiting") or {}
+            waiting = _as_dict(_as_dict(container.get("state")).get("waiting"))
             reason = str(waiting.get("reason") or "")
             # ContainerCreating is normal progress, not a blocker.
             if reason and reason != "ContainerCreating":
@@ -202,7 +207,7 @@ def _container_blocker(name: str, phase: str, status: dict) -> PodBlocker | None
     return None
 
 
-def _scheduling_blocker(name: str, phase: str, status: dict) -> PodBlocker | None:
+def _scheduling_blocker(name: str, phase: str, status: dict[str, Any]) -> PodBlocker | None:
     conditions = status.get("conditions") or []
     if not isinstance(conditions, list):
         return None

--- a/npa/src/npa/orchestration/skypilot/job_blockers.py
+++ b/npa/src/npa/orchestration/skypilot/job_blockers.py
@@ -148,6 +148,9 @@ def inspect_job_blockers(
         cmd[1:1] = ["--context", context.strip()]
     if namespace.strip():
         cmd.extend(["-n", namespace.strip()])
+    else:
+        # SkyPilot's namespace is configurable, so do not assume the context default.
+        cmd.append("--all-namespaces")
     execute = runner or subprocess.run
     try:
         result = execute(
@@ -175,7 +178,8 @@ def inspect_job_blockers(
         items = [item for item in items if _pod_belongs_to_job(item, str(job_id))]
         if not items:
             report.error = (
-                f"no pods found for managed job {job_id}; nothing has been scheduled yet"
+                f"no pods found for managed job {job_id}; it is between tasks, or "
+                "nothing has been scheduled yet"
             )
             return report
     report.blockers = _blockers_from_pods(items)

--- a/npa/tests/cli/test_cleanup_and_drain.py
+++ b/npa/tests/cli/test_cleanup_and_drain.py
@@ -1,0 +1,337 @@
+"""Teardown gaps found while cleaning up after a PAIDF run."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+from typer.testing import CliRunner
+import yaml
+
+from npa.cli import cleanup as cleanup_cli
+from npa.cli.main import app
+from npa.clients.config import ConfigError, _resolve_project_section
+from npa.cluster.drain import (
+    blocking_pod_disruption_budgets,
+    describe_drain_expectation,
+)
+
+
+runner = CliRunner()
+
+
+# --- `npa cleanup` -----------------------------------------------------------
+
+
+@pytest.fixture()
+def npa_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    (home / ".npa").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+def test_cleanup_is_registered_as_one_command() -> None:
+    # The teardown runbook is six ordered steps; without a single entry point it
+    # is easy to miss the hung Sky job or the leftover service account.
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "cleanup" in result.output
+
+
+def test_cleanup_reports_local_leftovers_without_removing_them(npa_home: Path) -> None:
+    (npa_home / ".npa" / "skypilot-venv").mkdir()
+    (npa_home / ".npa" / "terraform-plugin-cache").mkdir()
+    (npa_home / ".npa" / "clusters" / "gone").mkdir(parents=True)
+
+    result = runner.invoke(app, ["cleanup", "--skip-jobs"])
+
+    assert result.exit_code == 0, result.output
+    assert "skypilot-venv" in result.output
+    assert "terraform-plugin-cache" in result.output
+    assert "clusters/gone" in result.output
+    assert (npa_home / ".npa" / "skypilot-venv").exists()
+
+
+def test_cleanup_yes_removes_only_local_caches(npa_home: Path) -> None:
+    venv = npa_home / ".npa" / "skypilot-venv"
+    venv.mkdir()
+    sky = npa_home / ".sky"
+    sky.mkdir()
+
+    result = runner.invoke(app, ["cleanup", "--skip-jobs", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert not venv.exists()
+    assert not sky.exists()
+
+
+def test_cleanup_keep_sky_leaves_skypilot_state(npa_home: Path) -> None:
+    venv = npa_home / ".npa" / "skypilot-venv"
+    venv.mkdir()
+    sky = npa_home / ".sky"
+    sky.mkdir()
+
+    result = runner.invoke(app, ["cleanup", "--skip-jobs", "--yes", "--keep-sky"])
+
+    assert result.exit_code == 0, result.output
+    assert not venv.exists()
+    assert sky.exists()
+
+
+def test_cleanup_reports_service_accounts_but_never_deletes_them(npa_home: Path) -> None:
+    result = runner.invoke(app, ["cleanup", "--skip-jobs"])
+
+    assert "lerobot-training" in result.output
+    assert "never deleted" in result.output
+    # `npa configure` creates it and no destroy path removes it, so it must be
+    # named -- but it is frequently shared, so npa must not remove it either.
+    assert "reported, not deleted" in result.output
+
+
+def test_cleanup_names_a_managed_job_that_still_blocks_teardown(
+    monkeypatch: pytest.MonkeyPatch, npa_home: Path
+) -> None:
+    monkeypatch.setattr(
+        cleanup_cli, "_nonterminal_jobs", lambda sky_bin: (["2"], "")
+    )
+
+    result = runner.invoke(app, ["cleanup"])
+
+    assert "managed jobs still non-terminal: 2" in result.output
+    assert "blocks `sky down`" in result.output
+    assert "stays PENDING forever" in result.output
+
+
+def test_cleanup_prints_the_ordered_runbook(npa_home: Path) -> None:
+    result = runner.invoke(app, ["cleanup", "--skip-jobs"])
+
+    assert "Full teardown order:" in result.output
+    for step in ("sky jobs cancel", "agent destroy", "cluster down"):
+        assert step in result.output
+
+
+def test_cleanup_json_report(npa_home: Path) -> None:
+    (npa_home / ".npa" / "config.yaml").write_text(
+        yaml.safe_dump({"projects": {"demo": {}}}), encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["cleanup", "--skip-jobs", "--json"])
+
+    payload = json.loads(result.output)
+    assert payload["projects"] == ["demo"]
+    assert "lerobot-training" in payload["service_accounts"]
+    assert payload["runbook"]
+
+
+# --- PodDisruptionBudget drain guidance --------------------------------------
+
+
+def _pdb(namespace: str, name: str, allowed: int, *, desired: int = 1, current: int = 1) -> dict:
+    return {
+        "metadata": {"namespace": namespace, "name": name},
+        "status": {
+            "disruptionsAllowed": allowed,
+            "desiredHealthy": desired,
+            "currentHealthy": current,
+        },
+    }
+
+
+def _pdb_runner(payload: dict, *, returncode: int = 0, stderr: str = ""):
+    def run(cmd, **kwargs):  # noqa: ANN001 - test stub
+        return subprocess.CompletedProcess(
+            cmd, returncode, stdout=json.dumps(payload), stderr=stderr
+        )
+
+    return run
+
+
+def test_only_budgets_that_allow_no_evictions_are_reported() -> None:
+    payload = {
+        "items": [
+            _pdb("kube-system", "coredns", 0),
+            _pdb("kube-system", "metrics-server", 1),
+            _pdb("kube-system", "cilium-operator", 0),
+        ]
+    }
+
+    blockers, error = blocking_pod_disruption_budgets(runner=_pdb_runner(payload))
+
+    assert error == ""
+    assert [blocker.name for blocker in blockers] == ["cilium-operator", "coredns"]
+
+
+def test_the_guidance_names_the_budgets_and_sets_expectations() -> None:
+    payload = {"items": [_pdb("kube-system", "coredns", 0)]}
+    blockers, _ = blocking_pod_disruption_budgets(runner=_pdb_runner(payload))
+
+    guidance = describe_drain_expectation(blockers)
+
+    assert "kube-system/coredns" in guidance
+    # The reported symptom was a ~6 minute silence that looked like a hang.
+    assert "look stalled" in guidance
+    assert "expected" in guidance
+
+
+def test_no_blocking_budgets_produces_no_guidance() -> None:
+    payload = {"items": [_pdb("kube-system", "coredns", 1)]}
+    blockers, _ = blocking_pod_disruption_budgets(runner=_pdb_runner(payload))
+
+    assert blockers == []
+    assert describe_drain_expectation(blockers) == ""
+
+
+def test_an_unreachable_cluster_is_reported_not_assumed_clean() -> None:
+    blockers, error = blocking_pod_disruption_budgets(
+        runner=_pdb_runner({}, returncode=1, stderr="connection refused")
+    )
+
+    assert blockers == []
+    assert "connection refused" in error
+
+
+def test_cluster_down_previews_the_drain(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from npa.cli.cluster import terraform_lifecycle
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        terraform_lifecycle,
+        "_report_drain_blockers",
+        lambda kubeconfig: seen.append("called"),
+    )
+    monkeypatch.setattr(terraform_lifecycle, "_require_bin", lambda name: name)
+    monkeypatch.setattr(terraform_lifecycle, "_terraform_env", lambda nebius_bin: {})
+    monkeypatch.setattr(
+        terraform_lifecycle, "_run_stream", lambda *args, **kwargs: None
+    )
+    tf_dir = tmp_path / "deploy" / "cluster"
+    tf_dir.mkdir(parents=True)
+
+    result = runner.invoke(
+        app, ["cluster", "down", "--force", "--terraform-dir", str(tf_dir)]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen == ["called"]
+
+
+# --- explicit project alias that no longer exists ----------------------------
+
+
+def test_an_explicit_alias_is_reported_when_no_projects_remain() -> None:
+    # After teardown removes the alias, passing --project used to be ignored: the
+    # command failed later complaining it could not tell which Nebius project to
+    # use, never mentioning the alias the operator had passed.
+    with pytest.raises(ConfigError) as excinfo:
+        _resolve_project_section({"projects": {}}, "test-rtx")
+
+    message = str(excinfo.value)
+    assert "test-rtx" in message
+    assert "--project-id" in message
+
+
+def test_an_explicit_alias_is_reported_when_config_is_empty() -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        _resolve_project_section({}, "test-rtx")
+
+    assert "test-rtx" in str(excinfo.value)
+
+
+def test_an_explicit_alias_that_exists_still_resolves() -> None:
+    section = _resolve_project_section({"projects": {"demo": {"project_id": "p1"}}}, "demo")
+
+    assert section == {"project_id": "p1"}
+
+
+def test_no_alias_still_falls_back_to_legacy_config() -> None:
+    # Legacy flat configs have no `projects` map at all; they must keep working
+    # when no alias is requested.
+    section = _resolve_project_section({"workbenches": {"default": {"a": 1}}}, None)
+
+    assert section["workbenches"] == {"default": {"a": 1}}
+
+
+# --- a PENDING managed job explains itself in `workflow status` --------------
+
+
+def test_status_explains_a_pending_job_whose_pod_cannot_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from npa.cli.workbench import workflow as workflow_cli
+    from npa.orchestration.skypilot.job_blockers import JobBlockerReport, PodBlocker
+
+    monkeypatch.setattr(
+        workflow_cli,
+        "_resolve_sky_bin",
+        lambda sky_bin="": "/tmp/sky",
+    )
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.workflow.workflow_task_statuses",
+        lambda job_id, **kwargs: [{"cluster_name": "sky-abc"}],
+    )
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.job_blockers.inspect_job_blockers",
+        lambda **kwargs: JobBlockerReport(
+            job_id="2",
+            cluster_name="sky-abc",
+            blockers=[PodBlocker(pod="worker-0", phase="Pending", reason="ImagePullBackOff")],
+        ),
+    )
+
+    blockers = workflow_cli._stalled_job_blockers("2", "PENDING")
+
+    assert blockers[0]["reason"] == "ImagePullBackOff"
+    assert "retries this forever" in blockers[0]["remedy"]
+
+
+def test_a_running_job_is_not_probed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from npa.cli.workbench import workflow as workflow_cli
+
+    def explode(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202 - must not run
+        raise AssertionError("a healthy job must not be probed")
+
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.workflow.workflow_task_statuses", explode
+    )
+
+    assert workflow_cli._stalled_job_blockers("2", "RUNNING") == []
+    assert workflow_cli._stalled_job_blockers("", "PENDING") == []
+
+
+def test_status_output_shows_the_blocked_pods() -> None:
+    from npa.cli.workbench.workflow import OutputFormat, _emit_workflow_status
+
+    result = _emit_workflow_status
+    import io
+    import contextlib
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        result(
+            {
+                "run_id": "paidf-1",
+                "status": "PENDING",
+                "sky_job_id": "2",
+                "run_prefix_uri": "s3://b/p",
+                "blockers": [
+                    {
+                        "pod": "worker-0",
+                        "reason": "ImagePullBackOff",
+                        "message": "403 Forbidden",
+                        "remedy": "check pull permission",
+                    }
+                ],
+            },
+            OutputFormat.text,
+        )
+
+    output = buffer.getvalue()
+    assert "blocked: 1 pod(s) cannot start" in output
+    assert "worker-0: ImagePullBackOff - 403 Forbidden" in output
+    assert "Suggested action: check pull permission" in output

--- a/npa/tests/orchestration/skypilot/test_cleanup.py
+++ b/npa/tests/orchestration/skypilot/test_cleanup.py
@@ -366,7 +366,10 @@ def test_cleanup_jobs_controller_discovers_exact_name_and_confirms_delete(
 
     assert calls[0][0] == [str(sky_bin), "status", "--refresh", "--output", "json"]
     assert calls[0][1] is None
-    assert calls[1] == ([str(sky_bin), "down", "--yes", "sky-jobs-controller-abc123"], "delete\n")
+    # The managed-job queue is checked before teardown, because `sky down` refuses
+    # while any managed job is still non-terminal.
+    assert calls[1][0] == [str(sky_bin), "jobs", "queue", "--all", "--output", "json"]
+    assert calls[2] == ([str(sky_bin), "down", "--yes", "sky-jobs-controller-abc123"], "delete\n")
     assert result.resources_removed == ["sky-jobs-controller-abc123"]
     assert result.errors == []
 
@@ -442,3 +445,211 @@ def test_no_code_path_sets_autostop_down_true() -> None:
     assert '"down": True' not in sources
     assert "'down': True" not in sources
     assert "down: true" not in sources.lower()
+
+
+# --- `sky jobs cancel` -> `sky down` race -------------------------------------
+#
+# `sky jobs cancel` returns once cancellation is *scheduled*. The controller keeps
+# reporting the job as CANCELLING, and `sky down` on the controller refuses while
+# any managed job is non-terminal, so cancelling and immediately tearing down fails
+# with an error telling the operator to do what they just did.
+
+_IN_PROGRESS_ERROR = (
+    "sky.exceptions.NotSupportedError: In-progress managed jobs found. "
+    "To avoid resource leakage, cancel all jobs first: sky jobs cancel -a"
+)
+
+
+def _queue(*jobs: dict[str, object]) -> str:
+    import json as _json
+
+    return _json.dumps(list(jobs))
+
+
+def test_cleanup_all_for_run_waits_for_cancelled_jobs_before_tearing_down(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    sky_bin = _fake_sky(tmp_path)
+    calls: list[list[str]] = []
+    queue_reads = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[1:3] == ["jobs", "queue"]:
+            queue_reads["n"] += 1
+            # First read finds the live job; after cancel it lingers as
+            # CANCELLING, then finally reports CANCELLED.
+            status = {1: "RUNNING", 2: "CANCELLING"}.get(queue_reads["n"], "CANCELLED")
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=_queue({"job_id": 7, "name": "run-abc123456789", "status": status}), stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(cleanup_module.time, "sleep", lambda _seconds: None)
+
+    result = cleanup_all_for_run("run-abc123456789", isolated_config_dir=tmp_path, sky_bin=sky_bin)
+
+    verbs = [cmd[1:3] for cmd in calls]
+    cancel_at = verbs.index(["jobs", "cancel"])
+    down_at = next(i for i, cmd in enumerate(calls) if cmd[1] == "down")
+    # The queue is re-read between cancel and down until the job is terminal.
+    assert ["jobs", "queue"] in verbs[cancel_at:down_at]
+    assert queue_reads["n"] >= 3
+    assert result.errors == []
+
+
+def test_cleanup_all_for_run_reports_a_job_that_never_finishes_cancelling(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    sky_bin = _fake_sky(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1:3] == ["jobs", "queue"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=_queue({"job_id": 7, "name": "run-abc123456789", "status": "CANCELLING"}), stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(cleanup_module.time, "sleep", lambda _seconds: None)
+
+    result = cleanup_all_for_run(
+        "run-abc123456789", isolated_config_dir=tmp_path, sky_bin=sky_bin, job_drain_timeout=0
+    )
+
+    assert any("still non-terminal" in error for error in result.errors)
+    assert any("7" in error for error in result.errors)
+
+
+def test_controller_teardown_retries_after_the_in_progress_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    sky_bin = _fake_sky(tmp_path)
+    downs = {"n": 0}
+    queue_reads = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == "status":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout='[{"name": "sky-jobs-controller-abc123", "status": "UP"}]', stderr=""
+            )
+        if cmd[1:3] == ["jobs", "queue"]:
+            queue_reads["n"] += 1
+            status = "CANCELLING" if queue_reads["n"] == 1 else "CANCELLED"
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=_queue({"job_id": 2, "status": status}), stderr=""
+            )
+        if cmd[1] == "down":
+            downs["n"] += 1
+            # A job that finished cancelling between the poll and this call still
+            # trips the guard the first time.
+            if downs["n"] == 1:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=_IN_PROGRESS_ERROR)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(cleanup_module.time, "sleep", lambda _seconds: None)
+
+    result = cleanup_jobs_controller(isolated_config_dir=tmp_path, sky_bin=sky_bin)
+
+    assert downs["n"] == 2
+    assert result.resources_removed == ["sky-jobs-controller-abc123"]
+    assert result.errors == []
+
+
+def test_controller_teardown_explains_a_job_that_will_not_drain(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    sky_bin = _fake_sky(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == "status":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout='[{"name": "sky-jobs-controller-abc123", "status": "UP"}]', stderr=""
+            )
+        if cmd[1:3] == ["jobs", "queue"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=_queue({"job_id": 2, "status": "RUNNING"}), stderr=""
+            )
+        if cmd[1] == "down":
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=_IN_PROGRESS_ERROR)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(cleanup_module.time, "sleep", lambda _seconds: None)
+
+    result = cleanup_jobs_controller(
+        isolated_config_dir=tmp_path, sky_bin=sky_bin, job_drain_timeout=0
+    )
+
+    assert result.resources_removed == []
+    joined = " ".join(result.errors)
+    assert "refuses while managed job(s) 2" in joined
+    assert "sky jobs cancel -a" in joined
+
+
+def test_a_readable_queue_that_is_already_terminal_does_not_wait(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    sky_bin = _fake_sky(tmp_path)
+    slept: list[float] = []
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=_queue({"job_id": 7, "status": "SUCCEEDED"}), stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    drained, still_running = cleanup_module.wait_for_jobs_terminal(
+        ["7"], isolated_config_dir=tmp_path, sky_bin=sky_bin, sleep=slept.append
+    )
+
+    assert drained is True
+    assert still_running == []
+    assert slept == []
+
+
+def test_an_unreadable_queue_does_not_stall_teardown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # Cleanup is best-effort; a broken controller must not hold teardown hostage.
+    sky_bin = _fake_sky(tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="controller unreachable")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    drained, still_running = cleanup_module.wait_for_jobs_terminal(
+        ["7"], isolated_config_dir=tmp_path, sky_bin=sky_bin, sleep=lambda _s: None
+    )
+
+    assert drained is True
+    assert still_running == []
+
+
+def test_a_job_group_is_terminal_only_when_every_task_is(tmp_path) -> None:
+    statuses = cleanup_module._job_statuses(
+        [
+            {"job_id": 3, "task_id": 0, "status": "SUCCEEDED"},
+            {"job_id": 3, "task_id": 1, "status": "RUNNING"},
+        ]
+    )
+
+    assert statuses["3"] == "RUNNING"
+
+
+@pytest.mark.parametrize(
+    ("detail", "expected"),
+    [
+        (_IN_PROGRESS_ERROR, True),
+        ("In progress managed jobs found", True),
+        ("cluster not found", False),
+        ("", False),
+    ],
+)
+def test_in_progress_guard_is_recognized(detail: str, expected: bool) -> None:
+    assert cleanup_module.looks_like_in_progress_jobs_error(detail) is expected

--- a/npa/tests/orchestration/skypilot/test_job_blockers.py
+++ b/npa/tests/orchestration/skypilot/test_job_blockers.py
@@ -130,10 +130,12 @@ def test_an_unreachable_cluster_is_an_error_not_a_clean_bill_of_health() -> None
     assert "unavailable" in report.render()
 
 
-def test_a_job_with_no_cluster_yet_says_so() -> None:
-    report = inspect_job_blockers(job_id="2", cluster_name="")
+def test_a_job_with_no_pods_yet_says_so() -> None:
+    runner = _runner(_pods())
 
-    assert "nothing has been scheduled" in report.error
+    report = inspect_job_blockers(job_id="2", cluster_name="", runner=runner)
+
+    assert "nothing has been scheduled yet" in report.error
 
 
 def test_missing_kubectl_is_reported() -> None:
@@ -170,3 +172,47 @@ def test_render_lists_each_blocked_pod() -> None:
     assert "blockers (2)" in rendered
     assert "worker-0" in rendered and "worker-1" in rendered
     assert "Suggested action:" in rendered
+
+
+# --- lookup by job id ---------------------------------------------------------
+#
+# `sky jobs queue` reports cluster_name_on_cloud as null for a job that never
+# provisioned -- which is exactly the job worth diagnosing. SkyPilot labels its
+# pods `<task>-<job_id>-<user_hash>`, so the job id is enough to find them.
+
+
+def _labelled_pod(label: str, reason: str) -> dict:
+    pod = _waiting_pod(f"{label}-head", reason)
+    pod["metadata"]["labels"] = {CLUSTER_LABEL: label}
+    return pod
+
+
+def test_pods_are_found_by_job_id_when_the_queue_reports_no_cluster() -> None:
+    runner = _runner(
+        _pods(
+            _labelled_pod("train-333-64ce57a0", "ImagePullBackOff"),
+            _labelled_pod("cosmos-curate-332-64ce57a0", "ImagePullBackOff"),
+        )
+    )
+
+    report = inspect_job_blockers(job_id="333", runner=runner)
+
+    assert [blocker.pod for blocker in report.blockers] == ["train-333-64ce57a0-head"]
+    # A bare label selector, filtered client-side by the job id component.
+    assert f"{CLUSTER_LABEL}" in runner.seen["cmd"]  # type: ignore[attr-defined]
+
+
+def test_a_job_id_must_match_a_whole_label_component() -> None:
+    # Job 3 must not match `train-333-abc`.
+    runner = _runner(_pods(_labelled_pod("train-333-64ce57a0", "ImagePullBackOff")))
+
+    report = inspect_job_blockers(job_id="3", runner=runner)
+
+    assert report.blockers == []
+    assert "nothing has been scheduled yet" in report.error
+
+
+def test_no_cluster_and_no_job_id_is_an_error() -> None:
+    report = inspect_job_blockers()
+
+    assert "no cluster name or job id" in report.error

--- a/npa/tests/orchestration/skypilot/test_job_blockers.py
+++ b/npa/tests/orchestration/skypilot/test_job_blockers.py
@@ -216,3 +216,23 @@ def test_no_cluster_and_no_job_id_is_an_error() -> None:
     report = inspect_job_blockers()
 
     assert "no cluster name or job id" in report.error
+
+
+def test_the_lookup_is_not_limited_to_the_context_default_namespace() -> None:
+    # SkyPilot's namespace is configurable, so a default-namespace-only query
+    # would silently report a healthy job.
+    runner = _runner(_pods())
+
+    inspect_job_blockers(job_id="333", runner=runner)
+
+    assert "--all-namespaces" in runner.seen["cmd"]  # type: ignore[attr-defined]
+
+
+def test_an_explicit_namespace_is_honored() -> None:
+    runner = _runner(_pods())
+
+    inspect_job_blockers(cluster_name="sky-abc", namespace="sky", runner=runner)
+
+    cmd = runner.seen["cmd"]  # type: ignore[attr-defined]
+    assert "-n" in cmd and "sky" in cmd
+    assert "--all-namespaces" not in cmd

--- a/npa/tests/orchestration/skypilot/test_job_blockers.py
+++ b/npa/tests/orchestration/skypilot/test_job_blockers.py
@@ -1,0 +1,172 @@
+"""A managed job whose pod cannot start must explain itself.
+
+Kubernetes retries image pulls and scheduling forever, so SkyPilot keeps
+reporting such a job as PENDING and it never becomes FAILED. The reported case
+sat that way for ~14 hours before anyone cancelled it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from npa.orchestration.skypilot.job_blockers import (
+    CLUSTER_LABEL,
+    inspect_job_blockers,
+)
+
+
+def _pods(*items: dict) -> str:
+    return json.dumps({"items": list(items)})
+
+
+def _waiting_pod(name: str, reason: str, message: str = "") -> dict:
+    return {
+        "metadata": {"name": name},
+        "status": {
+            "phase": "Pending",
+            "containerStatuses": [
+                {"state": {"waiting": {"reason": reason, "message": message}}}
+            ],
+        },
+    }
+
+
+def _runner(stdout: str, *, returncode: int = 0, stderr: str = ""):
+    seen: dict[str, list[str]] = {}
+
+    def run(cmd, **kwargs):  # noqa: ANN001 - test stub
+        seen["cmd"] = list(cmd)
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+    run.seen = seen  # type: ignore[attr-defined]
+    return run
+
+
+def test_image_pull_backoff_is_reported_with_the_pull_permission_remedy() -> None:
+    runner = _runner(
+        _pods(
+            _waiting_pod(
+                "sky-abc-worker-0",
+                "ImagePullBackOff",
+                'Back-off pulling image "cr.example/npa-cosmos2-transfer:2.5.1"',
+            )
+        )
+    )
+
+    report = inspect_job_blockers(job_id="2", cluster_name="sky-abc", runner=runner)
+
+    assert report.blocked is True
+    assert report.blockers[0].reason == "ImagePullBackOff"
+    assert "retries this forever" in report.remedy()
+    assert "different permission from pulling" in report.remedy()
+    assert "stays PENDING instead of failing" in report.remedy()
+
+
+def test_the_pods_are_found_by_skypilots_own_cluster_label() -> None:
+    runner = _runner(_pods())
+
+    inspect_job_blockers(cluster_name="sky-abc", context="npa-cluster", runner=runner)
+
+    cmd = runner.seen["cmd"]  # type: ignore[attr-defined]
+    assert f"{CLUSTER_LABEL}=sky-abc" in cmd
+    assert "--context" in cmd and "npa-cluster" in cmd
+
+
+def test_an_unschedulable_pod_points_at_the_accelerator_request() -> None:
+    runner = _runner(
+        _pods(
+            {
+                "metadata": {"name": "sky-abc-worker-0"},
+                "status": {
+                    "phase": "Pending",
+                    "conditions": [
+                        {
+                            "type": "PodScheduled",
+                            "status": "False",
+                            "reason": "Unschedulable",
+                            "message": "0/3 nodes are available: insufficient nvidia.com/gpu",
+                        }
+                    ],
+                },
+            }
+        )
+    )
+
+    report = inspect_job_blockers(cluster_name="sky-abc", runner=runner)
+
+    assert report.blockers[0].reason == "Unschedulable"
+    assert "single node" in report.remedy()
+
+
+def test_a_running_pod_is_not_a_blocker() -> None:
+    runner = _runner(
+        _pods({"metadata": {"name": "sky-abc-worker-0"}, "status": {"phase": "Running"}})
+    )
+
+    report = inspect_job_blockers(cluster_name="sky-abc", runner=runner)
+
+    assert report.blocked is False
+    assert report.render() == "blockers: none found"
+
+
+def test_container_creating_is_progress_not_a_blocker() -> None:
+    runner = _runner(_pods(_waiting_pod("sky-abc-worker-0", "ContainerCreating")))
+
+    report = inspect_job_blockers(cluster_name="sky-abc", runner=runner)
+
+    assert report.blocked is False
+
+
+def test_an_unreachable_cluster_is_an_error_not_a_clean_bill_of_health() -> None:
+    runner = _runner("", returncode=1, stderr="Unable to connect to the server")
+
+    report = inspect_job_blockers(cluster_name="sky-abc", runner=runner)
+
+    assert report.blocked is False
+    assert "Unable to connect" in report.error
+    assert "unavailable" in report.render()
+
+
+def test_a_job_with_no_cluster_yet_says_so() -> None:
+    report = inspect_job_blockers(job_id="2", cluster_name="")
+
+    assert "nothing has been scheduled" in report.error
+
+
+def test_missing_kubectl_is_reported() -> None:
+    def run(cmd, **kwargs):  # noqa: ANN001 - test stub
+        raise OSError("No such file or directory: 'kubectl'")
+
+    report = inspect_job_blockers(cluster_name="sky-abc", runner=run)
+
+    assert "could not run kubectl" in report.error
+
+
+@pytest.mark.parametrize(
+    "reason", ["ErrImagePull", "InvalidImageName", "CreateContainerConfigError", "CrashLoopBackOff"]
+)
+def test_every_retry_forever_reason_carries_a_remedy(reason: str) -> None:
+    runner = _runner(_pods(_waiting_pod("sky-abc-worker-0", reason)))
+
+    report = inspect_job_blockers(cluster_name="sky-abc", runner=runner)
+
+    assert report.blockers[0].reason == reason
+    assert report.remedy()
+
+
+def test_render_lists_each_blocked_pod() -> None:
+    runner = _runner(
+        _pods(
+            _waiting_pod("worker-0", "ImagePullBackOff"),
+            _waiting_pod("worker-1", "ImagePullBackOff"),
+        )
+    )
+
+    rendered = inspect_job_blockers(cluster_name="sky-abc", runner=runner).render()
+
+    assert "blockers (2)" in rendered
+    assert "worker-0" in rendered and "worker-1" in rendered
+    assert "Suggested action:" in rendered

--- a/skills/atomic/submit-workflow/SKILL.md
+++ b/skills/atomic/submit-workflow/SKILL.md
@@ -74,6 +74,24 @@ healthy `sky check kubernetes`:
   `PermissionDenied` / `Unauthenticated` even though the `nebius` CLI works.
   `unset NEBIUS_IAM_TOKEN NPA_NEBIUS_IAM_TOKEN` before submitting/deploying.
 
+## Teardown
+
+- **Cancel then wait, then tear down.** `sky jobs cancel` only *schedules*
+  cancellation; `sky down` on the jobs controller refuses while any managed job is
+  non-terminal, so cancelling and immediately tearing down fails with
+  `NotSupportedError: In-progress managed jobs found`. `cleanup_all_for_run` and
+  `cleanup_jobs_controller` now wait for the queue to drain and retry that specific
+  error; if you drive `sky` by hand, poll `sky jobs queue --all` first.
+- **A PENDING job may be dead, not slow.** A pod stuck in `ImagePullBackOff` or
+  `Unschedulable` is retried by Kubernetes forever, so the job never becomes FAILED.
+  `npa workbench workflow status` reports the pod-level reason for a PENDING job.
+- **`npa cleanup`** reports what a teardown left behind (local caches, project
+  entries, non-terminal managed jobs, the service accounts `npa configure` creates)
+  and prints the ordered runbook. `--yes` removes the local caches only; it never
+  deletes cloud resources or service accounts.
+- **`npa cluster down`** previews the PodDisruptionBudgets that will hold up the
+  node drain, so a multi-minute silence is expected rather than alarming.
+
 ## Verify
 
 ```bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleaning up after a PAIDF run took six commands in a specific order, and four of the six steps had a failure mode that either looked like a hang or silently left something behind. This PR fixes the product behavior behind each one.

The recurring theme is the same one that produced the 14-hour zombie job: **the platform retries instead of failing.** A cancelled job stays `CANCELLING`, a pod that cannot pull stays `Pending`, a drain blocked by a PodDisruptionBudget just keeps retrying. None of that is wrong, but none of it is visible either, so the operator cannot tell "working on it" from "will never finish". Each fix here makes the difference observable.

### 1. `sky down` raced `sky jobs cancel`

`sky jobs cancel` returns as soon as cancellation is *scheduled*. The controller keeps reporting the job as `CANCELLING`, and `sky down` refuses while any managed job is non-terminal — so cancelling and immediately tearing down failed with `NotSupportedError: In-progress managed jobs found... cancel all jobs first`, telling the operator to do exactly what they had just done.

`cleanup_all_for_run` now waits for the jobs it cancelled to reach a terminal state before running `sky down`, and `cleanup_jobs_controller` drains the queue before touching the controller. Because a job can also finish cancelling *between* the poll and the call, the specific in-progress error is recognized and retried once the queue drains. A job that genuinely will not drain is reported by id with the manual recovery step, rather than surfacing as a raw SkyPilot traceback.

Two details worth calling out: a job group reports one row per task, so a job counts as non-terminal until *every* row is; and an unreadable queue is treated as drained, because cleanup is best-effort and must not be held hostage by a broken controller.

### 2. A managed job sat PENDING for ~14 hours

Kubernetes retries image pulls and scheduling forever, so a worker pod that cannot start never fails — and SkyPilot keeps reporting `PENDING`. Nothing distinguished "slow to start" from "dead".

New `job_blockers` module asks the pods directly, using SkyPilot's own `skypilot-cluster-name` label, and reports the container's waiting reason with a remedy: `ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`, `CreateContainerConfigError`, `CrashLoopBackOff`, and `Unschedulable`. `npa workbench workflow status` runs it for a `PENDING`/`STARTING` job and prints which pods are blocked and why. `ContainerCreating` is deliberately not a blocker — that is normal progress.

Checking this against the live controller changed the design. `sky jobs queue` reported `cluster_name_on_cloud: null` even for a **RUNNING** task, so a cluster-name-only lookup would almost never have fired — the feature would have looked correct in tests and done nothing in production. The real pods are labelled `<task>-<job_id>-<user_hash>` (e.g. `train-333-64ce57a0`), so the lookup falls back to matching the job id as a whole label component (job `3` must not match `train-333-abc`). Live probing also showed SkyPilot's namespace is not necessarily the context default, so the search covers all namespaces unless one is given.

### 3. Cluster teardown went quiet for ~6 minutes

Draining respects PodDisruptionBudgets, and single-replica platform add-ons (`coredns`, `cilium-operator`, `metrics-server`) allow zero disruptions on a small node pool. The wait is expected but indistinguishable from a hang. `npa cluster down` now previews the budgets that currently permit no evictions, names them, and says the silence is expected — so the wait is bounded and explained rather than alarming. An unreachable cluster is reported, never assumed clean.

### 4. `--project <alias>` was silently ignored once the alias was gone

With `projects: {}` — what teardown leaves behind — `_resolve_project_section` fell through to the legacy-config branches and returned an empty section, discarding the alias entirely. The command then failed downstream complaining it could not tell which Nebius project to use, never mentioning the alias the operator had passed. An explicitly requested alias that cannot be resolved is now reported by name, pointing at `--project-id` or `npa configure`. Legacy flat configs still resolve when no alias is requested.

### 5 & 6. No single teardown command, and a documented IAM leftover

New `npa cleanup` reports what a teardown left behind — local caches (`skypilot-venv`, `terraform-plugin-cache`, `~/.sky`), empty `agents/` / `clusters/` / `workbenches/` alias directories, configured project entries, non-terminal managed jobs, and the service accounts `npa configure` creates — then prints the ordered runbook. `--yes` removes the local caches (`--keep-sky` preserves `~/.sky`).

It never deletes cloud resources, and it **reports rather than deletes service accounts**. `lerobot-training` is created by `npa configure` and removed by no destroy path, but it is frequently shared with unrelated work in the same project, so naming it is the useful behavior and deleting it is not.

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks. Full suite **4481 passed, 256 skipped**; `ruff check src tests` clean; `mypy src/npa` shows **372 errors on both this branch and `origin/main`** (measured in a clean worktree — no new ones); `scripts/build_docs.sh --check` reports `docs/cli is up to date`.
- [x] Confirmed every new behavioral test **fails on the pre-fix tree** — reverted the touched sources to `origin/main` and re-ran: 12 failures in the cleanup race tests plus collection errors for the three new modules, then restored.
- [x] Validated live on the dev VM. `npa cleanup` against real state found 3 genuinely non-terminal managed jobs, 12 configured projects, and the real local caches, and deleted nothing without `--yes`. `--yes --keep-sky` was exercised in an isolated `HOME`: it removed the caches and the empty alias directories, preserved `~/.sky`, and preserved a non-empty directory. The job-blocker lookup was run against the live cluster and correctly reported a running job as unblocked and a between-tasks job as having no pods.
- [x] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py` (guardrails: 58 passed).
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

One note on flakiness: an unrelated test (`test_agent_retrieval.py::test_retrieve_returns_ranked_citations`) failed once in a full-suite run and passed both in isolation and on an identical rerun of the same command. It does not touch anything in this PR, and `tests/cli/` is green on unmodified `main`.

Dev-VM work was isolated in its own git worktree, removed afterwards; `~/.npa`, the shared SkyPilot venv, and other agents' sessions were left untouched (`--yes` was never run against the shared home).

## Skill Maintenance

- [x] Added a Teardown section to `skills/atomic/submit-workflow/SKILL.md` covering the cancel-then-wait rule, the PENDING-may-be-dead rule, `npa cleanup`, and the drain preview. Also added four entries to `docs/workbench/troubleshooting/known-footguns.md` and a teardown section to the README.

## Relationship to #240

[PR #240](https://github.com/nebius/nebius-physical-ai/pull/240) fixes the causes that produced this run's stuck job (registry 403 preflight, accelerator resolution, the SkyPilot controller hang). This PR fixes the teardown path and makes a stuck job diagnosable regardless of cause. They touch mostly different files and are independent; both branch from `main`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0b84b02-991e-4f73-ade8-af9df20d3b30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0b84b02-991e-4f73-ade8-af9df20d3b30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

