### PR TITLE
Add Cosmos 3 access preflight guide and xet/401-403 diagnostics

### DIFF
--- a/docs/workbench/cosmos3-access-preflight.md
+++ b/docs/workbench/cosmos3-access-preflight.md
@@ -1,0 +1,125 @@
+# Cosmos 3 access preflight: accounts, tokens, and gated-repo diagnostics
+
+Clearing gated Hugging Face access is the most common reason a Cosmos 3
+generation run fails before it produces anything. This page is the full
+checklist: create the account, scope the token, accept the right license for
+the serving path you are using, and read the two failure signatures that look
+like credential problems but are not the same one.
+
+See [`cosmos3-generate.md`](cosmos3-generate.md) for the credential table this
+extends and for `--dry-run`, which resolves everything below except the
+network calls themselves, so you can confirm mode and checkpoint on a laptop
+before spending GPU time.
+
+## Hugging Face account and token
+
+1. Create a Hugging Face account at <https://huggingface.co/join> if you do
+   not already have one.
+2. Create a token at <https://huggingface.co/settings/tokens>. A read-scoped
+   token is enough; generation only downloads weights, it never pushes.
+3. Export it as `HF_TOKEN` (or set `NPA_COSMOS3_HF_TOKEN_ENV` to the name of
+   an env var you already use for a different token).
+4. Accept the license for every gated repo your run touches before the run,
+   not during it. `require_model_access` only checks that a token is present;
+   it cannot check that the token's account has accepted a given repo's
+   license, so an unaccepted license surfaces later, mid-download, as the 403
+   case in the diagnostic below.
+
+## Two gated guardrail repos, split by serving path
+
+Cosmos 3's guardrail models are gated separately from the base checkpoint,
+and **which guardrail repo you need depends on how you are serving the
+model**, not on which Cosmos 3 checkpoint you picked. Accepting one license
+does not accept the other.
+
+| Serving path | Guardrail repo | Accept the license at |
+| --- | --- | --- |
+| `npa workbench cosmos3 generate` (this repo, cosmos-framework) | `nvidia/Cosmos-Guardrail1` | <https://huggingface.co/nvidia/Cosmos-Guardrail1> |
+| vLLM-Omni serving (e.g. the `vllm/vllm-omni:cosmos3` container, outside npa) | `nvidia/Cosmos-1.0-Guardrail` | <https://huggingface.co/nvidia/Cosmos-1.0-Guardrail> |
+
+An operator who has cleared the vLLM-Omni guardrail repo for a serving
+deployment and then runs `npa workbench cosmos3 generate` for the first time
+still fails mid-download until they separately accept
+`nvidia/Cosmos-Guardrail1`, and the reverse is also true. Both paths can skip
+the guardrail download entirely: pass `--no-guardrails` to
+`npa workbench cosmos3 generate` per run, or to `vllm serve` at server launch
+on the vLLM-Omni path.
+
+## The 401-vs-403 diagnostic
+
+A gated-repo failure during download can come from two different causes that
+produce two different HTTP status codes. Distinguishing them tells you
+whether the problem is the token or the license:
+
+| Request | Status | Meaning |
+| --- | --- | --- |
+| Anonymous request to the gated repo URL | `401` | No valid token reached Hugging Face: it is missing, empty, malformed, or revoked. |
+| Authenticated request with the token you configured | `403` | The token is valid and reached Hugging Face; the account behind it has not accepted this repo's license yet. |
+
+Measured signature, from the vLLM-Omni serving path (`nvidia/Cosmos-1.0-Guardrail`,
+before the license was accepted; shown because the same status-code
+diagnostic applies on either path):
+
+```
+GatedRepoError: 401 Client Error
+Cannot access gated repo for url
+https://huggingface.co/nvidia/Cosmos-1.0-Guardrail/resolve/.../blocklist/custom/branding
+Access to model nvidia/Cosmos-1.0-Guardrail is restricted.
+RuntimeError: Orchestrator initialization failed: 401 Client Error.
+```
+
+Before the license was accepted, an authenticated fetch of the same URL
+returned `403` while an anonymous fetch returned `401`; that split is what
+identified the problem as a missing license acceptance rather than a bad
+token, and license acceptance resolved it immediately. On the npa path,
+`require_model_access` catches the no-token case before any download starts;
+if you already have `HF_TOKEN` set and generation still fails partway through
+fetching the guardrail weights, read the HTTP status in the traceback against
+this table before assuming the token itself is bad.
+
+## Xet download failure and workaround
+
+With a valid token and an accepted license, download can still fail inside
+Hugging Face's Xet transfer client:
+
+```
+huggingface_hub/file_download.py:1920 _download_to_tmp_and_move
+  -> xet_get(...)
+    -> huggingface_hub/file_download.py:563  session.new_file_download_group(...)
+RuntimeError: Task error: Unable to parse string as hex hash value
+```
+
+This is [huggingface/xet-core#895](https://github.com/huggingface/xet-core/issues/895),
+closed 2026-07-28. It reproduces on the exact pin pair `hf-xet 1.5.1` plus
+`huggingface_hub 1.23.0`. It was measured here on a gated guardrail-repo
+download; on the same environment and pins, a large ungated checkpoint had
+downloaded cleanly beforehand, so not every download on the affected pair
+triggers it. Treat the failure signature, not the download type, as the
+indicator.
+
+**Workaround:** set `HF_HUB_DISABLE_XET=1` in the environment before the run
+starts. This falls back to the standard HTTP downloader instead of the Xet
+client. Measured on the affected pair: the 146-file, 17 GB guardrail repo
+that failed under Xet downloaded in 1m52s with `HF_HUB_DISABLE_XET=1` set,
+and the run proceeded normally afterward.
+
+This is scoped to the affected pin pair, not a default for every
+environment: newer `huggingface_hub`/`hf-xet` releases fix the issue, and
+setting the variable unconditionally would silently disable a faster
+download path for environments that do not need it. `npa workbench cosmos3
+generate` checks the installed `hf-xet` and `huggingface_hub` versions in the
+runtime environment and prints a warning naming this workaround only when it
+detects the affected pair; it does not set the variable for you.
+
+## Checklist
+
+1. Create a Hugging Face account and a read-scoped token.
+2. Export the token as `HF_TOKEN` (or point `NPA_COSMOS3_HF_TOKEN_ENV` at it).
+3. Accept `nvidia/Cosmos-Guardrail1` for the npa generation path, and
+   separately accept `nvidia/Cosmos-1.0-Guardrail` if you also serve through
+   vLLM-Omni.
+4. If a download fails, check whether an anonymous request to the same URL
+   returns `401` (bad/missing token) or an authenticated one returns `403`
+   (unaccepted license) before assuming the token is wrong.
+5. If the failure is `Unable to parse string as hex hash value` from
+   `huggingface_hub`'s Xet client, set `HF_HUB_DISABLE_XET=1` and retry.

--- a/docs/workbench/cosmos3-access-preflight.md
+++ b/docs/workbench/cosmos3-access-preflight.md
@@ -58,7 +58,10 @@ whether the problem is the token or the license:
 
 Measured signature, from the vLLM-Omni serving path (`nvidia/Cosmos-1.0-Guardrail`,
 before the license was accepted; shown because the same status-code
-diagnostic applies on either path):
+diagnostic applies on either path). The status below is `401` rather than the
+`403` this section describes because the container held no token, so its fetch
+was anonymous: the first row of the table above. The `403` came from a manual
+authenticated request against the same URL:
 
 ```
 GatedRepoError: 401 Client Error

--- a/docs/workbench/cosmos3-generate.md
+++ b/docs/workbench/cosmos3-generate.md
@@ -46,6 +46,15 @@ This is enforced in three places: `require_model_access` refuses to launch
 inference without the token, the build fails if a checkpoint file lands in a
 layer, and `verify_env.py` re-asserts the absence of weights inside the image.
 
+Clearing the license for this repo's own gated guardrail model
+(`nvidia/Cosmos-Guardrail1`) does not clear the license for the *different*
+gated guardrail repo a vLLM-Omni serving deployment pulls
+(`nvidia/Cosmos-1.0-Guardrail`). See
+[`cosmos3-access-preflight.md`](cosmos3-access-preflight.md) for account
+setup, the two-repo table, the 401-vs-403 diagnostic for a gated-download
+failure, and the Xet download workaround for a specific Hugging Face client
+pin.
+
 Guardrails are **on** unless you pass `--no-guardrails`, and every result
 manifest records `guardrails` so a run's posture stays auditable.
 
@@ -195,6 +204,7 @@ before generation starts.
 | `mode ... conditions on an input image/video` | An `image2video` / `video2video` / `image2image` run without `--input-path`. |
 | `Found no NVIDIA driver` | The container reached real inference but has no GPU. Generation is GPU-only. |
 | `cosmos-framework produced no image/video artifact` | Inference exited 0 but wrote nothing; check the upstream log above the error for a guardrail rejection. |
+| `Unable to parse string as hex hash value` from `huggingface_hub`'s Xet client | A download failure specific to the `hf-xet 1.5.1` + `huggingface_hub 1.23.0` pin pair (`huggingface/xet-core#895`), observed on a gated guardrail-repo download. Set `HF_HUB_DISABLE_XET=1` and retry; see [`cosmos3-access-preflight.md`](cosmos3-access-preflight.md). |
 
 For access checks before a run (`gh`/HF/NGC reachability) see
 `npa workbench cosmos check`. For the un-baked, clone-at-job-time text-to-image

--- a/docs/workbench/troubleshooting/known-footguns.md
+++ b/docs/workbench/troubleshooting/known-footguns.md
@@ -103,3 +103,19 @@ deploy health checks use SSH. Live commands honor the saved strategy and can
 self-heal legacy aliases by falling back through a transient SSH-local route.
 
 Category for follow-up: BYOVM networking.
+
+## Xet Transfer Rejects Gated Cosmos Downloads
+
+Symptom: a Hugging Face download of a gated Cosmos repo fails with `Unable to
+parse string as hex hash value`, with a valid token and an accepted license.
+
+Root cause: huggingface/xet-core#895 breaks the Xet transfer client on exactly
+`huggingface_hub==1.23.0` plus `hf-xet==1.5.1`. Newer releases fix it.
+
+Current workaround: set `HF_HUB_DISABLE_XET=1` and retry, or upgrade the pair.
+`npa workbench cosmos3 generate` warns on stderr when it detects that exact
+pin pair in the runtime venv; it does not set the variable itself, because
+disabling Xet costs unaffected environments the faster download path. See
+`docs/workbench/cosmos3-access-preflight.md`.
+
+Category for follow-up: dependencies.

--- a/npa/src/npa/workbench/cosmos/generate.py
+++ b/npa/src/npa/workbench/cosmos/generate.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -54,6 +55,15 @@ HF_TOKEN_ENV_OVERRIDE = "NPA_COSMOS3_HF_TOKEN_ENV"
 NGC_API_KEY_ENV_OVERRIDE = "NPA_COSMOS3_NGC_API_KEY_ENV"
 DEFAULT_NGC_API_KEY_ENV = "NGC_API_KEY"
 REQUIRE_NGC_ENV = "NPA_COSMOS3_REQUIRE_NGC"
+
+ACCESS_PREFLIGHT_DOC = "docs/workbench/cosmos3-access-preflight.md"
+
+# huggingface/xet-core#895: a gated-repo download fails with "Unable to parse
+# string as hex hash value" on exactly this pin pair. Fixed in later releases
+# of both packages, so this is a warning naming the known-bad pair, not an
+# unconditional env default. See ACCESS_PREFLIGHT_DOC.
+XET_AFFECTED_HUGGINGFACE_HUB_VERSION = "1.23.0"
+XET_AFFECTED_HF_XET_VERSION = "1.5.1"
 
 _IMAGE_SUFFIXES = (".jpg", ".jpeg", ".png", ".webp", ".bmp")
 _VIDEO_SUFFIXES = (".mp4", ".webm", ".mkv", ".mov")
@@ -159,7 +169,12 @@ def require_model_access(
                 f"download {' and '.join(needs)} from Hugging Face. Set HF_TOKEN "
                 f"(or {HF_TOKEN_ENV_OVERRIDE}) to a token that has accepted those "
                 "licenses. A staged local/s3 --checkpoint only removes this "
-                "requirement when --no-guardrails is also passed."
+                "requirement when --no-guardrails is also passed. If a token is "
+                "already set and a download still fails: an anonymous request to "
+                "the gated repo's URL returning 401 means the token is missing or "
+                "invalid, while an authenticated request returning 403 means the "
+                f"token works but its license has not been accepted yet; see "
+                f"{ACCESS_PREFLIGHT_DOC}."
             )
         hf_auth = "configured"
 
@@ -173,6 +188,77 @@ def require_model_access(
         ngc_auth = "configured"
 
     return {"hf_auth": hf_auth, "ngc_auth": ngc_auth}
+
+
+def _installed_package_versions(
+    python: Path, packages: tuple[str, ...], *, runner: Any = None
+) -> dict[str, str]:
+    """Best-effort read of ``packages`` versions inside ``python``'s environment.
+
+    Returns an empty dict on any failure (missing interpreter, package not
+    installed, non-zero exit): this backs a warning, not a preflight gate, so
+    it must never block or fail a run on its own.
+    """
+
+    probe = (
+        "import importlib.metadata as m, json, sys\n"
+        "out = {}\n"
+        "for name in sys.argv[1:]:\n"
+        "    try:\n"
+        "        out[name] = m.version(name)\n"
+        "    except m.PackageNotFoundError:\n"
+        "        pass\n"
+        "print(json.dumps(out))\n"
+    )
+    run = runner or subprocess.run
+    try:
+        completed = run(
+            [str(python), "-c", probe, *packages],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    if getattr(completed, "returncode", 1) != 0:
+        return {}
+    try:
+        versions = json.loads(getattr(completed, "stdout", "") or "{}")
+    except ValueError:
+        return {}
+    return {k: str(v) for k, v in versions.items() if isinstance(k, str)}
+
+
+def check_xet_pin(repo: Path, *, runner: Any = None) -> str:
+    """Warn when the runtime venv has the known-bad Xet-download pin pair.
+
+    huggingface/xet-core#895 makes a gated-repo download fail with
+    "Unable to parse string as hex hash value" on exactly
+    ``huggingface_hub==1.23.0`` plus ``hf-xet==1.5.1``. Returns a warning
+    string naming the ``HF_HUB_DISABLE_XET=1`` workaround when that exact
+    pair is installed, or "" when the pair cannot be confirmed (package
+    missing, versions differ, or the check itself failed). This never sets
+    the environment variable itself: newer releases fix the issue, so
+    disabling Xet unconditionally would cost every unaffected environment a
+    faster download path for no reason.
+    """
+
+    versions = _installed_package_versions(
+        _venv_python(repo), ("huggingface_hub", "hf-xet"), runner=runner
+    )
+    if (
+        versions.get("huggingface_hub") == XET_AFFECTED_HUGGINGFACE_HUB_VERSION
+        and versions.get("hf-xet") == XET_AFFECTED_HF_XET_VERSION
+    ):
+        return (
+            "huggingface_hub "
+            f"{XET_AFFECTED_HUGGINGFACE_HUB_VERSION} + hf-xet "
+            f"{XET_AFFECTED_HF_XET_VERSION} is affected by "
+            "huggingface/xet-core#895 (gated-repo download fails with "
+            "'Unable to parse string as hex hash value'). Set "
+            f"HF_HUB_DISABLE_XET=1 and retry; see {ACCESS_PREFLIGHT_DOC}."
+        )
+    return ""
 
 
 def build_generate_spec(
@@ -403,6 +489,10 @@ def run_cosmos3_generate(
         guardrails=bool(plan["guardrails"]),
         environ=env,
     )
+    if plan["guardrails"]:
+        xet_warning = check_xet_pin(Path(plan["repo"]))
+        if xet_warning:
+            print(f"WARNING: {xet_warning}", file=sys.stderr)
 
     output_root = Path(plan["output_dir"])
     output_root.mkdir(parents=True, exist_ok=True)
@@ -659,6 +749,7 @@ __all__ = [
     "VIDEO_MODES",
     "VISION_REQUIRED_MODES",
     "build_generate_spec",
+    "check_xet_pin",
     "cosmos3_generate_available",
     "cosmos3_repo",
     "generate_and_publish",

--- a/npa/src/npa/workbench/cosmos/generate.py
+++ b/npa/src/npa/workbench/cosmos/generate.py
@@ -169,12 +169,11 @@ def require_model_access(
                 f"download {' and '.join(needs)} from Hugging Face. Set HF_TOKEN "
                 f"(or {HF_TOKEN_ENV_OVERRIDE}) to a token that has accepted those "
                 "licenses. A staged local/s3 --checkpoint only removes this "
-                "requirement when --no-guardrails is also passed. If a token is "
-                "already set and a download still fails: an anonymous request to "
-                "the gated repo's URL returning 401 means the token is missing or "
-                "invalid, while an authenticated request returning 403 means the "
-                f"token works but its license has not been accepted yet; see "
-                f"{ACCESS_PREFLIGHT_DOC}."
+                "requirement when --no-guardrails is also passed. With no token "
+                "set, a fetch of a gated repo is anonymous and fails with 401; "
+                "if you set a token and then see 403 instead, the token itself "
+                "is reaching Hugging Face and the account behind it still has to "
+                f"accept the repo's license. See {ACCESS_PREFLIGHT_DOC}."
             )
         hf_auth = "configured"
 
@@ -225,6 +224,8 @@ def _installed_package_versions(
     try:
         versions = json.loads(getattr(completed, "stdout", "") or "{}")
     except ValueError:
+        return {}
+    if not isinstance(versions, dict):
         return {}
     return {k: str(v) for k, v in versions.items() if isinstance(k, str)}
 
@@ -453,13 +454,16 @@ def run_cosmos3_generate(
     parallelism_preset: str = DEFAULT_PARALLELISM_PRESET,
     environ: Mapping[str, str] | None = None,
     runner: Any = None,
+    version_probe_runner: Any = None,
 ) -> dict[str, Any]:
     """Run a real Cosmos 3 generation; return the artifact plus its metadata.
 
     Guardrails stay on unless ``no_guardrails`` is explicitly requested. Raises
     :class:`Cosmos3GenerateError` when the runtime is absent, the operator's
     Hugging Face credentials are missing, inference fails, or no media artifact
-    was produced.
+    was produced. ``version_probe_runner`` overrides only the xet pin check's
+    subprocess seam, so a test can drive that check without also mocking the
+    inference call or the check itself; production leaves it ``None``.
     """
 
     env = dict(environ if environ is not None else os.environ)
@@ -489,8 +493,11 @@ def run_cosmos3_generate(
         guardrails=bool(plan["guardrails"]),
         environ=env,
     )
-    if plan["guardrails"]:
-        xet_warning = check_xet_pin(Path(plan["repo"]))
+    if access["hf_auth"] == "configured":
+        # Scoped to "this run downloads from Hugging Face", not to guardrails:
+        # xet-core#895 is a transfer bug, so a guardrails-off run that still
+        # pulls its checkpoint from HF hits it too.
+        xet_warning = check_xet_pin(Path(plan["repo"]), runner=version_probe_runner)
         if xet_warning:
             print(f"WARNING: {xet_warning}", file=sys.stderr)
 

--- a/npa/tests/workbench/test_cosmos3_generate.py
+++ b/npa/tests/workbench/test_cosmos3_generate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,7 @@ from npa.workbench.cosmos.generate import (
     XET_AFFECTED_HF_XET_VERSION,
     XET_AFFECTED_HUGGINGFACE_HUB_VERSION,
     Cosmos3GenerateError,
+    _installed_package_versions,
     build_generate_spec,
     check_xet_pin,
     cosmos3_generate_available,
@@ -132,6 +134,7 @@ def test_require_model_access_missing_token_error_names_the_401_403_diagnostic()
         require_model_access(checkpoint="Cosmos3-Nano", environ={})
 
     message = str(excinfo.value)
+    assert "anonymous" in message
     assert "401" in message
     assert "403" in message
     assert "docs/workbench/cosmos3-access-preflight.md" in message
@@ -264,13 +267,76 @@ def test_check_xet_pin_fails_open_when_the_probe_cannot_run(tmp_path: Path) -> N
     assert check_xet_pin(repo, runner=broken_runner) == ""
 
 
-def test_run_generate_warns_on_stderr_for_the_affected_xet_pin(
+def test_installed_package_versions_probe_runs_against_a_real_interpreter() -> None:
+    """Execute the literal probe string, the one part a fake runner cannot check."""
+
+    versions = _installed_package_versions(
+        Path(sys.executable), ("pytest", "no-such-dist-xyz")
+    )
+
+    assert versions["pytest"] == pytest.__version__
+    assert "no-such-dist-xyz" not in versions
+
+
+def test_check_xet_pin_probes_the_venv_interpreter_for_both_packages(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    repo, _ = _fake_runtime(tmp_path)
+    seen: list[list[str]] = []
+
+    def capturing_runner(argv, **kwargs):
+        seen.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, "{}", "")
+
+    check_xet_pin(repo, runner=capturing_runner)
+
+    argv = seen[0]
+    assert argv[0] == str(repo / ".venv" / "bin" / "python")
+    assert argv[1] == "-c"
+    assert tuple(argv[3:]) == ("huggingface_hub", "hf-xet")
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        "nonzero-exit",
+        "timeout",
+        "malformed-json",
+        "json-but-not-an-object",
+    ],
+)
+def test_check_xet_pin_fails_open_on_every_probe_failure_mode(
+    tmp_path: Path, outcome: str
+) -> None:
+    """A warning must never become a gate: every failure returns "" silently."""
+
+    repo, _ = _fake_runtime(tmp_path)
+
+    def runner(argv, **kwargs):
+        if outcome == "nonzero-exit":
+            return subprocess.CompletedProcess(argv, 1, "", "boom")
+        if outcome == "timeout":
+            raise subprocess.TimeoutExpired(argv, 30)
+        if outcome == "malformed-json":
+            return subprocess.CompletedProcess(argv, 0, "not json at all", "")
+        return subprocess.CompletedProcess(argv, 0, "[]", "")
+
+    assert check_xet_pin(repo, runner=runner) == ""
+    assert _installed_package_versions(
+        repo / ".venv" / "bin" / "python", ("huggingface_hub",), runner=runner
+    ) == {}
+
+
+def _generate_with_probe(
+    tmp_path: Path,
+    output_dir: Path,
+    versions: dict[str, str],
+    *,
+    no_guardrails: bool = False,
+) -> None:
+    """Drive the real check_xet_pin gate through run_cosmos3_generate's seam."""
+
     _, env = _fake_runtime(tmp_path)
-    output_dir = tmp_path / "out"
 
     def fake_runner(argv, **kwargs):
         sample = output_dir / "npa-generate"
@@ -278,24 +344,57 @@ def test_run_generate_warns_on_stderr_for_the_affected_xet_pin(
         (sample / "vision.jpg").write_bytes(b"y" * 2048)
         return subprocess.CompletedProcess(argv, 0)
 
-    import npa.workbench.cosmos.generate as generate_module
-
-    monkeypatch.setattr(
-        generate_module,
-        "check_xet_pin",
-        lambda repo, **_: (
-            "huggingface_hub 1.23.0 + hf-xet 1.5.1 is affected by "
-            "huggingface/xet-core#895. Set HF_HUB_DISABLE_XET=1 and retry."
-        ),
-    )
     run_cosmos3_generate(
         prompt="a robot arm",
         output_dir=output_dir,
         environ=env,
+        no_guardrails=no_guardrails,
         runner=fake_runner,
+        version_probe_runner=_version_probe_runner(versions),
+    )
+
+
+AFFECTED_PAIR = {
+    "huggingface_hub": XET_AFFECTED_HUGGINGFACE_HUB_VERSION,
+    "hf-xet": XET_AFFECTED_HF_XET_VERSION,
+}
+
+
+def test_run_generate_warns_on_stderr_for_the_affected_xet_pin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _generate_with_probe(tmp_path, tmp_path / "out", AFFECTED_PAIR)
+
+    assert "HF_HUB_DISABLE_XET=1" in capsys.readouterr().err
+
+
+def test_run_generate_still_warns_with_guardrails_off(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """xet-core#895 is a Hugging Face transfer bug, not a guardrail one.
+
+    A --no-guardrails run still downloads its checkpoint from Hugging Face, so
+    gating the warning on guardrails would hide it from exactly the runs the
+    doc tells operators to try first.
+    """
+
+    _generate_with_probe(
+        tmp_path, tmp_path / "out", AFFECTED_PAIR, no_guardrails=True
     )
 
     assert "HF_HUB_DISABLE_XET=1" in capsys.readouterr().err
+
+
+def test_run_generate_is_silent_on_an_unaffected_xet_pin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _generate_with_probe(
+        tmp_path,
+        tmp_path / "out",
+        {"huggingface_hub": "1.26.0", "hf-xet": "1.6.0"},
+    )
+
+    assert "HF_HUB_DISABLE_XET" not in capsys.readouterr().err
 
 
 def test_availability_is_false_without_the_baked_runtime(tmp_path: Path) -> None:

--- a/npa/tests/workbench/test_cosmos3_generate.py
+++ b/npa/tests/workbench/test_cosmos3_generate.py
@@ -13,8 +13,11 @@ import yaml
 from npa.workbench.cosmos.generate import (
     DEFAULT_CHECKPOINT,
     GENERATE_MODES,
+    XET_AFFECTED_HF_XET_VERSION,
+    XET_AFFECTED_HUGGINGFACE_HUB_VERSION,
     Cosmos3GenerateError,
     build_generate_spec,
+    check_xet_pin,
     cosmos3_generate_available,
     generate_plan,
     require_model_access,
@@ -122,6 +125,18 @@ def test_require_model_access_demands_operator_hf_token() -> None:
     ) == {"hf_auth": "configured", "ngc_auth": "skipped"}
 
 
+def test_require_model_access_missing_token_error_names_the_401_403_diagnostic() -> None:
+    """The 401 (bad token) vs 403 (unaccepted license) split, plus a doc pointer."""
+
+    with pytest.raises(Cosmos3GenerateError) as excinfo:
+        require_model_access(checkpoint="Cosmos3-Nano", environ={})
+
+    message = str(excinfo.value)
+    assert "401" in message
+    assert "403" in message
+    assert "docs/workbench/cosmos3-access-preflight.md" in message
+
+
 def test_require_model_access_skips_token_only_when_nothing_is_fetched() -> None:
     """A staged checkpoint alone does not exempt the run.
 
@@ -200,6 +215,87 @@ def test_resolve_hf_token_honours_the_env_name_override() -> None:
     env = {"NPA_COSMOS3_HF_TOKEN_ENV": "MY_HF", "MY_HF": "token-value"}
 
     assert resolve_hf_token(env) == "token-value"
+
+
+def _version_probe_runner(versions: dict[str, str]):
+    def run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 0, json.dumps(versions), "")
+
+    return run
+
+
+def test_check_xet_pin_warns_only_on_the_exact_affected_pair(tmp_path: Path) -> None:
+    repo, _ = _fake_runtime(tmp_path)
+
+    warning = check_xet_pin(
+        repo,
+        runner=_version_probe_runner(
+            {
+                "huggingface_hub": XET_AFFECTED_HUGGINGFACE_HUB_VERSION,
+                "hf-xet": XET_AFFECTED_HF_XET_VERSION,
+            }
+        ),
+    )
+
+    assert "HF_HUB_DISABLE_XET=1" in warning
+    assert "xet-core#895" in warning
+    assert "docs/workbench/cosmos3-access-preflight.md" in warning
+
+
+def test_check_xet_pin_is_silent_on_a_newer_unaffected_pair(tmp_path: Path) -> None:
+    repo, _ = _fake_runtime(tmp_path)
+
+    warning = check_xet_pin(
+        repo,
+        runner=_version_probe_runner(
+            {"huggingface_hub": "1.26.0", "hf-xet": "1.6.0"}
+        ),
+    )
+
+    assert warning == ""
+
+
+def test_check_xet_pin_fails_open_when_the_probe_cannot_run(tmp_path: Path) -> None:
+    repo, _ = _fake_runtime(tmp_path)
+
+    def broken_runner(argv, **kwargs):
+        raise OSError("no such interpreter")
+
+    assert check_xet_pin(repo, runner=broken_runner) == ""
+
+
+def test_run_generate_warns_on_stderr_for_the_affected_xet_pin(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, env = _fake_runtime(tmp_path)
+    output_dir = tmp_path / "out"
+
+    def fake_runner(argv, **kwargs):
+        sample = output_dir / "npa-generate"
+        sample.mkdir(parents=True)
+        (sample / "vision.jpg").write_bytes(b"y" * 2048)
+        return subprocess.CompletedProcess(argv, 0)
+
+    import npa.workbench.cosmos.generate as generate_module
+
+    monkeypatch.setattr(
+        generate_module,
+        "check_xet_pin",
+        lambda repo, **_: (
+            "huggingface_hub 1.23.0 + hf-xet 1.5.1 is affected by "
+            "huggingface/xet-core#895. Set HF_HUB_DISABLE_XET=1 and retry."
+        ),
+    )
+    run_cosmos3_generate(
+        prompt="a robot arm",
+        output_dir=output_dir,
+        environ=env,
+        runner=fake_runner,
+    )
+
+    assert "HF_HUB_DISABLE_XET=1" in capsys.readouterr().err
 
 
 def test_availability_is_false_without_the_baked_runtime(tmp_path: Path) -> None:


### PR DESCRIPTION
### What breaks today

Two failure modes hit anyone clearing gated Hugging Face access for Cosmos 3,
and neither is documented anywhere in this repo.

**Two separately-gated guardrail repos, split by serving path.** This repo's
`npa workbench cosmos3 generate` path pulls `nvidia/Cosmos-Guardrail1`.
Serving the same model through vLLM-Omni (outside npa, for example the
`vllm/vllm-omni:cosmos3` container) pulls a different gated repo,
`nvidia/Cosmos-1.0-Guardrail`. Accepting one license does not accept the
other, so an operator who cleared one path still fails the other with no
indication why. Measured on the vLLM-Omni path before the license was
accepted:

    GatedRepoError: 401 Client Error
    Cannot access gated repo for url
    https://huggingface.co/nvidia/Cosmos-1.0-Guardrail/resolve/.../blocklist/custom/branding
    Access to model nvidia/Cosmos-1.0-Guardrail is restricted.
    RuntimeError: Orchestrator initialization failed: 401 Client Error.

**A 401-vs-403 split that identifies the actual problem.** Before that
license was accepted, an authenticated request to the same URL returned 403
while an anonymous request returned 401. That split is what showed the
problem was a missing license acceptance, not a bad token; accepting the
license resolved it immediately. Nothing in the repo's error text or docs
mentions this diagnostic.

**An undocumented xet download failure.** With a valid token and an accepted
license, download can still fail inside `huggingface_hub`'s Xet transfer
client:

    huggingface_hub/file_download.py:1920 _download_to_tmp_and_move
      -> xet_get(...)
        -> huggingface_hub/file_download.py:563  session.new_file_download_group(...)
    RuntimeError: Task error: Unable to parse string as hex hash value

This is huggingface/xet-core#895, closed 2026-07-28, which reproduces on the
exact pin pair `hf-xet 1.5.1` plus `huggingface_hub 1.23.0`. `HF_HUB_DISABLE_XET`
appears nowhere in this repo today. Measured workaround: setting
`HF_HUB_DISABLE_XET=1` downloaded the affected 146-file, 17 GB guardrail repo
in 1m52s and the run proceeded normally.

### What this change does

A new doc, `docs/workbench/cosmos3-access-preflight.md`, walks through Hugging
Face account and token setup, names both gated guardrail repos and which
serving path needs which, gives the 401-vs-403 diagnostic table, and documents
the xet failure signature and workaround. `docs/workbench/cosmos3-generate.md`
gets a short pointer to it from the credential section and a new row in its
troubleshooting table for the xet symptom.

On the code side, `require_model_access`'s missing-token error now also names
the 401-vs-403 split and points at the new doc, for the case where a token is
already set but a download still fails. A new `check_xet_pin` function probes
the installed `huggingface_hub` and `hf-xet` versions in the generation
runtime and prints a warning naming the `HF_HUB_DISABLE_XET=1` workaround only
when it detects the exact affected pair; it never sets the variable itself,
since newer releases of both packages fix the issue and disabling Xet
unconditionally would cost unaffected environments a faster download path for
no reason. The probe fails open: any error reading the versions (missing
interpreter, package not installed, non-zero exit) returns no warning rather
than blocking the run.

### What this deliberately does not do

No new tool, no new CLI command, and no change to `GUARDRAIL_MODEL_ID`; it
stays `nvidia/Cosmos-Guardrail1`, which is correct for the serving path this
repo ships. This is a docs-plus-small-code change on an existing preflight,
not a new access-checking surface.

### Evidence

- 401/403 split, the xet signature, and the `HF_HUB_DISABLE_XET=1` timing:
  measured during Cosmos3-Super bring-up on 8x H200 with vLLM-Omni, logged
  live as it happened.
- Guardrail repo split confirmed against both Hugging Face repos directly.

### Tests

`npa/tests/workbench/test_cosmos3_generate.py` adds coverage for the extended
error text (401/403 hint, doc pointer), `check_xet_pin` on the affected pair,
an unaffected pair, and a failed probe, and the warning path in
`run_cosmos3_generate`. Full existing suite for this module (34 tests)
continues to pass, and the repo's own `ruff check` gate is clean on every
touched file.

A follow-up guide for self-hosted Cosmos3-Super serving on Nebius hardware is
in progress separately.
