### PR TITLE
Make public image publishing incremental

### DIFF
--- a/docs/workbench/container-packaging.md
+++ b/docs/workbench/container-packaging.md
@@ -349,6 +349,13 @@ copies the rest. Two properties matter here:
   gets a pull failure for those tags until the image is built and the workflow re-run.
   Adding one later costs one more visibility flip.
 
+The copy itself is incremental. After the complete source preflight and licensing gates,
+the publisher compares each source and target manifest digest. An exact match prints
+``Already current; skipping copy`` and performs no registry write; only a missing or changed
+target runs ``crane copy``. This makes it safe to re-run the full guarded plan when one new
+image lands without republishing every existing image. A second run after the one-time GHCR
+visibility flips likewise skips all matching copies and only re-verifies anonymous pulls.
+
 or the `Publish public images` GitHub Actions workflow (manual dispatch,
 dry-run by default). **Consumers in any tenant** then pull the OSS images by
 pointing the resolver at the public mirror:

--- a/npa/src/npa/deploy/publish_public.py
+++ b/npa/src/npa/deploy/publish_public.py
@@ -20,10 +20,12 @@ Example (dry run first, then execute):
     python -m npa.deploy.publish_public --target ghcr.io/nebius/nebius-physical-ai --dry-run
     python -m npa.deploy.publish_public --target ghcr.io/nebius/nebius-physical-ai
 
-The copy path preflights the source registry first and verifies the result after, so a
-stale credential fails before anything is written and a copy cannot report success while
-nothing is publicly pullable. Making the packages public is the one step that cannot be
-automated (see ``package_settings_url``); the verification prints a click-through list.
+The copy path preflights the source registry first, skips targets whose manifest digest
+already matches the source, and verifies the result after. A stale credential therefore
+fails before anything is written, unchanged images are not recopied, and a copy cannot
+report success while nothing is publicly pullable. Making the packages public is the one
+step that cannot be automated (see ``package_settings_url``); the verification prints a
+click-through list.
 
 ``--describe-credential`` reads a source-registry credential on stdin and reports its
 expiry offline, because the credential is what actually breaks: a Nebius access token
@@ -404,11 +406,77 @@ def visibility_checklist(failures: list[tuple[PublishItem, str]]) -> str:
     return "\n".join(lines)
 
 
-def _crane_copy(item: PublishItem) -> None:
+def _crane_digest(ref: str, *, timeout: float = _PREFLIGHT_TIMEOUT_SECONDS) -> tuple[bool, str]:
+    """Return ``(True, digest)`` or ``(False, registry error)`` for ``ref``.
+
+    ``crane copy`` is content-addressed, but invoking it for every image still walks and
+    negotiates every manifest and layer. Comparing the top-level manifest digest first
+    lets repeat workflow runs prove that a tag is already current without writing it
+    again. The source preflight remains separate and complete: incrementality must not
+    weaken the credential, pin, or licensing gates.
+    """
     crane = shutil.which("crane")
     if not crane:
         raise RuntimeError("crane not found on PATH; install go-containerregistry crane")
+    try:
+        completed = subprocess.run(
+            [crane, "digest", ref],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"timed out after {timeout:g}s"
+    if completed.returncode == 0:
+        output = (completed.stdout or "").strip().splitlines()
+        if output:
+            return True, output[-1]
+        return False, "crane returned an empty digest"
+    detail = (completed.stderr or completed.stdout or "").strip().splitlines()
+    return False, detail[-1] if detail else f"crane exited {completed.returncode}"
+
+
+def _crane_copy(item: PublishItem) -> bool:
+    """Copy ``item`` only when the target is absent or has a different digest.
+
+    Returns ``True`` when a copy ran and ``False`` when the exact source digest was
+    already present. A target denial is allowed to reach ``crane copy`` because a new
+    private GHCR package can be unreadable through the pull path while the workflow's
+    token is still authorised to create it; the copy remains the authoritative write
+    check. Transient or unknown digest failures stop instead of risking an unnecessary
+    rewrite.
+    """
+    crane = shutil.which("crane")
+    if not crane:
+        raise RuntimeError("crane not found on PATH; install go-containerregistry crane")
+
+    source_ok, source_detail = _crane_digest(item.source_ref)
+    if not source_ok:
+        raise RuntimeError(
+            f"could not resolve source digest for {item.source_ref}: {source_detail}"
+        )
+
+    target_ok, target_detail = _crane_digest(item.target_ref)
+    if target_ok and target_detail == source_detail:
+        print(f"Already current; skipping copy: {item.target_ref} ({source_detail})")
+        return False
+    if target_ok:
+        print(
+            f"Digest changed; copying {item.target_ref}: "
+            f"{target_detail} -> {source_detail}"
+        )
+    else:
+        failure_kind = classify_preflight_failure(target_detail)
+        if failure_kind == "other":
+            raise RuntimeError(
+                f"could not determine target digest for {item.target_ref}: {target_detail}; "
+                "refusing to copy because the target may already be current"
+            )
+        print(f"Target absent or unreadable ({target_detail}); copying {item.target_ref}")
+
     subprocess.run([crane, "copy", item.source_ref, item.target_ref], check=True)
+    return True
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -538,9 +606,18 @@ def main(argv: list[str] | None = None) -> int:
     publishable = _preflight_or_explain(plan, skip_missing=args.skip_missing)
     if not publishable:
         return 1
+    copied = 0
+    already_current = 0
     for item in publishable:
-        _crane_copy(item)
-    print(f"\nCopied {len(publishable)} image(s).")
+        # Existing tests and third-party instrumentation historically returned ``None``
+        # from _crane_copy; count every result except the explicit incremental ``False``
+        # as a copy for backwards-compatible instrumentation.
+        if _crane_copy(item) is False:
+            already_current += 1
+        else:
+            copied += 1
+    print(f"\nCopied {copied} image(s).")
+    print(f"Skipped {already_current} already-current image(s).")
 
     # Copying is not publishing, so do not stop here and report success. Verifying
     # inline means the operator learns the real state -- and gets the click-through

--- a/npa/tests/deploy/test_public_publish.py
+++ b/npa/tests/deploy/test_public_publish.py
@@ -530,6 +530,197 @@ def test_a_copy_exits_zero_only_once_the_packages_are_public(monkeypatch) -> Non
     assert publish_public.main(["--target", "ghcr.io/example/workbench"]) == 0
 
 
+def test_crane_copy_skips_a_target_with_the_exact_source_digest(monkeypatch, capsys) -> None:
+    """Repeat publishes must prove equality without invoking the registry write path."""
+    from npa.deploy import publish_public
+    from npa.deploy.publish_public import PublishItem
+
+    item = PublishItem(
+        tool="lerobot",
+        source_ref="source.example/npa-lerobot:1.0",
+        target_ref="target.example/npa-lerobot:1.0",
+    )
+    monkeypatch.setattr(publish_public.shutil, "which", lambda _: "/usr/bin/crane")
+    monkeypatch.setattr(
+        publish_public,
+        "_crane_digest",
+        lambda ref, **_: (True, "sha256:identical"),
+    )
+
+    def no_copy(*args, **kwargs) -> None:  # pragma: no cover - must not run
+        raise AssertionError(f"matching digests must not invoke crane copy: {args}")
+
+    monkeypatch.setattr(publish_public.subprocess, "run", no_copy)
+
+    assert publish_public._crane_copy(item) is False
+    assert "Already current; skipping copy" in capsys.readouterr().out
+
+
+def test_crane_digest_returns_the_registry_digest(monkeypatch) -> None:
+    from npa.deploy import publish_public
+
+    class Result:
+        returncode = 0
+        stdout = "sha256:current\n"
+        stderr = ""
+
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    monkeypatch.setattr(publish_public.shutil, "which", lambda _: "/usr/bin/crane")
+
+    def run(args, **kwargs):  # noqa: ANN001, ANN202 - subprocess test double
+        calls.append((args, kwargs))
+        return Result()
+
+    monkeypatch.setattr(publish_public.subprocess, "run", run)
+
+    assert publish_public._crane_digest("registry.example/image:1") == (
+        True,
+        "sha256:current",
+    )
+    assert calls[0][0] == ["/usr/bin/crane", "digest", "registry.example/image:1"]
+    assert calls[0][1]["check"] is False
+
+
+def test_crane_digest_preserves_the_registry_error(monkeypatch) -> None:
+    from npa.deploy import publish_public
+
+    class Result:
+        returncode = 1
+        stdout = ""
+        stderr = "Error: fetching digest\nMANIFEST_UNKNOWN: manifest unknown\n"
+
+    monkeypatch.setattr(publish_public.shutil, "which", lambda _: "/usr/bin/crane")
+    monkeypatch.setattr(publish_public.subprocess, "run", lambda *args, **kwargs: Result())
+
+    assert publish_public._crane_digest("registry.example/image:missing") == (
+        False,
+        "MANIFEST_UNKNOWN: manifest unknown",
+    )
+
+
+def test_crane_copy_updates_a_target_with_a_different_digest(monkeypatch, capsys) -> None:
+    from npa.deploy import publish_public
+    from npa.deploy.publish_public import PublishItem
+
+    item = PublishItem(
+        tool="lerobot",
+        source_ref="source.example/npa-lerobot:1.0",
+        target_ref="target.example/npa-lerobot:1.0",
+    )
+    digests = {
+        item.source_ref: (True, "sha256:new"),
+        item.target_ref: (True, "sha256:old"),
+    }
+    calls: list[list[str]] = []
+    monkeypatch.setattr(publish_public.shutil, "which", lambda _: "/usr/bin/crane")
+    monkeypatch.setattr(
+        publish_public,
+        "_crane_digest",
+        lambda ref, **_: digests[ref],
+    )
+    monkeypatch.setattr(
+        publish_public.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append(args),
+    )
+
+    assert publish_public._crane_copy(item) is True
+    assert calls == [["/usr/bin/crane", "copy", item.source_ref, item.target_ref]]
+    assert "Digest changed; copying" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "target_error",
+    [
+        "MANIFEST_UNKNOWN: manifest unknown",
+        "NAME_UNKNOWN: repository name not known",
+        "DENIED: requested access to the resource is denied",
+    ],
+)
+def test_crane_copy_creates_a_missing_or_pull_denied_target(
+    monkeypatch, target_error: str
+) -> None:
+    """A first GHCR push can create a package the pull path cannot read yet."""
+    from npa.deploy import publish_public
+    from npa.deploy.publish_public import PublishItem
+
+    item = PublishItem(
+        tool="lerobot",
+        source_ref="source.example/npa-lerobot:1.0",
+        target_ref="target.example/npa-lerobot:1.0",
+    )
+    digests = {
+        item.source_ref: (True, "sha256:new"),
+        item.target_ref: (False, target_error),
+    }
+    calls: list[list[str]] = []
+    monkeypatch.setattr(publish_public.shutil, "which", lambda _: "/usr/bin/crane")
+    monkeypatch.setattr(
+        publish_public,
+        "_crane_digest",
+        lambda ref, **_: digests[ref],
+    )
+    monkeypatch.setattr(
+        publish_public.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append(args),
+    )
+
+    assert publish_public._crane_copy(item) is True
+    assert calls == [["/usr/bin/crane", "copy", item.source_ref, item.target_ref]]
+
+
+def test_crane_copy_refuses_an_unknown_target_digest_failure(monkeypatch) -> None:
+    """A transient read failure must not turn into a blind repeat write."""
+    from npa.deploy import publish_public
+    from npa.deploy.publish_public import PublishItem
+
+    item = PublishItem(
+        tool="lerobot",
+        source_ref="source.example/npa-lerobot:1.0",
+        target_ref="target.example/npa-lerobot:1.0",
+    )
+    digests = {
+        item.source_ref: (True, "sha256:new"),
+        item.target_ref: (False, "timed out after 60s"),
+    }
+    monkeypatch.setattr(publish_public.shutil, "which", lambda _: "/usr/bin/crane")
+    monkeypatch.setattr(
+        publish_public,
+        "_crane_digest",
+        lambda ref, **_: digests[ref],
+    )
+
+    with pytest.raises(RuntimeError, match="refusing to copy"):
+        publish_public._crane_copy(item)
+
+
+def test_repeat_publish_skips_all_matching_copies_but_still_verifies(
+    monkeypatch, capsys
+) -> None:
+    """Incrementality removes writes, not the final anonymous-public assertion."""
+    from npa.deploy import publish_public
+
+    plan = publish_public.build_publish_plan(target_registry="ghcr.io/example/workbench")
+    verified: list[str] = []
+    monkeypatch.setattr(
+        publish_public, "_crane_manifest_readable", lambda ref, **_: (True, "ok")
+    )
+    monkeypatch.setattr(publish_public, "_crane_copy", lambda item: False)
+
+    def public(ref: str, **_: object) -> tuple[bool, str]:
+        verified.append(ref)
+        return True, "HTTP 200"
+
+    monkeypatch.setattr(publish_public, "anonymous_pull_ok", public)
+
+    assert publish_public.main(["--target", "ghcr.io/example/workbench"]) == 0
+    output = capsys.readouterr().out
+    assert "Copied 0 image(s)." in output
+    assert f"Skipped {len(plan)} already-current image(s)." in output
+    assert verified == [item.target_ref for item in plan]
+
+
 def test_settings_url_encodes_the_repository_nested_package_name() -> None:
     from npa.deploy.publish_public import package_settings_url
 


### PR DESCRIPTION
## What changed

- compare the source and target top-level manifest digests before every public mirror copy
- skip `crane copy` when the target already carries the exact source digest
- copy only missing, pull-denied-new, or changed targets, and refuse blind writes after unknown/transient target-read failures
- preserve the complete source preflight, redistribution selector, Isaac payload gate, and anonymous-public verification on every run
- report copied and already-current counts separately and document the incremental behavior

## Why

The manual publisher rebuilt its complete guarded plan on every dispatch and invoked `crane copy` for every readable image, even when 18 existing public targets already matched their source tags. A new image should not require rewriting every unchanged package.

## Operator impact

After this merges, run `Publish public images` normally. Existing matching packages print `Already current; skipping copy`; only missing or changed tags are copied. The one-time GHCR visibility flip for a newly created package is unchanged. Re-running after those flips performs no matching copies and only verifies anonymous pullability.

## Validation

- `ruff` on the changed Python and tests
- 84 focused publisher, public-mirror workflow, and skills guard tests passed
- 419 deployment, Docker packaging/licensing, and skills tests passed
- full non-E2E suite: 5,607 passed, 47 skipped, 1 xpassed
- read-only live registry check confirmed an existing Nebius source tag and GHCR target resolve to the same digest used by the skip decision

No image, tag, redistribution classification, registry visibility, or GHCR package was changed by this PR.
