### PR TITLE
Add workbench image contribution skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ The source of truth is `skills/index.yaml`. The tree is organized as:
 - `skills/workflows/agent-fresh-operate/SKILL.md`: npa-driven agent teardown, fresh-setup, tiered verify gates, and deploy failure recovery on the operator/dev VM.
 - `skills/workflows/author-npa-workflow/SKILL.md`: author and validate declarative `npa.workflow/v0.0.1` specs (`validate-spec`, `plan-spec`, toolRef catalog).
 - `skills/workflows/byof-onboard/SKILL.md`: BYOF OSS repo onboarding (Ubuntu/Isaac base, container-verify, agent `onboard_solution`).
+- `skills/workflows/contribute-workbench-image/SKILL.md`: external fork PR through licensing review, trusted image build, registry-byte validation, and incremental GHCR publication.
 - `skills/workflows/onboard-world-model/SKILL.md`: generic playbook for onboarding and containerizing a world model (learned action-conditioned simulator) as a multi-GPU BYOF registry candidate — containerize, stage a real dataset, encode the train→tokenize→dynamics→dream→visualize loop as capability smokes, validate on real GPUs (Open Dreamer is the reference example).
 - `skills/workflows/generate-npa-workflow/SKILL.md`: design new creative npa.workflow pipelines from the catalog (loops, gates, reference YAML).
 - `skills/workflows/diagram-to-npa-workflow/SKILL.md`: turn an architecture diagram + step write-up into a working npa.workflow/v0.0.1 YAML (boxes/arrows/diamonds/back-edges → states, loops, gates, catalog toolRefs); generalizes across sim2real, AV, RL, and Cosmos pipelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,10 @@ Base image and tag conventions are backed by:
 - `docs/security/image-reproducibility.md`
 - `.github/workflows/image-security-scan.yml`
 
+For the complete external-fork-to-release procedure, including the maintainer
+trust boundary, licensing gate, trusted registry build, and incremental GHCR
+publication, follow `skills/workflows/contribute-workbench-image/SKILL.md`.
+
 The current tag-family strategy is `cuda12` for production CUDA 12.x images and
 `cuda13-b300` for B300 and future Blackwell images. The latter remains blocked
 or vendor-paced for much of the stack.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,8 @@ Base image and tag conventions are backed by:
 For the complete external-fork-to-release procedure, including the maintainer
 trust boundary, licensing gate, trusted registry build, and incremental GHCR
 publication, follow `skills/workflows/contribute-workbench-image/SKILL.md`.
+The contributor-facing checklist is
+`docs/workbench/contributing-a-containerized-solution.md`.
 
 The current tag-family strategy is `cuda12` for production CUDA 12.x images and
 `cuda13-b300` for B300 and future Blackwell images. The latter remains blocked

--- a/docs/workbench/contributing-a-containerized-solution.md
+++ b/docs/workbench/contributing-a-containerized-solution.md
@@ -1,0 +1,238 @@
+# Contributing a Containerized Solution
+
+This guide is for contributors who want an open-source Physical AI solution to
+run as an NPA container and, when appropriate, become a published Workbench
+image. It covers the contribution and evidence expected in the pull request.
+
+You do not need Nebius registry credentials to contribute. The Nebius Physical
+AI team rebuilds reviewed code, pushes the official image, validates the
+registry artifact, and decides whether to publish it. Never request, copy, or
+commit an official registry credential.
+
+## 1. Choose the integration level
+
+Start at the lowest level that proves the solution's real capability:
+
+| Level | Use it when | Main contribution |
+| --- | --- | --- |
+| BYOF candidate | A public repository needs to be containerized and tested | Pinned source, install command, capability smoke, and BYOF workflow |
+| Solution workflow | Users need a repeatable train, evaluate, infer, or generate pipeline | BYOF or curated image plus an `npa.workflow` spec |
+| First-class Workbench tool | The solution has a stable maintained API/CLI surface | Dockerfile, image registration, CLI/SDK/YAML integration, golden evaluation, docs, and skill |
+
+See `docs/architecture/oss-onboarding-ladder.md` for the promotion criteria.
+Do not add a first-class tool when a BYOF candidate or solution workflow is the
+honest product boundary.
+
+## 2. Ground the proposal in upstream behavior
+
+Pin the upstream repository to a full commit SHA or immutable release tag. Read
+its maintained README, install guide, examples, model/data instructions, and
+license before writing the container.
+
+Describe each capability you want NPA to accept using the upstream project's
+own name. For every capability, record:
+
+| Field | Required evidence |
+| --- | --- |
+| Capability | Upstream environment id, config, script, API, or example name |
+| Upstream source | Repository URL, exact ref, and documentation path or URL |
+| Command | Smallest documented command that proves the capability |
+| Runtime | Ubuntu, Isaac Lab runtime-fetch, custom base, service, or job |
+| Compute | CPU, GPU model/architecture, GPU count, memory, and other required devices |
+| Inputs and outputs | Real input contract and the artifact produced |
+| Status | `accepted` only after a live pass; otherwise `deferred` with the blocker |
+
+An import check, CUDA availability check, or successful container start is not
+proof of a solution capability.
+
+## 3. Prepare the containerization change
+
+Fork the repository, branch from current `main`, and keep all reconstruction
+inputs in the pull request.
+
+For a BYOF registry candidate:
+
+1. Add `npa/workflows/workbench/npa-workflows/byof-<solution>.yaml`.
+2. Use `workload: solution-smoke`, not only `container-verify`.
+3. Pin the install in `build_command`.
+4. Put the documented capability command in `smoke_command`.
+5. Write a named JSON result under `$NPA_SMOKE_OUTPUT_DIR`; it must contain at
+   least `solution`, `capability`, and a capability-specific proof value.
+
+Use the CLI dry run to check that the BYOF request is accepted without building,
+pushing, or launching infrastructure:
+
+```bash
+npa/.venv/bin/npa workbench byof run \
+  --repo-url <public-repository-url> \
+  --repo-ref <full-commit-or-immutable-tag> \
+  --base-profile ubuntu \
+  --workload solution-smoke \
+  --build-command '<pinned-install-command>' \
+  --smoke-command '<real-capability-command>' \
+  --solution-name <solution-slug> \
+  --capability-name <upstream-capability-id> \
+  --smoke-artifact-name <solution>_<capability>.json \
+  --skip-push \
+  --skip-run \
+  --dry-run \
+  --output json
+```
+
+Use `--base-profile isaac-lab` only for a solution that actually requires that
+stack. Isaac-dependent runtime commands must run through
+`/isaac-sim/python.sh` and must test refusal when the operator has not accepted
+the required EULAs.
+
+For a first-class Workbench image, add or update all applicable surfaces:
+
+- `npa/docker/workbench/<tool>/Dockerfile` and preferably `build.sh`;
+- `npa/docker/workbench/packaging-contract.yaml`;
+- `npa/src/npa/deploy/images.py` and the supported version source;
+- the real CLI, Python wrapper/SDK, and workflow/toolRef resolution;
+- focused tests and a golden capability evaluation;
+- human documentation and the relevant root skill/index entry.
+
+Use a new additive tag. Never reuse or overwrite a released public tag.
+
+## 4. Make the image reproducible and safe to inspect
+
+The final image must:
+
+- use digest-pinned base images where the registry supports resolution;
+- run as a non-root user;
+- contain no build credential, token, private key, or tenant identifier;
+- keep gated weights, datasets, proprietary SDKs, and model caches out of image
+  layers;
+- fetch gated material at runtime using the operator's credential and license
+  acceptance when that design is legally valid;
+- expose an explicit entrypoint and health behavior appropriate to its
+  `service`, `job`, or `interactive` packaging tier; and
+- retain required license and attribution files.
+
+Public-image builds must not require an application credential. If a build can
+only succeed with a gated vendor token, stop and document the licensing and
+distribution question instead of hiding the token in BuildKit.
+
+## 5. Classify what the image actually distributes
+
+Review these layers separately:
+
+1. the upstream source;
+2. the complete baked runtime, including the base image, wheels, system
+   packages, SDKs, binaries, fonts, textures, and assets; and
+3. model weights and data.
+
+Record the authoritative license source and access date for each. Set
+`redistribution: public` only if every byte in the resulting image may be given
+to third parties. If a license is ambiguous, product-specific terms conflict
+with general terms, or field-of-use restrictions apply, mark the decision as
+blocked and request human review.
+
+This is engineering evidence, not legal advice. A permissive repository badge
+does not establish that a vendor wheel, runtime, model, or dataset is
+redistributable.
+
+## 6. Run real CPU and GPU capability tests
+
+The pull request must include real execution evidence appropriate to the
+solution's claims:
+
+- **CPU-only solution:** run the documented capability on a real CPU and prove
+  its functional output. Do not substitute an import or `--help` check.
+- **GPU solution:** run the documented capability on a real compatible GPU.
+  Record the GPU model, architecture, count, driver/runtime versions, command,
+  exit status, and output artifact. A `torch.cuda.is_available()` check alone
+  is not sufficient.
+- **CPU and GPU modes claimed:** exercise both paths.
+- **Multi-GPU claim:** require the requested device count in the test and prove
+  that the application created the intended mesh or distributed workers.
+
+Prefer the smallest real example, but let it perform the actual inference,
+training step, simulation step, render, conversion, query, or service request
+being advertised. Use real representative input rather than an echo or a
+manifest-only stub.
+
+Include this test record in the PR:
+
+| Evidence | What to report |
+| --- | --- |
+| Source | Exact repository ref and PR commit |
+| Image | Candidate name/tag and immutable digest, if one was pushed to a contributor-owned registry |
+| Hardware | CPU model or GPU model/architecture/count and relevant memory |
+| Command | Exact build and capability commands with secrets removed |
+| Result | Exit status and concise measured output |
+| Artifact | Filename, type, size, hash or key metrics, and how it was inspected |
+| Limits | Untested paths, unavailable hardware/assets, residual vulnerabilities, and deferred capabilities |
+
+If the needed hardware is unavailable, keep the capability `deferred`. The NPA
+team may perform the missing live run during review, but the capability is not
+registry-ready until a real test passes.
+
+## 7. Run repository checks
+
+Use the repository virtual environment:
+
+```bash
+python3 -m venv npa/.venv
+npa/.venv/bin/pip install -e "npa[dev]"
+npa/.venv/bin/python -m pytest \
+  npa/tests/docker/ npa/tests/deploy/ \
+  npa/tests/guardrails/test_skills_index.py -q
+npa/.venv/bin/python -m pytest \
+  npa/tests/workflows/test_byof_solution_smokes.py -q
+```
+
+Also run the focused tests for the solution and validate/plan any new workflow
+spec. Do not commit project IDs, tenant IDs, registry IDs, bucket names, IPs,
+private endpoints, customer names, credentials, or generated model/data
+artifacts.
+
+## 8. Open the pull request
+
+In addition to the repository PR template, include:
+
+- the upstream repository and exact ref;
+- the capability table and links to upstream documentation;
+- base image name and digest, approximate image size, and target architecture;
+- a statement that no application credential is required at build time;
+- source, baked-runtime, weights, data, and asset licensing evidence;
+- the proposed packaging tier and redistribution class;
+- exact unit, image, CPU/GPU, and live capability results;
+- the named output artifacts and how they were validated; and
+- known vulnerabilities, residual risks, and deferred capabilities.
+
+Do not include an official registry URI or ask for registry credentials. A
+candidate in a contributor-owned registry is optional and is never treated as
+the official artifact.
+
+## 9. What the Nebius Physical AI team does
+
+After the code and evidence are reviewed, the Nebius Physical AI team will:
+
+1. build the exact trusted commit using the checked-in build path;
+2. assign the approved additive tag and push it to the private Nebius source
+   registry;
+3. inspect the pushed registry bytes, including manifest/config, non-root user,
+   layer history, secrets, SBOM/vulnerabilities, and any payload whose absence
+   is part of the licensing decision;
+4. pull that exact image in the real NPA/SkyPilot/Kubernetes path and repeat the
+   required CPU and/or GPU capability test;
+5. record the immutable source and public digests; and
+6. after explicit publication authorization, mirror only a `public`-classified
+   image to GHCR and verify anonymous pulls.
+
+Publishing is not performed by untrusted fork CI. A new GHCR package also needs
+a one-time manual visibility decision by an administrator; later tags inherit
+that package visibility and unchanged images are skipped by the incremental
+publisher.
+
+## Related guidance
+
+- `skills/workflows/contribute-workbench-image/SKILL.md`
+- `skills/workflows/oss-solution-registry-onboard/SKILL.md`
+- `skills/workflows/byof-onboard/SKILL.md`
+- `skills/atomic/solution-licensing/SKILL.md`
+- `docs/workbench/container-packaging.md`
+- `docs/security/container-golden-evals.md`
+- `docs/security/image-reproducibility.md`

--- a/docs/workbench/contributing-a-containerized-solution.md
+++ b/docs/workbench/contributing-a-containerized-solution.md
@@ -1,177 +1,120 @@
 # Contributing a Containerized Solution
 
-This guide is for contributors who want an open-source Physical AI solution to
-run as an NPA container and, when appropriate, become a published Workbench
-image. It covers the contribution and evidence expected in the pull request.
+Use this checklist to add an open-source solution to NPA. The contributor
+supplies reproducible code and real test evidence. The Nebius Physical AI team
+builds, scans, pushes, and, when approved, publishes the official image.
 
-You do not need Nebius registry credentials to contribute. The Nebius Physical
-AI team rebuilds reviewed code, pushes the official image, validates the
-registry artifact, and decides whether to publish it. Never request, copy, or
-commit an official registry credential.
+Contributors do **not** need official registry credentials.
 
-## 1. Choose the integration level
+## Agent contract
 
-Start at the lowest level that proves the solution's real capability:
+Collect before editing:
 
-| Level | Use it when | Main contribution |
-| --- | --- | --- |
-| BYOF candidate | A public repository needs to be containerized and tested | Pinned source, install command, capability smoke, and BYOF workflow |
-| Solution workflow | Users need a repeatable train, evaluate, infer, or generate pipeline | BYOF or curated image plus an `npa.workflow` spec |
-| First-class Workbench tool | The solution has a stable maintained API/CLI surface | Dockerfile, image registration, CLI/SDK/YAML integration, golden evaluation, docs, and skill |
+- upstream repository and immutable commit/tag;
+- solution name and upstream capability to prove;
+- required CPU/GPU architecture and count;
+- real input, command, and expected output artifact; and
+- authoritative licenses for source, baked runtime, weights, and data.
 
-See `docs/architecture/oss-onboarding-ladder.md` for the promotion criteria.
-Do not add a first-class tool when a BYOF candidate or solution workflow is the
-honest product boundary.
+Stop and report instead of proceeding when:
 
-## 2. Ground the proposal in upstream behavior
+- the public-image build requires a credential;
+- any baked component's redistribution rights are unclear;
+- gated weights, data, SDKs, or proprietary assets would enter an image layer;
+- a released public tag would be reused; or
+- the claimed capability cannot be tested on its required hardware.
 
-Pin the upstream repository to a full commit SHA or immutable release tag. Read
-its maintained README, install guide, examples, model/data instructions, and
-license before writing the container.
+Never weaken a license guard, expose registry credentials to fork CI, or commit
+tenant, project, registry, bucket, key, IP, or secret values.
 
-Describe each capability you want NPA to accept using the upstream project's
-own name. For every capability, record:
+## 1. Choose the smallest integration
 
-| Field | Required evidence |
+| Path | Add |
 | --- | --- |
-| Capability | Upstream environment id, config, script, API, or example name |
-| Upstream source | Repository URL, exact ref, and documentation path or URL |
-| Command | Smallest documented command that proves the capability |
-| Runtime | Ubuntu, Isaac Lab runtime-fetch, custom base, service, or job |
-| Compute | CPU, GPU model/architecture, GPU count, memory, and other required devices |
-| Inputs and outputs | Real input contract and the artifact produced |
-| Status | `accepted` only after a live pass; otherwise `deferred` with the blocker |
+| BYOF candidate | Pinned install, real `solution-smoke`, and `byof-<solution>.yaml` |
+| Solution workflow | Candidate/curated image plus an `npa.workflow` spec |
+| First-class Workbench tool | Dockerfile, image pin/contract, CLI/SDK/workflow wiring, tests, docs, and skill |
 
-An import check, CUDA availability check, or successful container start is not
-proof of a solution capability.
+Use `docs/architecture/oss-onboarding-ladder.md` for promotion criteria.
 
-## 3. Prepare the containerization change
+## 2. Implement a reproducible container
 
-Fork the repository, branch from current `main`, and keep all reconstruction
-inputs in the pull request.
-
-For a BYOF registry candidate:
+For a BYOF candidate:
 
 1. Add `npa/workflows/workbench/npa-workflows/byof-<solution>.yaml`.
-2. Use `workload: solution-smoke`, not only `container-verify`.
-3. Pin the install in `build_command`.
-4. Put the documented capability command in `smoke_command`.
-5. Write a named JSON result under `$NPA_SMOKE_OUTPUT_DIR`; it must contain at
-   least `solution`, `capability`, and a capability-specific proof value.
-
-Use the CLI dry run to check that the BYOF request is accepted without building,
-pushing, or launching infrastructure:
+2. Use `workload: solution-smoke` with the real upstream capability command.
+3. Pin the source/install and write a named JSON result under
+   `$NPA_SMOKE_OUTPUT_DIR` containing `solution`, `capability`, and a real proof
+   value.
+4. Verify request construction without pushing or launching infrastructure:
 
 ```bash
 npa/.venv/bin/npa workbench byof run \
   --repo-url <public-repository-url> \
-  --repo-ref <full-commit-or-immutable-tag> \
+  --repo-ref <immutable-ref> \
   --base-profile ubuntu \
   --workload solution-smoke \
   --build-command '<pinned-install-command>' \
   --smoke-command '<real-capability-command>' \
-  --solution-name <solution-slug> \
-  --capability-name <upstream-capability-id> \
+  --solution-name <solution> \
+  --capability-name <capability> \
   --smoke-artifact-name <solution>_<capability>.json \
-  --skip-push \
-  --skip-run \
-  --dry-run \
-  --output json
+  --skip-push --skip-run --dry-run --output json
 ```
 
-Use `--base-profile isaac-lab` only for a solution that actually requires that
-stack. Isaac-dependent runtime commands must run through
-`/isaac-sim/python.sh` and must test refusal when the operator has not accepted
-the required EULAs.
-
-For a first-class Workbench image, add or update all applicable surfaces:
+For a first-class image, add or update:
 
 - `npa/docker/workbench/<tool>/Dockerfile` and preferably `build.sh`;
 - `npa/docker/workbench/packaging-contract.yaml`;
-- `npa/src/npa/deploy/images.py` and the supported version source;
-- the real CLI, Python wrapper/SDK, and workflow/toolRef resolution;
-- focused tests and a golden capability evaluation;
-- human documentation and the relevant root skill/index entry.
+- `npa/src/npa/deploy/images.py` and its version source;
+- real CLI/SDK/workflow resolution and focused tests; and
+- relevant documentation and root skill/index entry.
 
-Use a new additive tag. Never reuse or overwrite a released public tag.
+Use a new additive tag, a digest-pinned base when resolvable, a non-root final
+user, and no baked credentials, gated content, or generated artifacts.
 
-## 4. Make the image reproducible and safe to inspect
+## 3. Classify redistribution
 
-The final image must:
+Classify these independently:
 
-- use digest-pinned base images where the registry supports resolution;
-- run as a non-root user;
-- contain no build credential, token, private key, or tenant identifier;
-- keep gated weights, datasets, proprietary SDKs, and model caches out of image
-  layers;
-- fetch gated material at runtime using the operator's credential and license
-  acceptance when that design is legally valid;
-- expose an explicit entrypoint and health behavior appropriate to its
-  `service`, `job`, or `interactive` packaging tier; and
-- retain required license and attribution files.
+1. upstream source;
+2. everything baked into the runtime image; and
+3. weights, datasets, and other assets.
 
-Public-image builds must not require an application credential. If a build can
-only succeed with a gated vendor token, stop and document the licensing and
-distribution question instead of hiding the token in BuildKit.
+Set `redistribution: public` only when every shipped byte may be handed to third
+parties. Otherwise use `restricted` or stop for human review. Keep gated content
+as an operator-authorized runtime fetch when legally valid. Record the decision
+in `npa/docker/workbench/packaging-contract.yaml`.
 
-## 5. Classify what the image actually distributes
+## 4. Prove the real capability
 
-Review these layers separately:
+The PR must contain live evidence matching every claim:
 
-1. the upstream source;
-2. the complete baked runtime, including the base image, wheels, system
-   packages, SDKs, binaries, fonts, textures, and assets; and
-3. model weights and data.
+- CPU claim: run the functional workload on a real CPU.
+- GPU claim: run it on a compatible real GPU and record model, architecture,
+  count, driver/runtime, command, exit status, and output artifact.
+- CPU and GPU claim: run both.
+- Multi-GPU claim: prove the requested device count and created mesh/workers.
 
-Record the authoritative license source and access date for each. Set
-`redistribution: public` only if every byte in the resulting image may be given
-to third parties. If a license is ambiguous, product-specific terms conflict
-with general terms, or field-of-use restrictions apply, mark the decision as
-blocked and request human review.
+Imports, `--help`, container start, and `torch.cuda.is_available()` are not
+capability tests. Use the smallest real inference, training step, simulation,
+render, conversion, query, or service request. Mark untested capabilities
+`deferred`; do not call them accepted.
 
-This is engineering evidence, not legal advice. A permissive repository badge
-does not establish that a vendor wheel, runtime, model, or dataset is
-redistributable.
+Include this compact evidence block in the PR:
 
-## 6. Run real CPU and GPU capability tests
+```text
+Upstream: <repo>@<immutable-ref>
+Capability: <upstream capability name>
+Image: <candidate tag/digest, if any>
+Hardware: <CPU or GPU model/architecture/count>
+Command: <exact command, secrets removed>
+Result: <exit status and key measured output>
+Artifact: <path/type/size/hash or inspected metrics>
+Limits: <deferred paths and residual risks>
+```
 
-The pull request must include real execution evidence appropriate to the
-solution's claims:
-
-- **CPU-only solution:** run the documented capability on a real CPU and prove
-  its functional output. Do not substitute an import or `--help` check.
-- **GPU solution:** run the documented capability on a real compatible GPU.
-  Record the GPU model, architecture, count, driver/runtime versions, command,
-  exit status, and output artifact. A `torch.cuda.is_available()` check alone
-  is not sufficient.
-- **CPU and GPU modes claimed:** exercise both paths.
-- **Multi-GPU claim:** require the requested device count in the test and prove
-  that the application created the intended mesh or distributed workers.
-
-Prefer the smallest real example, but let it perform the actual inference,
-training step, simulation step, render, conversion, query, or service request
-being advertised. Use real representative input rather than an echo or a
-manifest-only stub.
-
-Include this test record in the PR:
-
-| Evidence | What to report |
-| --- | --- |
-| Source | Exact repository ref and PR commit |
-| Image | Candidate name/tag and immutable digest, if one was pushed to a contributor-owned registry |
-| Hardware | CPU model or GPU model/architecture/count and relevant memory |
-| Command | Exact build and capability commands with secrets removed |
-| Result | Exit status and concise measured output |
-| Artifact | Filename, type, size, hash or key metrics, and how it was inspected |
-| Limits | Untested paths, unavailable hardware/assets, residual vulnerabilities, and deferred capabilities |
-
-If the needed hardware is unavailable, keep the capability `deferred`. The NPA
-team may perform the missing live run during review, but the capability is not
-registry-ready until a real test passes.
-
-## 7. Run repository checks
-
-Use the repository virtual environment:
+## 5. Validate and open the PR
 
 ```bash
 python3 -m venv npa/.venv
@@ -183,56 +126,30 @@ npa/.venv/bin/python -m pytest \
   npa/tests/workflows/test_byof_solution_smokes.py -q
 ```
 
-Also run the focused tests for the solution and validate/plan any new workflow
-spec. Do not commit project IDs, tenant IDs, registry IDs, bucket names, IPs,
-private endpoints, customer names, credentials, or generated model/data
-artifacts.
+Also run focused solution tests and validate/plan each new workflow. Open the
+PR against `main` with the evidence block, base image/digest, approximate size,
+target architecture, packaging tier, redistribution class, license sources,
+build-time credential statement, and known risks.
 
-## 8. Open the pull request
+## Maintainer handoff
 
-In addition to the repository PR template, include:
+After review, the Nebius Physical AI team will:
 
-- the upstream repository and exact ref;
-- the capability table and links to upstream documentation;
-- base image name and digest, approximate image size, and target architecture;
-- a statement that no application credential is required at build time;
-- source, baked-runtime, weights, data, and asset licensing evidence;
-- the proposed packaging tier and redistribution class;
-- exact unit, image, CPU/GPU, and live capability results;
-- the named output artifacts and how they were validated; and
-- known vulnerabilities, residual risks, and deferred capabilities.
+1. rebuild the exact trusted commit and push the approved additive tag to the
+   private source registry;
+2. scan the pushed bytes for secrets, vulnerabilities, restricted payloads,
+   weights, caches, and non-root/runtime-contract violations;
+3. pull that digest through the real NPA path and repeat the required CPU/GPU
+   capability tests; and
+4. after explicit authorization, mirror only a `public` image to GHCR and
+   verify anonymous pulls.
 
-Do not include an official registry URI or ask for registry credentials. A
-candidate in a contributor-owned registry is optional and is never treated as
-the official artifact.
+Fork CI never publishes official images. New GHCR packages need one manual
+administrator visibility change; later unchanged images are skipped by the
+incremental publisher.
 
-## 9. What the Nebius Physical AI team does
-
-After the code and evidence are reviewed, the Nebius Physical AI team will:
-
-1. build the exact trusted commit using the checked-in build path;
-2. assign the approved additive tag and push it to the private Nebius source
-   registry;
-3. inspect the pushed registry bytes, including manifest/config, non-root user,
-   layer history, secrets, SBOM/vulnerabilities, and any payload whose absence
-   is part of the licensing decision;
-4. pull that exact image in the real NPA/SkyPilot/Kubernetes path and repeat the
-   required CPU and/or GPU capability test;
-5. record the immutable source and public digests; and
-6. after explicit publication authorization, mirror only a `public`-classified
-   image to GHCR and verify anonymous pulls.
-
-Publishing is not performed by untrusted fork CI. A new GHCR package also needs
-a one-time manual visibility decision by an administrator; later tags inherit
-that package visibility and unchanged images are skipped by the incremental
-publisher.
-
-## Related guidance
+Related policy:
 
 - `skills/workflows/contribute-workbench-image/SKILL.md`
-- `skills/workflows/oss-solution-registry-onboard/SKILL.md`
-- `skills/workflows/byof-onboard/SKILL.md`
 - `skills/atomic/solution-licensing/SKILL.md`
 - `docs/workbench/container-packaging.md`
-- `docs/security/container-golden-evals.md`
-- `docs/security/image-reproducibility.md`

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -395,6 +395,17 @@ skills:
       - type: cli_help
         args: ["workbench", "cosmos3", "generate", "--help"]
         contains: "guardrails"
+  - name: contribute-workbench-image
+    category: workflows
+    when_to_use: "Carry an external or maintainer-authored NPA image change from a fork PR through license classification, trusted build, private registry validation, and incremental GHCR publication."
+    path: skills/workflows/contribute-workbench-image/SKILL.md
+    smoke:
+      - type: file_exists
+        path: docs/workbench/container-packaging.md
+      - type: file_exists
+        path: npa/docker/workbench/packaging-contract.yaml
+      - type: file_exists
+        path: .github/workflows/publish-public-images.yml
   - name: cosmos3-npa-workflow
     category: workflows
     when_to_use: "Write, validate, or submit an npa.workflow/v0.0.1 YAML that runs Cosmos 3 generation (the declarative spec, not the SkyPilot template)."

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -401,6 +401,8 @@ skills:
     path: skills/workflows/contribute-workbench-image/SKILL.md
     smoke:
       - type: file_exists
+        path: docs/workbench/contributing-a-containerized-solution.md
+      - type: file_exists
         path: docs/workbench/container-packaging.md
       - type: file_exists
         path: npa/docker/workbench/packaging-contract.yaml

--- a/skills/workflows/contribute-workbench-image/SKILL.md
+++ b/skills/workflows/contribute-workbench-image/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: contribute-workbench-image
+description: Use when an external contributor or maintainer adds or changes an NPA workbench container image and must carry it safely from a fork pull request through licensing review, trusted build, private source-registry push, live validation, and incremental GHCR publication.
+---
+
+# Contribute A Workbench Image
+
+Keep source contribution, trusted building, and public publication as separate
+approval boundaries. Let anyone propose reproducible image code. Let only a
+maintainer run reviewed code with registry access, and let an authorized human
+make the irreversible public-release decision.
+
+## Load The Governing Rules
+
+Read these before changing an image:
+
+- `docs/workbench/container-packaging.md`
+- `skills/atomic/solution-licensing/SKILL.md`
+- `skills/atomic/build-and-push-image/SKILL.md`
+- `skills/atomic/testing-conventions/SKILL.md`
+
+Use `npa/.venv/bin/python` for repository validation. Keep tenant, project,
+registry, bucket, service-account, key, IP, and secret values out of committed
+files. Preserve unrelated dirty-tree changes.
+
+## Choose The Role
+
+### External contributor
+
+Prepare code and evidence in a fork. Do not request, receive, or use the
+official registry credentials. An optional candidate image may live in the
+contributor's own registry, but maintainers must rebuild the official artifact
+from reviewed repository source.
+
+### Maintainer
+
+Review the fork with unprivileged CI, merge or reproduce the reviewed commit on
+a maintainer-owned branch, build the exact trusted commit, validate the pushed
+bytes, and publish only after explicit authorization.
+
+Never check out or execute untrusted fork code in a privileged
+`pull_request_target` or `workflow_run` job. Never expose registry credentials
+to a fork PR, a contributor-controlled action, or a build step that requires a
+secret. Public-image builds must need no build-time application credential;
+gated runtimes, weights, and data belong in an operator-authorized runtime
+fetch.
+
+## Prepare The Contribution
+
+1. Fork the repository and branch from current `origin/main`.
+2. Use a new, additive tag. Do not reuse or overwrite a released public tag.
+3. Build from checked-in source under `npa/docker/workbench/<tool>/`; do not
+   make a detached Dockerfile or an image that can only be reconstructed from a
+   developer machine.
+4. Add or update the applicable surfaces:
+
+   - `Dockerfile` and, when useful, `build.sh`
+   - `npa/docker/workbench/packaging-contract.yaml`
+   - `npa/src/npa/deploy/images.py` and the supported version source
+   - CLI, SDK, and `npa.workflow` image resolution when behavior changes
+   - golden evaluation, focused tests, human documentation, and the relevant
+     tool skill
+
+5. Make the final stage non-root, pin resolvable bases by digest, keep secrets
+   out of layers, and make service health behavior machine-checkable.
+6. Classify the source, baked runtime, and weights/data separately. Record
+   `redistribution: public` only when every shipped component may be handed to
+   third parties. Record ambiguity and stop for human review; never weaken a
+   guard or relabel an artifact merely to make publication pass.
+7. Keep gated weights, datasets, and proprietary SDKs out of layers. Fetch them
+   at runtime using the operator's own credential and acceptance when that
+   design is legally valid. Test any refusal or acceptance gate as product
+   behavior.
+
+## Validate The Pull Request
+
+Create the repository virtualenv if needed, then run focused checks before the
+full non-live suite:
+
+```bash
+python3 -m venv npa/.venv
+npa/.venv/bin/pip install -e "npa[dev]"
+npa/.venv/bin/python -m pytest \
+  npa/tests/docker/ npa/tests/deploy/ \
+  npa/tests/guardrails/test_skills_index.py -q
+make test PYTHON=npa/.venv/bin/python
+make lint PYTHON=npa/.venv/bin/python
+```
+
+Build locally without credentials when practical. For a runtime-fetch image,
+test both refusal without acceptance/credentials and success with the
+operator-supplied runtime inputs. Add committed live-infrastructure coverage
+for a new or changed workflow/tool path, following `testing-conventions`.
+
+Open the fork PR against `main`. Include:
+
+- exact image name and proposed tag;
+- base image and digest;
+- expected architecture and approximate size;
+- build-time credential statement;
+- source, runtime, weights, and data license evidence;
+- packaging tier and redistribution class;
+- unit, image, and live functional results; and
+- known vulnerabilities or residual release risks.
+
+## Build The Trusted Artifact
+
+After review, build from the exact trusted commit. Prefer the checked-in
+`build.sh`; otherwise use `docker buildx build --push` so a large image streams
+to the configured private source registry rather than unpacking into the local
+daemon. Resolve the registry from NPA configuration and pass it as an argument;
+do not commit its concrete identifier.
+
+```bash
+npa/docker/workbench/<tool>/build.sh \
+  --registry "$NPA_REGISTRY" \
+  --tag <new-tag> \
+  --push
+
+crane manifest "$NPA_REGISTRY/npa-<tool>:<new-tag>" >/dev/null
+```
+
+If the checked-in script has different flags, use its help rather than
+inventing an alternate build path. Match the pushed name and tag exactly to the
+pin resolved by `npa.deploy.images`.
+
+Inspect the registry artifact, not only the Dockerfile or local daemon:
+
+- run the appropriate Trivy/SBOM and layer-history checks;
+- scan the full filesystem for payloads whose absence is part of the license
+  decision;
+- confirm non-root runtime and absence of credentials, caches, weights, and
+  checkpoints;
+- run the real capability test on the intended CPU/GPU architecture; and
+- record the immutable manifest digest and exact source commit.
+
+Never publish a `restricted` image. A successful build is not evidence that
+redistribution is permitted.
+
+## Verify Source And Public State
+
+Do not infer current coverage from the number of GHCR package pages. A package
+may be public while the repository's newly pinned tag is absent.
+
+Check every pinned source tag with the configured read credential:
+
+```bash
+unset NEBIUS_IAM_TOKEN NPA_NEBIUS_IAM_TOKEN
+npa/scripts/nebius_registry_docker_login.sh
+npa/.venv/bin/python -m npa.deploy.publish_public --preflight
+```
+
+Check every exact target tag through the anonymous path:
+
+```bash
+npa/.venv/bin/python -m npa.deploy.publish_public --verify-public
+```
+
+Interpret the results precisely:
+
+- source missing: build/push the pinned tag or correct the pin;
+- source present and target HTTP 404: the tag still needs mirroring;
+- both present with equal `crane digest` output: current and complete;
+- both present with different digests: stop and investigate tag reuse or an
+  unintended rebuild before copying anything; and
+- source denial: fix identity or permissions; never treat it as a missing
+  image.
+
+## Publish Incrementally
+
+Public publication is an explicit human decision. Do not dispatch it, change a
+package's visibility, or accept a release risk without authorization for the
+exact plan.
+
+1. Run **Publish public images** on `main` with `dry_run=true` and
+   `skip_missing=false`.
+2. Review the plan, source preflight, license gates, and exact pins.
+3. After authorization, run it once with `dry_run=false`.
+4. Confirm the summary says every planned image is anonymously pullable.
+
+The publisher compares manifest digests and skips unchanged images. It does not
+republish the entire mirror. A new tag in an existing package inherits that
+package's public visibility. A completely new package is private after its
+first push and needs one manual **Danger Zone -> Change visibility -> Public**
+operation by an administrator, followed by verification. Treat that change as
+irreversible.
+
+## Completion Evidence
+
+Report the PR and merge commit, source and GHCR digests, scan results, real
+functional-test result, publication run URL, and anonymous verification count.
+State missing or mismatched tags explicitly. Clean up temporary credentials,
+builders, worktrees, and scratch files after preserving the evidence needed in
+the PR.

--- a/skills/workflows/contribute-workbench-image/SKILL.md
+++ b/skills/workflows/contribute-workbench-image/SKILL.md
@@ -14,6 +14,7 @@ make the irreversible public-release decision.
 
 Read these before changing an image:
 
+- `docs/workbench/contributing-a-containerized-solution.md`
 - `docs/workbench/container-packaging.md`
 - `skills/atomic/solution-licensing/SKILL.md`
 - `skills/atomic/build-and-push-image/SKILL.md`

--- a/skills/workflows/contribute-workbench-image/SKILL.md
+++ b/skills/workflows/contribute-workbench-image/SKILL.md
@@ -142,18 +142,25 @@ redistribution is permitted.
 Do not infer current coverage from the number of GHCR package pages. A package
 may be public while the repository's newly pinned tag is absent.
 
+Set `NPA_PUBLIC_REGISTRY` to the intended public target before either check.
+The explicit `--target` arguments below avoid silently validating a different
+configured registry.
+
 Check every pinned source tag with the configured read credential:
 
 ```bash
+: "${NPA_PUBLIC_REGISTRY:?set NPA_PUBLIC_REGISTRY to the intended public registry}"
 unset NEBIUS_IAM_TOKEN NPA_NEBIUS_IAM_TOKEN
 npa/scripts/nebius_registry_docker_login.sh
-npa/.venv/bin/python -m npa.deploy.publish_public --preflight
+npa/.venv/bin/python -m npa.deploy.publish_public \
+  --target "$NPA_PUBLIC_REGISTRY" --preflight
 ```
 
 Check every exact target tag through the anonymous path:
 
 ```bash
-npa/.venv/bin/python -m npa.deploy.publish_public --verify-public
+npa/.venv/bin/python -m npa.deploy.publish_public \
+  --target "$NPA_PUBLIC_REGISTRY" --verify-public
 ```
 
 Interpret the results precisely:

--- a/skills/workflows/contribute-workbench-image/agents/openai.yaml
+++ b/skills/workflows/contribute-workbench-image/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Contribute Workbench Image"
-  short_description: "Safely contribute and release NPA container images"
-  default_prompt: "Use $contribute-workbench-image to prepare an NPA image contribution and guide its trusted build and GHCR publication."

--- a/skills/workflows/contribute-workbench-image/agents/openai.yaml
+++ b/skills/workflows/contribute-workbench-image/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Contribute Workbench Image"
+  short_description: "Safely contribute and release NPA container images"
+  default_prompt: "Use $contribute-workbench-image to prepare an NPA image contribution and guide its trusted build and GHCR publication."


### PR DESCRIPTION
## Summary

- add a `contribute-workbench-image` workflow skill for external contributors and maintainers
- add a contributor-facing containerization guide covering integration level, reproducible builds, licensing, and PR evidence
- require real CPU and/or GPU capability testing in the PR; import, container-start, and CUDA-availability checks are not sufficient
- clarify that contributors need no official registry credentials: the Nebius Physical AI team rebuilds the trusted commit, pushes and scans the official artifact, repeats live testing, and performs any authorized GHCR publication
- separate unprivileged fork PR validation from trusted registry builds and irreversible public publication
- document exact-pin source/GHCR verification and incremental publishing so unchanged public images are not recopied
- index the skill and link the workflow from `AGENTS.md` and `CONTRIBUTING.md`

## Why

The repository accepts public fork PRs, but an official image must be rebuilt from reviewed repository source by a maintainer. Fork code must never receive source-registry or GHCR write credentials. The skill and guide make that trust boundary, the licensing decision, the required live capability evidence, and the maintainer release handoff explicit.

They also record an operational distinction exposed by live validation: public package visibility does not by itself prove that every exact tag pinned by `main` is present and current.

## Review fixes

- remove the unused `agents/openai.yaml` descriptor rather than introducing an unconsumed repository convention in this PR
- require `NPA_PUBLIC_REGISTRY` and pass it explicitly with `--target` for source preflight and anonymous public verification
- replace the uncommitted `quick_validate.py` claim with reviewer-reproducible repository checks
- add `docs/workbench/contributing-a-containerized-solution.md` and enforce its presence through the skill index smoke checks

## Live registry validation

Validated the 23-image publication plan from `origin/main` (`5ce58821`) on 2026-08-03:

- private source preflight: **23/23 readable**
- GHCR anonymous pullability: **23/23 public**
- GHCR/source digest parity: **23/23 exact matches**
- missing exact pins: **0**
- digest mismatches: **0**
- source failures: **0**
- full built-artifact redistribution scans: **23/23 clean**

No image was copied, no workflow was dispatched, and no package visibility was changed.

## Verification

- `npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py npa/tests/docker/test_packaging_contract.py npa/tests/deploy/test_public_publish.py -q` — **247 passed**
- BYOF CLI/profile/runner/live/workflow suite — **73 passed** with ambient Kubernetes context variables cleared so the tests use their mocked target
- the contributor guide's `npa workbench byof run ... --skip-push --skip-run --dry-run --output json` example shape — parsed successfully through the real CLI
- all guide-referenced repository paths — resolved
- `git diff --check` — passed
