### PR TITLE
test: make PR 218 heartbeat check deterministic

### DIFF
--- a/npa/tests/cli/test_agent_setup_convergence.py
+++ b/npa/tests/cli/test_agent_setup_convergence.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-import time
+import threading
 from types import SimpleNamespace
 
 import httpx
@@ -156,13 +156,20 @@ def test_blocking_calls_emit_structured_secret_free_heartbeats(monkeypatch, tmp_
         resume_command="",
     )
     events = []
+    periodic_heartbeat = threading.Event()
+
+    def emit(event) -> None:
+        events.append(event)
+        if event["heartbeat_sequence"] > 0:
+            periodic_heartbeat.set()
+
     with operation_heartbeats(
         operation,
         phase="remote_bootstrap",
         interval_seconds=0.01,
-        emit=events.append,
+        emit=emit,
     ):
-        time.sleep(0.035)
+        assert periodic_heartbeat.wait(timeout=1.0)
     assert len(events) >= 2
     assert all(event["operation_phase"] == "remote_bootstrap" for event in events)
     journal = operation.read()


### PR DESCRIPTION
## What changed

- Replaced the heartbeat test's fixed 35 ms sleep with a `threading.Event` that is set by the first periodic heartbeat.
- Kept the existing assertions for multiple events, phase identity, journal persistence, and secret-free metadata.

## Root cause

PR #218 added `test_blocking_calls_emit_structured_secret_free_heartbeats`, which assumed the heartbeat worker thread would be scheduled within 35 ms. In the archived Python 3.10 Actions attempt, the worker was not scheduled before the context exited, so only the synchronous sequence-0 event existed and the test failed (`1 failed, 8,759 passed, 356 skipped, 1 xpassed`). A rerun passed, confirming the failure was scheduling-sensitive rather than a production heartbeat defect.

The separate IAM-token concern recorded in PR #218 is already self-contained on merged `main`: `test_agent_only_deploy_omits_paidf_capacity_reservation` supplies `iam_token` in its mocked bootstrap result and passes with Nebius IAM environment variables removed.

## Impact

CI now waits for the behavior it is asserting instead of relying on host timing. Slow or loaded runners should no longer fail this test spuriously, while a heartbeat worker that never emits still fails the test.

## Validation

- `npa/.venv/bin/python -m ruff check npa/tests/cli/test_agent_setup_convergence.py` — passed, 0 findings.
- Credential-free focused pytest — 12 passed, 0 failed.
- Full non-E2E pytest, parallel (`-n auto`) — 8,767 passed, 48 skipped, 1 xpassed, 0 failed in 179.72s.
- Full non-E2E pytest, serial — 8,767 passed, 48 skipped, 1 xpassed, 0 failed in 624.92s.
- `git diff --check` — passed.

## Limitations

- Local validation used the repository Python 3.10 virtualenv; GitHub Actions remains the cross-version confirmation.
- No live-infrastructure validation was run because this follow-up changes only unit-test synchronization and does not alter production agent/deploy or workflow behavior.
