### PR TITLE
Close out Isaac Lab policy evaluation

### DIFF
--- a/docs/workbench/guides/quadruped-isaac-lab.md
+++ b/docs/workbench/guides/quadruped-isaac-lab.md
@@ -75,6 +75,9 @@ checkpoint, `policy_loaded`, held-out seed, per-episode reward/termination
 metrics, aggregate `success_rate`, and `passed` quality-gate result.
 Missing the requested rate leaves `status=success` with `passed=false`; only a
 runtime or policy-load failure makes the command non-zero.
+For automation, add `--output-format json`; the command promotes
+`eval_status`, `policy_loaded`, `success_rate`, and `passed` to top-level JSON
+fields instead of requiring log parsing.
 
 For manipulation and reach tasks, use `--success-metric goal-distance` with
 `--success-distance-m`; `auto` prefers a simulator-native success signal, then

--- a/docs/workbench/guides/quadruped-isaac-lab.md
+++ b/docs/workbench/guides/quadruped-isaac-lab.md
@@ -73,6 +73,8 @@ it never substitutes random actions. The output prefix receives
 `npa_isaac_lab_eval_summary.json` (`npa.isaac_lab.eval.v1`) with the resolved
 checkpoint, `policy_loaded`, held-out seed, per-episode reward/termination
 metrics, aggregate `success_rate`, and `passed` quality-gate result.
+Missing the requested rate leaves `status=success` with `passed=false`; only a
+runtime or policy-load failure makes the command non-zero.
 
 For manipulation and reach tasks, use `--success-metric goal-distance` with
 `--success-distance-m`; `auto` prefers a simulator-native success signal, then

--- a/docs/workbench/guides/quadruped-isaac-lab.md
+++ b/docs/workbench/guides/quadruped-isaac-lab.md
@@ -60,8 +60,23 @@ npa workbench isaac-lab train \
 ```bash
 npa workbench isaac-lab eval \
   --task Isaac-Velocity-Flat-Anymal-C-v0 \
-  --help
+  --input-path s3://your-bucket-name/isaac-lab/anymal-flat/ \
+  --num-episodes 20 \
+  --max-steps-per-episode 1000 \
+  --success-metric survival \
+  --min-success-rate 0.90 \
+  --output-path s3://your-bucket-name/isaac-lab/anymal-flat-eval/
 ```
+
+The evaluator fails closed if the supplied RSL-RL checkpoint cannot be loaded;
+it never substitutes random actions. The output prefix receives
+`npa_isaac_lab_eval_summary.json` (`npa.isaac_lab.eval.v1`) with the resolved
+checkpoint, `policy_loaded`, held-out seed, per-episode reward/termination
+metrics, aggregate `success_rate`, and `passed` quality-gate result.
+
+For manipulation and reach tasks, use `--success-metric goal-distance` with
+`--success-distance-m`; `auto` prefers a simulator-native success signal, then
+goal distance, and otherwise uses survival.
 
 ## Go bigger
 

--- a/docs/workbench/guides/sim2real-architecture.md
+++ b/docs/workbench/guides/sim2real-architecture.md
@@ -180,6 +180,19 @@ even when BYO trainer is configured.
 
 `run_heldout_eval()` writes `eval/heldout/report.json`.
 
+For a genuine Isaac-trained checkpoint, the default Stage 10 command is
+`npa.workflows.sim2real.byo_isaac_eval`. Its sibling job reuses the same shared
+policy loader, metric resolution, fail-closed behavior, and
+`npa.isaac_lab.eval.v1` summary implementation as
+`npa workbench isaac-lab eval`, while retaining Sim2Real's vectorized generated
+environments and camera capture. The detailed evaluator evidence is written to
+`eval/heldout/isaac-eval-summary.json` and carried in `report.json`.
+
+A runtime or policy-load failure fails Stage 10 and never produces synthetic
+fallback scores. Missing the configured success-rate bar produces a completed
+evaluation with `passed=false`; Stage 11 owns the promote/loop-back decision.
+Stage 14 remains the owner of run-level RRD and MCAP outputs.
+
 ```mermaid
 flowchart TD
   HE["run_heldout_eval"] --> BYO{"BYO_EVAL_COMMAND?"}

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -25,6 +25,7 @@ import typer
 from npa.clients.config import (
     ConfigError,
     resolve_environment,
+    resolve_project_storage,
     resolve_ssh_config,
     resolve_terraform_state,
     write_config,
@@ -1041,9 +1042,47 @@ def _resolve_deploy_storage_credentials(
     bootstrap_creds: dict[str, str],
     project_alias: str = "",
 ) -> dict[str, str]:
-    """Prefer configured artifact storage keys; fall back to bootstrap keys when needed."""
+    """Prefer project artifact storage, then shared or bootstrap credentials."""
     candidate = dict(bootstrap_creds)
     from npa.clients.credentials import load_credentials
+
+    project_name = str(project_alias or "").strip()
+    if project_name:
+        try:
+            project_storage = resolve_project_storage(
+                project_name,
+                include_shared_credentials=False,
+            )
+        except ConfigError:
+            project_storage = None
+        if project_storage is not None:
+            project_bucket = str(project_storage.checkpoint_bucket or "").strip()
+            project_prefix = ""
+            if project_bucket.startswith("s3://"):
+                rest = project_bucket[len("s3://"):]
+                project_bucket, _sep, project_prefix = rest.partition("/")
+                project_prefix = project_prefix.strip("/")
+            project_endpoint = str(
+                project_storage.endpoint_url
+                or f"https://storage.{region}.nebius.cloud"
+            ).strip()
+            project_access_key = str(project_storage.aws_access_key_id or "").strip()
+            project_secret_key = str(project_storage.aws_secret_access_key or "").strip()
+            if project_bucket and _storage_credentials_allow_writes(
+                bucket=project_bucket,
+                endpoint=project_endpoint,
+                access_key=project_access_key,
+                secret_key=project_secret_key,
+                region=region,
+                prefix=project_prefix,
+            ):
+                typer.echo("  Using project-configured artifact storage credentials for the agent.")
+                candidate["s3_bucket"] = project_bucket
+                candidate["s3_prefix"] = project_prefix
+                candidate["s3_endpoint"] = project_endpoint
+                candidate["nebius_api_key"] = project_access_key
+                candidate["nebius_secret_key"] = project_secret_key
+                return candidate
 
     shared = load_credentials(environ={})
     shared_bucket = str(shared.s3_bucket or "").strip()
@@ -1084,7 +1123,6 @@ def _resolve_deploy_storage_credentials(
         prefix=str(candidate.get("s3_prefix", "")),
     ):
         return candidate
-    project_name = str(project_alias or "").strip()
     if project_name:
         try:
             saved_state = resolve_terraform_state(project_name)

--- a/npa/src/npa/cli/isaac_lab/__init__.py
+++ b/npa/src/npa/cli/isaac_lab/__init__.py
@@ -1155,8 +1155,10 @@ def _build_eval_script(
         for name, value in environment.items()
     )
     future_import = "from __future__ import annotations\n"
-    if runner_source.startswith(future_import):
-        return future_import + prelude + runner_source[len(future_import) :]
+    future_offset = runner_source.find(future_import)
+    if future_offset >= 0:
+        insert_at = future_offset + len(future_import)
+        return runner_source[:insert_at] + prelude + runner_source[insert_at:]
     return prelude + runner_source
 
 
@@ -1165,7 +1167,12 @@ def _build_eval_status_check(output_dir: str) -> str:
 
     summary_path = f"{output_dir.rstrip('/')}/npa_isaac_lab_eval_summary.json"
     return f"""\
-python3 - {shlex.quote(summary_path)} <<'PYEVALSTATUS'
+NPA_EVAL_STATUS_PYTHON="$(command -v python3 || command -v python || true)"
+if [ -z "$NPA_EVAL_STATUS_PYTHON" ]; then
+  echo "ISAAC_LAB_EVAL_STATUS_FAILED no Python interpreter on PATH" >&2
+  exit 127
+fi
+"$NPA_EVAL_STATUS_PYTHON" - {shlex.quote(summary_path)} <<'PYEVALSTATUS'
 import json
 from pathlib import Path
 import sys
@@ -1182,7 +1189,11 @@ if summary.get("status") != "success" or summary.get("policy_loaded") is not Tru
         file=sys.stderr,
     )
     raise SystemExit(1)
-print("ISAAC_LAB_EVAL_STATUS_VERIFIED", flush=True)
+print(
+    "ISAAC_LAB_EVAL_STATUS_VERIFIED "
+    f"passed={{summary.get('passed')}} success_rate={{summary.get('success_rate')}}",
+    flush=True,
+)
 PYEVALSTATUS
 """
 

--- a/npa/src/npa/cli/isaac_lab/__init__.py
+++ b/npa/src/npa/cli/isaac_lab/__init__.py
@@ -1130,6 +1130,9 @@ def _build_eval_script(
     min_success_rate: float = 0.0,
     max_steps_per_episode: int = 200,
     seed: int = 42,
+    capture_video: bool = False,
+    video_length: int = 400,
+    video_fps: int = 30,
 ) -> str:
     runner_path = Path(__file__).with_name("eval_runner.py")
     runner_source = runner_path.read_text(encoding="utf-8")
@@ -1143,6 +1146,9 @@ def _build_eval_script(
         "NPA_ISAAC_EVAL_MIN_SUCCESS_RATE": str(min_success_rate),
         "NPA_ISAAC_EVAL_MAX_STEPS": str(max_steps_per_episode),
         "NPA_ISAAC_EVAL_SEED": str(seed),
+        "NPA_ISAAC_EVAL_VIDEO": "1" if capture_video else "0",
+        "NPA_ISAAC_EVAL_VIDEO_LENGTH": str(video_length),
+        "NPA_ISAAC_EVAL_VIDEO_FPS": str(video_fps),
     }
     prelude = "import os\n" + "".join(
         f"os.environ[{name!r}] = {value!r}\n"
@@ -2841,6 +2847,21 @@ def eval_cmd(
         "--min-success-rate",
         help="Aggregate success-rate threshold recorded in the pass/fail result.",
     ),
+    capture_video: bool = typer.Option(
+        False,
+        "--video",
+        help="Record the first evaluation episode as a run-specific MP4.",
+    ),
+    video_length: int = typer.Option(
+        400,
+        "--video-length",
+        help="Maximum simulator steps recorded when --video is enabled.",
+    ),
+    video_fps: int = typer.Option(
+        30,
+        "--video-fps",
+        help="Frame rate recorded in the MP4 when --video is enabled.",
+    ),
     output_path: str = typer.Option(
         "",
         "--output-path",
@@ -2868,6 +2889,10 @@ def eval_cmd(
             "--min-success-rate must be between 0 and 1, "
             f"got {min_success_rate}"
         )
+    if video_length <= 0:
+        _fail(f"--video-length must be positive, got {video_length}")
+    if video_fps <= 0:
+        _fail(f"--video-fps must be positive, got {video_fps}")
 
     cfg = _get_ssh_config()
     try:
@@ -2920,6 +2945,9 @@ def eval_cmd(
             min_success_rate=min_success_rate,
             max_steps_per_episode=max_steps_per_episode,
             seed=seed,
+            capture_video=capture_video,
+            video_length=video_length,
+            video_fps=video_fps,
         )
         + "PY\n"
         + _build_eval_status_check(remote_output_dir),

--- a/npa/src/npa/cli/isaac_lab/__init__.py
+++ b/npa/src/npa/cli/isaac_lab/__init__.py
@@ -625,7 +625,12 @@ def _prepare_remote_input_path(ssh: SSHClient, cfg, input_path: str) -> str:
         # a manifest whose paths point at the machine that produced it. Prefer
         # the real weights so an eval on a different VM never resolves a stale
         # absolute path from the manifest.
-        preferred_names = ("npa_isaac_lab_checkpoint.pt", "model.pt")
+        from npa.cli.isaac_lab.eval_runner import (
+            PORTABLE_CHECKPOINT_NAMES,
+            checkpoint_preference_key,
+        )
+
+        preferred_names = PORTABLE_CHECKPOINT_NAMES
         local_checkpoint = next(
             (
                 path
@@ -636,9 +641,17 @@ def _prepare_remote_input_path(ssh: SSHClient, cfg, input_path: str) -> str:
             None,
         )
         if local_checkpoint is None:
-            local_checkpoint = next(
-                (path for path in checkpoint_candidates if path.suffix in {".pt", ".pth"}),
-                checkpoint_candidates[0] if checkpoint_candidates else local_dir,
+            weight_candidates = [
+                path
+                for path in checkpoint_candidates
+                if path.suffix.lower() in {".pt", ".pth"}
+            ]
+            local_checkpoint = (
+                max(weight_candidates, key=checkpoint_preference_key)
+                if weight_candidates
+                else checkpoint_candidates[0]
+                if checkpoint_candidates
+                else local_dir
             )
         if local_checkpoint.is_dir():
             ssh.upload_directory(str(local_checkpoint), remote_dir)
@@ -1182,6 +1195,19 @@ if not summary_path.is_file():
     print(f"ISAAC_LAB_EVAL_STATUS_FAILED missing summary: {{summary_path}}", file=sys.stderr)
     raise SystemExit(1)
 summary = json.loads(summary_path.read_text(encoding="utf-8"))
+print(
+    "ISAAC_LAB_EVAL_RESULT_JSON "
+    + json.dumps(
+        {{
+            "eval_status": summary.get("status"),
+            "policy_loaded": summary.get("policy_loaded"),
+            "success_rate": summary.get("success_rate"),
+            "passed": summary.get("passed"),
+        }},
+        sort_keys=True,
+    ),
+    flush=True,
+)
 if summary.get("status") != "success" or summary.get("policy_loaded") is not True:
     print(
         "ISAAC_LAB_EVAL_STATUS_FAILED "
@@ -1196,6 +1222,21 @@ print(
 )
 PYEVALSTATUS
 """
+
+
+def _extract_eval_verdict(stdout: str) -> dict[str, Any]:
+    """Extract the structured evaluator verdict emitted by the status check."""
+
+    prefix = "ISAAC_LAB_EVAL_RESULT_JSON "
+    for line in reversed(stdout.splitlines()):
+        if not line.startswith(prefix):
+            continue
+        try:
+            verdict = json.loads(line[len(prefix) :])
+        except json.JSONDecodeError:
+            return {}
+        return verdict if isinstance(verdict, dict) else {}
+    return {}
 
 
 def _build_export_lerobot_script(
@@ -2991,6 +3032,10 @@ def eval_cmd(
         "output_dir": remote_output_dir,
         "duration_seconds": round(time.time() - start, 1),
     }
+    verdict = _extract_eval_verdict(stdout)
+    for field in ("eval_status", "policy_loaded", "success_rate", "passed"):
+        if field in verdict:
+            result[field] = verdict[field]
     if output_is_s3:
         # The inline evaluator writes a structured failure summary before
         # exiting, so upload the run directory on both success and failure.

--- a/npa/src/npa/cli/isaac_lab/__init__.py
+++ b/npa/src/npa/cli/isaac_lab/__init__.py
@@ -136,6 +136,12 @@ class WorkbenchRuntime(str, Enum):
     serverless = "serverless"
 
 
+class IsaacLabEvalMetric(str, Enum):
+    auto = "auto"
+    goal_distance = "goal-distance"
+    survival = "survival"
+
+
 ISAAC_CONTAINER_NAME = "npa-isaac-lab"
 
 
@@ -615,9 +621,25 @@ def _prepare_remote_input_path(ssh: SSHClient, cfg, input_path: str) -> str:
             for path in local_dir.rglob("*")
             if path.is_file() and path.name.endswith((".json", ".pt", ".pth"))
         )
-        local_checkpoint = (
-            checkpoint_candidates[0] if checkpoint_candidates else local_dir
+        # A training output prefix contains both a portable stable checkpoint and
+        # a manifest whose paths point at the machine that produced it. Prefer
+        # the real weights so an eval on a different VM never resolves a stale
+        # absolute path from the manifest.
+        preferred_names = ("npa_isaac_lab_checkpoint.pt", "model.pt")
+        local_checkpoint = next(
+            (
+                path
+                for name in preferred_names
+                for path in checkpoint_candidates
+                if path.name == name
+            ),
+            None,
         )
+        if local_checkpoint is None:
+            local_checkpoint = next(
+                (path for path in checkpoint_candidates if path.suffix in {".pt", ".pth"}),
+                checkpoint_candidates[0] if checkpoint_candidates else local_dir,
+            )
         if local_checkpoint.is_dir():
             ssh.upload_directory(str(local_checkpoint), remote_dir)
             return remote_dir
@@ -1098,183 +1120,64 @@ fi
     return script.replace("{extra_cmd_lines.rstrip()}", extra_cmd_lines.rstrip())
 
 def _build_eval_script(
-    task: str, checkpoint: str, num_episodes: int, output_dir: str
+    task: str,
+    checkpoint: str,
+    num_episodes: int,
+    output_dir: str,
+    *,
+    success_metric: IsaacLabEvalMetric = IsaacLabEvalMetric.auto,
+    success_distance_m: float = 0.05,
+    min_success_rate: float = 0.0,
+    max_steps_per_episode: int = 200,
+    seed: int = 42,
 ) -> str:
-    return f"""\
-import json
-import time
-from pathlib import Path
-
-from isaaclab.app import AppLauncher
-
-app_launcher = AppLauncher(headless=True)
-simulation_app = app_launcher.app
-
-import gymnasium as gym
-import torch
-
-import isaaclab_tasks  # noqa: F401
-from isaaclab_tasks.utils import parse_env_cfg
-
-task = {task!r}
-checkpoint_path = Path({checkpoint!r})
-num_episodes = {num_episodes}
-output_dir = Path({output_dir!r})
-max_steps_per_episode = 200
-success_dist_m = 0.05
-output_dir.mkdir(parents=True, exist_ok=True)
-device = "cuda:0" if torch.cuda.is_available() else "cpu"
-started = time.time()
-env = None
-
-
-def _resolve_ckpt(p):
-    # Accept a real rsl_rl model_*.pt OR an npa manifest json pointing at one.
-    try:
-        info = json.loads(Path(p).read_text())
-        for k in ("stable_checkpoint_path", "checkpoint_path"):
-            if info.get(k):
-                return info[k], info.get("format", "manifest")
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        pass
-    return str(p), "rsl_rl_checkpoint"
-
-
-try:
-    if not checkpoint_path.exists():
-        raise FileNotFoundError(f"checkpoint not found: {{checkpoint_path}}")
-    ckpt_file, checkpoint_format = _resolve_ckpt(checkpoint_path)
-
-    print(
-        f"ISAAC_LAB_EVAL_START task={{task}} checkpoint={{ckpt_file}} "
-        f"episodes={{num_episodes}} device={{device}}",
-        flush=True,
+    runner_path = Path(__file__).with_name("eval_runner.py")
+    runner_source = runner_path.read_text(encoding="utf-8")
+    environment = {
+        "NPA_ISAAC_EVAL_TASK": task,
+        "NPA_ISAAC_EVAL_CHECKPOINT": checkpoint,
+        "NPA_ISAAC_EVAL_EPISODES": str(num_episodes),
+        "NPA_ISAAC_EVAL_OUTPUT_DIR": output_dir,
+        "NPA_ISAAC_EVAL_SUCCESS_METRIC": success_metric.value,
+        "NPA_ISAAC_EVAL_SUCCESS_DISTANCE_M": str(success_distance_m),
+        "NPA_ISAAC_EVAL_MIN_SUCCESS_RATE": str(min_success_rate),
+        "NPA_ISAAC_EVAL_MAX_STEPS": str(max_steps_per_episode),
+        "NPA_ISAAC_EVAL_SEED": str(seed),
+    }
+    prelude = "import os\n" + "".join(
+        f"os.environ[{name!r}] = {value!r}\n"
+        for name, value in environment.items()
     )
-    env_cfg = parse_env_cfg(task, device=device, num_envs=1)
-    print("ISAAC_LAB_ENV_CREATE_START", flush=True)
-    env = gym.make(task, cfg=env_cfg)
-    print("ISAAC_LAB_ENV_CREATE_COMPLETE", flush=True)
+    future_import = "from __future__ import annotations\n"
+    if runner_source.startswith(future_import):
+        return future_import + prelude + runner_source[len(future_import) :]
+    return prelude + runner_source
 
-    # Load the TRAINED rsl_rl policy (not random actions) so eval reflects the
-    # real checkpoint. Falls back to a random policy only if loading fails, and
-    # records policy_loaded=false so the result is never silently faked.
-    policy = None
-    policy_loaded = False
-    try:
-        try:
-            from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
-        except Exception:
-            from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper
-        from rsl_rl.runners import OnPolicyRunner
-        wrapped = RslRlVecEnvWrapper(env)
-        agent_cfg = None
-        for loader in ("isaaclab_tasks.utils", "omni.isaac.lab_tasks.utils"):
-            try:
-                mod = __import__(loader, fromlist=["load_cfg_from_registry"])
-                agent_cfg = mod.load_cfg_from_registry(task, "rsl_rl_cfg_entry_point")
-                break
-            except Exception:
-                pass
-        acfg = agent_cfg.to_dict() if hasattr(agent_cfg, "to_dict") else dict(agent_cfg)
-        runner = OnPolicyRunner(wrapped, acfg, log_dir=None, device=device)
-        runner.load(ckpt_file)
-        policy = runner.get_inference_policy(device=device)
-        env = wrapped
-        policy_loaded = True
-        print("ISAAC_LAB_EVAL_POLICY_LOADED", flush=True)
-    except Exception as exc:
-        print(f"ISAAC_LAB_EVAL_POLICY_LOAD_FAILED {{exc!r}} -- random fallback", flush=True)
 
-    def _act(obs):
-        if policy_loaded and policy is not None and obs is not None:
-            with torch.inference_mode():
-                return policy(obs)
-        return torch.as_tensor(env.action_space.sample(), device=device, dtype=torch.float32)
+def _build_eval_status_check(output_dir: str) -> str:
+    """Enforce eval status even when an Isaac bootstrap shim masks Python's exit."""
 
-    def _step_env(env, actions):
-        # Gymnasium envs return 5 values; the rsl_rl VecEnv wrapper installed
-        # when a trained policy loads returns 4: (obs, rewards, dones, extras).
-        out = env.step(actions)
-        if len(out) == 5:
-            s_obs, s_rew, terminated, truncated, s_info = out
-            s_done = bool(torch.as_tensor(terminated).any().item()) or bool(torch.as_tensor(truncated).any().item())
-        else:
-            s_obs, s_rew, dones, s_info = out
-            s_done = bool(torch.as_tensor(dones).any().item())
-        return s_obs, s_rew, s_done, s_info
+    summary_path = f"{output_dir.rstrip('/')}/npa_isaac_lab_eval_summary.json"
+    return f"""\
+python3 - {shlex.quote(summary_path)} <<'PYEVALSTATUS'
+import json
+from pathlib import Path
+import sys
 
-    def _goal_dist():
-        try:
-            u = env.unwrapped
-            cmd = u.command_manager.get_command("object_pose")
-            obj = u.scene["object"].data.root_pos_w[:, :3]
-            goal = cmd[:, :3] + u.scene.env_origins[:, :3]
-            return float(torch.linalg.norm(obj - goal, dim=1).min().item())
-        except Exception:
-            return None
-
-    episode_results = []
-    for episode in range(num_episodes):
-        reset_out = env.reset()
-        obs = reset_out[0] if isinstance(reset_out, tuple) else reset_out
-        episode_reward = 0.0
-        steps_ran = 0
-        min_dist = None
-        for step in range(max_steps_per_episode):
-            actions = _act(obs)
-            obs, rewards, done, _ = _step_env(env, actions)
-            episode_reward += float(torch.as_tensor(rewards).mean().item())
-            steps_ran = step + 1
-            d = _goal_dist()
-            if d is not None:
-                min_dist = d if min_dist is None else min(min_dist, d)
-            if done:
-                break
-
-        success = bool(min_dist is not None and min_dist < success_dist_m)
-        result = {{
-            "episode": episode + 1,
-            "steps": steps_ran,
-            "reward": episode_reward,
-            "min_object_goal_distance_m": min_dist,
-            "success": success,
-        }}
-        episode_results.append(result)
-        print(
-            f"ISAAC_LAB_EVAL_EPISODE episode={{episode + 1}}/{{num_episodes}} "
-            f"steps={{steps_ran}} reward={{episode_reward:.6f}} "
-            f"min_dist={{min_dist}} success={{success}}",
-            flush=True,
-        )
-
-    mean_reward = sum(item["reward"] for item in episode_results) / num_episodes
-    dists = [r["min_object_goal_distance_m"] for r in episode_results if r["min_object_goal_distance_m"] is not None]
-    success_rate = sum(1 for r in episode_results if r["success"]) / num_episodes
-    summary = {{
-        "status": "success",
-        "task": task,
-        "checkpoint": str(checkpoint_path),
-        "checkpoint_format": checkpoint_format,
-        "policy_loaded": policy_loaded,
-        "num_episodes": num_episodes,
-        "max_steps_per_episode": max_steps_per_episode,
-        "device": device,
-        "mean_reward": mean_reward,
-        "success_rate": success_rate,
-        "mean_min_object_goal_distance_m": (sum(dists) / len(dists)) if dists else None,
-        "success_dist_m": success_dist_m,
-        "episodes": episode_results,
-        "duration_seconds": round(time.time() - started, 3),
-    }}
-    summary_path = output_dir / "npa_isaac_lab_eval_summary.json"
-    summary["output_path"] = str(summary_path)
-    summary_path.write_text(json.dumps(summary, indent=2))
-    print("ISAAC_LAB_EVAL_COMPLETE")
-    print(json.dumps(summary, indent=2), flush=True)
-finally:
-    if env is not None:
-        env.close()
-    simulation_app.close()
+summary_path = Path(sys.argv[1])
+if not summary_path.is_file():
+    print(f"ISAAC_LAB_EVAL_STATUS_FAILED missing summary: {{summary_path}}", file=sys.stderr)
+    raise SystemExit(1)
+summary = json.loads(summary_path.read_text(encoding="utf-8"))
+if summary.get("status") != "success" or summary.get("policy_loaded") is not True:
+    print(
+        "ISAAC_LAB_EVAL_STATUS_FAILED "
+        f"status={{summary.get('status')}} policy_loaded={{summary.get('policy_loaded')}}",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+print("ISAAC_LAB_EVAL_STATUS_VERIFIED", flush=True)
+PYEVALSTATUS
 """
 
 
@@ -2913,6 +2816,31 @@ def eval_cmd(
     num_episodes: int = typer.Option(
         10, "--num-episodes", help="Number of evaluation episodes."
     ),
+    max_steps_per_episode: int = typer.Option(
+        200,
+        "--max-steps-per-episode",
+        help="Maximum simulator steps in each evaluation episode.",
+    ),
+    seed: int = typer.Option(
+        42,
+        "--seed",
+        help="Base held-out seed for a repeatable rollout sequence.",
+    ),
+    success_metric: IsaacLabEvalMetric = typer.Option(
+        IsaacLabEvalMetric.auto,
+        "--success-metric",
+        help="Success predicate: auto, goal-distance, or survival.",
+    ),
+    success_distance_m: float = typer.Option(
+        0.05,
+        "--success-distance-m",
+        help="Goal-distance threshold in metres when that metric is selected.",
+    ),
+    min_success_rate: float = typer.Option(
+        0.0,
+        "--min-success-rate",
+        help="Aggregate success-rate threshold recorded in the pass/fail result.",
+    ),
     output_path: str = typer.Option(
         "",
         "--output-path",
@@ -2928,6 +2856,18 @@ def eval_cmd(
     """Run Isaac Lab evaluation on the VM via SSH."""
     if num_episodes <= 0:
         _fail(f"--num-episodes must be positive, got {num_episodes}")
+    if max_steps_per_episode <= 0:
+        _fail(
+            "--max-steps-per-episode must be positive, "
+            f"got {max_steps_per_episode}"
+        )
+    if success_distance_m <= 0:
+        _fail(f"--success-distance-m must be positive, got {success_distance_m}")
+    if not 0.0 <= min_success_rate <= 1.0:
+        _fail(
+            "--min-success-rate must be between 0 and 1, "
+            f"got {min_success_rate}"
+        )
 
     cfg = _get_ssh_config()
     try:
@@ -2969,7 +2909,20 @@ def eval_cmd(
         cfg,
         prefix
         + f"mkdir -p {shlex.quote(remote_output_dir)}\n"
-        + f"{python_bin} - <<'PY'\n{_build_eval_script(task, remote_checkpoint, num_episodes, remote_output_dir)}PY\n",
+        + f"{python_bin} - <<'PY'\n"
+        + _build_eval_script(
+            task,
+            remote_checkpoint,
+            num_episodes,
+            remote_output_dir,
+            success_metric=success_metric,
+            success_distance_m=success_distance_m,
+            min_success_rate=min_success_rate,
+            max_steps_per_episode=max_steps_per_episode,
+            seed=seed,
+        )
+        + "PY\n"
+        + _build_eval_status_check(remote_output_dir),
     )
     stream_logs = output_format != OutputFormat.json
 
@@ -2990,23 +2943,30 @@ def eval_cmd(
         "input_path": checkpoint_ref,
         "checkpoint": remote_checkpoint,
         "num_episodes": num_episodes,
+        "max_steps_per_episode": max_steps_per_episode,
+        "seed": seed,
+        "success_metric": success_metric.value,
+        "success_distance_m": success_distance_m,
+        "min_success_rate": min_success_rate,
         "output_path": target_output,
         "output_dir": remote_output_dir,
         "duration_seconds": round(time.time() - start, 1),
     }
+    if output_is_s3:
+        # The inline evaluator writes a structured failure summary before
+        # exiting, so upload the run directory on both success and failure.
+        try:
+            result["output_path"] = _upload_remote_directory_to_s3(
+                ssh, cfg, remote_output_dir, target_output
+            )
+        except Exception as exc:
+            result["status"] = "failed"
+            result["exit_code"] = 1
+            result["output_upload_error"] = str(exc)
+            exit_code = 1
     if exit_code != 0:
         result["stderr"] = stderr.strip()[-500:] if stderr else ""
     else:
-        if output_is_s3:
-            try:
-                result["output_path"] = _upload_remote_directory_to_s3(
-                    ssh, cfg, remote_output_dir, target_output
-                )
-            except Exception as exc:
-                result["status"] = "failed"
-                result["exit_code"] = 1
-                result["output_upload_error"] = str(exc)
-                exit_code = 1
         if output_format == OutputFormat.json and stdout.strip():
             result["stdout_tail"] = stdout.strip()[-1000:]
 

--- a/npa/src/npa/cli/isaac_lab/eval_runner.py
+++ b/npa/src/npa/cli/isaac_lab/eval_runner.py
@@ -32,10 +32,17 @@ class EvalConfig:
     min_success_rate: float = 0.0
     max_steps_per_episode: int = 200
     seed: int = 42
+    capture_video: bool = False
+    video_length: int = 400
+    video_fps: int = 30
 
     @property
     def summary_path(self) -> Path:
         return self.output_dir / "npa_isaac_lab_eval_summary.json"
+
+    @property
+    def video_dir(self) -> Path:
+        return self.output_dir / "video"
 
     @classmethod
     def from_environment(cls) -> "EvalConfig":
@@ -55,6 +62,9 @@ class EvalConfig:
                 os.environ.get("NPA_ISAAC_EVAL_MAX_STEPS", "200")
             ),
             seed=int(os.environ.get("NPA_ISAAC_EVAL_SEED", "42")),
+            capture_video=_env_flag("NPA_ISAAC_EVAL_VIDEO"),
+            video_length=int(os.environ.get("NPA_ISAAC_EVAL_VIDEO_LENGTH", "400")),
+            video_fps=int(os.environ.get("NPA_ISAAC_EVAL_VIDEO_FPS", "30")),
         )
 
     def validate(self) -> None:
@@ -73,6 +83,10 @@ class EvalConfig:
             raise ValueError("success_distance_m must be positive")
         if not 0.0 <= self.min_success_rate <= 1.0:
             raise ValueError("min_success_rate must be between 0 and 1")
+        if self.video_length <= 0:
+            raise ValueError("video_length must be positive")
+        if self.video_fps <= 0:
+            raise ValueError("video_fps must be positive")
 
 
 def _required_env(name: str) -> str:
@@ -80,6 +94,10 @@ def _required_env(name: str) -> str:
     if not value:
         raise ValueError(f"{name} is required")
     return value
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def resolve_checkpoint(path: Path) -> tuple[Path, str]:
@@ -286,7 +304,10 @@ def run_eval(config: EvalConfig) -> dict[str, Any]:
     try:
         from isaaclab.app import AppLauncher
 
-        simulation_app = AppLauncher(headless=True).app
+        simulation_app = AppLauncher(
+            headless=True,
+            enable_cameras=config.capture_video,
+        ).app
 
         import gymnasium as gym
         import torch
@@ -312,7 +333,25 @@ def run_eval(config: EvalConfig) -> dict[str, Any]:
 
         stage = "environment_create"
         print("ISAAC_LAB_ENV_CREATE_START", flush=True)
-        env = gym.make(config.task, cfg=env_config)
+        render_mode = "rgb_array" if config.capture_video else None
+        env = gym.make(config.task, cfg=env_config, render_mode=render_mode)
+        if config.capture_video:
+            config.video_dir.mkdir(parents=True, exist_ok=True)
+            env = gym.wrappers.RecordVideo(
+                env,
+                video_folder=str(config.video_dir),
+                episode_trigger=lambda episode_id: episode_id == 0,
+                video_length=config.video_length,
+                name_prefix="isaac-lab-eval",
+                fps=config.video_fps,
+                disable_logger=True,
+            )
+            print(
+                "ISAAC_LAB_EVAL_VIDEO_ENABLED "
+                f"directory={config.video_dir} length={config.video_length} "
+                f"fps={config.video_fps}",
+                flush=True,
+            )
         print("ISAAC_LAB_ENV_CREATE_COMPLETE", flush=True)
 
         stage = "policy_load"
@@ -423,6 +462,25 @@ def run_eval(config: EvalConfig) -> dict[str, Any]:
                 flush=True,
             )
 
+        captured_videos: list[str] = []
+        if config.capture_video:
+            stage = "video_finalize"
+            env.close()
+            env = None
+            captured_videos = [
+                str(path)
+                for path in sorted(config.video_dir.glob("*.mp4"))
+                if path.stat().st_size > 0
+            ]
+            if not captured_videos:
+                raise RuntimeError(
+                    f"video capture was requested but no MP4 was written under {config.video_dir}"
+                )
+            print(
+                "ISAAC_LAB_EVAL_VIDEO_COMPLETE " + " ".join(captured_videos),
+                flush=True,
+            )
+
         stage = "metric_resolution"
         success_metric = resolve_success_metric(config.success_metric, episode_results)
         apply_success_metric(
@@ -466,6 +524,12 @@ def run_eval(config: EvalConfig) -> dict[str, Any]:
             "mean_min_goal_distance_m": (
                 sum(distances) / len(distances) if distances else None
             ),
+            "video": {
+                "enabled": config.capture_video,
+                "fps": config.video_fps,
+                "length_steps": config.video_length,
+                "files": captured_videos,
+            },
             "episodes": episode_results,
             "duration_seconds": round(time.time() - started, 3),
             "output_path": str(config.summary_path),

--- a/npa/src/npa/cli/isaac_lab/eval_runner.py
+++ b/npa/src/npa/cli/isaac_lab/eval_runner.py
@@ -1,0 +1,503 @@
+"""Standalone, fail-closed Isaac Lab RSL-RL checkpoint evaluator.
+
+The workbench CLI embeds this file into its remote SSH command. Kubernetes
+validation jobs can mount and execute the same file directly, which keeps live
+GPU evidence aligned with the shipped evaluator instead of maintaining a
+second evaluation script.
+"""
+
+from dataclasses import dataclass
+import json
+import logging
+import os
+from pathlib import Path
+import time
+import traceback
+from typing import Any
+
+
+EVAL_FORMAT = "npa.isaac_lab.eval.v1"
+SUPPORTED_SUCCESS_METRICS = {"auto", "goal-distance", "survival"}
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EvalConfig:
+    task: str
+    checkpoint: Path
+    num_episodes: int
+    output_dir: Path
+    success_metric: str = "auto"
+    success_distance_m: float = 0.05
+    min_success_rate: float = 0.0
+    max_steps_per_episode: int = 200
+    seed: int = 42
+
+    @property
+    def summary_path(self) -> Path:
+        return self.output_dir / "npa_isaac_lab_eval_summary.json"
+
+    @classmethod
+    def from_environment(cls) -> "EvalConfig":
+        return cls(
+            task=_required_env("NPA_ISAAC_EVAL_TASK"),
+            checkpoint=Path(_required_env("NPA_ISAAC_EVAL_CHECKPOINT")),
+            num_episodes=int(os.environ.get("NPA_ISAAC_EVAL_EPISODES", "10")),
+            output_dir=Path(_required_env("NPA_ISAAC_EVAL_OUTPUT_DIR")),
+            success_metric=os.environ.get("NPA_ISAAC_EVAL_SUCCESS_METRIC", "auto"),
+            success_distance_m=float(
+                os.environ.get("NPA_ISAAC_EVAL_SUCCESS_DISTANCE_M", "0.05")
+            ),
+            min_success_rate=float(
+                os.environ.get("NPA_ISAAC_EVAL_MIN_SUCCESS_RATE", "0.0")
+            ),
+            max_steps_per_episode=int(
+                os.environ.get("NPA_ISAAC_EVAL_MAX_STEPS", "200")
+            ),
+            seed=int(os.environ.get("NPA_ISAAC_EVAL_SEED", "42")),
+        )
+
+    def validate(self) -> None:
+        if not self.task:
+            raise ValueError("task must not be empty")
+        if self.num_episodes <= 0:
+            raise ValueError("num_episodes must be positive")
+        if self.max_steps_per_episode <= 0:
+            raise ValueError("max_steps_per_episode must be positive")
+        if self.success_metric not in SUPPORTED_SUCCESS_METRICS:
+            raise ValueError(
+                f"unsupported success metric {self.success_metric!r}; "
+                f"expected one of {sorted(SUPPORTED_SUCCESS_METRICS)}"
+            )
+        if self.success_distance_m <= 0:
+            raise ValueError("success_distance_m must be positive")
+        if not 0.0 <= self.min_success_rate <= 1.0:
+            raise ValueError("min_success_rate must be between 0 and 1")
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def resolve_checkpoint(path: Path) -> tuple[Path, str]:
+    """Resolve real RSL-RL weights from a file, directory, or NPA manifest."""
+
+    if not path.exists():
+        raise FileNotFoundError(f"checkpoint not found: {path}")
+    if path.is_dir():
+        candidates = [path / "npa_isaac_lab_checkpoint.pt"]
+        candidates.extend(
+            sorted(
+                path.rglob("model_*.pt"),
+                key=lambda candidate: (candidate.stat().st_mtime, str(candidate)),
+                reverse=True,
+            )
+        )
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate, "rsl_rl_checkpoint"
+        raise FileNotFoundError(
+            f"checkpoint directory contains no RSL-RL weights: {path}"
+        )
+
+    if path.suffix.lower() != ".json":
+        return path, "rsl_rl_checkpoint"
+
+    try:
+        info = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"checkpoint manifest is not valid JSON: {path}") from exc
+    for key in ("stable_checkpoint_path", "checkpoint_path"):
+        if not info.get(key):
+            continue
+        declared = Path(str(info[key]))
+        for candidate in (
+            declared,
+            path.parent / declared.name,
+            path.parent / "npa_isaac_lab_checkpoint.pt",
+        ):
+            if candidate.is_file():
+                return candidate, str(info.get("format") or "manifest")
+    raise FileNotFoundError(
+        f"manifest does not resolve to local RSL-RL weights: {path}"
+    )
+
+
+def resolve_success_metric(
+    requested: str, episode_results: list[dict[str, Any]]
+) -> str:
+    """Resolve ``auto`` without inventing a task-specific success predicate."""
+
+    if requested != "auto":
+        return requested
+    if any(item.get("native_success") is not None for item in episode_results):
+        return "native-success"
+    if all(item.get("min_goal_distance_m") is not None for item in episode_results):
+        return "goal-distance"
+    return "survival"
+
+
+def apply_success_metric(
+    metric: str,
+    episode_results: list[dict[str, Any]],
+    *,
+    success_distance_m: float,
+    task: str,
+) -> None:
+    """Attach a boolean success result to every measured episode."""
+
+    for item in episode_results:
+        if metric == "native-success":
+            if item.get("native_success") is None:
+                raise RuntimeError(
+                    "native success metric was not emitted for every episode"
+                )
+            item["success"] = bool(item["native_success"])
+        elif metric == "goal-distance":
+            if item.get("min_goal_distance_m") is None:
+                raise RuntimeError(
+                    f"task {task} did not expose object_pose or ee_pose goal distance; "
+                    "select --success-metric survival"
+                )
+            item["success"] = float(item["min_goal_distance_m"]) <= success_distance_m
+        elif metric == "survival":
+            item["success"] = not bool(item.get("terminated"))
+        else:
+            raise ValueError(f"unsupported resolved success metric: {metric}")
+
+
+def _as_bool(value: Any, torch: Any) -> bool | None:
+    if value is None:
+        return None
+    try:
+        return bool(torch.as_tensor(value).any().item())
+    except Exception:
+        return bool(value)
+
+
+def _native_success(info: Any, torch: Any) -> bool | None:
+    if not isinstance(info, dict):
+        return None
+    for key in ("success", "is_success", "goal_reached"):
+        if key in info:
+            return _as_bool(info[key], torch)
+    return None
+
+
+def _step_env(
+    env: Any, actions: Any, torch: Any
+) -> tuple[Any, Any, bool, bool, bool, bool | None]:
+    """Normalize Gymnasium and RSL-RL vector-wrapper step signatures."""
+
+    output = env.step(actions)
+    if len(output) == 5:
+        observation, reward, terminated, truncated, info = output
+        did_terminate = bool(torch.as_tensor(terminated).any().item())
+        timed_out = bool(torch.as_tensor(truncated).any().item())
+        done = did_terminate or timed_out
+    else:
+        observation, reward, dones, info = output
+        done = bool(torch.as_tensor(dones).any().item())
+        timeout_value = info.get("time_outs") if isinstance(info, dict) else None
+        if timeout_value is None and isinstance(info, dict):
+            timeout_value = info.get("timeouts")
+        timed_out = (
+            bool(_as_bool(timeout_value, torch)) if timeout_value is not None else False
+        )
+        did_terminate = done and not timed_out
+    return (
+        observation,
+        reward,
+        done,
+        did_terminate,
+        timed_out,
+        _native_success(info, torch),
+    )
+
+
+def _goal_distance(env: Any, torch: Any) -> tuple[float | None, str]:
+    unwrapped = env.unwrapped
+    try:
+        command = unwrapped.command_manager.get_command("object_pose")
+        obj = unwrapped.scene["object"].data.root_pos_w[:, :3]
+        goal = command[:, :3] + unwrapped.scene.env_origins[:, :3]
+        return (
+            float(torch.linalg.norm(obj - goal, dim=1).min().item()),
+            "object_pose",
+        )
+    except Exception as exc:
+        _LOGGER.debug("object_pose goal distance is unavailable", exc_info=exc)
+    try:
+        command = unwrapped.command_manager.get_command("ee_pose")
+        end_effector = unwrapped.scene["ee_frame"].data.target_pos_w[..., 0, :3]
+        goal = command[:, :3] + unwrapped.scene.env_origins[:, :3]
+        return (
+            float(torch.linalg.norm(end_effector - goal, dim=1).min().item()),
+            "ee_pose",
+        )
+    except Exception:
+        return None, ""
+
+
+def _write_failure(
+    config: EvalConfig,
+    *,
+    stage: str,
+    error: Exception,
+    started: float,
+    resolved_checkpoint: str = "",
+) -> dict[str, Any]:
+    failure = {
+        "format": EVAL_FORMAT,
+        "status": "failed",
+        "stage": stage,
+        "task": config.task,
+        "checkpoint": str(config.checkpoint),
+        "resolved_checkpoint": resolved_checkpoint,
+        "policy_loaded": False,
+        "num_episodes": config.num_episodes,
+        "max_steps_per_episode": config.max_steps_per_episode,
+        "seed": config.seed,
+        "error_type": type(error).__name__,
+        "error": str(error),
+        "duration_seconds": round(time.time() - started, 3),
+        "output_path": str(config.summary_path),
+    }
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    config.summary_path.write_text(json.dumps(failure, indent=2), encoding="utf-8")
+    print("ISAAC_LAB_EVAL_FAILED", flush=True)
+    print(json.dumps(failure, indent=2), flush=True)
+    return failure
+
+
+def run_eval(config: EvalConfig) -> dict[str, Any]:
+    """Load one real checkpoint and evaluate it in a headless Isaac Lab task."""
+
+    config.validate()
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    started = time.time()
+    stage = "runtime_start"
+    simulation_app = None
+    env = None
+    resolved_checkpoint = ""
+    try:
+        from isaaclab.app import AppLauncher
+
+        simulation_app = AppLauncher(headless=True).app
+
+        import gymnasium as gym
+        import torch
+
+        import isaaclab_tasks  # noqa: F401
+        from isaaclab_tasks.utils import parse_env_cfg
+
+        stage = "checkpoint_resolution"
+        checkpoint_file, checkpoint_format = resolve_checkpoint(config.checkpoint)
+        resolved_checkpoint = str(checkpoint_file)
+
+        print(
+            f"ISAAC_LAB_EVAL_START task={config.task} "
+            f"checkpoint={checkpoint_file} episodes={config.num_episodes} "
+            f"device={'cuda:0' if torch.cuda.is_available() else 'cpu'}",
+            flush=True,
+        )
+        device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        torch.manual_seed(config.seed)
+        env_config = parse_env_cfg(config.task, device=device, num_envs=1)
+        if hasattr(env_config, "seed"):
+            env_config.seed = config.seed
+
+        stage = "environment_create"
+        print("ISAAC_LAB_ENV_CREATE_START", flush=True)
+        env = gym.make(config.task, cfg=env_config)
+        print("ISAAC_LAB_ENV_CREATE_COMPLETE", flush=True)
+
+        stage = "policy_load"
+        try:
+            try:
+                from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
+            except Exception:
+                from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper
+            from rsl_rl.runners import OnPolicyRunner
+
+            agent_config = None
+            for loader in ("isaaclab_tasks.utils", "omni.isaac.lab_tasks.utils"):
+                try:
+                    module = __import__(loader, fromlist=["load_cfg_from_registry"])
+                    agent_config = module.load_cfg_from_registry(
+                        config.task, "rsl_rl_cfg_entry_point"
+                    )
+                    break
+                except Exception as exc:
+                    _LOGGER.debug(
+                        "RSL-RL config loader %s did not resolve task %s",
+                        loader,
+                        config.task,
+                        exc_info=exc,
+                    )
+            if agent_config is None:
+                raise RuntimeError(
+                    f"no rsl_rl_cfg_entry_point registered for task {config.task}"
+                )
+            runner_config = (
+                agent_config.to_dict()
+                if hasattr(agent_config, "to_dict")
+                else dict(agent_config)
+            )
+            wrapped = RslRlVecEnvWrapper(env)
+            runner = OnPolicyRunner(wrapped, runner_config, log_dir=None, device=device)
+            runner.load(str(checkpoint_file))
+            policy = runner.get_inference_policy(device=device)
+            env = wrapped
+            print("ISAAC_LAB_EVAL_POLICY_LOADED", flush=True)
+        except Exception:
+            raise
+
+        stage = "rollout"
+        episode_results: list[dict[str, Any]] = []
+        for episode in range(config.num_episodes):
+            try:
+                reset_output = env.reset(seed=config.seed + episode)
+            except TypeError:
+                reset_output = env.reset()
+            observation = (
+                reset_output[0] if isinstance(reset_output, tuple) else reset_output
+            )
+            episode_reward = 0.0
+            steps_ran = 0
+            minimum_distance = None
+            distance_source = ""
+            terminated = False
+            timed_out = False
+            native_success = None
+            for step in range(config.max_steps_per_episode):
+                if observation is None:
+                    raise RuntimeError("policy observation is unavailable")
+                with torch.inference_mode():
+                    actions = policy(observation)
+                (
+                    observation,
+                    rewards,
+                    done,
+                    terminated,
+                    timed_out,
+                    step_success,
+                ) = _step_env(env, actions, torch)
+                episode_reward += float(torch.as_tensor(rewards).mean().item())
+                steps_ran = step + 1
+                if step_success is not None:
+                    native_success = step_success
+                distance, source = _goal_distance(env, torch)
+                if distance is not None:
+                    minimum_distance = (
+                        distance
+                        if minimum_distance is None
+                        else min(minimum_distance, distance)
+                    )
+                    distance_source = source
+                if done:
+                    break
+
+            episode_results.append(
+                {
+                    "episode": episode + 1,
+                    "steps": steps_ran,
+                    "reward": episode_reward,
+                    "mean_reward_per_step": episode_reward / max(1, steps_ran),
+                    "min_goal_distance_m": minimum_distance,
+                    "goal_distance_source": distance_source,
+                    "terminated": terminated,
+                    "timed_out": timed_out or steps_ran >= config.max_steps_per_episode,
+                    "native_success": native_success,
+                }
+            )
+            print(
+                f"ISAAC_LAB_EVAL_EPISODE "
+                f"episode={episode + 1}/{config.num_episodes} "
+                f"steps={steps_ran} reward={episode_reward:.6f} "
+                f"min_dist={minimum_distance} terminated={terminated} "
+                f"timed_out={timed_out}",
+                flush=True,
+            )
+
+        stage = "metric_resolution"
+        success_metric = resolve_success_metric(config.success_metric, episode_results)
+        apply_success_metric(
+            success_metric,
+            episode_results,
+            success_distance_m=config.success_distance_m,
+            task=config.task,
+        )
+        mean_reward = sum(item["reward"] for item in episode_results) / len(
+            episode_results
+        )
+        distances = [
+            float(item["min_goal_distance_m"])
+            for item in episode_results
+            if item["min_goal_distance_m"] is not None
+        ]
+        success_rate = sum(1 for item in episode_results if item["success"]) / len(
+            episode_results
+        )
+        summary = {
+            "format": EVAL_FORMAT,
+            "status": "success",
+            "task": config.task,
+            "checkpoint": str(config.checkpoint),
+            "resolved_checkpoint": str(checkpoint_file),
+            "checkpoint_format": checkpoint_format,
+            "policy_loaded": True,
+            "num_episodes": config.num_episodes,
+            "max_steps_per_episode": config.max_steps_per_episode,
+            "seed": config.seed,
+            "device": device,
+            "mean_reward": mean_reward,
+            "success_rate": success_rate,
+            "success_metric_requested": config.success_metric,
+            "success_metric": success_metric,
+            "success_distance_m": (
+                config.success_distance_m if success_metric == "goal-distance" else None
+            ),
+            "min_success_rate": config.min_success_rate,
+            "passed": success_rate >= config.min_success_rate,
+            "mean_min_goal_distance_m": (
+                sum(distances) / len(distances) if distances else None
+            ),
+            "episodes": episode_results,
+            "duration_seconds": round(time.time() - started, 3),
+            "output_path": str(config.summary_path),
+        }
+        config.summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        print("ISAAC_LAB_EVAL_COMPLETE", flush=True)
+        print(json.dumps(summary, indent=2), flush=True)
+        return summary
+    except Exception as exc:
+        _write_failure(
+            config,
+            stage=stage,
+            error=exc,
+            started=started,
+            resolved_checkpoint=resolved_checkpoint,
+        )
+        traceback.print_exc()
+        raise
+    finally:
+        if env is not None:
+            env.close()
+        if simulation_app is not None:
+            simulation_app.close()
+
+
+def main() -> int:
+    try:
+        run_eval(EvalConfig.from_environment())
+    except Exception:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npa/src/npa/cli/isaac_lab/eval_runner.py
+++ b/npa/src/npa/cli/isaac_lab/eval_runner.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import time
 import traceback
 from typing import Any
@@ -21,6 +22,11 @@ from typing import Any
 EVAL_FORMAT = "npa.isaac_lab.eval.v1"
 SUPPORTED_SUCCESS_METRICS = {"auto", "goal-distance", "survival"}
 _LOGGER = logging.getLogger(__name__)
+PORTABLE_CHECKPOINT_NAMES = (
+    "npa_isaac_lab_checkpoint.pt",
+    "model_latest.pt",
+    "model.pt",
+)
 
 
 @dataclass(frozen=True)
@@ -108,17 +114,13 @@ def resolve_checkpoint(path: Path) -> tuple[Path, str]:
     if not path.exists():
         raise FileNotFoundError(f"checkpoint not found: {path}")
     if path.is_dir():
-        candidates = [path / "npa_isaac_lab_checkpoint.pt"]
-        candidates.extend(
-            sorted(
-                path.rglob("model_*.pt"),
-                key=lambda candidate: (candidate.stat().st_mtime, str(candidate)),
-                reverse=True,
-            )
-        )
-        for candidate in candidates:
-            if candidate.is_file():
-                return candidate, "rsl_rl_checkpoint"
+        candidates = [
+            candidate
+            for candidate in path.rglob("*")
+            if candidate.is_file() and candidate.suffix.lower() in {".pt", ".pth"}
+        ]
+        if candidates:
+            return max(candidates, key=checkpoint_preference_key), "rsl_rl_checkpoint"
         raise FileNotFoundError(
             f"checkpoint directory contains no RSL-RL weights: {path}"
         )
@@ -135,15 +137,36 @@ def resolve_checkpoint(path: Path) -> tuple[Path, str]:
             continue
         declared = Path(str(info[key]))
         for candidate in (
-            declared,
-            path.parent / declared.name,
             path.parent / "npa_isaac_lab_checkpoint.pt",
+            path.parent / "model_latest.pt",
+            path.parent / "model.pt",
+            path.parent / declared.name,
+            declared,
         ):
             if candidate.is_file():
                 return candidate, str(info.get("format") or "manifest")
     raise FileNotFoundError(
         f"manifest does not resolve to local RSL-RL weights: {path}"
     )
+
+
+def checkpoint_preference_key(path: Path) -> tuple[int, int, float, str]:
+    """Rank portable/final weights ahead of numbered and arbitrary checkpoints."""
+
+    try:
+        modified = path.stat().st_mtime
+    except OSError:
+        modified = 0.0
+    if path.name in PORTABLE_CHECKPOINT_NAMES:
+        # Earlier entries are the strongest contract names.
+        rank = len(PORTABLE_CHECKPOINT_NAMES) - PORTABLE_CHECKPOINT_NAMES.index(
+            path.name
+        )
+        return 3, rank, modified, str(path)
+    numbered = re.fullmatch(r"model_(\d+)\.(?:pt|pth)", path.name)
+    if numbered:
+        return 2, int(numbered.group(1)), modified, str(path)
+    return 1, 0, modified, str(path)
 
 
 def resolve_success_metric(
@@ -153,6 +176,8 @@ def resolve_success_metric(
 
     if requested != "auto":
         return requested
+    if not episode_results:
+        raise ValueError("episode_results must not be empty")
     if episode_results and all(
         item.get("native_success") is not None for item in episode_results
     ):
@@ -196,8 +221,9 @@ def _as_bool(value: Any, torch: Any) -> bool | None:
         return None
     try:
         return bool(torch.as_tensor(value).any().item())
-    except Exception:
-        return bool(value)
+    except Exception as exc:
+        _LOGGER.debug("native success conversion is unavailable", exc_info=exc)
+        return None
 
 
 def _native_success(info: Any, torch: Any) -> bool | None:
@@ -260,7 +286,8 @@ def _goal_distance(env: Any, torch: Any) -> tuple[float | None, str]:
             float(torch.linalg.norm(end_effector - goal, dim=1).min().item()),
             "ee_pose",
         )
-    except Exception:
+    except Exception as exc:
+        _LOGGER.debug("ee_pose goal distance is unavailable", exc_info=exc)
         return None, ""
 
 
@@ -329,8 +356,15 @@ def write_eval_summary(
         success_distance_m=config.success_distance_m,
         task=config.task,
     )
-    mean_reward = sum(float(item.get("reward", 0.0)) for item in episode_results) / len(
-        episode_results
+    reward_values = [
+        float(item["reward"])
+        for item in episode_results
+        if item.get("reward") is not None
+    ]
+    mean_reward = (
+        sum(reward_values) / len(reward_values)
+        if len(reward_values) == len(episode_results)
+        else None
     )
     distances = [
         float(item["min_goal_distance_m"])

--- a/npa/src/npa/cli/isaac_lab/eval_runner.py
+++ b/npa/src/npa/cli/isaac_lab/eval_runner.py
@@ -6,6 +6,8 @@ GPU evidence aligned with the shipped evaluator instead of maintaining a
 second evaluation script.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 import json
 import logging
@@ -151,7 +153,9 @@ def resolve_success_metric(
 
     if requested != "auto":
         return requested
-    if any(item.get("native_success") is not None for item in episode_results):
+    if episode_results and all(
+        item.get("native_success") is not None for item in episode_results
+    ):
         return "native-success"
     if all(item.get("min_goal_distance_m") is not None for item in episode_results):
         return "goal-distance"
@@ -260,7 +264,128 @@ def _goal_distance(env: Any, torch: Any) -> tuple[float | None, str]:
         return None, ""
 
 
-def _write_failure(
+def load_rsl_rl_policy(
+    env: Any,
+    *,
+    task: str,
+    checkpoint_file: Path,
+    device: str,
+) -> tuple[Any, Any]:
+    """Wrap an Isaac environment and load a real RSL-RL inference policy."""
+
+    try:
+        from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
+    except Exception:
+        from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper
+    from rsl_rl.runners import OnPolicyRunner
+
+    agent_config = None
+    for loader in ("isaaclab_tasks.utils", "omni.isaac.lab_tasks.utils"):
+        try:
+            module = __import__(loader, fromlist=["load_cfg_from_registry"])
+            agent_config = module.load_cfg_from_registry(
+                task, "rsl_rl_cfg_entry_point"
+            )
+            break
+        except Exception as exc:
+            _LOGGER.debug(
+                "RSL-RL config loader %s did not resolve task %s",
+                loader,
+                task,
+                exc_info=exc,
+            )
+    if agent_config is None:
+        raise RuntimeError(f"no rsl_rl_cfg_entry_point registered for task {task}")
+    runner_config = (
+        agent_config.to_dict()
+        if hasattr(agent_config, "to_dict")
+        else dict(agent_config)
+    )
+    wrapped = RslRlVecEnvWrapper(env)
+    runner = OnPolicyRunner(wrapped, runner_config, log_dir=None, device=device)
+    runner.load(str(checkpoint_file))
+    return wrapped, runner.get_inference_policy(device=device)
+
+
+def write_eval_summary(
+    config: EvalConfig,
+    *,
+    episode_results: list[dict[str, Any]],
+    checkpoint_file: Path,
+    checkpoint_format: str,
+    device: str,
+    started: float,
+    captured_videos: list[str] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Apply the shared metric contract and write a successful eval summary."""
+
+    if not episode_results:
+        raise ValueError("episode_results must not be empty")
+    success_metric = resolve_success_metric(config.success_metric, episode_results)
+    apply_success_metric(
+        success_metric,
+        episode_results,
+        success_distance_m=config.success_distance_m,
+        task=config.task,
+    )
+    mean_reward = sum(float(item.get("reward", 0.0)) for item in episode_results) / len(
+        episode_results
+    )
+    distances = [
+        float(item["min_goal_distance_m"])
+        for item in episode_results
+        if item.get("min_goal_distance_m") is not None
+    ]
+    success_rate = sum(1 for item in episode_results if item["success"]) / len(
+        episode_results
+    )
+    videos = captured_videos or []
+    summary = {
+        "format": EVAL_FORMAT,
+        "status": "success",
+        "task": config.task,
+        "checkpoint": str(config.checkpoint),
+        "resolved_checkpoint": str(checkpoint_file),
+        "checkpoint_format": checkpoint_format,
+        "policy_loaded": True,
+        "num_episodes": len(episode_results),
+        "max_steps_per_episode": config.max_steps_per_episode,
+        "seed": config.seed,
+        "device": device,
+        "mean_reward": mean_reward,
+        "success_rate": success_rate,
+        "success_metric_requested": config.success_metric,
+        "success_metric": success_metric,
+        "success_distance_m": (
+            config.success_distance_m if success_metric == "goal-distance" else None
+        ),
+        "min_success_rate": config.min_success_rate,
+        # A false value means evaluation completed but missed the quality bar.
+        # Sim2Real Stage 11 owns the loop decision; runtime/policy-load failures
+        # remain non-zero and fail closed.
+        "passed": success_rate >= config.min_success_rate,
+        "mean_min_goal_distance_m": (
+            sum(distances) / len(distances) if distances else None
+        ),
+        "video": {
+            "enabled": config.capture_video,
+            "fps": config.video_fps,
+            "length_steps": config.video_length,
+            "files": videos,
+        },
+        "episodes": episode_results,
+        "duration_seconds": round(time.time() - started, 3),
+        "output_path": str(config.summary_path),
+    }
+    if extra:
+        summary.update(extra)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    config.summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary
+
+
+def write_failure_summary(
     config: EvalConfig,
     *,
     stage: str,
@@ -355,45 +480,13 @@ def run_eval(config: EvalConfig) -> dict[str, Any]:
         print("ISAAC_LAB_ENV_CREATE_COMPLETE", flush=True)
 
         stage = "policy_load"
-        try:
-            try:
-                from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
-            except Exception:
-                from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper
-            from rsl_rl.runners import OnPolicyRunner
-
-            agent_config = None
-            for loader in ("isaaclab_tasks.utils", "omni.isaac.lab_tasks.utils"):
-                try:
-                    module = __import__(loader, fromlist=["load_cfg_from_registry"])
-                    agent_config = module.load_cfg_from_registry(
-                        config.task, "rsl_rl_cfg_entry_point"
-                    )
-                    break
-                except Exception as exc:
-                    _LOGGER.debug(
-                        "RSL-RL config loader %s did not resolve task %s",
-                        loader,
-                        config.task,
-                        exc_info=exc,
-                    )
-            if agent_config is None:
-                raise RuntimeError(
-                    f"no rsl_rl_cfg_entry_point registered for task {config.task}"
-                )
-            runner_config = (
-                agent_config.to_dict()
-                if hasattr(agent_config, "to_dict")
-                else dict(agent_config)
-            )
-            wrapped = RslRlVecEnvWrapper(env)
-            runner = OnPolicyRunner(wrapped, runner_config, log_dir=None, device=device)
-            runner.load(str(checkpoint_file))
-            policy = runner.get_inference_policy(device=device)
-            env = wrapped
-            print("ISAAC_LAB_EVAL_POLICY_LOADED", flush=True)
-        except Exception:
-            raise
+        env, policy = load_rsl_rl_policy(
+            env,
+            task=config.task,
+            checkpoint_file=checkpoint_file,
+            device=device,
+        )
+        print("ISAAC_LAB_EVAL_POLICY_LOADED", flush=True)
 
         stage = "rollout"
         episode_results: list[dict[str, Any]] = []
@@ -482,64 +575,20 @@ def run_eval(config: EvalConfig) -> dict[str, Any]:
             )
 
         stage = "metric_resolution"
-        success_metric = resolve_success_metric(config.success_metric, episode_results)
-        apply_success_metric(
-            success_metric,
-            episode_results,
-            success_distance_m=config.success_distance_m,
-            task=config.task,
+        summary = write_eval_summary(
+            config,
+            episode_results=episode_results,
+            checkpoint_file=checkpoint_file,
+            checkpoint_format=checkpoint_format,
+            device=device,
+            started=started,
+            captured_videos=captured_videos,
         )
-        mean_reward = sum(item["reward"] for item in episode_results) / len(
-            episode_results
-        )
-        distances = [
-            float(item["min_goal_distance_m"])
-            for item in episode_results
-            if item["min_goal_distance_m"] is not None
-        ]
-        success_rate = sum(1 for item in episode_results if item["success"]) / len(
-            episode_results
-        )
-        summary = {
-            "format": EVAL_FORMAT,
-            "status": "success",
-            "task": config.task,
-            "checkpoint": str(config.checkpoint),
-            "resolved_checkpoint": str(checkpoint_file),
-            "checkpoint_format": checkpoint_format,
-            "policy_loaded": True,
-            "num_episodes": config.num_episodes,
-            "max_steps_per_episode": config.max_steps_per_episode,
-            "seed": config.seed,
-            "device": device,
-            "mean_reward": mean_reward,
-            "success_rate": success_rate,
-            "success_metric_requested": config.success_metric,
-            "success_metric": success_metric,
-            "success_distance_m": (
-                config.success_distance_m if success_metric == "goal-distance" else None
-            ),
-            "min_success_rate": config.min_success_rate,
-            "passed": success_rate >= config.min_success_rate,
-            "mean_min_goal_distance_m": (
-                sum(distances) / len(distances) if distances else None
-            ),
-            "video": {
-                "enabled": config.capture_video,
-                "fps": config.video_fps,
-                "length_steps": config.video_length,
-                "files": captured_videos,
-            },
-            "episodes": episode_results,
-            "duration_seconds": round(time.time() - started, 3),
-            "output_path": str(config.summary_path),
-        }
-        config.summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
         print("ISAAC_LAB_EVAL_COMPLETE", flush=True)
         print(json.dumps(summary, indent=2), flush=True)
         return summary
     except Exception as exc:
-        _write_failure(
+        write_failure_summary(
             config,
             stage=stage,
             error=exc,

--- a/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
@@ -256,8 +256,8 @@ try:
             print("could not set env_cfg.seed:", repr(e), flush=True)
         try:
             torch.manual_seed(SEED); np.random.seed(SEED % (2**32))
-        except Exception:
-            pass
+        except Exception as e:
+            print("could not seed torch/numpy:", repr(e), flush=True)
         print("EVAL_SEED_APPLIED", SEED, flush=True)
     # Add a workspace camera so we can RENDER the robot/object interaction for
     # Rerun viz. Isaac Lab's "world" convention camera looks along +X; place it
@@ -313,8 +313,8 @@ try:
         try:
             for k in list(o.keys()):
                 o[k] = _to_batched(o[k])
-        except Exception:
-            pass
+        except Exception as e:
+            print("could not normalize batched observations:", repr(e), flush=True)
         return o
     def _policy_tensor(o):
         if torch.is_tensor(o):
@@ -942,8 +942,13 @@ def run_isaac_eval_job(
         try:
             failed_summary = _download_json(per_env_uri)
             failure_detail = "\nsummary=" + json.dumps(failed_summary, sort_keys=True)
-        except Exception:
-            pass
+        except Exception as summary_exc:
+            print(
+                "byo_isaac_eval: failed sibling summary was unavailable: "
+                f"{summary_exc}",
+                file=sys.stderr,
+                flush=True,
+            )
         raise SystemExit(
             f"byo_isaac_eval: eval job {job_name} failed: {terminal_detail}"
             f"{failure_detail}\n{logs.stdout}"

--- a/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
@@ -46,6 +46,21 @@ _ISAAC_EVAL_SUMMARY_URI = ""
 # --------------------------------------------------------------------------- #
 # Pure helpers (unit-tested without a cluster)
 # --------------------------------------------------------------------------- #
+def _success_threshold_from_env() -> float:
+    raw = _env("NPA_SIM2REAL_THRESHOLD", "0.0") or "0.0"
+    try:
+        threshold = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"NPA_SIM2REAL_THRESHOLD must be a number in [0, 1], got {raw!r}"
+        ) from exc
+    if not 0.0 <= threshold <= 1.0:
+        raise ValueError(
+            f"NPA_SIM2REAL_THRESHOLD must be in [0, 1], got {threshold}"
+        )
+    return threshold
+
+
 def extract_checkpoint_uri(inner_evidence: dict[str, Any]) -> str:
     """Pull the trained-policy checkpoint S3 URI from inner-loop evidence.
 
@@ -150,7 +165,7 @@ def per_env_from_distances(
 ) -> list[dict[str, Any]]:
     """Convert per-env final object-to-goal distances into scored per-env rows.
 
-    score = clamp(1 - dist/(2*success_dist), 0, 1); success = dist < threshold.
+    score = clamp(1 - dist/(2*success_dist), 0, 1); success = dist <= threshold.
     A genuine measurement of the trained policy, grounded in the task metric.
     When provided, rows are labelled by the GENERATED env_id/seed they came from.
     """
@@ -166,7 +181,7 @@ def per_env_from_distances(
         rows.append(
             {
                 "env_id": env_id,
-                "success": bool(d < success_dist_m),
+                "success": bool(d <= success_dist_m),
                 "score": round(score, 6),
                 "details": details,
             }
@@ -291,7 +306,8 @@ try:
     try:
         reset_out = env.reset()
         obs = reset_out[0] if isinstance(reset_out, tuple) else reset_out
-    except Exception:
+    except Exception as e:
+        print("reset failed; falling back to get_observations:", repr(e), flush=True)
         obs, _ = env.get_observations()
     print("OBS_TYPE", type(obs).__name__, "realN", realN, flush=True)
     N = realN
@@ -421,6 +437,7 @@ try:
     stage = "rollout"
     min_dist = np.full(N, 1e9)
     reward_sum = np.zeros(N, dtype=np.float64)
+    reward_available = True
     for _step in range(STEPS):
         with torch.inference_mode():
             actions = policy(_batched_obs(obs))
@@ -429,10 +446,22 @@ try:
         if hasattr(actions, "ndim") and actions.ndim == 1:
             actions = actions.reshape(N, -1)
         obs, rewards, dones, extras = env.step(actions)
-        try:
-            reward_sum += torch.as_tensor(rewards).detach().cpu().numpy().reshape(-1)[:N]
-        except Exception:
-            pass
+        if reward_available:
+            try:
+                reward_values = (
+                    torch.as_tensor(rewards).detach().cpu().numpy().reshape(-1)
+                )
+                if reward_values.size != N:
+                    raise ValueError(
+                        "reward batch does not match environment count: "
+                        f"rewards={reward_values.size} envs={N}"
+                    )
+                if not np.isfinite(reward_values).all():
+                    raise ValueError("reward batch contains non-finite values")
+                reward_sum += reward_values
+            except Exception as e:
+                reward_available = False
+                print("reward_metric_unavailable", repr(e), flush=True)
         if _step % CAP_EVERY == 0:
             capture(_step)
         # object-to-goal distance: prefer an explicit metric, else infer.
@@ -454,8 +483,9 @@ try:
                 per = torch.linalg.norm(obj - goal, dim=1).detach().cpu().numpy()
                 min_dist = np.minimum(min_dist, per);
                 continue
-        except Exception:
-            pass
+        except Exception as e:
+            if _step == 0:
+                print("object_pose_distance_unavailable", repr(e), flush=True)
         if d is not None:
             min_dist = np.minimum(min_dist, np.full(N, d))
     capture(STEPS)  # final frame
@@ -471,8 +501,12 @@ try:
             "episode": i + 1,
             "env_id": _env_id(i),
             "steps": STEPS,
-            "reward": float(reward_sum[i]),
-            "mean_reward_per_step": float(reward_sum[i]) / max(1, STEPS),
+            "reward": float(reward_sum[i]) if reward_available else None,
+            "mean_reward_per_step": (
+                float(reward_sum[i]) / max(1, STEPS)
+                if reward_available
+                else None
+            ),
             "min_goal_distance_m": distances[i],
             "goal_distance_source": "object_pose",
             "terminated": False,
@@ -505,7 +539,7 @@ except Exception as e:
         stage=stage,
         error=e,
         started=STARTED,
-        resolved_checkpoint=CKPT if stage not in {"runtime_start", "checkpoint_resolution"} else "",
+        resolved_checkpoint=CKPT if Path(CKPT).is_file() else "",
     )
     persist(summary)
     exit_code = 1
@@ -572,7 +606,7 @@ def build_isaac_eval_job_manifest(
     service_account: str,
     gpu_product: str,
     gpu_resource: str = "nvidia.com/gpu",
-    image_pull_policy: str = "IfNotPresent",
+    image_pull_policy: str = "Always",
     seed: int = 0,
     object_usd: str = "",
     env_ids_json: str = "[]",
@@ -727,10 +761,9 @@ def build_isaac_eval_job_manifest(
                         {
                             "name": "eval",
                             "image": image,
-                            # Build-tagged Isaac images are immutable for a run.
-                            # Reuse a validated node cache when a short-lived
-                            # registry token expires; fresh nodes still pull via
-                            # the credential refresh above.
+                            # The shared Sim2Real policy honors the operator
+                            # override and image provenance (tag versus digest).
+                            # Train, rollout, and eval all use the same decision.
                             "imagePullPolicy": image_pull_policy,
                             # Isaac Lab images launch through /isaac-sim/isaaclab.sh and
                             # write under the prebuilt workspace; current RTX PRO runtime
@@ -741,6 +774,9 @@ def build_isaac_eval_job_manifest(
                                 "requests": {gpu_resource: "1"},
                             },
                             "envFrom": [
+                                # Isaac bootstrap and artifact I/O do not require
+                                # NGC/HF credentials. Keep customer override tokens
+                                # optional while storage credentials remain required.
                                 {
                                     "secretRef": {
                                         "name": "hf-ngc-tokens",
@@ -864,9 +900,10 @@ def run_isaac_eval_job(
     sa = _env("NPA_SIM2REAL_K8S_SERVICE_ACCOUNT", "agent-sa")
     gpu_product = _env("NPA_SIM2REAL_K8S_GPU_PRODUCT", DEFAULT_GPU_PRODUCT)
     success_dist = float(_env("NPA_BYO_ISAAC_SUCCESS_DIST_M", str(DEFAULT_SUCCESS_DIST_M)) or DEFAULT_SUCCESS_DIST_M)
-    min_success_rate = float(_env("NPA_SIM2REAL_THRESHOLD", "0.0") or 0.0)
+    min_success_rate = _success_threshold_from_env()
     timeout_s = int(_env("NPA_BYO_ISAAC_JOB_TIMEOUT_S", "5400") or 5400)
     from npa.workflows.sim2real.byo_isaac_trainer import artifact_tag, k8s_job_name
+    from npa.workflows.sim2real.engine import _image_pull_policy
 
     eval_tag = artifact_tag(_env("NPA_SIM2REAL_EVAL_TAG"))
     job_name = k8s_job_name("s2r-byo-isaac-eval", run_id, eval_tag)
@@ -922,6 +959,7 @@ def run_isaac_eval_job(
         service_account=sa, gpu_product=gpu_product, seed=seed, object_usd=object_usd,
         env_ids_json=json.dumps([e["env_id"] for e in gen]), renders_s3_prefix=renders_prefix,
         success_dist_m=success_dist, min_success_rate=min_success_rate,
+        image_pull_policy=_image_pull_policy(image),
         robot_spec=robot_spec_dict, robot_usd_uri=robot_usd_uri, task_config=task_config_dict,
     )
     _refresh_registry_pull_secret(image, namespace=namespace)
@@ -1024,6 +1062,11 @@ def main() -> int:
     run_id = _env("NPA_SIM2REAL_RUN_ID") or _env("RUN_ID") or "byo-isaac"
     task = _env("NPA_SIM2REAL_ISAAC_TASK", DEFAULT_ISAAC_TASK)
     num_envs = int(_env("NPA_SIM2REAL_HELDOUT_ENV_COUNT", "4") or 4)
+    try:
+        _success_threshold_from_env()
+    except ValueError as exc:
+        print(f"byo_isaac_eval: {exc}", file=sys.stderr)
+        return 2
     # Heldout renders live next to the report so stage-14 viz finds them.
     _RENDERS_LOCAL_DIR = str(Path(output_json).parent / "renders")
     success_dist = float(_env("NPA_BYO_ISAAC_SUCCESS_DIST_M", str(DEFAULT_SUCCESS_DIST_M)) or DEFAULT_SUCCESS_DIST_M)

--- a/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
@@ -26,6 +26,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +39,8 @@ DEFAULT_SUCCESS_DIST_M = 0.05
 # renders dir + surface the render manifest into the report (for Rerun viz).
 _RENDERS_LOCAL_DIR = ""
 _RENDER_MANIFEST: dict[str, Any] = {}
+_ISAAC_EVAL_SUMMARY: dict[str, Any] = {}
+_ISAAC_EVAL_SUMMARY_URI = ""
 
 
 # --------------------------------------------------------------------------- #
@@ -65,6 +68,8 @@ def build_heldout_report(
     isaac_task: str,
     checkpoint_uri: str,
     source: str,
+    isaac_eval_summary: dict[str, Any] | None = None,
+    isaac_eval_summary_uri: str = "",
 ) -> dict[str, Any]:
     """Build the payload _normalize_heldout_report consumes (per_env list)."""
 
@@ -86,7 +91,7 @@ def build_heldout_report(
         success_summary["mean_object_goal_distance_m"] = round(sum(dists) / len(dists), 6)
         success_summary["min_object_goal_distance_m"] = round(min(dists), 6)
 
-    return {
+    report = {
         "schema": "npa.sim2real.heldout_eval.v1",
         "source": source,
         "sim_backend": "isaac",
@@ -96,6 +101,11 @@ def build_heldout_report(
         "success_summary": success_summary,
         "per_env": per_env,
     }
+    if isaac_eval_summary:
+        report["isaac_eval_summary"] = isaac_eval_summary
+    if isaac_eval_summary_uri:
+        report["isaac_eval_summary_uri"] = isaac_eval_summary_uri
+    return report
 
 
 def read_generated_envs(envs_dir: str, *, limit: int = 0) -> list[dict[str, Any]]:
@@ -164,25 +174,45 @@ def per_env_from_distances(
     return rows
 
 
-# In-Isaac rollout script (runs in the sibling Job). Defensive: tries the
-# standard Isaac Lab + rsl_rl play API, derives per-env final object-to-goal
-# distance, and writes per_env_distances.json. Verbose so the first run reveals
-# the exact API if anything mismatches.
+# In-Isaac rollout adapter (runs in the sibling Job). It keeps the Sim2Real-only
+# vectorized generated-environment and camera behavior, while importing policy
+# loading, metric resolution, summary schema, and fail-closed reporting from the
+# same eval_runner.py used by ``npa workbench isaac-lab eval``.
 ISAAC_EVAL_SCRIPT = r'''
-import json, os, sys, traceback
+import json, os, sys, time, traceback
+from pathlib import Path
 import numpy as np
+from isaac_eval_runner import (
+    EvalConfig,
+    load_rsl_rl_policy,
+    write_eval_summary,
+    write_failure_summary,
+)
 N = int(os.environ.get("EVAL_NUM_ENVS", "4"))
 STEPS = int(os.environ.get("EVAL_MAX_STEPS", "300"))
 TASK = os.environ["EVAL_TASK"]
 CKPT = os.environ["EVAL_CKPT_LOCAL"]
 OUT = os.environ["EVAL_OUT_JSON"]
 SEED = int(os.environ.get("EVAL_SEED", "0"))  # generated-env seed (envgen envs.jsonl)
-def dump(distances, note, episodes=None):
-    json.dump({"object_goal_distances": list(distances), "note": note,
-               "render_episodes": episodes or []},
-              open(OUT, "w"))
-    print("EVAL_WROTE", OUT, note, "episodes", len(episodes or []), flush=True)
+CONFIG = EvalConfig(
+    task=TASK,
+    checkpoint=Path(CKPT),
+    num_episodes=N,
+    output_dir=Path(OUT).parent,
+    success_metric="goal-distance",
+    success_distance_m=float(os.environ.get("EVAL_SUCCESS_DISTANCE_M", "0.05")),
+    min_success_rate=float(os.environ.get("EVAL_MIN_SUCCESS_RATE", "0.0")),
+    max_steps_per_episode=STEPS,
+    seed=SEED,
+)
+STARTED = time.time()
+stage = "runtime_start"
+exit_code = 0
+def persist(summary):
+    Path(OUT).write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print("EVAL_WROTE", OUT, summary.get("status"), flush=True)
 try:
+    CONFIG.validate()
     from isaaclab.app import AppLauncher
     app = AppLauncher(headless=True, enable_cameras=True).app
     import gymnasium as gym, torch
@@ -206,11 +236,7 @@ try:
     from isaaclab_tasks.utils import parse_env_cfg
     import isaaclab.sim as sim_utils
     from isaaclab.sensors import TiledCameraCfg
-    try:
-        from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
-    except Exception:
-        from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper  # older layout
-    from rsl_rl.runners import OnPolicyRunner
+    stage = "environment_config"
     env_cfg = parse_env_cfg(TASK, device="cuda:0", num_envs=N)
     # CUSTOM asset: override the manipuland USD so eval scores the policy on the
     # same custom object it trained on (physically simulated, not the stock cube).
@@ -249,26 +275,13 @@ try:
         height=256,
         spawn=sim_utils.PinholeCameraCfg(focal_length=24.0, clipping_range=(0.05, 20.0)),
     )
+    stage = "environment_create"
     env = gym.make(TASK, cfg=env_cfg)
-    env = RslRlVecEnvWrapper(env)
-    # Load the COMPLETE rsl_rl agent cfg from the task registry (has save_interval,
-    # network dims, etc.) — a hand-built cfg is missing keys OnPolicyRunner needs.
-    agent_cfg = None
-    for loader in ("isaaclab_tasks.utils", "omni.isaac.lab_tasks.utils"):
-        try:
-            mod = __import__(loader, fromlist=["load_cfg_from_registry"])
-            agent_cfg = mod.load_cfg_from_registry(TASK, "rsl_rl_cfg_entry_point")
-            print("loaded agent cfg via", loader, flush=True)
-            break
-        except Exception as e:
-            print("cfg loader", loader, "failed:", repr(e), flush=True)
-    if agent_cfg is None:
-        raise RuntimeError("could not load rsl_rl_cfg_entry_point for task")
-    acfg = agent_cfg.to_dict() if hasattr(agent_cfg, "to_dict") else dict(agent_cfg)
-    print("AGENT_CFG_KEYS", sorted(acfg.keys()), flush=True)
-    runner = OnPolicyRunner(env, acfg, log_dir=None, device="cuda:0")
-    runner.load(CKPT)
-    policy = runner.get_inference_policy(device="cuda:0")
+    stage = "policy_load"
+    env, policy = load_rsl_rl_policy(
+        env, task=TASK, checkpoint_file=Path(CKPT), device="cuda:0"
+    )
+    print("ISAAC_LAB_EVAL_POLICY_LOADED", flush=True)
     # The ACTUAL env count is the single source of truth for per-env sizing.
     realN = int(getattr(env.unwrapped, "num_envs", N) or N)
     # Reset FIRST to force a fully-batched [realN, obs_dim] observation. Calling
@@ -405,7 +418,9 @@ try:
         except Exception as e:
             print("capture_err", repr(e), flush=True)
         capture_pointcloud()
+    stage = "rollout"
     min_dist = np.full(N, 1e9)
+    reward_sum = np.zeros(N, dtype=np.float64)
     for _step in range(STEPS):
         with torch.inference_mode():
             actions = policy(_batched_obs(obs))
@@ -413,7 +428,11 @@ try:
             print("STEP0 act_shape", tuple(getattr(actions, "shape", ())), flush=True)
         if hasattr(actions, "ndim") and actions.ndim == 1:
             actions = actions.reshape(N, -1)
-        obs, _, dones, extras = env.step(actions)
+        obs, rewards, dones, extras = env.step(actions)
+        try:
+            reward_sum += torch.as_tensor(rewards).detach().cpu().numpy().reshape(-1)[:N]
+        except Exception:
+            pass
         if _step % CAP_EVERY == 0:
             capture(_step)
         # object-to-goal distance: prefer an explicit metric, else infer.
@@ -440,11 +459,56 @@ try:
         if d is not None:
             min_dist = np.minimum(min_dist, np.full(N, d))
     capture(STEPS)  # final frame
-    episodes = [{"env_id": _env_id(i), "frames": frame_names[i]} for i in range(N) if frame_names[i]]
-    dump([float(x if x < 1e8 else 0.5) for x in min_dist], "rollout_ok", episodes)
+    render_episodes = [
+        {"env_id": _env_id(i), "frames": frame_names[i]}
+        for i in range(N) if frame_names[i]
+    ]
+    distances = [float(x) for x in min_dist]
+    if any(not np.isfinite(x) or x >= 1e8 for x in distances):
+        raise RuntimeError("object_pose goal distance was unavailable for one or more environments")
+    episode_results = [
+        {
+            "episode": i + 1,
+            "env_id": _env_id(i),
+            "steps": STEPS,
+            "reward": float(reward_sum[i]),
+            "mean_reward_per_step": float(reward_sum[i]) / max(1, STEPS),
+            "min_goal_distance_m": distances[i],
+            "goal_distance_source": "object_pose",
+            "terminated": False,
+            "timed_out": True,
+            "native_success": None,
+        }
+        for i in range(N)
+    ]
+    stage = "metric_resolution"
+    summary = write_eval_summary(
+        CONFIG,
+        episode_results=episode_results,
+        checkpoint_file=Path(CKPT),
+        checkpoint_format="rsl_rl_checkpoint",
+        device="cuda:0",
+        started=STARTED,
+        extra={
+            "sim2real_stage": 10,
+            "object_goal_distances": distances,
+            "render_episodes": render_episodes,
+            "note": "rollout_ok",
+        },
+    )
+    persist(summary)
+    print("ISAAC_LAB_EVAL_COMPLETE", flush=True)
 except Exception as e:
     traceback.print_exc()
-    dump([0.5]*N, "rollout_failed:%s" % e)
+    summary = write_failure_summary(
+        CONFIG,
+        stage=stage,
+        error=e,
+        started=STARTED,
+        resolved_checkpoint=CKPT if stage not in {"runtime_start", "checkpoint_resolution"} else "",
+    )
+    persist(summary)
+    exit_code = 1
 # With enable_cameras the Isaac app hangs on exit (even app.close() blocks), so the
 # post-script bash upload never runs. Upload distances + renders HERE from boto3,
 # then hard-exit the process so nothing hangs.
@@ -468,8 +532,9 @@ try:
     print("BYO_EVAL_DONE", flush=True)
 except Exception as _e:
     print("inproc_upload_err", repr(_e), flush=True)
+    exit_code = 1
 sys.stdout.flush(); sys.stderr.flush()
-os._exit(0)
+os._exit(exit_code)
 '''
 
 
@@ -507,10 +572,13 @@ def build_isaac_eval_job_manifest(
     service_account: str,
     gpu_product: str,
     gpu_resource: str = "nvidia.com/gpu",
+    image_pull_policy: str = "IfNotPresent",
     seed: int = 0,
     object_usd: str = "",
     env_ids_json: str = "[]",
     renders_s3_prefix: str = "",
+    success_dist_m: float = DEFAULT_SUCCESS_DIST_M,
+    min_success_rate: float = 0.0,
     robot_spec: dict[str, Any] | None = None,
     robot_usd_uri: str = "",
     task_config: dict[str, Any] | None = None,
@@ -526,6 +594,10 @@ def build_isaac_eval_job_manifest(
 
     import shlex as _shlex
     import json as _json
+
+    from npa.cli.isaac_lab import eval_runner as _eval_runner
+
+    shared_eval_source = Path(_eval_runner.__file__).read_text(encoding="utf-8")
 
     # Opt-in BYO-robot eval: ship the isaac_byo_robot_task module + stage the
     # customer robot USD, and pass the spec via NPA_BYO_ROBOT_SPEC_JSON. The
@@ -571,24 +643,8 @@ def build_isaac_eval_job_manifest(
             + task_cfg_export
         )
 
-    render_upload = ""
-    if renders_s3_prefix:
-        render_upload = (
-            'RENDERS_URI=' + _shlex.quote(renders_s3_prefix) + ' "$PY" - <<\'RLEOF\'\n'
-            "import os, boto3, glob\n"
-            "from urllib.parse import urlparse\n"
-            "u = urlparse(os.environ['RENDERS_URI'])\n"
-            "s3 = boto3.client('s3', endpoint_url=os.environ.get('AWS_ENDPOINT_URL') or None)\n"
-            "base = u.path.lstrip('/').rstrip('/')\n"
-            "n = 0\n"
-            "for p in glob.glob('/tmp/evalwork/renders/**/*.png', recursive=True):\n"
-            "    rel = os.path.relpath(p, '/tmp/evalwork/renders')\n"
-            "    s3.upload_file(p, u.netloc, base + '/' + rel); n += 1\n"
-            "print('UPLOADED_RENDERS', n, os.environ['RENDERS_URI'])\n"
-            "RLEOF\n"
-        )
     script = (
-        "set -uo pipefail\n"
+        "set -euo pipefail\n"
         'exec > >(tee -a /tmp/byo-eval.log) 2>&1\n'
         'if [ -x /isaac-sim/python.sh ]; then\n'
         '  PY=/isaac-sim/python.sh\n'
@@ -607,6 +663,8 @@ def build_isaac_eval_job_manifest(
         "mkdir -p /tmp/evalwork/renders; cd /tmp/evalwork\n"
         f'export EVAL_TASK="{task}" EVAL_NUM_ENVS="{num_envs}" EVAL_SEED="{seed}" '
         f'EVAL_OBJECT_USD="{object_usd}" EVAL_ENV_IDS={_shlex.quote(env_ids_json)} '
+        f'EVAL_SUCCESS_DISTANCE_M={_shlex.quote(str(success_dist_m))} '
+        f'EVAL_MIN_SUCCESS_RATE={_shlex.quote(str(min_success_rate))} '
         f'EVAL_OUT_S3={_shlex.quote(per_env_s3_uri)} '
         f'EVAL_RENDERS_S3={_shlex.quote(renders_s3_prefix)} '
         'EVAL_RENDERS_DIR=/tmp/evalwork/renders '
@@ -621,19 +679,13 @@ def build_isaac_eval_job_manifest(
         "print('DOWNLOADED_CKPT', os.environ['CKPT_URI'])\n"
         "DLEOF\n"
         + robot_block
+        + "cat > /tmp/evalwork/isaac_eval_runner.py <<'EVALRUNNEREOF'\n"
+        + shared_eval_source
+        + "\nEVALRUNNEREOF\n"
         + 'cat > /tmp/evalwork/eval_rollout.py <<\'PYEOF\'\n'
         f"{ISAAC_EVAL_SCRIPT}\n"
         "PYEOF\n"
-        '"$PY" /tmp/evalwork/eval_rollout.py || echo "EVAL_SCRIPT_RC=$?"\n'
-        'OUT_URI="' + per_env_s3_uri + '" "$PY" - <<\'ULEOF\'\n'
-        "import os, boto3\n"
-        "from urllib.parse import urlparse\n"
-        "u = urlparse(os.environ['OUT_URI'])\n"
-        "s3 = boto3.client('s3', endpoint_url=os.environ.get('AWS_ENDPOINT_URL') or None)\n"
-        "s3.upload_file('/tmp/evalwork/per_env_distances.json', u.netloc, u.path.lstrip('/'))\n"
-        "print('UPLOADED_DISTANCES', os.environ['OUT_URI'])\n"
-        "ULEOF\n"
-        + render_upload
+        '"$PY" /tmp/evalwork/eval_rollout.py\n'
         + 'echo "BYO_EVAL_DONE"\n'
     )
     return {
@@ -675,7 +727,11 @@ def build_isaac_eval_job_manifest(
                         {
                             "name": "eval",
                             "image": image,
-                            "imagePullPolicy": "Always",
+                            # Build-tagged Isaac images are immutable for a run.
+                            # Reuse a validated node cache when a short-lived
+                            # registry token expires; fresh nodes still pull via
+                            # the credential refresh above.
+                            "imagePullPolicy": image_pull_policy,
                             # Isaac Lab images launch through /isaac-sim/isaaclab.sh and
                             # write under the prebuilt workspace; current RTX PRO runtime
                             # requires root for that path. Keep this scoped to BYO Isaac jobs.
@@ -685,7 +741,12 @@ def build_isaac_eval_job_manifest(
                                 "requests": {gpu_resource: "1"},
                             },
                             "envFrom": [
-                                {"secretRef": {"name": "hf-ngc-tokens"}},
+                                {
+                                    "secretRef": {
+                                        "name": "hf-ngc-tokens",
+                                        "optional": True,
+                                    }
+                                },
                                 {"secretRef": {"name": "npa-storage-credentials"}},
                             ],
                             "env": [{"name": "AWS_ENDPOINT_URL", "value": s3_endpoint}]
@@ -724,6 +785,71 @@ def _download_json(uri: str) -> dict[str, Any]:
     return json.loads(Path(local).read_text())
 
 
+def _refresh_registry_pull_secret(image: str, *, namespace: str) -> None:
+    """Best-effort refresh for the short-lived Nebius registry credential."""
+
+    if _env("NPA_SIM2REAL_SKIP_REGISTRY_REFRESH") == "1":
+        return
+    try:
+        from npa.workflows.sim2real.registry_auth import (
+            ensure_registry_pull_secret_for_images,
+        )
+
+        ensure_registry_pull_secret_for_images(
+            image,
+            namespace=namespace,
+            kubeconfig=_env("KUBECONFIG"),
+        )
+        print("byo_isaac_eval: refreshed registry pull secret", flush=True)
+    except Exception as exc:
+        # The pod may still pull through another configured secret or a cached
+        # image. Preserve that fallback, but make the refresh failure visible.
+        print(
+            f"byo_isaac_eval: registry pull-secret refresh skipped: {exc}",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+def _wait_for_job_terminal(
+    job_name: str,
+    *,
+    namespace: str,
+    timeout_s: int,
+) -> tuple[bool, str]:
+    """Return promptly for either Complete or Failed Kubernetes Job state."""
+
+    deadline = time.monotonic() + timeout_s
+    last_detail = ""
+    while time.monotonic() < deadline:
+        probe = _kubectl(
+            ["get", "job", job_name, "-n", namespace, "-o", "json"],
+            timeout=120,
+        )
+        if probe.returncode == 0:
+            try:
+                payload = json.loads(probe.stdout)
+            except (TypeError, json.JSONDecodeError):
+                last_detail = "job status response was not valid JSON"
+            else:
+                for condition in payload.get("status", {}).get("conditions", []):
+                    if str(condition.get("status")).lower() != "true":
+                        continue
+                    condition_type = str(condition.get("type") or "")
+                    detail = str(
+                        condition.get("message")
+                        or condition.get("reason")
+                        or condition_type
+                    )
+                    if condition_type == "Complete":
+                        return True, detail
+                    if condition_type == "Failed":
+                        return False, detail
+        else:
+            last_detail = probe.stderr.strip() or probe.stdout.strip()
+        time.sleep(5)
+    return False, last_detail or f"timed out after {timeout_s}s"
+
 def run_isaac_eval_job(
     run_id: str,
     *,
@@ -738,6 +864,7 @@ def run_isaac_eval_job(
     sa = _env("NPA_SIM2REAL_K8S_SERVICE_ACCOUNT", "agent-sa")
     gpu_product = _env("NPA_SIM2REAL_K8S_GPU_PRODUCT", DEFAULT_GPU_PRODUCT)
     success_dist = float(_env("NPA_BYO_ISAAC_SUCCESS_DIST_M", str(DEFAULT_SUCCESS_DIST_M)) or DEFAULT_SUCCESS_DIST_M)
+    min_success_rate = float(_env("NPA_SIM2REAL_THRESHOLD", "0.0") or 0.0)
     timeout_s = int(_env("NPA_BYO_ISAAC_JOB_TIMEOUT_S", "5400") or 5400)
     from npa.workflows.sim2real.byo_isaac_trainer import artifact_tag, k8s_job_name
 
@@ -794,21 +921,56 @@ def run_isaac_eval_job(
         s3_endpoint=_env("AWS_ENDPOINT_URL"), namespace=namespace,
         service_account=sa, gpu_product=gpu_product, seed=seed, object_usd=object_usd,
         env_ids_json=json.dumps([e["env_id"] for e in gen]), renders_s3_prefix=renders_prefix,
+        success_dist_m=success_dist, min_success_rate=min_success_rate,
         robot_spec=robot_spec_dict, robot_usd_uri=robot_usd_uri, task_config=task_config_dict,
     )
+    _refresh_registry_pull_secret(image, namespace=namespace)
     _kubectl(["delete", "job", job_name, "-n", namespace, "--ignore-not-found"], timeout=60)
     apply = _kubectl(["apply", "-f", "-"], stdin=json.dumps(manifest), timeout=120)
     if apply.returncode != 0:
         raise SystemExit(f"byo_isaac_eval: kubectl apply failed: {apply.stderr}")
     print(f"byo_isaac_eval: applied {job_name} (seed={seed}, generated_envs={len(gen)}); "
           f"waiting up to {timeout_s}s", flush=True)
-    wait = _kubectl(["wait", f"job/{job_name}", "-n", namespace,
-                     "--for=condition=complete", f"--timeout={timeout_s}s"], timeout=timeout_s + 60)
-    if wait.returncode != 0:
+    completed, terminal_detail = _wait_for_job_terminal(
+        job_name,
+        namespace=namespace,
+        timeout_s=timeout_s,
+    )
+    if not completed:
         logs = _kubectl(["logs", f"job/{job_name}", "-n", namespace, "--tail=80"], timeout=120)
-        raise SystemExit(f"byo_isaac_eval: eval job {job_name} did not complete: {wait.stderr}\n{logs.stdout}")
+        failure_detail = ""
+        try:
+            failed_summary = _download_json(per_env_uri)
+            failure_detail = "\nsummary=" + json.dumps(failed_summary, sort_keys=True)
+        except Exception:
+            pass
+        raise SystemExit(
+            f"byo_isaac_eval: eval job {job_name} failed: {terminal_detail}"
+            f"{failure_detail}\n{logs.stdout}"
+        )
     out = _download_json(per_env_uri)
+    if (
+        out.get("format") != "npa.isaac_lab.eval.v1"
+        or out.get("status") != "success"
+        or out.get("policy_loaded") is not True
+    ):
+        raise RuntimeError(
+            "byo_isaac_eval: sibling did not produce a successful learned-policy "
+            f"summary: format={out.get('format')} status={out.get('status')} "
+            f"policy_loaded={out.get('policy_loaded')}"
+        )
     distances = out.get("object_goal_distances", [])
+    if len(distances) != num_envs:
+        raise RuntimeError(
+            "byo_isaac_eval: sibling summary distance count does not match "
+            f"requested environments: expected={num_envs} actual={len(distances)}"
+        )
+    global _ISAAC_EVAL_SUMMARY, _ISAAC_EVAL_SUMMARY_URI
+    _ISAAC_EVAL_SUMMARY = out
+    _ISAAC_EVAL_SUMMARY_URI = per_env_uri
+    if _RENDERS_LOCAL_DIR:
+        summary_path = Path(_RENDERS_LOCAL_DIR).parent / "isaac-eval-summary.json"
+        summary_path.write_text(json.dumps(out, indent=2), encoding="utf-8")
     # Pull the rendered frames of the (custom) object down to the local heldout
     # renders dir so stage-14 Rerun viz logs them under heldout/camera/**.
     episodes = out.get("render_episodes") or []
@@ -831,10 +993,25 @@ def run_isaac_eval_job(
     global _RENDER_MANIFEST
     _RENDER_MANIFEST = {"schema": "npa.sim2real.heldout_renders.v1", "sim_backend": "isaac",
                         "isaac_task": task, "episodes": episodes}
-    return per_env_from_distances(distances, success_dist_m=success_dist, env_ids=env_ids, seeds=seeds)
+    successes = [bool(item.get("success")) for item in out.get("episodes", [])]
+    rows = per_env_from_distances(
+        distances,
+        success_dist_m=success_dist,
+        env_ids=env_ids,
+        seeds=seeds,
+    )
+    if len(successes) == len(rows):
+        for row, success in zip(rows, successes):
+            row["success"] = success
+    return rows
 
 
 def main() -> int:
+    global _RENDERS_LOCAL_DIR, _RENDER_MANIFEST
+    global _ISAAC_EVAL_SUMMARY, _ISAAC_EVAL_SUMMARY_URI
+    _RENDER_MANIFEST = {}
+    _ISAAC_EVAL_SUMMARY = {}
+    _ISAAC_EVAL_SUMMARY_URI = ""
     output_json = _env("NPA_SIM2REAL_OUTPUT_JSON")
     if not output_json:
         print("byo_isaac_eval: NPA_SIM2REAL_OUTPUT_JSON not set", file=sys.stderr)
@@ -843,7 +1020,6 @@ def main() -> int:
     task = _env("NPA_SIM2REAL_ISAAC_TASK", DEFAULT_ISAAC_TASK)
     num_envs = int(_env("NPA_SIM2REAL_HELDOUT_ENV_COUNT", "4") or 4)
     # Heldout renders live next to the report so stage-14 viz finds them.
-    global _RENDERS_LOCAL_DIR
     _RENDERS_LOCAL_DIR = str(Path(output_json).parent / "renders")
     success_dist = float(_env("NPA_BYO_ISAAC_SUCCESS_DIST_M", str(DEFAULT_SUCCESS_DIST_M)) or DEFAULT_SUCCESS_DIST_M)
 
@@ -878,6 +1054,8 @@ def main() -> int:
     report = build_heldout_report(
         per_env, isaac_task=task, checkpoint_uri=checkpoint_uri,
         source="byo_isaac_eval_dryrun" if _env("NPA_BYO_ISAAC_DRYRUN") == "1" else "byo_isaac_eval",
+        isaac_eval_summary=_ISAAC_EVAL_SUMMARY or None,
+        isaac_eval_summary_uri=_ISAAC_EVAL_SUMMARY_URI,
     )
     report["generated_envs_tested"] = len(generated_envs)
     report["generated_env_ids"] = [e["env_id"] for e in generated_envs]

--- a/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
@@ -347,6 +347,7 @@ def build_isaac_rollout_job_manifest(
     service_account: str,
     gpu_product: str,
     gpu_resource: str = "nvidia.com/gpu",
+    image_pull_policy: str = "Always",
     object_usd: str = "",
 ) -> dict[str, Any]:
     """Isaac policy-rollout Job: roll the policy, capture frames+actions, upload.
@@ -439,7 +440,7 @@ def build_isaac_rollout_job_manifest(
                         {
                             "name": "rollout",
                             "image": image,
-                            "imagePullPolicy": "Always",
+                            "imagePullPolicy": image_pull_policy,
                             # Isaac Lab images launch through /isaac-sim/isaaclab.sh and
                             # write under the prebuilt workspace; current RTX PRO runtime
                             # requires root for that path. Keep this scoped to BYO Isaac jobs.
@@ -522,6 +523,7 @@ def run_isaac_rollout_job(
 ) -> list[str]:
     task = _env("NPA_SIM2REAL_ISAAC_TASK", DEFAULT_ISAAC_TASK)
     image = _env("NPA_SIM2REAL_ISAAC_IMAGE") or _env("ISAAC_IMAGE")
+    from npa.workflows.sim2real.engine import _image_pull_policy
     bucket = _env("NPA_SIM2REAL_BUCKET") or _env("S3_BUCKET") or _env("NPA_SIM2REAL_S3_BUCKET")
     namespace = _env("NPA_SIM2REAL_K8S_NAMESPACE", "default")
     sa = _env("NPA_SIM2REAL_K8S_SERVICE_ACCOUNT", "agent-sa")
@@ -551,6 +553,7 @@ def run_isaac_rollout_job(
         rollout_count=rollout_count, steps_per_rollout=steps_per_rollout,
         checkpoint_uri=checkpoint_uri, out_s3_prefix=out_s3, s3_endpoint=endpoint,
         namespace=namespace, service_account=sa, gpu_product=gpu_product,
+        image_pull_policy=_image_pull_policy(image),
         object_usd=object_usd,
     )
     _kubectl(["delete", "job", job_name, "-n", namespace, "--ignore-not-found"], timeout=60)

--- a/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
@@ -378,6 +378,7 @@ def build_isaac_job_manifest(
     service_account: str,
     gpu_product: str,
     gpu_resource: str = "nvidia.com/gpu",
+    image_pull_policy: str = "Always",
     reward_overrides: dict[str, float] | None = None,
     object_usd: str = "",
     object_scale: str = "",
@@ -683,7 +684,7 @@ def build_isaac_job_manifest(
                         {
                             "name": "trainer",
                             "image": image,
-                            "imagePullPolicy": "Always",
+                            "imagePullPolicy": image_pull_policy,
                             # Isaac Lab images launch through /isaac-sim/isaaclab.sh and
                             # write under the prebuilt workspace; current RTX PRO runtime
                             # requires root for that path. Keep this scoped to BYO Isaac jobs.
@@ -854,6 +855,7 @@ def run_isaac_training_job(run_id: str, *, signal_json: str) -> dict[str, Any]:
     image = _env("ISAAC_IMAGE") or _env("NPA_SIM2REAL_ISAAC_IMAGE")
     if not image:
         raise SystemExit("byo_isaac_trainer: ISAAC_IMAGE/NPA_SIM2REAL_ISAAC_IMAGE not set")
+    from npa.workflows.sim2real.engine import _image_pull_policy
     bucket = _env("NPA_SIM2REAL_BUCKET") or _env("S3_BUCKET")
     endpoint = _env("AWS_ENDPOINT_URL")
     namespace = _env("NPA_SIM2REAL_K8S_NAMESPACE", "default")
@@ -990,6 +992,7 @@ def run_isaac_training_job(run_id: str, *, signal_json: str) -> dict[str, Any]:
         namespace=namespace,
         service_account=service_account,
         gpu_product=gpu_product,
+        image_pull_policy=_image_pull_policy(image),
         reward_overrides=reward_overrides,
         object_usd=object_usd,
         object_scale=object_scale,

--- a/npa/src/npa/workflows/sim2real/engine.py
+++ b/npa/src/npa/workflows/sim2real/engine.py
@@ -3420,6 +3420,10 @@ def _normalize_heldout_report(
         "generated_env_ids",
         "policy_checkpoint",
         "deployable_policy_eval",
+        # Canonical Isaac evaluator evidence emitted by the Stage 10 sibling.
+        # Stage 11 still owns the threshold decision; Stage 14 still owns RRD/MCAP.
+        "isaac_eval_summary",
+        "isaac_eval_summary_uri",
     ):
         if payload.get(key):
             report[key] = payload[key]

--- a/npa/src/npa/workflows/sim2real/isaac_byo_robot_task.py
+++ b/npa/src/npa/workflows/sim2real/isaac_byo_robot_task.py
@@ -1224,8 +1224,17 @@ try:
         print("ROBOT_RESUME_LOADED", resume_ckpt, flush=True)
     runner.learn(num_learning_iterations=ITERS, init_at_random_ep_len=True)
     # Defensive explicit save (learn saves at save_interval; ensure one exists).
+    # On a resumed run ``current_learning_iteration`` includes the checkpoint's
+    # prior iterations, while ``ITERS`` is only the number added by this run.
+    # Preserve the historical fresh-run ``model_<ITERS>.pt`` name, but never
+    # overwrite an older numeric checkpoint with the resumed final policy.
+    final_iteration = max(
+        ITERS, int(getattr(runner, "current_learning_iteration", ITERS))
+    )
+    final_checkpoint = os.path.join(OUT, "model_%d.pt" % final_iteration)
     try:
-        runner.save(os.path.join(OUT, "model_%d.pt" % ITERS))
+        runner.save(final_checkpoint)
+        print("ROBOT_FINAL_CHECKPOINT", final_checkpoint, flush=True)
     except Exception as e:
         print("explicit save failed (learn may have saved already):", repr(e), flush=True)
     import glob

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -214,6 +214,48 @@ def test_resolve_deploy_storage_credentials_prefers_shared_artifact_bucket(monke
     assert resolved["nebius_api_key"] == "ak-shared"
 
 
+def test_resolve_deploy_storage_credentials_prefers_selected_project_storage(monkeypatch) -> None:
+    from npa.cli.agent import _resolve_deploy_storage_credentials
+
+    monkeypatch.setattr(
+        "npa.cli.agent.resolve_project_storage",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            checkpoint_bucket="s3://project-bucket/isaac-runs/",
+            endpoint_url="https://storage.us-central1.nebius.cloud",
+            aws_access_key_id="ak-project",
+            aws_secret_access_key="sk-project",
+        ),
+    )
+    monkeypatch.setattr(
+        "npa.clients.credentials.load_credentials",
+        lambda **_kwargs: SimpleNamespace(
+            s3_bucket="s3://shared-bucket/",
+            s3_endpoint="https://storage.eu-north1.nebius.cloud",
+            s3_access_key_id="ak-shared",
+            s3_secret_access_key="sk-shared",
+        ),
+    )
+    monkeypatch.setattr("npa.cli.agent._storage_credentials_allow_writes", lambda **_kwargs: True)
+    bootstrap = {
+        "service_account_id": "sa-agent",
+        "s3_bucket": "bootstrap-bucket",
+        "s3_endpoint": "https://storage.us-central1.nebius.cloud",
+        "nebius_api_key": "ak-bootstrap",
+        "nebius_secret_key": "sk-bootstrap",
+    }
+
+    resolved = _resolve_deploy_storage_credentials(
+        region="us-central1",
+        bootstrap_creds=bootstrap,
+        project_alias="target-project",
+    )
+
+    assert resolved["service_account_id"] == "sa-agent"
+    assert resolved["s3_bucket"] == "project-bucket"
+    assert resolved["s3_prefix"] == "isaac-runs"
+    assert resolved["nebius_api_key"] == "ak-project"
+
+
 def test_resolve_deploy_storage_credentials_falls_back_to_shared(monkeypatch) -> None:
     from npa.cli.agent import _resolve_deploy_storage_credentials
 

--- a/npa/tests/cli/test_isaac_lab_cli.py
+++ b/npa/tests/cli/test_isaac_lab_cli.py
@@ -804,6 +804,11 @@ def test_isaac_lab_eval_builds_remote_command(mocker) -> None:
             "survival",
             "--min-success-rate",
             "0.75",
+            "--video",
+            "--video-length",
+            "120",
+            "--video-fps",
+            "15",
             "--output-dir",
             "/tmp/isaac-eval",
         ],
@@ -828,6 +833,11 @@ def test_isaac_lab_eval_builds_remote_command(mocker) -> None:
     assert "survival" in cmd
     assert "NPA_ISAAC_EVAL_MIN_SUCCESS_RATE" in cmd
     assert "0.75" in cmd
+    assert "NPA_ISAAC_EVAL_VIDEO" in cmd
+    assert "NPA_ISAAC_EVAL_VIDEO_LENGTH" in cmd
+    assert "120" in cmd
+    assert "NPA_ISAAC_EVAL_VIDEO_FPS" in cmd
+    assert "15" in cmd
     assert "/tmp/isaac-eval" in cmd
     assert "npa.isaac_lab.eval.v1" in cmd
     assert "ISAAC_LAB_EVAL_POLICY_LOAD_FAILED" not in cmd

--- a/npa/tests/cli/test_isaac_lab_cli.py
+++ b/npa/tests/cli/test_isaac_lab_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 
 from botocore.exceptions import ClientError
@@ -795,6 +796,14 @@ def test_isaac_lab_eval_builds_remote_command(mocker) -> None:
             "/opt/isaac-lab/runs/model.pt",
             "--num-episodes",
             "3",
+            "--max-steps-per-episode",
+            "123",
+            "--seed",
+            "99",
+            "--success-metric",
+            "survival",
+            "--min-success-rate",
+            "0.75",
             "--output-dir",
             "/tmp/isaac-eval",
         ],
@@ -807,12 +816,155 @@ def test_isaac_lab_eval_builds_remote_command(mocker) -> None:
     assert "import isaaclab_tasks" in cmd
     assert "parse_env_cfg" in cmd
     assert "Isaac-Reach-Franka-v0" in cmd
-    assert "checkpoint_path = Path(" in cmd
+    assert "NPA_ISAAC_EVAL_CHECKPOINT" in cmd
     assert "/opt/isaac-lab/runs/model.pt" in cmd
-    assert "num_episodes = 3" in cmd
+    assert "NPA_ISAAC_EVAL_EPISODES" in cmd
+    assert "3" in cmd
+    assert "NPA_ISAAC_EVAL_MAX_STEPS" in cmd
+    assert "123" in cmd
+    assert "NPA_ISAAC_EVAL_SEED" in cmd
+    assert "99" in cmd
+    assert "NPA_ISAAC_EVAL_SUCCESS_METRIC" in cmd
+    assert "survival" in cmd
+    assert "NPA_ISAAC_EVAL_MIN_SUCCESS_RATE" in cmd
+    assert "0.75" in cmd
     assert "/tmp/isaac-eval" in cmd
+    assert "npa.isaac_lab.eval.v1" in cmd
+    assert "ISAAC_LAB_EVAL_POLICY_LOAD_FAILED" not in cmd
+    assert "random fallback" not in cmd
     assert "ISAAC_LAB_EVAL_EPISODE" in cmd
     assert "ISAAC_LAB_EVAL_COMPLETE" in cmd
+    assert "ISAAC_LAB_EVAL_STATUS_VERIFIED" in cmd
+
+
+def test_isaac_lab_eval_inline_script_compiles() -> None:
+    from npa.cli.isaac_lab import IsaacLabEvalMetric, _build_eval_script
+
+    script = _build_eval_script(
+        "Isaac-Velocity-Flat-Anymal-C-v0",
+        "/tmp/model.pt",
+        2,
+        "/tmp/eval",
+        success_metric=IsaacLabEvalMetric.survival,
+        success_distance_m=0.05,
+        min_success_rate=0.8,
+        max_steps_per_episode=300,
+        seed=123,
+    )
+
+    compile(script, "<isaac-lab-eval>", "exec")
+
+
+@pytest.mark.parametrize(
+    ("status", "policy_loaded", "expected_exit"),
+    [("success", True, 0), ("failed", False, 1)],
+)
+def test_isaac_lab_eval_status_check_enforces_summary(
+    tmp_path: Path, status: str, policy_loaded: bool, expected_exit: int
+) -> None:
+    from npa.cli.isaac_lab import _build_eval_status_check
+
+    (tmp_path / "npa_isaac_lab_eval_summary.json").write_text(
+        json.dumps({"status": status, "policy_loaded": policy_loaded})
+    )
+
+    completed = subprocess.run(
+        ["bash", "-lc", _build_eval_status_check(str(tmp_path))],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == expected_exit
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (["--max-steps-per-episode", "0"], "must be positive"),
+        (["--success-distance-m", "0"], "must be positive"),
+        (["--min-success-rate", "1.1"], "must be between 0 and 1"),
+    ],
+)
+def test_isaac_lab_eval_rejects_invalid_metric_options(args, message, mocker) -> None:
+    mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
+    ssh_cls = mocker.patch("npa.cli.isaac_lab.SSHClient")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "eval",
+            "--task",
+            "Isaac-Reach-Franka-v0",
+            "--checkpoint",
+            "/tmp/model.pt",
+            *args,
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert message in result.output
+    ssh_cls.assert_not_called()
+
+
+def test_isaac_lab_eval_uploads_failure_summary_directory(mocker) -> None:
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (1, "ISAAC_LAB_EVAL_FAILED", "checkpoint load failed")
+    mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
+    mocker.patch("npa.cli.isaac_lab.SSHClient", return_value=ssh)
+    upload = mocker.patch(
+        "npa.cli.isaac_lab._upload_remote_directory_to_s3",
+        return_value="s3://bucket/eval/",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "eval",
+            "--task",
+            "Isaac-Reach-Franka-v0",
+            "--checkpoint",
+            "/tmp/model.pt",
+            "--output-path",
+            "s3://bucket/eval/",
+        ],
+    )
+
+    assert result.exit_code == 1
+    upload.assert_called_once()
+
+
+def test_isaac_lab_s3_checkpoint_prefers_portable_stable_weights(mocker) -> None:
+    from npa.cli import isaac_lab
+
+    ssh = mocker.MagicMock()
+    storage = mocker.MagicMock()
+
+    def download_path(_uri: str, destination: str) -> None:
+        root = Path(destination)
+        root.mkdir(parents=True)
+        (root / "npa_isaac_lab_checkpoint_manifest.json").write_text(
+            json.dumps({"stable_checkpoint_path": "/stale/training/vm/model_1.pt"})
+        )
+        (root / "npa_isaac_lab_checkpoint.pt").write_bytes(b"weights")
+
+    storage.download_path.side_effect = download_path
+    mocker.patch("npa.cli.isaac_lab._storage_client", return_value=storage)
+
+    remote = isaac_lab._prepare_remote_input_path(
+        ssh,
+        _ssh_cfg(),
+        "s3://bucket/isaac-lab/train/",
+    )
+
+    assert remote.endswith("/npa_isaac_lab_checkpoint.pt")
+    uploaded_local, uploaded_remote = ssh.upload_file.call_args.args
+    assert Path(uploaded_local).name == "npa_isaac_lab_checkpoint.pt"
+    assert uploaded_remote == remote
 
 
 def test_isaac_lab_public_path_options_reject_local_paths(mocker) -> None:

--- a/npa/tests/cli/test_isaac_lab_cli.py
+++ b/npa/tests/cli/test_isaac_lab_cli.py
@@ -824,20 +824,13 @@ def test_isaac_lab_eval_builds_remote_command(mocker) -> None:
     assert "NPA_ISAAC_EVAL_CHECKPOINT" in cmd
     assert "/opt/isaac-lab/runs/model.pt" in cmd
     assert "NPA_ISAAC_EVAL_EPISODES" in cmd
-    assert "3" in cmd
     assert "NPA_ISAAC_EVAL_MAX_STEPS" in cmd
-    assert "123" in cmd
     assert "NPA_ISAAC_EVAL_SEED" in cmd
-    assert "99" in cmd
     assert "NPA_ISAAC_EVAL_SUCCESS_METRIC" in cmd
-    assert "survival" in cmd
     assert "NPA_ISAAC_EVAL_MIN_SUCCESS_RATE" in cmd
-    assert "0.75" in cmd
     assert "NPA_ISAAC_EVAL_VIDEO" in cmd
     assert "NPA_ISAAC_EVAL_VIDEO_LENGTH" in cmd
-    assert "120" in cmd
     assert "NPA_ISAAC_EVAL_VIDEO_FPS" in cmd
-    assert "15" in cmd
     assert "/tmp/isaac-eval" in cmd
     assert "npa.isaac_lab.eval.v1" in cmd
     assert "ISAAC_LAB_EVAL_POLICY_LOAD_FAILED" not in cmd
@@ -845,6 +838,37 @@ def test_isaac_lab_eval_builds_remote_command(mocker) -> None:
     assert "ISAAC_LAB_EVAL_EPISODE" in cmd
     assert "ISAAC_LAB_EVAL_COMPLETE" in cmd
     assert "ISAAC_LAB_EVAL_STATUS_VERIFIED" in cmd
+
+
+def test_isaac_lab_eval_script_has_exact_runtime_options() -> None:
+    from npa.cli.isaac_lab import IsaacLabEvalMetric, _build_eval_script
+
+    script = _build_eval_script(
+        "Isaac-Reach-Franka-v0",
+        "/opt/isaac-lab/runs/model.pt",
+        3,
+        "/tmp/isaac-eval",
+        success_metric=IsaacLabEvalMetric.survival,
+        min_success_rate=0.75,
+        max_steps_per_episode=123,
+        seed=99,
+        capture_video=True,
+        video_length=120,
+        video_fps=15,
+    )
+
+    expected = {
+        "NPA_ISAAC_EVAL_EPISODES": "3",
+        "NPA_ISAAC_EVAL_MAX_STEPS": "123",
+        "NPA_ISAAC_EVAL_SEED": "99",
+        "NPA_ISAAC_EVAL_SUCCESS_METRIC": "survival",
+        "NPA_ISAAC_EVAL_MIN_SUCCESS_RATE": "0.75",
+        "NPA_ISAAC_EVAL_VIDEO": "1",
+        "NPA_ISAAC_EVAL_VIDEO_LENGTH": "120",
+        "NPA_ISAAC_EVAL_VIDEO_FPS": "15",
+    }
+    for name, value in expected.items():
+        assert f"os.environ[{name!r}] = {value!r}" in script
 
 
 def test_isaac_lab_eval_inline_script_compiles() -> None:
@@ -880,7 +904,12 @@ def test_isaac_lab_eval_status_check_enforces_summary(
 
     (tmp_path / "npa_isaac_lab_eval_summary.json").write_text(
         json.dumps(
-            {"status": status, "policy_loaded": policy_loaded, "passed": passed}
+            {
+                "status": status,
+                "policy_loaded": policy_loaded,
+                "passed": passed,
+                "success_rate": 0.25,
+            }
         )
     )
 
@@ -892,6 +921,49 @@ def test_isaac_lab_eval_status_check_enforces_summary(
     )
 
     assert completed.returncode == expected_exit
+    from npa.cli.isaac_lab import _extract_eval_verdict
+
+    assert _extract_eval_verdict(completed.stdout) == {
+        "eval_status": status,
+        "passed": passed,
+        "policy_loaded": policy_loaded,
+        "success_rate": 0.25,
+    }
+
+
+def test_isaac_lab_eval_json_includes_structured_verdict(mocker) -> None:
+    ssh = mocker.MagicMock()
+    ssh.run.return_value = (
+        0,
+        'ISAAC_LAB_EVAL_RESULT_JSON {"eval_status":"success",'
+        '"passed":false,"policy_loaded":true,"success_rate":0.25}\n'
+        "ISAAC_LAB_EVAL_STATUS_VERIFIED passed=False success_rate=0.25\n",
+        "",
+    )
+    mocker.patch("npa.cli.isaac_lab.resolve_ssh_config", return_value=_ssh_cfg())
+    mocker.patch("npa.cli.isaac_lab.SSHClient", return_value=ssh)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "isaac-lab",
+            "eval",
+            "--task",
+            "Isaac-Reach-Franka-v0",
+            "--checkpoint",
+            "/tmp/model.pt",
+            "--output-format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["eval_status"] == "success"
+    assert payload["policy_loaded"] is True
+    assert payload["success_rate"] == 0.25
+    assert payload["passed"] is False
 
 
 @pytest.mark.parametrize(
@@ -981,6 +1053,34 @@ def test_isaac_lab_s3_checkpoint_prefers_portable_stable_weights(mocker) -> None
     uploaded_local, uploaded_remote = ssh.upload_file.call_args.args
     assert Path(uploaded_local).name == "npa_isaac_lab_checkpoint.pt"
     assert uploaded_remote == remote
+
+
+def test_isaac_lab_s3_checkpoint_prefers_model_latest_over_numbered(mocker) -> None:
+    from npa.cli import isaac_lab
+
+    ssh = mocker.MagicMock()
+    storage = mocker.MagicMock()
+
+    def download_path(_uri: str, destination: str) -> None:
+        root = Path(destination)
+        root.mkdir(parents=True)
+        (root / "npa_isaac_lab_checkpoint_manifest.json").write_text(
+            json.dumps({"checkpoint_path": "/stale/training/vm/model_500.pt"})
+        )
+        (root / "model_latest.pt").write_bytes(b"latest")
+        (root / "model_500.pt").write_bytes(b"500")
+        (root / "model_1500.pt").write_bytes(b"1500")
+
+    storage.download_path.side_effect = download_path
+    mocker.patch("npa.cli.isaac_lab._storage_client", return_value=storage)
+
+    remote = isaac_lab._prepare_remote_input_path(
+        ssh,
+        _ssh_cfg(),
+        "s3://bucket/isaac-lab/train/",
+    )
+
+    assert remote.endswith("/model_latest.pt")
 
 
 def test_isaac_lab_public_path_options_reject_local_paths(mocker) -> None:

--- a/npa/tests/cli/test_isaac_lab_cli.py
+++ b/npa/tests/cli/test_isaac_lab_cli.py
@@ -866,16 +866,22 @@ def test_isaac_lab_eval_inline_script_compiles() -> None:
 
 
 @pytest.mark.parametrize(
-    ("status", "policy_loaded", "expected_exit"),
-    [("success", True, 0), ("failed", False, 1)],
+    ("status", "policy_loaded", "passed", "expected_exit"),
+    [("success", True, False, 0), ("failed", False, False, 1)],
 )
 def test_isaac_lab_eval_status_check_enforces_summary(
-    tmp_path: Path, status: str, policy_loaded: bool, expected_exit: int
+    tmp_path: Path,
+    status: str,
+    policy_loaded: bool,
+    passed: bool,
+    expected_exit: int,
 ) -> None:
     from npa.cli.isaac_lab import _build_eval_status_check
 
     (tmp_path / "npa_isaac_lab_eval_summary.json").write_text(
-        json.dumps({"status": status, "policy_loaded": policy_loaded})
+        json.dumps(
+            {"status": status, "policy_loaded": policy_loaded, "passed": passed}
+        )
     )
 
     completed = subprocess.run(

--- a/npa/tests/cli/test_isaac_lab_eval_runner.py
+++ b/npa/tests/cli/test_isaac_lab_eval_runner.py
@@ -99,3 +99,19 @@ def test_eval_config_validates_quality_gate() -> None:
 
     with pytest.raises(ValueError, match="between 0 and 1"):
         config.validate()
+
+
+def test_eval_config_reads_video_environment(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("NPA_ISAAC_EVAL_TASK", "Isaac-Cartpole-v0")
+    monkeypatch.setenv("NPA_ISAAC_EVAL_CHECKPOINT", str(tmp_path / "model.pt"))
+    monkeypatch.setenv("NPA_ISAAC_EVAL_OUTPUT_DIR", str(tmp_path / "eval"))
+    monkeypatch.setenv("NPA_ISAAC_EVAL_VIDEO", "yes")
+    monkeypatch.setenv("NPA_ISAAC_EVAL_VIDEO_LENGTH", "123")
+    monkeypatch.setenv("NPA_ISAAC_EVAL_VIDEO_FPS", "24")
+
+    config = EvalConfig.from_environment()
+
+    assert config.capture_video is True
+    assert config.video_length == 123
+    assert config.video_fps == 24
+    assert config.video_dir == tmp_path / "eval" / "video"

--- a/npa/tests/cli/test_isaac_lab_eval_runner.py
+++ b/npa/tests/cli/test_isaac_lab_eval_runner.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from npa.cli.isaac_lab.eval_runner import (
+    EvalConfig,
+    apply_success_metric,
+    resolve_checkpoint,
+    resolve_success_metric,
+)
+
+
+def test_resolve_checkpoint_prefers_portable_stable_weights(tmp_path: Path) -> None:
+    stable = tmp_path / "npa_isaac_lab_checkpoint.pt"
+    stable.write_bytes(b"weights")
+    older = tmp_path / "logs" / "model_1.pt"
+    older.parent.mkdir()
+    older.write_bytes(b"older")
+
+    resolved, checkpoint_format = resolve_checkpoint(tmp_path)
+
+    assert resolved == stable
+    assert checkpoint_format == "rsl_rl_checkpoint"
+
+
+def test_resolve_checkpoint_repairs_stale_manifest_path(tmp_path: Path) -> None:
+    stable = tmp_path / "npa_isaac_lab_checkpoint.pt"
+    stable.write_bytes(b"weights")
+    manifest = tmp_path / "npa_isaac_lab_checkpoint_manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "format": "npa_isaac_lab_rsl_rl_checkpoint_v1",
+                "stable_checkpoint_path": "/old/vm/npa_isaac_lab_checkpoint.pt",
+            }
+        )
+    )
+
+    resolved, checkpoint_format = resolve_checkpoint(manifest)
+
+    assert resolved == stable
+    assert checkpoint_format == "npa_isaac_lab_rsl_rl_checkpoint_v1"
+
+
+def test_resolve_checkpoint_rejects_manifest_without_weights(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"checkpoint_path": "/old/vm/model_1.pt"}))
+
+    with pytest.raises(FileNotFoundError, match="does not resolve"):
+        resolve_checkpoint(manifest)
+
+
+@pytest.mark.parametrize(
+    ("episodes", "expected"),
+    [
+        ([{"native_success": True, "min_goal_distance_m": None}], "native-success"),
+        ([{"native_success": None, "min_goal_distance_m": 0.1}], "goal-distance"),
+        ([{"native_success": None, "min_goal_distance_m": None}], "survival"),
+    ],
+)
+def test_resolve_success_metric_auto(episodes, expected: str) -> None:
+    assert resolve_success_metric("auto", episodes) == expected
+
+
+def test_apply_goal_distance_and_survival_metrics() -> None:
+    goal_episodes = [
+        {"min_goal_distance_m": 0.04},
+        {"min_goal_distance_m": 0.08},
+    ]
+    apply_success_metric(
+        "goal-distance",
+        goal_episodes,
+        success_distance_m=0.05,
+        task="Isaac-Lift-Cube-Franka-v0",
+    )
+    assert [episode["success"] for episode in goal_episodes] == [True, False]
+
+    survival_episodes = [{"terminated": False}, {"terminated": True}]
+    apply_success_metric(
+        "survival",
+        survival_episodes,
+        success_distance_m=0.05,
+        task="Isaac-Velocity-Flat-Anymal-C-v0",
+    )
+    assert [episode["success"] for episode in survival_episodes] == [True, False]
+
+
+def test_eval_config_validates_quality_gate() -> None:
+    config = EvalConfig(
+        task="Isaac-Cartpole-v0",
+        checkpoint=Path("/tmp/model.pt"),
+        num_episodes=1,
+        output_dir=Path("/tmp/eval"),
+        min_success_rate=1.1,
+    )
+
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        config.validate()

--- a/npa/tests/cli/test_isaac_lab_eval_runner.py
+++ b/npa/tests/cli/test_isaac_lab_eval_runner.py
@@ -8,6 +8,7 @@ import pytest
 
 from npa.cli.isaac_lab.eval_runner import (
     EvalConfig,
+    _as_bool,
     apply_success_metric,
     resolve_checkpoint,
     resolve_success_metric,
@@ -47,6 +48,43 @@ def test_resolve_checkpoint_repairs_stale_manifest_path(tmp_path: Path) -> None:
     assert checkpoint_format == "npa_isaac_lab_rsl_rl_checkpoint_v1"
 
 
+def test_resolve_checkpoint_prefers_model_latest_over_numbered(tmp_path: Path) -> None:
+    latest = tmp_path / "model_latest.pt"
+    latest.write_bytes(b"latest")
+    (tmp_path / "model_1500.pt").write_bytes(b"numbered")
+
+    resolved, _ = resolve_checkpoint(tmp_path)
+
+    assert resolved == latest
+
+
+def test_resolve_checkpoint_uses_highest_numbered_fallback(tmp_path: Path) -> None:
+    (tmp_path / "model_500.pt").write_bytes(b"older")
+    newest = tmp_path / "model_1500.pt"
+    newest.write_bytes(b"newest")
+    (tmp_path / "model_1000.pt").write_bytes(b"middle")
+
+    resolved, _ = resolve_checkpoint(tmp_path)
+
+    assert resolved == newest
+
+
+def test_resolve_checkpoint_prefers_portable_sibling_over_declared_path(
+    tmp_path: Path,
+) -> None:
+    declared = tmp_path / "old" / "model_9000.pt"
+    declared.parent.mkdir()
+    declared.write_bytes(b"stale-but-present")
+    portable = tmp_path / "model_latest.pt"
+    portable.write_bytes(b"portable")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"checkpoint_path": str(declared)}))
+
+    resolved, _ = resolve_checkpoint(manifest)
+
+    assert resolved == portable
+
+
 def test_resolve_checkpoint_rejects_manifest_without_weights(tmp_path: Path) -> None:
     manifest = tmp_path / "manifest.json"
     manifest.write_text(json.dumps({"checkpoint_path": "/old/vm/model_1.pt"}))
@@ -74,6 +112,24 @@ def test_resolve_success_metric_auto_requires_native_success_for_every_episode()
     ]
 
     assert resolve_success_metric("auto", episodes) == "goal-distance"
+
+
+def test_resolve_success_metric_auto_rejects_empty_episodes() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        resolve_success_metric("auto", [])
+
+
+def test_as_bool_returns_none_when_tensor_conversion_fails() -> None:
+    class _BrokenTorch:
+        @staticmethod
+        def as_tensor(_value):
+            raise TypeError("not tensor-like")
+
+    class _TruthyValue:
+        def __bool__(self) -> bool:
+            return True
+
+    assert _as_bool(_TruthyValue(), _BrokenTorch()) is None
 
 
 def test_apply_goal_distance_and_survival_metrics() -> None:
@@ -159,3 +215,28 @@ def test_write_eval_summary_keeps_quality_failure_separate_from_runtime(
     assert summary["policy_loaded"] is True
     assert summary["success_rate"] == 0.5
     assert summary["passed"] is False
+
+
+def test_write_eval_summary_preserves_unavailable_reward_as_null(
+    tmp_path: Path,
+) -> None:
+    checkpoint = tmp_path / "model.pt"
+    config = EvalConfig(
+        task="Isaac-Lift-Cube-Franka-v0",
+        checkpoint=checkpoint,
+        num_episodes=1,
+        output_dir=tmp_path / "eval",
+        success_metric="goal-distance",
+    )
+
+    summary = write_eval_summary(
+        config,
+        episode_results=[{"reward": None, "min_goal_distance_m": 0.01}],
+        checkpoint_file=checkpoint,
+        checkpoint_format="rsl_rl_checkpoint",
+        device="cuda:0",
+        started=time.time(),
+    )
+
+    assert summary["mean_reward"] is None
+    assert summary["episodes"][0]["reward"] is None

--- a/npa/tests/cli/test_isaac_lab_eval_runner.py
+++ b/npa/tests/cli/test_isaac_lab_eval_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import time
 
 import pytest
 
@@ -10,6 +11,7 @@ from npa.cli.isaac_lab.eval_runner import (
     apply_success_metric,
     resolve_checkpoint,
     resolve_success_metric,
+    write_eval_summary,
 )
 
 
@@ -65,6 +67,15 @@ def test_resolve_success_metric_auto(episodes, expected: str) -> None:
     assert resolve_success_metric("auto", episodes) == expected
 
 
+def test_resolve_success_metric_auto_requires_native_success_for_every_episode() -> None:
+    episodes = [
+        {"native_success": True, "min_goal_distance_m": 0.01},
+        {"native_success": None, "min_goal_distance_m": 0.20},
+    ]
+
+    assert resolve_success_metric("auto", episodes) == "goal-distance"
+
+
 def test_apply_goal_distance_and_survival_metrics() -> None:
     goal_episodes = [
         {"min_goal_distance_m": 0.04},
@@ -115,3 +126,36 @@ def test_eval_config_reads_video_environment(monkeypatch, tmp_path: Path) -> Non
     assert config.video_length == 123
     assert config.video_fps == 24
     assert config.video_dir == tmp_path / "eval" / "video"
+
+
+def test_write_eval_summary_keeps_quality_failure_separate_from_runtime(
+    tmp_path: Path,
+) -> None:
+    checkpoint = tmp_path / "model.pt"
+    config = EvalConfig(
+        task="Isaac-Lift-Cube-Franka-v0",
+        checkpoint=checkpoint,
+        num_episodes=2,
+        output_dir=tmp_path / "eval",
+        success_metric="goal-distance",
+        success_distance_m=0.05,
+        min_success_rate=1.0,
+    )
+    episodes = [
+        {"reward": 1.0, "min_goal_distance_m": 0.01},
+        {"reward": 0.0, "min_goal_distance_m": 0.20},
+    ]
+
+    summary = write_eval_summary(
+        config,
+        episode_results=episodes,
+        checkpoint_file=checkpoint,
+        checkpoint_format="rsl_rl_checkpoint",
+        device="cuda:0",
+        started=time.time(),
+    )
+
+    assert summary["status"] == "success"
+    assert summary["policy_loaded"] is True
+    assert summary["success_rate"] == 0.5
+    assert summary["passed"] is False

--- a/npa/tests/workflows/test_byo_isaac_eval.py
+++ b/npa/tests/workflows/test_byo_isaac_eval.py
@@ -25,7 +25,7 @@ def test_extract_checkpoint_uri_absent_returns_empty():
 def test_per_env_from_distances_scoring():
     rows = ev.per_env_from_distances([0.0, 0.05, 0.2], success_dist_m=0.05)
     assert rows[0]["success"] is True and rows[0]["score"] == 1.0
-    assert rows[1]["success"] is False  # 0.05 is not < 0.05
+    assert rows[1]["success"] is True  # boundary agrees with eval_runner (<=)
     assert rows[2]["success"] is False and rows[2]["score"] == 0.0
     assert rows[0]["details"]["object_goal_distance_m"] == 0.0
 
@@ -41,7 +41,7 @@ def test_build_isaac_eval_job_manifest_shape():
     )
     c = m["spec"]["template"]["spec"]["containers"][0]
     assert c["image"].endswith("npa-isaac-lab:2.3.2.post1")
-    assert c["imagePullPolicy"] == "IfNotPresent"
+    assert c["imagePullPolicy"] == "Always"
     assert c["resources"]["limits"]["nvidia.com/gpu"] == "1"
     args = c["args"][0]
     assert "Isaac-Lift-Cube-Franka-v0" in args
@@ -72,6 +72,7 @@ def test_run_isaac_eval_job_uses_outer_iteration_artifact_tag(monkeypatch):
         captured["renders_s3_prefix"] = kwargs["renders_s3_prefix"]
         captured["min_success_rate"] = kwargs["min_success_rate"]
         captured["success_dist_m"] = kwargs["success_dist_m"]
+        captured["image_pull_policy"] = kwargs["image_pull_policy"]
         return {"kind": "Job"}
 
     monkeypatch.setattr(ev, "build_isaac_eval_job_manifest", fake_build)
@@ -101,6 +102,7 @@ def test_run_isaac_eval_job_uses_outer_iteration_artifact_tag(monkeypatch):
     monkeypatch.setenv("NPA_SIM2REAL_BUCKET", "bkt")
     monkeypatch.setenv("NPA_SIM2REAL_EVAL_TAG", "outer-02")
     monkeypatch.setenv("NPA_SIM2REAL_THRESHOLD", "0.75")
+    monkeypatch.setenv("NPA_SIM2REAL_IMAGE_PULL_POLICY", "Never")
 
     rows = ev.run_isaac_eval_job(
         "myrun",
@@ -117,6 +119,7 @@ def test_run_isaac_eval_job_uses_outer_iteration_artifact_tag(monkeypatch):
     assert captured["renders_s3_prefix"].endswith("/byo-eval/s2r-byo-isaac-eval-myrun-outer-02/renders")
     assert captured["min_success_rate"] == 0.75
     assert captured["success_dist_m"] == ev.DEFAULT_SUCCESS_DIST_M
+    assert captured["image_pull_policy"] == "Never"
 
 
 def test_wait_for_job_terminal_returns_failed_without_waiting(monkeypatch):
@@ -226,6 +229,21 @@ def test_eval_script_uses_oblique_workspace_camera_for_renders():
     assert 'convention="world"' in script
     assert "width=256" in script and "height=256" in script
     assert "clipping_range=(0.05, 20.0)" in script
+
+
+def test_eval_script_marks_unavailable_reward_null_instead_of_zero() -> None:
+    script = ev.ISAAC_EVAL_SCRIPT
+
+    assert "reward_metric_unavailable" in script
+    assert '"reward": float(reward_sum[i]) if reward_available else None' in script
+    assert "reward batch does not match environment count" in script
+
+
+def test_main_rejects_invalid_threshold_before_launch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("NPA_SIM2REAL_OUTPUT_JSON", str(tmp_path / "report.json"))
+    monkeypatch.setenv("NPA_SIM2REAL_THRESHOLD", "90")
+
+    assert ev.main() == 2
 
 
 def test_eval_manifest_embeds_custom_object_usd():

--- a/npa/tests/workflows/test_byo_isaac_eval.py
+++ b/npa/tests/workflows/test_byo_isaac_eval.py
@@ -41,12 +41,21 @@ def test_build_isaac_eval_job_manifest_shape():
     )
     c = m["spec"]["template"]["spec"]["containers"][0]
     assert c["image"].endswith("npa-isaac-lab:2.3.2.post1")
+    assert c["imagePullPolicy"] == "IfNotPresent"
     assert c["resources"]["limits"]["nvidia.com/gpu"] == "1"
     args = c["args"][0]
     assert "Isaac-Lift-Cube-Franka-v0" in args
     assert "s3://b/run1/model_latest.pt" in args      # downloads the checkpoint
     assert "eval_rollout.py" in args                  # runs the policy rollout
     assert "per_env_distances.json" in args           # uploads measured distances
+    assert "isaac_eval_runner.py" in args             # shared canonical evaluator
+    assert "load_rsl_rl_policy" in args
+    assert '|| echo "EVAL_SCRIPT_RC=$?"' not in args  # fail closed
+    assert "[0.5]*N" not in args                      # no fabricated failure result
+    assert c["envFrom"][0]["secretRef"] == {
+        "name": "hf-ngc-tokens",
+        "optional": True,
+    }
 
 
 def test_run_isaac_eval_job_uses_outer_iteration_artifact_tag(monkeypatch):
@@ -61,14 +70,37 @@ def test_run_isaac_eval_job_uses_outer_iteration_artifact_tag(monkeypatch):
         captured["job_name"] = kwargs["job_name"]
         captured["per_env_s3_uri"] = kwargs["per_env_s3_uri"]
         captured["renders_s3_prefix"] = kwargs["renders_s3_prefix"]
+        captured["min_success_rate"] = kwargs["min_success_rate"]
+        captured["success_dist_m"] = kwargs["success_dist_m"]
         return {"kind": "Job"}
 
     monkeypatch.setattr(ev, "build_isaac_eval_job_manifest", fake_build)
-    monkeypatch.setattr(ev, "_kubectl", lambda *a, **k: _Proc())
-    monkeypatch.setattr(ev, "_download_json", lambda _uri: {"object_goal_distances": [0.01]})
+    monkeypatch.setattr(ev, "_refresh_registry_pull_secret", lambda *a, **k: None)
+
+    def fake_kubectl(args, **_kwargs):
+        proc = _Proc()
+        if args[:2] == ["get", "job"]:
+            proc.stdout = json.dumps(
+                {"status": {"conditions": [{"type": "Complete", "status": "True"}]}}
+            )
+        return proc
+
+    monkeypatch.setattr(ev, "_kubectl", fake_kubectl)
+    monkeypatch.setattr(
+        ev,
+        "_download_json",
+        lambda _uri: {
+            "format": "npa.isaac_lab.eval.v1",
+            "status": "success",
+            "policy_loaded": True,
+            "object_goal_distances": [0.01],
+            "episodes": [{"success": True}],
+        },
+    )
     monkeypatch.setenv("NPA_SIM2REAL_ISAAC_IMAGE", "reg/npa-isaac-lab:2.3.2.post1")
     monkeypatch.setenv("NPA_SIM2REAL_BUCKET", "bkt")
     monkeypatch.setenv("NPA_SIM2REAL_EVAL_TAG", "outer-02")
+    monkeypatch.setenv("NPA_SIM2REAL_THRESHOLD", "0.75")
 
     rows = ev.run_isaac_eval_job(
         "myrun",
@@ -83,6 +115,36 @@ def test_run_isaac_eval_job_uses_outer_iteration_artifact_tag(monkeypatch):
         "/byo-eval/s2r-byo-isaac-eval-myrun-outer-02/per_env_distances.json"
     )
     assert captured["renders_s3_prefix"].endswith("/byo-eval/s2r-byo-isaac-eval-myrun-outer-02/renders")
+    assert captured["min_success_rate"] == 0.75
+    assert captured["success_dist_m"] == ev.DEFAULT_SUCCESS_DIST_M
+
+
+def test_wait_for_job_terminal_returns_failed_without_waiting(monkeypatch):
+    class _Proc:
+        returncode = 0
+        stderr = ""
+        stdout = json.dumps(
+            {
+                "status": {
+                    "conditions": [
+                        {
+                            "type": "Failed",
+                            "status": "True",
+                            "message": "policy load failed",
+                        }
+                    ]
+                }
+            }
+        )
+
+    monkeypatch.setattr(ev, "_kubectl", lambda *a, **k: _Proc())
+
+    completed, detail = ev._wait_for_job_terminal(
+        "eval-job", namespace="default", timeout_s=60
+    )
+
+    assert completed is False
+    assert detail == "policy load failed"
 
 
 def test_dryrun_main_writes_normalizable_report(tmp_path, monkeypatch):
@@ -158,6 +220,7 @@ def test_eval_manifest_embeds_generated_seed():
 
 def test_eval_script_uses_oblique_workspace_camera_for_renders():
     script = ev.ISAAC_EVAL_SCRIPT
+    compile(script, "<sim2real-isaac-eval>", "exec")
     assert "pos=(-2.0, 0.0, 1.0)" in script
     assert "rot=(0.9945, 0.0, 0.1045, 0.0)" in script
     assert 'convention="world"' in script
@@ -225,6 +288,12 @@ def test_normalize_heldout_preserves_render_manifest_and_provenance():
         "deployable_policy_eval": True,
         "generated_envs_tested": 1,
         "generated_env_ids": ["env-00000"],
+        "isaac_eval_summary": {
+            "format": "npa.isaac_lab.eval.v1",
+            "status": "success",
+            "policy_loaded": True,
+        },
+        "isaac_eval_summary_uri": "s3://b/run/isaac-eval-summary.json",
     }
     cfg = build_config_from_env(threshold=0.45, s3_bucket="", run_id="t")
     report = _normalize_heldout_report(payload, config=cfg, outer_iteration=1,
@@ -233,6 +302,8 @@ def test_normalize_heldout_preserves_render_manifest_and_provenance():
     assert report["policy_checkpoint"].endswith("model_latest.pt")
     assert report["deployable_policy_eval"] is True
     assert report["generated_envs_tested"] == 1
+    assert report["isaac_eval_summary"]["policy_loaded"] is True
+    assert report["isaac_eval_summary_uri"].startswith("s3://")
 
 
 def test_build_heldout_report_multi_threshold_success_summary():

--- a/npa/tests/workflows/test_byo_isaac_policy_rollout.py
+++ b/npa/tests/workflows/test_byo_isaac_policy_rollout.py
@@ -90,6 +90,7 @@ def test_build_isaac_rollout_job_manifest_shape():
     assert m["kind"] == "Job"
     c = m["spec"]["template"]["spec"]["containers"][0]
     assert c["image"] == "reg/npa-isaac-lab:2.3.2.post1"
+    assert c["imagePullPolicy"] == "Always"
     script = c["args"][0]
     # downloads the checkpoint, applies the custom object, runs the rollout script.
     assert "DOWNLOADED_CKPT" in script
@@ -131,6 +132,7 @@ def test_run_isaac_rollout_job_uses_outer_iteration_artifact_tag(tmp_path, monke
     def fake_build(**kwargs):
         captured["job_name"] = kwargs["job_name"]
         captured["out_s3_prefix"] = kwargs["out_s3_prefix"]
+        captured["image_pull_policy"] = kwargs["image_pull_policy"]
         return {"kind": "Job"}
 
     monkeypatch.setitem(sys.modules, "boto3", _FakeBoto3())
@@ -140,6 +142,7 @@ def test_run_isaac_rollout_job_uses_outer_iteration_artifact_tag(tmp_path, monke
     monkeypatch.setattr(pr, "materialize_rollout_dirs", lambda *a, **k: [])
     monkeypatch.setenv("NPA_SIM2REAL_ISAAC_IMAGE", "reg/npa-isaac-lab:2.3.2.post1")
     monkeypatch.setenv("NPA_SIM2REAL_BUCKET", "bkt")
+    monkeypatch.setenv("NPA_SIM2REAL_IMAGE_PULL_POLICY", "Never")
 
     pr.run_isaac_rollout_job(
         tmp_path / "actions" / "train" / "outer-02" / "iter-01",
@@ -150,3 +153,4 @@ def test_run_isaac_rollout_job_uses_outer_iteration_artifact_tag(tmp_path, monke
 
     assert captured["job_name"].endswith("outer-02-iter-01")
     assert captured["out_s3_prefix"].endswith("/byo-rollouts/outer-02-iter-01")
+    assert captured["image_pull_policy"] == "Never"

--- a/npa/tests/workflows/test_byo_isaac_trainer.py
+++ b/npa/tests/workflows/test_byo_isaac_trainer.py
@@ -98,6 +98,7 @@ def test_build_isaac_job_manifest_shape():
     spec = manifest["spec"]["template"]["spec"]
     container = spec["containers"][0]
     assert container["image"] == "reg/npa-isaac-lab:2.3.2.post1"
+    assert container["imagePullPolicy"] == "Always"
     assert container["resources"]["limits"]["nvidia.com/gpu"] == "1"
     assert spec["nodeSelector"]["nvidia.com/gpu.product"].startswith("NVIDIA-RTX-PRO")
     args = container["args"][0]
@@ -397,6 +398,7 @@ def test_run_isaac_training_job_tags_s3_path_per_iteration(monkeypatch):
     def fake_build(*args, **kwargs):
         captured["s3_output_uri"] = kwargs["s3_output_uri"]
         captured["resume_uri"] = kwargs.get("resume_uri", "")
+        captured["image_pull_policy"] = kwargs["image_pull_policy"]
         return {"manifest": True}
 
     class _Proc:
@@ -412,6 +414,7 @@ def test_run_isaac_training_job_tags_s3_path_per_iteration(monkeypatch):
     monkeypatch.setenv("NPA_SIM2REAL_BUCKET", "bkt")
     monkeypatch.setenv("NPA_SIM2REAL_TRAINER_TAG", "outer-02-iter-01")
     monkeypatch.setenv("NPA_SIM2REAL_RESUME_CHECKPOINT_URI", "s3://bkt/prior/model_latest.pt")
+    monkeypatch.setenv("NPA_SIM2REAL_IMAGE_PULL_POLICY", "Never")
     monkeypatch.delenv("NPA_BYO_ISAAC_PHYSICS", raising=False)
 
     result = byo.run_isaac_training_job("myrun", signal_json="ignored")
@@ -420,5 +423,6 @@ def test_run_isaac_training_job_tags_s3_path_per_iteration(monkeypatch):
     assert "byo-trainer" in captured["s3_output_uri"]
     # resume uri threaded through to the manifest builder
     assert captured["resume_uri"] == "s3://bkt/prior/model_latest.pt"
+    assert captured["image_pull_policy"] == "Never"
     # returned checkpoint points at the tagged path
     assert result["checkpoint_path"].endswith("/outer-02-iter-01/model_latest.pt")

--- a/npa/tests/workflows/test_isaac_byo_robot_task.py
+++ b/npa/tests/workflows/test_isaac_byo_robot_task.py
@@ -323,6 +323,10 @@ def test_train_wrapper_enforces_boot_before_isaac_imports():
     # trains via the rsl_rl runner and emits the done/ckpt markers
     assert "OnPolicyRunner" in s and "runner.learn" in s
     assert "ROBOT_TRAIN_DONE" in s
+    # A resumed run must name its explicit final checkpoint with the runner's
+    # absolute iteration rather than overwrite model_<added iterations>.pt.
+    assert 'getattr(runner, "current_learning_iteration", ITERS)' in s
+    assert "ROBOT_FINAL_CHECKPOINT" in s
     # refuses a silent stock fallback when a customer USD was requested
     assert "ROBOT_USD_MISMATCH" in s
     # surfaces the retarget plan + the honest task/robot compatibility verdict

--- a/skills/tools/isaac-lab/SKILL.md
+++ b/skills/tools/isaac-lab/SKILL.md
@@ -59,6 +59,28 @@ npa workbench isaac-lab system-info
 npa workbench isaac-lab list
 ```
 
+### Standalone checkpoint eval
+
+`npa workbench isaac-lab eval` runs the supplied RSL-RL policy headlessly; it
+does not invoke a VLM. Checkpoint loading is fail-closed: a load error produces
+a structured failure artifact and a non-zero command result, never a
+random-action substitute.
+
+Choose the success predicate to match the task:
+
+- `--success-metric survival` for locomotion, with termination as failure;
+- `--success-metric goal-distance --success-distance-m <metres>` for
+  manipulation or reach tasks;
+- `--success-metric auto` to prefer a simulator-native success signal, then a
+  measurable goal distance, and otherwise survival.
+
+Use `--seed`, `--num-episodes`, `--max-steps-per-episode`, and
+`--min-success-rate` for a repeatable held-out evaluation. The output is
+`npa_isaac_lab_eval_summary.json` with format `npa.isaac_lab.eval.v1`; it
+records checkpoint provenance, `policy_loaded`, per-episode metrics,
+`success_rate`, and `passed`. An S3 output prefix is uploaded on both runtime
+success and failure so failed evaluations remain diagnosable.
+
 ## Custom Forks
 
 Canonical onboarding starts at `docs/workbench/getting-started.md`; do not

--- a/skills/tools/isaac-lab/SKILL.md
+++ b/skills/tools/isaac-lab/SKILL.md
@@ -81,7 +81,10 @@ records checkpoint provenance, `policy_loaded`, per-episode metrics,
 `success_rate`, and `passed`. An S3 output prefix is uploaded on both runtime
 success and failure so failed evaluations remain diagnosable. `passed=false`
 does not turn a completed rollout into a runtime error; automation should gate
-on `passed` (the Sim2Real workflow does this in Stage 11).
+on `passed` (the Sim2Real workflow does this in Stage 11). With
+`--output-format json`, `eval_status`, `policy_loaded`, `success_rate`, and
+`passed` are top-level structured CLI fields; callers do not need to scrape
+the remote log tail.
 
 ## Custom Forks
 

--- a/skills/tools/isaac-lab/SKILL.md
+++ b/skills/tools/isaac-lab/SKILL.md
@@ -79,7 +79,9 @@ Use `--seed`, `--num-episodes`, `--max-steps-per-episode`, and
 `npa_isaac_lab_eval_summary.json` with format `npa.isaac_lab.eval.v1`; it
 records checkpoint provenance, `policy_loaded`, per-episode metrics,
 `success_rate`, and `passed`. An S3 output prefix is uploaded on both runtime
-success and failure so failed evaluations remain diagnosable.
+success and failure so failed evaluations remain diagnosable. `passed=false`
+does not turn a completed rollout into a runtime error; automation should gate
+on `passed` (the Sim2Real workflow does this in Stage 11).
 
 ## Custom Forks
 
@@ -120,6 +122,17 @@ Select with `--sim-backend`, env `NPA_SIM2REAL_SIM_BACKEND`, or the runbook
 YAML. Both backends emit the identical `npa.sim2real.heldout_eval.v1` per-env
 schema (`env_id`/`score`/`success`/`details`), so `report.json` and the
 outer-loop gate are backend-agnostic. The VLM eval (Cosmos-Reason) is unchanged.
+
+When Stage 10 has a genuine Isaac trainer checkpoint, object storage, and a
+registry-qualified Isaac image, it selects `byo_isaac_eval`. That vectorized
+adapter uses the standalone evaluator's shared `load_rsl_rl_policy`, metric,
+`npa.isaac_lab.eval.v1`, and failure-summary implementation while retaining
+generated-environment IDs/seeds and held-out camera capture. It writes
+`eval/heldout/isaac-eval-summary.json` and nests the same evidence in
+`eval/heldout/report.json`. Runtime, checkpoint, or policy-load failure aborts
+Stage 10; `passed=false` means the eval completed below its quality bar and is
+handled by the Stage 11 threshold gate. Stage 14 remains responsible for the
+run-level RRD/MCAP visualization artifacts.
 
 Asset handling mirrors the Genesis no-fallback provenance discipline:
 


### PR DESCRIPTION
## What changed

- replace the inline Isaac Lab evaluator with a reusable, versioned `npa.isaac_lab.eval.v1` runner
- fail closed when checkpoint resolution or RSL-RL policy loading fails; never substitute random actions or fabricated rollout distances
- add held-out controls and task-appropriate `auto`, `goal-distance`, and `survival` success metrics
- deterministically prefer portable/final weights (`npa_isaac_lab_checkpoint.pt`, `model_latest.pt`, then `model.pt`) and the highest numeric checkpoint fallback
- preserve structured S3 failure artifacts and enforce their status when the Isaac bootstrap shim masks a child exit code
- expose `eval_status`, `policy_loaded`, `success_rate`, and `passed` as top-level `--output-format json` fields
- add opt-in camera/video capture (`--video`, length, and FPS controls) with a fail-closed MP4 artifact check
- incorporate the shared policy loader, metric resolution, summary schema, and failure writer into canonical Sim2Real Stage 10
- keep Stage 11 as the policy-quality gate and Stage 14 as the RRD/MCAP owner
- use the canonical Sim2Real image-pull policy for Isaac train, policy-rollout, and eval Jobs; the operator override and digest/tag provenance now apply consistently
- emit `null`, with a visible warning, when Stage 10 cannot measure rewards instead of silently publishing zero reward
- validate the Sim2Real success threshold before launching the GPU sibling and use the same inclusive distance boundary in both evaluator adapters
- document the standalone and Sim2Real policy-eval workflows and explicitly keep VLM evaluation out of scope

## Why

The previous evaluator could silently execute random actions after a checkpoint-load failure, used a manipulation-specific distance metric for every task, and could select a stale or mid-training checkpoint instead of the portable final weights. Container evaluation also trusted the Isaac bootstrap shim's exit code, which can mask a failed Python child process.

Sim2Real Stage 10 carried a second embedded policy loader, converted rollout failures into synthetic `0.5 m` distances, and could silently report zero reward after a batch-conversion error. Stage 10 now reuses the canonical evaluator contract, preserves its detailed evidence in `eval/heldout/report.json`, and writes `eval/heldout/isaac-eval-summary.json`. Runtime, checkpoint, policy-load, and artifact failures abort the stage; an unavailable auxiliary reward is explicit `null` while the real goal-distance verdict remains usable.

## Additional scope already present in this PR

- agent deploy now prefers the selected project's object-storage configuration over shared bootstrap credentials; this prevents the agent from indexing a different project's artifact bucket
- resumed Isaac training preserves the final numeric checkpoint name while fresh runs retain the existing naming behavior
- `hf-ngc-tokens` is optional for the eval sibling because the OSS Isaac bootstrap and S3 artifact path do not require NGC/HF credentials; the storage credential remains mandatory

## Impact

Isaac Lab evaluation now proves whether a real learned policy was loaded, emits repeatable per-episode and aggregate metrics, records an explicit quality result, and returns non-zero for load/runtime/artifact failures. A completed evaluation below the configured rate remains `status=success`, `passed=false`; Sim2Real Stage 11 decides promote versus loop-back. Stage 14 remains responsible for run-level RRD and MCAP artifacts. No VLM evaluation is invoked.

## Validation

- focused Isaac/Sim2Real/agent regression suite: `349 passed`
- guardrails: `1472 passed, 1 skipped`
- complete non-E2E suite: `6651 passed, 47 skipped, 1 xpassed`
- Ruff and `git diff --check`: pass
- real multi-GPU closeout run: `isaac-mgpu-viz-uscentral1-20260806t204819z`
  - 4 × NVIDIA RTX PRO 6000 Blackwell Server Edition GPUs in `us-central1`
  - 64 episodes, 58 successes, 90.625% aggregate success, all workers passed
  - RRD, MP4, MCAP, aggregate, checkpoint, manifest, and four worker summaries indexed as 10 run artifacts
- fail-closed RTX PRO 6000 run: Kubernetes Job `isaac-eval-failclosed-enforced` exited 1 at `stage=policy_load` with `policy_loaded=false`
- review-fix live Sim2Real Stage 10 validation (2 GPUs concurrently on distinct nodes, 4 generated environments per GPU):
  - `s2r262fix2a-20260807t210200z`: learned policy loaded, 3/4 success, mean reward `139.8881`, zero null rewards, 90 render artifacts
  - `s2r262fix2b-20260807t210200z`: learned policy loaded, 4/4 success, mean reward `146.5878`, zero null rewards, 90 render artifacts
  - both Jobs completed and preserved `npa.isaac_lab.eval.v1` inside normalized Stage 10 reports

The closeout evaluation intentionally contains no VLM stage.
