### PR TITLE
Audit LeRobot version support against upstream 0.6.1, and fix the extras 0.6.0 shipped without

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ tmp/
 *.tmp
 *.temp
 
+# Wheel cache for npa/scripts/audit_lerobot_release.py
+.tmp-lerobot-wheels/
+
 # Node dependencies
 node_modules/
 

--- a/docs/workbench/lerobot-version-support-audit-20260813.md
+++ b/docs/workbench/lerobot-version-support-audit-20260813.md
@@ -1,0 +1,281 @@
+# LeRobot version support audit and proposal — 2026-08-13
+
+Upstream LeRobot is at **0.6.1** (released 2026-08-03). This workbench defaults
+to **0.5.1** (2026-04-07) and offers **0.6.0** (2026-07-06) as a selectable
+alternative. This audit answers whether the workbench should support 0.6.1, what
+it would cost, and what is already wrong independent of that decision.
+
+Every claim below was checked against the published wheels rather than the
+release notes, and is reproducible with the pre-flight added alongside this
+document:
+
+```bash
+npa/.venv/bin/python npa/scripts/audit_lerobot_release.py 0.6.1 --baseline 0.5.1
+```
+
+## Recommendation
+
+**Adopt 0.6.1 as an additional supported version, and make it the default once
+the GPU gates pass. Do not treat this as a risky upgrade — treat the current
+0.5.1 default as the risk.**
+
+The upgrade itself is nearly free. All 19 LeRobot bindings this repo holds
+resolve unchanged in 0.6.1; the sole breaking rename in 0.6.1
+(`lerobot.types` → `lerobot.lerobot_types`) is not referenced anywhere in this
+repo; the dataset format is unchanged; and the CLI contract is identical to
+0.6.0's, which `version_compat.py` already models. The scaffolding built by
+[#191](https://github.com/nebius/nebius-physical-ai/pull/191) means adding a
+third version is mostly manifest data, not new code.
+
+The more consequential finding is separate from the upgrade: **two published
+images install a torch/torchvision/diffusers stack that upstream 0.5.1 declares
+incompatible**, and one of them — `npa-lerobot-policy:0.1.1` — is a current pin,
+not a superseded tag.
+
+## Scope: what "supporting LeRobot" actually spans
+
+"Support the latest LeRobot" is not one decision. LeRobot enters this repo
+through five independent surfaces, each with its own failure mode and its own
+upgrade cost:
+
+| Surface | How it binds | Breaks when |
+|---|---|---|
+| Python API | 19 `from lerobot...` bindings across the policy server, Genesis student eval, workflow dataset staging, and the research profiler | a module is renamed or a symbol removed |
+| CLI subprocess | `lerobot-train` / `lerobot-eval` argv built in four places | an entry point or draccus flag is renamed |
+| Dataset format | three hand-rolled writers emit `meta/info.json` + `data/chunk-*` + `videos/` directly | `CODEBASE_VERSION` bumps or `info.json` gains required keys |
+| Container images | four image families pin LeRobot at build time | Python or torch bounds move |
+| Orchestration | three `workbench.lerobot.*` catalog toolRefs and the sim2real staged engine | the image they route to changes shape |
+
+The Python API and CLI surfaces are the ones release notes talk about. The
+dataset and container surfaces are the ones that actually cost effort here.
+
+## Where LeRobot is pinned today
+
+| Image | LeRobot | Python | Torch stack | Status |
+|---|---|---|---|---|
+| `npa-lerobot:cuda13-b300-0.5.1-…` (**default**) | 0.5.1 from git `1396b9f` | 3.12 | torch 2.9.0 / tv 0.24.0 / torchcodec 0.8.1 cu130 | clean |
+| `npa-lerobot:0.5.1` (CUDA 12 semver) | 0.5.1 | 3.12 | torch 2.12.1 / tv 0.27.1 / diffusers ≥0.38 | **conflicting** |
+| `npa-lerobot:0.6.0` (CUDA 12 semver) | 0.6.0 | 3.12 | resolver-chosen | clean |
+| `npa-lerobot-policy:0.1.1` | 0.5.1 | 3.12 | torch 2.12.1 / tv 0.27.1 / diffusers ≥0.38 | **conflicting** |
+| `npa-genesis:…0.4.6…` | 0.4.4 | 3.10 / 3.11 | torch 2.6.0 / tv 0.21.0 | clean, but frozen |
+| `npa-lerobot-vlm-rl:cuda13-b300-0.1.1-…` | inherits Genesis 0.4.4 | 3.11 | inherits | clean, but frozen |
+
+Version knowledge is duplicated across `npa/pyproject.toml`,
+`lerobot_version_manifest.json`, `deploy/images.py`, `smoke/_versions.py`,
+`smoke/golden_evals.yaml`, `terraform/variables.tf`, `cloud_init.yaml.tpl`,
+`setup/install_lerobot.sh`, `lerobot/build.sh`, `lerobot/Dockerfile`, and four
+skill/doc files. [#191](https://github.com/nebius/nebius-physical-ai/pull/191)
+touched 26 files to add one version.
+
+## What 0.6.1 changes
+
+0.6.1 is a consolidation release. The single declared breaking change is the
+`lerobot.types` → `lerobot.lerobot_types` module rename. The bulk of the diff is
+internal refactoring — shared VLA components across pi0/pi0.5/eo1/pi0_fast/
+smolvla, policy components resolved by convention, Transformers subclassing
+instead of vendoring for wall-x and x-vla — plus HF Storage Bucket streaming
+(`repo_type="bucket"`), which is why `huggingface-hub` moves to ≥1.6.0.
+
+For context on the jump from the current default, 0.6.0 carried the larger
+break: extras became mandatory for dataset/training deps, `eval_freq` became
+`env_eval_freq`, `sac` became `gaussian_actor`, `--dataset.vcodec` became
+`--dataset.rgb_encoder.vcodec`, and GR00T N1.5 became N1.7.
+
+### Compatibility findings
+
+Checked against the 0.5.1, 0.6.0, and 0.6.1 wheels:
+
+- **Import surface: 19/19 bindings resolve in 0.6.1**, unchanged all the way
+  back from 0.5.1. `lerobot.types` is not imported anywhere in this repo — the
+  only reference is an archived work log — so 0.6.1's one breaking change is a
+  no-op here.
+- **Signatures are additive only.** `make_pre_post_processors` gained
+  `pretrained_revision` and `EpisodeAwareSampler` gained `seed` /
+  `absolute_to_relative_idx` (both in 0.6.0); `LeRobotDataset.__init__` gained
+  keyword-only `token` in 0.6.1. Every parameter this repo passes by keyword
+  still exists.
+- **CLI contract is identical to 0.6.0.** `lerobot-train` and `lerobot-eval`
+  entry points, `TrainPipelineConfig.env_eval_freq`,
+  `PreTrainedConfig.pretrained_path`, and the draccus `PATH_KEY = "path"` alias
+  behind `--policy.path` are all unchanged. The existing 0.6.0 manifest entry is
+  therefore correct for 0.6.1 as-is.
+- **Dataset format is unchanged.** `CODEBASE_VERSION` is still `v3.0` in 0.6.1,
+  so `sim_to_lerobot.py`, `isaac_lab_lerobot.py`, and `groot.py` need no
+  migration. Better, 0.6.x replaced the untyped `info.json` dict with a
+  `DatasetInfo` dataclass whose `from_dict` explicitly *ignores unknown keys for
+  forward compatibility*, and the field set exactly covers what our writers emit.
+- **None of 0.6.0's other breaks apply.** This repo never passes
+  `--dataset.vcodec`, never uses the `sac` policy type, and never writes
+  per-frame `subtask_index`.
+- **The validated B300 torch stack already satisfies 0.6.1.** torch 2.9.0 /
+  torchvision 0.24.0 / torchcodec 0.8.1 sit inside 0.6.1's declared
+  `torch<2.12,>=2.7`, `torchvision<0.27,>=0.22`, `torchcodec<0.12,>=0.3`. The
+  Blackwell Dockerfile needs no torch change to build 0.6.1.
+
+Two new entry points arrive in 0.6.x that this repo does not yet use:
+`lerobot-rollout` and `lerobot-annotate`. `workbench.lerobot.policy_rollout`
+currently implements rollouts through `lerobot-eval`, and the Physical AI Data
+Factory blueprint has its own annotate stage. Both are worth a look later;
+neither is upgrade-blocking.
+
+## Defects in the current state
+
+These exist today and are not caused by upgrading. They are the reason the
+recommendation is "move forward" rather than "stay put".
+
+**D1 — Two images force a dependency stack upstream 0.5.1 declares
+incompatible.** `npa/docker/workbench/lerobot/Dockerfile` (non-0.6 branch) and
+`npa/docker/workbench/lerobot-policy/Dockerfile` both run
+`pip install --upgrade torch==2.12.1 torchvision==0.27.1 "diffusers>=0.38.0"`
+*after* installing `lerobot==0.5.1`, which declares `torch<2.11.0`,
+`torchvision<0.26.0`, and `diffusers<0.36.0`. All three violate. Because the
+upgrade is a second pip invocation, pip does not re-resolve and the build
+succeeds, so the breakage ships silently — this is the mechanical root cause of
+the "0.5.1 fails LeRobot training at step 0 with a torch/torchcodec ABI
+mismatch" note already in `CHANGELOG.md`. `npa-lerobot:0.5.1` is documented as
+superseded, but **`npa-lerobot-policy:0.1.1` is a current pin** in
+`[tool.npa.supported-tools]`.
+
+**D2 — The manifest's torch pins are dead data.** `torch_pin`,
+`torchvision_pin`, and `diffusers_pin` for 0.5.1 are read only by
+`torch_install_pins()`, which has no production caller — the sole references are
+its own unit test. The pins that actually execute are hardcoded in the two
+Dockerfiles. A contract that nothing enforces will be trusted by the next author
+and is already inconsistent with the VM installer, which pins neither
+(`install_lerobot.sh` installs unpinned `torch torchvision` from the cu124
+index).
+
+**D3 — 0.6.0 has no hardware-validated image.** The 0.5.1 manifest entry carries
+an `image_tag` and an `image_digest`; the 0.6.0 entry carries neither, so
+`resolve_lerobot_image_tag("0.6.0")` falls through to the bare `0.6.0` semver
+tag built from the CUDA 12 Dockerfile. Selecting `--lerobot-version 0.6.0`
+therefore silently opts out of the Blackwell-validated image family that the
+default uses.
+
+**D4 — The stated reason for pinning the default at 0.5.1 is stale.**
+`skills/tools/lerobot/SKILL.md` and `skills/workflows/byof-onboard/SKILL.md`
+justify the 0.5.1 default as "keep for GR00T N1.5 / sim2real policy image
+parity". But `npa-groot` clones NVIDIA's Isaac-GR00T directly and already ships
+**N1.7** — it does not consume LeRobot's `groot` extra at all. Only the sim2real
+parity half of that justification survives.
+
+**D5 — The sim2real stack is hard-capped at LeRobot 0.4.4 by Python, not by
+choice.** LeRobot has required **Python ≥3.12 since 0.5.0**. `npa-base` builds a
+Python **3.11** venv and the CUDA 12 Genesis image builds on Ubuntu 22.04's
+Python **3.10**. Genesis and the `npa-lerobot-vlm-rl` trainer derived from it
+therefore cannot move past 0.4.4 (Feb 2026) without an interpreter change. This
+is the one genuinely invasive item in this audit, and nothing in the docs
+currently records it as a constraint.
+
+## Proposal
+
+### P1 — Add 0.6.1 as a supported version
+
+Cheapest possible change, because 0.6.1's CLI contract equals 0.6.0's. The
+manifest entry is the 0.6.0 entry plus an image tag:
+
+```json
+"0.6.1": {
+  "pip_extras": "training,evaluation,pusht,libero",
+  "train_env_eval_flag": "env_eval_freq",
+  "eval_checkpoint_flag": "policy.path",
+  "policy_eval_checkpoint_flag": "policy.pretrained_path",
+  "torch_pin": null,
+  "torchvision_pin": null,
+  "diffusers_pin": null
+}
+```
+
+Beyond the manifest, a version addition touches the same surface #191 did:
+`pyproject.toml`, `deploy/images.py`, `lerobot/Dockerfile` (extend the `0.6.0`
+branch condition to all 0.6.x), `lerobot/build.sh`, `terraform/variables.tf`,
+`cloud_init.yaml.tpl`, `setup/install_lerobot.sh`, `smoke/golden_evals.yaml`, and
+the four skill/doc files. `smoke/_versions.py` needs no change: its
+`startswith("0.6")` test already yields `env_eval_freq` for 0.6.1.
+
+Note that 0.6.1 tightens `diffusers` to `<0.40.0,>=0.38.0` — the opposite
+direction from 0.5.1's `<0.36.0`. Any image that pins diffusers must pin it
+per-LeRobot-version, not globally.
+
+### P2 — Fix D1 before, not with, the upgrade
+
+The conflicting force-upgrade should be removed from
+`lerobot-policy/Dockerfile` and from the non-0.6 branch of `lerobot/Dockerfile`,
+and `lerobot-policy/requirements.txt` moved to a LeRobot version whose declared
+bounds match the torch stack actually wanted. This is worth doing on its own
+merits: `npa-lerobot-policy:0.1.1` is a live pin serving the BYO-policy path, and
+today it ships a dependency set upstream says will not work. Rebuilding it on
+0.6.1 resolves the conflict and the ABI mismatch in one move, since 0.6.1 is the
+first release whose `diffusers>=0.38.0` floor matches what the image wants.
+
+### P3 — Delete or wire up the manifest torch pins (D2)
+
+Either give `torch_install_pins()` a real caller (have the Dockerfiles read the
+manifest rather than hardcode) or drop the three keys. The first is better — it
+makes `audit_lerobot_release.py` a genuine gate on the image build. The second is
+acceptable. Leaving unenforced pins in a file named "manifest" is not.
+
+### P4 — Give the non-default version a validated image (D3)
+
+Whichever version is *not* the default still needs an `image_tag` and
+`image_digest` in the manifest, produced by the same
+`validate_blackwell_image.sh` path as the default. Otherwise `--lerobot-version`
+quietly switches users onto a different, less-validated image family.
+
+### P5 — Record the Python 3.12 wall for the sim2real stack (D5)
+
+Genesis and `npa-lerobot-vlm-rl` cannot follow LeRobot forward while their
+interpreters are 3.10/3.11. Two options, neither cheap:
+
+- Add a dedicated Python 3.12 `/opt/lerobot/venv` to the Genesis image, exactly
+  as `Dockerfile.b300` already does for `npa-lerobot`, leaving Genesis itself on
+  its own interpreter. This is the precedent-following option and keeps Genesis
+  and RSL-RL untouched.
+- Move `npa-base` to Python 3.12 and rebuild the dependent image family. Larger
+  blast radius across every tool built on `npa-base`.
+
+Until one of those lands, the docs should state plainly that the sim2real
+trainer runs LeRobot 0.4.4 and that this is an interpreter constraint, so nobody
+reads the `npa-lerobot` version selector and assumes the sim2real path follows.
+
+### P6 — Keep the default at 0.5.1 until the gates pass, then move it
+
+Promoting the default is the one change with real blast radius: it moves golden
+evals, the sim2real policy image, and every `npa workbench lerobot` invocation
+that does not pass `--lerobot-version`. Sequence it as add-then-promote, and
+when promoting, correct the stale GR00T N1.5 rationale in the two skill files
+(D4) rather than copying it forward.
+
+## Validation plan
+
+Static pre-flight is a triage tool, not a merge gate. The gates should match the
+precedent set by #191, which validated 0.6.0 on a real H100:
+
+1. `npa/.venv/bin/python npa/scripts/audit_lerobot_release.py 0.6.1` — passes today.
+2. Unit and CLI suites (`make test`).
+3. Build `npa-lerobot:0.6.1` from the CUDA 12 Dockerfile and the B300 variant.
+4. On real GPU: `python -m npa.smoke.test_lerobot_env` (4/4) and
+   `python -m npa.smoke.test_lerobot_functional` (5/5, 50-step PushT train +
+   eval) with `NPA_LEROBOT_VERSION=0.6.1`.
+5. `validate_blackwell_image.sh` for the B300 tag, recording `published_digest`
+   into `blackwell-dc-images.json` and the manifest.
+6. A `workbench.lerobot.policy_train` workflow run end-to-end, since that stage
+   installs npa into `/opt/lerobot/venv` and is the path most sensitive to the
+   0.6.x lean-extras change.
+
+Step 4 is the one that cannot be skipped: 0.6.0's move to mandatory extras means
+an import that resolves statically can still fail at runtime if the extra set is
+wrong. That failure mode is exactly what `[training,evaluation,pusht,libero]`
+exists to prevent, and only a real run proves it.
+
+## What this audit does not cover
+
+It reads wheel source with `ast` and never imports LeRobot, so it says nothing
+about runtime behaviour, kernel compatibility, throughput, or checkpoint
+portability. It does not evaluate whether pre-0.6 public checkpoints such as
+`lerobot/diffusion_pusht` migrate cleanly to the 0.6 processor format — a known
+issue already noted in `CHANGELOG.md` and unchanged by 0.6.1. It does not assess
+the new `lerobot-rollout` and `lerobot-annotate` entry points beyond noting they
+exist. And it makes no claim about registry bytes; image-level redistribution
+and payload review remain governed by
+`skills/atomic/solution-licensing/SKILL.md`.

--- a/docs/workbench/lerobot-version-support-audit-20260813.md
+++ b/docs/workbench/lerobot-version-support-audit-20260813.md
@@ -13,6 +13,11 @@ document:
 npa/.venv/bin/python npa/scripts/audit_lerobot_release.py 0.6.1 --baseline 0.5.1
 ```
 
+The conclusions were then **executed** against a real LeRobot 0.6.1 install on
+the dev VM and against the shipped `npa-lerobot:0.6.0` image on an H100. That
+step is what turned up D6, a defect no amount of static reading would have
+found — see [Executed validation](#executed-validation).
+
 ## Recommendation
 
 **Adopt 0.6.1 as an additional supported version, and make it the default once
@@ -27,10 +32,12 @@ repo; the dataset format is unchanged; and the CLI contract is identical to
 [#191](https://github.com/nebius/nebius-physical-ai/pull/191) means adding a
 third version is mostly manifest data, not new code.
 
-The more consequential finding is separate from the upgrade: **two published
+The more consequential findings are separate from the upgrade. **Two published
 images install a torch/torchvision/diffusers stack that upstream 0.5.1 declares
 incompatible**, and one of them — `npa-lerobot-policy:0.1.1` — is a current pin,
-not a superseded tag.
+not a superseded tag. And running the existing `npa-lerobot:0.6.0` image on an
+H100 showed **it cannot construct a Diffusion Policy at all** (D6): 0.6.0 moved
+`diffusers` behind an extra we never requested. That one is fixed in this PR.
 
 ## Scope: what "supporting LeRobot" actually spans
 
@@ -150,7 +157,9 @@ an `image_tag` and an `image_digest`; the 0.6.0 entry carries neither, so
 `resolve_lerobot_image_tag("0.6.0")` falls through to the bare `0.6.0` semver
 tag built from the CUDA 12 Dockerfile. Selecting `--lerobot-version 0.6.0`
 therefore silently opts out of the Blackwell-validated image family that the
-default uses.
+default uses. That bare tag does exist in the registry and runs — it is what D6
+was reproduced on — it simply has no recorded digest and no hardware gate, which
+is why a defect of D6's size could sit in it unnoticed.
 
 **D4 — The stated reason for pinning the default at 0.5.1 is stale.**
 `skills/tools/lerobot/SKILL.md` and `skills/workflows/byof-onboard/SKILL.md`
@@ -158,6 +167,34 @@ justify the 0.5.1 default as "keep for GR00T N1.5 / sim2real policy image
 parity". But `npa-groot` clones NVIDIA's Isaac-GR00T directly and already ships
 **N1.7** — it does not consume LeRobot's `groot` extra at all. Only the sim2real
 parity half of that justification survives.
+
+**D6 — `npa-lerobot:0.6.0` cannot run Diffusion Policy.** *(found by running the
+image; fixed in this PR)* 0.6.0 moved `diffusers` and `transformers` out of the
+base install and behind extras, and enforces them with `require_package()`
+**inside each policy's `__init__`**. Our extras string was never updated, so
+`lerobot[training,evaluation,pusht,libero]` installs no `diffusers`, the module
+still imports cleanly, and the failure lands at
+`make_policy()` — that is, at run time, on the real training command:
+
+```
+lerobot/policies/diffusion/modeling_diffusion.py:77 in __init__
+    require_package("diffusers", extra="diffusion")
+ImportError: 'diffusers' is required but not installed.
+             Install it with: pip install 'lerobot[diffusion]'
+```
+
+0.5.1 is unaffected because `diffusers` is a *core* dependency there, which is
+also why the default B300 image — built from a genuine 0.5.1 commit — was never
+exposed. The blast radius is anyone who opts into `--lerobot-version 0.6.0`,
+plus anyone who would have promoted 0.6.x to default. Two details corroborate
+that the extras set has been drifting: the Dockerfiles hand-install `num2words`,
+which is precisely what the `smolvla` extra supplies, and `libero` is the only
+reason `transformers` is present at all (transitively, by accident).
+
+Fixed here by requesting the extras the policies gate on
+(`…,libero,diffusion,smolvla`) in both the manifest and the Dockerfile, and by
+teaching the pre-flight to resolve the extras graph and cross-check it against
+the `require_package` gates it finds in each policy module.
 
 **D5 — The sim2real stack is hard-capped at LeRobot 0.4.4 by Python, not by
 choice.** LeRobot has required **Python ≥3.12 since 0.5.0**. `npa-base` builds a
@@ -176,7 +213,7 @@ manifest entry is the 0.6.0 entry plus an image tag:
 
 ```json
 "0.6.1": {
-  "pip_extras": "training,evaluation,pusht,libero",
+  "pip_extras": "training,evaluation,pusht,libero,diffusion,smolvla",
   "train_env_eval_flag": "env_eval_freq",
   "eval_checkpoint_flag": "policy.path",
   "policy_eval_checkpoint_flag": "policy.pretrained_path",
@@ -192,6 +229,9 @@ branch condition to all 0.6.x), `lerobot/build.sh`, `terraform/variables.tf`,
 `cloud_init.yaml.tpl`, `setup/install_lerobot.sh`, `smoke/golden_evals.yaml`, and
 the four skill/doc files. `smoke/_versions.py` needs no change: its
 `startswith("0.6")` test already yields `env_eval_freq` for 0.6.1.
+
+The extras string carries the D6 fix forward; without `diffusion` and `smolvla`
+a 0.6.1 entry would inherit the same broken policy coverage 0.6.0 shipped with.
 
 Note that 0.6.1 tightens `diffusers` to `<0.40.0,>=0.38.0` — the opposite
 direction from 0.5.1's `<0.36.0`. Any image that pins diffusers must pin it
@@ -246,27 +286,89 @@ that does not pass `--lerobot-version`. Sequence it as add-then-promote, and
 when promoting, correct the stale GR00T N1.5 rationale in the two skill files
 (D4) rather than copying it forward.
 
-## Validation plan
+## Executed validation
 
-Static pre-flight is a triage tool, not a merge gate. The gates should match the
-precedent set by #191, which validated 0.6.0 on a real H100:
+Static pre-flight is triage, not a merge gate, so the audit's conclusions were
+executed against a real install. This is what found D6.
 
-1. `npa/.venv/bin/python npa/scripts/audit_lerobot_release.py 0.6.1` — passes today.
-2. Unit and CLI suites (`make test`).
-3. Build `npa-lerobot:0.6.1` from the CUDA 12 Dockerfile and the B300 variant.
-4. On real GPU: `python -m npa.smoke.test_lerobot_env` (4/4) and
+**Real LeRobot 0.6.1, dev VM, Python 3.12.13, torch 2.9.0, CPU.** Installed
+`lerobot[training,evaluation,pusht]==0.6.1` into a clean venv and ran the
+contract rather than reading it:
+
+| Claim | Result |
+|---|---|
+| 19/19 bindings resolve | all 19 **import** for real, including `DiffusionPolicy` and `SmolVLAPolicy` |
+| `env_eval_freq` replaces `eval_freq` | `lerobot-train --help` offers `--env_eval_freq`, and no longer `--eval_freq` |
+| `--policy.path` still works | accepted — parsing reaches a Hub lookup, while a bogus `--policy.x` is rejected as unrecognized. It is absent from `--help` because draccus resolves the path alias before argument parsing, which is easy to misread as a break |
+| adapters need no migration | a dataset written by `npa/adapter/sim_to_lerobot.py` loads under 0.6.1 `LeRobotDataset`, with video frames decoded and the expected `observation.state` / `action` / `observation.images.*` keys |
+| the workbench train path works | `lerobot-train --policy.type=act` runs real steps on that dataset and checkpoints (exit 0) |
+
+**The gap between "imports" and "works".** Every policy imported, so a smoke
+test built on imports would have passed. Constructing them is where 0.6.x
+actually enforces its extras, and that is the failure the workbench would hit:
+
+```
+--policy.type=act        exit 0   trains and checkpoints
+--policy.type=diffusion  exit 1   ImportError in make_policy(): 'diffusers' is required
+--policy.type=diffusion  exit 0   trains and checkpoints, after adding lerobot[diffusion]
+```
+
+### Executed validation — GPU
+
+The above is a hand-built CPU venv, so it proves the *contract* but not the
+*artifact*. Pulling the shipped `npa-lerobot:0.6.0` image onto an H100 80GB
+(driver 580.126.09, CUDA 13.0) confirms the defect is in the image itself:
+
+```
+lerobot 0.6.0 | torch 2.11.0+cu130 | cuda available: True | NVIDIA H100 80GB HBM3
+diffusers in image:    0        <- absent
+transformers in image: 1        <- present, but only transitively via [libero]
+
+A. DiffusionPolicy as shipped  -> ImportError: 'diffusers' is required but not installed
+B. ACTPolicy as shipped        -> ValueError: You must provide at least one image ...
+C. DiffusionPolicy + diffusers -> ValueError: You must provide at least one image ...
+```
+
+B is the control: `ValueError` means construction got past dependency checks and
+reached ordinary config validation of the deliberately empty config used here.
+C returning *the same* error as B is the point — once the extra is present,
+Diffusion behaves exactly like ACT, so the missing extra was the entire defect.
+
+Incidentally the image ships `torch 2.11.0+cu130`, which already sits inside
+0.6.1's declared `torch<2.12,>=2.7`.
+
+The pre-flight now models this: it resolves the manifest's extras through the
+self-referential extra graph (`diffusion` → `diffusers-dep` → `diffusers`) and
+cross-checks the result against the `require_package` gates it finds in each
+policy module. Run against the pre-fix manifest it reports:
+
+```
+LeRobot 0.6.0
+  [FAIL] policy-extras: --policy.type=diffusion needs diffusers (add extra 'diffusion')
+LeRobot 0.5.1
+  [PASS] policy-extras: lerobot[pusht,libero] constructs ['act', 'diffusion', 'smolvla']
+```
+
+## Remaining gates before 0.6.1 becomes default
+
+The above covers the API, CLI, dataset, and extras contract. What is left is
+image-level and needs a build, matching the precedent set by #191:
+
+1. Build `npa-lerobot:0.6.1` from the CUDA 12 Dockerfile and the B300 variant.
+2. On real GPU: `python -m npa.smoke.test_lerobot_env` (4/4) and
    `python -m npa.smoke.test_lerobot_functional` (5/5, 50-step PushT train +
    eval) with `NPA_LEROBOT_VERSION=0.6.1`.
-5. `validate_blackwell_image.sh` for the B300 tag, recording `published_digest`
+3. `validate_blackwell_image.sh` for the B300 tag, recording `published_digest`
    into `blackwell-dc-images.json` and the manifest.
-6. A `workbench.lerobot.policy_train` workflow run end-to-end, since that stage
-   installs npa into `/opt/lerobot/venv` and is the path most sensitive to the
-   0.6.x lean-extras change.
+4. A `workbench.lerobot.policy_train` workflow run end-to-end, since that stage
+   installs npa into `/opt/lerobot/venv`.
 
-Step 4 is the one that cannot be skipped: 0.6.0's move to mandatory extras means
-an import that resolves statically can still fail at runtime if the extra set is
-wrong. That failure mode is exactly what `[training,evaluation,pusht,libero]`
-exists to prevent, and only a real run proves it.
+One caveat the CPU rig surfaced and could not settle: in a CPU-only venv,
+`torchcodec` 0.11.1 failed to load against `torch 2.9.0+cpu` and LeRobot fell
+back to PyAV. That is a property of the ad-hoc CPU rig, not of the workbench
+images, which pin torchcodec 0.8.1 against cu130 torch — but it is the same
+torch/torchcodec ABI coupling that D1 describes, so step 2 should confirm
+torchcodec loads rather than silently falling back.
 
 ## What this audit does not cover
 

--- a/npa/docker/workbench/lerobot/Dockerfile
+++ b/npa/docker/workbench/lerobot/Dockerfile
@@ -76,11 +76,14 @@ WORKDIR /opt/lerobot
 
 # 0.5.1 keeps the historic [pusht,libero] extra bundle + pinned torch upgrades.
 # 0.6.0 uses lean feature extras and must NOT force torch>=2.12 (upstream ceiling).
+# 0.6.0 also moved diffusers/transformers behind extras and enforces them in each
+# policy's __init__, so diffusion and smolvla must be requested explicitly or
+# --policy.type=diffusion fails inside make_policy() at run time, not at build.
 RUN python3.12 -m venv /opt/lerobot/venv \
     && /opt/lerobot/venv/bin/python -m pip install --upgrade pip setuptools wheel \
     && if [ "${LEROBOT_VERSION}" = "0.6.0" ]; then \
          /opt/lerobot/venv/bin/pip install \
-           "lerobot[training,evaluation,pusht,libero]==${LEROBOT_VERSION}" \
+           "lerobot[training,evaluation,pusht,libero,diffusion,smolvla]==${LEROBOT_VERSION}" \
            boto3 \
            fastapi~=0.136.1 \
            num2words \

--- a/npa/scripts/audit_lerobot_release.py
+++ b/npa/scripts/audit_lerobot_release.py
@@ -34,16 +34,19 @@ from __future__ import annotations
 import argparse
 import ast
 import json
+import re
 import shutil
 import sys
 import urllib.error
 import urllib.request
 import zipfile
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -101,6 +104,21 @@ CALLABLE_PARAMS: tuple[tuple[str, str, tuple[str, ...], str], ...] = (
 
 # Console scripts this repo shells out to.
 REQUIRED_ENTRY_POINTS = ("lerobot-train", "lerobot-eval")
+
+# Policy types this repo trains or evaluates, and the module that implements
+# each. LeRobot 0.6.x enforces optional dependencies at *construction* time
+# (``require_package`` inside ``__init__``), so a policy whose extra is missing
+# still imports cleanly and only fails once ``make_policy`` runs. Checking the
+# import surface alone cannot see that; this maps each policy to its gates.
+POLICY_MODULES: tuple[tuple[str, str, str], ...] = (
+    ("act", "lerobot/policies/act/modeling_act.py", "npa/genesis/eval_student.py"),
+    (
+        "diffusion",
+        "lerobot/policies/diffusion/modeling_diffusion.py",
+        "npa/genesis/eval_student.py, golden evals",
+    ),
+    ("smolvla", "lerobot/policies/smolvla/modeling_smolvla.py", "npa/genesis/eval_student.py"),
+)
 
 # Dataset layout version our adapters write; a bump here means every
 # npa/adapter/*_lerobot.py writer needs migrating.
@@ -272,6 +290,80 @@ def _declared_bounds(root: Path) -> dict[str, str]:
     return bounds
 
 
+def _extra_requirements(root: Path) -> tuple[dict[str, list[Requirement]], list[Requirement]]:
+    """Split ``Requires-Dist`` into per-extra requirements and unconditional ones."""
+
+    per_extra: dict[str, list[Requirement]] = {}
+    base: list[Requirement] = []
+    for line in (_dist_info(root) / "METADATA").read_text(encoding="utf-8").splitlines():
+        if not line.startswith("Requires-Dist:"):
+            continue
+        req = Requirement(line.split(":", 1)[1].strip())
+        extras = re.findall(r'extra\s*==\s*[\'"]([^\'"]+)[\'"]', str(req.marker or ""))
+        if extras:
+            for extra in extras:
+                per_extra.setdefault(extra, []).append(req)
+        else:
+            base.append(req)
+    return per_extra, base
+
+
+def _extra_closure(root: Path, extras: Iterable[str]) -> set[str]:
+    """Distributions installed by ``pip install lerobot[<extras>]``.
+
+    Extras reference each other (``training`` -> ``dataset``, ``diffusion`` ->
+    ``diffusers-dep``), so this walks the self-referential graph to a fixpoint.
+    """
+
+    per_extra, base = _extra_requirements(root)
+    provided = {canonicalize_name(req.name) for req in base}
+    queue = list(extras)
+    seen: set[str] = set()
+    while queue:
+        extra = queue.pop()
+        if extra in seen:
+            continue
+        seen.add(extra)
+        for req in per_extra.get(extra, []):
+            if canonicalize_name(req.name) == "lerobot":
+                queue.extend(req.extras)
+            else:
+                provided.add(canonicalize_name(req.name))
+    return provided
+
+
+def _require_package_gates(root: Path, relpath: str) -> list[tuple[str, str]]:
+    """``(package, extra)`` pairs a module demands at construction time."""
+
+    path = root / relpath
+    if not path.exists():
+        return []
+    gates: list[tuple[str, str]] = []
+    for node in ast.walk(_parse(path)):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if name != "require_package" or not node.args:
+            continue
+        pkg = node.args[0]
+        if not isinstance(pkg, ast.Constant) or not isinstance(pkg.value, str):
+            continue
+        extra = next(
+            (
+                kw.value.value
+                for kw in node.keywords
+                if kw.arg == "extra"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+            ),
+            "",
+        )
+        if (pkg.value, extra) not in gates:
+            gates.append((pkg.value, extra))
+    return gates
+
+
 def _entry_points(root: Path) -> set[str]:
     path = _dist_info(root) / "entry_points.txt"
     if not path.exists():
@@ -340,6 +432,44 @@ def check_entry_points(root: Path, report: Report) -> None:
         else f"missing {missing}",
     )
     report.add("available-entry-points", True, ", ".join(extra) or "none")
+
+
+def check_policy_extras(root: Path, report: Report, manifest_entry: dict[str, Any] | None) -> None:
+    """Do the manifest's extras actually let every policy we use be constructed?"""
+
+    if manifest_entry is None:
+        report.add(
+            "policy-extras",
+            True,
+            "version not in lerobot_version_manifest.json -- no extras declared yet",
+        )
+        return
+
+    declared = [e.strip() for e in str(manifest_entry.get("pip_extras", "")).split(",") if e.strip()]
+    provided = _extra_closure(root, declared)
+
+    problems: list[str] = []
+    satisfied: list[str] = []
+    for policy, relpath, provenance in POLICY_MODULES:
+        missing = [
+            f"{pkg} (add extra '{extra}')"
+            for pkg, extra in _require_package_gates(root, relpath)
+            if canonicalize_name(pkg) not in provided
+        ]
+        if missing:
+            problems.append(f"--policy.type={policy} needs {', '.join(missing)} <- {provenance}")
+        else:
+            satisfied.append(policy)
+
+    report.add(
+        "policy-extras",
+        not problems,
+        f"lerobot[{','.join(declared)}] constructs {satisfied or 'no policies'}"
+        if not problems
+        else "; ".join(problems)
+        + " -- these gates fire in __init__, so the policy imports and only"
+        " fails when make_policy() runs",
+    )
 
 
 def check_dataset_format(root: Path, report: Report) -> None:
@@ -479,6 +609,7 @@ def audit(version: str, cache_dir: Path, *, offline: bool) -> Report:
     check_signatures(root, report)
     check_entry_points(root, report)
     check_dataset_format(root, report)
+    check_policy_extras(root, report, manifest_entry)
     check_cli_flags(root, report, manifest_entry)
     check_dependency_bounds(root, report, manifest_entry)
     return report

--- a/npa/scripts/audit_lerobot_release.py
+++ b/npa/scripts/audit_lerobot_release.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python
+"""Check a LeRobot release against the exact surface this repo binds to.
+
+Every LeRobot release note says "some import paths have changed". That sentence
+cannot be actioned by reading it: the only question that matters here is whether
+*the symbols, CLI entry points, flags, and dependency bounds this repo actually
+uses* still hold in the candidate release. This answers that mechanically, from
+the published wheel, before anyone builds a multi-GB CUDA image.
+
+    npa/.venv/bin/python npa/scripts/audit_lerobot_release.py 0.6.1
+    npa/.venv/bin/python npa/scripts/audit_lerobot_release.py 0.6.1 --baseline 0.5.1
+    npa/.venv/bin/python npa/scripts/audit_lerobot_release.py 0.6.1 --json
+
+Wheels are cached under ``--cache-dir`` (default ``.tmp-lerobot-wheels``), so a
+second run is offline. ``--offline`` refuses to reach PyPI at all and fails when
+the wheel is not already cached.
+
+What it does and does not prove
+-------------------------------
+It reads the wheel's Python source with ``ast``; it never imports LeRobot, so it
+runs on any machine with no CUDA, no torch, and no GPU. That makes it a fast
+*pre-flight*: a PASS means the upgrade is not blocked by a renamed module,
+removed symbol, dropped parameter, renamed CLI flag, changed dataset
+``CODEBASE_VERSION``, or a torch/torchvision/diffusers bound that contradicts a
+pin this repo forces. It cannot prove runtime behaviour. A real GPU train+eval
+smoke (``npa.smoke.test_lerobot_functional``) remains the merge gate.
+
+The surface below is a reviewed list with call-site provenance, not a scrape.
+When a new call site starts using LeRobot, add it here too.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import shutil
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CACHE_DIR = REPO_ROOT / ".tmp-lerobot-wheels"
+PYPI_JSON = "https://pypi.org/pypi/lerobot/{version}/json"
+
+# ── The surface this repo binds to ──────────────────────────────────────────
+# (module, symbol, call-site provenance). symbol=None checks the module only.
+IMPORT_SURFACE: tuple[tuple[str, str | None, str], ...] = (
+    ("lerobot.datasets.lerobot_dataset", "LeRobotDataset", "npa/workflows/lerobot_dataset.py"),
+    ("lerobot.datasets", "LeRobotDataset", "npa/setup/install_lerobot.sh"),
+    ("lerobot.datasets.factory", "make_dataset", "research/lerobot-deploy/training/profile_train.py"),
+    ("lerobot.datasets.sampler", "EpisodeAwareSampler", "research/lerobot-deploy/training/profile_train.py"),
+    ("lerobot.configs.policies", "PreTrainedConfig", "npa/server/app.py, npa/genesis/eval_student.py"),
+    ("lerobot.configs.train", "TrainPipelineConfig", "research/lerobot-deploy/training/profile_train.py"),
+    ("lerobot.configs.default", "DatasetConfig", "research/lerobot-deploy/training/profile_train.py"),
+    ("lerobot.configs.default", "EvalConfig", "research/lerobot-deploy/training/profile_train.py"),
+    ("lerobot.configs.default", "WandBConfig", "research/lerobot-deploy/training/profile_train.py"),
+    ("lerobot.policies.factory", "make_policy", "npa/server/app.py"),
+    ("lerobot.policies.factory", "make_pre_post_processors", "npa/server/app.py, npa/genesis/eval_student.py"),
+    ("lerobot.policies.utils", "prepare_observation_for_inference", "npa/server/app.py"),
+    ("lerobot.policies.act.modeling_act", "ACTPolicy", "npa/genesis/eval_student.py"),
+    ("lerobot.policies.act.configuration_act", "ACTConfig", "npa/smoke/test_lerobot_env.py"),
+    ("lerobot.policies.diffusion.modeling_diffusion", "DiffusionPolicy", "npa/genesis/eval_student.py"),
+    ("lerobot.policies.smolvla.modeling_smolvla", "SmolVLAPolicy", "npa/genesis/eval_student.py"),
+    ("lerobot.optim.factory", "make_optimizer_and_scheduler", "research/lerobot-deploy/training/profile_train.py"),
+    ("lerobot.utils.device_utils", "get_safe_torch_device", "npa/server/app.py"),
+    ("lerobot.envs.configs", "EnvConfig", "npa/server/app.py"),
+)
+
+# Parameters this repo passes by keyword. Upstream may append parameters freely;
+# it may not remove one of these without breaking a call site.
+CALLABLE_PARAMS: tuple[tuple[str, str, tuple[str, ...], str], ...] = (
+    ("lerobot/policies/factory.py", "make_policy", ("cfg", "env_cfg", "ds_meta"), "npa/server/app.py"),
+    (
+        "lerobot/policies/factory.py",
+        "make_pre_post_processors",
+        ("policy_cfg", "pretrained_path"),
+        "npa/server/app.py",
+    ),
+    (
+        "lerobot/policies/utils.py",
+        "prepare_observation_for_inference",
+        ("observation", "device", "task", "robot_type"),
+        "npa/server/app.py",
+    ),
+    (
+        "lerobot/datasets/lerobot_dataset.py",
+        "LeRobotDataset.__init__",
+        ("repo_id", "root", "episodes", "revision"),
+        "npa/workflows/lerobot_dataset.py",
+    ),
+    ("lerobot/optim/factory.py", "make_optimizer_and_scheduler", ("cfg", "policy"), "profile_train.py"),
+)
+
+# Console scripts this repo shells out to.
+REQUIRED_ENTRY_POINTS = ("lerobot-train", "lerobot-eval")
+
+# Dataset layout version our adapters write; a bump here means every
+# npa/adapter/*_lerobot.py writer needs migrating.
+EXPECTED_CODEBASE_VERSION = "v3.0"
+
+# Versions the B300 Dockerfile force-installs regardless of LeRobot version.
+# The per-version pins are not hardcoded here: they are read from this repo's
+# own manifest, so this doubles as a check that the manifest is not lying.
+B300_IMAGE_PINS: dict[str, str] = {
+    "torch": "2.9.0",
+    "torchvision": "0.24.0",
+    "torchcodec": "0.8.1",
+}
+MANIFEST_PIN_KEYS = {
+    "torch_pin": "torch",
+    "torchvision_pin": "torchvision",
+    "diffusers_pin": "diffusers",
+}
+
+
+@dataclass
+class Report:
+    """Collected check results for one candidate version."""
+
+    version: str
+    checks: list[dict[str, Any]] = field(default_factory=list)
+
+    def add(self, name: str, ok: bool, detail: str, *, warn: bool = False) -> None:
+        status = "PASS" if ok else ("WARN" if warn else "FAIL")
+        self.checks.append({"check": name, "status": status, "detail": detail})
+
+    @property
+    def failed(self) -> list[dict[str, Any]]:
+        return [c for c in self.checks if c["status"] == "FAIL"]
+
+
+# ── Wheel acquisition ───────────────────────────────────────────────────────
+
+
+def fetch_wheel(version: str, cache_dir: Path, *, offline: bool) -> Path:
+    """Return an unpacked wheel tree for ``version``, downloading if needed."""
+
+    target = cache_dir / f"lerobot-{version}"
+    if (target / "lerobot" / "__init__.py").exists():
+        return target
+    if offline:
+        raise SystemExit(f"--offline set but no cached wheel for {version} at {target}")
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        with urllib.request.urlopen(PYPI_JSON.format(version=version), timeout=60) as resp:
+            payload = json.load(resp)
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise SystemExit(f"Could not reach PyPI for lerobot {version}: {exc}") from exc
+
+    url = next((u["url"] for u in payload["urls"] if u["packagetype"] == "bdist_wheel"), None)
+    if url is None:
+        raise SystemExit(f"lerobot {version} publishes no wheel")
+
+    archive = cache_dir / f"lerobot-{version}.whl"
+    with urllib.request.urlopen(url, timeout=300) as resp, archive.open("wb") as handle:
+        shutil.copyfileobj(resp, handle)
+    if target.exists():
+        shutil.rmtree(target)
+    with zipfile.ZipFile(archive) as zf:
+        zf.extractall(target)
+    return target
+
+
+# ── Static inspection helpers ───────────────────────────────────────────────
+
+
+def _module_file(root: Path, dotted: str) -> Path | None:
+    rel = dotted.replace(".", "/")
+    for candidate in (root / f"{rel}.py", root / rel / "__init__.py"):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+
+
+def _top_level_names(path: Path) -> set[str]:
+    """Names a module defines or re-exports (import-from counts as re-export)."""
+
+    names: set[str] = set()
+    try:
+        tree = _parse(path)
+    except SyntaxError:
+        return names
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+        elif isinstance(node, ast.ImportFrom):
+            names.update(a.asname or a.name for a in node.names)
+        elif isinstance(node, ast.Import):
+            names.update(a.asname or a.name.split(".")[0] for a in node.names)
+    return names
+
+
+def _function_params(root: Path, relpath: str, dotted: str) -> set[str] | None:
+    """Return parameter names for ``dotted`` (``Class.method`` supported)."""
+
+    path = root / relpath
+    if not path.exists():
+        return None
+    try:
+        tree = _parse(path)
+    except SyntaxError:
+        return None
+
+    def collect(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+        args = fn.args
+        found = {a.arg for a in args.posonlyargs + args.args + args.kwonlyargs}
+        if args.kwarg:  # **kwargs absorbs anything we pass
+            found.add("**")
+        return found
+
+    if "." in dotted:
+        cls_name, method = dotted.split(".", 1)
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and node.name == cls_name:
+                for sub in node.body:
+                    if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)) and sub.name == method:
+                        return collect(sub)
+        return None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == dotted:
+            return collect(node)
+    return None
+
+
+def _dataclass_fields(root: Path, relpath: str, cls_name: str) -> set[str]:
+    """Return annotated attribute names on a class (draccus config fields)."""
+
+    path = root / relpath
+    if not path.exists():
+        return set()
+    for node in _parse(path).body:
+        if isinstance(node, ast.ClassDef) and node.name == cls_name:
+            return {
+                sub.target.id
+                for sub in node.body
+                if isinstance(sub, ast.AnnAssign) and isinstance(sub.target, ast.Name)
+            }
+    return set()
+
+
+def _dist_info(root: Path) -> Path:
+    return next(root.glob("lerobot-*.dist-info"))
+
+
+def _declared_bounds(root: Path) -> dict[str, str]:
+    """First declared specifier per dependency we care about."""
+
+    bounds: dict[str, str] = {}
+    for line in (_dist_info(root) / "METADATA").read_text(encoding="utf-8").splitlines():
+        if not line.startswith("Requires-Dist:"):
+            continue
+        req = Requirement(line.split(":", 1)[1].strip())
+        if req.name in {"torch", "torchvision", "diffusers", "torchcodec"}:
+            bounds.setdefault(req.name, str(req.specifier))
+    return bounds
+
+
+def _entry_points(root: Path) -> set[str]:
+    path = _dist_info(root) / "entry_points.txt"
+    if not path.exists():
+        return set()
+    return {
+        line.split("=", 1)[0].strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if "=" in line and not line.startswith("[")
+    }
+
+
+def _requires_python(root: Path) -> str:
+    for line in (_dist_info(root) / "METADATA").read_text(encoding="utf-8").splitlines():
+        if line.startswith("Requires-Python:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+# ── Checks ──────────────────────────────────────────────────────────────────
+
+
+def check_imports(root: Path, report: Report) -> None:
+    missing = []
+    for module, symbol, provenance in IMPORT_SURFACE:
+        path = _module_file(root, module)
+        if path is None:
+            missing.append(f"{module} (module gone) <- {provenance}")
+        elif symbol and symbol not in _top_level_names(path):
+            missing.append(f"{module}:{symbol} (symbol gone) <- {provenance}")
+    total = len(IMPORT_SURFACE)
+    report.add(
+        "import-surface",
+        not missing,
+        f"{total - len(missing)}/{total} bindings resolve"
+        + ("; missing: " + ", ".join(missing) if missing else ""),
+    )
+
+
+def check_signatures(root: Path, report: Report) -> None:
+    problems = []
+    for relpath, dotted, params, provenance in CALLABLE_PARAMS:
+        actual = _function_params(root, relpath, dotted)
+        if actual is None:
+            problems.append(f"{dotted} not found in {relpath} <- {provenance}")
+            continue
+        if "**" in actual:
+            continue
+        dropped = sorted(p for p in params if p not in actual)
+        if dropped:
+            problems.append(f"{dotted} dropped {dropped} <- {provenance}")
+    report.add(
+        "callable-parameters",
+        not problems,
+        "all keyword parameters still accepted" if not problems else "; ".join(problems),
+    )
+
+
+def check_entry_points(root: Path, report: Report) -> None:
+    available = _entry_points(root)
+    missing = [ep for ep in REQUIRED_ENTRY_POINTS if ep not in available]
+    extra = sorted(available - set(REQUIRED_ENTRY_POINTS))
+    report.add(
+        "console-entry-points",
+        not missing,
+        f"required present ({', '.join(REQUIRED_ENTRY_POINTS)})" if not missing
+        else f"missing {missing}",
+    )
+    report.add("available-entry-points", True, ", ".join(extra) or "none")
+
+
+def check_dataset_format(root: Path, report: Report) -> None:
+    path = root / "lerobot" / "datasets" / "dataset_metadata.py"
+    found = ""
+    if path.exists():
+        for node in _parse(path).body:
+            if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "CODEBASE_VERSION" for t in node.targets
+            ):
+                if isinstance(node.value, ast.Constant):
+                    found = str(node.value.value)
+    ok = found == EXPECTED_CODEBASE_VERSION
+    report.add(
+        "dataset-codebase-version",
+        ok,
+        f"{found or 'not found'} (adapters write {EXPECTED_CODEBASE_VERSION})"
+        + ("" if ok else " -- npa/adapter/*_lerobot.py writers need migrating"),
+    )
+
+
+def check_cli_flags(root: Path, report: Report, manifest_entry: dict[str, Any] | None) -> None:
+    train_fields = _dataclass_fields(root, "lerobot/configs/train.py", "TrainPipelineConfig")
+    policy_fields = _dataclass_fields(root, "lerobot/configs/policies.py", "PreTrainedConfig")
+
+    present = sorted(f for f in ("eval_freq", "env_eval_freq") if f in train_fields)
+    report.add(
+        "train-env-eval-flag",
+        bool(present),
+        f"TrainPipelineConfig exposes {present}" if present else "neither eval_freq nor env_eval_freq found",
+    )
+    report.add(
+        "eval-checkpoint-flag",
+        "pretrained_path" in policy_fields,
+        "PreTrainedConfig.pretrained_path present (--policy.pretrained_path)"
+        if "pretrained_path" in policy_fields
+        else "PreTrainedConfig.pretrained_path missing",
+    )
+
+    parser = root / "lerobot" / "configs" / "parser.py"
+    has_path_key = parser.exists() and 'PATH_KEY = "path"' in parser.read_text(encoding="utf-8")
+    report.add(
+        "policy-path-alias",
+        has_path_key,
+        'parser.PATH_KEY == "path" (--policy.path)' if has_path_key else "PATH_KEY alias changed",
+    )
+
+    if manifest_entry:
+        declared = str(manifest_entry.get("train_env_eval_flag", ""))
+        ok = declared in train_fields
+        report.add(
+            "manifest-agrees-with-wheel",
+            ok,
+            f"manifest declares train_env_eval_flag={declared!r}, wheel {'has' if ok else 'LACKS'} it",
+        )
+
+
+def _pin_floor(spec: str) -> str:
+    """Lowest version a pin like ``torch==2.12.1`` or ``diffusers>=0.38.0`` allows."""
+
+    return spec.split("==")[-1].split(">=")[-1].strip()
+
+
+def _conflicts(pins: dict[str, str], bounds: dict[str, str]) -> list[str]:
+    problems = []
+    for package, pinned in pins.items():
+        declared = bounds.get(package)
+        if declared is None:
+            continue
+        if Version(pinned) not in Requirement(f"{package}{declared}").specifier:
+            problems.append(f"{package}=={pinned} violates {declared}")
+    return problems
+
+
+def check_dependency_bounds(
+    root: Path, report: Report, manifest_entry: dict[str, Any] | None
+) -> None:
+    bounds = _declared_bounds(root)
+    report.add("requires-python", True, _requires_python(root) or "unspecified")
+    report.add("declared-bounds", True, ", ".join(f"{k}{v}" for k, v in sorted(bounds.items())))
+
+    problems = _conflicts(B300_IMAGE_PINS, bounds)
+    report.add(
+        "b300-image torch stack",
+        not problems,
+        "torch 2.9.0 / torchvision 0.24.0 / torchcodec 0.8.1 satisfy declared bounds"
+        if not problems
+        else "; ".join(problems),
+    )
+
+    if manifest_entry is None:
+        report.add(
+            "manifest torch pins",
+            True,
+            "version not in lerobot_version_manifest.json -- nothing pinned yet",
+            warn=True,
+        )
+        return
+
+    pins = {
+        package: _pin_floor(str(manifest_entry[key]))
+        for key, package in MANIFEST_PIN_KEYS.items()
+        if manifest_entry.get(key)
+    }
+    if not pins:
+        report.add(
+            "manifest torch pins",
+            True,
+            "manifest forces no torch pins for this version (upstream resolver decides)",
+        )
+        return
+
+    problems = _conflicts(pins, bounds)
+    report.add(
+        "manifest torch pins",
+        not problems,
+        f"{pins} satisfy declared bounds" if not problems
+        else "; ".join(problems) + " -- these are force-installed after `pip install lerobot`,"
+        " so pip does not re-resolve and the image ships broken",
+    )
+
+
+def load_manifest_entry(version: str) -> dict[str, Any] | None:
+    path = REPO_ROOT / "npa" / "src" / "npa" / "deploy" / "lerobot_version_manifest.json"
+    if not path.exists():
+        return None
+    versions = json.loads(path.read_text(encoding="utf-8")).get("versions", {})
+    entry = versions.get(version)
+    return entry if isinstance(entry, dict) else None
+
+
+def audit(version: str, cache_dir: Path, *, offline: bool) -> Report:
+    root = fetch_wheel(version, cache_dir, offline=offline)
+    manifest_entry = load_manifest_entry(version)
+    report = Report(version=version)
+    check_imports(root, report)
+    check_signatures(root, report)
+    check_entry_points(root, report)
+    check_dataset_format(root, report)
+    check_cli_flags(root, report, manifest_entry)
+    check_dependency_bounds(root, report, manifest_entry)
+    return report
+
+
+def render(report: Report) -> None:
+    print(f"\nLeRobot {report.version}")
+    print("-" * 78)
+    for check in report.checks:
+        print(f"  [{check['status']:<4}] {check['check']}: {check['detail']}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("version", help="candidate LeRobot version, e.g. 0.6.1")
+    parser.add_argument("--baseline", help="also audit this version for comparison")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--offline", action="store_true", help="use cached wheels only")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    reports = [audit(args.version, args.cache_dir, offline=args.offline)]
+    if args.baseline:
+        reports.append(audit(args.baseline, args.cache_dir, offline=args.offline))
+
+    if args.json:
+        print(json.dumps([{"version": r.version, "checks": r.checks} for r in reports], indent=2))
+    else:
+        for report in reports:
+            render(report)
+
+    candidate = reports[0]
+    sys.stdout.flush()
+    if candidate.failed:
+        print(
+            f"\nFAIL: {len(candidate.failed)} blocking finding(s) for lerobot {candidate.version}.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\nPASS: lerobot {candidate.version} satisfies this repo's static LeRobot surface.")
+    print("Static pre-flight only -- a real GPU train+eval smoke is still the merge gate.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/npa/src/npa/deploy/lerobot_version_manifest.json
+++ b/npa/src/npa/deploy/lerobot_version_manifest.json
@@ -17,14 +17,14 @@
       "notes": "Default package pin. The image_tag selects the separately validated Python 3.12 / torch 2.9 cu130 B300 build; the VM installer pins below remain the legacy in-place install contract."
     },
     "0.6.0": {
-      "pip_extras": "training,evaluation,pusht,libero",
+      "pip_extras": "training,evaluation,pusht,libero,diffusion,smolvla",
       "train_env_eval_flag": "env_eval_freq",
       "eval_checkpoint_flag": "policy.path",
       "policy_eval_checkpoint_flag": "policy.pretrained_path",
       "torch_pin": null,
       "torchvision_pin": null,
       "diffusers_pin": null,
-      "notes": "Lean install extras; torch must stay <2.12 per upstream. Do not force-upgrade torch after install."
+      "notes": "Lean install extras; torch must stay <2.12 per upstream. Do not force-upgrade torch after install. 0.6.0 moved diffusers and transformers behind extras and enforces them in each policy's __init__, so the diffusion and smolvla extras are required for --policy.type=diffusion and =smolvla; the smolvla extra also supplies num2words."
     }
   }
 }

--- a/npa/tests/scripts/test_audit_lerobot_release.py
+++ b/npa/tests/scripts/test_audit_lerobot_release.py
@@ -1,0 +1,211 @@
+"""The LeRobot release pre-flight must fail on the breakages it claims to catch.
+
+A green checker that cannot go red is worse than no checker, so each check is
+driven against a synthetic wheel tree that is deliberately broken in exactly one
+way. The fixture mirrors the real wheel layout (``lerobot/`` package plus a
+``lerobot-<v>.dist-info/`` directory) closely enough for ``ast``-based
+inspection, which is all the script does — it never imports LeRobot.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "npa" / "scripts" / "audit_lerobot_release.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("audit_lerobot_release", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # @dataclass resolves annotations through sys.modules, so register before exec.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+audit_mod = _load()
+
+
+METADATA = """Metadata-Version: 2.4
+Name: lerobot
+Version: {version}
+Requires-Python: >=3.12
+Requires-Dist: torch<2.12.0,>=2.7
+Requires-Dist: torchvision<0.27.0,>=0.22.0
+Requires-Dist: torchcodec<0.12.0,>=0.3.0; extra == "dataset"
+Requires-Dist: diffusers<0.40.0,>=0.38.0; extra == "diffusers-dep"
+"""
+
+ENTRY_POINTS = """[console_scripts]
+lerobot-train = lerobot.scripts.lerobot_train:main
+lerobot-eval = lerobot.scripts.lerobot_eval:main
+"""
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+@pytest.fixture
+def wheel(tmp_path: Path) -> Path:
+    """A synthetic wheel tree that satisfies every check."""
+
+    root = tmp_path / "lerobot-9.9.9"
+    dist = root / "lerobot-9.9.9.dist-info"
+    _write(dist / "METADATA", METADATA.format(version="9.9.9"))
+    _write(dist / "entry_points.txt", ENTRY_POINTS)
+
+    for module, symbol, _ in audit_mod.IMPORT_SURFACE:
+        rel = module.replace(".", "/")
+        target = root / rel / "__init__.py" if module == "lerobot.datasets" else root / f"{rel}.py"
+        existing = target.read_text(encoding="utf-8") if target.exists() else ""
+        if symbol and symbol not in existing:
+            kind = "class" if symbol[0].isupper() else "def"
+            body = f"{kind} {symbol}: ...\n" if kind == "class" else f"def {symbol}(*args, **kwargs): ...\n"
+            _write(target, existing + body)
+
+    # Callables whose parameter names the script asserts on.
+    _write(
+        root / "lerobot/policies/factory.py",
+        "def make_policy(cfg, ds_meta=None, env_cfg=None, rename_map=None): ...\n"
+        "def make_pre_post_processors(policy_cfg, pretrained_path=None, **kwargs): ...\n",
+    )
+    _write(
+        root / "lerobot/policies/utils.py",
+        "def prepare_observation_for_inference(observation, device, task=None, robot_type=None): ...\n",
+    )
+    _write(
+        root / "lerobot/datasets/lerobot_dataset.py",
+        "class LeRobotDataset:\n"
+        "    def __init__(self, repo_id, root=None, episodes=None, revision=None): ...\n",
+    )
+    _write(root / "lerobot/optim/factory.py", "def make_optimizer_and_scheduler(cfg, policy): ...\n")
+
+    _write(root / "lerobot/datasets/dataset_metadata.py", 'CODEBASE_VERSION = "v3.0"\n')
+    _write(
+        root / "lerobot/configs/train.py",
+        "class TrainPipelineConfig:\n    env_eval_freq: int = 20_000\n",
+    )
+    _write(
+        root / "lerobot/configs/policies.py",
+        "class PreTrainedConfig:\n    pretrained_path: str | None = None\n",
+    )
+    _write(root / "lerobot/configs/parser.py", 'PATH_KEY = "path"\n')
+    return root
+
+
+def _run(monkeypatch, wheel: Path, manifest: dict | None = None):
+    monkeypatch.setattr(audit_mod, "fetch_wheel", lambda *a, **k: wheel)
+    monkeypatch.setattr(audit_mod, "load_manifest_entry", lambda version: manifest)
+    return audit_mod.audit("9.9.9", wheel.parent, offline=True)
+
+
+def _status(report, name: str) -> str:
+    return next(c["status"] for c in report.checks if c["check"] == name)
+
+
+def test_intact_wheel_passes_every_check(monkeypatch, wheel):
+    report = _run(monkeypatch, wheel)
+    assert report.failed == [], report.failed
+
+
+def test_renamed_module_is_caught(monkeypatch, wheel):
+    (wheel / "lerobot/policies/factory.py").unlink()
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "import-surface") == "FAIL"
+
+
+def test_removed_symbol_is_caught(monkeypatch, wheel):
+    path = wheel / "lerobot/utils/device_utils.py"
+    path.write_text("def something_else(): ...\n", encoding="utf-8")
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "import-surface") == "FAIL"
+
+
+def test_dropped_keyword_parameter_is_caught(monkeypatch, wheel):
+    # `env_cfg` is passed by keyword from npa/server/app.py.
+    (wheel / "lerobot/policies/factory.py").write_text(
+        "def make_policy(cfg, ds_meta=None): ...\n"
+        "def make_pre_post_processors(policy_cfg, pretrained_path=None, **kwargs): ...\n",
+        encoding="utf-8",
+    )
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "callable-parameters") == "FAIL"
+
+
+def test_kwargs_absorbs_unknown_parameters(monkeypatch, wheel):
+    (wheel / "lerobot/optim/factory.py").write_text(
+        "def make_optimizer_and_scheduler(**kwargs): ...\n", encoding="utf-8"
+    )
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "callable-parameters") == "PASS"
+
+
+def test_missing_entry_point_is_caught(monkeypatch, wheel):
+    dist = wheel / "lerobot-9.9.9.dist-info" / "entry_points.txt"
+    dist.write_text("[console_scripts]\nlerobot-train = x:main\n", encoding="utf-8")
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "console-entry-points") == "FAIL"
+
+
+def test_dataset_format_bump_is_caught(monkeypatch, wheel):
+    (wheel / "lerobot/datasets/dataset_metadata.py").write_text(
+        'CODEBASE_VERSION = "v4.0"\n', encoding="utf-8"
+    )
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "dataset-codebase-version") == "FAIL"
+
+
+def test_renamed_train_flag_is_caught(monkeypatch, wheel):
+    (wheel / "lerobot/configs/train.py").write_text(
+        "class TrainPipelineConfig:\n    validation_cadence: int = 1\n", encoding="utf-8"
+    )
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "train-env-eval-flag") == "FAIL"
+
+
+def test_manifest_flag_disagreeing_with_wheel_is_caught(monkeypatch, wheel):
+    report = _run(monkeypatch, wheel, manifest={"train_env_eval_flag": "eval_freq"})
+    assert _status(report, "manifest-agrees-with-wheel") == "FAIL"
+
+
+def test_manifest_flag_agreeing_with_wheel_passes(monkeypatch, wheel):
+    report = _run(monkeypatch, wheel, manifest={"train_env_eval_flag": "env_eval_freq"})
+    assert _status(report, "manifest-agrees-with-wheel") == "PASS"
+
+
+def test_forced_torch_pin_outside_declared_bounds_is_caught(monkeypatch, wheel):
+    # Upstream declares torch<2.12.0; forcing 2.12.1 afterwards ships a broken image.
+    report = _run(monkeypatch, wheel, manifest={"torch_pin": "torch==2.12.1"})
+    assert _status(report, "manifest torch pins") == "FAIL"
+
+
+def test_forced_torch_pin_inside_declared_bounds_passes(monkeypatch, wheel):
+    report = _run(monkeypatch, wheel, manifest={"torch_pin": "torch==2.9.0"})
+    assert _status(report, "manifest torch pins") == "PASS"
+
+
+def test_lower_bound_pin_below_declared_ceiling_is_caught(monkeypatch, wheel):
+    # `diffusers>=0.30.0` floors below the declared >=0.38.0 floor.
+    report = _run(monkeypatch, wheel, manifest={"diffusers_pin": "diffusers>=0.30.0"})
+    assert _status(report, "manifest torch pins") == "FAIL"
+
+
+def test_repo_manifest_versions_are_all_auditable():
+    """Every version this repo claims to support must be described well enough to check."""
+
+    manifest = json.loads(
+        (REPO_ROOT / "npa/src/npa/deploy/lerobot_version_manifest.json").read_text(encoding="utf-8")
+    )
+    for version in manifest["supported_versions"]:
+        entry = audit_mod.load_manifest_entry(version)
+        assert entry is not None, f"{version} listed as supported but has no manifest entry"
+        assert entry.get("train_env_eval_flag"), f"{version} declares no train_env_eval_flag"

--- a/npa/tests/scripts/test_audit_lerobot_release.py
+++ b/npa/tests/scripts/test_audit_lerobot_release.py
@@ -41,6 +41,10 @@ Requires-Dist: torch<2.12.0,>=2.7
 Requires-Dist: torchvision<0.27.0,>=0.22.0
 Requires-Dist: torchcodec<0.12.0,>=0.3.0; extra == "dataset"
 Requires-Dist: diffusers<0.40.0,>=0.38.0; extra == "diffusers-dep"
+Requires-Dist: transformers<5.6.0,>=5.4.0; extra == "transformers-dep"
+Requires-Dist: lerobot[diffusers-dep]; extra == "diffusion"
+Requires-Dist: lerobot[transformers-dep]; extra == "smolvla"
+Requires-Dist: lerobot[transformers-dep]; extra == "libero"
 """
 
 ENTRY_POINTS = """[console_scripts]
@@ -197,6 +201,46 @@ def test_lower_bound_pin_below_declared_ceiling_is_caught(monkeypatch, wheel):
     # `diffusers>=0.30.0` floors below the declared >=0.38.0 floor.
     report = _run(monkeypatch, wheel, manifest={"diffusers_pin": "diffusers>=0.30.0"})
     assert _status(report, "manifest torch pins") == "FAIL"
+
+
+def _gate_diffusion_on_diffusers(wheel: Path) -> None:
+    """Mirror 0.6.x, which enforces the extra inside ``DiffusionPolicy.__init__``."""
+
+    (wheel / "lerobot/policies/diffusion/modeling_diffusion.py").write_text(
+        "class DiffusionPolicy:\n"
+        "    def __init__(self, config):\n"
+        '        require_package("diffusers", extra="diffusion")\n',
+        encoding="utf-8",
+    )
+
+
+def test_policy_extra_missing_from_manifest_is_caught(monkeypatch, wheel):
+    # The module still imports; only construction fails. Checking the import
+    # surface cannot see this, which is exactly how it shipped in 0.6.0.
+    _gate_diffusion_on_diffusers(wheel)
+    report = _run(monkeypatch, wheel, manifest={"pip_extras": "training,evaluation,pusht,libero"})
+    assert _status(report, "import-surface") == "PASS"
+    assert _status(report, "policy-extras") == "FAIL"
+
+
+def test_policy_extra_present_in_manifest_passes(monkeypatch, wheel):
+    # `diffusion` only reaches diffusers through `lerobot[diffusers-dep]`, so
+    # this also proves the self-referential extra graph is walked.
+    _gate_diffusion_on_diffusers(wheel)
+    report = _run(monkeypatch, wheel, manifest={"pip_extras": "pusht,diffusion"})
+    assert _status(report, "policy-extras") == "PASS"
+
+
+def test_policy_extras_skipped_when_version_unknown_to_manifest(monkeypatch, wheel):
+    _gate_diffusion_on_diffusers(wheel)
+    report = _run(monkeypatch, wheel, manifest=None)
+    assert _status(report, "policy-extras") == "PASS"
+
+
+def test_ungated_policy_needs_no_extra(monkeypatch, wheel):
+    # ACT declares no require_package gate, so a bare install can construct it.
+    report = _run(monkeypatch, wheel, manifest={"pip_extras": "pusht"})
+    assert _status(report, "policy-extras") == "PASS"
 
 
 def test_repo_manifest_versions_are_all_auditable():

--- a/npa/tests/test_lerobot_version_compat.py
+++ b/npa/tests/test_lerobot_version_compat.py
@@ -25,7 +25,10 @@ def test_supported_versions_include_default_and_060() -> None:
 
 def test_pip_spec_and_train_flags_differ_by_version() -> None:
     assert lerobot_pip_spec("0.5.1") == "lerobot[pusht,libero]==0.5.1"
-    assert lerobot_pip_spec("0.6.0") == "lerobot[training,evaluation,pusht,libero]==0.6.0"
+    assert (
+        lerobot_pip_spec("0.6.0")
+        == "lerobot[training,evaluation,pusht,libero,diffusion,smolvla]==0.6.0"
+    )
     assert train_env_eval_flag("0.5.1") == "eval_freq"
     assert train_env_eval_flag("0.6.0") == "env_eval_freq"
     assert train_env_eval_arg(100, version="0.5.1") == "--eval_freq=100"
@@ -40,6 +43,16 @@ def test_eval_checkpoint_and_torch_pins() -> None:
     )
     assert "torch==2.12.1" in torch_install_pins("0.5.1")
     assert torch_install_pins("0.6.0") == []
+
+
+def test_060_requests_the_extras_its_policies_gate_on() -> None:
+    """0.6.0 moved diffusers/transformers behind extras and enforces them in
+    each policy's ``__init__``, so a missing extra builds fine and only fails
+    once ``make_policy`` runs. 0.5.1 ships both as core dependencies."""
+
+    spec = lerobot_pip_spec("0.6.0")
+    assert "diffusion" in spec, "--policy.type=diffusion needs lerobot[diffusion]"
+    assert "smolvla" in spec, "--policy.type=smolvla needs lerobot[smolvla]"
 
 
 def test_unsupported_version_raises(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audits whether the workbench should support the latest LeRobot (**0.6.1**, released 2026-08-03, while we default to **0.5.1** from 2026-04-07), then **runs the conclusions against a real install** rather than stopping at static analysis. That second step found a shipped defect.

**Recommendation: adopt 0.6.1 as an additional supported version and promote it to default once the image gates pass.** The upgrade is nearly free; the current state carries more risk than the move.

Three artifacts:

- `docs/workbench/lerobot-version-support-audit-20260813.md` — the audit and proposal.
- `npa/scripts/audit_lerobot_release.py` — a static pre-flight that makes the audit reproducible for the *next* release, plus tests.
- A fix for **D6**, below.

## The defect the real run found (D6)

`npa-lerobot:0.6.0` **cannot construct a Diffusion Policy**. LeRobot 0.6.0 moved `diffusers` and `transformers` out of the base install and behind extras, and enforces them with `require_package()` **inside each policy's `__init__`**. Our extras string was never updated, so `lerobot[training,evaluation,pusht,libero]` installs no `diffusers`, the module still *imports* cleanly, and the failure lands at `make_policy()` — at run time, on the real training command.

Reproduced on an **H100 80GB** with the image pulled from the registry:

```
lerobot 0.6.0 | torch 2.11.0+cu130 | cuda available: True | NVIDIA H100 80GB HBM3
diffusers in image:    0        <- absent
transformers in image: 1        <- present, but only transitively via [libero]

A. DiffusionPolicy as shipped  -> ImportError: 'diffusers' is required but not installed
B. ACTPolicy as shipped        -> ValueError: You must provide at least one image ...
C. DiffusionPolicy + diffusers -> ValueError: You must provide at least one image ...
```

B is the control: `ValueError` means construction got past dependency checks into ordinary config validation. C returning *the same* error as B is the point — with the extra present, Diffusion behaves exactly like ACT, so the missing extra was the entire defect.

Also reproduced end-to-end through the actual training command on a real 0.6.1 install:

```
--policy.type=act        exit 0   trains and checkpoints
--policy.type=diffusion  exit 1   ImportError in make_policy(): 'diffusers' is required
--policy.type=diffusion  exit 0   trains and checkpoints, after adding lerobot[diffusion]
```

**Scope.** 0.5.1 is unaffected — `diffusers` is a *core* dependency there — which is why the default B300 image, built from a genuine 0.5.1 commit, was never exposed. This hits anyone opting into `--lerobot-version 0.6.0`, and would have hit everyone had 0.6.x been promoted to default. Two details show the extras set was already drifting: the Dockerfiles hand-install `num2words`, which is exactly what the `smolvla` extra supplies, and `libero` is the only reason `transformers` is present at all.

**Fix:** request the extras the policies gate on (`…,libero,diffusion,smolvla`) in the manifest and Dockerfile, and teach the pre-flight to resolve the extras graph (`diffusion` → `diffusers-dep` → `diffusers`) and cross-check it against the `require_package` gates it finds in each policy module. Against the pre-fix manifest it now reports:

```
LeRobot 0.6.0
  [FAIL] policy-extras: --policy.type=diffusion needs diffusers (add extra 'diffusion')
LeRobot 0.5.1
  [PASS] policy-extras: lerobot[pusht,libero] constructs ['act', 'diffusion', 'smolvla']
```

## Why adopting 0.6.1 is cheap

Checked against the published wheels, then executed against a real 0.6.1 install (Python 3.12.13, torch 2.9.0):

| Claim | Executed result |
|---|---|
| 19/19 bindings resolve | all 19 **import** for real |
| `env_eval_freq` replaces `eval_freq` | `lerobot-train --help` offers `--env_eval_freq`, no longer `--eval_freq` |
| `--policy.path` still works | accepted — parsing reaches a Hub lookup, while a bogus `--policy.x` is rejected. Absent from `--help` only because draccus resolves the path alias pre-parse, which is easy to misread as a break |
| adapters need no migration | a dataset written by `npa/adapter/sim_to_lerobot.py` loads under 0.6.1 `LeRobotDataset`, video decoded, expected keys present |
| the workbench train path works | `lerobot-train --policy.type=act` runs real steps and checkpoints |

Plus: 0.6.1's only breaking change (`lerobot.types` → `lerobot.lerobot_types`) is unreferenced here; signature changes are additive; `CODEBASE_VERSION` is still `v3.0` and 0.6.x made `info.json` parsing forward-compatible; the validated B300 torch stack already satisfies 0.6.1's bounds; and none of 0.6.0's other breaks apply (we never pass `--dataset.vcodec`, never use `sac`, never write `subtask_index`).

## Other findings, independent of the upgrade

- **`npa-lerobot-policy:0.1.1` is a current pin shipping a dependency set upstream declares unusable.** It installs `lerobot[pusht]==0.5.1`, then force-upgrades torch 2.12.1 / torchvision 0.27.1 / diffusers ≥0.38 — all three outside 0.5.1's declared bounds. Because the upgrade is a second `pip` call, nothing re-resolves and the build succeeds silently. This is the mechanical root cause of the torch/torchcodec ABI mismatch already noted in `CHANGELOG.md`.
- **The manifest's torch pins are dead data** — `torch_install_pins()` has no production caller.
- **0.6.0 has no hardware-validated image.** The bare tag exists and runs (it is what D6 was reproduced on), but has no recorded digest and no hardware gate — which is how a defect of D6's size sat in it unnoticed.
- **The stated reason for the 0.5.1 default is stale** — it cites GR00T N1.5 parity, but `npa-groot` clones Isaac-GR00T directly and ships N1.7.
- **Genesis and the sim2real trainer are capped at LeRobot 0.4.4 by their interpreters**, not by choice: LeRobot has required Python ≥3.12 since 0.5.0, `npa-base` is 3.11 and the CUDA-12 Genesis base is 3.10. The one genuinely invasive item, and not recorded anywhere.

## Verification

- [x] Real install: `lerobot[training,evaluation,pusht]==0.6.1` on the dev VM (Python 3.12.13, torch 2.9.0) — 19/19 imports, CLI flags, adapter dataset round-trip with video decode, real ACT training run.
- [x] Real GPU: shipped `npa-lerobot:0.6.0` on an H100 80GB (driver 580.126.09, CUDA 13.0), via a `batch/v1` Job. Job and the temporary pull secret were deleted afterwards; the dev VM venv was removed.
- [x] `make test` → 8847 passed, 37 skipped. The 2 failures in `tests/workflows/test_bdd100k_pipeline.py` are pre-existing and environmental (they shell out to the `npa` console script, absent from PATH in this sandbox); confirmed identical on `origin/main` in a clean worktree.
- [x] Guardrails → 1685 passed. `audit_workbench_image_tags.py` → clean. Skills index → 3 passed.
- [x] New/updated tests: `npa/tests/scripts/test_audit_lerobot_release.py` → 18 passed, each driving a synthetic wheel broken in exactly one way, including four covering the extras graph and the `require_package` gates. `npa/tests/test_lerobot_version_compat.py` → 6 passed.
- [x] `ruff check` clean on all changed Python.
- [x] Public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Remaining gates before 0.6.1 becomes default

Image-level work that needs a build, matching the precedent set by #191: build `npa-lerobot:0.6.1` (CUDA 12 + B300), run `test_lerobot_env` / `test_lerobot_functional` on real GPU, `validate_blackwell_image.sh` with digest recording, and one `workbench.lerobot.policy_train` run. The CPU rig also surfaced one thing it could not settle: `torchcodec` 0.11.1 failed to load against `torch 2.9.0+cpu` and LeRobot fell back to PyAV. That is a property of the ad-hoc CPU rig, not the workbench images — but it is the same ABI coupling D1 describes, so the GPU gate should confirm torchcodec loads rather than silently falling back.

## Skill Maintenance

- [x] The behavior change here is the extras string, which is manifest/Dockerfile data rather than skill guidance. The proposal names the skill files a follow-up implementation PR must update (`skills/tools/lerobot/SKILL.md` and `skills/workflows/byof-onboard/SKILL.md`, both carrying the stale GR00T N1.5 rationale).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff8ff-42e9-7922-b68b-67bdc85ccf27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff8ff-42e9-7922-b68b-67bdc85ccf27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

