### PR TITLE
Fix the Publish public images credential, and clear the Node 20 deprecation repo-wide

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,7 +9,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install gitleaks

--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -57,10 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -84,10 +84,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.omniverse_payload_scan_image != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload the report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: omniverse-payload-report
           path: omniverse-payload-report.json
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Trivy config scan
         uses: aquasecurity/trivy-action@v0.36.0
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload config SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-config.sarif
           category: trivy-config
@@ -211,7 +211,7 @@ jobs:
 
       - name: Upload image SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-${{ matrix.name }}.sarif
           category: trivy-image-${{ matrix.name }}

--- a/.github/workflows/publish-public-images.yml
+++ b/.github/workflows/publish-public-images.yml
@@ -21,12 +21,25 @@
 # real rehearsal: it resolves the plan, proves the source credential, reads every pinned
 # source tag, and runs the gate. Only the copy and the public verification are skipped.
 #
-# Required secret to actually copy:
-#   NEBIUS_CR_TOKEN — a Nebius CR token (static key or access token) with viewer
-#                     on the source registry, used as the docker password (user
-#                     "iam"). GHCR push uses the built-in GITHUB_TOKEN. A dry run
-#                     without it still prints the plan, but says it could not check
-#                     the source registry.
+# SOURCE REGISTRY CREDENTIAL. Nebius CR authenticates `docker login` as user "iam" with
+# either kind of secret below. They differ only in how long they survive, which is the
+# whole game for a workflow that is dispatched by hand months apart:
+#
+#   NEBIUS_SA_CREDENTIALS_JSON — preferred. An authorized-key credentials JSON for a
+#                     service account holding viewer on the source registry. The job
+#                     mints a fresh access token during the run, so nothing expires
+#                     between dispatches and no one has to re-paste anything. Opt-in:
+#                     the job falls back to NEBIUS_CR_TOKEN when this is unset.
+#   NEBIUS_CR_TOKEN — a pre-issued token. This MUST be a long-lived static key
+#                     (`nebius iam static-key issue --service=CONTAINER_REGISTRY`,
+#                     6 months by default), NOT the output of `nebius iam
+#                     get-access-token`: an access token lives 12 hours, so a stored
+#                     one is already dead by the next manual dispatch. That is exactly
+#                     how the first run of this workflow failed — 23 identical
+#                     UNAUTHORIZED reads, nothing published.
+#
+# GHCR push uses the built-in GITHUB_TOKEN. A dry run with neither source secret still
+# prints the plan, but says it could not check the source registry.
 
 name: Publish public images
 
@@ -51,10 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -80,25 +93,61 @@ jobs:
 
       - name: Login to GHCR
         if: ${{ inputs.dry_run == false }}
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ghcr.io -u "${{ github.actor }}" --password-stdin
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: printf '%s' "$GH_TOKEN" | crane auth login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      # Runs in dry-run too, so the safe rehearsal actually rehearses the credential.
-      # NEBIUS_CR_TOKEN is short-lived, and a dry run that skipped the login could only
-      # ever tell you the plan was well-formed.
-      - name: Login to Nebius source registry
+      # Runs in dry-run too, so the safe rehearsal actually rehearses the credential. A dry
+      # run that skipped this could only ever tell you the plan was well-formed, which was
+      # never the thing that broke.
+      #
+      # Secrets arrive through `env:` rather than `${{ }}` interpolation, which would splice
+      # them into the script text where a quote or newline changes what runs.
+      - name: Authenticate to the Nebius source registry
         id: source-login
+        env:
+          NEBIUS_SA_CREDENTIALS_JSON: ${{ secrets.NEBIUS_SA_CREDENTIALS_JSON }}
+          NEBIUS_CR_TOKEN: ${{ secrets.NEBIUS_CR_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [ -z "${{ secrets.NEBIUS_CR_TOKEN }}" ]; then
-            if [ "${{ inputs.dry_run }}" = "true" ]; then
-              echo "::notice::NEBIUS_CR_TOKEN is not set, so this dry run cannot check the source registry."
+          set -euo pipefail
+          umask 077
+          token_file="$RUNNER_TEMP/npa-source-registry-token"
+          sa_file="$RUNNER_TEMP/nebius-sa-credentials.json"
+          trap 'rm -f "$token_file" "$sa_file"' EXIT
+
+          if [ -n "${NEBIUS_SA_CREDENTIALS_JSON:-}" ]; then
+            # Minting in-run is the only credential path with no expiry to manage: the SA key
+            # is long-lived and the token it yields only has to outlive this job.
+            echo "Minting a fresh access token from NEBIUS_SA_CREDENTIALS_JSON."
+            curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
+            export PATH="$HOME/.nebius/bin:$PATH"
+            printf '%s' "$NEBIUS_SA_CREDENTIALS_JSON" > "$sa_file"
+            nebius profile create \
+              --endpoint api.nebius.cloud \
+              --service-account-file "$sa_file" \
+              --profile publish-public-images
+            nebius --profile publish-public-images iam get-access-token > "$token_file"
+          elif [ -n "${NEBIUS_CR_TOKEN:-}" ]; then
+            printf '%s' "$NEBIUS_CR_TOKEN" > "$token_file"
+          else
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::notice::Neither NEBIUS_SA_CREDENTIALS_JSON nor NEBIUS_CR_TOKEN is set, so this dry run cannot check the source registry."
               echo "available=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "NEBIUS_CR_TOKEN secret is required to copy from the Nebius source registry" >&2
+            echo "A source registry credential (NEBIUS_SA_CREDENTIALS_JSON or NEBIUS_CR_TOKEN) is required to copy" >&2
             exit 1
           fi
+
+          # Offline verdict on the credential itself, before the ~2-minute manifest sweep.
+          # An expired access token is the one failure this workflow has actually had, and
+          # it is readable from the token's own `exp` claim -- so report it in a second,
+          # by name, instead of as 23 indistinguishable UNAUTHORIZED lines.
+          python -m npa.deploy.publish_public --describe-credential < "$token_file"
+
           for host in cr.eu-north1.nebius.cloud cr.us-central1.nebius.cloud; do
-            echo "${{ secrets.NEBIUS_CR_TOKEN }}" | crane auth login "$host" -u iam --password-stdin
+            crane auth login "$host" -u iam --password-stdin < "$token_file"
           done
           echo "available=true" >> "$GITHUB_OUTPUT"
 

--- a/docs/workbench/container-packaging.md
+++ b/docs/workbench/container-packaging.md
@@ -244,17 +244,51 @@ The copy path is bracketed by two checks it runs itself. Before writing anything
 reads every **source** manifest, because `crane auth login` writes a config file and
 exits 0 for any string without ever contacting the registry — so a stale credential
 would otherwise surface partway through the copy loop with some packages already
-created. `UNAUTHORIZED` means the token is dead, `MANIFEST_UNKNOWN` means the pinned
-tag was never pushed. Run it alone with `--preflight`, and mint a fresh source token
-with:
+created. `UNAUTHORIZED` on *every* image means the credential never resolved to an
+identity at all; `UNAUTHORIZED` on *some* means the identity lacks `viewer` on those
+repositories; `MANIFEST_UNKNOWN` means the pinned tag was never pushed. Run it alone
+with `--preflight`. Locally, mint a fresh source token with:
 
 ```bash
 nebius iam get-access-token | crane auth login cr.eu-north1.nebius.cloud -u iam --password-stdin
 ```
 
-In CI that token is the `NEBIUS_CR_TOKEN` repository secret (GHCR push uses the
-built-in `GITHUB_TOKEN`). It is short-lived, so re-mint it rather than assuming the
-stored value still works. You do not have to guess: the `Publish public images`
+### The CI credential must not be an access token
+
+**Do not put the output of `nebius iam get-access-token` in a CI secret.** An access
+token lives **12 hours**, and `Publish public images` is dispatched by hand — so a
+stored one is dead long before the next run. That is precisely how the workflow's first
+run failed: all 23 source reads returned `UNAUTHORIZED: authentication required: failed
+to get profile`, which is Nebius CR's way of saying the bearer token resolved to no
+identity. The preflight caught it before anything was written, so nothing was published
+and no package was created.
+
+Use one of the two durable credentials instead (GHCR push always uses the built-in
+`GITHUB_TOKEN`):
+
+| Secret | What it is | Lifetime |
+| --- | --- | --- |
+| `NEBIUS_SA_CREDENTIALS_JSON` | authorized-key credentials JSON for a service account with `viewer` on the source registry; the job mints a fresh token per run | no expiry to manage |
+| `NEBIUS_CR_TOKEN` | a static key issued for the registry service | 6 months by default, up to 3 years |
+
+The workflow prefers `NEBIUS_SA_CREDENTIALS_JSON` and falls back to `NEBIUS_CR_TOKEN`.
+Issue a static key with:
+
+```bash
+nebius iam static-key issue \
+  --account-service-account-id=<service-account-id> \
+  --service=CONTAINER_REGISTRY
+```
+
+Either way the credential is checked offline before the two-minute manifest sweep, so an
+expired token is named as such in seconds rather than arriving as a wall of identical
+`UNAUTHORIZED` lines:
+
+```bash
+printf '%s' "$TOKEN" | python -m npa.deploy.publish_public --describe-credential
+```
+
+You do not have to guess whether a real run would work: the `Publish public images`
 workflow's default **dry run is a full rehearsal** — it resolves the plan, logs in to
 the source registry, preflights every pinned tag, and runs the Isaac gate, skipping
 only the copy and the public verification. A green dry run means the real run will get

--- a/npa/src/npa/deploy/publish_public.py
+++ b/npa/src/npa/deploy/publish_public.py
@@ -24,15 +24,23 @@ The copy path preflights the source registry first and verifies the result after
 stale credential fails before anything is written and a copy cannot report success while
 nothing is publicly pullable. Making the packages public is the one step that cannot be
 automated (see ``package_settings_url``); the verification prints a click-through list.
+
+``--describe-credential`` reads a source-registry credential on stdin and reports its
+expiry offline, because the credential is what actually breaks: a Nebius access token
+lives 12 hours, so anything stored in CI must be a static key issued for
+CONTAINER_REGISTRY instead (see ``describe_credential``).
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import json
 import shutil
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -135,6 +143,87 @@ def preflight_sources(plan: list[PublishItem]) -> list[tuple[PublishItem, str]]:
         if not ok:
             failures.append((item, detail))
     return failures
+
+
+# --------------------------------------------------------------------------------------
+# Source credential inspection
+#
+# The source registry credential is the one thing about a publish that expires on its own,
+# and the two credentials Nebius accepts for `docker login -u iam` are wildly different in
+# that respect: an access token from `nebius iam get-access-token` lives 12 HOURS, while a
+# static key issued for CONTAINER_REGISTRY lives 6 months by default. A manual-dispatch
+# workflow holding a stored access token is therefore expired essentially always -- which is
+# exactly how run #1 failed, with 23 identical UNAUTHORIZED lines after a two-minute sweep.
+#
+# An access token is a JWT, so its expiry is readable offline. Checking it before the sweep
+# turns that into an immediate, unambiguous verdict, and -- more importantly -- names the
+# remedy that does not expire again next week.
+# --------------------------------------------------------------------------------------
+
+
+def _decode_jwt_expiry(token: str) -> int | None:
+    """The ``exp`` claim of a JWT-shaped bearer token, or ``None``.
+
+    Best-effort and deliberately non-verifying: the goal is to read the expiry the issuer
+    already put in the token, not to validate it. A static key is an opaque string rather
+    than a JWT, so returning ``None`` is the normal answer for the credential we actually
+    want in CI, and must never be reported as a problem.
+    """
+    parts = token.strip().split(".")
+    if len(parts) != 3:
+        return None
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)  # base64url in a JWT is unpadded
+    try:
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return None
+    expiry = claims.get("exp") if isinstance(claims, dict) else None
+    return expiry if isinstance(expiry, int) else None
+
+
+def describe_credential(token: str, *, now: float | None = None) -> tuple[bool, str]:
+    """Whether ``token`` is usable, and a one-line verdict that never echoes the secret.
+
+    ``False`` is returned only when the credential is *provably* dead — a JWT whose ``exp``
+    has passed. Anything unreadable is reported as usable, because this check exists to
+    convert one specific recurring failure into a fast, precise message, not to become a
+    second gate that can wrongly refuse a working credential.
+    """
+    now = time.time() if now is None else now
+    token = token.strip()
+    if not token:
+        return False, "the credential is empty"
+
+    expiry = _decode_jwt_expiry(token)
+    if expiry is None:
+        return True, (
+            "the credential has no readable expiry, which is expected for a static key "
+            "(`nebius iam static-key issue --service=CONTAINER_REGISTRY`)"
+        )
+    remaining = expiry - now
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(expiry))
+    if remaining <= 0:
+        return False, (
+            f"the credential EXPIRED at {stamp} ({_approx_duration(-remaining)} ago). A "
+            "Nebius access token lives 12 hours, so a stored one is dead by the next "
+            "dispatch; issue a long-lived static key instead:\n"
+            "  nebius iam static-key issue --account-service-account-id=<sa-id> "
+            "--service=CONTAINER_REGISTRY"
+        )
+    return True, (
+        f"the credential is an access token valid until {stamp} "
+        f"({_approx_duration(remaining)} left). It will not survive to the next dispatch — "
+        "a static key issued for CONTAINER_REGISTRY lasts 6 months."
+    )
+
+
+def _approx_duration(seconds: float) -> str:
+    seconds = max(0.0, seconds)
+    for unit, size in (("d", 86400.0), ("h", 3600.0), ("m", 60.0)):
+        if seconds >= size:
+            return f"{seconds / size:.0f}{unit}"
+    return f"{seconds:.0f}s"
 
 
 # --------------------------------------------------------------------------------------
@@ -321,6 +410,17 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--describe-credential",
+        action="store_true",
+        help=(
+            "Read a source-registry credential on stdin and report whether it is usable, "
+            "without contacting any registry and without echoing the secret. Exits non-zero "
+            "only when the credential is provably expired. Runs before the preflight so an "
+            "expired 12-hour access token fails in a second with the reason, instead of as "
+            "a wall of UNAUTHORIZED lines."
+        ),
+    )
+    parser.add_argument(
         "--checklist",
         action="store_true",
         help=(
@@ -329,6 +429,13 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+
+    # Before the plan: this mode inspects a credential and touches neither registry, so it
+    # must not require a target registry it has no use for.
+    if args.describe_credential:
+        usable, verdict = describe_credential(sys.stdin.read())
+        print(f"Source registry credential: {verdict}", file=sys.stdout if usable else sys.stderr)
+        return 0 if usable else 1
 
     if not (args.target or "").strip():
         parser.error("no target registry; pass --target or set NPA_PUBLIC_REGISTRY")
@@ -397,17 +504,35 @@ def _preflight_or_explain(plan: list[PublishItem]) -> bool:
     failures = preflight_sources(plan)
     if not failures:
         return False
-    print(
+    lines = [
         f"\n{len(failures)} of {len(plan)} source image(s) could not be read; nothing was "
-        "copied.\n"
-        "UNAUTHORIZED means the source registry credential is missing or expired — mint a\n"
-        "fresh one and log in again:\n"
-        "  nebius iam get-access-token | crane auth login <registry-host> -u iam "
-        "--password-stdin\n"
-        "MANIFEST_UNKNOWN means the pinned tag is not in the source registry — build and\n"
-        "push that image, or correct its pin, before publishing.",
-        file=sys.stderr,
-    )
+        "copied."
+    ]
+    # Whether EVERY read failed is the diagnostic, not just the registry's error code: one
+    # UNAUTHORIZED could be a per-repository grant, but all of them means the credential
+    # never resolved to an identity at all ("failed to get profile"), so there is no point
+    # looking at roles or at the tags.
+    if len(failures) == len(plan) and all("UNAUTHORIZED" in detail for _, detail in failures):
+        lines.append(
+            "Every read failed with UNAUTHORIZED, so this is the credential rather than any\n"
+            "single tag or grant — the token did not resolve to an identity.\n"
+            "In CI, prefer a credential that does not expire between dispatches. An access\n"
+            "token from `nebius iam get-access-token` lives 12 HOURS, so a stored one is dead\n"
+            "by the next manual run; a static key issued for the registry lasts 6 months:\n"
+            "  nebius iam static-key issue --account-service-account-id=<sa-id> "
+            "--service=CONTAINER_REGISTRY\n"
+            "Locally, re-mint and log in again:\n"
+            "  nebius iam get-access-token | crane auth login <registry-host> -u iam "
+            "--password-stdin"
+        )
+    else:
+        lines.append(
+            "UNAUTHORIZED on SOME images means the credential works but its identity lacks\n"
+            "viewer on those repositories — fix the role, not the token.\n"
+            "MANIFEST_UNKNOWN means the pinned tag is not in the source registry — build and\n"
+            "push that image, or correct its pin, before publishing."
+        )
+    print("\n".join(lines), file=sys.stderr)
     return True
 
 

--- a/npa/tests/deploy/test_public_publish.py
+++ b/npa/tests/deploy/test_public_publish.py
@@ -17,6 +17,8 @@ membership is empty.
 
 from __future__ import annotations
 
+import base64
+import json
 from pathlib import Path
 
 import pytest
@@ -575,3 +577,180 @@ def test_the_checklist_labels_a_package_the_way_its_settings_page_does() -> None
         "(https://github.com/orgs/nebius/packages/container/"
         "nebius-physical-ai%2Fnpa-lerobot/settings)"
     )
+
+
+# --------------------------------------------------------------------------------------
+# Source credential expiry
+#
+# The workflow's first real dispatch failed with 23 identical
+# "UNAUTHORIZED ... failed to get profile" reads, because the stored NEBIUS_CR_TOKEN was a
+# `nebius iam get-access-token` value and those live 12 hours. Nothing was published (the
+# preflight held), but the diagnosis cost a two-minute sweep and reads like a registry or
+# permissions problem rather than "the secret is a kind of credential that cannot work
+# here". These pin the offline verdict that replaces that.
+# --------------------------------------------------------------------------------------
+
+
+def _jwt(exp: int | None) -> str:
+    """A JWT-shaped token, unsigned — describe_credential must never verify signatures."""
+
+    def segment(payload: dict[str, object]) -> str:
+        raw = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+        return raw.rstrip("=")  # real JWTs are unpadded base64url
+
+    claims: dict[str, object] = {"sub": "serviceaccount-abc"}
+    if exp is not None:
+        claims["exp"] = exp
+    return f"{segment({'alg': 'RS256'})}.{segment(claims)}.c2lnbmF0dXJl"
+
+
+def test_an_expired_access_token_is_reported_as_expired_not_as_a_registry_problem() -> None:
+    from npa.deploy.publish_public import describe_credential
+
+    now = 1_800_000_000.0
+    usable, verdict = describe_credential(_jwt(int(now) - 6 * 86400), now=now)
+
+    assert not usable
+    assert "EXPIRED" in verdict
+    assert "6d ago" in verdict
+    # The remedy has to be the credential that does not expire again next week, or the fix
+    # is to paste another 12-hour token and rediscover this in a month.
+    assert "static-key issue" in verdict
+    assert "--service=CONTAINER_REGISTRY" in verdict
+
+
+def test_a_valid_access_token_is_usable_but_still_flagged_as_too_short_lived() -> None:
+    """It works right now, which is the trap: it will not survive to the next dispatch."""
+    from npa.deploy.publish_public import describe_credential
+
+    now = 1_800_000_000.0
+    usable, verdict = describe_credential(_jwt(int(now) + 4 * 3600), now=now)
+
+    assert usable
+    assert "4h left" in verdict
+    assert "next dispatch" in verdict
+
+
+def test_an_opaque_static_key_is_usable_and_is_not_called_a_problem() -> None:
+    """A static key is not a JWT, so having no readable expiry is the GOOD outcome.
+
+    Treating "unreadable" as suspect would turn this diagnostic into a gate that refuses
+    the one credential CI is supposed to use.
+    """
+    from npa.deploy.publish_public import describe_credential
+
+    usable, verdict = describe_credential("nbstatic-opaque-key-value")
+
+    assert usable
+    assert "static key" in verdict
+    assert "EXPIRED" not in verdict
+
+
+def test_a_malformed_credential_is_never_guessed_to_be_expired() -> None:
+    """Three dots and garbage inside must fall back to "no readable expiry", not a verdict."""
+    from npa.deploy.publish_public import describe_credential
+
+    usable, verdict = describe_credential("not-base64.$$$not-json$$$.sig")
+
+    assert usable
+    assert "no readable expiry" in verdict
+
+
+def test_an_empty_credential_is_refused() -> None:
+    from npa.deploy.publish_public import describe_credential
+
+    usable, verdict = describe_credential("   \n")
+
+    assert not usable
+    assert "empty" in verdict
+
+
+def test_describe_credential_never_echoes_the_secret() -> None:
+    """This runs in CI logs, so the verdict must carry the expiry and nothing else."""
+    from npa.deploy.publish_public import describe_credential
+
+    for token in (_jwt(1), _jwt(4_000_000_000), "nbstatic-super-secret", _jwt(None)):
+        _, verdict = describe_credential(token)
+        assert token not in verdict
+        for part in token.split("."):
+            assert len(part) < 8 or part not in verdict
+
+
+def test_the_credential_check_exits_non_zero_on_an_expired_token(monkeypatch, capsys) -> None:
+    """The workflow relies on the exit code to stop before the manifest sweep."""
+    import io
+
+    from npa.deploy import publish_public
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(_jwt(1)))
+    rc = publish_public.main(["--describe-credential"])
+
+    assert rc == 1
+    assert "EXPIRED" in capsys.readouterr().err
+
+
+def test_the_credential_check_needs_no_target_registry(monkeypatch) -> None:
+    """It contacts nothing, so requiring a --target it cannot use would be a papercut that
+    makes the check awkward to run by hand."""
+    import io
+
+    from npa.deploy import publish_public
+
+    monkeypatch.delenv("NPA_PUBLIC_REGISTRY", raising=False)
+    monkeypatch.setattr("sys.stdin", io.StringIO("nbstatic-opaque-key-value"))
+
+    assert publish_public.main(["--target", "", "--describe-credential"]) == 0
+
+
+def test_the_credential_check_copies_nothing(monkeypatch) -> None:
+    import io
+
+    from npa.deploy import publish_public
+
+    def explode(item) -> None:  # pragma: no cover - must not run
+        raise AssertionError("--describe-credential must not copy anything")
+
+    monkeypatch.setattr(publish_public, "_crane_copy", explode)
+    monkeypatch.setattr("sys.stdin", io.StringIO("nbstatic-opaque-key-value"))
+
+    assert publish_public.main(["--describe-credential"]) == 0
+
+
+def test_a_wholesale_unauthorized_preflight_blames_the_credential(monkeypatch, capsys) -> None:
+    """All reads failing is a different diagnosis from some failing, and the old message
+    conflated them — it recommended re-minting a 12-hour token, which is what caused it."""
+    from npa.deploy import publish_public
+
+    monkeypatch.setattr(
+        publish_public,
+        "_crane_manifest_readable",
+        lambda ref, **_: (False, "UNAUTHORIZED: authentication required: failed to get profile"),
+    )
+
+    rc = publish_public.main(["--target", "ghcr.io/example/workbench", "--preflight"])
+    err = capsys.readouterr().err
+
+    assert rc == 1
+    assert "Every read failed" in err
+    assert "static-key issue" in err
+    assert "lacks\nviewer" not in err, "a per-repository role hint would misdirect here"
+
+
+def test_a_partial_preflight_failure_blames_the_role_or_the_tag(monkeypatch, capsys) -> None:
+    from npa.deploy import publish_public
+
+    plan = publish_public.build_publish_plan(target_registry="ghcr.io/example/workbench")
+    broken = plan[0].source_ref
+
+    monkeypatch.setattr(
+        publish_public,
+        "_crane_manifest_readable",
+        lambda ref, **_: (False, "MANIFEST_UNKNOWN: manifest unknown") if ref == broken else (True, "ok"),
+    )
+
+    rc = publish_public.main(["--target", "ghcr.io/example/workbench", "--preflight"])
+    err = capsys.readouterr().err
+
+    assert rc == 1
+    assert "MANIFEST_UNKNOWN" in err
+    assert "Every read failed" not in err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What failed

[Run #1 of `Publish public images`](https://github.com/nebius/nebius-physical-ai/actions/runs/30765750564) failed at **Preflight the source registry credential and every pinned tag**. All 23 source reads returned the same thing:

```
UNAUTHORIZED: authentication required: failed to get profile
```

`failed to get profile` is Nebius CR's phrasing for "this bearer token resolved to no identity". Every read failing identically makes it a credential-level fault, not a per-repository grant or a missing tag.

**The credential was the wrong *kind*.** `NEBIUS_CR_TOKEN` held the output of `nebius iam get-access-token`, and [a Nebius access token lives 12 hours](https://docs.nebius.com/iam/authorization/access-tokens). This workflow is manual-dispatch only, so a stored access token is essentially always expired by the time someone runs it. [Nebius' own CI/CD guidance](https://docs.nebius.com/container-registry/authentication#working-in-a-ci/cd-environment) says to use a service account and either a long-lived static key or a token minted per run — the workflow's docs said "static key or access token" as though the choice were cosmetic.

Nothing was published and no GHCR package was created: the preflight gate did its job, which matters because GHCR publication is irreversible.

## The credential fix

**A credential that survives between dispatches.** Two sources, preferred in order:

| Secret | What it is | Lifetime |
| --- | --- | --- |
| `NEBIUS_SA_CREDENTIALS_JSON` | authorized-key credentials JSON for a service account with `viewer` on the source registry; the job mints a fresh token during the run | nothing to expire |
| `NEBIUS_CR_TOKEN` | a static key (`nebius iam static-key issue --service=CONTAINER_REGISTRY`) | 6 months default, up to 3 years |

The service-account path is opt-in and inert until that secret exists; `NEBIUS_CR_TOKEN` remains the fallback.

**A one-second diagnosis instead of a two-minute one.** An access token is a JWT, so its expiry is readable offline. `--describe-credential` reads a credential on stdin and exits non-zero only when it is *provably* expired. Against the token that actually failed:

```
Source registry credential: the credential EXPIRED at 2026-07-27T20:56:05Z (6d ago). A
Nebius access token lives 12 hours, so a stored one is dead by the next dispatch; issue a
long-lived static key instead:
  nebius iam static-key issue --account-service-account-id=<sa-id> --service=CONTAINER_REGISTRY
```

An opaque static key has no readable expiry, which is the *correct* outcome for the credential CI should hold, so it is never reported as a problem — this stays a fast diagnostic and does not become a second gate that can refuse a working credential.

**A preflight message that points at the right thing.** It now separates every read failing (the credential resolved to no identity) from some failing (a per-repository role, or a tag that was never pushed). The old text conflated them and recommended re-minting the 12-hour token that caused the failure.

**Secret handling.** Secrets reach the script through `env:` rather than `${{ }}` interpolation, which splices them into the script text where a quote or newline changes what runs.

## The Node 20 deprecation

The failed run's second annotation was GitHub's Node 20 warning. Which actions are actually on Node 20 was read off completed run logs rather than guessed — the publish job named `checkout@v4` and `setup-python@v5` but **not** `setup-crane@v0.4`, and `image-security-scan` additionally named `codeql-action/upload-sarif@v3`. `upload-artifact@v4` is `node20` in its own `action.yml` but sits in a dispatch-only job, so it had never surfaced in a log.

| Action | Change | Note |
| --- | --- | --- |
| `actions/checkout` | v4 → v6 | the standard the other nine workflows already use |
| `actions/setup-python` | v5 → v6 | likewise |
| `github/codeql-action/upload-sarif` | v3 → v4 | [drop-in Node 24 successor](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/), same inputs |
| `actions/upload-artifact` | v4 → v5 | first Node 24 major |

`aquasecurity/trivy-action` and `imjasonh/setup-crane` need no change. No pre-Node-24 reference remains in `.github/workflows`, so the warning is cleared across the repo, not just in the workflow that failed.

## Verification

- 4744 tests pass with the repo's documented invocation (`cd npa && pytest tests`); `ruff check src tests` is clean. 18 of the 50 tests in `test_public_publish.py` are new: expiry decoding, the static-key non-verdict, malformed tokens never being guessed as expired, the verdict never echoing the secret, exit codes, and both preflight diagnoses.
- `actionlint` passes on every workflow — and was confirmed to actually bite by running it against a deliberately broken file, so the clean pass is not a silent one.
- The new credential step is `shellcheck`-clean and was executed locally against all three cases with a stubbed `crane`: an expired access token fails in under a second with the reason and sets no `available` output; no credential in dry-run emits the notice and continues; a static key logs into both registry hosts and reports `available=true`. The `trap` leaves no secret files in `RUNNER_TEMP` in any case.

The service-account minting branch has **not** been exercised against live Nebius IAM — there are no Nebius credentials in this environment. It is guarded behind a secret that does not exist yet, so it cannot affect the current path, and the workflow's dry run is a full rehearsal, which is the safe place to exercise it first.

## To actually unblock a publish

Replace the `NEBIUS_CR_TOKEN` secret with a static key (or add `NEBIUS_SA_CREDENTIALS_JSON`), then dispatch with the default `dry_run=true`. That rehearses the plan, the credential, every pinned tag, and the Isaac gate without writing anything.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bbe8e73-aec1-459b-ba11-f14349825cd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bbe8e73-aec1-459b-ba11-f14349825cd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

