### PR TITLE
Fix Wan selected-image publication

### DIFF
--- a/.github/scripts/publish_selected_public_image.py
+++ b/.github/scripts/publish_selected_public_image.py
@@ -6,9 +6,11 @@ import argparse
 
 from npa.deploy.publish_public import (
     _crane_copy,
+    _mark_copy_phase_complete,
     _preflight_or_explain,
     build_publish_plan,
     verify_public,
+    visibility_checklist,
 )
 
 
@@ -18,7 +20,9 @@ def main() -> int:
     parser.add_argument("--source-registry", default=None)
     parser.add_argument("--target", required=True)
     parser.add_argument(
-        "--mode", choices=("plan", "preflight", "publish", "verify"), required=True
+        "--mode",
+        choices=("plan", "preflight", "publish", "verify", "checklist"),
+        required=True,
     )
     args = parser.parse_args()
 
@@ -39,8 +43,10 @@ def main() -> int:
 
     if args.mode == "plan":
         return 0
-    if args.mode == "verify":
+    if args.mode in {"verify", "checklist"}:
         failures = verify_public(selected)
+        if failures and args.mode == "checklist":
+            print(visibility_checklist(failures))
         return 1 if failures else 0
 
     publishable = _preflight_or_explain(selected)
@@ -49,9 +55,13 @@ def main() -> int:
     if args.mode == "preflight":
         return 0
 
+    # Preflight returns the digest-frozen Wan item. Do not fall back to ``item`` here:
+    # that is the mutable tag-form plan entry and the copy guard correctly rejects it.
+    item = publishable[0]
     copied = _crane_copy(item)
+    _mark_copy_phase_complete()
     print("Copied 1 image." if copied else "Already current; copied 0 images.")
-    failures = verify_public(selected)
+    failures = verify_public(publishable)
     return 1 if failures else 0
 
 

--- a/.github/workflows/publish-public-images.yml
+++ b/.github/workflows/publish-public-images.yml
@@ -228,6 +228,7 @@ jobs:
       # worked but nothing is publicly pullable. That is the expected outcome of the FIRST
       # publish; the summary below turns it into a click-through list.
       - name: Publish and verify
+        id: publish
         if: ${{ inputs.dry_run == false }}
         env:
           SOURCE_REGISTRY: ${{ inputs.source_registry || vars.NPA_PUBLISH_SOURCE_REGISTRY }}
@@ -247,7 +248,10 @@ jobs:
           fi
 
       - name: Write the visibility checklist to the job summary
-        if: ${{ failure() && inputs.dry_run == false }}
+        if: ${{ failure() && inputs.dry_run == false && steps.publish.outputs.copy_phase_completed == 'true' }}
+        env:
+          SOURCE_REGISTRY: ${{ inputs.source_registry || vars.NPA_PUBLISH_SOURCE_REGISTRY }}
+          SELECTED_TOOL: ${{ inputs.tool || vars.NPA_PUBLISH_TOOL }}
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<'MD'
           ## Images copied, but not yet public
@@ -266,11 +270,21 @@ jobs:
 
           MD
           # Only the packages that are still private, so the list shrinks as they are flipped.
-          python -m npa.deploy.publish_public \
-            --target "${{ steps.target.outputs.value }}" \
-            ${{ inputs.skip_missing && '--skip-missing' || '' }} \
-            --verify-public --checklist 2>/dev/null \
-            | grep '^- \[ \]' >> "$GITHUB_STEP_SUMMARY" || true
+          args=(--target "${{ steps.target.outputs.value }}")
+          if [ -n "$SOURCE_REGISTRY" ]; then
+            args+=(--source-registry "$SOURCE_REGISTRY")
+          fi
+          if [ -n "$SELECTED_TOOL" ]; then
+            python .github/scripts/publish_selected_public_image.py \
+              "${args[@]}" --tool "$SELECTED_TOOL" --mode checklist 2>/dev/null \
+              | grep '^- \[ \]' >> "$GITHUB_STEP_SUMMARY" || true
+          else
+            python -m npa.deploy.publish_public \
+              "${args[@]}" \
+              ${{ inputs.skip_missing && '--skip-missing' || '' }} \
+              --verify-public --checklist 2>/dev/null \
+              | grep '^- \[ \]' >> "$GITHUB_STEP_SUMMARY" || true
+          fi
           cat >> "$GITHUB_STEP_SUMMARY" <<'MD'
 
           Re-run this workflow with `dry_run=false` to re-verify, or run locally:
@@ -278,4 +292,15 @@ jobs:
           ```
           npa/.venv/bin/python -m npa.deploy.publish_public --verify-public
           ```
+          MD
+
+      - name: Write pre-copy failure guidance to the job summary
+        if: ${{ failure() && inputs.dry_run == false && steps.publish.outputs.copy_phase_completed != 'true' }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'MD'
+          ## Publication stopped before copy completion
+
+          The job did not record completion of the registry copy phase. Do **not** infer
+          that a package was created, and do not change GHCR visibility based on this run.
+          Inspect the failing step and fix that error before dispatching another publish.
           MD

--- a/npa/src/npa/deploy/publish_public.py
+++ b/npa/src/npa/deploy/publish_public.py
@@ -75,6 +75,21 @@ class PublishItem:
     target_ref: str
 
 
+def _mark_copy_phase_complete() -> None:
+    """Tell GitHub Actions that every planned copy operation completed.
+
+    The publish command can still exit non-zero after this point when GHCR created a
+    private package and anonymous verification fails. Keeping that state separate from
+    the process exit status prevents a pre-copy failure from producing irreversible
+    package-visibility instructions.
+    """
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+    with Path(github_output).open("a", encoding="utf-8") as output:
+        output.write("copy_phase_completed=true\n")
+
+
 def build_publish_plan(
     *,
     target_registry: str,
@@ -1029,6 +1044,7 @@ def main(argv: list[str] | None = None) -> int:
             already_current += 1
         else:
             copied += 1
+    _mark_copy_phase_complete()
     print(f"\nCopied {copied} image(s).")
     print(f"Skipped {already_current} already-current image(s).")
 

--- a/npa/tests/deploy/test_public_publish.py
+++ b/npa/tests/deploy/test_public_publish.py
@@ -545,9 +545,12 @@ def test_a_token_endpoint_refusal_is_reported_as_a_verdict_not_a_glitch(
 
 
 def test_the_copy_path_writes_nothing_when_a_source_is_unreadable(
-    monkeypatch, capsys
+    monkeypatch, capsys, tmp_path
 ) -> None:
     from npa.deploy import publish_public
+
+    github_output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
 
     def explode(item) -> None:  # pragma: no cover - must not run
         raise AssertionError(
@@ -565,6 +568,7 @@ def test_the_copy_path_writes_nothing_when_a_source_is_unreadable(
 
     assert rc == 1
     assert "nothing was copied" in capsys.readouterr().err
+    assert not github_output.exists()
 
 
 def test_preflight_reports_the_registrys_own_reason(monkeypatch) -> None:
@@ -972,12 +976,14 @@ def test_wan_publication_gate_blocks_copy_before_any_write(monkeypatch, capsys) 
 
 
 def test_a_successful_copy_still_fails_while_the_packages_are_private(
-    monkeypatch, capsys
+    monkeypatch, capsys, tmp_path
 ) -> None:
     """Copying every image and exiting 0 would be the silent false success we guard against."""
     from npa.deploy import publish_public
 
     copied: list[str] = []
+    github_output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
     monkeypatch.setattr(
         publish_public, "_crane_manifest_readable", lambda ref, **_: (True, "ok")
     )
@@ -993,6 +999,7 @@ def test_a_successful_copy_still_fails_while_the_packages_are_private(
 
     assert rc == 1
     assert copied, "the copy itself must still have happened"
+    assert github_output.read_text(encoding="utf-8") == "copy_phase_completed=true\n"
     assert "The copy succeeded" in captured.err, "must not read as a failed copy"
     # The click-through list is the whole point: no hunting for 20-odd packages by hand.
     assert "/packages/container/" in captured.out

--- a/npa/tests/deploy/test_selected_public_publish.py
+++ b/npa/tests/deploy/test_selected_public_publish.py
@@ -1,0 +1,159 @@
+"""Behavioral coverage for the single-image public publisher wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from npa.deploy.publish_public import PublishItem
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / ".github" / "scripts" / "publish_selected_public_image.py"
+
+
+def _load_script():  # noqa: ANN202 - imported script module is intentionally dynamic
+    spec = importlib.util.spec_from_file_location("publish_selected_public_image", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_publish_uses_the_digest_pinned_item_returned_by_preflight(
+    monkeypatch,
+) -> None:
+    module = _load_script()
+    digest = "sha256:" + "a" * 64
+    selected = PublishItem(
+        tool="wan2-2",
+        source_ref="source.example/npa-wan2-2:accepted",
+        target_ref="ghcr.io/example/npa-wan2-2:accepted",
+    )
+    pinned = PublishItem(
+        tool=selected.tool,
+        source_ref=f"source.example/npa-wan2-2@{digest}",
+        target_ref=selected.target_ref,
+    )
+    copied: list[PublishItem] = []
+    verified: list[list[PublishItem]] = []
+    copy_phase_marks: list[bool] = []
+
+    monkeypatch.setattr(module, "build_publish_plan", lambda **_: [selected])
+    monkeypatch.setattr(module, "_preflight_or_explain", lambda _: [pinned])
+    monkeypatch.setattr(module, "_crane_copy", lambda item: copied.append(item) or True)
+    monkeypatch.setattr(
+        module, "_mark_copy_phase_complete", lambda: copy_phase_marks.append(True)
+    )
+    monkeypatch.setattr(
+        module, "verify_public", lambda plan: verified.append(plan) or []
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "--tool",
+            "wan2-2",
+            "--target",
+            "ghcr.io/example",
+            "--mode",
+            "publish",
+        ],
+    )
+
+    assert module.main() == 0
+    assert copied == [pinned]
+    assert verified == [[pinned]]
+    assert copy_phase_marks == [True]
+
+
+def test_copy_phase_is_not_marked_when_preflight_stops_publication(
+    monkeypatch,
+) -> None:
+    module = _load_script()
+    selected = PublishItem(
+        tool="wan2-2",
+        source_ref="source.example/npa-wan2-2:accepted",
+        target_ref="ghcr.io/example/npa-wan2-2:accepted",
+    )
+
+    monkeypatch.setattr(module, "build_publish_plan", lambda **_: [selected])
+    monkeypatch.setattr(module, "_preflight_or_explain", lambda _: [])
+    monkeypatch.setattr(
+        module,
+        "_crane_copy",
+        lambda _: (_ for _ in ()).throw(AssertionError("copy must not run")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_mark_copy_phase_complete",
+        lambda: (_ for _ in ()).throw(AssertionError("marker must not be written")),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "--tool",
+            "wan2-2",
+            "--target",
+            "ghcr.io/example",
+            "--mode",
+            "publish",
+        ],
+    )
+
+    assert module.main() == 1
+
+
+def test_checklist_is_scoped_to_the_selected_image(monkeypatch, capsys) -> None:
+    module = _load_script()
+    selected = PublishItem(
+        tool="wan2-2",
+        source_ref="source.example/npa-wan2-2:accepted",
+        target_ref="ghcr.io/example/npa-wan2-2:accepted",
+    )
+    unrelated = PublishItem(
+        tool="lerobot",
+        source_ref="source.example/npa-lerobot:accepted",
+        target_ref="ghcr.io/example/npa-lerobot:accepted",
+    )
+    failures = [(selected, "HTTP 403")]
+    verified: list[list[PublishItem]] = []
+
+    monkeypatch.setattr(
+        module, "build_publish_plan", lambda **_: [selected, unrelated]
+    )
+    monkeypatch.setattr(
+        module, "verify_public", lambda plan: verified.append(plan) or failures
+    )
+    monkeypatch.setattr(module, "visibility_checklist", lambda _: "- [ ] Wan package")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "--tool",
+            "wan2-2",
+            "--target",
+            "ghcr.io/example",
+            "--mode",
+            "checklist",
+        ],
+    )
+
+    assert module.main() == 1
+    assert verified == [[selected]]
+    assert "- [ ] Wan package" in capsys.readouterr().out
+
+
+def test_copy_phase_marker_uses_the_github_output_file(monkeypatch, tmp_path) -> None:
+    from npa.deploy import publish_public
+
+    github_output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    publish_public._mark_copy_phase_complete()
+
+    assert github_output.read_text(encoding="utf-8") == "copy_phase_completed=true\n"

--- a/npa/tests/guardrails/test_public_mirror_workflows.py
+++ b/npa/tests/guardrails/test_public_mirror_workflows.py
@@ -111,3 +111,26 @@ def test_only_the_publish_workflow_can_write_to_ghcr() -> None:
         "publishing is irreversible; it must never be triggered by a push or a schedule"
     )
     assert spec["permissions"].get("packages") == "write"
+
+
+def test_visibility_guidance_requires_a_completed_copy_phase() -> None:
+    """A pre-copy exception must never produce irreversible visibility instructions."""
+    steps = _steps(PUBLISH)
+    publish = next(step for step in steps if step.get("name") == "Publish and verify")
+    visibility = next(
+        step
+        for step in steps
+        if step.get("name") == "Write the visibility checklist to the job summary"
+    )
+    pre_copy = next(
+        step
+        for step in steps
+        if step.get("name") == "Write pre-copy failure guidance to the job summary"
+    )
+
+    assert publish["id"] == "publish"
+    assert "steps.publish.outputs.copy_phase_completed == 'true'" in visibility["if"]
+    assert "Images copied, but not yet public" in visibility["run"]
+    assert "--tool \"$SELECTED_TOOL\" --mode checklist" in visibility["run"]
+    assert "steps.publish.outputs.copy_phase_completed != 'true'" in pre_copy["if"]
+    assert "do not change GHCR visibility" in pre_copy["run"]


### PR DESCRIPTION
## What changed

- Preserve the digest-pinned `wan2-2` source returned by publication preflight and pass that exact reference to the copy guard.
- Record a `copy_phase_completed` GitHub Actions output only after every planned copy operation completes.
- Show irreversible GHCR visibility instructions only when that output is present; pre-copy failures now receive safe diagnostic guidance.
- Keep the visibility checklist scoped to the selected tool instead of checking unrelated packages.
- Add behavioral regression coverage for the selected publisher, copy-state signaling, and workflow summary conditions.

## Why

The selected-image wrapper preflighted a digest-pinned Wan item but then discarded it and called `_crane_copy` with the original mutable tag. The copy guard correctly rejected that reference before invoking `crane copy`. The workflow nevertheless emitted its generic "Images copied, but not yet public" summary for any non-dry-run failure, incorrectly suggesting an irreversible visibility change.

## Impact

An authorized `wan2-2` publication can now retain the exact-digest safety boundary and reach the registry copy. A pre-copy exception can no longer claim that a package was copied or direct an operator to change package visibility. If the copy completes but the new GHCR package remains private, the existing one-time manual visibility workflow is still shown.

## Validation

- `npa/.venv/bin/python -m pytest npa/tests/ --ignore=npa/tests/e2e --timeout=120 -q` — 7,062 passed, 47 skipped, 1 xpassed.
- `npa/.venv/bin/python -m pytest npa/tests/deploy/test_selected_public_publish.py npa/tests/deploy/test_public_publish.py npa/tests/guardrails/test_public_mirror_workflows.py --timeout=120 -q` — 97 passed.
- `cd npa && .venv/bin/python -m ruff check src tests` — passed.
- Focused Ruff checks for the GitHub helper and all changed Python files — passed.
- `git diff --check` — passed.

## Limitations

No registry write or package visibility change was performed from this branch. After merge, the release should repeat the Wan-only dry run, then the already-authorized real publish; a newly created private GHCR package still requires an organization administrator to make it public before final anonymous verification succeeds.
