### PR TITLE
Add a Cosmos3-Super serving container (npa-cosmos3-serving)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Nebius Physical AI.
 | [workbench/](workbench/) | Workbench solution docs, including getting started, cookbooks, and troubleshooting |
 | [workbench/kubernetes.md](workbench/kubernetes.md) | User setup and operational guide for running Workbench on managed Kubernetes |
 | [workbench/cosmos3-generate.md](workbench/cosmos3-generate.md) | Cosmos 3 generation (`npa-cosmos3`) — build, run via CLI/SDK/workflow, and the runtime-credential posture that keeps weights out of the image |
+| [workbench/cosmos3-super-serving.md](workbench/cosmos3-super-serving.md) | Cosmos3-Super serving (`npa-cosmos3-serving`), an 8-GPU single-node endpoint: build, run, readiness window, and guardrail posture |
 | [../npa/workflows/workbench/npa-workflows/README.md](../npa/workflows/workbench/npa-workflows/README.md) | **Workflow catalog** — find the right `npa.workflow` spec by what you want to do |
 | [architecture/solutions-model.md](architecture/solutions-model.md) | Platform model for adding and maintaining solutions |
 | [architecture/cli-namespaces.md](architecture/cli-namespaces.md) | CLI namespace conventions |

--- a/docs/workbench/cosmos3-super-serving.md
+++ b/docs/workbench/cosmos3-super-serving.md
@@ -1,0 +1,251 @@
+# Cosmos3-Super serving on the workbench (`npa-cosmos3-serving`)
+
+`npa workbench cosmos3 generate` runs Cosmos 3 generation as a batch job: one
+invocation, one artifact, and a full model load every time. For the 64B
+`Cosmos3-Super` checkpoint that load costs minutes, so a synthetic-data
+workload that wants many clips pays it over and over.
+
+This image is the serving half. It loads `nvidia/Cosmos3-Super` once and serves
+an OpenAI-compatible endpoint against resident weights, on one 8-GPU node.
+
+| Piece | Path |
+| --- | --- |
+| Image | `npa/docker/workbench/cosmos3-serving/Dockerfile` (`npa-cosmos3-serving`) |
+| Entrypoint | `npa/docker/workbench/cosmos3-serving/entrypoint.sh` |
+| Build gate | `npa/docker/workbench/cosmos3-serving/verify_env.py` |
+| Build script | `npa/docker/workbench/cosmos3-serving/build.sh` |
+| Image contract tests | `npa/tests/docker/test_cosmos3_serving_image_contract.py` |
+
+The image wraps NVIDIA's own `vllm/vllm-omni` serving runtime, pinned by digest,
+and adds a preflight entrypoint and a build gate.
+
+## What this is not, yet
+
+The image is **not registered as a deployable workbench tool**. There is no
+`npa workbench cosmos3 serve` CLI verb, no SDK surface, no workflow integration,
+and no entry in the packaging contract, the datacenter Blackwell verdict
+manifest, `CONTAINER_IMAGE_NAMES`, or the golden-eval manifest.
+
+That is a deliberate stopping point rather than an omission, because those
+registrations are one chain rather than four independent edits: a packaging
+contract entry obliges a Blackwell verdict, which obliges a
+`CONTAINER_IMAGE_NAMES` key and a supported-tools version pin, which obliges a
+golden-eval manifest entry backed by a real capability smoke that needs an
+8-GPU node to run. Build it as one deliberate change, with a version scheme and
+a smoke tier chosen on purpose, or not at all.
+
+## Weights are never in the image
+
+The base runtime carries no checkpoint bytes and this layer adds none. The
+`Cosmos3-Super` checkpoint, the guardrail models, and every other gated artifact
+download **at run time** with the operator's own Hugging Face token, under that
+operator's own license acceptance. That is the same posture `npa-cosmos3` holds,
+and the reason the built image carries no gated weight bytes to redistribute.
+Redistribution of the base runtime itself follows its own upstream license; this
+layer adds only the entrypoint, the build gate, and configuration.
+
+`verify_env.py` runs at build time and fails the build if a weight file larger
+than 50 MB landed in any layer, the same guarantee `npa-cosmos3` enforces.
+
+## Access preflight
+
+Two access gates fail confusingly on a clean host. Both are covered in full by
+`docs/workbench/cosmos3-access-preflight.md`, which is added by
+nebius/nebius-physical-ai#264.
+
+**The serving path pulls a different gated guardrail repo than the batch path.**
+`npa workbench cosmos3 generate` pulls `nvidia/Cosmos-Guardrail1`. This image
+pulls `nvidia/Cosmos-1.0-Guardrail`. They are separate Hugging Face repos with
+separate license acceptances, and clearing one does not clear the other. The
+entrypoint refuses to start when guardrails are on and no token is present,
+because without that check the fetch goes out anonymous and dies with a `401`
+several minutes into startup, which reads like a bad token rather than a missing
+one. If a token **is** set and the download still fails, the status code
+separates the two causes: `401` from an anonymous request means no valid token
+reached Hugging Face, `403` from an authenticated one means the account has not
+accepted that repo's license.
+
+**The base image's pinned Hugging Face client pair breaks the guardrail
+download.** `HF_HUB_DISABLE_XET=1` is set in the image, which is a departure
+from `npa workbench cosmos3 generate`, where the same condition only produces a
+warning. The difference is ownership of the pins. That path runs in whatever
+environment the operator built, so setting the variable on their behalf would
+silently disable a faster download path for environments that do not need it.
+This Dockerfile chose its own base image, and that base pins `hf-xet` 1.5.1 with
+`huggingface_hub` 1.23.0, the exact pair
+[huggingface/xet-core#895](https://github.com/huggingface/xet-core/issues/895)
+reproduces on. `verify_env.py` re-reads the installed pair at build time and
+fails the build once a base bump moves off it, naming the line to delete, so the
+workaround cannot outlive the defect it works around.
+
+## Build
+
+No GPU is needed to build.
+
+```bash
+bash npa/docker/workbench/cosmos3-serving/build.sh --registry <your-registry>
+bash npa/docker/workbench/cosmos3-serving/build.sh --registry <your-registry> --push
+```
+
+The build runs `verify_env.py` inside the image, which checks four things: the
+vLLM-Omni serving stack imports, the xet workaround still matches the installed
+pins, the entrypoint assembles the serve command it advertises, and no weight
+file is present in a layer. The third check executes the real entrypoint in
+dry-run mode rather than restating its expected argv, so a change to the script
+that breaks the serve command fails the build rather than the first 8-GPU boot.
+
+## Run
+
+```bash
+docker run -d --name cosmos3-serving --gpus all --ipc=host --shm-size 32g \
+  --ulimit nofile=1048576:1048576 \
+  -v <hf-cache-dir>:/opt/npa-cosmos3-serving/hf-cache \
+  -e HF_TOKEN=<your-token> \
+  -p 8000:8000 \
+  <your-registry>/npa-cosmos3-serving:<tag>
+```
+
+The mounted cache must be writable by uid 1000: the image runs as a non-root
+user, and a cache mounted from a root-owned host directory is readable but not
+writable. The entrypoint checks this before any download starts, because
+otherwise the failure surfaces as a lock error partway through fetching 17 GB of
+guardrail weights.
+
+`--ipc=host` and the `nofile` ulimit are the vendor runtime's requirements, not
+this layer's.
+
+### Configuration surface
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `NPA_COSMOS3_SERVE_MODEL` | `nvidia/Cosmos3-Super` | Model to serve |
+| `NPA_COSMOS3_SERVE_HOST` | `0.0.0.0` | Bind address |
+| `NPA_COSMOS3_SERVE_PORT` | `8000` | Bind port |
+| `NPA_COSMOS3_SERVE_GUARDRAILS` | `on` | `off` passes `--no-guardrails` and drops the token requirement |
+| `NPA_COSMOS3_SERVE_INIT_TIMEOUT` | `1800` | Passed through as `--init-timeout` |
+| `NPA_COSMOS3_SERVE_GPUS` | `8` | GPU count the preflight requires |
+| `NPA_COSMOS3_SERVE_EXTRA_ARGS` | empty | Appended verbatim to the serve command |
+| `NPA_COSMOS3_SERVE_DRY_RUN` | `0` | Print the serve command and exit |
+| `NPA_COSMOS3_SERVE_SKIP_GPU_CHECK` | `0` | Bypass the GPU-count preflight |
+
+The parallel configuration is **pinned**, not exposed:
+`--cfg-parallel-size 2 --ulysses-degree 4 --use-hsdp --hsdp-shard-size 8`. That
+is the configuration the model card recommends for 8x H200, H100, or A100, and
+measurement on 8x H200 backed it: it was the fastest of five strategies tried,
+about 9% faster than plain `--tensor-parallel-size 8` at both 35 and 50 steps.
+The measured block is in
+[vllm-project/vllm-omni#5909](https://github.com/vllm-project/vllm-omni/pull/5909).
+`NPA_COSMOS3_SERVE_EXTRA_ARGS` is the escape hatch for anyone who wants a
+different strategy, and `NPA_COSMOS3_SERVE_GPUS` has to be set to match.
+
+Generation parameters are **not** part of this surface. Steps, frame count,
+resolution, seed, and per-request guardrail posture are request fields on
+`/v1/videos`, not server flags, so they are chosen per call rather than per
+server.
+
+### Generate a clip
+
+```bash
+curl -sS -X POST http://localhost:8000/v1/videos/sync \
+  -H "Accept: video/mp4" \
+  --form-string "prompt=<your prompt>" \
+  --form-string "size=1280x720" \
+  --form-string "num_frames=189" \
+  --form-string "fps=24" \
+  --form-string "num_inference_steps=35" \
+  --form-string "guidance_scale=6.0" \
+  --form-string "flow_shift=10.0" \
+  --form-string "max_sequence_length=4096" \
+  --form-string "seed=17" \
+  -o clip.mp4
+```
+
+## Readiness takes minutes
+
+This is the operational fact most likely to be got wrong. Measured on 8x H200,
+HSDP-sharded configurations reached `Application startup complete` in roughly
+280 to 290 seconds with the model weights already in the host page cache, and
+about 320 seconds longer than that on a cold cache. `--init-timeout 1800` was
+never approached.
+
+This image's own validation run reached readiness in 592 seconds on a cold cache,
+which is the number to plan against for a node that has just been started.
+
+The image's `HEALTHCHECK` therefore carries a 20 minute `start-period`. A
+readiness probe tuned for an ordinary web service reports a healthy boot as a
+failure and restarts it into another one, which is a loop that never converges.
+A probe tuned even for the warm figure would have failed the 592 second boot
+above. Orchestrators driving this image need the same allowance.
+
+Memory during that load, with `--hsdp-shard-size 8`: 17.3 GiB per GPU at model
+load, and roughly 43 GiB per GPU resident while serving.
+
+## Guardrails
+
+Guardrails are **on** by default, matching the model card. Turning them off is
+per server, through `NPA_COSMOS3_SERVE_GUARDRAILS=off`, and the request API also
+accepts a per-request posture.
+
+Two things worth knowing before choosing a default for a shared server.
+Guardrails add roughly 20 seconds of one-time initialization and 17 GB of extra
+weights on disk. Their per-request cost is content-dependent rather than a fixed
+tax: measured overhead ranged from a few seconds on short randomized prompts to
+about 15% on a richly described one at the same shape, so any single overhead
+figure is scoped to the prompt it came from.
+
+Guardrails also change the output bytes rather than only gating requests, so a
+clip generated with them on is not the same clip generated with them off.
+
+## Determinism is per server instance
+
+Within one running server, output is bitwise reproducible at a fixed seed.
+Across a restart it is not: the same seed and configuration produce a different
+clip, at a magnitude comparable to the difference between two adjacent frames of
+the same video. Same-seed comparisons are only valid inside one server instance,
+which matters for any evaluation harness that restarts servers between arms.
+
+## Concurrency
+
+Cosmos 3 models do not support step-level batching in vLLM-Omni
+([vllm-project/vllm-omni#4340](https://github.com/vllm-project/vllm-omni/issues/4340)
+lists Step Execution as unsupported for them). Concurrent requests queue and
+serialize rather than sharing GPU work, so client-side queue depth and timeouts
+are the design surface, not server-side batch tuning.
+
+## Validated on real GPUs
+
+Built and run on 8x H200 SXM (143,771 MiB each, driver 580.126.09), guardrails on,
+against base digest `sha256:6d2630c7d637b699557573f2c3fee8df5d4d0cd718977aa22549ed6a6ef30587`.
+
+| Stage | Result |
+| --- | --- |
+| Build with no GPU | Succeeded; the build gate passed all four checks inside the image |
+| Startup to `Application startup complete` | 592 s, cold page cache |
+| One t2v request (1280x720, 189 frames, 24 fps, 35 steps, seed 17) | HTTP 200, server-side `stage_gen_time_ms` 138,721 |
+| Clip verification | h264 1280x720 yuv420p, 24 fps, 189 frames read, 7.875 s, full decode clean, not blank |
+| Memory while serving | 43.8 to 44.0 GiB per GPU on ranks 1 to 7; 50.3 GiB on rank 0, which also hosts the API server and the guardrail models |
+
+The generation figure sits inside the band already measured for this
+configuration and prompt on the same hardware without the container wrapper, so
+the wrapper adds no measurable cost.
+
+All three preflight refusals were exercised against real conditions rather than
+simulated ones: a missing token, a host cache genuinely owned by a different uid
+than the container's runtime user, and four GPUs against the pinned 8-GPU
+config. Each refused before the server started.
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| `guardrails are on but no HF_TOKEN` | The preflight refusing to start a boot that would 401 several minutes in. Supply a token that has accepted `nvidia/Cosmos-1.0-Guardrail`, or set `NPA_COSMOS3_SERVE_GUARDRAILS=off`. |
+| `Hugging Face cache ... is not writable` | The mounted cache is not writable by uid 1000. Chown it, or point `HF_HOME` somewhere writable. |
+| `the pinned parallel config needs 8 GPUs, found N` | The pinned strategy is an 8-GPU decomposition. Override it through `NPA_COSMOS3_SERVE_EXTRA_ARGS` and set `NPA_COSMOS3_SERVE_GPUS` to match. |
+| `Unable to parse string as hex hash value` | The xet defect the image already works around. Confirm `HF_HUB_DISABLE_XET=1` survived into the container environment. |
+| Health check fails during startup | The probe is tighter than the real readiness window. See the readiness section above. |
+| `403` on a guardrail download with a valid token | The token's account has not accepted `nvidia/Cosmos-1.0-Guardrail`. Accepting `nvidia/Cosmos-Guardrail1` does not clear it. |
+
+## Related
+
+- `docs/workbench/cosmos3-generate.md`: the batch generation tool this serves alongside.
+- `docs/workbench/cosmos3-access-preflight.md`: the full credential and license checklist (added by nebius/nebius-physical-ai#264).

--- a/docs/workbench/cosmos3-super-serving.md
+++ b/docs/workbench/cosmos3-super-serving.md
@@ -111,8 +111,16 @@ writable. The entrypoint checks this before any download starts, because
 otherwise the failure surfaces as a lock error partway through fetching 17 GB of
 guardrail weights.
 
+Budget the cache before first start: the `Cosmos3-Super` checkpoint is about
+124 GB on disk plus 17 GB of guardrail weights, so plan roughly 145 GB. The
+first-ever download is its own cost, separate from and larger than the
+readiness figures below, which were measured with weights already on disk.
+
 `--ipc=host` and the `nofile` ulimit are the vendor runtime's requirements, not
-this layer's.
+this layer's. To run the vendor runtime bare, without this image's preflights,
+the serve command the Dockerfile assembles works directly against
+`vllm/vllm-omni:cosmos3`; the measured behavior on this page applies to both,
+because they run the same server.
 
 ### Configuration surface
 
@@ -133,7 +141,18 @@ The parallel configuration is **pinned**, not exposed:
 is the configuration the model card recommends for 8x H200, H100, or A100, and
 measurement on 8x H200 backed it: it was the fastest of five strategies tried,
 about 9% faster than plain `--tensor-parallel-size 8` at both 35 and 50 steps.
-The measured block is in
+
+| Configuration | 35 steps | 50 steps |
+| --- | --- | --- |
+| Pinned config above | ~121 s | ~166 s |
+| `--tensor-parallel-size 8` | ~131 s | ~181 s |
+
+Server-reported generation times at 1280x720, 189 frames, guardrails off;
+client wall time adds roughly 3 to 4 seconds. Every measured cell fits
+`latency ~= 14.4s + steps x per_step` to within 0.3%: the ~14.4 s outside the
+denoise loop is the same across every strategy tried, and the entire difference
+between configurations is denoise-step rate (3.03 to 3.06 s/step for the pinned
+config, 3.33 to 3.36 for tensor parallelism). The full measured block is in
 [vllm-project/vllm-omni#5909](https://github.com/vllm-project/vllm-omni/pull/5909).
 `NPA_COSMOS3_SERVE_EXTRA_ARGS` is the escape hatch for anyone who wants a
 different strategy, and `NPA_COSMOS3_SERVE_GPUS` has to be set to match.
@@ -166,7 +185,11 @@ This is the operational fact most likely to be got wrong. Measured on 8x H200,
 HSDP-sharded configurations reached `Application startup complete` in roughly
 280 to 290 seconds with the model weights already in the host page cache, and
 about 320 seconds longer than that on a cold cache. `--init-timeout 1800` was
-never approached.
+never approached. The 280 to 290 second figure is a property of HSDP-sharded
+weight loading: the one non-HSDP strategy measured, `--tensor-parallel-size 8`
+on a single boot, reached readiness in about 90 seconds warm, so anyone
+overriding the parallel configuration through `NPA_COSMOS3_SERVE_EXTRA_ARGS`
+should re-measure readiness rather than inherit these numbers.
 
 This image's own validation run reached readiness in 592 seconds on a cold cache,
 which is the number to plan against for a node that has just been started.
@@ -201,8 +224,10 @@ clip generated with them on is not the same clip generated with them off.
 Within one running server, output is bitwise reproducible at a fixed seed.
 Across a restart it is not: the same seed and configuration produce a different
 clip, at a magnitude comparable to the difference between two adjacent frames of
-the same video. Same-seed comparisons are only valid inside one server instance,
-which matters for any evaluation harness that restarts servers between arms.
+the same video (median 28 dB PSNR against the pre-restart clip, versus 27.9 dB
+between adjacent frames within one clip). Same-seed comparisons are only valid
+inside one server instance, which matters for any evaluation harness that
+restarts servers between arms.
 
 ## Concurrency
 
@@ -211,6 +236,22 @@ Cosmos 3 models do not support step-level batching in vLLM-Omni
 lists Step Execution as unsupported for them). Concurrent requests queue and
 serialize rather than sharing GPU work, so client-side queue depth and timeouts
 are the design surface, not server-side batch tuning.
+
+Measured at 1280x720, 189 frames, 35 steps, guardrails on:
+
+| Concurrency | Throughput | Mean latency | Median latency | Peak memory |
+| --- | --- | --- | --- | --- |
+| 1 | 28.21 clips/hr | 127.6 s | 127.6 s | 38,562 MB |
+| 2 | 30.43 clips/hr | 208.2 s | 230.1 s | 38,562 MB |
+| 4 | 30.78 clips/hr | 382.0 s | 461.4 s | 38,564 MB |
+| 8 | 30.96 clips/hr | 729.0 s | 923.3 s | 38,564 MB |
+
+Peak memory holding flat within 2 MB across an eightfold increase in in-flight
+work is the hard evidence for the no-batching design. Throughput gains from 1
+to 8 concurrent requests are under 10% and nearly all collected at concurrency
+2, while median latency doubles at each step. There is little reason to run
+this server above concurrency 2 unless the marginal 9.8% of throughput is worth
+a 7.2x median-latency cost.
 
 ## Validated on real GPUs
 
@@ -229,10 +270,23 @@ The generation figure sits inside the band already measured for this
 configuration and prompt on the same hardware without the container wrapper, so
 the wrapper adds no measurable cost.
 
+The base pin is not currently load-bearing for that cell: re-checked on the
+vendor's `v0.26.0` image, the same flags produced 124 s against 123 s on the
+pinned image (guardrails off, one run per image), with output parity inside the
+same-configuration restart band.
+
 All three preflight refusals were exercised against real conditions rather than
 simulated ones: a missing token, a host cache genuinely owned by a different uid
 than the container's runtime user, and four GPUs against the pinned 8-GPU
 config. Each refused before the server started.
+
+## Artifact handoff
+
+The served endpoint returns bytes and keeps no record. `npa workbench cosmos3
+generate` writes a `generate.json` manifest recording prompt, seed, guardrail
+posture, and shape alongside each artifact; this server does not. A workload
+that needs that provenance should record the request fields and the response's
+sha256 on the client side and upload them alongside the clip.
 
 ## Troubleshooting
 

--- a/npa/docker/workbench/cosmos3-serving/Dockerfile
+++ b/npa/docker/workbench/cosmos3-serving/Dockerfile
@@ -1,0 +1,81 @@
+# npa-cosmos3-serving: nvidia/Cosmos3-Super served as an OpenAI-compatible
+# endpoint, on one 8-GPU node.
+#
+# This is the serving sibling of npa-cosmos3. That image runs cosmos-framework
+# as a batch job and pays model load on every invocation; for the 64B Super
+# checkpoint that load is measured in minutes. This image loads once and serves
+# many requests against resident weights.
+#
+# WEIGHTS ARE NEVER BAKED, the same rule npa-cosmos3 follows. The base image is
+# NVIDIA's own vLLM-Omni serving runtime, pinned by digest, and it carries no
+# checkpoint bytes. nvidia/Cosmos3-Super, the guardrail models, and everything
+# else gated download AT RUN TIME with the operator's own Hugging Face token,
+# under that operator's own license acceptance. The build gate below asserts
+# that no weight file landed in a layer, which is what keeps this image
+# redistributable (packaging-contract.yaml redistribution: public).
+#
+# Pinned by digest, not by tag: `vllm/vllm-omni:cosmos3` is a moving tag, and
+# every measured claim in docs/workbench/cosmos3-super-serving.md was taken
+# against this exact digest.
+ARG BASE_IMAGE=vllm/vllm-omni@sha256:6d2630c7d637b699557573f2c3fee8df5d4d0cd718977aa22549ed6a6ef30587
+FROM ${BASE_IMAGE}
+
+ARG COSMOS3_SERVING_VERSION=0.1.0
+
+LABEL npa.tool="cosmos3-serving" \
+      npa.version="${COSMOS3_SERVING_VERSION}"
+
+USER root
+
+# HF_HUB_DISABLE_XET is set here, and that is a deliberate departure from
+# `npa workbench cosmos3 generate`, which only warns. The difference is who
+# controls the pins. That path runs in whatever environment the operator built,
+# so setting the variable for them would silently disable a faster download path
+# on environments that do not need it. Here the pins are baked into the base
+# image this Dockerfile chose: hf-xet 1.5.1 with huggingface_hub 1.23.0, the
+# exact pair huggingface/xet-core#895 reproduces on. On that pair the gated
+# guardrail download dies with "Unable to parse string as hex hash value"
+# several minutes into startup. verify_env.py re-checks the installed pair at
+# build time and fails the build once a base bump moves off it, so this line
+# cannot outlive the defect it works around.
+ENV PYTHONUNBUFFERED=1 \
+    HF_HUB_DISABLE_XET=1 \
+    HF_HOME=/opt/npa-cosmos3-serving/hf-cache \
+    NPA_COSMOS3_SERVE_MODEL=nvidia/Cosmos3-Super \
+    NPA_COSMOS3_SERVE_HOST=0.0.0.0 \
+    NPA_COSMOS3_SERVE_PORT=8000 \
+    NPA_COSMOS3_SERVE_GUARDRAILS=on \
+    NPA_COSMOS3_SERVE_INIT_TIMEOUT=1800 \
+    NPA_COSMOS3_SERVE_GPUS=8
+
+COPY docker/workbench/cosmos3-serving/entrypoint.sh /opt/npa-cosmos3-serving/entrypoint.sh
+COPY docker/workbench/cosmos3-serving/verify_env.py /opt/npa-cosmos3-serving/verify_env.py
+
+# The runtime user owns its home and its cache before the image drops to it. The
+# cache directory is a mount point in practice; it exists here so a run without a
+# mount still starts instead of failing on a missing path.
+RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 ubuntu \
+    && mkdir -p /opt/npa-cosmos3-serving/hf-cache /home/ubuntu \
+    && chmod 0755 /opt/npa-cosmos3-serving/entrypoint.sh \
+    && chown -R ubuntu:ubuntu /opt/npa-cosmos3-serving /home/ubuntu
+
+USER ubuntu
+ENV HOME=/home/ubuntu
+
+# Build gate. Runs with no GPU and no weights: it confirms the serving stack
+# imports, that the xet workaround above still matches the installed pins, that
+# the entrypoint assembles the serve command it claims to, and that no weight
+# file is present in any layer.
+RUN python3 /opt/npa-cosmos3-serving/verify_env.py
+
+EXPOSE 8000
+
+# The readiness window is minutes, not seconds. HSDP-sharded configs reached
+# 'Application startup complete' in roughly 280-290 s with the weights already in
+# the page cache, and about 320 s longer on a cold one. start-period covers the
+# cold case; a tighter probe would report a healthy boot as a failure and restart
+# it into another one.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=1200s --retries=3 \
+  CMD python3 -c "import os,urllib.request; urllib.request.urlopen('http://127.0.0.1:'+os.environ.get('NPA_COSMOS3_SERVE_PORT','8000')+'/v1/models', timeout=8)" || exit 1
+
+ENTRYPOINT ["/opt/npa-cosmos3-serving/entrypoint.sh"]

--- a/npa/docker/workbench/cosmos3-serving/build.sh
+++ b/npa/docker/workbench/cosmos3-serving/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Build (and optionally push) npa-cosmos3-serving: Cosmos3-Super as a served
+# endpoint on one 8-GPU node.
+#
+# The image wraps NVIDIA's vLLM-Omni runtime at a pinned digest and adds a
+# preflight entrypoint. Model weights are never baked; they download at runtime
+# with the operator's own Hugging Face credentials. No GPU is needed to build.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NPA_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+REGISTRY="${REGISTRY:-cr.eu-north1.nebius.cloud/e00cm0vc6t09m0z5gw}"
+BASE_IMAGE="${COSMOS3_SERVING_BASE_IMAGE:-}"
+TAG="${COSMOS3_SERVING_TAG:-0.1.0}"
+PUSH=0
+
+usage() {
+  sed -n '2,6p' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --registry) REGISTRY="${2:?}"; shift 2 ;;
+    --base-image) BASE_IMAGE="${2:?}"; shift 2 ;;
+    --tag) TAG="${2:?}"; shift 2 ;;
+    --push) PUSH=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+LOCAL_REF="npa-cosmos3-serving:${TAG}"
+REMOTE_REF="${REGISTRY}/npa-cosmos3-serving:${TAG}"
+
+BUILD_ARGS=()
+if [[ -n "${BASE_IMAGE}" ]]; then
+  BUILD_ARGS+=(--build-arg "BASE_IMAGE=${BASE_IMAGE}")
+fi
+
+echo "=== build ${LOCAL_REF} ==="
+docker build --platform linux/amd64 \
+  -f "${SCRIPT_DIR}/Dockerfile" \
+  "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}" \
+  -t "${LOCAL_REF}" \
+  -t "${REMOTE_REF}" \
+  "${NPA_ROOT}"
+
+if [[ "${PUSH}" == "1" ]]; then
+  echo "=== push ${REMOTE_REF} ==="
+  docker push "${REMOTE_REF}"
+fi
+
+echo "Done: ${REMOTE_REF} push=${PUSH}"

--- a/npa/docker/workbench/cosmos3-serving/entrypoint.sh
+++ b/npa/docker/workbench/cosmos3-serving/entrypoint.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# npa-cosmos3-serving entrypoint: preflight, then serve.
+#
+# Everything that can fail before the server binds a port is checked here and
+# reported with the fix, because the alternative is a stack trace several
+# minutes into a startup that costs 8 GPUs. The three checks are the three ways
+# this container has actually failed to start: a missing token against a gated
+# guardrail repo, an unwritable Hugging Face cache mount, and a GPU count that
+# does not match the pinned parallel config.
+set -euo pipefail
+
+MODEL="${NPA_COSMOS3_SERVE_MODEL:-nvidia/Cosmos3-Super}"
+HOST="${NPA_COSMOS3_SERVE_HOST:-0.0.0.0}"
+PORT="${NPA_COSMOS3_SERVE_PORT:-8000}"
+GUARDRAILS="${NPA_COSMOS3_SERVE_GUARDRAILS:-on}"
+INIT_TIMEOUT="${NPA_COSMOS3_SERVE_INIT_TIMEOUT:-1800}"
+EXPECTED_GPUS="${NPA_COSMOS3_SERVE_GPUS:-8}"
+EXTRA_ARGS="${NPA_COSMOS3_SERVE_EXTRA_ARGS:-}"
+DRY_RUN="${NPA_COSMOS3_SERVE_DRY_RUN:-0}"
+SKIP_GPU_CHECK="${NPA_COSMOS3_SERVE_SKIP_GPU_CHECK:-0}"
+
+fail() {
+  echo "[npa-cosmos3-serving] ERROR: $*" >&2
+  exit 1
+}
+
+note() {
+  echo "[npa-cosmos3-serving] $*"
+}
+
+case "${GUARDRAILS}" in
+  on | off) ;;
+  *) fail "NPA_COSMOS3_SERVE_GUARDRAILS must be 'on' or 'off', got '${GUARDRAILS}'" ;;
+esac
+
+# --- preflight 1: gated guardrail access -------------------------------------
+#
+# The serving path pulls nvidia/Cosmos-1.0-Guardrail, which is gated separately
+# from the batch path's nvidia/Cosmos-Guardrail1: accepting one license does not
+# accept the other. Without a token the fetch goes out anonymous and dies mid
+# startup with a 401 that reads like a bad token rather than a missing one.
+if [ "${GUARDRAILS}" = "on" ] && [ -z "${HF_TOKEN:-}${HUGGING_FACE_HUB_TOKEN:-}" ]; then
+  fail "guardrails are on but no HF_TOKEN (or HUGGING_FACE_HUB_TOKEN) is set.
+       This image bakes no weights, so the gated guardrail repo
+       nvidia/Cosmos-1.0-Guardrail downloads at run time under YOUR Hugging Face
+       license acceptance. Without a token the download is anonymous and fails
+       with 401 several minutes into startup. Accept the license at
+       https://huggingface.co/nvidia/Cosmos-1.0-Guardrail and pass the token, or
+       set NPA_COSMOS3_SERVE_GUARDRAILS=off to serve without guardrails.
+       Diagnostic if a token IS set and the download still fails: 401 from an
+       anonymous request means the token never reached Hugging Face, 403 from an
+       authenticated one means the account has not accepted this repo's license.
+       Accepting nvidia/Cosmos-Guardrail1 does not clear this repo."
+fi
+
+# --- preflight 2: writable Hugging Face cache --------------------------------
+#
+# The image runs as a non-root user, so a cache mounted from a root-owned host
+# directory is readable but not writable, and the failure surfaces as a lock
+# error partway through a download rather than at mount time.
+CACHE_DIR="${HF_HOME:-/opt/npa-cosmos3-serving/hf-cache}"
+mkdir -p "${CACHE_DIR}" 2>/dev/null || true
+if [ ! -w "${CACHE_DIR}" ]; then
+  fail "Hugging Face cache '${CACHE_DIR}' is not writable by uid $(id -u).
+       Point HF_HOME at a writable path, or chown the mounted cache to the
+       container's runtime user. Weights and guardrail models are downloaded
+       into this directory at run time; none of them ship in the image."
+fi
+
+# --- preflight 3: GPU count matches the pinned parallel config ---------------
+#
+# The pinned config below is CFG-parallel 2 x Ulysses 4 with HSDP shard 8, which
+# is an 8-GPU decomposition. Handing it a different GPU count fails inside
+# distributed init with a shape error, so check it here where the message can
+# name the cause.
+if [ "${SKIP_GPU_CHECK}" != "1" ]; then
+  if ! command -v nvidia-smi >/dev/null 2>&1; then
+    fail "nvidia-smi not found: this container serves on GPUs only.
+         Set NPA_COSMOS3_SERVE_SKIP_GPU_CHECK=1 to bypass this check, or
+         NPA_COSMOS3_SERVE_DRY_RUN=1 to print the serve command and exit."
+  fi
+  visible="$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l | tr -d ' ')"
+  if [ "${visible}" != "${EXPECTED_GPUS}" ]; then
+    fail "the pinned parallel config needs ${EXPECTED_GPUS} GPUs, found ${visible}.
+         This image pins an 8-GPU single-node decomposition. For a different GPU
+         count, override the strategy through NPA_COSMOS3_SERVE_EXTRA_ARGS and set
+         NPA_COSMOS3_SERVE_GPUS to match."
+  fi
+fi
+
+# --- serve -------------------------------------------------------------------
+#
+# The parallel config is pinned rather than exposed. It is the fastest of five
+# strategies measured on 8x H200 at the model card's own example shape, about 9%
+# faster than plain tensor parallelism at both 35 and 50 steps, and it is the
+# configuration the model card itself recommends for 8x H200 / H100 / A100.
+# Generation parameters (steps, frame count, resolution, per-request guardrail
+# posture) are request fields on /v1/videos, not server flags, so they are not
+# part of this surface.
+argv=(
+  vllm serve "${MODEL}"
+  --omni
+  --host "${HOST}"
+  --port "${PORT}"
+  --cfg-parallel-size 2
+  --ulysses-degree 4
+  --use-hsdp
+  --hsdp-shard-size 8
+  --init-timeout "${INIT_TIMEOUT}"
+)
+
+if [ "${GUARDRAILS}" = "off" ]; then
+  argv+=(--no-guardrails)
+fi
+
+if [ -n "${EXTRA_ARGS}" ]; then
+  # Deliberate word splitting: this is an operator-supplied flag string.
+  # shellcheck disable=SC2206
+  argv+=(${EXTRA_ARGS})
+fi
+
+note "model=${MODEL} guardrails=${GUARDRAILS} port=${PORT} xet_disabled=${HF_HUB_DISABLE_XET:-unset}"
+note "startup to 'Application startup complete' takes minutes, not seconds: HSDP-sharded"
+note "configs reached ready in roughly 280-290 s on a warm page cache and about 320 s"
+note "longer on a cold one. Readiness probes tighter than that kill healthy boots."
+note "exec: ${argv[*]}"
+
+if [ "${DRY_RUN}" = "1" ]; then
+  note "dry run: not starting the server"
+  exit 0
+fi
+
+exec "${argv[@]}"

--- a/npa/docker/workbench/cosmos3-serving/verify_env.py
+++ b/npa/docker/workbench/cosmos3-serving/verify_env.py
@@ -1,0 +1,194 @@
+"""Build-time verification for the npa-cosmos3-serving image.
+
+Runs inside the image with no GPU and no weights. It checks the four things
+that can be wrong about this image without anyone noticing until an 8-GPU node
+is already running:
+
+1. The vLLM-Omni serving stack imports and reports a version.
+2. The ``hf-xet``/``huggingface_hub`` pins the Dockerfile's
+   ``HF_HUB_DISABLE_XET=1`` works around are still the pins actually installed.
+   Once a base-image bump moves off the affected pair, this fails the build and
+   names the line to delete, so the workaround cannot quietly outlive the defect.
+3. The entrypoint assembles the serve command it advertises. This runs the real
+   script in dry-run mode rather than restating its argv here, because a copy of
+   the expected command would pass while the script produced something else.
+4. No model weight file is present in any layer, which is what keeps the image
+   redistributable.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ENTRYPOINT = Path("/opt/npa-cosmos3-serving/entrypoint.sh")
+
+# huggingface/xet-core#895: "Unable to parse string as hex hash value" during a
+# gated-repo download. Closed 2026-07-28, after this base image was published.
+XET_AFFECTED_PINS = {"hf-xet": "1.5.1", "huggingface_hub": "1.23.0"}
+
+# The 8-GPU decomposition the entrypoint pins, and the flags that carry it.
+REQUIRED_SERVE_FLAGS = (
+    "--omni",
+    "--cfg-parallel-size 2",
+    "--ulysses-degree 4",
+    "--use-hsdp",
+    "--hsdp-shard-size 8",
+)
+
+WEIGHT_SUFFIXES = (".safetensors", ".ckpt", ".pth", ".pt", ".bin", ".gguf")
+WEIGHT_MIN_BYTES = 50 * 1024 * 1024
+WEIGHT_SCAN_ROOTS = (
+    "/opt/npa-cosmos3-serving",
+    "/home/ubuntu",
+    "/root",
+    "/app",
+    "/workspace",
+)
+
+failures: list[str] = []
+
+
+def step(name: str, fn) -> None:
+    try:
+        detail = fn()
+    except Exception as exc:  # noqa: BLE001 - report every failure, then exit non-zero
+        failures.append(name)
+        print(f"[FAIL] {name}: {type(exc).__name__}: {exc}")
+    else:
+        print(f"[ok]   {name}" + (f": {detail}" if detail else ""))
+
+
+def _distribution_version(name: str) -> str | None:
+    from importlib.metadata import PackageNotFoundError, version
+
+    for candidate in (name, name.replace("-", "_"), name.replace("_", "-")):
+        try:
+            return version(candidate)
+        except PackageNotFoundError:
+            continue
+    return None
+
+
+def check_serving_stack() -> str:
+    import vllm
+
+    reported = [f"vllm={vllm.__version__}"]
+    try:
+        import vllm_omni
+    except ImportError:
+        # Older builds fold the omni surface into vllm itself; the serve-time
+        # `--omni` flag is what actually matters and the entrypoint check covers it.
+        reported.append("vllm_omni=in-tree")
+    else:
+        reported.append(f"vllm_omni={getattr(vllm_omni, '__version__', 'unknown')}")
+    return " ".join(reported)
+
+
+def check_xet_workaround_still_applies() -> str:
+    if os.environ.get("HF_HUB_DISABLE_XET") != "1":
+        raise RuntimeError(
+            "HF_HUB_DISABLE_XET is not set to 1 in the image environment; the "
+            "gated guardrail download fails on this image's pinned pair"
+        )
+
+    installed = {name: _distribution_version(name) for name in XET_AFFECTED_PINS}
+    missing = [name for name, found in installed.items() if found is None]
+    if missing:
+        raise RuntimeError(f"could not resolve installed versions for {missing}")
+
+    if installed != XET_AFFECTED_PINS:
+        raise RuntimeError(
+            "the base image no longer pins the pair that huggingface/xet-core#895 "
+            f"reproduces on (expected {XET_AFFECTED_PINS}, found {installed}). "
+            "Re-test a guardrails-on startup without the workaround; if it is clean, "
+            "delete HF_HUB_DISABLE_XET from the Dockerfile and this check with it."
+        )
+    return f"{installed} still affected, HF_HUB_DISABLE_XET=1 justified"
+
+
+def check_entrypoint_assembles_the_serve_command() -> str:
+    """Execute the real entrypoint in dry-run and read the command it built."""
+
+    if not ENTRYPOINT.is_file():
+        raise RuntimeError(f"{ENTRYPOINT} is missing")
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "NPA_COSMOS3_SERVE_DRY_RUN": "1",
+            "NPA_COSMOS3_SERVE_SKIP_GPU_CHECK": "1",
+            # No token exists at build time, so exercise the guardrails-off arm.
+            "NPA_COSMOS3_SERVE_GUARDRAILS": "off",
+        }
+    )
+    result = subprocess.run(
+        [str(ENTRYPOINT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"entrypoint dry run exited {result.returncode}: {result.stderr.strip()}"
+        )
+
+    exec_lines = [line for line in result.stdout.splitlines() if "exec: " in line]
+    if not exec_lines:
+        raise RuntimeError(f"entrypoint printed no serve command: {result.stdout!r}")
+    command = exec_lines[-1].split("exec: ", 1)[1]
+
+    for flag in REQUIRED_SERVE_FLAGS:
+        if flag not in command:
+            raise RuntimeError(f"serve command is missing {flag!r}: {command}")
+    if "--no-guardrails" not in command:
+        raise RuntimeError(f"guardrails=off did not reach the serve command: {command}")
+    return command
+
+
+def check_no_baked_weights() -> str:
+    hf_home = os.environ.get("HF_HOME")
+    roots = [Path(root) for root in WEIGHT_SCAN_ROOTS]
+    if hf_home:
+        roots.append(Path(hf_home))
+
+    baked: list[str] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            try:
+                if (
+                    path.is_file()
+                    and not path.is_symlink()
+                    and path.suffix.lower() in WEIGHT_SUFFIXES
+                    and path.stat().st_size > WEIGHT_MIN_BYTES
+                ):
+                    baked.append(str(path))
+            except OSError:
+                continue
+    if baked:
+        raise RuntimeError(f"model weights present in the image: {baked[:5]}")
+    return "no weight files baked (checkpoints download at runtime)"
+
+
+def main() -> int:
+    step("vLLM-Omni serving stack", check_serving_stack)
+    step("xet workaround matches installed pins", check_xet_workaround_still_applies)
+    step("entrypoint builds the pinned serve command", check_entrypoint_assembles_the_serve_command)
+    step("no baked weights", check_no_baked_weights)
+
+    print()
+    if failures:
+        print(f"[FAIL] npa-cosmos3-serving environment verification failed: {failures}")
+        return 1
+    print("[PASS] npa-cosmos3-serving environment verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/npa/tests/docker/test_cosmos3_serving_image_contract.py
+++ b/npa/tests/docker/test_cosmos3_serving_image_contract.py
@@ -1,0 +1,332 @@
+"""Guard the npa-cosmos3-serving image's contract and its preflight behavior.
+
+Two halves, and the second is the point of the file.
+
+The static half is the same shape as ``test_cosmos3_image_contract.py``: the
+image is redistributable only because it carries no model weights, and the base
+runtime is pinned by digest because every measured claim in the docs was taken
+against that digest.
+
+The behavioral half **runs the real entrypoint**. It puts a recording ``vllm``
+and a configurable ``nvidia-smi`` on PATH and reads the argv the script actually
+built, so the preflight branches and the serve-command assembly are executed
+rather than restated. Asserting against a copy of the expected command would
+pass while the script produced something else, which is exactly the gap the
+review of the access-preflight change called out.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+NPA_ROOT = REPO_ROOT / "npa"
+IMAGE_DIR = NPA_ROOT / "docker/workbench/cosmos3-serving"
+DOCKERFILE = IMAGE_DIR / "Dockerfile"
+ENTRYPOINT = IMAGE_DIR / "entrypoint.sh"
+VERIFY_ENV = IMAGE_DIR / "verify_env.py"
+CONTRACT = NPA_ROOT / "docker/workbench/packaging-contract.yaml"
+
+# The digest the serving numbers in docs/workbench/cosmos3-super-serving.md were
+# measured against.
+PINNED_DIGEST = "sha256:6d2630c7d637b699557573f2c3fee8df5d4d0cd718977aa22549ed6a6ef30587"
+
+# Anything that would pull weight bytes into a build layer.
+WEIGHT_FETCH_PATTERNS = (
+    r"hf\s+download",
+    r"huggingface-cli\s+download",
+    r"snapshot_download",
+    r"git\s+lfs\s+pull",
+)
+
+
+def _load_verify_env():
+    """Import the in-image build gate so its constants cannot drift from these tests.
+
+    Bytecode writing is suppressed for the duration: the gate lives in the image's
+    build context, and a ``__pycache__`` left beside it would ship into a layer.
+    """
+    spec = importlib.util.spec_from_file_location("cosmos3_serving_verify_env", VERIFY_ENV)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.dont_write_bytecode = previous
+    return module
+
+
+def _dockerfile_instructions() -> str:
+    lines = [
+        line
+        for line in DOCKERFILE.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Static contract
+# ---------------------------------------------------------------------------
+
+
+def test_image_files_exist_and_the_entrypoint_is_executable() -> None:
+    assert DOCKERFILE.is_file()
+    assert ENTRYPOINT.is_file()
+    assert VERIFY_ENV.is_file()
+    assert os.access(ENTRYPOINT, os.X_OK), "entrypoint.sh must be committed executable"
+
+
+def test_base_runtime_is_pinned_by_digest() -> None:
+    instructions = _dockerfile_instructions()
+
+    assert PINNED_DIGEST in instructions, (
+        "the base runtime must stay pinned to the digest the serving numbers were "
+        "measured against; `vllm/vllm-omni:cosmos3` is a moving tag"
+    )
+    assert re.search(r"ARG BASE_IMAGE=\S+@sha256:[0-9a-f]{64}", instructions)
+
+
+def test_dockerfile_never_downloads_model_weights() -> None:
+    instructions = _dockerfile_instructions()
+
+    for pattern in WEIGHT_FETCH_PATTERNS:
+        assert not re.search(pattern, instructions, flags=re.IGNORECASE), (
+            f"npa-cosmos3-serving Dockerfile matches {pattern!r}: weights must "
+            "download at runtime with the operator's own credentials, never into a layer."
+        )
+
+
+def test_dockerfile_runs_the_build_gate_and_drops_to_a_non_root_user() -> None:
+    instructions = _dockerfile_instructions()
+
+    assert "verify_env.py" in instructions, "the build must run its own gate"
+    users = re.findall(r"(?im)^\s*USER\s+(\S+)\s*$", instructions)
+    assert users and users[-1] == "ubuntu"
+    assert "EXPOSE 8000" in instructions
+
+
+def test_dockerfile_sets_the_xet_workaround_this_base_image_needs() -> None:
+    """Setting it here is correct precisely because the pins are baked in.
+
+    `npa workbench cosmos3 generate` only warns, because it runs in whatever
+    environment the operator built. This Dockerfile chose the base image, so it
+    owns the pins, and verify_env.py fails the build once a bump moves off them.
+    """
+    instructions = _dockerfile_instructions()
+
+    assert "HF_HUB_DISABLE_XET=1" in instructions
+    verify_env = _load_verify_env()
+    assert verify_env.XET_AFFECTED_PINS == {"hf-xet": "1.5.1", "huggingface_hub": "1.23.0"}
+
+
+def test_healthcheck_allows_for_the_real_startup_time() -> None:
+    """HSDP-sharded configs need minutes. A tight probe restarts healthy boots."""
+    instructions = _dockerfile_instructions()
+
+    match = re.search(r"--start-period=(\d+)s", instructions)
+    assert match, "the healthcheck must declare a start-period"
+    assert int(match.group(1)) >= 900, (
+        "start-period must cover a cold-cache startup: HSDP configs reached ready "
+        "in roughly 280-290 s warm and about 320 s longer cold"
+    )
+
+
+def test_the_image_is_deliberately_not_yet_a_registered_workbench_tool() -> None:
+    """Pin the choice, so registering it later is a decision rather than a drift.
+
+    Registration is one chain, not one edit: a ``packaging-contract.yaml`` entry
+    obliges a datacenter Blackwell verdict, which obliges a
+    ``CONTAINER_IMAGE_NAMES`` key and a supported-tools pin, which obliges a
+    golden-eval manifest entry backed by a real 8-GPU capability smoke. This
+    change ships the container and leaves that chain to the maintainer, and the
+    docs page says so rather than leaving the absence to look like an oversight.
+    """
+    from npa.deploy.images import CONTAINER_IMAGE_NAMES
+
+    contract = yaml.safe_load(CONTRACT.read_text(encoding="utf-8"))
+    assert "cosmos3-serving" not in contract["images"]
+    assert "cosmos3-serving" not in CONTAINER_IMAGE_NAMES
+
+    docs = (REPO_ROOT / "docs/workbench/cosmos3-super-serving.md").read_text(encoding="utf-8")
+    assert "not registered as a deployable workbench tool" in docs
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: run the real entrypoint
+# ---------------------------------------------------------------------------
+
+RECORDING_VLLM = """#!/usr/bin/env bash
+printf '%s\\n' "$*" > "${NPA_TEST_ARGV_FILE}"
+exit 0
+"""
+
+FAKE_NVIDIA_SMI = """#!/usr/bin/env bash
+seq 0 $(( {gpus} - 1 ))
+"""
+
+
+@pytest.fixture
+def harness(tmp_path):
+    """PATH with a recording ``vllm``, plus a knob for the visible GPU count."""
+    if shutil.which("bash") is None:  # pragma: no cover - bash is present everywhere we run
+        pytest.skip("bash is required to execute the entrypoint")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    argv_file = tmp_path / "argv.txt"
+
+    vllm = bin_dir / "vllm"
+    vllm.write_text(RECORDING_VLLM, encoding="utf-8")
+    vllm.chmod(0o755)
+
+    cache = tmp_path / "hf-cache"
+    cache.mkdir()
+
+    def run(gpus: int | None = 8, **env_overrides):
+        if gpus is not None:
+            smi = bin_dir / "nvidia-smi"
+            smi.write_text(FAKE_NVIDIA_SMI.format(gpus=gpus), encoding="utf-8")
+            smi.chmod(0o755)
+        else:
+            (bin_dir / "nvidia-smi").unlink(missing_ok=True)
+
+        env = {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "HOME": str(tmp_path),
+            "HF_HOME": str(cache),
+            "NPA_TEST_ARGV_FILE": str(argv_file),
+        }
+        env.update({key: str(value) for key, value in env_overrides.items()})
+        argv_file.unlink(missing_ok=True)
+        result = subprocess.run(
+            [str(ENTRYPOINT)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+            check=False,
+        )
+        served = argv_file.read_text(encoding="utf-8").strip() if argv_file.exists() else None
+        return result, served
+
+    return run
+
+
+def test_entrypoint_execs_the_pinned_eight_gpu_config(harness) -> None:
+    result, served = harness(gpus=8, HF_TOKEN="hf_fake_token_for_test")
+
+    assert result.returncode == 0, result.stderr
+    assert served is not None, "the entrypoint never reached vllm"
+    verify_env = _load_verify_env()
+    for flag in verify_env.REQUIRED_SERVE_FLAGS:
+        assert flag in served, f"{flag!r} missing from: {served}"
+    assert served.startswith("serve nvidia/Cosmos3-Super")
+    # Guardrails default to on, which means the flag that disables them is absent.
+    assert "--no-guardrails" not in served
+    assert "--init-timeout 1800" in served
+
+
+def test_guardrails_off_passes_the_flag_and_needs_no_token(harness) -> None:
+    result, served = harness(gpus=8, NPA_COSMOS3_SERVE_GUARDRAILS="off")
+
+    assert result.returncode == 0, result.stderr
+    assert served is not None
+    assert "--no-guardrails" in served
+
+
+def test_guardrails_on_without_a_token_fails_before_the_server_starts(harness) -> None:
+    result, served = harness(gpus=8)
+
+    assert result.returncode != 0
+    assert served is None, "the server must not start when the guardrail fetch will 401"
+    assert "nvidia/Cosmos-1.0-Guardrail" in result.stderr
+    # The 401-vs-403 split is what tells an operator whether the token or the
+    # license acceptance is the problem, so the message has to carry both.
+    assert "401" in result.stderr and "403" in result.stderr
+
+
+def test_a_gpu_count_that_does_not_fit_the_pinned_config_fails_fast(harness) -> None:
+    result, served = harness(gpus=4, HF_TOKEN="hf_fake_token_for_test")
+
+    assert result.returncode != 0
+    assert served is None
+    assert "found 4" in result.stderr
+    assert "8 GPUs" in result.stderr
+
+
+def test_a_matching_override_lets_a_different_gpu_count_through(harness) -> None:
+    result, served = harness(
+        gpus=4,
+        HF_TOKEN="hf_fake_token_for_test",
+        NPA_COSMOS3_SERVE_GPUS=4,
+        NPA_COSMOS3_SERVE_EXTRA_ARGS="--tensor-parallel-size 4",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert served is not None
+    assert "--tensor-parallel-size 4" in served
+
+
+def test_missing_nvidia_smi_fails_rather_than_starting_on_cpu(harness) -> None:
+    result, served = harness(gpus=None, HF_TOKEN="hf_fake_token_for_test")
+
+    assert result.returncode != 0
+    assert served is None
+    assert "nvidia-smi not found" in result.stderr
+
+
+def test_an_unwritable_cache_mount_is_caught_before_the_download(harness, tmp_path) -> None:
+    if os.geteuid() == 0:  # pragma: no cover - root ignores the mode bits
+        pytest.skip("root can write to a read-only directory")
+    locked = tmp_path / "locked-cache"
+    locked.mkdir()
+    locked.chmod(0o500)
+    try:
+        result, served = harness(gpus=8, HF_TOKEN="hf_fake_token_for_test", HF_HOME=str(locked))
+    finally:
+        locked.chmod(0o700)
+
+    assert result.returncode != 0
+    assert served is None
+    assert "not writable" in result.stderr
+
+
+def test_an_invalid_guardrail_value_is_rejected_rather_than_treated_as_off(harness) -> None:
+    result, served = harness(gpus=8, NPA_COSMOS3_SERVE_GUARDRAILS="false")
+
+    assert result.returncode != 0
+    assert served is None
+    assert "must be 'on' or 'off'" in result.stderr
+
+
+def test_dry_run_prints_the_command_without_starting_the_server(harness) -> None:
+    result, served = harness(
+        gpus=None,
+        NPA_COSMOS3_SERVE_GUARDRAILS="off",
+        NPA_COSMOS3_SERVE_DRY_RUN=1,
+        NPA_COSMOS3_SERVE_SKIP_GPU_CHECK=1,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert served is None, "a dry run must not exec the server"
+    assert "vllm serve nvidia/Cosmos3-Super" in result.stdout
+
+
+def test_the_token_never_reaches_the_logs(harness) -> None:
+    secret = "hf_do_not_log_this_value"
+    result, _ = harness(gpus=8, HF_TOKEN=secret)
+
+    assert secret not in result.stdout
+    assert secret not in result.stderr


### PR DESCRIPTION
Adds a container that serves `nvidia/Cosmos3-Super` as an OpenAI-compatible endpoint on one 8-GPU
node, wrapping NVIDIA's `vllm/vllm-omni` runtime at a pinned digest.

This is the container slice only, built at Timothy's request off the 8x H200 measurement work
behind vllm-project/vllm-omni#5909. The workbench tool surface around it (a CLI verb, the SDK, the
workflow toolRef, tool registration) is deliberately not here; the open questions below are what I
would want settled before building it.

## The gap

npa reaches Cosmos 3 in two shapes today. `cosmos serve` runs the reasoner tower on vLLM, and
`cosmos3 generate` runs single-job batch generation through cosmos-framework in the `npa-cosmos3`
image. Neither loads the generator once and serves many requests against resident weights.

The workload that wants this is synthetic-data production. A batch job pays model load on every
invocation, and for the 64B Super checkpoint that cost is large: on 8x H200, HSDP-sharded configs
reach ready in roughly 280 to 290 s warm, and a cold page cache adds about 320 s on top. This
container pays it once.

## What is in the change

- `npa/docker/workbench/cosmos3-serving/Dockerfile`, from `vllm/vllm-omni` pinned by digest. No
  weights in the image, the same rule `npa-cosmos3` follows: the checkpoint and the gated guardrail
  models download at run time under the operator's own license acceptance, and the build fails if a
  weight file lands in a layer. The image drops to a non-root runtime user.
- `entrypoint.sh`, which preflights three failure modes and then execs the serve command.
- `verify_env.py`, a build gate that runs with no GPU.
- `npa/tests/docker/test_cosmos3_serving_image_contract.py`, 17 tests.
- `docs/workbench/cosmos3-super-serving.md`, plus an index row.

### The three preflight checks

Each one is a way this container has actually failed to start, and each costs minutes of 8 GPUs when
it surfaces as a stack trace instead of a message.

1. **Gated guardrail access.** The serving path pulls `nvidia/Cosmos-1.0-Guardrail`, which is gated
   separately from the batch path's `nvidia/Cosmos-Guardrail1`; accepting one license does not accept
   the other. With guardrails on and no token, the fetch goes out anonymous and dies with a 401
   several minutes into startup, which reads like a bad token rather than a missing one. The
   entrypoint refuses first and carries the 401 versus 403 split in the message.
2. **Cache writability.** The image runs as uid 1000, so a cache mounted from a host directory owned
   by someone else is readable but not writable, and the failure otherwise surfaces as a lock error
   partway through fetching 17 GB of guardrail weights.
3. **GPU count.** The pinned parallel config is an 8-GPU decomposition, and a different count fails
   inside distributed init with a shape error.

### On `HF_HUB_DISABLE_XET`

The image sets it. That is a departure from `npa workbench cosmos3 generate`, which only warns on
the same condition, and the difference is ownership of the pins. That path runs in whatever
environment the operator built, so setting the variable on their behalf would silently disable a
faster download path for environments that do not need it. This Dockerfile chose its base image,
and that base pins `hf-xet` 1.5.1 with `huggingface_hub` 1.23.0, the exact pair
huggingface/xet-core#895 reproduces on. `verify_env.py` re-reads the installed pair at build time
and fails the build once a base bump moves off it, naming the line to delete, so the workaround
cannot outlive the defect.

### On the tests

The behavioral half of the test file runs the real entrypoint with a recording `vllm` and a
configurable `nvidia-smi` on PATH, and reads the argv the script actually built. Asserting against a
copy of the expected command would pass while the script produced something else. The same applies
to the build gate: it executes the entrypoint in dry-run mode rather than restating its expected
output.

## Validation

Built and run on 8x H200 SXM (143,771 MiB each, driver 580.126.09) against base digest
`sha256:6d2630c7d637b699557573f2c3fee8df5d4d0cd718977aa22549ed6a6ef30587`, guardrails on.

| Stage | Result |
| --- | --- |
| Build, no GPU | Succeeded; the build gate passed all four checks inside the image |
| Startup to `Application startup complete` | 592 s, cold page cache |
| One t2v request, 1280x720, 189 frames, 24 fps, 35 steps, seed 17 | HTTP 200, server-side `stage_gen_time_ms` 138,721 |
| Clip | h264 1280x720 yuv420p, 24 fps, 189 frames read, 7.875 s, full decode clean, luma 11 to 238 with mean near 121 across sampled frames, so not blank |
| Memory while serving | 43.8 to 44.0 GiB per GPU on ranks 1 to 7, 50.3 GiB on rank 0, which also hosts the API server and the guardrail models |

The generation figure sits inside the band already measured for this configuration and prompt on the
same hardware without the wrapper, so the wrapper adds no measurable cost.

All three preflight refusals were exercised against real conditions rather than simulated ones,
including a host cache that genuinely belonged to a different uid than the container's runtime user.
A fourth case fired unplanned during the run: an empty token string, caught by the same check as the
first, before a boot that would have died minutes later.

The 592 s cold boot is worth one note on its own. It is the reason the image's `HEALTHCHECK` carries
a 20 minute `start-period`. A probe tuned even for the warm figure would have failed that boot and
restarted it into another one.

## Open questions, and I am happy to take direction on all of them

**Scope: single node.** This assumes 8 GPUs on one node and does not design for multi-node. Say if
multi-node has to be in the shape from the start.

**Config surface.** The parallel config is pinned rather than exposed:
`--cfg-parallel-size 2 --ulysses-degree 4 --use-hsdp --hsdp-shard-size 8`. That is what the model
card recommends for 8x H200, H100, or A100, and it was the fastest of five strategies measured on
8x H200, about 9% faster than plain tensor parallelism at both 35 and 50 steps. An env var appends
extra flags as an escape hatch. The alternative is exposing the parallel flags directly and
inheriting their support burden. Generation parameters are not in this surface at all, since steps,
frames, resolution, and per-request guardrail posture are request fields on `/v1/videos` rather than
server flags.

**Guardrail default.** On, matching the model card. For a shared server the per-request opt-out is a
policy question rather than a convenience one, and guardrails alter the output bytes rather than only
gating requests, so a clip generated with them on is not the same clip generated with them off.

**Naming.** `npa-cosmos3-serving` avoids colliding with the reasoner's `cosmos serve`, but if a tool
verb lands later, `cosmos3 serve` sits awkwardly next to it. Happy to rename.

**Tool registration, deliberately not done here.** The image is not in the packaging contract, the
datacenter Blackwell verdict manifest, `CONTAINER_IMAGE_NAMES`, or the golden-eval manifest, and the
docs page says so. Those four are one chain rather than four edits: a contract entry obliges a
Blackwell verdict, which obliges a `CONTAINER_IMAGE_NAMES` key and a supported-tools version pin,
which obliges a golden-eval entry backed by a real capability smoke that needs an 8-GPU node to run.
That seemed like your call on version scheme and smoke tier rather than mine to assume. I am glad to
do it in this PR if you want it here.

**Who builds the tool surface.** The measured groundwork is done and public in #5909, and the access
path is in #264. The remaining work is npa integration, which touches your architecture more than it
touches Cosmos. I can build it behind whatever direction comes out of this review, or hand over the
evidence and fixtures if you would rather own it.

## One dependency

The docs page links `docs/workbench/cosmos3-access-preflight.md`, which is added by #264 and is not
on main yet. If #264 lands first the link resolves; if this lands first, that link is dead until it
does. Happy to reorder, or to drop the link and inline the two paragraphs it points at.

Full validation logs, the generated clip, and the preflight transcripts are available on request.
