### PR TITLE
Unblock the mirror: skip unbuilt images, share one credential path, check it weekly

### DIFF
--- a/.github/workflows/public-mirror-health.yml
+++ b/.github/workflows/public-mirror-health.yml
@@ -1,0 +1,104 @@
+# Is the public mirror publishable RIGHT NOW? Read-only; copies nothing, ever.
+#
+# `Publish public images` is dispatched by hand, months apart, and both of its failures were
+# invisible until the moment someone tried to use it:
+#
+#   1. The stored source credential had expired. A Nebius access token lives 12 hours; even
+#      the static key that replaced it expires (6 months by default) and its expiry cannot be
+#      read out of the token, so nothing in the repo can warn about it.
+#   2. Five pinned images had never been built and pushed. The publish plan comes from the
+#      packaging contract -- what this repo BUILDS -- while the registry holds what someone
+#      PUSHED, and a new tool sits in that gap until its image is built.
+#
+# Discovering either on publish day costs a round trip through whoever owns the Nebius tenant.
+# This runs the same read-only preflight on a schedule so both show up early.
+#
+# WHAT FAILS THIS JOB, and what deliberately does not:
+#   - a dead or missing credential, or a denial on any image: FAILS. Actionable and urgent,
+#     and it is the early warning the static key's invisible expiry otherwise denies us.
+#   - images absent from the registry (NAME_UNKNOWN / MANIFEST_UNKNOWN): reported, does NOT
+#     fail. Those are expected for a tool that landed before its image was built, and a job
+#     that is permanently red for a known reason teaches everyone to ignore it.
+# That split is exactly what `--skip-missing` means, so this is the publisher's own logic
+# rather than a second implementation that could disagree with it.
+
+name: Public mirror health
+
+on:
+  schedule:
+    # Weekly. Frequent enough to catch a credential that expired since the last check well
+    # before someone needs it; rare enough that ~23 manifest reads are free.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: Source registry credential and pinned tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: python -m pip install -e ./npa
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Authenticate to the Nebius source registry
+        env:
+          NEBIUS_SA_CREDENTIALS_JSON: ${{ secrets.NEBIUS_SA_CREDENTIALS_JSON }}
+          NEBIUS_CR_TOKEN: ${{ secrets.NEBIUS_CR_TOKEN }}
+        run: ./npa/scripts/ci_source_registry_login.sh
+
+      # Writes nothing. --skip-missing is what makes absence non-fatal while keeping a
+      # credential or role fault fatal; the skipped images are listed in the log.
+      - name: Preflight every pinned source tag
+        id: preflight
+        run: |
+          python -m npa.deploy.publish_public \
+            --target "ghcr.io/${GITHUB_REPOSITORY,,}" \
+            --skip-missing --preflight 2>&1 | tee "$RUNNER_TEMP/preflight.txt"
+
+      - name: Summarise
+        if: always()
+        run: |
+          {
+            echo "## Public mirror preflight"
+            echo
+            if [ "${{ steps.preflight.outcome }}" = "success" ]; then
+              echo "The source credential works and every readable pin resolves."
+            else
+              echo "**The source registry could not be read.** This is a credential or role"
+              echo "fault, not a missing image — see the log."
+              echo
+              echo "A static key issued for CONTAINER_REGISTRY expires (6 months by default)"
+              echo "and its expiry is not readable from the token, so this job is the only"
+              echo "warning. Re-issue and update the \`NEBIUS_CR_TOKEN\` secret:"
+              echo
+              echo '```'
+              echo "nebius iam static-key issue \\"
+              echo "  --account-service-account-id=<service-account-id> \\"
+              echo "  --service=CONTAINER_REGISTRY"
+              echo '```'
+            fi
+            echo
+            if grep -q '^Skipping ' "$RUNNER_TEMP/preflight.txt" 2>/dev/null; then
+              echo "### Pinned images not in the source registry"
+              echo
+              echo "Declared in the packaging contract but never built and pushed, so they are"
+              echo "absent from the mirror and will fail at pull time for consumers:"
+              echo
+              echo '```'
+              grep -A100 '^Skipping ' "$RUNNER_TEMP/preflight.txt" | grep '  cr\.' || true
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-public-images.yml
+++ b/.github/workflows/publish-public-images.yml
@@ -54,6 +54,14 @@ on:
         description: "Dry run (plan only, no copy)"
         type: boolean
         default: true
+      skip_missing:
+        description: >-
+          Publish what exists, skipping images the source registry does not have yet.
+          The plan comes from the packaging contract (what the repo BUILDS), so a tool
+          that landed before its image was built otherwise blocks every ready image.
+          A denial is never skipped.
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -158,7 +166,11 @@ jobs:
       # packages already created. It writes nothing, so it is safe in dry-run.
       - name: Preflight the source registry credential and every pinned tag
         if: ${{ steps.source-login.outputs.available == 'true' }}
-        run: python -m npa.deploy.publish_public --target "${{ steps.target.outputs.value }}" --preflight
+        run: |
+          python -m npa.deploy.publish_public \
+            --target "${{ steps.target.outputs.value }}" \
+            ${{ inputs.skip_missing && '--skip-missing' || '' }} \
+            --preflight
 
       # Last line of defence before an irreversible action. publish_public trusts the
       # packaging contract, which is a statement about the Dockerfiles; this checks the
@@ -208,7 +220,10 @@ jobs:
       # publish; the summary below turns it into a click-through list.
       - name: Publish and verify
         if: ${{ inputs.dry_run == false }}
-        run: python -m npa.deploy.publish_public --target "${{ steps.target.outputs.value }}"
+        run: |
+          python -m npa.deploy.publish_public \
+            --target "${{ steps.target.outputs.value }}" \
+            ${{ inputs.skip_missing && '--skip-missing' || '' }}
 
       - name: Write the visibility checklist to the job summary
         if: ${{ failure() && inputs.dry_run == false }}
@@ -232,6 +247,7 @@ jobs:
           # Only the packages that are still private, so the list shrinks as they are flipped.
           python -m npa.deploy.publish_public \
             --target "${{ steps.target.outputs.value }}" \
+            ${{ inputs.skip_missing && '--skip-missing' || '' }} \
             --verify-public --checklist 2>/dev/null \
             | grep '^- \[ \]' >> "$GITHUB_STEP_SUMMARY" || true
           cat >> "$GITHUB_STEP_SUMMARY" <<'MD'

--- a/.github/workflows/publish-public-images.yml
+++ b/.github/workflows/publish-public-images.yml
@@ -116,48 +116,9 @@ jobs:
         env:
           NEBIUS_SA_CREDENTIALS_JSON: ${{ secrets.NEBIUS_SA_CREDENTIALS_JSON }}
           NEBIUS_CR_TOKEN: ${{ secrets.NEBIUS_CR_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -euo pipefail
-          umask 077
-          token_file="$RUNNER_TEMP/npa-source-registry-token"
-          sa_file="$RUNNER_TEMP/nebius-sa-credentials.json"
-          trap 'rm -f "$token_file" "$sa_file"' EXIT
-
-          if [ -n "${NEBIUS_SA_CREDENTIALS_JSON:-}" ]; then
-            # Minting in-run is the only credential path with no expiry to manage: the SA key
-            # is long-lived and the token it yields only has to outlive this job.
-            echo "Minting a fresh access token from NEBIUS_SA_CREDENTIALS_JSON."
-            curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
-            export PATH="$HOME/.nebius/bin:$PATH"
-            printf '%s' "$NEBIUS_SA_CREDENTIALS_JSON" > "$sa_file"
-            nebius profile create \
-              --endpoint api.nebius.cloud \
-              --service-account-file "$sa_file" \
-              --profile publish-public-images
-            nebius --profile publish-public-images iam get-access-token > "$token_file"
-          elif [ -n "${NEBIUS_CR_TOKEN:-}" ]; then
-            printf '%s' "$NEBIUS_CR_TOKEN" > "$token_file"
-          else
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "::notice::Neither NEBIUS_SA_CREDENTIALS_JSON nor NEBIUS_CR_TOKEN is set, so this dry run cannot check the source registry."
-              echo "available=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "A source registry credential (NEBIUS_SA_CREDENTIALS_JSON or NEBIUS_CR_TOKEN) is required to copy" >&2
-            exit 1
-          fi
-
-          # Offline verdict on the credential itself, before the ~2-minute manifest sweep.
-          # An expired access token is the one failure this workflow has actually had, and
-          # it is readable from the token's own `exp` claim -- so report it in a second,
-          # by name, instead of as 23 indistinguishable UNAUTHORIZED lines.
-          python -m npa.deploy.publish_public --describe-credential < "$token_file"
-
-          for host in cr.eu-north1.nebius.cloud cr.us-central1.nebius.cloud; do
-            crane auth login "$host" -u iam --password-stdin < "$token_file"
-          done
-          echo "available=true" >> "$GITHUB_OUTPUT"
+          # A dry run without secrets still reports the plan and says what it could not check.
+          REQUIRE_CREDENTIAL: ${{ inputs.dry_run == false }}
+        run: ./npa/scripts/ci_source_registry_login.sh
 
       # `crane auth login` writes a config file and exits 0 for any string -- it never
       # contacts the registry -- so the step above proves nothing about NEBIUS_CR_TOKEN.

--- a/docs/workbench/container-packaging.md
+++ b/docs/workbench/container-packaging.md
@@ -278,8 +278,9 @@ Use one of the two durable credentials instead (GHCR push always uses the built-
 | `NEBIUS_SA_CREDENTIALS_JSON` | authorized-key credentials JSON for a service account with `viewer` on the source registry; the job mints a fresh token per run | no expiry to manage |
 | `NEBIUS_CR_TOKEN` | a static key issued for the registry service | 6 months by default, up to 3 years |
 
-The workflow prefers `NEBIUS_SA_CREDENTIALS_JSON` and falls back to `NEBIUS_CR_TOKEN`.
-Issue a static key with:
+The workflow prefers `NEBIUS_SA_CREDENTIALS_JSON` and falls back to `NEBIUS_CR_TOKEN`; both
+are resolved by `npa/scripts/ci_source_registry_login.sh`, shared by the publish and health
+workflows so the credential path cannot drift between them. Issue a static key with:
 
 ```bash
 nebius iam static-key issue \
@@ -287,12 +288,31 @@ nebius iam static-key issue \
   --service=CONTAINER_REGISTRY
 ```
 
+> **A static key expires and nothing in this repo can see it coming.** Its lifetime is set at
+> issue time (6 months by default) and is *not* readable from the token, unlike an access
+> token's `exp`. So record the expiry date wherever you keep operational reminders — not in
+> the repo, which must not carry tenant identifiers — and rely on the **Public mirror health**
+> workflow for the early warning: it runs the same read-only preflight weekly and goes red on
+> a dead credential, months before anyone next needs to publish. Verify the service account
+> holds `viewer` on the source registry; without it every read is denied.
+
 Either way the credential is checked offline before the two-minute manifest sweep, so an
 expired token is named as such in seconds rather than arriving as a wall of identical
 `UNAUTHORIZED` lines:
 
 ```bash
 printf '%s' "$TOKEN" | python -m npa.deploy.publish_public --describe-credential
+```
+
+That check is a fast diagnostic, not proof the credential *works* — an opaque static key has
+no expiry to read, so it always passes. Prove a credential by reading a real manifest with it,
+and point `DOCKER_CONFIG` at an empty directory first so the read cannot succeed on an ambient
+login you already had:
+
+```bash
+export DOCKER_CONFIG="$(mktemp -d)"
+printf '%s' "$TOKEN" | crane auth login cr.eu-north1.nebius.cloud -u iam --password-stdin
+crane manifest cr.eu-north1.nebius.cloud/<registry-id>/npa-lerobot:<tag> >/dev/null && echo ok
 ```
 
 You do not have to guess whether a real run would work: the `Publish public images`

--- a/docs/workbench/container-packaging.md
+++ b/docs/workbench/container-packaging.md
@@ -244,10 +244,17 @@ The copy path is bracketed by two checks it runs itself. Before writing anything
 reads every **source** manifest, because `crane auth login` writes a config file and
 exits 0 for any string without ever contacting the registry — so a stale credential
 would otherwise surface partway through the copy loop with some packages already
-created. `UNAUTHORIZED` on *every* image means the credential never resolved to an
-identity at all; `UNAUTHORIZED` on *some* means the identity lacks `viewer` on those
-repositories; `MANIFEST_UNKNOWN` means the pinned tag was never pushed. Run it alone
-with `--preflight`. Locally, mint a fresh source token with:
+created. Run it alone with `--preflight`. The registry's own error code says which
+of three unrelated problems you have:
+
+| Code | Meaning | Fix |
+| --- | --- | --- |
+| `UNAUTHORIZED` on **every** image | the credential resolved to no identity | replace the credential (below) |
+| `UNAUTHORIZED` on **some** images | the identity lacks `viewer` on those repositories | fix the role, not the token |
+| `NAME_UNKNOWN` | no such repository — the image was never built and pushed | build and push it, or `--skip-missing` |
+| `MANIFEST_UNKNOWN` | the repository exists but not this tag — the pin points at an unpushed build | correct the pin, or `--skip-missing` |
+
+Locally, mint a fresh source token with:
 
 ```bash
 nebius iam get-access-token | crane auth login cr.eu-north1.nebius.cloud -u iam --password-stdin
@@ -293,6 +300,34 @@ workflow's default **dry run is a full rehearsal** — it resolves the plan, log
 the source registry, preflights every pinned tag, and runs the Isaac gate, skipping
 only the copy and the public verification. A green dry run means the real run will get
 as far as writing.
+
+### The plan is what we build, not what is pushed
+
+The publish plan is derived from the packaging contract, which records what this repo
+**builds**. The registry holds what someone actually **pushed**. Those two diverge every
+time a new tool lands — Dockerfile, contract entry and version pin merge together, while
+building and pushing the image is a separate manual step (there is no build-and-push
+automation). A brand-new tool is therefore *expected* to be absent from the registry for a
+while, and the preflight reports it as `NAME_UNKNOWN`.
+
+By default that blocks the publish, which is the right default: silently mirroring a subset
+would make a pin regression that dropped an image look exactly like success. When the gap is
+known and intended, publish the ready images anyway:
+
+```bash
+python -m npa.deploy.publish_public --skip-missing            # or the workflow's skip_missing input
+```
+
+It drops only the images the registry has no copy of, prints each one with the reason, and
+copies the rest. Two properties matter here:
+
+- **A denial is never skipped.** `UNAUTHORIZED` / `DENIED` stops the run even with
+  `--skip-missing`, because a credential or role fault would otherwise quietly shrink the
+  published set. Denial also wins when a registry answers `NAME_UNKNOWN` for a repository
+  the identity cannot see.
+- **Skipped images are absent from the mirror**, so a consumer pointing `NPA_REGISTRY` at it
+  gets a pull failure for those tags until the image is built and the workflow re-run.
+  Adding one later costs one more visibility flip.
 
 or the `Publish public images` GitHub Actions workflow (manual dispatch,
 dry-run by default). **Consumers in any tenant** then pull the OSS images by

--- a/npa/scripts/ci_source_registry_login.sh
+++ b/npa/scripts/ci_source_registry_login.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Log `crane` into the Nebius source registry for a CI job, from whichever credential the
+# environment provides, and refuse to continue on one that is provably expired.
+#
+# Two workflows need this (publish-public-images and public-mirror-health) and getting it
+# wrong is how the mirror broke twice, so it lives here rather than inline in each.
+#
+# CREDENTIALS, preferred in the order tried. Nebius CR authenticates `docker login` as user
+# "iam" with either, and they differ only in how long they survive -- which is the whole game
+# for a workflow dispatched by hand months apart:
+#
+#   NEBIUS_SA_CREDENTIALS_JSON  an authorized-key credentials JSON for a service account with
+#                               viewer on the registry. A fresh access token is minted here,
+#                               in the job, so nothing expires between dispatches.
+#   NEBIUS_CR_TOKEN             a pre-issued token. Must be a long-lived static key
+#                               (`nebius iam static-key issue --service=CONTAINER_REGISTRY`,
+#                               6 months by default), NOT `nebius iam get-access-token`
+#                               output: an access token lives 12 hours, so a stored one is
+#                               dead by the next dispatch. That was the first failure.
+#
+# Other environment:
+#   REQUIRE_CREDENTIAL  "true" (default) to fail when neither secret is set; "false" to
+#                       report `available=false` and exit 0, so a rehearsal without secrets
+#                       still runs and says what it could not check.
+#   PYTHON              interpreter with `npa` importable (default `python`; locally use
+#                       npa/.venv/bin/python).
+#   GITHUB_OUTPUT       when set, `available=true|false` is appended for later `if:` guards.
+#   RUNNER_TEMP         scratch directory (default: a fresh mktemp -d).
+#
+# The token is never echoed: it is written to a 0600 file, piped from there, and shredded on
+# exit including on failure.
+set -euo pipefail
+umask 077
+
+PYTHON="${PYTHON:-python}"
+REQUIRE_CREDENTIAL="${REQUIRE_CREDENTIAL:-true}"
+scratch="${RUNNER_TEMP:-$(mktemp -d)}"
+token_file="${scratch}/npa-source-registry-token"
+sa_file="${scratch}/nebius-sa-credentials.json"
+trap 'rm -f "${token_file}" "${sa_file}"' EXIT
+
+# Both hosts: the primary registry and its mirror. Only the primary is read by the current
+# plan, but a --source-registry override pointing at the mirror must not need a second login.
+REGISTRY_HOSTS="${REGISTRY_HOSTS:-cr.eu-north1.nebius.cloud cr.us-central1.nebius.cloud}"
+
+emit_available() {
+  [ -n "${GITHUB_OUTPUT:-}" ] && echo "available=$1" >> "${GITHUB_OUTPUT}"
+  return 0
+}
+
+if [ -n "${NEBIUS_SA_CREDENTIALS_JSON:-}" ]; then
+  echo "Minting a fresh access token from NEBIUS_SA_CREDENTIALS_JSON."
+  if ! command -v nebius >/dev/null 2>&1; then
+    curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
+    export PATH="${HOME}/.nebius/bin:${PATH}"
+  fi
+  printf '%s' "${NEBIUS_SA_CREDENTIALS_JSON}" > "${sa_file}"
+  nebius profile create \
+    --endpoint api.nebius.cloud \
+    --service-account-file "${sa_file}" \
+    --profile npa-ci-source-registry
+  nebius --profile npa-ci-source-registry iam get-access-token > "${token_file}"
+elif [ -n "${NEBIUS_CR_TOKEN:-}" ]; then
+  printf '%s' "${NEBIUS_CR_TOKEN}" > "${token_file}"
+elif [ "${REQUIRE_CREDENTIAL}" != "true" ]; then
+  echo "::notice::Neither NEBIUS_SA_CREDENTIALS_JSON nor NEBIUS_CR_TOKEN is set, so the source registry cannot be checked."
+  emit_available false
+  exit 0
+else
+  echo "A source registry credential (NEBIUS_SA_CREDENTIALS_JSON or NEBIUS_CR_TOKEN) is required" >&2
+  exit 1
+fi
+
+# Offline verdict before any registry round trip. An expired access token is the failure this
+# has actually had, and it is readable from the token's own `exp`, so name it in a second
+# rather than as a wall of indistinguishable UNAUTHORIZED lines two minutes later.
+"${PYTHON}" -m npa.deploy.publish_public --describe-credential < "${token_file}"
+
+# `crane auth login` writes a config file and exits 0 for ANY string without contacting the
+# registry, so this proves nothing on its own -- the caller must still read a real manifest.
+for host in ${REGISTRY_HOSTS}; do
+  crane auth login "${host}" -u iam --password-stdin < "${token_file}"
+done
+emit_available true

--- a/npa/src/npa/deploy/publish_public.py
+++ b/npa/src/npa/deploy/publish_public.py
@@ -29,6 +29,11 @@ automated (see ``package_settings_url``); the verification prints a click-throug
 expiry offline, because the credential is what actually breaks: a Nebius access token
 lives 12 hours, so anything stored in CI must be a static key issued for
 CONTAINER_REGISTRY instead (see ``describe_credential``).
+
+``--skip-missing`` publishes the images that exist when some pin refers to an image nobody
+has built yet. The plan comes from the packaging contract (what the repo BUILDS) while the
+registry holds what was pushed, so that gap is routine for a young tool; a denial is never
+skipped (see ``classify_preflight_failure``).
 """
 
 from __future__ import annotations
@@ -143,6 +148,37 @@ def preflight_sources(plan: list[PublishItem]) -> list[tuple[PublishItem, str]]:
         if not ok:
             failures.append((item, detail))
     return failures
+
+
+# The plan is derived from the packaging contract, which states what the repo BUILDS -- an
+# intent. The registry holds what someone actually pushed. Those diverge whenever a new tool
+# lands (Dockerfile, contract entry and pin merged) before its image is built, and the repo
+# has no build-and-push automation, so the divergence is normal rather than exceptional.
+#
+# The two states need opposite handling, which is why they are classified rather than lumped
+# into "unreadable". A never-pushed image is a legitimate state that must not hold the ready
+# images hostage; a credential or role problem must NEVER be skipped past, because skipping
+# it would silently shrink the published set and look like success.
+_MISSING_MARKERS = ("NAME_UNKNOWN", "MANIFEST_UNKNOWN")
+_DENIED_MARKERS = ("UNAUTHORIZED", "DENIED", "FORBIDDEN")
+
+
+def classify_preflight_failure(detail: str) -> str:
+    """``"missing"``, ``"denied"`` or ``"other"`` for a preflight failure reason.
+
+    ``missing`` means the registry answered authoritatively that it has no such repository
+    (``NAME_UNKNOWN``) or no such tag (``MANIFEST_UNKNOWN``) -- the image was never pushed.
+    ``denied`` covers anything that is about the identity, which is never skippable.
+    """
+    upper = detail.upper()
+    # Denial wins over absence: a registry that hides repositories behind authz can answer
+    # NAME_UNKNOWN for something that exists but is not visible to this identity, and
+    # treating that as "not built yet" would quietly drop a publishable image.
+    if any(marker in upper for marker in _DENIED_MARKERS):
+        return "denied"
+    if any(marker in upper for marker in _MISSING_MARKERS):
+        return "missing"
+    return "other"
 
 
 # --------------------------------------------------------------------------------------
@@ -421,6 +457,17 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--skip-missing",
+        action="store_true",
+        help=(
+            "Publish the images that exist, skipping any the source registry does not have "
+            "yet (NAME_UNKNOWN / MANIFEST_UNKNOWN), and report exactly which were skipped. "
+            "The plan comes from the packaging contract, which records what this repo BUILDS, "
+            "so a tool that landed before its image was built otherwise blocks every ready "
+            "image. A denial is never skipped — that is a credential or role fault."
+        ),
+    )
+    parser.add_argument(
         "--checklist",
         action="store_true",
         help=(
@@ -460,50 +507,89 @@ def main(argv: list[str] | None = None) -> int:
     for item in plan:
         print(f"  {item.source_ref}  ->  {item.target_ref}")
     if args.verify_public:
+        expected = plan
+        if args.skip_missing:
+            # Otherwise the checklist would list packages for images that were never copied,
+            # linking to settings pages that 404 -- and the run would report "not public"
+            # about something nobody tried to publish.
+            print("\nPreflighting source images to exclude the ones not built yet:")
+            expected = _preflight_or_explain(plan, skip_missing=True)
+            if not expected:
+                return 1
         print("\nVerifying anonymous (unauthenticated) pullability:")
-        failures = verify_public(plan)
+        failures = verify_public(expected)
         if failures:
-            _explain_private_packages(failures, total=len(plan))
+            _explain_private_packages(failures, total=len(expected))
             if args.checklist:
                 print("\n" + visibility_checklist(failures))
             return 1
-        print(f"\nAll {len(plan)} image(s) are publicly pullable.")
+        print(f"\nAll {len(expected)} image(s) are publicly pullable.")
         return 0
 
     if args.preflight:
         print("\nPreflighting source images (authenticated read, nothing written):")
-        return 1 if _preflight_or_explain(plan) else 0
+        return 0 if _preflight_or_explain(plan, skip_missing=args.skip_missing) else 1
 
     if args.dry_run:
         print("(dry run — nothing copied)")
         return 0
 
     print("\nPreflighting source images (authenticated read, nothing written):")
-    if _preflight_or_explain(plan):
+    publishable = _preflight_or_explain(plan, skip_missing=args.skip_missing)
+    if not publishable:
         return 1
-    for item in plan:
+    for item in publishable:
         _crane_copy(item)
-    print(f"\nCopied {len(plan)} image(s).")
+    print(f"\nCopied {len(publishable)} image(s).")
 
     # Copying is not publishing, so do not stop here and report success. Verifying
     # inline means the operator learns the real state -- and gets the click-through
     # list for the one step that cannot be automated -- from the command that did
     # the copy, rather than from a separate invocation they have to know to run.
     print("\nVerifying anonymous (unauthenticated) pullability:")
-    failures = verify_public(plan)
+    failures = verify_public(publishable)
     if failures:
-        _explain_private_packages(failures, total=len(plan), after_copy=True)
+        _explain_private_packages(failures, total=len(publishable), after_copy=True)
         print("\n" + visibility_checklist(failures))
         return 1
-    print(f"\nAll {len(plan)} image(s) are publicly pullable.")
+    print(f"\nAll {len(publishable)} image(s) are publicly pullable.")
     return 0
 
 
-def _preflight_or_explain(plan: list[PublishItem]) -> bool:
-    """Run the source preflight; explain and return True if it failed."""
+def _preflight_or_explain(plan: list[PublishItem], *, skip_missing: bool = False) -> list[PublishItem]:
+    """Run the source preflight and return the items that are safe to copy.
+
+    Returns an empty list when the run must stop. With ``skip_missing`` the never-pushed
+    images are dropped from the returned set instead of failing the run, so a young tool
+    whose image has not been built yet cannot block the images that are ready.
+    """
     failures = preflight_sources(plan)
     if not failures:
-        return False
+        return list(plan)
+
+    by_kind: dict[str, list[tuple[PublishItem, str]]] = {}
+    for item, detail in failures:
+        by_kind.setdefault(classify_preflight_failure(detail), []).append((item, detail))
+    missing = by_kind.get("missing", [])
+    blocking = by_kind.get("denied", []) + by_kind.get("other", [])
+
+    if skip_missing and missing and not blocking:
+        print(
+            f"\nSkipping {len(missing)} of {len(plan)} image(s) that are not in the source "
+            "registry yet (--skip-missing). The packaging contract records what this repo\n"
+            "builds; these have not been built and pushed, so there is nothing to mirror:",
+            file=sys.stderr,
+        )
+        for item, detail in missing:
+            print(f"  {item.source_ref}  ({_missing_reason(detail)})", file=sys.stderr)
+        print(
+            "Build and push them, then re-run to add them to the mirror. Until then they are\n"
+            "absent from the public registry and will fail at pull time for consumers.",
+            file=sys.stderr,
+        )
+        skipped = {item.source_ref for item, _ in missing}
+        return [item for item in plan if item.source_ref not in skipped]
+
     lines = [
         f"\n{len(failures)} of {len(plan)} source image(s) could not be read; nothing was "
         "copied."
@@ -512,10 +598,12 @@ def _preflight_or_explain(plan: list[PublishItem]) -> bool:
     # UNAUTHORIZED could be a per-repository grant, but all of them means the credential
     # never resolved to an identity at all ("failed to get profile"), so there is no point
     # looking at roles or at the tags.
-    if len(failures) == len(plan) and all("UNAUTHORIZED" in detail for _, detail in failures):
+    if len(failures) == len(plan) and all(
+        classify_preflight_failure(detail) == "denied" for _, detail in failures
+    ):
         lines.append(
-            "Every read failed with UNAUTHORIZED, so this is the credential rather than any\n"
-            "single tag or grant — the token did not resolve to an identity.\n"
+            "Every read was denied, so this is the credential rather than any single tag or\n"
+            "grant — the token did not resolve to an identity.\n"
             "In CI, prefer a credential that does not expire between dispatches. An access\n"
             "token from `nebius iam get-access-token` lives 12 HOURS, so a stored one is dead\n"
             "by the next manual run; a static key issued for the registry lasts 6 months:\n"
@@ -526,14 +614,43 @@ def _preflight_or_explain(plan: list[PublishItem]) -> bool:
             "--password-stdin"
         )
     else:
-        lines.append(
-            "UNAUTHORIZED on SOME images means the credential works but its identity lacks\n"
-            "viewer on those repositories — fix the role, not the token.\n"
-            "MANIFEST_UNKNOWN means the pinned tag is not in the source registry — build and\n"
-            "push that image, or correct its pin, before publishing."
-        )
+        if blocking:
+            lines.append(
+                f"{len(blocking)} image(s) failed for a reason that is NOT absence, so nothing "
+                "was skipped:"
+            )
+            lines.extend(f"  {item.source_ref}  {detail}" for item, detail in blocking)
+            lines.append(
+                "A denial on some images means the credential works but its identity lacks\n"
+                "viewer on those repositories — fix the role, not the token."
+            )
+        if missing:
+            lines.append(
+                f"{len(missing)} image(s) are simply not in the source registry:"
+            )
+            lines.extend(
+                f"  {item.source_ref}  ({_missing_reason(detail)})" for item, detail in missing
+            )
+            lines.append(
+                "Build and push those images, or correct their pins. To publish the rest now\n"
+                "and add these once they are built, re-run with --skip-missing (or the\n"
+                "workflow's skip_missing input)."
+            )
     print("\n".join(lines), file=sys.stderr)
-    return True
+    return []
+
+
+def _missing_reason(detail: str) -> str:
+    """Which kind of absence, keeping the registry's own code so the line stays greppable.
+
+    The two need different fixes: no repository at all means the image was never built,
+    while a missing tag means something was pushed but the pin points elsewhere.
+    """
+    if "NAME_UNKNOWN" in detail.upper():
+        return "NAME_UNKNOWN — no such repository; this image has never been pushed"
+    if "MANIFEST_UNKNOWN" in detail.upper():
+        return "MANIFEST_UNKNOWN — repository exists but not this tag; the pin points at an unpushed build"
+    return detail
 
 
 def _explain_private_packages(

--- a/npa/tests/deploy/test_public_publish.py
+++ b/npa/tests/deploy/test_public_publish.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -731,7 +732,7 @@ def test_a_wholesale_unauthorized_preflight_blames_the_credential(monkeypatch, c
     err = capsys.readouterr().err
 
     assert rc == 1
-    assert "Every read failed" in err
+    assert "Every read was denied" in err
     assert "static-key issue" in err
     assert "lacks\nviewer" not in err, "a per-repository role hint would misdirect here"
 
@@ -753,4 +754,214 @@ def test_a_partial_preflight_failure_blames_the_role_or_the_tag(monkeypatch, cap
 
     assert rc == 1
     assert "MANIFEST_UNKNOWN" in err
-    assert "Every read failed" not in err
+    assert "Every read was denied" not in err
+
+
+# --------------------------------------------------------------------------------------
+# Images that were never built
+#
+# The plan comes from the packaging contract, which records what this repo BUILDS. The
+# registry holds what someone actually pushed. Run #2 of the workflow found five images in
+# the gap: npa-cosmos-curate, npa-cosmos-evaluator, npa-cosmos3 and npa-foxglove-embed had
+# no repository at all (NAME_UNKNOWN -- landed with a Dockerfile, a contract entry and a pin,
+# but were never built), and npa-cosmos2-transfer had a repository but not the pinned tag
+# (MANIFEST_UNKNOWN). Eighteen images were ready and none of them could be published.
+#
+# Absence is a legitimate state for a young tool, so it must be skippable. A denial never is:
+# skipping it would quietly shrink the published set while reporting success.
+# --------------------------------------------------------------------------------------
+
+# The literal strings Nebius CR returned, so the classifier is pinned against real output.
+_NAME_UNKNOWN = (
+    "NAME_UNKNOWN: repository name not known to registry: Entity Folder not found for "
+    "registry e00example"
+)
+_MANIFEST_UNKNOWN = "MANIFEST_UNKNOWN: manifest unknown: Tag not found for manifest npa-x:null"
+_FAILED_TO_GET_PROFILE = "UNAUTHORIZED: authentication required: failed to get profile"
+
+
+@pytest.mark.parametrize(
+    ("detail", "kind"),
+    [
+        (_NAME_UNKNOWN, "missing"),
+        (_MANIFEST_UNKNOWN, "missing"),
+        (_FAILED_TO_GET_PROFILE, "denied"),
+        ("DENIED: requested access to the resource is denied", "denied"),
+        ("timed out after 60s", "other"),
+        ("crane exited 137", "other"),
+    ],
+)
+def test_preflight_failures_are_classified_by_what_they_require(detail, kind) -> None:
+    from npa.deploy.publish_public import classify_preflight_failure
+
+    assert classify_preflight_failure(detail) == kind
+
+
+def test_a_denial_that_also_says_name_unknown_is_never_treated_as_absence() -> None:
+    """A registry may answer NAME_UNKNOWN for a repository the identity cannot see.
+
+    Reading that as "not built yet" would silently drop a publishable image from the mirror,
+    so denial has to win over absence.
+    """
+    from npa.deploy.publish_public import classify_preflight_failure
+
+    assert classify_preflight_failure("UNAUTHORIZED: NAME_UNKNOWN: not visible") == "denied"
+
+
+def _run2_readability(plan):
+    """The exact pass/fail split run #2 saw: 18 readable, 4 absent repos, 1 absent tag."""
+    never_built = {"npa-cosmos-curate", "npa-cosmos-evaluator", "npa-cosmos3", "npa-foxglove-embed"}
+    unpushed_tag = {"npa-cosmos2-transfer"}
+
+    def readable(ref: str, **_: object) -> tuple[bool, str]:
+        image = ref.rsplit("/", 1)[-1].split(":", 1)[0]
+        if image in never_built:
+            return False, _NAME_UNKNOWN
+        if image in unpushed_tag:
+            return False, _MANIFEST_UNKNOWN
+        return True, "ok"
+
+    return readable
+
+
+def test_unbuilt_images_block_the_publish_by_default(monkeypatch, capsys) -> None:
+    """Silently publishing a subset would be the wrong default: a pin regression that
+    dropped an image would look exactly like success."""
+    from npa.deploy import publish_public
+
+    plan = publish_public.build_publish_plan(target_registry="ghcr.io/example/workbench")
+    monkeypatch.setattr(publish_public, "_crane_manifest_readable", _run2_readability(plan))
+
+    def explode(item) -> None:  # pragma: no cover - must not run
+        raise AssertionError("nothing may be copied without --skip-missing")
+
+    monkeypatch.setattr(publish_public, "_crane_copy", explode)
+
+    rc = publish_public.main(["--target", "ghcr.io/example/workbench"])
+    err = capsys.readouterr().err
+
+    assert rc == 1
+    assert "5 of 23" in err
+    # Both codes must survive into the explanation: they need different fixes, and an
+    # operator greps for the registry's own wording.
+    assert "NAME_UNKNOWN" in err and "never been pushed" in err
+    assert "MANIFEST_UNKNOWN" in err and "unpushed build" in err
+    assert "--skip-missing" in err, "the way forward has to be named where it is discovered"
+
+
+def test_skip_missing_publishes_the_ready_images_and_names_the_skipped(monkeypatch, capsys) -> None:
+    from npa.deploy import publish_public
+
+    plan = publish_public.build_publish_plan(target_registry="ghcr.io/example/workbench")
+    monkeypatch.setattr(publish_public, "_crane_manifest_readable", _run2_readability(plan))
+    copied: list[str] = []
+    monkeypatch.setattr(publish_public, "_crane_copy", lambda item: copied.append(item.target_ref))
+    monkeypatch.setattr(publish_public, "anonymous_pull_ok", lambda ref, **_: (True, "HTTP 200"))
+
+    rc = publish_public.main(["--target", "ghcr.io/example/workbench", "--skip-missing"])
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert len(copied) == len(plan) - 5
+    for image in ("npa-cosmos3", "npa-foxglove-embed", "npa-cosmos2-transfer"):
+        assert not any(f"/{image}:" in ref for ref in copied), image
+        # Skipping quietly would leave a hole in the mirror nobody knew about.
+        assert image in captured.err, image
+    assert any("/npa-lerobot:" in ref for ref in copied), "ready images must still publish"
+    assert "Copied 18 image(s)." in captured.out
+
+
+def test_skip_missing_never_skips_past_a_denial(monkeypatch, capsys) -> None:
+    """The one case that must still stop the run: mixing absence with a permission fault.
+
+    Skipping the denied image would publish a smaller set and exit 0, which is the silent
+    false success this whole path exists to prevent.
+    """
+    from npa.deploy import publish_public
+
+    plan = publish_public.build_publish_plan(target_registry="ghcr.io/example/workbench")
+    denied = plan[3].source_ref
+
+    def readable(ref: str, **_: object) -> tuple[bool, str]:
+        if ref == denied:
+            return False, _FAILED_TO_GET_PROFILE
+        return (False, _NAME_UNKNOWN) if ref == plan[0].source_ref else (True, "ok")
+
+    monkeypatch.setattr(publish_public, "_crane_manifest_readable", readable)
+
+    def explode(item) -> None:  # pragma: no cover - must not run
+        raise AssertionError("a denial must stop the run even with --skip-missing")
+
+    monkeypatch.setattr(publish_public, "_crane_copy", explode)
+
+    rc = publish_public.main(["--target", "ghcr.io/example/workbench", "--skip-missing"])
+    err = capsys.readouterr().err
+
+    assert rc == 1
+    assert "NOT absence" in err
+    assert denied in err, "name the image that blocked the run"
+    assert "lacks" in err and "viewer" in err
+
+
+def test_skip_missing_preflight_alone_reports_success(monkeypatch) -> None:
+    """So a dry run can confirm the publish would proceed before anything is written."""
+    from npa.deploy import publish_public
+
+    plan = publish_public.build_publish_plan(target_registry="ghcr.io/example/workbench")
+    monkeypatch.setattr(publish_public, "_crane_manifest_readable", _run2_readability(plan))
+
+    assert (
+        publish_public.main(
+            ["--target", "ghcr.io/example/workbench", "--skip-missing", "--preflight"]
+        )
+        == 0
+    )
+
+
+def test_verify_public_with_skip_missing_ignores_the_unpublished(monkeypatch, capsys) -> None:
+    """The checklist must not list packages nobody tried to publish — those links 404."""
+    from npa.deploy import publish_public
+
+    plan = publish_public.build_publish_plan(target_registry="ghcr.io/example/workbench")
+    monkeypatch.setattr(publish_public, "_crane_manifest_readable", _run2_readability(plan))
+    monkeypatch.setattr(publish_public, "anonymous_pull_ok", lambda ref, **_: (False, "HTTP 403"))
+
+    rc = publish_public.main(
+        ["--target", "ghcr.io/example/workbench", "--skip-missing", "--verify-public", "--checklist"]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert captured.out.count("- [ ] ") == len(plan) - 5
+    # Match whole package names: "npa-cosmos3-reason" contains "npa-cosmos3" as a substring
+    # and IS readable, so a substring check would fail for the wrong reason.
+    listed = set(re.findall(r"- \[ \] \[workbench/([^\]]+)\]", captured.out))
+    assert "npa-cosmos3" not in listed
+    assert "npa-cosmos3-reason" in listed, "a readable image whose name shares a prefix stays"
+    assert listed.isdisjoint(
+        {"npa-cosmos3", "npa-cosmos-curate", "npa-cosmos-evaluator", "npa-foxglove-embed",
+         "npa-cosmos2-transfer"}
+    )
+
+
+def test_the_post_copy_verification_only_covers_what_was_copied(monkeypatch, capsys) -> None:
+    """Verifying the skipped ones too would fail a publish that did everything asked of it."""
+    from npa.deploy import publish_public
+
+    plan = publish_public.build_publish_plan(target_registry="ghcr.io/example/workbench")
+    monkeypatch.setattr(publish_public, "_crane_manifest_readable", _run2_readability(plan))
+    monkeypatch.setattr(publish_public, "_crane_copy", lambda item: None)
+
+    verified: list[str] = []
+
+    def anon(ref: str, **_: object) -> tuple[bool, str]:
+        verified.append(ref)
+        return True, "HTTP 200"
+
+    monkeypatch.setattr(publish_public, "anonymous_pull_ok", anon)
+
+    rc = publish_public.main(["--target", "ghcr.io/example/workbench", "--skip-missing"])
+
+    assert rc == 0
+    assert len(verified) == len(plan) - 5
+    assert not any("npa-cosmos3:" in ref for ref in verified)

--- a/npa/tests/guardrails/test_public_mirror_workflows.py
+++ b/npa/tests/guardrails/test_public_mirror_workflows.py
@@ -1,0 +1,103 @@
+"""The two public-mirror workflows must keep sharing one credential path, and the health
+check must stay read-only.
+
+Both of the mirror's real failures were credential-shaped, and the fix was to put that logic
+in one script instead of inlining it per workflow. Two workflows now depend on it, so these
+guard the properties that make the split safe rather than the wording of any one file:
+
+- neither workflow re-inlines credential handling (the drift that makes one of them wrong)
+- the health check cannot copy or publish anything, ever
+- the health check cannot become permanently red for a known-absent image, which is how a
+  scheduled job trains people to ignore it
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+LOGIN_SCRIPT = "npa/scripts/ci_source_registry_login.sh"
+PUBLISH = WORKFLOWS / "publish-public-images.yml"
+HEALTH = WORKFLOWS / "public-mirror-health.yml"
+
+
+def _steps(path: Path) -> list[dict]:
+    spec = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return [step for job in spec["jobs"].values() for step in job["steps"]]
+
+
+def _run_scripts(path: Path) -> list[str]:
+    return [step["run"] for step in _steps(path) if isinstance(step.get("run"), str)]
+
+
+@pytest.mark.parametrize("path", [PUBLISH, HEALTH], ids=lambda p: p.name)
+def test_both_workflows_exist_and_share_the_login_script(path: Path) -> None:
+    assert path.is_file(), path
+    assert any(LOGIN_SCRIPT in run for run in _run_scripts(path)), (
+        f"{path.name} must authenticate via {LOGIN_SCRIPT}"
+    )
+
+
+def test_the_shared_login_script_is_executable() -> None:
+    script = Path(__file__).resolve().parents[3] / LOGIN_SCRIPT
+    assert script.is_file()
+    # A workflow invokes it as ./npa/scripts/..., which needs the bit set in git.
+    assert script.stat().st_mode & 0o111, f"{LOGIN_SCRIPT} must be executable"
+
+
+@pytest.mark.parametrize("path", [PUBLISH, HEALTH], ids=lambda p: p.name)
+def test_no_workflow_reinlines_the_credential_handling(path: Path) -> None:
+    """Two copies of this logic means one of them is wrong, and it is the one nobody ran."""
+    for run in _run_scripts(path):
+        if LOGIN_SCRIPT in run:
+            continue
+        assert "iam get-access-token" not in run, (
+            f"{path.name} mints a token inline; call {LOGIN_SCRIPT} instead"
+        )
+        assert "crane auth login" not in run or "ghcr.io" in run, (
+            f"{path.name} logs into a source registry inline; call {LOGIN_SCRIPT} instead"
+        )
+
+
+def test_the_health_check_never_copies_anything() -> None:
+    """It runs on a schedule with no human watching, against a registry where publication is
+    irreversible. Every publish_public invocation in it must be an explicitly read-only mode."""
+    read_only = ("--preflight", "--verify-public", "--describe-credential")
+    invocations = [run for run in _run_scripts(HEALTH) if "npa.deploy.publish_public" in run]
+    assert invocations, "the health check must actually run the publisher's preflight"
+    for run in invocations:
+        assert any(flag in run for flag in read_only), f"non-read-only publisher call: {run}"
+        assert "--dry-run" not in run, "--dry-run skips the preflight; use --preflight"
+
+
+def test_the_health_check_tolerates_images_that_are_not_built_yet() -> None:
+    """Without --skip-missing it would be red for as long as any pin lacks a pushed image,
+    and a permanently red scheduled job is one nobody reads."""
+    preflight = [
+        run for run in _run_scripts(HEALTH) if "--preflight" in run and "publish_public" in run
+    ]
+    assert preflight, "expected a preflight invocation"
+    for run in preflight:
+        assert "--skip-missing" in run
+
+
+def test_the_health_check_is_scheduled_and_read_only_by_permission() -> None:
+    spec = yaml.safe_load(HEALTH.read_text(encoding="utf-8"))
+    # PyYAML 1.1 resolves a bare `on:` key to the boolean True.
+    triggers = spec.get("on") or spec[True]
+    assert "schedule" in triggers, "early warning requires a schedule, not just dispatch"
+    assert "workflow_dispatch" in triggers, "must also be runnable on demand"
+    # No packages: write. It reads the source registry and must not be able to push to GHCR.
+    assert spec["permissions"] == {"contents": "read"}
+
+
+def test_only_the_publish_workflow_can_write_to_ghcr() -> None:
+    spec = yaml.safe_load(PUBLISH.read_text(encoding="utf-8"))
+    triggers = spec.get("on") or spec[True]
+    assert set(triggers) == {"workflow_dispatch"}, (
+        "publishing is irreversible; it must never be triggered by a push or a schedule"
+    )
+    assert spec["permissions"].get("packages") == "write"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What run #2 found

The credential fix from [#242](https://github.com/nebius/nebius-physical-ai/pull/242) worked — [run #2](https://github.com/nebius/nebius-physical-ai/actions/runs/30772157039) authenticated cleanly and **18 of 23** source reads returned `ok`. It then failed on the other five, for a completely different reason:

| Image | Registry said | Meaning |
| --- | --- | --- |
| `npa-cosmos-curate:0.1.2` | `NAME_UNKNOWN` | no such repository |
| `npa-cosmos-evaluator:0.1.2` | `NAME_UNKNOWN` | no such repository |
| `npa-cosmos3:1.2.2-cu130` | `NAME_UNKNOWN` | no such repository |
| `npa-foxglove-embed:0.58.0` | `NAME_UNKNOWN` | no such repository |
| `npa-cosmos2-transfer:2.5.1-skypilot-ready-20260801T053000Z` | `MANIFEST_UNKNOWN` | repository exists, tag doesn't |

All five trace to recently merged PRs — #231 (curate, evaluator, the cosmos2-transfer retag), #232 (foxglove-embed), #235 (cosmos3). Each landed as Dockerfile + packaging-contract entry + version pin. Building and pushing is a separate manual step with no automation, so nothing had built them yet. An independent local credential run reached the same five.

**This gap is structural.** The publish plan is derived from the packaging contract — what the repo *builds*. The registry holds what someone *pushed*. Every new tool sits in that gap until its image is built, so as written the mirror is hostage to the least-ready image.

## 1. Absence no longer blocks the ready images

Preflight failures are now classified, and only absence is skippable:

```bash
python -m npa.deploy.publish_public --skip-missing   # or the workflow's skip_missing input
```

Against run #2's exact failure set that copies the 18 ready images and prints each skip with its reason (`NAME_UNKNOWN — no such repository; this image has never been pushed`).

Three properties are load-bearing:

- **A denial is never skipped.** `UNAUTHORIZED` / `DENIED` stops the run even with `--skip-missing`, because skipping a credential or role fault would quietly shrink the published set while exiting 0 — the silent false success this module guards against elsewhere. Denial also wins when a registry answers `NAME_UNKNOWN` for a repository the identity merely cannot *see*.
- **Blocking stays the default.** Silently mirroring a subset would make a pin regression that dropped an image look identical to success.
- **Only what was copied gets verified.** The post-copy check and job summary checklist now cover the copied set, so the checklist no longer links to settings pages for packages nobody published (those links 404).

## 2. One credential path, shared

The static key now backing `NEBIUS_CR_TOKEN` expires in about six months, and unlike an access token **its lifetime is not readable from the token** — `--describe-credential` correctly reports "no readable expiry", so nothing in the repo can warn before it dies. Since the publish workflow is dispatched by hand months apart, that expiry would surface exactly like the first failure: on publish day, blocking someone, needing a round trip through whoever owns the tenant.

Fixing that needs a second workflow, which means two workflows need the same credential resolution — so it moves to `npa/scripts/ci_source_registry_login.sh`. Two copies would mean one is wrong, and it would be the one nobody ran. The script is also usable locally, which the inline block wasn't.

## 3. A weekly read-only health check

`Public mirror health` runs the same preflight on a schedule:

- **Fails** on a dead credential or a denial — the early warning the invisible expiry otherwise denies us, months before anyone next needs to publish. The job summary includes the re-issue command.
- **Reports without failing** on images that are merely absent, because a scheduled job that is permanently red for a known-unbuilt image is one nobody reads.

That split is precisely what `--skip-missing` means, so it reuses the publisher's own logic rather than becoming a second opinion that could disagree with it.

## Verification

- **63 tests** in `test_public_publish.py` (13 new). The fixture reproduces run #2's exact split — 18 readable, 4 absent repositories, 1 absent tag — using the literal error strings Nebius CR returned, so the classifier is pinned against real output rather than my paraphrase. Covered: blocking by default with nothing copied; `--skip-missing` copying exactly 18 and naming all 5; a denial mixed with absence still halting; `NAME_UNKNOWN` inside an `UNAUTHORIZED` message classified as denial; the checklist excluding skipped packages while keeping `npa-cosmos3-reason`, whose name contains a skipped image's name as a prefix.
- **9 new guardrail tests** covering the properties that make the shared-script split safe: neither workflow re-inlines credential handling, the health check cannot copy or publish anything, it cannot lose `--skip-missing`, and only the publish workflow can write to GHCR or be triggered by anything but a manual dispatch. **Both new guards were mutation-tested** to confirm they fail when the property is violated.
- The extracted script was executed against all four credential cases with a stubbed `crane` and is **behaviour-identical** to the inline block it replaces: static key logs into both hosts and reports `available=true`; an expired access token fails in under a second; no credential with `REQUIRE_CREDENTIAL=false` emits the notice and continues; required-but-absent fails. The `trap` leaves no token material behind in any case.
- 5541 tests pass; `ruff`, `shellcheck`, and `actionlint` all clean. Two failures in `test_bdd100k_pipeline.py` are pre-existing on `main` and unrelated (they shell out to an `npa` binary absent from this environment) — verified by running them on `main`.

## What this does and doesn't get you

With `skip_missing=true` the mirror publishes 18 of 23. The five skipped images are genuinely absent, so `NPA_REGISTRY=ghcr.io/nebius/nebius-physical-ai` fails at pull time for those tags until someone builds and pushes them and re-runs. Adding one later costs one more visibility flip. The alternative is to build all five first — correct, but `npa-cosmos3` is a large CUDA image, so this unblocks the mirror today without pretending the gap isn't there.

Docs record the renewal procedure, that the key's expiry belongs in operational reminders rather than the repo (which must not carry tenant identifiers), and the isolated-`DOCKER_CONFIG` method for proving a credential actually reads — since `--describe-credential` passes any opaque key by design.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bbe8e73-aec1-459b-ba11-f14349825cd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bbe8e73-aec1-459b-ba11-f14349825cd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

