### PR TITLE
Reduce redundant PR CI jobs

### DIFF
--- a/.github/workflows/confidentiality-scan.yml
+++ b/.github/workflows/confidentiality-scan.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Keep workflows independent, but let a newer commit supersede older work for
+  # the same PR. Non-PR runs use run_id and are never cancelled by this policy.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  # Keep workflows independent, but let a newer commit supersede older work for
+  # the same PR. Non-PR runs use run_id and are never cancelled by this policy.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest

--- a/.github/workflows/harness-guardrails.yml
+++ b/.github/workflows/harness-guardrails.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Keep workflows independent, but let a newer commit supersede older work for
+  # the same PR. Non-PR runs use run_id and are never cancelled by this policy.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   guardrails:
     runs-on: ubuntu-latest

--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -29,6 +29,12 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  # Keep workflows independent, but let a newer commit supersede older work for
+  # the same PR. Scheduled and manual scans use run_id so they run to completion.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   tag-strategy-check:
     name: Two-tag strategy consistency

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,14 @@ name: Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  # An open PR already receives pull_request runs, so feature-branch pushes do
+  # not need a second copy. Cancel older lint work when that PR advances.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ruff:
@@ -21,26 +28,6 @@ jobs:
 
       - name: Ruff check (blocking)
         run: cd npa && ruff check src tests
-
-  mypy:
-    # Advisory only for now: the tree has no type-checking history. Flip
-    # continue-on-error to false once the baseline is clean.
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install npa and mypy
-        run: cd npa && pip install -e ".[full]" mypy
-
-      - name: Mypy (advisory, non-blocking)
-        continue-on-error: true
-        run: cd npa && mypy src/npa --ignore-missing-imports --no-error-summary
 
   docs-drift:
     # Fail when docs/cli/ is out of date relative to `npa --help`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,14 @@ name: Test
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  # An open PR already receives pull_request runs, so feature-branch pushes do
+  # not need a second copy. Cancel older tests when that PR advances.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -10,9 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Cover the supported floor (3.10), a common current version, and the
-        # latest release so requires-python = ">=3.10" is actually tested.
-        python-version: ["3.10", "3.12", "3.14"]
+        # PRs get one representative version for fast feedback. Main still
+        # covers the supported floor, common version, and latest release.
+        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.12"]' || '["3.10","3.12","3.14"]') }}
     env:
       NPA_PROJECT_ID: project-test-00000000
       NPA_S3_BUCKET: test-bucket-00000000

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,29 @@
+name: Type check (manual)
+
+# Type checking is advisory while the repository has no clean baseline. Keep it
+# available on demand without spending a runner on every commit for a job whose
+# result cannot block a merge.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install npa and mypy
+        run: cd npa && pip install -e ".[full]" mypy
+
+      - name: Mypy (advisory)
+        continue-on-error: true
+        run: cd npa && mypy src/npa --ignore-missing-imports --no-error-summary

--- a/npa/tests/guardrails/test_ci_workflows.py
+++ b/npa/tests/guardrails/test_ci_workflows.py
@@ -1,0 +1,71 @@
+"""Guard the CI controls that prevent duplicate and superseded PR work."""
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+AUTOMATIC_PR_WORKFLOWS = (
+    "confidentiality-scan.yml",
+    "gitleaks.yml",
+    "harness-guardrails.yml",
+    "image-security-scan.yml",
+    "lint.yml",
+    "test.yml",
+)
+
+
+def _load_workflow(name: str) -> dict:
+    # BaseLoader preserves the key `on`; PyYAML's YAML 1.1 SafeLoader treats it
+    # as a boolean, while GitHub Actions follows YAML 1.2 semantics here.
+    with (WORKFLOW_DIR / name).open(encoding="utf-8") as workflow_file:
+        return yaml.load(workflow_file, Loader=yaml.BaseLoader)
+
+
+def test_automatic_pr_workflows_cancel_superseded_commits() -> None:
+    expected_group = (
+        "${{ github.workflow }}-"
+        "${{ github.event.pull_request.number || github.run_id }}"
+    )
+    expected_cancel = "${{ github.event_name == 'pull_request' }}"
+
+    discovered = {
+        path.name
+        for path in WORKFLOW_DIR.glob("*.y*ml")
+        if "pull_request" in _load_workflow(path.name)["on"]
+    }
+    assert discovered == set(AUTOMATIC_PR_WORKFLOWS)
+
+    for name in AUTOMATIC_PR_WORKFLOWS:
+        workflow = _load_workflow(name)
+        assert "pull_request" in workflow["on"], name
+        assert workflow["concurrency"] == {
+            "group": expected_group,
+            "cancel-in-progress": expected_cancel,
+        }, name
+
+
+def test_test_and_lint_do_not_duplicate_feature_branch_pushes() -> None:
+    for name in ("test.yml", "lint.yml"):
+        workflow = _load_workflow(name)
+        assert workflow["on"]["push"] == {"branches": ["main"]}, name
+
+
+def test_pr_test_matrix_uses_one_version_and_main_keeps_compatibility() -> None:
+    workflow = _load_workflow("test.yml")
+    versions = workflow["jobs"]["test"]["strategy"]["matrix"]["python-version"]
+
+    assert "github.event_name == 'pull_request'" in versions
+    assert "[\"3.12\"]" in versions
+    assert "[\"3.10\",\"3.12\",\"3.14\"]" in versions
+
+
+def test_advisory_mypy_is_manual_only() -> None:
+    lint = _load_workflow("lint.yml")
+    typecheck = _load_workflow("typecheck.yml")
+
+    assert "mypy" not in lint["jobs"]
+    assert typecheck["on"] == {"workflow_dispatch": ""}
+    assert set(typecheck["jobs"]) == {"mypy"}


### PR DESCRIPTION
## Summary

- cancel superseded runs independently for each automatic PR workflow
- stop `Test` and `Lint` from also running on feature-branch push events
- run the test suite on Python 3.12 for PRs while retaining the full 3.10/3.12/3.14 compatibility matrix on `main`
- move the advisory, non-blocking mypy job to a manual workflow
- add guardrail tests that preserve the reduced-CI behavior

## Why

The repository had no PR concurrency groups, so every commit in a push burst continued running after newer commits made it obsolete. `Test` and `Lint` also used unrestricted `push` plus `pull_request` triggers, which ran both workflows twice for every commit on an open PR. The test matrix and advisory mypy job amplified that duplication.

For a routine non-container PR commit, this reduces the Test/Lint portion from 12 runner jobs to 3 and the overall automatic total from approximately 15 jobs to 6. Security, confidentiality, and main-branch compatibility coverage remain enabled.

## Validation

- `actionlint`: passed
- `npa/.venv/bin/python -m pytest npa/tests/guardrails/test_ci_workflows.py -q`: 4 passed
- `npa/.venv/bin/python -m ruff check npa/tests/guardrails/test_ci_workflows.py`: passed
- broader guardrails: 1,514 passed, 1 skipped; 3 unrelated existing failures remain (BYOF profile path, missing `fleet` command in the current venv, and `leisaac` contract registration)
