### PR TITLE
Build legally redistributable Cosmos Transfer 2.5 image

### DIFF
--- a/docs/workbench/container-packaging.md
+++ b/docs/workbench/container-packaging.md
@@ -451,6 +451,10 @@ direct service-to-service file coupling.
 
 ## Related docs
 
+- Cosmos Transfer 2.5 has an artifact-by-artifact redistribution record at
+  `npa/docker/workbench/cosmos2-transfer/REDISTRIBUTION.md`; its `public`
+  classification is valid only after the registry-image audits named there pass.
+
 - `docs/security/container-golden-evals.md` — usefulness + safety contract
 - `docs/security/image-reproducibility.md` — digests and tag families
 - `docs/architecture/oss-onboarding-ladder.md` — OSS → marketplace promotion

--- a/docs/workbench/cosmos2-transfer-20260803-release-audit.md
+++ b/docs/workbench/cosmos2-transfer-20260803-release-audit.md
@@ -1,0 +1,158 @@
+# Cosmos Transfer 2.5 release audit — 2026-08-03
+
+This is an engineering redistribution and release record, not legal advice. It
+qualifies only the exact registry bytes below. Artifact-level license evidence
+and runtime obligations are recorded in
+`npa/docker/workbench/cosmos2-transfer/REDISTRIBUTION.md`.
+
+## Candidate identity and provenance
+
+| Field | Qualified value |
+|---|---|
+| Run | `npa-cosmos2-legal-20260803T025147Z` |
+| Private source tag | `npa-cosmos2-transfer:2.5.1-skypilot-ready-20260801T053000Z` |
+| OCI index digest | `sha256:9b4c5eb505353aa3dea37284c662f3cff306fa7c902f040e559f7939173345cc` |
+| Linux/amd64 image digest | `sha256:cda3588d417518aec14d66a292f2dd4984739bc922492f2e78cae2bee377e450` |
+| Config digest | `sha256:1935be2a054d17aa9188415c9899b49951d1708b43bce49e93a0983bb5aafe4c` |
+| Attestation manifest | `sha256:d43d579cb8e1e60afe546cb5746a7454e3d5c9bc7f6a806a5cf12c6ddaaa0540` |
+| Cosmos Transfer revision | `67d56b7d550a3911024a32dc23ae0bae5258e633` |
+| Build base | `nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04@sha256:3986465b3dd3b4d602c07061f2cff417e0bfb24810129408d4eb12e111015a6c` |
+| Final base | `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04@sha256:9175fa92f96de35a8cfb9493f0dfcf9435c7a597e9d95ad41d2cae382a95e3f9` |
+| uv image (build and runtime tools) | `ghcr.io/astral-sh/uv:0.8.12@sha256:e1d7fa999ae39871fc2fd6c9c572d970cc877a239d2a16238a204c23772d1c0e` |
+| Python / Ubuntu snapshot | CPython `3.10.18` / `20260801T053000Z` |
+| Build credentials | none |
+| Packaging contract | `tier: job`, `redistribution: public` |
+
+The pushed index has one `linux/amd64` image plus its SBOM/provenance
+attestation. The image has 22 compressed layers totaling 8,663,394,825 bytes;
+the merged filesystem declares 17,323,651,113 bytes. The config selects user
+`ubuntu`, an exec-form `/opt/cosmos2-transfer/entrypoint.sh`, a runtime volume
+at `/opt/cosmos/model-cache`, and limits NLTK's operator-authorized download
+root to that volume. `LD_LIBRARY_PATH` covers the CUDA runtime directory whose
+unversioned `libcudart.so` compatibility link targets the inherited
+`libcudart.so.12`. Its revision label matches the full source SHA. Build logs
+contained no mutable APT endpoint, credential name, credential-shaped value,
+or actual runtime/registry secret value.
+
+## Registry-byte audit
+
+All checks below addressed the registry digest, not the local Docker daemon.
+
+| Check | Result |
+|---|---|
+| Manifest and config | one `linux/amd64` child; non-root `ubuntu`; 67 history entries; zero credential-pattern matches in config/history |
+| Every-layer inventory | 22/22 layers read; 68,362 members and 58,002 files; zero Git/LFS paths and zero sensitive/cache payloads |
+| Merged filesystem | 55,735 files, 7,587 directories, 65,318 members; zero `.git`/LFS paths and zero sensitive paths |
+| Large files | 90 files over 10 MiB, totaling 15,876,898,970 bytes; all classified CUDA/Python libraries or executables (including the Apache-2.0/MIT `uv` runtime tool), no media/checkpoints |
+| Media | 40 package-owned test/icon/documentation files, 365,651 bytes total; largest 122,772 bytes; no upstream Cosmos `assets/` media |
+| Weight-like suffixes | seven classified non-model files: two text startup hooks, one SciPy BSD Sobol table, and four Apache SentencePiece Unicode tables |
+| Model caches | only empty declared runtime cache directories; no Hugging Face, NGC, Torch, or checkpoint bytes |
+| `/root` | only inherited `.bashrc` and `.profile`; no application, cache, key, or credential payload |
+| License/notice inventory | 622 merged-filesystem license/notice paths |
+| Omniverse payload scan | 65,318 entries; clean; zero payload and history hits |
+| SBOM | in-toto SPDX attestation for the exact child: 596 packages, 5,072 files, and 8,331 relationships |
+| Provenance | in-toto SLSA v1 attestation for the exact child; five digest-pinned builder/base materials; no credential-shaped content |
+
+## Trivy triage
+
+The installed Trivy version scanned the exact registry child for OS and Python
+vulnerabilities, secret patterns, license coverage, and configuration findings.
+It reported 492 vulnerabilities: 0 critical, 53 high, 398 medium, and 41 low;
+87 have an upstream fixed version and 405 do not. It found zero secrets.
+
+Two of the high findings are non-executable metadata references rather than
+installed vulnerable code. pip 26.2 intentionally carries its own dependency
+SBOM at `pip/_vendor/bom.cdx.json`; that document names msgpack 1.1.2 and
+setuptools 70.3.0, so BuildKit and Trivy report one high for each. The same SPDX
+attestation separately identifies the actual installed msgpack 1.2.1 and
+setuptools 83.0.0. The Docker build imports those versions exactly and proves
+the standalone base interpreter has neither package. The old SBOM records are
+retained as attribution evidence rather than deleted to hide scanner output.
+They correspond to [GHSA-6v7p-g79w-8964](https://github.com/advisories/GHSA-6v7p-g79w-8964),
+[GHSA-5rjg-fvgr-3xxf](https://github.com/advisories/GHSA-5rjg-fvgr-3xxf), and
+[GHSA-h35f-9h28-mq5c](https://github.com/advisories/GHSA-h35f-9h28-mq5c).
+
+The 51 executable-code high findings are: GitPython 3.1.45 (13 fixed), Pillow 11.3.0 (13
+fixed), OpenEXR 3.4.2 (5 fixed), pyasn1 0.6.1 (5 fixed), urllib3 2.5.0 (4
+fixed), PyJWT 2.10.1 (2 fixed), cryptography 46.0.3 (2 fixed), diffusers
+0.35.2 (2 fixed), transformers 4.51.3 (2 fixed), protobuf 6.33.0 (1 fixed), pyarrow 22.0.0 (1
+fixed), and FlashAttention 2.7.3 (1 without a fixed version).
+
+The 50 real fixable highs remain in NVIDIA's immutable, hash-locked inference
+closure; replacing that many intertwined findings across 12 packages without an upstream lock
+would weaken reproducibility and inference compatibility. They are therefore a
+documented residual release risk, not a silent waiver, and should be addressed
+by advancing the complete upstream lock after compatibility testing. The sole
+unfixed high, CVE-2026-31253, concerns unsafe pickle checkpoint loading in a
+FlashAttention training helper. This image uses the FlashAttention inference
+kernel and operator-authorized NVIDIA gated weights; it does not invoke that
+training helper or accept untrusted checkpoint uploads. The installed code is
+still present, so the finding remains a security risk for any out-of-scope use.
+
+Trivy emitted 8,057 license records: 2 critical, 844 high, 18 medium, 6,610
+low, and 583 unknown. Both critical records are the same attribution copied in
+PyArrow's license bundle and Cosmos's `ATTRIBUTIONS.md`: Apache Arrow 22 states
+that vendored `whereami` is dual licensed under MIT and WTFPLv2, and reproduces
+the MIT grant. The MIT option is selected; the duplicate WTFPL detections are
+not an ambiguity. The 852 high records are reciprocal/restricted classifications,
+not missing notices. Their package copyright/license files remain in the image,
+and redistribution retains corresponding-source, notice, and LGPL relinking
+obligations. The authoritative dual-license text is Apache Arrow's tagged
+[`LICENSE.txt`](https://raw.githubusercontent.com/apache/arrow/apache-arrow-22.0.0/LICENSE.txt).
+
+## Functional release gates
+
+Four superseded private candidates were rejected by the real GPU/workflow gates rather
+than waived: the first revealed that Transformers imports NumPy's small BSD
+`_natype.py` helper through SciPy; the second reached the prompt guardrail and
+showed that NLTK PathSec needed the dedicated mounted model-cache root; the
+third passed both guardrails and reached the first diffusion step, where
+Transformer Engine exposed the CUDA runtime image's missing unversioned
+`libcudart.so` linker name. A fourth passed raw inference but failed the managed
+workflow after source setup because SkyPilot had masked upstream's runtime
+`uvx` dependency. The final image ships `uv` and `uvx` from the same
+digest-pinned, Apache-2.0/MIT image used by NVIDIA upstream. Each correction has
+a build-time assertion. Only the final registry digest and successful live
+results below qualify.
+
+The catalog's serverless golden declaration remains H100. The live Kubernetes
+cluster had no H100 node, so the GPU-selection procedure selected the available
+96 GiB RTX PRO 6000 Blackwell: it exceeds the measured 62,822 MiB requirement
+and exercises the image's CUDA 12.8 / compute-capability 12.0 FlashAttention
+path. Managed job 362 used the exact registry child above and passed as UID
+1000 with torch 2.7.0+cu128, `uvx 0.8.12`, CUDA available, and a real
+FlashAttention kernel. Removing `HF_TOKEN` exited 78 before a download and the
+logs contained no credential. With the token injected only at run time, the
+repository-authored fixture drove `examples/inference.py` for four diffusion
+steps in 341.127 seconds. The output was a decodable 1280x720 MP4 with 93 frames,
+5.8125 seconds duration, 5,537,600 bytes, and SHA-256
+`b85870845a816dda3d62bd906f8bc58250b1b0d1a90c90054865c30ac1491eb7`.
+The mounted cache held 17,436 files / 36,448,258,402 bytes; no model or token
+entered the image.
+
+Managed workflow job 363 (`npa-wf-gpu-cosmos2-transfer-ca6a03fa`) then used
+that same child digest through the repository's live submit path. The actual
+Kubernetes pod reported the qualified digest as its image ID and remained alive
+while SkyPilot completed its non-root SSH, rsync, and sudo bootstrap. The
+recorded interpreter was `/opt/cosmos/cosmos-transfer2.5/.venv/bin/python`.
+`workbench.cosmos2.transfer_execute` fetched gated weights only into the mounted
+runtime cache and completed the production 35-step edge-conditioned inference.
+SkyPilot reported `SUCCEEDED` after 13 minutes 7 seconds of job execution (14
+minutes 19 seconds including managed-job setup).
+
+The result was downloaded back from object storage and independently inspected.
+Its `npa.cosmos2.transfer.v1` manifest reported `status: executed`, a distinct
+non-control generated video, and eight uploaded PNG frames. `ffprobe` decoded
+the H.264 output as 1280x720 at 16 fps with 93 frames and 5.8125 seconds of video.
+The file is 5,635,256 bytes with SHA-256
+`5c245706db69ece6e7c300d4c215eea4834cd02a3ed5b8428b735dba449f8da8`.
+The manifest's byte count, generated-video URI, clip, conditioning metadata,
+and frame inventory agreed with the downloaded artifacts.
+
+## Publication boundary
+
+This run pushes only the additive private source-registry tag above. It does not
+publish or copy any image to GHCR, alter package visibility, or dispatch the
+`Publish public images` workflow. A later public publication must independently
+revalidate this exact digest, satisfy the runtime/reciprocal-license obligations,
+and accept the documented vulnerability risk.

--- a/docs/workbench/cosmos2-transfer-20260803-release-audit.md
+++ b/docs/workbench/cosmos2-transfer-20260803-release-audit.md
@@ -103,8 +103,12 @@ obligations. The authoritative dual-license text is Apache Arrow's tagged
 ## Functional release gates
 
 Four superseded private candidates were rejected by the real GPU/workflow gates rather
-than waived: the first revealed that Transformers imports NumPy's small BSD
-`_natype.py` helper through SciPy; the second reached the prompt guardrail and
+than waived: the first revealed that the SigLIP/scientific-Python import path reaches
+`numpy.testing`, whose pinned NumPy 2.2.6
+`numpy/testing/_private/utils.py` unconditionally imports `pd_NA` from
+`numpy/_core/tests/_natype.py`. Test-tree pruning therefore retains that one small
+BSD-licensed source helper, and the Docker build's SigLIP/SciPy import is the checked
+runtime assertion for it. The second candidate reached the prompt guardrail and
 showed that NLTK PathSec needed the dedicated mounted model-cache root; the
 third passed both guardrails and reached the first diffusion step, where
 Transformer Engine exposed the CUDA runtime image's missing unversioned
@@ -129,6 +133,18 @@ steps in 341.127 seconds. The output was a decodable 1280x720 MP4 with 93 frames
 `b85870845a816dda3d62bd906f8bc58250b1b0d1a90c90054865c30ac1491eb7`.
 The mounted cache held 17,436 files / 36,448,258,402 bytes; no model or token
 entered the image.
+
+Three deliberately conservative packaging details remain coupled to this pinned
+dependency closure. The forbidden-payload guard treats every unreviewed `.pth` as
+checkpoint-like and permits only the two known venv startup hooks; adding another
+`.pth` requires an explicit artifact, runtime, and license review plus a narrow path
+allowlist update. It must not be accepted by inspecting file contents. The global
+`/usr/local/bin/python3` venv shim is also intentional: SkyPilot and
+orchestrator-supplied commands invoke `python3`, while `/usr/bin/python3` remains for
+system tooling. Finally, `smoke_functional.sh` safely captures fixture JSON from
+stdout because the generator emits exactly one JSON object after success and its
+ffmpeg subprocess uses `-hide_banner -loglevel error`, which keeps diagnostics on
+stderr; a failed generator terminates the shell before JSON parsing.
 
 Managed workflow job 363 (`npa-wf-gpu-cosmos2-transfer-ca6a03fa`) then used
 that same child digest through the repository's live submit path. The actual

--- a/docs/workbench/guides/physical-ai-data-factory-deploy.md
+++ b/docs/workbench/guides/physical-ai-data-factory-deploy.md
@@ -319,9 +319,10 @@ npa workbench workflow submit "$SPEC" \
 If your cluster advertises a different product name for the same GPU (e.g.
 `RTXPRO-6000-BLACKWELL-SERVER-EDITION`), pass that exact name:
 `NPA_WORKFLOW_GPU_ACCELERATOR=<name>:N`. Variant parallelism is auto-detected from
-the GPU count; override with `NPA_COSMOS_VARIANT_PARALLELISM`. Condition each
-variant on the run's real input clip (preserve geometry/motion, change only
-appearance) with `NPA_COSMOS_CONDITION_ON_INPUT=1`.
+the GPU count; override with `NPA_COSMOS_VARIANT_PARALLELISM`. Every managed
+variant is conditioned on a supported video already uploaded beneath the run's
+`input/` prefix (preserve geometry/motion, change only appearance); missing or
+inaccessible input fails closed before inference.
 
 ---
 

--- a/docs/workbench/guides/physical-ai-data-factory.md
+++ b/docs/workbench/guides/physical-ai-data-factory.md
@@ -66,9 +66,19 @@ where NPA substitutes its own endpoint.
 > `variables` (which drives that clip's Rerun label). So a config with N
 > augmentations produces **N scenario variants**, recorded via `variant_count` /
 > `multiply_mode` in the augment manifest, curation, and finalize reports.
-> Optionally condition each variant on the run's real input clip
-> (`NPA_COSMOS_CONDITION_ON_INPUT=1`) so the geometry/motion is preserved while
-> only the appearance changes (edge control computed on-the-fly).
+> The managed transfer conditions every variant on a supported video under the
+> run's `config.trigger_uri` (`input/`), preserving geometry/motion while changing
+> appearance (edge control is computed on-the-fly).
+
+### Migration: a real input video is required
+
+`workbench.cosmos2.transfer_execute` now fails closed unless its configured
+`trigger_uri` contains a readable `.mp4`, `.mov`, `.webm`, `.mkv`, or `.avi`.
+An empty/video-free prefix reports that no supported video exists; storage setup,
+authentication, listing, and download failures report a separate access error.
+The bundled upstream sample is no longer a fallback because it was removed for
+redistribution reasons. Upload the source video beneath the run's `input/` prefix
+before submitting either first-class managed workflow.
 
 ## Runtime placement
 

--- a/docs/workbench/npa-workflow-tool-catalog.md
+++ b/docs/workbench/npa-workflow-tool-catalog.md
@@ -24,7 +24,7 @@ This table must list every `TOOL_CATALOG` key (enforced by
 | `workbench.token_factory.caption` | `npa workbench token-factory caption` | `config.images_uri` | `config.captions_uri` | no |
 | `workbench.token_factory.generate` | `npa workbench token-factory generate` | `config.prompts_uri` | `config.generations_uri` | no |
 | `workbench.cosmos2.transfer` | `npa workbench cosmos2 transfer` | `config.trigger_uri` | `config.augment_uri` | no |
-| `workbench.cosmos2.transfer_execute` | `npa workbench cosmos2 transfer --execute` | `config.trigger_uri` | `config.augment_uri` | yes (real Cosmos Transfer 2.5 on GPU; uploads video + frames to S3) |
+| `workbench.cosmos2.transfer_execute` | `npa workbench cosmos2 transfer --execute` | supported video under `config.trigger_uri` (required) | `config.augment_uri` | yes (real, input-conditioned Cosmos Transfer 2.5 on GPU; uploads video + frames to S3 and fails closed without input) |
 | `workbench.cosmos3.generate` | `npa workbench cosmos3 generate` | `config.prompt`, `config.cosmos3_mode`, `config.cosmos3_checkpoint` | `config.output_uri` | yes (real Cosmos 3 omni-model generation on GPU in `npa-cosmos3`; gated weights download at runtime with the operator's HF token) |
 | `workbench.cosmos3.reason` | `npa workbench cosmos3 reason` | `config.scene_uri` | `config.reason_uri` | no |
 | `workbench.cosmos_evaluator.evaluate` | `npa workbench cosmos-evaluator evaluate` | `config.rollouts_uri`, `config.input_uri`, `config.configs_uri` | `config.scores_uri` | yes (real NVIDIA Cosmos Evaluator: hallucination + VLM attribute verification) |

--- a/npa/docker/workbench/cosmos2-transfer/Dockerfile
+++ b/npa/docker/workbench/cosmos2-transfer/Dockerfile
@@ -1,137 +1,218 @@
-# Capability wrapper for npa-cosmos2-transfer.
-#
-# Golden eval in this repo means "does this container actually do its job" — a
-# real capability test, not a CUDA probe. So this wrapper bakes the REAL
-# Cosmos-Transfer2.5 inference environment (Python 3.10 + torch cu128 +
-# flash-attn + all deps via `uv sync`) on top of the upstream transfer runtime,
-# and ships a golden-eval script that runs an actual video-to-video transfer on a
-# bundled robot control example and asserts a generated video is produced.
-#
-# The upstream 2.5.x image ships the cosmos-transfer2.5 sources but does not bake
-# a flash-attn-compatible venv, and pins .python-version=3.13 while the flash-attn
-# wheel is cp310-only — both are corrected here.
-ARG BASE_IMAGE=npa-cosmos2-transfer:2.5.0
-FROM ${BASE_IMAGE}
+# syntax=docker/dockerfile:1.7
 
-USER root
-WORKDIR /opt/cosmos/cosmos-transfer2.5
-
-# UV_PYTHON_INSTALL_DIR keeps the interpreter out of /root. Built as root, uv
-# otherwise puts it in /root/.local/share/uv/python and the venv's bin/python is a
-# symlink into that tree; /root is 0700, so the image's own final USER ubuntu got
-# `Permission denied` (exit 126) for every inference call and the venv was unusable
-# as shipped.
-ENV UV_LINK_MODE=copy \
-    UV_PYTHON_INSTALL_DIR=/opt/cosmos/uv-python \
-    UV_LEGACY_PYTHON_DIR=/root/.local/share/uv/python
-
-# Build the real inference env. `uv sync --extra=cu128` resolves torch cu128 +
-# flash-attn (cp310) + the full transfer2.5 dependency set from the upstream lock.
+# Redistributable Cosmos Transfer 2.5 capability image.
 #
-# Two paths, because BASE_IMAGE may be either the upstream runtime or an
-# already-built transfer image (the upstream 2.5.0 base is not always available to
-# rebuild from):
-#
-#   fresh base      -> uv installs the interpreter into UV_PYTHON_INSTALL_DIR and
-#                      syncs the venv against it.
-#   built artifact  -> the venv already holds the right packages but its bin/python
-#                      symlinks into /root, so relocate the interpreter and repoint
-#                      the venv at it. Re-running `uv sync` here would re-download
-#                      the whole cu128 torch set for no benefit.
-#
-# Either way the layer ends with the interpreter outside /root, which is what makes
-# the venv usable by the non-root user this image runs as.
-RUN set -eux; \
-    resolved="$(readlink -f .venv/bin/python 2>/dev/null || true)"; \
-    case "$resolved" in \
-      "${UV_LEGACY_PYTHON_DIR}"/*) relocate=1 ;; \
-      *) relocate=0 ;; \
-    esac; \
-    if [ "$relocate" = 1 ]; then \
-      old_root="${resolved%/bin/*}"; \
-      new_root="${UV_PYTHON_INSTALL_DIR}/$(basename "$old_root")"; \
-      mkdir -p "${UV_PYTHON_INSTALL_DIR}"; \
-      cp -a "${UV_LEGACY_PYTHON_DIR}/." "${UV_PYTHON_INSTALL_DIR}/"; \
-      # uv's tree contains an absolute version symlink (cpython-3.10-... ->
-      # cpython-3.10.20-...), and `cp -a` copies such links verbatim — so the copy
-      # still points back into the legacy tree and resolving through it lands in
-      # /root again. Repoint every absolute link that targets the old location.
-      find "${UV_PYTHON_INSTALL_DIR}" -type l | while read -r link; do \
-        target="$(readlink "$link")"; \
-        case "$target" in \
-          "${UV_LEGACY_PYTHON_DIR}"/*) \
-            ln -sfn "${UV_PYTHON_INSTALL_DIR}/${target#"${UV_LEGACY_PYTHON_DIR}/"}" "$link" ;; \
-        esac; \
-      done; \
-      for link in .venv/bin/python .venv/bin/python3 .venv/bin/python3.10; do \
-        [ -L "$link" ] || continue; \
-        target="$(readlink "$link")"; \
-        case "$target" in \
-          "${UV_LEGACY_PYTHON_DIR}"/*) ln -sfn "${new_root}/bin/$(basename "$target")" "$link" ;; \
-        esac; \
-      done; \
-      # Rewrite by directory prefix, not by the resolved path: pyvenv.cfg records the
-      # interpreter through uv's version symlink (cpython-3.10-...) while readlink -f
-      # resolves to the real directory (cpython-3.10.20-...). Matching only the
-      # resolved form leaves `home =` pointing into the legacy tree, and Python takes
-      # sys._home from it — which surfaces much later as a PermissionError from
-      # distutils.sysconfig rather than from the venv itself. `cp -a` copied both the
-      # real directory and the symlink, so a prefix swap is correct for either form.
-      sed -i "s|${UV_LEGACY_PYTHON_DIR}|${UV_PYTHON_INSTALL_DIR}|g" .venv/pyvenv.cfg; \
-      rm -rf "${UV_LEGACY_PYTHON_DIR}"; \
-    else \
-      uv python install 3.10; \
-      echo "3.10" > .python-version; \
-      uv sync --extra=cu128 --python 3.10; \
-    fi; \
-    case "$(readlink -f .venv/bin/python)" in \
-      "${UV_LEGACY_PYTHON_DIR}"/*) echo "interpreter still under ${UV_LEGACY_PYTHON_DIR}" >&2; exit 1 ;; \
-    esac; \
-    grep -q "${UV_LEGACY_PYTHON_DIR}" .venv/pyvenv.cfg \
-      && { echo "pyvenv.cfg still points at ${UV_LEGACY_PYTHON_DIR}" >&2; exit 1; } || true; \
-    if [ -d "${UV_PYTHON_INSTALL_DIR}" ] \
-       && find "${UV_PYTHON_INSTALL_DIR}" -type l -lname "${UV_LEGACY_PYTHON_DIR}/*" | grep -q .; then \
-      echo "relocated tree still links back into ${UV_LEGACY_PYTHON_DIR}" >&2; exit 1; \
-    fi
+# This build intentionally starts from NVIDIA's public CUDA container, not from a
+# privately assembled npa-cosmos2-transfer parent. The source and every Python
+# dependency are immutable inputs: the source checkout is a full commit SHA and
+# `uv sync --locked` consumes the upstream hash-bearing lockfile. No credential is
+# accepted or needed during the build. Gated model weights are fetched only at run
+# time into HF_HOME after the operator supplies HF_TOKEN and accepts the NVIDIA Open
+# Model License.
+ARG CUDA_BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04@sha256:3986465b3dd3b4d602c07061f2cff417e0bfb24810129408d4eb12e111015a6c
+ARG CUDA_RUNTIME_IMAGE=nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04@sha256:9175fa92f96de35a8cfb9493f0dfcf9435c7a597e9d95ad41d2cae382a95e3f9
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.8.12@sha256:e1d7fa999ae39871fc2fd6c9c572d970cc877a239d2a16238a204c23772d1c0e
+ARG UBUNTU_SNAPSHOT=20260801T053000Z
 
-COPY --chmod=755 docker/workbench/cosmos2-transfer/smoke_functional.sh /opt/cosmos2-transfer/smoke_functional.sh
-COPY --chmod=755 docker/workbench/cosmos2-transfer/entrypoint.sh /opt/cosmos2-transfer/entrypoint.sh
+FROM ${UV_IMAGE} AS uv-bin
 
-# openssh-server, rsync, and sudo are what SkyPilot's Kubernetes provisioner shells
-# out to per pod (`$(prefix_cmd) apt install openssh-server rsync -y`, then
-# `service ssh restart`, with prefix_cmd = sudo for a non-root user). Without them
-# the setup script fails and the container exits before SkyPilot can exec into it.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      netcat-openbsd openssh-server procps rsync sudo \
+FROM ${CUDA_BASE_IMAGE} AS build
+
+ARG COSMOS_TRANSFER_REVISION=67d56b7d550a3911024a32dc23ae0bae5258e633
+ARG COSMOS_PYTHON_VERSION=3.10.18
+ARG UBUNTU_SNAPSHOT
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    GIT_LFS_SKIP_SMUDGE=1 \
+    UV_LINK_MODE=copy \
+    UV_NO_CACHE=1 \
+    UV_PYTHON_INSTALL_DIR=/opt/cosmos/uv-python
+
+COPY --from=uv-bin /uv /usr/local/bin/uv
+
+RUN rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*.list \
+      /etc/apt/sources.list.d/*.sources \
+    && printf '%s\n' \
+      'Types: deb' \
+      "URIs: https://snapshot.ubuntu.com/ubuntu/${UBUNTU_SNAPSHOT}/" \
+      'Suites: noble noble-updates noble-backports noble-security' \
+      'Components: main restricted universe multiverse' \
+      'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
+      > /etc/apt/sources.list.d/ubuntu.sources \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git \
     && rm -rf /var/lib/apt/lists/*
 
-RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 ubuntu
-RUN echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu \
-    && chmod 0440 /etc/sudoers.d/ubuntu \
-    && chown -R ubuntu:ubuntu \
-      /opt/cosmos2-transfer \
-      /opt/cosmos/cosmos-transfer2.5/.venv \
-      "${UV_PYTHON_INSTALL_DIR}"
+WORKDIR /opt/cosmos/cosmos-transfer2.5
 
-# The venv must be usable by the non-root user the image actually runs as.
-#
-# `import torch` alone is too weak a check: it never reads sys._home, so a
-# pyvenv.cfg still pointing into /root passes here and then fails deep in an
-# inference run (megatron -> torch.utils.cpp_extension -> setuptools ->
-# distutils.sysconfig -> PermissionError). Exercising distutils.sysconfig is what
-# actually proves the relocation is complete.
-RUN su ubuntu -s /bin/bash -c \
-      '/opt/cosmos/cosmos-transfer2.5/.venv/bin/python -c "\
-import sys, torch, flash_attn; \
-from distutils.sysconfig import customize_compiler, get_config_var; \
-home = sys._home or \"\"; \
-assert \"/root\" not in home, home; \
-get_config_var(\"prefix\"); \
-print(\"venv usable as ubuntu:\", torch.__version__, \"home=\", home)"'
+# Both fetch and checkout explicitly disable LFS smudging. Fetching the immutable
+# SHA directly avoids depending on a moving branch or tag. The entire Git database,
+# all upstream assets (including LFS pointers), examples other than the real
+# inference entrypoint, docs, tests, and caches are removed before this RUN is
+# committed, so they never appear in an image layer.
+RUN set -eux; \
+    git init; \
+    git remote add origin https://github.com/nvidia-cosmos/cosmos-transfer2.5.git; \
+    GIT_LFS_SKIP_SMUDGE=1 git -c filter.lfs.smudge= -c filter.lfs.required=false \
+      fetch --depth=1 --filter=blob:none origin "${COSMOS_TRANSFER_REVISION}"; \
+    GIT_LFS_SKIP_SMUDGE=1 git -c filter.lfs.smudge= -c filter.lfs.required=false \
+      checkout --detach FETCH_HEAD; \
+    test "$(git rev-parse HEAD)" = "${COSMOS_TRANSFER_REVISION}"; \
+    grep -q 'filter=lfs' .gitattributes; \
+    rm -rf .git assets .github docker docs scripts tests; \
+    find examples -mindepth 1 -maxdepth 1 ! -name inference.py -exec rm -rf -- {} +; \
+    test -f examples/inference.py; \
+    test ! -e assets; \
+    test ! -e .git
 
+COPY --chmod=755 docker/workbench/cosmos2-transfer/assert_no_forbidden_payload.sh \
+    /usr/local/bin/assert-no-forbidden-cosmos2-payload
+COPY docker/workbench/cosmos2-transfer/security-overrides.txt \
+    /tmp/cosmos2-security-overrides.txt
+
+# Python itself and the complete cu128 inference environment are exact-version or
+# lockfile pinned. `--no-editable` makes the venv independent of removed source-only
+# material while retaining the Apache source tree used for provenance and debugging.
+RUN set -eux; \
+    uv python install "${COSMOS_PYTHON_VERSION}"; \
+    printf '%s\n' "${COSMOS_PYTHON_VERSION}" > .python-version; \
+    uv sync --locked --no-dev --no-editable --extra=cu128 \
+      --python "${COSMOS_PYTHON_VERSION}"; \
+    uv pip install --python .venv/bin/python --no-deps \
+      --requirement /tmp/cosmos2-security-overrides.txt; \
+    .venv/bin/python -c 'import defusedxml, importlib.metadata, msgpack, nltk, numpy; assert importlib.metadata.version("defusedxml") == "0.7.1"; assert importlib.metadata.version("nltk") == "3.10.0"; assert importlib.metadata.version("pip") == "26.2"; assert importlib.metadata.version("msgpack") == "1.2.1"; assert importlib.metadata.version("setuptools") == "83.0.0"; assert tuple(map(int, numpy.__version__.split(".")[:1])) >= (2,)'; \
+    .venv/bin/python -m pip --version; \
+    rm -rf .venv/lib/python3.10/site-packages/matplotlib/mpl-data/sample_data; \
+    rm -rf .venv/lib/python3.10/site-packages/skimage/data \
+      .venv/lib/python3.10/site-packages/wandb/bin; \
+    cp .venv/lib/python3.10/site-packages/numpy/_core/tests/_natype.py \
+      /tmp/numpy-_natype.py; \
+    find .venv/lib/python3.10/site-packages/numpy \
+      .venv/lib/python3.10/site-packages/scipy \
+      -type d -name tests -prune -exec rm -rf -- {} +; \
+    install -D -m 0644 /tmp/numpy-_natype.py \
+      .venv/lib/python3.10/site-packages/numpy/_core/tests/_natype.py; \
+    rm -f /tmp/numpy-_natype.py; \
+    test ! -e .venv/lib/python3.10/site-packages/matplotlib/mpl-data/sample_data; \
+    test ! -e .venv/lib/python3.10/site-packages/skimage/data; \
+    test ! -e .venv/lib/python3.10/site-packages/wandb/bin; \
+    test "$(readlink -f .venv/bin/python)" = \
+      "$(find "${UV_PYTHON_INSTALL_DIR}" -path '*/bin/python3.10' -type f -print -quit)"; \
+    ! grep -q '/root' .venv/pyvenv.cfg; \
+    .venv/bin/python -c 'import importlib.metadata, flash_attn, scipy.linalg, torch, wandb; from transformers import SiglipModel; assert importlib.metadata.version("nltk") == "3.10.0"; assert importlib.metadata.version("defusedxml") == "0.7.1"; assert wandb.run is None; print(torch.__version__)'; \
+    base_site="$(find "${UV_PYTHON_INSTALL_DIR}" -path '*/lib/python3.10/site-packages' -type d -print -quit)"; \
+    base_python="$(find "${UV_PYTHON_INSTALL_DIR}" -path '*/bin/python3.10' -type f -print -quit)"; \
+    test -n "${base_site}"; \
+    test -n "${base_python}"; \
+    rm -rf "${base_site}"/pip "${base_site}"/pip-*.dist-info \
+      "${base_site}"/setuptools "${base_site}"/setuptools-*.dist-info \
+      "${base_site}"/_distutils_hack "${base_site}"/distutils-precedence.pth; \
+    "${base_python}" -c 'import importlib.util; assert importlib.util.find_spec("pip") is None; assert importlib.util.find_spec("setuptools") is None'; \
+    assert-no-forbidden-cosmos2-payload /opt/cosmos/cosmos-transfer2.5
+
+FROM ${CUDA_RUNTIME_IMAGE} AS runtime
+
+ARG COSMOS_TRANSFER_REVISION=67d56b7d550a3911024a32dc23ae0bae5258e633
+ARG UBUNTU_SNAPSHOT
+
+LABEL org.opencontainers.image.title="NPA Cosmos Transfer 2.5" \
+      org.opencontainers.image.description="Cosmos Transfer 2.5 source runtime; model weights are operator-fetched at run time" \
+      org.opencontainers.image.source="https://github.com/nvidia-cosmos/cosmos-transfer2.5" \
+      org.opencontainers.image.revision="${COSMOS_TRANSFER_REVISION}" \
+      org.opencontainers.image.licenses="Apache-2.0 AND LicenseRef-NVIDIA-Deep-Learning-Container"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    HF_HOME=/opt/cosmos/model-cache/huggingface \
+    HUGGINGFACE_HUB_CACHE=/opt/cosmos/model-cache/huggingface/hub \
+    NLTK_DATA=/opt/cosmos/model-cache \
+    TORCH_HOME=/opt/cosmos/model-cache/torch \
+    XDG_CACHE_HOME=/opt/cosmos/model-cache/xdg \
+    TOKENIZERS_PARALLELISM=false \
+    UV_PYTHON_INSTALL_DIR=/opt/cosmos/uv-python
+
+# Upstream deliberately invokes `uvx hf ...` to download gated model files at
+# run time. Ship the two binaries from the same digest-pinned, dual-licensed uv
+# image used by the build; no package or model download occurs here.
+COPY --from=uv-bin /uv /usr/local/bin/uv
+COPY --from=uv-bin /uvx /usr/local/bin/uvx
+
+# ffmpeg creates and validates the repository-authored procedural fixture. SSH,
+# rsync, sudo, procps, and netcat are the runtime prerequisites of SkyPilot's
+# Kubernetes bootstrap for a non-root container.
+RUN rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*.list \
+      /etc/apt/sources.list.d/*.sources \
+    && printf '%s\n' \
+      'Types: deb' \
+      "URIs: https://snapshot.ubuntu.com/ubuntu/${UBUNTU_SNAPSHOT}/" \
+      'Suites: noble noble-updates noble-backports noble-security' \
+      'Components: main restricted universe multiverse' \
+      'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
+      > /etc/apt/sources.list.d/ubuntu.sources \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates ffmpeg netcat-openbsd openssh-server procps rsync sudo \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /etc/ssh/ssh_host_* \
+    && test -z "$(find /etc/ssh -maxdepth 1 -type f -name 'ssh_host_*' -print -quit)" \
+    && mkdir -p /run/sshd
+
+# Transformer Engine loads the unversioned CUDA runtime name directly. NVIDIA's
+# runtime image ships the versioned redistributable library but, unlike the devel
+# image, not its unversioned linker symlink. Supply that compatibility name from
+# the same digest-pinned runtime bits and keep the containing directory explicit.
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda-12.8/targets/x86_64-linux/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+RUN set -eux; \
+    cudart_dir=/usr/local/cuda-12.8/targets/x86_64-linux/lib; \
+    test -e "${cudart_dir}/libcudart.so.12"; \
+    ln -sfn libcudart.so.12 "${cudart_dir}/libcudart.so"; \
+    ldconfig
+
+COPY --from=build --chown=1000:1000 /opt/cosmos /opt/cosmos
+COPY --from=build /usr/local/bin/assert-no-forbidden-cosmos2-payload \
+    /usr/local/bin/assert-no-forbidden-cosmos2-payload
+COPY --chmod=755 docker/workbench/cosmos2-transfer/smoke_functional.sh \
+    /opt/cosmos2-transfer/smoke_functional.sh
+COPY --chmod=755 docker/workbench/cosmos2-transfer/entrypoint.sh \
+    /opt/cosmos2-transfer/entrypoint.sh
+COPY --chmod=755 src/npa/workbench/cosmos/fixture.py \
+    /opt/cosmos2-transfer/generate_fixture.py
+COPY docker/workbench/cosmos2-transfer/REDISTRIBUTION.md \
+    /usr/share/doc/npa-cosmos2-transfer/REDISTRIBUTION.md
+
+RUN set -eux; \
+    id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 ubuntu; \
+    printf '%s\n' 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu; \
+    chmod 0440 /etc/sudoers.d/ubuntu; \
+    printf '%s\n' '#!/bin/sh' \
+      'exec /opt/cosmos/cosmos-transfer2.5/.venv/bin/python "$@"' \
+      > /usr/local/bin/python3; \
+    chmod 0755 /usr/local/bin/python3; \
+    ln -sfn python3 /usr/local/bin/python; \
+    mkdir -p /opt/cosmos2-transfer \
+      /opt/cosmos/model-cache/huggingface \
+      /opt/cosmos/model-cache/torch \
+      /opt/cosmos/model-cache/xdg \
+      /opt/cosmos-data/hf_cache; \
+    chown -R ubuntu:ubuntu /opt/cosmos/model-cache /opt/cosmos2-transfer /opt/cosmos-data; \
+    assert-no-forbidden-cosmos2-payload /opt/cosmos/cosmos-transfer2.5; \
+    su ubuntu -s /bin/bash -c \
+      '/opt/cosmos/cosmos-transfer2.5/.venv/bin/python -c "import sys, torch, flash_attn; from distutils.sysconfig import get_config_var; assert \"/root\" not in (sys._home or \"\"); get_config_var(\"prefix\")"'; \
+    su ubuntu -s /bin/bash -c \
+      '/opt/cosmos/cosmos-transfer2.5/.venv/bin/python -c "import os; from pathlib import Path; from nltk.pathsec import _get_allowed_roots; assert Path(os.environ[\"NLTK_DATA\"]).resolve() in _get_allowed_roots()"'; \
+    su ubuntu -s /bin/bash -c \
+      '/opt/cosmos/cosmos-transfer2.5/.venv/bin/python -c "import ctypes; ctypes.CDLL(\"libcudart.so\")"'; \
+    su ubuntu -s /bin/bash -c \
+      'test "$(command -v python3)" = /usr/local/bin/python3 && python3 -c "import cosmos_transfer2" && python3 -m pip --version'; \
+    su ubuntu -s /bin/bash -c \
+      'test "$(command -v uvx)" = /usr/local/bin/uvx && uvx --version'; \
+    su ubuntu -s /bin/bash -c \
+      'test -w /opt/cosmos/model-cache/huggingface && test -x /opt/cosmos/cosmos-transfer2.5/.venv/bin/python'
+
+VOLUME ["/opt/cosmos/model-cache"]
+WORKDIR /opt/cosmos/cosmos-transfer2.5
 USER ubuntu
 
-# The inherited `ENTRYPOINT ["/bin/bash"]` swallowed the args Kubernetes passes, so
-# SkyPilot's keep-alive command exited 126 and every GPU stage pinned to this image
-# failed to provision. This entrypoint execs its arguments instead.
+# An orchestrator-supplied argv must execute verbatim; this is the SkyPilot setup
+# behavior fixed by PR #231.
 ENTRYPOINT ["/opt/cosmos2-transfer/entrypoint.sh"]

--- a/npa/docker/workbench/cosmos2-transfer/Dockerfile
+++ b/npa/docker/workbench/cosmos2-transfer/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux; \
     printf '%s\n' "${COSMOS_PYTHON_VERSION}" > .python-version; \
     uv sync --locked --no-dev --no-editable --extra=cu128 \
       --python "${COSMOS_PYTHON_VERSION}"; \
-    uv pip install --python .venv/bin/python --no-deps \
+    uv pip install --python .venv/bin/python --no-deps --require-hashes \
       --requirement /tmp/cosmos2-security-overrides.txt; \
     .venv/bin/python -c 'import defusedxml, importlib.metadata, msgpack, nltk, numpy; assert importlib.metadata.version("defusedxml") == "0.7.1"; assert importlib.metadata.version("nltk") == "3.10.0"; assert importlib.metadata.version("pip") == "26.2"; assert importlib.metadata.version("msgpack") == "1.2.1"; assert importlib.metadata.version("setuptools") == "83.0.0"; assert tuple(map(int, numpy.__version__.split(".")[:1])) >= (2,)'; \
     .venv/bin/python -m pip --version; \
@@ -180,6 +180,8 @@ COPY --chmod=755 src/npa/workbench/cosmos/fixture.py \
 COPY docker/workbench/cosmos2-transfer/REDISTRIBUTION.md \
     /usr/share/doc/npa-cosmos2-transfer/REDISTRIBUTION.md
 
+# Deliberately shadow the global python3: SkyPilot and orchestrator-supplied
+# commands invoke python3; /usr/bin/python3 remains available to system tooling.
 RUN set -eux; \
     id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 ubuntu; \
     printf '%s\n' 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu; \

--- a/npa/docker/workbench/cosmos2-transfer/REDISTRIBUTION.md
+++ b/npa/docker/workbench/cosmos2-transfer/REDISTRIBUTION.md
@@ -1,0 +1,84 @@
+# Cosmos Transfer 2.5 redistribution evidence
+
+This document records an engineering redistribution classification. It is not legal advice.
+It applies only to the image built by the adjacent Dockerfile from the
+immutable inputs below. Evidence was accessed on 2026-08-03. A built-image audit
+is mandatory before the packaging contract may classify the image `public`.
+
+## Immutable provenance
+
+- Image tag: `npa-cosmos2-transfer:2.5.1-skypilot-ready-20260801T053000Z`
+- Upstream source: `https://github.com/nvidia-cosmos/cosmos-transfer2.5`
+- Upstream revision: `67d56b7d550a3911024a32dc23ae0bae5258e633`
+- CUDA build base: `nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04`
+- CUDA build linux/amd64 manifest: `sha256:3986465b3dd3b4d602c07061f2cff417e0bfb24810129408d4eb12e111015a6c`
+- CUDA final runtime base: `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04`
+- CUDA runtime linux/amd64 manifest: `sha256:9175fa92f96de35a8cfb9493f0dfcf9435c7a597e9d95ad41d2cae382a95e3f9`
+- uv build/runtime image: `ghcr.io/astral-sh/uv:0.8.12`
+- uv linux/amd64 manifest: `sha256:e1d7fa999ae39871fc2fd6c9c572d970cc877a239d2a16238a204c23772d1c0e`
+- Python: uv-managed CPython `3.10.18`
+- Ubuntu archive snapshot: `20260801T053000Z`
+- Python closure: upstream `uv.lock`, installed with `uv sync --locked --no-dev
+  --no-editable --extra=cu128`, plus the hash-pinned vulnerability fixes in
+  `security-overrides.txt`
+
+## Artifact classification
+
+| Artifact category | Evidence and classification | Image treatment |
+|---|---|---|
+| Cosmos Transfer source | The pinned repository declares Apache-2.0 in [`LICENSE`](https://github.com/nvidia-cosmos/cosmos-transfer2.5/blob/67d56b7d550a3911024a32dc23ae0bae5258e633/LICENSE) and `pyproject.toml`. | Included at the full SHA. `LICENSE` and `ATTRIBUTIONS.md` are retained. |
+| Upstream `assets/` and Git LFS objects | The pinned `.gitattributes` routes `assets/**` and media suffixes through LFS. The tree contains 444 LFS paths (258,036,941 declared bytes), including third-party example and post-training media. No explicit license covering every media origin was found. Classification: ambiguous, therefore not redistributable here. | `GIT_LFS_SKIP_SMUDGE=1` is set for fetch and checkout. `.git`, `.git/lfs`, and the entire `assets/` tree are removed in the checkout layer and forbidden by a build assertion. |
+| Cosmos Transfer model weights | NVIDIA publishes the gated model under the [NVIDIA Open Model License](https://www.nvidia.com/content/dam/en-zz/Solutions/license-agreements/enterprise-software/nvidia-open-model-license-agreement-16-6-2025.pdf). Operators must accept its terms for themselves. | No checkpoint is baked. `HF_TOKEN` is accepted only at runtime; inference refuses before download when it is absent. The cache is a runtime volume. |
+| CUDA/cuDNN base runtime | The public NGC CUDA page identifies the container and its governing [NVIDIA Deep Learning Container License](https://developer.download.nvidia.com/licenses/NVIDIA_Deep_Learning_Container_License.pdf). That license expressly permits distributing a compatible derived whole container for running the distributor's application, subject to its notice, NVIDIA-GPU-use, ownership, and protective-terms conditions. This image adds the complete Cosmos application and is not a standalone redistribution of extracted NVIDIA components. The [CUDA Toolkit EULA](https://docs.nvidia.com/cuda/archive/12.0.1/eula/index.html) separately identifies distributable runtime components when incorporated into an application with material additional functionality. | The devel image is a discarded build stage; the final image inherits the smaller digest-pinned runtime base. `NGC-DL-CONTAINER-LICENSE` must remain present. The OCI license/source labels and this notice make the NVIDIA conditions visible to recipients. |
+| Python dependencies | Direct source dependencies are fixed by the pinned lockfile. The only direct Git dependency is [Video-Depth-Anything at `f70048c9599cc9221e7d70b098621909316fa4a4`](https://github.com/jeanachoi/Video-Depth-Anything/tree/f70048c9599cc9221e7d70b098621909316fa4a4), whose repository license is Apache-2.0. Registry artifacts are hash-pinned by `uv.lock`; installed package license metadata/files and the upstream attribution bundle are subject to the final Trivy/SBOM audit. PyPI's primary records identify [NLTK 3.10.0](https://pypi.org/project/nltk/3.10.0/) and [msgpack 1.2.1](https://pypi.org/project/msgpack/1.2.1/) as Apache-2.0, [defusedxml 0.7.1](https://pypi.org/project/defusedxml/0.7.1/) as PSF-2.0, and [pip 26.2](https://pypi.org/project/pip/26.2/) plus [setuptools 83.0.0](https://pypi.org/project/setuptools/83.0.0/) as MIT; their exact wheel URLs and SHA-256 fragments are checked in. | The production, non-dev locked closure is included. Four security replacements plus pip required by SkyPilot's source-overlay bootstrap are installed from hash-verifying PEP 503 wheel URLs using `--no-deps`; the build imports or invokes them and asserts every exact installed version. The unused pip/setuptools bundled with the standalone base interpreter are removed, while the venv retains only the current audited packaging tools it needs. The upstream lock contains two package-metadata conflicts (Megatron's NumPy range and the local `cosmos-oss` version declaration), so a whole-environment `uv pip check` would reject NVIDIA's otherwise unchanged lock and is not used as a substitute for real inference. Matplotlib's unnecessary `mpl-data/sample_data`, the unused scikit-image data/fetch module, W&B's unused native services, and NumPy/SciPy binary test fixtures are removed before the build assertion. NumPy's single BSD-licensed `_core/tests/_natype.py` source helper remains because NumPy's own `numpy.testing` import requires it through SciPy/Transformers; a build-time SigLIP/SciPy import proves that dependency. SciPy 1.15.3's [`_sobol_direction_numbers.npz`](https://github.com/scipy/scipy/blob/v1.15.3/scipy/stats/_sobol_direction_numbers.npz) is runtime algorithm data governed by SciPy's [BSD license](https://github.com/scipy/scipy/blob/v1.15.3/LICENSE.txt), not media or a model, and is narrowly allowed. SentencePiece's small `.bin` files are Unicode normalization tables governed by its Apache-2.0 package license, not learned weights. `_virtualenv.pth` and the venv's `distutils-precedence.pth` are text startup hooks, not checkpoints. Those exact paths are narrowly allowed and every other `.pth`/`.npz` remains forbidden. Any other unclassified or incompatible license discovered in the actual registry image blocks the `public` classification. |
+| Python interpreter | The uv-managed CPython 3.10.18 archive is supplied by [Astral's python-build-standalone project](https://github.com/astral-sh/python-build-standalone), which publishes its build logic under MPL-2.0 and preserves the PSF and bundled-library license material in the distribution. CPython itself is governed by the [Python Software Foundation License](https://docs.python.org/3/license.html). | The exact version is installed under `/opt/cosmos/uv-python`; the registry filesystem audit must confirm its bundled license material is present. |
+| uv | [uv is dual Apache-2.0/MIT](https://github.com/astral-sh/uv#license). The pinned upstream Cosmos runtime invokes `uvx hf` for gated checkpoint retrieval rather than embedding a model client or credential. | The digest-pinned `uv` and `uvx` executables are included in the final image so operator-authorized model downloads work in every orchestrator environment; no package or model bytes are fetched at build time. |
+| Ubuntu packages | Runtime packages come from Ubuntu's official [snapshot service](https://snapshot.ubuntu.com/) at immutable snapshot `20260801T053000Z`; Ubuntu documents snapshots as the supported mechanism for reproducible package states. Before `apt-get update`, every inherited APT source (including the mutable CUDA source) is removed and one exact snapshot-only deb822 source is written. Exact installed versions and license files are captured by the registry-image SBOM and Trivy license scan. Ubuntu publishes the matching source packages and copyright records; GPL/LGPL and other reciprocal components remain redistributable only while their corresponding-source, notice, and relinking obligations are met. | The inherited runtime is upgraded from the same immutable snapshot before CA certificates, FFmpeg, netcat, OpenSSH, procps, rsync, and sudo are installed. A license gap or unmet reciprocal-license obligation in the built closure blocks redistribution. |
+| Live-test input | `src/npa/workbench/cosmos/fixture.py` authors a moving grid and boxes using FFmpeg `lavfi`; it copies no external pixel, video, model, or dataset bytes. Its JSON follows the pinned Apache-2.0 `InferenceArguments`/`EdgeConfig` schema and requests four diffusion steps. | The generator is included; the generated MP4 and spec exist only in run scratch/S3 input, never in image layers. |
+
+## Enforced build boundary
+
+The Dockerfile accepts no secret build argument or environment variable. The build
+script removes `HF_TOKEN`, `NGC_API_KEY`, and Nebius IAM token variables from the
+BuildKit process. Public source, Ubuntu, PyPI, PyTorch, NVIDIA Cosmos dependency,
+and GitHub endpoints are the only build-time network sources.
+
+`assert_no_forbidden_payload.sh` fails the build for:
+
+- `.git` or Git LFS metadata;
+- the upstream `assets/` tree or source-side media;
+- any checkpoint/weight-like suffix, regardless of file size;
+- Hugging Face or Torch model caches; and
+- unexpected source files larger than 10 MiB outside the locked venv.
+
+The guard runs once in the source build stage and again in the final stage. Release
+qualification must additionally inspect the registry manifest, config/history,
+exported filesystem, and every layer; run the Omniverse payload scanner; run Trivy
+vulnerability, secret, and license scans; and retain an SBOM. Dockerfile inspection
+alone is not evidence that the built bytes satisfy this classification.
+
+The cross-stage environment copy assigns UID/GID 1000 directly. This preserves the
+non-root runtime ownership without a second copy-on-write layer containing the full
+dependency tree.
+
+`openssh-server` is present only for SkyPilot bootstrap compatibility. Its package
+post-install step generates random host keys, so the same build layer deletes every
+`/etc/ssh/ssh_host_*` file. SkyPilot generates ephemeral keys during live bootstrap;
+no reusable host private key is embedded in the image.
+
+## Runtime obligations
+
+- Run only on NVIDIA GPUs as required by the inherited NVIDIA runtime terms.
+- Preserve the Apache-2.0 license, upstream attributions, this notice, and the
+  inherited NVIDIA container license.
+- Supply `HF_TOKEN` only at runtime after the operator has accepted the model
+  license. Never embed or forward the token into image history, artifacts, or logs.
+- Mount `/opt/cosmos/model-cache` for gated weights. Do not promote that cache into
+  a derived image or published artifact.
+- Keep NLTK's path-security enforcement enabled. `NLTK_DATA` authorizes only the
+  dedicated `/opt/cosmos/model-cache` volume because the gated Guardrail model
+  resolves its NLTK tables through Hugging Face blob links inside that volume.
+- Preserve package copyright files and make corresponding source available as
+  required by GPL/LGPL and other reciprocal licenses identified by the SBOM.
+- Re-run the complete classification and built-byte audit whenever the source,
+  base digest, lockfile, system packages, or fixture changes.

--- a/npa/docker/workbench/cosmos2-transfer/assert_no_forbidden_payload.sh
+++ b/npa/docker/workbench/cosmos2-transfer/assert_no_forbidden_payload.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Fail a Cosmos Transfer image build if non-redistributable or unnecessary payload
+# appears in the source tree. This is deliberately independent of Docker tooling so
+# the exact same guard can run during the build and against an exported image rootfs.
+set -euo pipefail
+
+ROOT="${1:-/opt/cosmos/cosmos-transfer2.5}"
+[[ -d "${ROOT}" ]] || { echo "forbidden-payload guard: missing ${ROOT}" >&2; exit 1; }
+
+fail_find() {
+  local label="$1"
+  shift
+  local match
+  match="$(find "${ROOT}" "$@" -print)"
+  if [[ -n "${match}" ]]; then
+    echo "forbidden-payload guard: ${label}: ${match}" >&2
+    exit 1
+  fi
+}
+
+# Source provenance must not carry Git object databases or any upstream media tree.
+fail_find "Git/LFS metadata is baked" -type d \( -name .git -o -path '*/.git/lfs' \)
+[[ ! -e "${ROOT}/assets" ]] || {
+  echo "forbidden-payload guard: upstream assets directory is baked" >&2
+  exit 1
+}
+[[ ! -e "${ROOT}/.venv/lib/python3.10/site-packages/skimage/data" ]] || {
+  echo "forbidden-payload guard: unused scikit-image data/fetch module is baked" >&2
+  exit 1
+}
+[[ ! -e "${ROOT}/.venv/lib/python3.10/site-packages/wandb/bin" ]] || {
+  echo "forbidden-payload guard: unused W&B native service binary is baked" >&2
+  exit 1
+}
+
+# Model material and caches are always operator-fetched at run time. Do not assume
+# a small .pt/.bin is harmless: every weight-like suffix is rejected regardless of
+# size or location.
+fail_find "model/checkpoint file is baked" -type f \( \
+  -iname '*.pt' -o -iname '*.pth' -o -iname '*.ckpt' -o -iname '*.safetensors' \
+  -o -iname '*.onnx' -o -iname '*.engine' -o -iname '*.weights' -o -iname '*.gguf' \
+  -o -iname '*.npz' \
+\) \
+  ! -path '*/site-packages/_virtualenv.pth' \
+  ! -path '*/site-packages/distutils-precedence.pth' \
+  ! -path '*/site-packages/scipy/stats/_sobol_direction_numbers.npz'
+cache_match="$(find "${ROOT}" -path "${ROOT}/.venv" -prune -o -type d \( \
+  -iname 'huggingface' -o -iname 'torch-cache' \
+  -o -path '*/.cache/huggingface' -o -path '*/.cache/torch' \
+\) -print -quit)"
+[[ -z "${cache_match}" ]] || {
+  echo "forbidden-payload guard: model cache is baked: ${cache_match}" >&2
+  exit 1
+}
+
+# No upstream video/image/audio fixtures are needed. Package metadata icons inside
+# site-packages are not control inputs, so this source-only check prunes the venv.
+media_match="$(find "${ROOT}" -path "${ROOT}/.venv" -prune -o -type f \( \
+  -iname '*.mp4' -o -iname '*.mov' -o -iname '*.avi' -o -iname '*.mkv' \
+  -o -iname '*.webm' -o -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' \
+  -o -iname '*.webp' -o -iname '*.wav' -o -iname '*.mp3' \
+\) -print -quit)"
+[[ -z "${media_match}" ]] || {
+  echo "forbidden-payload guard: upstream media is baked: ${media_match}" >&2
+  exit 1
+}
+
+# A large non-code file outside the locked venv is almost certainly an accidental
+# fixture or model. Shared objects and archives belong only in site-packages.
+large_match="$(find "${ROOT}" -path "${ROOT}/.venv" -prune -o -type f -size +10M -print -quit)"
+[[ -z "${large_match}" ]] || {
+  echo "forbidden-payload guard: unexpected >10 MiB source payload: ${large_match}" >&2
+  exit 1
+}
+
+echo "forbidden-payload guard: clean (${ROOT})"

--- a/npa/docker/workbench/cosmos2-transfer/build.sh
+++ b/npa/docker/workbench/cosmos2-transfer/build.sh
@@ -1,51 +1,101 @@
 #!/usr/bin/env bash
-# Build (and optionally push) the golden-eval wrapper for npa-cosmos2-transfer.
+# Build the complete Cosmos Transfer 2.5 image from its immutable public sources.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 NPA_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-REGISTRY="${REGISTRY:-cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw}"
-BASE_IMAGE="${COSMOS2_TRANSFER_BASE_IMAGE:-${REGISTRY}/npa-cosmos2-transfer:2.5.0}"
+NPA_PYTHON="${NPA_ROOT}/.venv/bin/python"
+
+REGISTRY="${REGISTRY:-}"
 PUSH=0
 TAG=""
+CUDA_BASE_IMAGE=""
+SOURCE_REVISION=""
+PYTHON_VERSION=""
 
 usage() {
-  sed -n '2,6p' "$0"
+  echo "Usage: $0 [--registry HOST/PATH] [--tag TAG] [--push]" >&2
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --registry) REGISTRY="${2:?}"; shift 2 ;;
-    --base-image) BASE_IMAGE="${2:?}"; shift 2 ;;
     --tag) TAG="${2:?}"; shift 2 ;;
+    --base-image) CUDA_BASE_IMAGE="${2:?}"; shift 2 ;;
+    --source-revision) SOURCE_REVISION="${2:?}"; shift 2 ;;
+    --python-version) PYTHON_VERSION="${2:?}"; shift 2 ;;
     --push) PUSH=1; shift ;;
     -h | --help) usage; exit 0 ;;
-    *) echo "Unknown option: $1" >&2; exit 2 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 2 ;;
   esac
 done
 
+[[ -x "${NPA_PYTHON}" ]] || {
+  echo "ERROR: ${NPA_PYTHON} is required; create npa/.venv first" >&2
+  exit 1
+}
+
 if [[ -z "${TAG}" ]]; then
-  TAG="$("${NPA_ROOT}/.venv/bin/python" - <<'PY'
+  TAG="$(cd "${NPA_ROOT}" && "${NPA_PYTHON}" - <<'PY'
 from npa.deploy.images import supported_tool_version
+
 print(supported_tool_version("cosmos2-transfer"))
 PY
 )"
 fi
 
-LOCAL_REF="npa-cosmos2-transfer:${TAG}"
-REMOTE_REF="${REGISTRY}/npa-cosmos2-transfer:${TAG}"
+if [[ "${PUSH}" == "1" && -z "${REGISTRY}" ]]; then
+  REGISTRY="$(cd "${NPA_ROOT}" && "${NPA_PYTHON}" - <<'PY'
+from npa.clients.config import resolve_container_registry
 
-echo "=== build cosmos2-transfer wrapper ${LOCAL_REF} (base=${BASE_IMAGE}) ==="
-docker build --platform linux/amd64 \
-  -f "${SCRIPT_DIR}/Dockerfile" \
-  --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
-  -t "${LOCAL_REF}" \
-  -t "${REMOTE_REF}" \
-  "${NPA_ROOT}"
-
-if [[ "${PUSH}" == "1" ]]; then
-  echo "=== push ${REMOTE_REF} ==="
-  docker push "${REMOTE_REF}"
+print(resolve_container_registry())
+PY
+)"
 fi
 
-echo "Done: ${REMOTE_REF} push=${PUSH}"
+LOCAL_REF="npa-cosmos2-transfer:${TAG}"
+if [[ "${PUSH}" == "1" ]]; then
+  [[ -n "${REGISTRY}" ]] || { echo "ERROR: no source registry is configured" >&2; exit 1; }
+  IMAGE_REF="${REGISTRY%/}/npa-cosmos2-transfer:${TAG}"
+else
+  IMAGE_REF="${LOCAL_REF}"
+fi
+
+run_component="${NPA_RUN_ID:-cosmos2-transfer-$$}"
+run_component="$(printf '%s' "${run_component}" | tr -c '[:alnum:]_.-' '-')"
+BUILDX_BUILDER="${NPA_BUILDX_BUILDER:-npa-${run_component}}"
+CREATED_BUILDER=0
+cleanup_builder() {
+  if [[ "${CREATED_BUILDER}" == "1" ]]; then
+    docker buildx rm "${BUILDX_BUILDER}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup_builder EXIT
+
+if ! docker buildx inspect "${BUILDX_BUILDER}" >/dev/null 2>&1; then
+  docker buildx create --name "${BUILDX_BUILDER}" \
+    --driver docker-container --bootstrap >/dev/null
+  CREATED_BUILDER=1
+fi
+
+BUILD_ARGS=(
+  --builder "${BUILDX_BUILDER}"
+  --platform linux/amd64
+  --file "${SCRIPT_DIR}/Dockerfile"
+  --tag "${IMAGE_REF}"
+)
+[[ -z "${CUDA_BASE_IMAGE}" ]] || BUILD_ARGS+=(--build-arg "CUDA_BASE_IMAGE=${CUDA_BASE_IMAGE}")
+[[ -z "${SOURCE_REVISION}" ]] || BUILD_ARGS+=(--build-arg "COSMOS_TRANSFER_REVISION=${SOURCE_REVISION}")
+[[ -z "${PYTHON_VERSION}" ]] || BUILD_ARGS+=(--build-arg "COSMOS_PYTHON_VERSION=${PYTHON_VERSION}")
+
+if [[ "${PUSH}" == "1" ]]; then
+  BUILD_ARGS+=(--push --provenance=mode=max --sbom=true)
+else
+  BUILD_ARGS+=(--load --provenance=false)
+fi
+
+echo "Building ${LOCAL_REF} from the checked-in immutable inputs (build credentials: none)"
+env -u HF_TOKEN -u NGC_API_KEY -u NEBIUS_IAM_TOKEN -u NPA_NEBIUS_IAM_TOKEN \
+  docker buildx build "${BUILD_ARGS[@]}" "${NPA_ROOT}"
+
+echo "Built: ${IMAGE_REF}"

--- a/npa/docker/workbench/cosmos2-transfer/entrypoint.sh
+++ b/npa/docker/workbench/cosmos2-transfer/entrypoint.sh
@@ -17,4 +17,13 @@ set -euo pipefail
 if [ "$#" -eq 0 ]; then
   exec /bin/bash
 fi
+
+# Direct inference must fail before Hugging Face can start a partial or anonymous
+# gated-model download. Check only presence; never print the credential.
+for arg in "$@"; do
+  if [[ "${arg}" == *"examples/inference.py"* ]] && [[ -z "${HF_TOKEN:-}" ]]; then
+    echo "ERROR: HF_TOKEN is required at run time for gated Cosmos Transfer weights; no download was attempted." >&2
+    exit 78
+  fi
+done
 exec "$@"

--- a/npa/docker/workbench/cosmos2-transfer/security-overrides.txt
+++ b/npa/docker/workbench/cosmos2-transfer/security-overrides.txt
@@ -1,0 +1,9 @@
+# Exact, hash-verified PyPI wheel URLs for fixes to the pinned upstream lock.
+# uv 0.8.12 validates transitive requirement metadata under --require-hashes even
+# with --no-deps. PEP 503 URL fragments still make uv verify these wheel bytes,
+# while --no-deps preserves the already locked dependency closure.
+https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl#sha256=a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
+https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl#sha256=54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf
+https://files.pythonhosted.org/packages/62/36/a3aed958d60531cb442b7ab4596cda7b3621cfb916f8ae1d6769795c7dc1/pip-26.2-py3-none-any.whl#sha256=931c303696af6fa3417112103b1cad26890e5a07eccb5b99783700e33f2b8aad
+https://files.pythonhosted.org/packages/fa/7f/5ce020168cf0439041526e95aa068c722c016aee21624e331aeabeee2e8e/msgpack-1.2.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl#sha256=83efa1c898e0fc5380fc0cabbf75164c52e3b5cbb45973710d75821928380c73
+https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl#sha256=29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3

--- a/npa/docker/workbench/cosmos2-transfer/smoke_functional.sh
+++ b/npa/docker/workbench/cosmos2-transfer/smoke_functional.sh
@@ -1,53 +1,140 @@
 #!/usr/bin/env bash
-# Golden eval for npa-cosmos2-transfer — a REAL capability test.
-#
-# Runs an actual Cosmos-Transfer2.5 video-to-video world-transfer inference on a
-# bundled robot control example and asserts a non-trivial generated video is
-# produced. This exercises the container's real job (synthetic-data augmentation
-# via world transfer), not just a torch+CUDA probe.
-#
-# GPU-gated and heavy: the model runs a multi-step diffusion sample and the gated
-# Cosmos-Transfer2.5-2B checkpoints auto-download on first use (HF_TOKEN + NVIDIA
-# Open Model License acceptance required). Budget ~10-15 min end to end.
+# Real Cosmos Transfer 2.5 golden evaluation using only a procedural input.
 set -euo pipefail
 
 REPO="${COSMOS_TRANSFER_REPO:-/opt/cosmos/cosmos-transfer2.5}"
-cd "${REPO}"
+PY="${REPO}/.venv/bin/python"
+GENERATOR="/opt/cosmos2-transfer/generate_fixture.py"
 
-# The capability image ships a ready py3.10 inference env (torch cu128 +
-# flash-attn). Self-heal if it is absent so the eval still exercises the real
-# model on an un-baked base image.
-if ! .venv/bin/python -c "import torch, flash_attn" >/dev/null 2>&1; then
-  echo "[setup] building cosmos-transfer2.5 inference env (py3.10 + cu128)"
-  uv python install 3.10
-  echo "3.10" > .python-version
-  uv sync --extra=cu128 --python 3.10
+if [[ -z "${HF_TOKEN:-}" ]]; then
+  echo "ERROR: HF_TOKEN is required at run time for the gated Cosmos Transfer weights; no download was attempted." >&2
+  exit 78
+fi
+[[ -x "${PY}" ]] || { echo "ERROR: baked Cosmos Transfer venv is unavailable" >&2; exit 1; }
+"${PY}" -c 'import flash_attn, torch; assert torch.cuda.is_available()'
+
+if [[ -n "${COSMOS_TRANSFER_WORKDIR:-}" ]]; then
+  WORKDIR="${COSMOS_TRANSFER_WORKDIR}"
+  mkdir -p "${WORKDIR}"
+else
+  WORKDIR="$(mktemp -d /tmp/npa-cosmos2-golden.XXXXXX)"
+fi
+FIXTURE_DIR="${WORKDIR}/fixture"
+OUT="${COSMOS_TRANSFER_OUT:-${WORKDIR}/output}"
+mkdir -p "${OUT}"
+
+fixture_json="$("${PY}" "${GENERATOR}" "${FIXTURE_DIR}" --num-steps 4)"
+SPEC="${FIXTURE_DIR}/npa-procedural-edge-spec.json"
+[[ -s "${SPEC}" ]] || { echo "ERROR: procedural spec was not generated" >&2; exit 1; }
+
+GPU_SAMPLES="${WORKDIR}/gpu-memory-mib.txt"
+monitor_pid=""
+if command -v nvidia-smi >/dev/null 2>&1; then
+  (
+    while true; do
+      nvidia-smi --query-compute-apps=used_memory --format=csv,noheader,nounits \
+        2>/dev/null || true
+      sleep 1
+    done
+  ) >"${GPU_SAMPLES}" &
+  monitor_pid="$!"
+fi
+stop_monitor() {
+  if [[ -n "${monitor_pid}" ]]; then
+    kill "${monitor_pid}" >/dev/null 2>&1 || true
+    wait "${monitor_pid}" >/dev/null 2>&1 || true
+  fi
+}
+trap stop_monitor EXIT
+
+started_ns="$(date +%s%N)"
+echo "[run] real Cosmos Transfer 2.5 inference (4 diffusion steps)"
+cd "${REPO}"
+"${PY}" examples/inference.py -i "${SPEC}" -o "${OUT}"
+finished_ns="$(date +%s%N)"
+stop_monitor
+monitor_pid=""
+
+gpu_name=""
+if command -v nvidia-smi >/dev/null 2>&1; then
+  gpu_name="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 || true)"
 fi
 
-SPEC="${COSMOS_TRANSFER_SPEC:-assets/robot_example/depth/robot_depth_spec.json}"
-OUT="${COSMOS_TRANSFER_OUT:-outputs/golden-eval}"
-rm -rf "${OUT}"
-
-echo "[run] cosmos-transfer2.5 inference: ${SPEC} -> ${OUT}"
-.venv/bin/python examples/inference.py -i "${SPEC}" -o "${OUT}"
-
-# Assert a real, non-trivial generated video exists (exclude the control-map viz).
-.venv/bin/python - "${OUT}" <<'PY'
+"${PY}" - "${OUT}" "${started_ns}" "${finished_ns}" "${GPU_SAMPLES}" \
+  "${gpu_name}" "${fixture_json}" <<'PY'
 import glob
+import hashlib
+import json
 import os
+import subprocess
 import sys
+from pathlib import Path
 
-out = sys.argv[1]
+out = Path(sys.argv[1])
+started_ns, finished_ns = int(sys.argv[2]), int(sys.argv[3])
+gpu_samples = Path(sys.argv[4])
+gpu_name = sys.argv[5]
+fixture = json.loads(sys.argv[6])
 videos = [
-    f
-    for f in glob.glob(os.path.join(out, "**", "*.mp4"), recursive=True)
-    if "control" not in os.path.basename(f)
+    Path(p)
+    for p in glob.glob(str(out / "**" / "*.mp4"), recursive=True)
+    if "control" not in Path(p).name.lower()
 ]
-big = [f for f in videos if os.path.getsize(f) > 100_000]
-if not big:
-    sizes = [(f, os.path.getsize(f)) for f in videos]
-    print(f"[FAIL] no non-trivial output video in {out}: {sizes}", file=sys.stderr)
-    raise SystemExit(1)
-result = big[0]
-print(f"[PASS] cosmos-transfer2.5 generated {result} ({os.path.getsize(result)} bytes)")
+videos = sorted((p for p in videos if p.stat().st_size > 100_000), key=lambda p: p.stat().st_size, reverse=True)
+if not videos:
+    raise SystemExit(f"no non-control, non-trivial output MP4 under {out}")
+video = videos[0]
+probe = json.loads(
+    subprocess.run(
+        [
+            "ffprobe", "-v", "error", "-count_frames", "-select_streams", "v:0",
+            "-show_entries", "stream=width,height,nb_read_frames,duration:format=duration",
+            "-of", "json", str(video),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+)
+stream = probe["streams"][0]
+width, height = int(stream["width"]), int(stream["height"])
+frames = int(stream.get("nb_read_frames") or 0)
+duration = float(stream.get("duration") or probe.get("format", {}).get("duration") or 0)
+if (width, height) != (fixture["width"], fixture["height"]):
+    raise SystemExit(f"unexpected output dimensions: {width}x{height}")
+if frames <= 0 or duration <= 0:
+    raise SystemExit(f"output is not decodable: frames={frames} duration={duration}")
+
+peak_mib = None
+if gpu_samples.is_file():
+    values = []
+    for line in gpu_samples.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            values.append(int(line.strip()))
+        except ValueError:
+            pass
+    if values:
+        peak_mib = max(values)
+
+metrics = {
+    "schema": "npa.cosmos2.golden_eval.v1",
+    "inference": "examples/inference.py",
+    "diffusion_steps": fixture["num_steps"],
+    "fixture_provenance": fixture["provenance"],
+    "gpu_type": gpu_name,
+    "peak_gpu_memory_mib": peak_mib,
+    "wall_seconds": round((finished_ns - started_ns) / 1_000_000_000, 3),
+    "output_path": str(video),
+    "output_bytes": video.stat().st_size,
+    "output_sha256": hashlib.sha256(video.read_bytes()).hexdigest(),
+    "width": width,
+    "height": height,
+    "frame_count": frames,
+    "duration_seconds": duration,
+}
+metrics_path = out / "npa-golden-eval-metrics.json"
+metrics_path.write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(json.dumps(metrics, sort_keys=True))
 PY
+
+echo "[PASS] real multi-step Cosmos Transfer output validated under ${OUT}"

--- a/npa/docker/workbench/packaging-contract.yaml
+++ b/npa/docker/workbench/packaging-contract.yaml
@@ -164,6 +164,19 @@ images:
     dockerfile: sim2real-eval/Dockerfile
     tier: job
     redistribution: public
+  cosmos2-transfer:
+    dockerfile: cosmos2-transfer/Dockerfile
+    tier: job
+    notes: >-
+      Complete source build at immutable commit
+      67d56b7d550a3911024a32dc23ae0bae5258e633 on digest-pinned public
+      CUDA build/runtime bases. Git LFS smudging is disabled; upstream assets, example media,
+      checkpoints, caches, and Git metadata are removed and build-guarded. Gated
+      NVIDIA Open Model License weights are fetched only at runtime with the
+      operator's HF_TOKEN into a mounted cache. The derived whole-container
+      distribution conditions and full artifact evidence are recorded in
+      cosmos2-transfer/REDISTRIBUTION.md; built-byte scans are a release gate.
+    redistribution: public
   cosmos3:
     dockerfile: cosmos3/Dockerfile
     tier: job

--- a/npa/src/npa/cli/agent_workflow.py
+++ b/npa/src/npa/cli/agent_workflow.py
@@ -1201,6 +1201,8 @@ def _data_factory_spec() -> dict[str, Any]:
                 "images_uri": "s3://{{config.bucket}}/{{config.prefix}}/input/",
                 "configs_uri": "s3://{{config.bucket}}/{{config.prefix}}/configs/",
                 "captions_uri": "s3://{{config.bucket}}/{{config.prefix}}/labeled_original/",
+                # Mandatory: managed Cosmos Transfer fails closed unless this
+                # prefix contains a supported input video.
                 "trigger_uri": "s3://{{config.bucket}}/{{config.prefix}}/input/",
                 "augment_uri": "s3://{{config.bucket}}/{{config.prefix}}/cosmos_augmented/",
                 "rollouts_uri": "s3://{{config.bucket}}/{{config.prefix}}/cosmos_augmented/",
@@ -1293,7 +1295,8 @@ def _data_factory_spec() -> dict[str, Any]:
                             "Stage 2b - Augment & Multiply. Cosmos Transfer 2.5 runs ONE GPU "
                             "inference per sampled combo (config.n_augmentations) and fans them "
                             "across the pod's GPUs (config.variant_parallelism), so N combos -> "
-                            "N scenario variants amplifying config.augment_subject. Member of the "
+                            "N input-conditioned scenario variants amplifying config.augment_subject. "
+                            "A supported video under config.trigger_uri is mandatory. Member of the "
                             "grade refinement loop, so loop_back genuinely re-renders."
                         ),
                         "needs": ["annotate-original"],

--- a/npa/src/npa/cli/workbench/cosmos2.py
+++ b/npa/src/npa/cli/workbench/cosmos2.py
@@ -110,11 +110,10 @@ def _variant_parallelism(num_variants: int) -> int:
 
 
 def _materialize_input_clip(src: str) -> str:
-    """Resolve a local path or ``s3://`` URI to a local video file to condition on.
+    """Resolve a local path or ``s3://`` URI to a local conditioning video.
 
-    For an ``s3://`` prefix, downloads it and returns the first video found. Returns
-    "" when nothing usable is present (caller then falls back to the default,
-    bundled-example behavior). Best-effort: never raises on a missing input.
+    Returns an empty string when no usable clip exists; an executing caller that
+    requested conditioning treats that as a hard error.
     """
     import glob as _glob
     import tempfile
@@ -179,8 +178,8 @@ def transfer_cmd(
     condition_on_input: bool = typer.Option(
         False,
         "--condition-on-input",
-        help="Condition on the first video under --input-uri (opt-in). Also enabled by "
-        "NPA_COSMOS_CONDITION_ON_INPUT=1. Default off preserves the bundled-example path.",
+        help="Condition on the first video under --input-uri. Also enabled by "
+        "NPA_COSMOS_CONDITION_ON_INPUT=1.",
     ),
     control: str = typer.Option(
         "edge",
@@ -228,8 +227,8 @@ def transfer_cmd(
         # Data Factory context (paidf `transfer_execute` passes --configs-uri, or the
         # caller opts into input-conditioning): the sampled appearance combo drives
         # the prompt, the augment optionally CONDITIONS on the run's real input clip
-        # (edge control computed on-the-fly — a genuine augmentation of that footage,
-        # not the bundled example), and the result is published in the per-clip layout
+        # (edge control computed on-the-fly — a genuine augmentation of that footage),
+        # and the result is published in the per-clip layout
         # that data_factory curate / build_run_rrd / provenance consume. Opt-in via
         # --input-video, --condition-on-input, or NPA_COSMOS_CONDITION_ON_INPUT=1.
         #
@@ -242,6 +241,11 @@ def transfer_cmd(
         local_input = ""
         if condition_requested:
             local_input = _materialize_input_clip(input_video or input_uri)
+            if not local_input:
+                raise typer.BadParameter(
+                    "input conditioning was requested but no video was found under "
+                    f"{input_video or input_uri!r}"
+                )
         # Env fallbacks let a submit tune conditioning without changing the toolRef argv.
         control = (os.environ.get("NPA_COSMOS_CONTROL", "").strip() or control)
         _cw = os.environ.get("NPA_COSMOS_CONTROL_WEIGHT", "").strip()

--- a/npa/src/npa/cli/workbench/cosmos2.py
+++ b/npa/src/npa/cli/workbench/cosmos2.py
@@ -112,32 +112,55 @@ def _variant_parallelism(num_variants: int) -> int:
 def _materialize_input_clip(src: str) -> str:
     """Resolve a local path or ``s3://`` URI to a local conditioning video.
 
-    Returns an empty string when no usable clip exists; an executing caller that
-    requested conditioning treats that as a hard error.
+    Returns an empty string only when the source was successfully inspected and no
+    supported video exists. Storage setup, listing, authentication, and download
+    failures propagate so the CLI can report them separately from an empty prefix.
     """
     import glob as _glob
+    import shutil
     import tempfile
+    from urllib.parse import urlsplit
 
     s = str(src or "").strip()
     if not s:
         return ""
     if not s.startswith("s3://"):
         return s if Path(s).is_file() else ""
-    try:
-        from npa.clients.storage import StorageClient
 
-        client = StorageClient.from_environment()
-        tmp = tempfile.mkdtemp(prefix="npa-cosmos-input-")
-        if s.lower().endswith(_VIDEO_EXTS):
-            return client.download_path(s, str(Path(tmp) / Path(s).name))
+    from npa.clients.storage import StorageClient
+
+    client = StorageClient.from_environment()
+    tmp = tempfile.mkdtemp(prefix="npa-cosmos-input-")
+    keep_tmp = False
+    try:
+        source_path = urlsplit(s).path
+        if source_path.lower().endswith(_VIDEO_EXTS):
+            downloaded = client.download_path(s, str(Path(tmp) / Path(source_path).name))
+            keep_tmp = True
+            return downloaded
         client.download_directory(s, tmp)
         vids = sorted(
             f for f in _glob.glob(str(Path(tmp) / "**" / "*"), recursive=True)
             if f.lower().endswith(_VIDEO_EXTS) and Path(f).is_file()
         )
-        return vids[0] if vids else ""
-    except Exception:  # noqa: BLE001 - input conditioning is opt-in; fall back cleanly
+        if vids:
+            keep_tmp = True
+            return vids[0]
         return ""
+    finally:
+        if not keep_tmp:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _materialize_conditioning_input(src: str) -> str:
+    """Adapt storage failures to a sanitized, actionable CLI error."""
+    try:
+        return _materialize_input_clip(src)
+    except Exception as exc:
+        raise typer.BadParameter(
+            "could not inspect or download the configured conditioning input; "
+            "verify the object-storage endpoint, credentials, permissions, and availability"
+        ) from exc
 
 
 @app.command("transfer")
@@ -224,13 +247,14 @@ def transfer_cmd(
     if execute or runtime_available:
         # Real Cosmos-Transfer2.5 world-transfer model.
         #
-        # Data Factory context (paidf `transfer_execute` passes --configs-uri, or the
-        # caller opts into input-conditioning): the sampled appearance combo drives
-        # the prompt, the augment optionally CONDITIONS on the run's real input clip
-        # (edge control computed on-the-fly — a genuine augmentation of that footage),
+        # Data Factory context (`transfer_execute` passes --configs-uri and always
+        # enables input conditioning): the sampled appearance combo drives the prompt,
+        # and the augment CONDITIONS on the run's real input clip (edge control
+        # computed on-the-fly — a genuine augmentation of that footage),
         # and the result is published in the per-clip layout
         # that data_factory curate / build_run_rrd / provenance consume. Opt-in via
-        # --input-video, --condition-on-input, or NPA_COSMOS_CONDITION_ON_INPUT=1.
+        # Generic callers opt in via --input-video, --condition-on-input, or
+        # NPA_COSMOS_CONDITION_ON_INPUT=1.
         #
         # Otherwise (generic `transfer` for sim2real / cosmos-gate / fanout): keep the
         # flat single-video publish + sim2real-engine field convention unchanged.
@@ -240,11 +264,11 @@ def transfer_cmd(
         data_factory_mode = bool(configs_uri) or condition_requested
         local_input = ""
         if condition_requested:
-            local_input = _materialize_input_clip(input_video or input_uri)
+            local_input = _materialize_conditioning_input(input_video or input_uri)
             if not local_input:
                 raise typer.BadParameter(
-                    "input conditioning was requested but no video was found under "
-                    f"{input_video or input_uri!r}"
+                    "input conditioning was requested, but no supported video "
+                    f"({', '.join(_VIDEO_EXTS)}) was found at the configured input"
                 )
         # Env fallbacks let a submit tune conditioning without changing the toolRef argv.
         control = (os.environ.get("NPA_COSMOS_CONTROL", "").strip() or control)

--- a/npa/src/npa/orchestration/npa_workflow/catalog.py
+++ b/npa/src/npa/orchestration/npa_workflow/catalog.py
@@ -364,6 +364,7 @@ TOOL_CATALOG: dict[str, ToolEntry] = {
             "{{run.id}}",
             "--configs-uri",
             "{{config.configs_uri}}",
+            "--condition-on-input",
             "--execute",
         ],
     ),

--- a/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
+++ b/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
@@ -1227,9 +1227,8 @@ def build_skypilot_task_doc(
     if image:
         envs["NPA_TASK_IMAGE"] = image.removeprefix("docker:")
     envs.update(isaac_eula_envs(str(scheduler_task.get("tool_ref") or "")))
-    # Opt-in passthrough: when set at submit, propagate Cosmos input-conditioning
-    # knobs to stage pods so the augment conditions on the run's real input clip
-    # (edge control) instead of the bundled example. Unset by default → no change.
+    # Optional tuning passthrough. The first-class transfer_execute toolRef always
+    # conditions on the workflow input; these variables can tune that real path.
     import os as _os_cond
 
     for _cond_var in (

--- a/npa/src/npa/smoke/capabilities.py
+++ b/npa/src/npa/smoke/capabilities.py
@@ -52,7 +52,7 @@ GOLDEN_EVAL_CAPABILITIES: dict[str, list[str]] = {
     ],
     "cosmos2-transfer": [
         "cosmos-transfer2.5 inference env (torch cu128 + flash-attn)",
-        "real video-to-video world transfer on a bundled robot control example",
+        "real video-to-video world transfer on a runtime-generated procedural control video",
         "generated output video produced (capability, not a CUDA probe)",
     ],
     "cosmos3": [

--- a/npa/src/npa/smoke/golden_evals.yaml
+++ b/npa/src/npa/smoke/golden_evals.yaml
@@ -274,17 +274,17 @@ containers:
         synthetic data augmentation.
     safety:
       runs_as: ubuntu
-      base_image: cosmos transfer runtime (built outside this repo)
-      network: transfer/serve endpoint
-      external_fetch: [huggingface, s3]
+      base_image: nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04 (linux/amd64 digest pinned)
+      network: runtime Hugging Face model fetch and workflow S3 I/O
+      external_fetch: [github-source-build, pypi-build, pytorch-cu128-build, huggingface-runtime, s3-runtime]
       notes: >-
-        Base transfer runtime is built outside this repo; this repo's wrapper
-        Dockerfile bakes the real cosmos-transfer2.5 inference venv (Python 3.10 +
-        torch cu128 + flash-attn via `uv sync`) so the container can actually run
-        transfer. The golden eval runs a real video-to-video transfer on a bundled
-        robot control example and asserts a generated video; the gated
-        Cosmos-Transfer2.5-2B checkpoints auto-download on first use (HF_TOKEN +
-        NVIDIA Open Model License).
+        Complete source build from immutable upstream commit 67d56b7d550a3911024a32dc23ae0bae5258e633
+        and the upstream locked cu128 dependency closure; no private parent. Git LFS
+        smudging is disabled and upstream assets, media, model weights, caches, and
+        Git metadata are forbidden. The golden eval creates a repository-authored
+        procedural input at runtime, runs four real diffusion steps, and numerically
+        validates the output MP4. Gated Cosmos-Transfer2.5-2B checkpoints download
+        only at runtime with the operator's HF_TOKEN and model-license acceptance.
     golden_eval:
       kind: container-smoke
       module: npa.smoke.test_cosmos2_transfer_functional

--- a/npa/src/npa/smoke/test_cosmos2_transfer_functional.py
+++ b/npa/src/npa/smoke/test_cosmos2_transfer_functional.py
@@ -1,60 +1,25 @@
-"""Cosmos2-Transfer golden eval — a REAL capability test.
+"""Cosmos Transfer 2.5 golden-eval adapter.
 
-Runs an actual Cosmos-Transfer2.5 video-to-video world-transfer inference on a
-bundled robot control example and asserts a non-trivial generated video is
-produced. This exercises the container's real job (synthetic-data augmentation
-via world transfer), not just a CUDA/import probe.
-
-The transfer runtime + inference venv live in
-``/opt/cosmos/cosmos-transfer2.5`` (Python 3.10 + torch cu128 + flash-attn). This
-module shells out to that venv so it stays import-safe on the default interpreter
-(the golden-eval driver also invokes ``smoke_functional.sh`` directly).
+The image-owned smoke script generates a repository-authored procedural video,
+runs the real multi-step ``examples/inference.py`` path, and validates the MP4
+numerically. Keeping this module as a thin adapter makes the manifest's ``module``
+and ``command`` fields exercise the same implementation.
 """
 
 from __future__ import annotations
 
-import glob
 import os
 import subprocess
 import sys
 
-REPO = os.environ.get("COSMOS_TRANSFER_REPO", "/opt/cosmos/cosmos-transfer2.5")
-SPEC = os.environ.get(
-    "COSMOS_TRANSFER_SPEC", "assets/robot_example/depth/robot_depth_spec.json"
+SMOKE_SCRIPT = os.environ.get(
+    "COSMOS_TRANSFER_SMOKE_SCRIPT",
+    "/opt/cosmos2-transfer/smoke_functional.sh",
 )
-OUT = os.environ.get("COSMOS_TRANSFER_OUT", "outputs/golden-eval")
 
 
 def main() -> int:
-    venv_python = os.path.join(REPO, ".venv", "bin", "python")
-    if not os.path.exists(venv_python):
-        print(f"[FAIL] cosmos-transfer2.5 inference venv missing at {venv_python}")
-        return 1
-
-    out_dir = os.path.join(REPO, OUT)
-    print(f"[run] cosmos-transfer2.5 inference: {SPEC} -> {OUT}")
-    proc = subprocess.run(
-        [venv_python, "examples/inference.py", "-i", SPEC, "-o", OUT],
-        cwd=REPO,
-        check=False,
-    )
-    if proc.returncode != 0:
-        print(f"[FAIL] inference exited {proc.returncode}")
-        return proc.returncode
-
-    videos = [
-        f
-        for f in glob.glob(os.path.join(out_dir, "**", "*.mp4"), recursive=True)
-        if "control" not in os.path.basename(f)
-    ]
-    big = [f for f in videos if os.path.getsize(f) > 100_000]
-    if not big:
-        print(f"[FAIL] no non-trivial output video in {out_dir}: "
-              f"{[(f, os.path.getsize(f)) for f in videos]}")
-        return 1
-    result = big[0]
-    print(f"[PASS] cosmos-transfer2.5 generated {result} ({os.path.getsize(result)} bytes)")
-    return 0
+    return subprocess.run(["bash", SMOKE_SCRIPT], check=False).returncode
 
 
 if __name__ == "__main__":

--- a/npa/src/npa/workbench/cosmos/fixture.py
+++ b/npa/src/npa/workbench/cosmos/fixture.py
@@ -1,0 +1,140 @@
+"""Generate a legally clean Cosmos Transfer 2.5 inference fixture.
+
+The fixture contains no copied media. FFmpeg synthesizes every frame from color,
+grid, and moving-shape filters authored here, and this module writes the smallest
+real edge-control spec accepted by the pinned upstream inference schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+DEFAULT_WIDTH = 1280
+DEFAULT_HEIGHT = 720
+DEFAULT_FPS = 16
+DEFAULT_FRAMES = 93
+DEFAULT_STEPS = 4
+
+
+def generate_fixture(
+    output_dir: Path,
+    *,
+    width: int = DEFAULT_WIDTH,
+    height: int = DEFAULT_HEIGHT,
+    fps: int = DEFAULT_FPS,
+    frames: int = DEFAULT_FRAMES,
+    num_steps: int = DEFAULT_STEPS,
+) -> dict[str, Any]:
+    """Create a procedural MP4 and matching multi-step edge-control JSON spec."""
+
+    if min(width, height, fps, frames, num_steps) <= 0:
+        raise ValueError("fixture dimensions, rate, frames, and steps must be positive")
+    if num_steps < 2:
+        raise ValueError("Cosmos Transfer live validation must be multi-step")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    video = output_dir / "npa-procedural-input.mp4"
+    spec = output_dir / "npa-procedural-edge-spec.json"
+    duration = frames / fps
+
+    # The source is a generated color plane. A grid and two independently moving
+    # boxes create stable edges and motion for on-the-fly Canny conditioning.
+    filters = (
+        "drawgrid=width=160:height=120:thickness=3:color=white@0.35,"
+        "drawbox=x='mod(t*150,iw-240)':y='ih/3':w=240:h=150:"
+        "color=0x36d399@1:t=fill,"
+        "drawbox=x='iw-180-mod(t*90,iw-360)':y='2*ih/3':w=180:h=100:"
+        "color=0xf59e0b@1:t=fill"
+    )
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=0x172033:s={width}x{height}:r={fps}:d={duration:.6f}",
+            "-vf",
+            filters,
+            "-frames:v",
+            str(frames),
+            "-an",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+            str(video),
+        ],
+        check=True,
+    )
+
+    payload: dict[str, Any] = {
+        "name": "npa_procedural_edge",
+        "prompt": (
+            "A photorealistic mobile robot moving through a clean industrial "
+            "workspace, natural lighting, detailed realistic materials"
+        ),
+        "video_path": str(video.resolve()),
+        "guidance": 3,
+        "num_steps": num_steps,
+        "seed": 20260801,
+        "max_frames": frames,
+        "num_video_frames_per_chunk": frames,
+        "resolution": str(height),
+        "keep_input_resolution": True,
+        "edge": {
+            "control_weight": 1.0,
+            "preset_edge_threshold": "medium",
+        },
+    }
+    spec.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return {
+        "video_path": str(video),
+        "spec_path": str(spec),
+        "width": width,
+        "height": height,
+        "fps": fps,
+        "frames": frames,
+        "duration_seconds": duration,
+        "num_steps": num_steps,
+        "provenance": "repository-authored deterministic FFmpeg lavfi filters",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--width", type=int, default=DEFAULT_WIDTH)
+    parser.add_argument("--height", type=int, default=DEFAULT_HEIGHT)
+    parser.add_argument("--fps", type=int, default=DEFAULT_FPS)
+    parser.add_argument("--frames", type=int, default=DEFAULT_FRAMES)
+    parser.add_argument("--num-steps", type=int, default=DEFAULT_STEPS)
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            generate_fixture(
+                args.output_dir,
+                width=args.width,
+                height=args.height,
+                fps=args.fps,
+                frames=args.frames,
+                num_steps=args.num_steps,
+            ),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/npa/src/npa/workbench/cosmos/transfer.py
+++ b/npa/src/npa/workbench/cosmos/transfer.py
@@ -234,7 +234,7 @@ def run_cosmos_transfer(
     if cuda_visible_devices is not None and str(cuda_visible_devices).strip() != "":
         env["CUDA_VISIBLE_DEVICES"] = str(cuda_visible_devices).strip()
     # Only the specs WE synthesized this call are ephemeral; never delete a
-    # bundled/example or caller-supplied spec. Per-variant tags keep siblings
+    # caller-supplied spec. Per-variant tags keep siblings
     # from clobbering each other, so removing exactly our file is fan-out safe.
     # Capture its content first so callers can still inspect the effective spec
     # after the file is gone (nothing depends on the ephemeral file persisting).

--- a/npa/src/npa/workbench/cosmos/transfer.py
+++ b/npa/src/npa/workbench/cosmos/transfer.py
@@ -23,9 +23,9 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_REPO = "/opt/cosmos/cosmos-transfer2.5"
-# Proven, self-contained control example bundled in the transfer repo. Produces a
-# real transferred video; used when the workflow does not supply its own spec.
-DEFAULT_SPEC = "assets/robot_example/depth/robot_depth_spec.json"
+# No upstream media is bundled in the redistributable image. Callers must supply
+# either an input clip (the preferred path) or an explicit operator-owned spec.
+DEFAULT_SPEC = ""
 
 # Control modalities Cosmos Transfer 2.5 computes ON-THE-FLY from the input
 # ``video_path`` (Canny edge / bilateral blur), so conditioning on an arbitrary
@@ -109,33 +109,37 @@ def _venv_has_torch(py: Path) -> bool:
 def cosmos_transfer_available() -> bool:
     """True when the real Cosmos-Transfer2.5 runtime is present and runnable.
 
-    Either the inference venv already has torch+flash-attn, or the repo + uv are
-    available so :func:`ensure_env` can build the venv on demand.
+    The redistributable image bakes the locked inference venv. Runtime dependency
+    self-healing would make the executed dependency set differ from the audited
+    image, so a missing venv is unavailable rather than a cue to download packages.
     """
 
     repo = cosmos_transfer_repo()
     if not (repo / "examples" / "inference.py").is_file():
         return False
-    if _venv_has_torch(_venv_python(repo)):
-        return True
-    return (repo / "pyproject.toml").is_file() and shutil.which("uv") is not None
+    return _venv_has_torch(_venv_python(repo))
 
 
 def ensure_env(repo: Path) -> Path:
-    """Return the inference venv python, building it (py3.10 + cu128) if absent."""
+    """Return the audited inference venv; never mutate or download at run time."""
 
     py = _venv_python(repo)
     if _venv_has_torch(py):
         return py
-    # The image pins .python-version=3.13, but the flash-attn wheel is cp310-only.
-    (repo / ".python-version").write_text("3.10\n", encoding="utf-8")
-    subprocess.run(["uv", "python", "install", "3.10"], cwd=repo, check=True)
-    subprocess.run(
-        ["uv", "sync", "--extra=cu128", "--python", "3.10"], cwd=repo, check=True
+    raise RuntimeError(
+        "cosmos-transfer2.5 audited inference venv is missing or unusable; "
+        "rebuild the pinned npa-cosmos2-transfer image"
     )
-    if not _venv_has_torch(py):
-        raise RuntimeError("cosmos-transfer2.5 inference env build did not yield torch+flash_attn")
-    return py
+
+
+def _require_runtime_hf_token() -> None:
+    """Refuse gated-model inference before any anonymous/partial download starts."""
+
+    if not os.environ.get("HF_TOKEN", "").strip():
+        raise RuntimeError(
+            "HF_TOKEN is required at run time for gated Cosmos Transfer weights; "
+            "no model download was attempted"
+        )
 
 
 def _spec_with_prompt(repo: Path, spec: str, prompt: str, *, tag: str = "") -> str:
@@ -182,8 +186,8 @@ def run_cosmos_transfer(
 ) -> dict[str, Any]:
     """Run a real Cosmos-Transfer2.5 inference; return the generated video + metadata.
 
-    ``spec`` is a controlnet_spec path relative to the transfer repo (defaults to
-    the env override ``COSMOS_TRANSFER_SPEC`` or the bundled depth example).
+    ``spec`` is a controlnet spec path relative to the transfer repo (or the
+    ``COSMOS_TRANSFER_SPEC`` environment override). No upstream fixture is baked.
     ``prompt`` (or ``COSMOS_TRANSFER_PROMPT``), when set, overrides the spec's text
     prompt so the sampled appearance actually conditions the augmentation.
 
@@ -191,11 +195,11 @@ def run_cosmos_transfer(
     controlnet spec is built with ``video_path`` = the input and an ``edge``/``vis``
     control computed on-the-fly, so the output is a real augmentation of the
     caller's footage (new appearance from ``prompt``, same structure/motion).
-    When ``input_video`` is absent, behavior is unchanged (bundled DEFAULT_SPEC or
-    the caller-supplied ``spec``), preserving the golden eval.
+    When ``input_video`` is absent, the caller must provide an operator-owned spec.
     """
 
     repo = cosmos_transfer_repo()
+    _require_runtime_hf_token()
     py = ensure_env(repo)
     tag = str(variant_tag or run_id or "input")
     conditioned_control = ""
@@ -211,6 +215,11 @@ def run_cosmos_transfer(
         )
     else:
         spec = spec or os.environ.get("COSMOS_TRANSFER_SPEC", DEFAULT_SPEC)
+        if not spec:
+            raise ValueError(
+                "Cosmos Transfer inference requires input_video or an explicit "
+                "COSMOS_TRANSFER_SPEC; no upstream media is bundled"
+            )
         prompt = prompt or os.environ.get("COSMOS_TRANSFER_PROMPT", "")
         if prompt:
             spec = _spec_with_prompt(repo, spec, prompt, tag=tag)

--- a/npa/tests/cli/test_agent_workflow.py
+++ b/npa/tests/cli/test_agent_workflow.py
@@ -115,6 +115,7 @@ def test_create_workflow_apis() -> None:
 
 def test_generate_data_factory_yaml_validates_and_plans() -> None:
     yaml_text = generate_data_factory_yaml()
+    generated = yaml.safe_load(yaml_text)
     result = validate_workflow_yaml_text(yaml_text)
     assert result["ok"] is True
     assert result["name"] == "physical-ai-data-factory"
@@ -136,6 +137,8 @@ def test_generate_data_factory_yaml_validates_and_plans() -> None:
     tool_refs = [step.get("tool_ref") for step in plan["steps"]]
     assert "workbench.cosmos2.transfer_execute" in tool_refs
     assert "workbench.token_factory.caption" in tool_refs
+    assert generated["config"]["trigger_uri"] == generated["config"]["input_uri"]
+    assert "supported video" in generated["states"]["augment"]["description"].lower()
 
 
 def test_extract_data_factory_params_fanout_gpus_subject() -> None:

--- a/npa/tests/docker/test_cosmos2_transfer_image.py
+++ b/npa/tests/docker/test_cosmos2_transfer_image.py
@@ -76,7 +76,11 @@ def test_lfs_media_models_and_build_credentials_are_excluded() -> None:
     assert "sha256=29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3" in overrides
     assert "files.pythonhosted.org" in overrides
     assert overrides.count("#sha256=") == 5
-    assert "--no-deps" in text
+    assert re.search(
+        r"uv pip install --python \.venv/bin/python --no-deps --require-hashes\s+\\\s+"
+        r"--requirement /tmp/cosmos2-security-overrides\.txt",
+        text,
+    )
     assert 'version("nltk") == "3.10.0"' in text
     assert 'version("defusedxml") == "0.7.1"' in text
     assert 'version("pip") == "26.2"' in text

--- a/npa/tests/docker/test_cosmos2_transfer_image.py
+++ b/npa/tests/docker/test_cosmos2_transfer_image.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 from npa.deploy.images import supported_tool_version
@@ -198,6 +200,9 @@ def test_build_script_resolves_registry_without_committed_identifier() -> None:
 
 
 def test_procedural_fixture_is_real_multistep_video(tmp_path: Path) -> None:
+    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+        pytest.skip("ffmpeg and ffprobe are required for procedural-video validation")
+
     result = generate_fixture(
         tmp_path,
         width=320,

--- a/npa/tests/docker/test_cosmos2_transfer_image.py
+++ b/npa/tests/docker/test_cosmos2_transfer_image.py
@@ -1,0 +1,274 @@
+"""Static and lightweight runtime gates for the redistributable Cosmos2 image."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from npa.deploy.images import supported_tool_version
+from npa.orchestration.npa_workflow.catalog import TOOL_CATALOG
+from npa.workbench.cosmos.fixture import generate_fixture
+
+ROOT = Path(__file__).resolve().parents[3]
+IMAGE_DIR = ROOT / "npa" / "docker" / "workbench" / "cosmos2-transfer"
+DOCKERFILE = IMAGE_DIR / "Dockerfile"
+SOURCE_SHA = "67d56b7d550a3911024a32dc23ae0bae5258e633"
+BUILD_BASE_SHA = "sha256:3986465b3dd3b4d602c07061f2cff417e0bfb24810129408d4eb12e111015a6c"
+RUNTIME_BASE_SHA = "sha256:9175fa92f96de35a8cfb9493f0dfcf9435c7a597e9d95ad41d2cae382a95e3f9"
+EXACT_TAG = "2.5.1-skypilot-ready-20260801T053000Z"
+
+
+def _dockerfile() -> str:
+    return DOCKERFILE.read_text(encoding="utf-8")
+
+
+def test_source_base_uv_and_python_are_immutable() -> None:
+    text = _dockerfile()
+    assert f"COSMOS_TRANSFER_REVISION={SOURCE_SHA}" in text
+    assert f"cudnn-devel-ubuntu24.04@{BUILD_BASE_SHA}" in text
+    assert f"cudnn-runtime-ubuntu24.04@{RUNTIME_BASE_SHA}" in text
+    assert "FROM ${CUDA_RUNTIME_IMAGE} AS runtime" in text
+    assert re.search(r"UV_IMAGE=\S+@sha256:[0-9a-f]{64}", text)
+    assert "COSMOS_PYTHON_VERSION=3.10.18" in text
+    assert "UBUNTU_SNAPSHOT=20260801T053000Z" in text
+    assert text.count("URIs: https://snapshot.ubuntu.com/ubuntu/${UBUNTU_SNAPSHOT}/") == 2
+    assert "/etc/apt/sources.list.d/*.sources" in text
+    assert "archive.ubuntu.com" not in text
+    assert "security.ubuntu.com" not in text
+    assert "developer.download.nvidia.com" not in text
+    assert "uv sync --locked --no-dev --no-editable --extra=cu128" in text
+    assert "apt-get upgrade -y" in text
+
+
+def test_lfs_media_models_and_build_credentials_are_excluded() -> None:
+    text = _dockerfile()
+    assert text.count("GIT_LFS_SKIP_SMUDGE=1") >= 3
+    assert "filter.lfs.smudge=" in text
+    assert "rm -rf .git assets" in text
+    assert "matplotlib/mpl-data/sample_data" in text
+    assert "skimage/data" in text
+    assert "wandb/bin" in text
+    assert "site-packages/scipy" in text
+    assert "numpy/_core/tests/_natype.py" in text
+    assert "from transformers import SiglipModel" in text
+    assert "assert-no-forbidden-cosmos2-payload" in text
+    assert not re.search(r"(?im)^\s*(ARG|ENV)\s+(HF_TOKEN|NGC_API_KEY|.*SECRET)", text)
+    assert not re.search(r"(?i)(huggingface|ngc).*(download|snapshot_download)", text)
+    assert not re.search(r"(?im)^\s*(COPY|ADD)\s+.*assets", text)
+
+    overrides = (IMAGE_DIR / "security-overrides.txt").read_text(encoding="utf-8")
+    assert "nltk-3.10.0-py3-none-any.whl" in overrides
+    assert "sha256=54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf" in overrides
+    assert "defusedxml-0.7.1-py2.py3-none-any.whl" in overrides
+    assert "sha256=a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61" in overrides
+    assert "pip-26.2-py3-none-any.whl" in overrides
+    assert "sha256=931c303696af6fa3417112103b1cad26890e5a07eccb5b99783700e33f2b8aad" in overrides
+    assert "msgpack-1.2.1-cp310-cp310-manylinux" in overrides
+    assert "sha256=83efa1c898e0fc5380fc0cabbf75164c52e3b5cbb45973710d75821928380c73" in overrides
+    assert "setuptools-83.0.0-py3-none-any.whl" in overrides
+    assert "sha256=29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3" in overrides
+    assert "files.pythonhosted.org" in overrides
+    assert overrides.count("#sha256=") == 5
+    assert "--no-deps" in text
+    assert 'version("nltk") == "3.10.0"' in text
+    assert 'version("defusedxml") == "0.7.1"' in text
+    assert 'version("pip") == "26.2"' in text
+    assert 'version("msgpack") == "1.2.1"' in text
+    assert 'version("setuptools") == "83.0.0"' in text
+    assert ".venv/bin/python -m pip --version" in text
+    assert 'importlib.util.find_spec("pip") is None' in text
+    assert 'importlib.util.find_spec("setuptools") is None' in text
+
+
+def test_forbidden_payload_guard_rejects_weight_and_media(tmp_path: Path) -> None:
+    guard = IMAGE_DIR / "assert_no_forbidden_payload.sh"
+    clean = tmp_path / "clean"
+    clean.mkdir()
+    subprocess.run(["bash", str(guard), str(clean)], check=True)
+
+    weight = clean / "tiny.pt"
+    weight.write_bytes(b"not harmless")
+    proc = subprocess.run(["bash", str(guard), str(clean)], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "model/checkpoint" in proc.stderr
+    weight.unlink()
+
+    allowed_site = clean / "lib" / "python3.10" / "site-packages"
+    allowed_site.mkdir(parents=True)
+    (allowed_site / "_virtualenv.pth").write_text("import _virtualenv\n", encoding="utf-8")
+    (allowed_site / "distutils-precedence.pth").write_text(
+        "import _distutils_hack\n", encoding="utf-8"
+    )
+    sobol = allowed_site / "scipy" / "stats" / "_sobol_direction_numbers.npz"
+    sobol.parent.mkdir(parents=True)
+    sobol.write_bytes(b"classified BSD runtime table")
+    subprocess.run(["bash", str(guard), str(clean)], check=True)
+
+    (allowed_site / "unclassified.pth").write_bytes(b"not a path config")
+    proc = subprocess.run(["bash", str(guard), str(clean)], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "unclassified.pth" in proc.stderr
+    (allowed_site / "unclassified.pth").unlink()
+
+    (clean / "sample.mp4").write_bytes(b"media")
+    proc = subprocess.run(["bash", str(guard), str(clean)], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "upstream media" in proc.stderr
+    (clean / "sample.mp4").unlink()
+
+    skimage_data = clean / ".venv" / "lib" / "python3.10" / "site-packages" / "skimage" / "data"
+    skimage_data.mkdir(parents=True)
+    proc = subprocess.run(["bash", str(guard), str(clean)], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "scikit-image data/fetch" in proc.stderr
+    skimage_data.rmdir()
+
+    wandb_bin = clean / ".venv" / "lib" / "python3.10" / "site-packages" / "wandb" / "bin"
+    wandb_bin.mkdir(parents=True)
+    proc = subprocess.run(["bash", str(guard), str(clean)], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "W&B native service" in proc.stderr
+
+
+def test_final_runtime_is_non_root_relocated_and_cache_writable_by_design() -> None:
+    text = _dockerfile()
+    assert re.search(r"(?m)^USER ubuntu$", text)
+    assert 'VOLUME ["/opt/cosmos/model-cache"]' in text
+    assert "NLTK_DATA=/opt/cosmos/model-cache" in text
+    assert "from nltk.pathsec import _get_allowed_roots" in text
+    assert "LD_LIBRARY_PATH=/usr/local/cuda/lib64:" in text
+    assert 'ln -sfn libcudart.so.12 "${cudart_dir}/libcudart.so"' in text
+    assert 'ctypes.CDLL(\\"libcudart.so\\")' in text
+    assert "UV_PYTHON_INSTALL_DIR=/opt/cosmos/uv-python" in text
+    assert "! grep -q '/root' .venv/pyvenv.cfg" in text
+    assert "COPY --from=build --chown=1000:1000 /opt/cosmos /opt/cosmos" in text
+    assert 'exec /opt/cosmos/cosmos-transfer2.5/.venv/bin/python "$@"' in text
+    assert "> /usr/local/bin/python3" in text
+    assert 'python3 -c "import cosmos_transfer2"' in text
+    assert "python3 -m pip --version" in text
+    assert "COPY --from=uv-bin /uv /usr/local/bin/uv" in text
+    assert "COPY --from=uv-bin /uvx /usr/local/bin/uvx" in text
+    assert 'test "$(command -v uvx)" = /usr/local/bin/uvx && uvx --version' in text
+    assert "chown -R ubuntu:ubuntu /opt/cosmos " not in text
+    assert "chown -R ubuntu:ubuntu /opt/cosmos/model-cache" in text
+    assert "test -w /opt/cosmos/model-cache/huggingface" in text
+    assert "rm -f /etc/ssh/ssh_host_*" in text
+
+
+def test_entrypoint_passes_arbitrary_argv_and_refuses_tokenless_inference() -> None:
+    entrypoint = IMAGE_DIR / "entrypoint.sh"
+    env = dict(os.environ)
+    env.pop("HF_TOKEN", None)
+    passthrough = subprocess.run(
+        ["bash", str(entrypoint), "/bin/sh", "-c", "printf skypilot-ready"],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert passthrough.stdout == "skypilot-ready"
+
+    denied = subprocess.run(
+        ["bash", str(entrypoint), "/bin/sh", "-c", "python examples/inference.py"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert denied.returncode == 78
+    assert "no download was attempted" in denied.stderr
+    assert "HF_TOKEN=" not in denied.stderr
+
+
+def test_build_script_resolves_registry_without_committed_identifier() -> None:
+    build_script = IMAGE_DIR / "build.sh"
+    text = build_script.read_text(encoding="utf-8")
+    assert os.access(build_script, os.X_OK)
+    assert os.access(IMAGE_DIR / "assert_no_forbidden_payload.sh", os.X_OK)
+    assert "resolve_container_registry" in text
+    assert "docker buildx build" in text
+    assert "--push --provenance=mode=max --sbom=true" in text
+    assert "env -u HF_TOKEN" in text
+    assert "cr.eu-" not in text
+    assert re.search(r"\b[etu][0-9a-z]{18,}\b", text) is None
+
+
+def test_procedural_fixture_is_real_multistep_video(tmp_path: Path) -> None:
+    result = generate_fixture(
+        tmp_path,
+        width=320,
+        height=240,
+        fps=8,
+        frames=16,
+        num_steps=2,
+    )
+    spec = json.loads(Path(result["spec_path"]).read_text(encoding="utf-8"))
+    assert spec["num_steps"] == 2
+    assert spec["edge"]["control_weight"] == 1.0
+    assert spec["video_path"] == str(Path(result["video_path"]).resolve())
+    probe = subprocess.run(
+        [
+            "ffprobe", "-v", "error", "-count_frames", "-select_streams", "v:0",
+            "-show_entries", "stream=width,height,nb_read_frames", "-of", "json",
+            result["video_path"],
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    stream = json.loads(probe.stdout)["streams"][0]
+    assert (stream["width"], stream["height"]) == (320, 240)
+    assert int(stream["nb_read_frames"]) == 16
+
+
+def test_exact_pin_golden_eval_and_workflow_use_the_legal_path() -> None:
+    assert supported_tool_version("cosmos2-transfer") == EXACT_TAG
+    golden = yaml.safe_load(
+        (ROOT / "npa" / "src" / "npa" / "smoke" / "golden_evals.yaml").read_text(
+            encoding="utf-8"
+        )
+    )["containers"]["cosmos2-transfer"]
+    assert golden["golden_eval"]["command"] == "bash /opt/cosmos2-transfer/smoke_functional.sh"
+    assert "procedural input" in golden["safety"]["notes"]
+    assert "built outside this repo" not in golden["safety"]["notes"]
+    argv = TOOL_CATALOG["workbench.cosmos2.transfer_execute"].argv_template
+    assert "--condition-on-input" in argv
+    assert "--execute" in argv
+    workflow = yaml.safe_load(
+        (
+            ROOT
+            / "npa"
+            / "workflows"
+            / "workbench"
+            / "npa-workflows"
+            / "cosmos2-transfer.yaml"
+        ).read_text(encoding="utf-8")
+    )
+    assert workflow["resources"]["transfer-gpu"]["accelerators"] == "RTXPRO6000:1"
+    pod_spec = workflow["resources"]["transfer-gpu"]["kubernetes"]["pod_config"]["spec"]
+    assert pod_spec["volumes"] == [{"name": "cosmos2-model-cache", "emptyDir": {}}]
+    assert pod_spec["containers"][0]["name"] == "ray-node"
+    assert pod_spec["containers"][0]["volumeMounts"] == [
+        {"name": "cosmos2-model-cache", "mountPath": "/opt/cosmos/model-cache"}
+    ]
+
+
+def test_redistribution_record_covers_every_artifact_category() -> None:
+    record = (IMAGE_DIR / "REDISTRIBUTION.md").read_text(encoding="utf-8")
+    for item in (
+        "Cosmos Transfer source",
+        "Git LFS objects",
+        "model weights",
+        "CUDA/cuDNN base runtime",
+        "Python dependencies",
+        "Live-test input",
+        SOURCE_SHA,
+        BUILD_BASE_SHA,
+        RUNTIME_BASE_SHA,
+    ):
+        assert item in record
+    assert "not legal advice" in record

--- a/npa/tests/docker/test_cosmos2_transfer_image.py
+++ b/npa/tests/docker/test_cosmos2_transfer_image.py
@@ -257,6 +257,8 @@ def test_exact_pin_golden_eval_and_workflow_use_the_legal_path() -> None:
             / "cosmos2-transfer.yaml"
         ).read_text(encoding="utf-8")
     )
+    assert workflow["states"]["transfer"]["toolRef"] == "workbench.cosmos2.transfer_execute"
+    assert workflow["config"]["trigger_uri"].endswith("/input/")
     assert workflow["resources"]["transfer-gpu"]["accelerators"] == "RTXPRO6000:1"
     pod_spec = workflow["resources"]["transfer-gpu"]["kubernetes"]["pod_config"]["spec"]
     assert pod_spec["volumes"] == [{"name": "cosmos2-model-cache", "emptyDir": {}}]

--- a/npa/tests/docker/test_cosmos_oss_images.py
+++ b/npa/tests/docker/test_cosmos_oss_images.py
@@ -243,92 +243,26 @@ def test_transfer_image_keeps_its_interpreter_out_of_root() -> None:
     )
     assert "chown -R ubuntu:ubuntu" in body and "/opt/cosmos/uv-python" in body
     # And the build proves it rather than assuming it.
-    assert "venv usable as ubuntu" in body, (
+    assert "su ubuntu -s /bin/bash -c" in body, (
         "the build must verify the venv runs as ubuntu, not just that it exists"
     )
-    # A prebuilt BASE_IMAGE already carries a venv pointing into /root, and uv would
-    # reuse it, so the repair branch is what makes UV_PYTHON_INSTALL_DIR effective.
-    assert "UV_LEGACY_PYTHON_DIR=/root/.local/share/uv/python" in body, (
-        "the legacy interpreter location must be named once so the repair can detect it"
+    assert "! grep -q '/root' .venv/pyvenv.cfg" in body, (
+        "the build must fail if pyvenv.cfg points into the root-only tree"
     )
-    assert 'interpreter still under ${UV_LEGACY_PYTHON_DIR}' in body, (
-        "the build must fail if the resolved interpreter is still the legacy one"
+    assert "UV_LEGACY_PYTHON_DIR" not in body, (
+        "a complete source build must never inherit or repair the opaque private parent's venv"
     )
 
 
-def test_transfer_relocation_repoints_a_root_venv(tmp_path: Path) -> None:
-    """Exercise the Dockerfile's relocation block against the layout it repairs.
+def test_transfer_builds_a_fresh_rootless_venv_instead_of_relocating_one() -> None:
+    """The clean-source build cannot regress to repairing an opaque parent's venv."""
 
-    Mirrors what the published image actually contains: a uv interpreter under
-    /root and a venv whose ``bin/python`` symlinks into it. Verified against the real
-    image in-cluster as well; this keeps the shell logic from regressing without one.
-    """
-
-    import re
-    import subprocess
-
-    legacy = tmp_path / "legacy" / "python"
-    interpreter = legacy / "cpython-3.10.20-linux-x86_64-gnu" / "bin"
-    interpreter.mkdir(parents=True)
-    (interpreter / "python3.10").write_text("#!/bin/sh\necho interpreter\n", encoding="utf-8")
-    (interpreter / "python3.10").chmod(0o755)
-
-    project = tmp_path / "project"
-    venv_bin = project / ".venv" / "bin"
-    venv_bin.mkdir(parents=True)
-    (venv_bin / "python").symlink_to(interpreter / "python3.10")
-    (venv_bin / "python3").symlink_to("python")
-    # uv records the interpreter in pyvenv.cfg through its version symlink, which is a
-    # different string from what `readlink -f` resolves to. Matching only the resolved
-    # form leaves `home =` in the legacy tree and Python takes sys._home from it.
-    symlinked = legacy / "cpython-3.10-linux-x86_64-gnu"
-    symlinked.symlink_to(interpreter.parent, target_is_directory=True)
-    (project / ".venv" / "pyvenv.cfg").write_text(
-        f"home = {symlinked / 'bin'}\nversion = 3.10.20\n", encoding="utf-8"
-    )
-
-    # Lift the block straight out of the Dockerfile so the test cannot drift from it.
-    # The two directories it works on are env vars precisely so this is drivable.
     body = _dockerfile("cosmos2-transfer")
-    block = body.split("RUN set -eux; \\", 1)[1].split("\n\n", 1)[0]
-    script = re.sub(r"\\\n\s*", " ", block)
-    install_dir = tmp_path / "relocated"
-
-    result = subprocess.run(
-        ["bash", "-c", "set -eux; " + script],
-        cwd=project,
-        capture_output=True,
-        text=True,
-        env={
-            "PATH": "/usr/bin:/bin",
-            "UV_PYTHON_INSTALL_DIR": str(install_dir),
-            "UV_LEGACY_PYTHON_DIR": str(legacy),
-        },
-    )
-    assert result.returncode == 0, result.stderr
-
-    resolved = (venv_bin / "python").resolve()
-    assert str(resolved).startswith(str(install_dir)), resolved
-    config = (project / ".venv" / "pyvenv.cfg").read_text(encoding="utf-8")
-    assert str(install_dir) in config
-    assert str(legacy) not in config, (
-        "pyvenv.cfg still points into the legacy tree; Python takes sys._home from it, "
-        "so an inference run fails later in distutils.sysconfig"
-    )
-    assert not legacy.exists(), (
-        "the stale interpreter tree should be removed so the trap cannot come back"
-    )
-    # `cp -a` copies uv's absolute version symlink verbatim, so the relocated tree can
-    # still point back into the legacy location and resolve into it.
-    dangling = [
-        path
-        for path in install_dir.rglob("*")
-        if path.is_symlink() and str(path.readlink()).startswith(str(legacy))
-    ]
-    assert not dangling, f"relocated tree still links into the legacy dir: {dangling}"
-    assert (install_dir / "cpython-3.10-linux-x86_64-gnu" / "bin" / "python3.10").exists(), (
-        "resolving through the version symlink must reach the relocated interpreter"
-    )
+    assert "ARG BASE_IMAGE=npa-cosmos2-transfer" not in body
+    assert 'uv python install "${COSMOS_PYTHON_VERSION}"' in body
+    assert 'uv sync --locked --no-dev --no-editable --extra=cu128' in body
+    assert 'readlink -f .venv/bin/python' in body
+    assert 'find "${UV_PYTHON_INSTALL_DIR}"' in body
 
 
 @pytest.mark.parametrize("image", IMAGES)

--- a/npa/tests/docker/test_packaging_contract.py
+++ b/npa/tests/docker/test_packaging_contract.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from npa.deploy.images import CONTAINER_IMAGE_NAMES
+
 ROOT = Path(__file__).resolve().parents[3]
 CONTRACT_PATH = ROOT / "npa" / "docker" / "workbench" / "packaging-contract.yaml"
 WORKBENCH_DOCKER = ROOT / "npa" / "docker" / "workbench"
@@ -131,6 +133,27 @@ def test_packaging_contract_file_exists() -> None:
     assert "job" in contract["tiers"]
     assert "interactive" in contract["tiers"]
     assert contract["images"]
+
+
+def test_first_class_pinned_dockerfiles_are_covered_by_contract() -> None:
+    """A pin plus an in-tree same-name Dockerfile may not bypass legal review.
+
+    Derived aliases such as ``envgen`` intentionally map to a differently named
+    Dockerfile and are covered through their parent contract entry. A first-class
+    ``workbench/<tool>/Dockerfile`` has no such excuse: adding its pin must add a
+    packaging classification in the same change.
+    """
+
+    contract_images = set(_load_contract()["images"])
+    first_class = {
+        tool
+        for tool in CONTAINER_IMAGE_NAMES
+        if (WORKBENCH_DOCKER / tool / "Dockerfile").is_file()
+    }
+    assert first_class <= contract_images, (
+        "pinned first-class Dockerfiles missing from packaging-contract.yaml: "
+        f"{sorted(first_class - contract_images)}"
+    )
 
 
 @pytest.mark.parametrize("image_name", sorted(_load_contract()["images"]))

--- a/npa/tests/e2e/npa_workflow_live_helpers.py
+++ b/npa/tests/e2e/npa_workflow_live_helpers.py
@@ -188,6 +188,26 @@ def seed_live_workflow_inputs(
             )
         return
 
+    if spec_name == "cosmos2-transfer.yaml":
+        # This is repository-authored procedural media, not an NVIDIA/upstream
+        # sample. The real transfer_execute path downloads it and generates its
+        # edge control on the fly inside the exact image under test.
+        import tempfile
+        from pathlib import Path
+
+        from npa.workbench.cosmos.fixture import generate_fixture
+
+        with tempfile.TemporaryDirectory(prefix="npa-cosmos2-fixture-") as tmp:
+            fixture = generate_fixture(Path(tmp), num_steps=4)
+            video = Path(str(fixture["video_path"]))
+            client.put_object(
+                Bucket=bucket,
+                Key=f"{marker}/input/{video.name}",
+                Body=video.read_bytes(),
+                ContentType="video/mp4",
+            )
+        return
+
     if spec_name in {"sonic-export.yaml", "sonic-export-eval.yaml"}:
         # `npa workbench sonic export` needs a loadable torch policy checkpoint. We do
         # not vendor NVIDIA's gated nvidia/GEAR-SONIC weights, so the operator stages a

--- a/npa/tests/e2e/test_npa_workflow_submit_live_e2e.py
+++ b/npa/tests/e2e/test_npa_workflow_submit_live_e2e.py
@@ -12,6 +12,7 @@ Optional filters:
   NPA_E2E_NPA_WORKFLOW_SUBMIT_MAX_WAIT_SECONDS=3600
   NPA_E2E_NPA_WORKFLOW_SUBMIT_POLL_SECONDS=30
   NPA_E2E_NPA_WORKFLOW_SUBMIT_CANCEL_ON_TIMEOUT=1
+  NPA_E2E_SKYPILOT_CONFIG_PATH=/tmp/run/skypilot-config.yaml
   NPA_REGISTRY / --registry via NPA_E2E_REGISTRY
   NEBIUS_TOKEN_FACTORY_KEY for cpu-tier Token Factory twins
 
@@ -131,6 +132,18 @@ def _case_max_wait(case: SubmitLiveCase) -> int:
     return case.max_wait_seconds or _max_wait()
 
 
+def _skypilot_config_args() -> list[str]:
+    """Use an operator-owned SkyPilot config for live-only pod settings."""
+
+    value = os.environ.get("NPA_E2E_SKYPILOT_CONFIG_PATH", "").strip()
+    if not value:
+        return []
+    path = Path(value)
+    if not path.is_file():
+        pytest.fail(f"NPA_E2E_SKYPILOT_CONFIG_PATH does not exist: {path}")
+    return ["--config-path", str(path)]
+
+
 def _poll_seconds() -> int:
     return int(os.environ.get("NPA_E2E_NPA_WORKFLOW_SUBMIT_POLL_SECONDS", "30"))
 
@@ -236,6 +249,7 @@ def test_npa_workflow_submit_live_reaches_terminal(
         "json",
     ]
     plan_args.extend(_image_args(case, e2e_registry))
+    plan_args.extend(_skypilot_config_args())
     assume = assume_decision_for(case.spec)
     if assume:
         plan_args.extend(["--assume-decision", assume])
@@ -269,6 +283,7 @@ def test_npa_workflow_submit_live_reaches_terminal(
     # declares `image_tool`, whose stages need the vendor image's own libraries.
     submit_args.extend(_image_args(case, e2e_registry))
     submit_args.extend(_secret_env_args(case))
+    submit_args.extend(_skypilot_config_args())
 
     if (
         os.environ.get("NPA_E2E_CLEAR_WORKBENCH_IMAGES", "").strip() in {"1", "true", "yes"}
@@ -417,6 +432,7 @@ def _runtime_submit_args(
     elif os.environ.get("NPA_E2E_CLEAR_WORKBENCH_IMAGES", "").strip() in {"1", "true", "yes"}:
         args.extend(["--image", "none"])
     args.extend(_secret_env_args(case))
+    args.extend(_skypilot_config_args())
     return args
 
 

--- a/npa/tests/orchestration/npa_workflow/test_daily_coverage.py
+++ b/npa/tests/orchestration/npa_workflow/test_daily_coverage.py
@@ -118,7 +118,12 @@ def test_declared_case_budget_survives_the_daily_runner_cap(monkeypatch) -> None
     whichever day the rotation reached it.
     """
     import importlib
+    from pathlib import Path
 
+    # The documented full-suite invocation runs from the repository root and
+    # points pytest at ``npa/tests``. In that layout the tests package's parent
+    # is not necessarily on sys.path, so make the package import deterministic.
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[3]))
     mod = importlib.import_module("tests.e2e.test_npa_workflow_submit_live_e2e")
     monkeypatch.setenv("NPA_E2E_NPA_WORKFLOW_SUBMIT_MAX_WAIT_SECONDS", "2400")
 

--- a/npa/tests/orchestration/npa_workflow/test_real_components.py
+++ b/npa/tests/orchestration/npa_workflow/test_real_components.py
@@ -79,13 +79,19 @@ def test_blueprint_run_shell_stages_are_real() -> None:
 
 
 def test_augment_runs_real_cosmos_transfer() -> None:
+    spec = _spec()
     states = _states()
     assert states["augment"].get("toolRef") == "workbench.cosmos2.transfer_execute", (
         "augment must run the real Cosmos Transfer 2.5 execute path"
     )
     argv = TOOL_CATALOG["workbench.cosmos2.transfer_execute"].argv_template
     assert "--execute" in argv, "transfer_execute must pass --execute to run the real model"
+    assert "--condition-on-input" in argv
     assert "--input-uri" in argv and "--output-uri" in argv
+    assert spec["config"]["trigger_uri"] == spec["config"]["input_uri"]
+    description = states["augment"]["description"].lower()
+    assert "supported video" in description
+    assert "no bundled upstream media" in description
 
 
 def test_evaluate_runs_the_real_cosmos_evaluator() -> None:

--- a/npa/tests/orchestration/npa_workflow/test_submit_live_matrix.py
+++ b/npa/tests/orchestration/npa_workflow/test_submit_live_matrix.py
@@ -116,6 +116,24 @@ def test_selected_submit_cases_explicit_empty_filter_fails(monkeypatch) -> None:
         selected_submit_cases()
 
 
+def test_live_submit_wrapper_preserves_explicit_operator_environment() -> None:
+    script = (
+        Path(__file__).resolve().parents[4]
+        / "scripts"
+        / "npa-workflow-submit-live-e2e.sh"
+    ).read_text(encoding="utf-8")
+    snapshot = script.index("declare -A _npa_explicit_env_values=()")
+    cloud_defaults = script.index("source /home/ubuntu/bin/npa-cloud-env.sh")
+    user_defaults = script.index('. "${HOME}/.npa/live-e2e.env"')
+    restore = script.index('for _npa_env_name in "${!_npa_explicit_env_values[@]}"')
+    python_select = script.index('PY="${NPA_LIVE_E2E_PYTHON_BIN:')
+
+    assert snapshot < cloud_defaults < user_defaults < restore < python_select
+    assert "NPA_*|SKYPILOT_DOCKER_*" in script
+    assert 'printf -v "$_npa_env_name"' in script
+    assert 'export "$_npa_env_name"' in script
+
+
 def test_submit_live_matrix_has_cpu_gpu_and_multi() -> None:
     tiers = {case.tier for case in SUBMIT_LIVE_MATRIX}
     assert tiers == {"cpu", "gpu", "multi"}

--- a/npa/tests/unit/test_byof_live.py
+++ b/npa/tests/unit/test_byof_live.py
@@ -59,7 +59,13 @@ def test_resolve_byof_kubernetes_target_falls_back_to_home_kubeconfig(
 def test_resolve_byof_kubernetes_target_from_cluster_state(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    # This unit path exercises cluster state, independent of the operator's live
+    # project configuration (which may itself declare a Kubernetes context).
+    monkeypatch.setattr("npa.workflows.byof.live._project_kubernetes_block", lambda _project: {})
+    monkeypatch.setattr("npa.workflows.byof.live._project_storage_block", lambda _project: {})
     monkeypatch.delenv("NPA_BYOF_K8S_CONTEXT", raising=False)
+    monkeypatch.delenv("NPA_K8S_CONTEXT", raising=False)
+    monkeypatch.delenv("KUBECONTEXT", raising=False)
     monkeypatch.delenv("NPA_BYOF_KUBECONFIG", raising=False)
     monkeypatch.delenv("KUBECONFIG", raising=False)
     cluster_dir = tmp_path / "clusters" / "customer-mk8s"

--- a/npa/tests/workbench/test_cosmos_transfer_available.py
+++ b/npa/tests/workbench/test_cosmos_transfer_available.py
@@ -38,8 +38,7 @@ def test_cosmos_transfer_available_false_on_permission_error(
     def _raise_perm(_py: Path) -> bool:
         raise PermissionError(13, "Permission denied")
 
-    # If _venv_has_torch itself raised, cosmos_transfer_available would crash;
-    # with the fix it returns False and falls through to the uv-availability check.
+    # A missing/broken audited venv is unavailable; runtime package self-healing
+    # is deliberately disabled for reproducibility.
     monkeypatch.setattr(transfer, "_venv_has_torch", lambda _py: False)
-    monkeypatch.setattr(transfer.shutil, "which", lambda _name: None)
     assert transfer.cosmos_transfer_available() is False

--- a/npa/tests/workbench/test_cosmos_transfer_input.py
+++ b/npa/tests/workbench/test_cosmos_transfer_input.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.cli.workbench import cosmos2
 from npa.workbench.cosmos import transfer as tx
+
+runner = CliRunner()
 
 
 def _fake_env(monkeypatch, repo: Path):
@@ -235,9 +241,47 @@ def test_materialize_input_clip_local_path(tmp_path: Path) -> None:
     assert _materialize_input_clip(str(tmp_path / "missing.mp4")) == ""
 
 
-def test_detect_gpu_count_from_cuda_visible_devices(monkeypatch) -> None:
-    from npa.cli.workbench import cosmos2
+def test_transfer_cli_rejects_conditioning_without_input_video(monkeypatch) -> None:
+    input_uri = "s3://test-bucket/run/input/"
+    materialized: list[str] = []
+    inference_called = False
 
+    monkeypatch.setattr(tx, "cosmos_transfer_available", lambda: True)
+
+    def fake_materialize(src: str) -> str:
+        materialized.append(src)
+        return ""
+
+    def fail_if_inferred(**_kwargs) -> dict:
+        nonlocal inference_called
+        inference_called = True
+        raise AssertionError("inference must not run without an input video")
+
+    monkeypatch.setattr(cosmos2, "_materialize_input_clip", fake_materialize)
+    monkeypatch.setattr(tx, "run_cosmos_transfer", fail_if_inferred)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "cosmos2",
+            "transfer",
+            "--input-uri",
+            input_uri,
+            "--output-uri",
+            "s3://test-bucket/run/augmented/",
+            "--condition-on-input",
+            "--execute",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "input conditioning was requested but no video was found" in result.output
+    assert materialized == [input_uri]
+    assert inference_called is False
+
+
+def test_detect_gpu_count_from_cuda_visible_devices(monkeypatch) -> None:
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3")
     assert cosmos2._detect_gpu_count() == 4
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
@@ -246,8 +290,6 @@ def test_detect_gpu_count_from_cuda_visible_devices(monkeypatch) -> None:
 
 
 def test_variant_parallelism_env_override_and_cap(monkeypatch) -> None:
-    from npa.cli.workbench import cosmos2
-
     monkeypatch.setenv("NPA_COSMOS_VARIANT_PARALLELISM", "4")
     # Capped at the number of variants so we never spawn idle workers.
     assert cosmos2._variant_parallelism(2) == 2

--- a/npa/tests/workbench/test_cosmos_transfer_input.py
+++ b/npa/tests/workbench/test_cosmos_transfer_input.py
@@ -1,8 +1,8 @@
 """Unit tests for optional input-conditioning in the Cosmos Transfer 2.5 runner.
 
 These cover the code path that makes the augment a REAL augmentation of the
-caller's input clip (edge control computed on-the-fly from ``video_path``) while
-leaving the default bundled-example behavior — and the golden eval — unchanged.
+caller's input clip (edge control computed on-the-fly from ``video_path``). No
+upstream fixture is used.
 No GPU / cosmos runtime is touched; the inference subprocess is mocked.
 """
 
@@ -17,6 +17,7 @@ from npa.workbench.cosmos import transfer as tx
 def _fake_env(monkeypatch, repo: Path):
     monkeypatch.setattr(tx, "cosmos_transfer_repo", lambda: repo)
     monkeypatch.setattr(tx, "ensure_env", lambda r: Path("/usr/bin/python3"))
+    monkeypatch.setenv("HF_TOKEN", "unit-test-placeholder")
 
     def fake_run(cmd, *args, **kwargs):
         cwd = Path(kwargs["cwd"])
@@ -71,8 +72,8 @@ def test_run_cosmos_transfer_conditions_on_input(tmp_path: Path, monkeypatch) ->
     assert res["input_video"] == str(clip)
     assert res["control"] == "edge"
     assert Path(res["video_path"]).exists()
-    # A conditioned spec was written that points at the input clip, not DEFAULT_SPEC.
-    assert res["spec"] != tx.DEFAULT_SPEC
+    # A conditioned spec was written that points at the input clip.
+    assert res["spec"]
     # The synthesized controlnet spec is ephemeral (removed after inference to
     # avoid accumulating in the repo dir); its content is returned for inspection.
     assert not (repo / res["spec"]).exists()
@@ -82,17 +83,40 @@ def test_run_cosmos_transfer_conditions_on_input(tmp_path: Path, monkeypatch) ->
     assert spec["prompt"] == "foggy morning"
 
 
-def test_run_cosmos_transfer_default_uses_bundled_spec(tmp_path: Path, monkeypatch) -> None:
+def test_run_cosmos_transfer_requires_input_or_explicit_spec(tmp_path: Path, monkeypatch) -> None:
     repo = tmp_path / "repo"
     (repo / "examples").mkdir(parents=True)
     _fake_env(monkeypatch, repo)
     monkeypatch.delenv("COSMOS_TRANSFER_SPEC", raising=False)
     monkeypatch.delenv("COSMOS_TRANSFER_PROMPT", raising=False)
 
-    res = tx.run_cosmos_transfer(run_id="r2")
-    assert res["input_conditioned"] is False
-    assert res["spec"] == tx.DEFAULT_SPEC
+    import pytest
+
+    with pytest.raises(ValueError, match="no upstream media is bundled"):
+        tx.run_cosmos_transfer(run_id="r2")
     assert not list(repo.glob("_npa_input_spec_*.json"))
+
+
+def test_run_cosmos_transfer_refuses_missing_token_before_env_or_download(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(tx, "cosmos_transfer_repo", lambda: repo)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    called = False
+
+    def fail_if_called(_repo: Path) -> Path:
+        nonlocal called
+        called = True
+        raise AssertionError("environment/download path must not run")
+
+    monkeypatch.setattr(tx, "ensure_env", fail_if_called)
+    import pytest
+
+    with pytest.raises(RuntimeError, match="no model download was attempted"):
+        tx.run_cosmos_transfer(input_video=str(tmp_path / "missing.mp4"))
+    assert called is False
 
 
 def test_publish_marks_real_gpu_mode_and_conditioning(tmp_path: Path, monkeypatch) -> None:

--- a/npa/tests/workbench/test_cosmos_transfer_input.py
+++ b/npa/tests/workbench/test_cosmos_transfer_input.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from npa.cli.main import app
@@ -96,8 +97,6 @@ def test_run_cosmos_transfer_requires_input_or_explicit_spec(tmp_path: Path, mon
     monkeypatch.delenv("COSMOS_TRANSFER_SPEC", raising=False)
     monkeypatch.delenv("COSMOS_TRANSFER_PROMPT", raising=False)
 
-    import pytest
-
     with pytest.raises(ValueError, match="no upstream media is bundled"):
         tx.run_cosmos_transfer(run_id="r2")
     assert not list(repo.glob("_npa_input_spec_*.json"))
@@ -118,8 +117,6 @@ def test_run_cosmos_transfer_refuses_missing_token_before_env_or_download(
         raise AssertionError("environment/download path must not run")
 
     monkeypatch.setattr(tx, "ensure_env", fail_if_called)
-    import pytest
-
     with pytest.raises(RuntimeError, match="no model download was attempted"):
         tx.run_cosmos_transfer(input_video=str(tmp_path / "missing.mp4"))
     assert called is False
@@ -241,6 +238,71 @@ def test_materialize_input_clip_local_path(tmp_path: Path) -> None:
     assert _materialize_input_clip(str(tmp_path / "missing.mp4")) == ""
 
 
+def test_materialize_input_clip_empty_s3_prefix_is_no_video(monkeypatch) -> None:
+    from npa.clients.storage import StorageClient
+
+    materialized_dirs: list[Path] = []
+
+    class EmptyPrefixStorage:
+        def download_directory(self, _src: str, local_dir: str) -> str:
+            materialized_dirs.append(Path(local_dir))
+            assert materialized_dirs[-1].is_dir()
+            return local_dir
+
+    monkeypatch.setattr(StorageClient, "from_environment", lambda: EmptyPrefixStorage())
+
+    assert cosmos2._materialize_input_clip("s3://test-bucket/empty/") == ""
+    assert materialized_dirs and not materialized_dirs[0].exists()
+
+
+@pytest.mark.parametrize("stage", ["authentication", "listing", "download"])
+def test_materialize_input_clip_propagates_storage_failures(
+    monkeypatch, stage: str
+) -> None:
+    from npa.clients.storage import StorageClient
+
+    failure = PermissionError(f"{stage} failed: credential=must-not-surface")
+
+    class FailingStorage:
+        def download_directory(self, _src: str, _local_dir: str) -> str:
+            raise failure
+
+        def download_path(self, _src: str, _local_path: str) -> str:
+            raise failure
+
+    def from_environment():
+        if stage == "authentication":
+            raise failure
+        return FailingStorage()
+
+    monkeypatch.setattr(StorageClient, "from_environment", from_environment)
+    source = "s3://test-bucket/input.mp4" if stage == "download" else "s3://test-bucket/input/"
+
+    with pytest.raises(PermissionError) as caught:
+        cosmos2._materialize_input_clip(source)
+    assert caught.value is failure
+
+
+def test_cli_materialization_error_is_sanitized_and_preserves_cause(monkeypatch) -> None:
+    secret = "do-not-print-this-token"
+    failure = PermissionError(f"access denied: token={secret}")
+    source = f"s3://test-bucket/input/?token={secret}"
+
+    def fail_materialize(_src: str) -> str:
+        raise failure
+
+    monkeypatch.setattr(cosmos2, "_materialize_input_clip", fail_materialize)
+
+    with pytest.raises(cosmos2.typer.BadParameter) as caught:
+        cosmos2._materialize_conditioning_input(source)
+    assert isinstance(caught.value, cosmos2.typer.BadParameter)
+    assert caught.value.__cause__ is failure
+    message = str(caught.value)
+    assert "could not inspect or download" in message
+    assert "credentials" in message
+    assert secret not in message
+
+
 def test_transfer_cli_rejects_conditioning_without_input_video(monkeypatch) -> None:
     input_uri = "s3://test-bucket/run/input/"
     materialized: list[str] = []
@@ -276,8 +338,50 @@ def test_transfer_cli_rejects_conditioning_without_input_video(monkeypatch) -> N
     )
 
     assert result.exit_code != 0
-    assert "input conditioning was requested but no video was found" in result.output
+    assert "no supported video" in result.output
+    assert input_uri not in result.output
     assert materialized == [input_uri]
+    assert inference_called is False
+
+
+def test_transfer_cli_reports_storage_failure_without_secret(monkeypatch) -> None:
+    secret = "do-not-print-this-token"
+    input_uri = f"s3://test-bucket/run/input/?token={secret}"
+    failure = PermissionError(f"access denied: credential={secret}")
+    inference_called = False
+
+    monkeypatch.setattr(tx, "cosmos_transfer_available", lambda: True)
+
+    def fail_materialize(_src: str) -> str:
+        raise failure
+
+    def fail_if_inferred(**_kwargs) -> dict:
+        nonlocal inference_called
+        inference_called = True
+        raise AssertionError("inference must not run after an input-storage failure")
+
+    monkeypatch.setattr(cosmos2, "_materialize_input_clip", fail_materialize)
+    monkeypatch.setattr(tx, "run_cosmos_transfer", fail_if_inferred)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "cosmos2",
+            "transfer",
+            "--input-uri",
+            input_uri,
+            "--output-uri",
+            "s3://test-bucket/run/augmented/",
+            "--condition-on-input",
+            "--execute",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "could not inspect or download" in result.output
+    assert "no supported video" not in result.output
+    assert secret not in result.output
     assert inference_called is False
 
 

--- a/npa/tests/workflows/test_cosmos2_manifest_publish.py
+++ b/npa/tests/workflows/test_cosmos2_manifest_publish.py
@@ -31,7 +31,7 @@ def test_manifest_lands_next_to_the_clip() -> None:
         "schema": "npa.cosmos2.transfer.v1",
         "status": "executed",
         "prompt": "a rainy warehouse",
-        "control_spec": "assets/robot_example/depth/robot_depth_spec.json",
+        "control_spec": "_npa_input_spec_test.json",
     }
 
     uri = cosmos2._publish_manifest(client, payload, "s3://bucket/run/augmented")

--- a/npa/workflows/physical-ai-data-factory.yaml
+++ b/npa/workflows/physical-ai-data-factory.yaml
@@ -79,6 +79,8 @@ config:
   max_tokens: "512"
 
   # --- S3 artifact layout: input / intermediate / output under one run prefix ---
+  # Mandatory managed-transfer input: input_uri/trigger_uri must contain at least
+  # one .mp4, .mov, .webm, .mkv, or .avi. Missing video fails before inference.
   input_uri: "s3://{{config.bucket}}/{{config.prefix}}/input/"
   images_uri: "s3://{{config.bucket}}/{{config.prefix}}/input/"
   configs_uri: "s3://{{config.bucket}}/{{config.prefix}}/configs/"
@@ -171,12 +173,10 @@ states:
       variants, each published as its own cosmos_augmented/<clip>/ dir (GPU tier).
       Appearance-only: lighting, background, cloth_color, surface -- never scene
       geometry.
-      By DEFAULT each variant re-renders the bundled Cosmos example under the
-      sampled prompt (appearance study, no source clip required). To augment the
-      run's OWN uploaded input/ footage instead -- preserving its geometry/motion
-      while only the appearance changes -- submit with
-      NPA_COSMOS_CONDITION_ON_INPUT=1 (or add --condition-on-input to the toolRef);
-      the edge/vis control is then computed on-the-fly from the input clip.
+      Every managed variant conditions on a supported video under trigger_uri
+      (the run's input/ prefix), preserving its geometry/motion while changing its
+      appearance. Missing or inaccessible input fails closed before inference.
+      No bundled upstream media is available as a fallback.
       This is a member of the `grade`
       refinement loop: on a loop_back decision the loop re-runs augment (re-render),
       re-verify, and re-gate, so a failed batch is actually re-augmented.

--- a/npa/workflows/workbench/npa-workflows/cosmos2-transfer.yaml
+++ b/npa/workflows/workbench/npa-workflows/cosmos2-transfer.yaml
@@ -26,6 +26,8 @@ config:
   bucket: example-bucket
   prefix: "cosmos2-transfer/{{run.id}}"
 
+  # Mandatory: this prefix must contain a supported input video. A missing,
+  # empty, or video-free prefix fails CLI validation before inference starts.
   trigger_uri: "s3://{{config.bucket}}/{{config.prefix}}/input/"
   augment_uri: "s3://{{config.bucket}}/{{config.prefix}}/augmented/"
   # Optional Config-Gen manifest. The transfer input itself is always required and

--- a/npa/workflows/workbench/npa-workflows/cosmos2-transfer.yaml
+++ b/npa/workflows/workbench/npa-workflows/cosmos2-transfer.yaml
@@ -28,16 +28,29 @@ config:
 
   trigger_uri: "s3://{{config.bucket}}/{{config.prefix}}/input/"
   augment_uri: "s3://{{config.bucket}}/{{config.prefix}}/augmented/"
-  # Optional Config-Gen manifest. Empty means the bundled-example path: the model still runs for
-  # real, it just is not conditioned on a sampled appearance combo.
+  # Optional Config-Gen manifest. The transfer input itself is always required and
+  # is converted into an on-the-fly edge control; no upstream media is bundled.
   configs_uri: ""
 
 resources:
   transfer-gpu:
     cloud: kubernetes
+    # The pinned 2B path requires about 65.4 GiB. RTX PRO 6000 provides 96 GiB;
+    # the CUDA 12.8 / sm_120 FlashAttention kernel path is a live release gate.
     accelerators: RTXPRO6000:1
     cpus: 16
     memory: 64Gi
+    kubernetes:
+      pod_config:
+        spec:
+          containers:
+            - name: ray-node
+              volumeMounts:
+                - name: cosmos2-model-cache
+                  mountPath: /opt/cosmos/model-cache
+          volumes:
+            - name: cosmos2-model-cache
+              emptyDir: {}
 
 initial: transfer
 

--- a/scripts/npa-workflow-submit-live-e2e.sh
+++ b/scripts/npa-workflow-submit-live-e2e.sh
@@ -49,6 +49,20 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${NPA_LIVE_E2E_REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/.." && pwd)}"
 cd "$REPO_ROOT"
 
+# Operator-provided values are authoritative. The optional files below provide
+# machine defaults, but historically overwrote an isolated clone's Python path,
+# spec selector, image digest, and registry credentials after the caller had
+# exported them. Preserve every relevant value that was already in the process
+# environment, without printing secret-bearing values.
+declare -A _npa_explicit_env_values=()
+while IFS= read -r _npa_env_name; do
+  case "$_npa_env_name" in
+    NPA_*|SKYPILOT_DOCKER_*|HF_TOKEN|NGC_API_KEY|NEBIUS_TOKEN_FACTORY_KEY|AWS_*)
+      _npa_explicit_env_values["$_npa_env_name"]="${!_npa_env_name}"
+      ;;
+  esac
+done < <(compgen -e)
+
 if [[ -f /home/ubuntu/bin/npa-cloud-env.sh ]]; then
   # shellcheck source=/dev/null
   source /home/ubuntu/bin/npa-cloud-env.sh
@@ -59,6 +73,11 @@ if [[ -f "${HOME}/.npa/live-e2e.env" ]]; then
   . "${HOME}/.npa/live-e2e.env"
   set +a
 fi
+for _npa_env_name in "${!_npa_explicit_env_values[@]}"; do
+  printf -v "$_npa_env_name" '%s' "${_npa_explicit_env_values[$_npa_env_name]}"
+  export "$_npa_env_name"
+done
+unset _npa_env_name _npa_explicit_env_values
 
 PY="${NPA_LIVE_E2E_PYTHON_BIN:-${REPO_ROOT}/npa/.venv/bin/python}"
 NPA="${REPO_ROOT}/npa/.venv/bin/npa"

--- a/skills/workflows/physical-ai-data-factory/SKILL.md
+++ b/skills/workflows/physical-ai-data-factory/SKILL.md
@@ -88,17 +88,18 @@ planned before it is returned (chat only emits runnable specs). `generate_data_f
 is the direct entry point; `generate_workflow_draft(intent="create_data_factory_workflow", user_text=...)`
 is the chat path.
 
-**Input conditioning (real augmentation of the caller's clip).** By default the
-augment renders the bundled, self-contained control example (`robot_depth_spec.json`),
-which keeps the golden eval hermetic but is NOT an augmentation of the run's own
-input. To make the output a genuine transform of the run's real footage, opt in:
-set `NPA_COSMOS_CONDITION_ON_INPUT=1` at submit (or pass `--condition-on-input` /
-`--input-video <path|s3://>` to `npa workbench cosmos2 transfer`). The augment then
-downloads the first clip under `--input-uri` (the run's `input/`), builds a
-controlnet spec with `video_path` = that clip and an **`edge`** (or `vis`) control
-computed on-the-fly, and the sampled appearance prompt drives the new look — so the
-output preserves the input's structure/motion with a new appearance. `edge`/`vis`
-need no precomputed control asset; `depth`/`seg` would need one, so input-only
+**Input conditioning (real augmentation of the caller's clip).** The managed
+`workbench.cosmos2.transfer_execute` path always conditions on the caller's real
+footage. Its `config.trigger_uri` must contain at least one supported video (`.mp4`,
+`.mov`, `.webm`, `.mkv`, or `.avi`); an empty, inaccessible, or video-free input
+fails closed before inference. Bundled upstream media was removed for
+redistribution reasons and is not a fallback. The augment downloads the first clip
+under `--input-uri` (the run's `input/`), builds a controlnet spec with `video_path`
+= that clip and an **`edge`** (or `vis`) control computed on-the-fly, and the sampled
+appearance prompt drives the new look — so the output preserves the input's
+structure/motion with a new appearance. Generic direct CLI callers can opt into the
+same behavior with `--condition-on-input` or `--input-video <path|s3://>`. `edge`/
+`vis` need no precomputed control asset; `depth`/`seg` would need one, so input-only
 conditioning falls back to `edge`. Conditioned runs record `mode:
 cosmos_transfer2.5_gpu` + `input_conditioned: true` + `conditioned_input` in the
 augment `metadata.json` / `manifest.json`, which the agent's provenance panel surfaces.
@@ -119,10 +120,10 @@ evaluate` runs two of upstream's checks per augmented variant and writes
   when a checkout is importable (`NPA_COSMOS_EVALUATOR_SRC`, else
   `/opt/cosmos-evaluator`) and otherwise runs the in-repo port of the same
   algorithm; the result's `engine` field says which ran, and the two agree to
-  ~1e-3. It only feeds the score for **input-conditioned** variants (see
-  `NPA_COSMOS_CONDITION_ON_INPUT` below) — without conditioning the two clips are
-  different scenes and the motion comparison carries no signal, so it stays
-  informational and the score is the attribute pass rate.
+  ~1e-3. Managed variants are input-conditioned, so this comparison contributes
+  to their score. For a generic unconditioned transfer the source and output are
+  different scenes, so it remains informational and the score is the attribute
+  pass rate.
 
 `grade_gate` thresholds on that report's `score`. It also still accepts the older
 `vlm_eval` report (`vlm_eval_stub.json`, a LEGACY filename of the vlm_eval tool's


### PR DESCRIPTION
## What changed

- replace the opaque private Cosmos Transfer 2.5 parent with a complete, immutable source build on digest-pinned CUDA build/runtime bases
- disable Git LFS smudging and remove/guard Git metadata, upstream assets/media, model weights, checkpoints, caches, and unexpected binary payloads
- preserve the non-root relocated venv, writable runtime-only model cache, SkyPilot argv passthrough, and runtime-only `HF_TOKEN` behavior
- add a repository-authored procedural conditioning fixture and make the first-class workflow execute the real conditioned inference path
- classify the image as `tier: job`, `redistribution: public`, add packaging-contract drift coverage, and record artifact-level license and built-byte audit evidence

## Why

The pinned private source-registry tag was missing. The prior Dockerfile wrapped an unauditable private 2.5.0 parent whose provenance was not checked in and whose filesystem contained about 486 MiB of duplicated upstream LFS/example media without sufficiently explicit redistribution evidence. That parent could not support a public-redistribution classification.

This change makes every build input reproducible from checked-in instructions, keeps gated model material outside the image, and validates the exact private-registry bytes through real Cosmos Transfer inference and live SkyPilot/Kubernetes execution.

## Qualified image

- tag: `npa-cosmos2-transfer:2.5.1-skypilot-ready-20260801T053000Z`
- OCI index: `sha256:9b4c5eb505353aa3dea37284c662f3cff306fa7c902f040e559f7939173345cc`
- linux/amd64 child: `sha256:cda3588d417518aec14d66a292f2dd4984739bc922492f2e78cae2bee377e450`
- upstream source: `67d56b7d550a3911024a32dc23ae0bae5258e633`

The image was pushed only to the private Nebius source registry. This run did not write or copy images to GHCR, alter visibility, or dispatch the public-publishing workflow.

## Validation

- focused static/unit/workflow suite: 428 passed
- full non-e2e suite: 5,616 passed, 47 skipped, 1 xpassed
- live-submit renderer/smoke: 151 passed; live managed workflow test: 1 passed
- shell syntax, targeted Ruff, YAML parse, packaging preflight, and added-source credential/identifier scans passed
- registry manifest/config/history, every-layer and merged-rootfs inventories, Omniverse scan, SBOM, SLSA provenance, Trivy vulnerability/secret/license scans completed
- raw real inference: RTX PRO 6000 Blackwell, 4 steps, 341.127 s, peak 62,822 MiB; 1280x720, 93 frames, 5.8125 s, SHA-256 `b85870845a816dda3d62bd906f8bc58250b1b0d1a90c90054865c30ac1491eb7`
- managed SkyPilot/Kubernetes workflow: `SUCCEEDED`, real 35-step conditioned inference; downloaded output was 1280x720, 93 frames, 5.8125 s, 5,635,256 bytes, SHA-256 `5c245706db69ece6e7c300d4c215eea4834cd02a3ed5b8428b735dba449f8da8`

## Residual risk

Trivy reports 51 executable-code high findings in the immutable upstream inference closure: 50 have fixes that require advancing and compatibility-testing the complete NVIDIA lock, and one unfixed FlashAttention pickle-loader issue is present but outside this inference-only path. The release audit records the complete triage and reciprocal-license obligations; these findings are not silently waived.

## Review follow-up (consolidated from #254)

- Integrated exact direct-child commit c76d58279d772556fd38b4f37585a8b7b7daba1f by fast-forward; no cherry-pick or replacement commit.
- Four-file follow-up: require hashes for Cosmos2 security overrides; bind the Docker regression test to that exact install command; document the mandatory input-video and intentional Python-wrapper contracts; and reject missing conditioned input before inference with CLI coverage.
- Validation after consolidation: 22 focused tests passed; 807 packaging/licensing, toolRef, workflow, real-component, and skill-index guardrails passed; targeted Ruff passed; workflow validate-spec and plan-spec passed; public-publish dry-run and final diff audit passed.
- No container rebuild or live GPU rerun was needed for this review-only hardening; PR #252 retains the existing qualified image and live inference evidence for the unchanged runtime path.

## Review follow-up: conditioned-input failures

### Migration

Managed `workbench.cosmos2.transfer_execute` now requires a readable `.mp4`, `.mov`, `.webm`, `.mkv`, or `.avi` under the configured `trigger_uri` / input URI. Missing or video-free input fails closed. The bundled upstream sample was removed for redistribution reasons and is not a fallback; upload a real source video beneath the workflow `input/` prefix before submission.

### Correctness and validation

- `_materialize_input_clip` returns an empty result only after a successful inspection finds no supported video. Storage setup, authentication, listing, and download failures now propagate to a sanitized, chained CLI error that does not echo the input URI or underlying exception text.
- Empty-prefix, authentication, listing, download, cause-chaining, CLI distinction, and secret-redaction regression cases are covered.
- All first-class static and agent-generated workflow consumers were checked: each resolves `transfer_execute` with an explicit `input/` source and `--condition-on-input`.
- Focused workflow/runtime suite: 125 passed. Docker/package guard suite: 217 passed.
- Hermetic full non-e2e suite: 5,623 passed, 47 skipped, 1 xpassed.
- Ruff, targeted mypy, docs drift, shell syntax, workflow validate/plan, diff checks, and redacted commit secret scan passed.
- The first full-suite invocation inherited the operator-only `NPA_SKYPILOT_BIN` selector and reached two unrelated live VLM endpoint setup tests outside `npa/tests/e2e`; both timed out and successfully tore down. With that ambient live selector unset, they self-skipped and the full non-e2e result above was green.
- No image was rebuilt or pushed and no live Cosmos GPU inference was repeated because the container inputs and inference success path are unchanged.
