### PR TITLE
Harden Cosmos2 Transfer review paths

### DIFF
--- a/npa/docker/workbench/cosmos2-transfer/Dockerfile
+++ b/npa/docker/workbench/cosmos2-transfer/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux; \
     printf '%s\n' "${COSMOS_PYTHON_VERSION}" > .python-version; \
     uv sync --locked --no-dev --no-editable --extra=cu128 \
       --python "${COSMOS_PYTHON_VERSION}"; \
-    uv pip install --python .venv/bin/python --no-deps \
+    uv pip install --python .venv/bin/python --no-deps --require-hashes \
       --requirement /tmp/cosmos2-security-overrides.txt; \
     .venv/bin/python -c 'import defusedxml, importlib.metadata, msgpack, nltk, numpy; assert importlib.metadata.version("defusedxml") == "0.7.1"; assert importlib.metadata.version("nltk") == "3.10.0"; assert importlib.metadata.version("pip") == "26.2"; assert importlib.metadata.version("msgpack") == "1.2.1"; assert importlib.metadata.version("setuptools") == "83.0.0"; assert tuple(map(int, numpy.__version__.split(".")[:1])) >= (2,)'; \
     .venv/bin/python -m pip --version; \
@@ -180,6 +180,8 @@ COPY --chmod=755 src/npa/workbench/cosmos/fixture.py \
 COPY docker/workbench/cosmos2-transfer/REDISTRIBUTION.md \
     /usr/share/doc/npa-cosmos2-transfer/REDISTRIBUTION.md
 
+# Deliberately shadow the global python3: SkyPilot and orchestrator-supplied
+# commands invoke python3; /usr/bin/python3 remains available to system tooling.
 RUN set -eux; \
     id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 ubuntu; \
     printf '%s\n' 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu; \

--- a/npa/tests/docker/test_cosmos2_transfer_image.py
+++ b/npa/tests/docker/test_cosmos2_transfer_image.py
@@ -76,7 +76,11 @@ def test_lfs_media_models_and_build_credentials_are_excluded() -> None:
     assert "sha256=29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3" in overrides
     assert "files.pythonhosted.org" in overrides
     assert overrides.count("#sha256=") == 5
-    assert "--no-deps" in text
+    assert re.search(
+        r"uv pip install --python \.venv/bin/python --no-deps --require-hashes\s+\\\s+"
+        r"--requirement /tmp/cosmos2-security-overrides\.txt",
+        text,
+    )
     assert 'version("nltk") == "3.10.0"' in text
     assert 'version("defusedxml") == "0.7.1"' in text
     assert 'version("pip") == "26.2"' in text

--- a/npa/tests/workbench/test_cosmos_transfer_input.py
+++ b/npa/tests/workbench/test_cosmos_transfer_input.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.cli.workbench import cosmos2
 from npa.workbench.cosmos import transfer as tx
+
+runner = CliRunner()
 
 
 def _fake_env(monkeypatch, repo: Path):
@@ -235,9 +241,47 @@ def test_materialize_input_clip_local_path(tmp_path: Path) -> None:
     assert _materialize_input_clip(str(tmp_path / "missing.mp4")) == ""
 
 
-def test_detect_gpu_count_from_cuda_visible_devices(monkeypatch) -> None:
-    from npa.cli.workbench import cosmos2
+def test_transfer_cli_rejects_conditioning_without_input_video(monkeypatch) -> None:
+    input_uri = "s3://test-bucket/run/input/"
+    materialized: list[str] = []
+    inference_called = False
 
+    monkeypatch.setattr(tx, "cosmos_transfer_available", lambda: True)
+
+    def fake_materialize(src: str) -> str:
+        materialized.append(src)
+        return ""
+
+    def fail_if_inferred(**_kwargs) -> dict:
+        nonlocal inference_called
+        inference_called = True
+        raise AssertionError("inference must not run without an input video")
+
+    monkeypatch.setattr(cosmos2, "_materialize_input_clip", fake_materialize)
+    monkeypatch.setattr(tx, "run_cosmos_transfer", fail_if_inferred)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "cosmos2",
+            "transfer",
+            "--input-uri",
+            input_uri,
+            "--output-uri",
+            "s3://test-bucket/run/augmented/",
+            "--condition-on-input",
+            "--execute",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "input conditioning was requested but no video was found" in result.output
+    assert materialized == [input_uri]
+    assert inference_called is False
+
+
+def test_detect_gpu_count_from_cuda_visible_devices(monkeypatch) -> None:
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3")
     assert cosmos2._detect_gpu_count() == 4
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
@@ -246,8 +290,6 @@ def test_detect_gpu_count_from_cuda_visible_devices(monkeypatch) -> None:
 
 
 def test_variant_parallelism_env_override_and_cap(monkeypatch) -> None:
-    from npa.cli.workbench import cosmos2
-
     monkeypatch.setenv("NPA_COSMOS_VARIANT_PARALLELISM", "4")
     # Capped at the number of variants so we never spawn idle workers.
     assert cosmos2._variant_parallelism(2) == 2

--- a/npa/workflows/workbench/npa-workflows/cosmos2-transfer.yaml
+++ b/npa/workflows/workbench/npa-workflows/cosmos2-transfer.yaml
@@ -26,6 +26,8 @@ config:
   bucket: example-bucket
   prefix: "cosmos2-transfer/{{run.id}}"
 
+  # Mandatory: this prefix must contain a supported input video. A missing,
+  # empty, or video-free prefix fails CLI validation before inference starts.
   trigger_uri: "s3://{{config.bucket}}/{{config.prefix}}/input/"
   augment_uri: "s3://{{config.bucket}}/{{config.prefix}}/augmented/"
   # Optional Config-Gen manifest. The transfer input itself is always required and


### PR DESCRIPTION
## Summary

- Require hashes when installing the exact Cosmos2 security override URLs, with focused static coverage that binds the flag to that install command.
- Document that the real transfer workflow requires an input video and fails before inference for a missing, empty, or video-free input prefix.
- Document the deliberate global Python wrapper used by SkyPilot while retaining the absolute system interpreter path.
- Add a CLI-level regression test for the missing conditioned-input video error and prove inference is not called.

## Why

This is a stacked follow-up to #252 implementing its four actionable review improvements. It tightens dependency integrity and makes the already-live input and interpreter contracts explicit without redesigning the image or workflow.

## User and developer impact

Operators get a clear mandatory-input contract and a user-visible nonzero CLI failure before GPU inference. Future security overrides without hashes fail during image build. Maintainers get regression coverage for both the Docker install flags and the CLI failure path.

## Verification

- [x] Focused Cosmos2 input and image tests: 22 passed.
- [x] Licensing, packaging, real-component, toolRef, skill-index, and workflow guardrails: 370 passed.
- [x] Targeted Ruff passed.
- [x] Cosmos2 workflow validate-spec and plan-spec passed; the plan retains --condition-on-input and --execute.
- [x] Full non-e2e suite: 5617 passed, 47 skipped, 1 xpassed.
- [x] Public-repo hygiene and changed-file scope checked.

## Limitations

Per the narrow review scope, this PR does not rebuild or republish the container, change the image tag or digests, reclassify licensing, alter model or media boundaries, or dispatch public image publication. No live GPU inference was repeated; #252 already contains the live qualification for the preserved runtime behavior.

## Skill maintenance

- [x] No root skill or skill index update is needed because this follow-up documents and tests behavior already introduced by #252.