### PR TITLE
PAIDF: scale the augment multiply across nodes, not just GPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ a versioned heading when a release is cut.
 
 ## Unreleased
 
+### PAIDF augment scales across nodes, not just GPUs
+
+The Physical AI Data Factory multiplied scenario variants across the GPUs of **one**
+augment pod, so the fan-out was capped by a single node. The variants are independent
+diffusions, so they now shard across a gang-scheduled block as well.
+
+- **`--var augment_nodes=N`** gang-schedules N augment pods
+  (`resources.gpu.num_nodes: "{{config.augment_nodes}}"`, default `1`). Concurrent
+  renders = `augment_nodes` × GPUs per node.
+- **`num_nodes` accepts a `{{config.*}}` token** on any resource profile, resolved
+  against the `--var`-merged config, so a shipped blueprint's block size is a submit
+  decision instead of a file edit. Bounds and error text are unchanged.
+- **`deployIfAbsent` sizes the cluster to the gang**: a profile asking for more nodes
+  than the cluster has does not fail, it sits `PENDING`, so the provisioner now takes
+  `num_nodes` as the GPU-node floor.
+- **The augment stage shards and rejoins.** SkyPilot runs the same command in every
+  pod, so node `k` of `N` renders variants `k, k+N, …` on node-local GPUs, publishes
+  its clip dirs under global variant indices, and writes
+  `cosmos_augmented/manifest-rank-<k>.json`; rank 0 waits for every shard and merges
+  them into the usual `manifest.json` (ordered by variant index, plus `node_count`
+  and per-rank `shards`). A rank that never reports fails the stage by name rather
+  than publishing an understated fan-out. Shard manifests are objects at the augment
+  prefix root, because every consumer counts a *subdirectory* there as a variant.
+  With one node nothing is written that was not written before.
+
 ### Retiring the raw SkyPilot task catalog (36 → 0 templates (of the 36; two arrived mid-sweep from #234/#235))
 
 `npa.workflow/v0.0.1` specs are becoming the only workflow authoring surface.

--- a/docs/workbench/guides/physical-ai-data-factory-deploy.md
+++ b/docs/workbench/guides/physical-ai-data-factory-deploy.md
@@ -663,12 +663,19 @@ ambient (often expired) token over the fresh CLI one.
 
 ---
 
-## 6. Multi-GPU fan-out (`RTXPRO6000:N`)
+## 6. Multi-GPU and multi-node fan-out (`RTXPRO6000:N`, `--var augment_nodes=N`)
 
 The `augment` stage runs **one Cosmos Transfer 2.5 diffusion per sampled scenario
 variant**. Request `N` GPUs and the stage fans the `N` variants across them (one
 variant per GPU), so `N` variants complete in roughly one variant's wall-clock
 instead of `N x`.
+
+The variants are independent diffusions, so they also scale across **nodes**:
+`--var augment_nodes=N` makes SkyPilot gang-schedule `N` identical augment pods
+and the stage shards the sampled combos by `SKYPILOT_NODE_RANK`. Concurrent
+renders = `augment_nodes` × GPUs per node. See
+[section 6b](#6b-multi-node-augment---var-augment_nodesn) for the artifact
+contract.
 
 - Set the number of variants with `config.n_augmentations` (via `--var`, default
   `2`).
@@ -704,6 +711,50 @@ variant is conditioned on the run's `input/` prefix: a supported video is used
 directly, or the required PNG/JPEG frames are assembled into a temporary clip
 (preserve input geometry/motion, change only appearance). Missing or inaccessible
 input fails closed before inference.
+
+### 6b. Multi-node augment (`--var augment_nodes=N`)
+
+One pod is bounded by the GPUs on a single node. `config.augment_nodes` is the
+second axis: the `gpu` profile declares `num_nodes: "{{config.augment_nodes}}"`, so
+raising it at submit time gang-schedules that many augment pods without editing the
+blueprint. `deployIfAbsent` provisions a cluster with at least that many GPU nodes,
+because a gang larger than the cluster does not fail — it sits `PENDING`.
+
+```bash
+# 16 variants: 4 nodes x 4 GPUs, all rendering at once.
+NPA_WORKFLOW_GPU_ACCELERATOR=RTXPRO6000:4 \
+npa workbench workflow submit "$SPEC" \
+  --run-id "$(date -u +paidf-4x4-%Y%m%dt%H%M%sz)" \
+  --var bucket=<your-artifact-bucket> \
+  --var n_augmentations=16 \
+  --var augment_nodes=4 \
+  --assume-decision promote_checkpoint \
+  --secret-env NEBIUS_TOKEN_FACTORY_KEY \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY
+```
+
+How the nodes divide the work and rejoin:
+
+- Every pod runs the same augment command and reads the same
+  `configs/manifest.json`. Node `k` of `N` renders variants `k, k+N, k+2N, …`
+  (striding, so the nodes stay within one variant of each other) and pins each of
+  its own concurrent renders to a local GPU starting at 0.
+- Variant indices are global, so clip names (`aug-<run-id>-<i>`) stay disjoint and
+  every clip dir is written by exactly one node.
+- Each node publishes `cosmos_augmented/manifest-rank-<k>.json`; **rank 0** waits
+  for all `N` shards and merges them into the usual
+  `cosmos_augmented/manifest.json`, ordered by variant index, with `node_count` and
+  a per-rank `shards` block added. A rank that never reports is a hard failure that
+  names it — the run manifest never quietly understates the fan-out.
+- Downstream stages are unchanged: they enumerate clip dirs, and the shard files
+  are objects at the prefix root rather than a subdirectory, so nothing counts them
+  as a variant.
+- `augment_nodes=1` (the default) writes no shard files and renders exactly as
+  before.
+
+Only `augment` is multi-node. Captioning, grading, curation, and visualization are
+CPU/Token-Factory stages that stay a single pod.
 
 ---
 

--- a/npa/src/npa/cli/workbench/cosmos2.py
+++ b/npa/src/npa/cli/workbench/cosmos2.py
@@ -203,6 +203,56 @@ def _detect_gpu_count() -> int:
         return 1
 
 
+def _gang_shard() -> tuple[int, int]:
+    """Return this worker's ``(rank, node_count)`` in the augment block.
+
+    A spec asks for a multi-node augment with ``resources.gpu.num_nodes``; SkyPilot
+    then gang-schedules that many identical pods for the one task and exports
+    ``SKYPILOT_NODE_RANK`` / ``SKYPILOT_NUM_NODES`` into each. Every pod runs this
+    same command, so without a shard the gang would render every variant N times.
+    ``NPA_COSMOS_NODE_RANK`` / ``NPA_COSMOS_NODE_COUNT`` override for local runs.
+
+    An inconsistent identity fails closed: silently collapsing to one node would
+    duplicate GPU work and leave the run manifest reporting a fan-out that never
+    happened.
+    """
+
+    def _read(*names: str) -> str:
+        for name in names:
+            value = str(os.environ.get(name, "")).strip()
+            if value:
+                return value
+        return ""
+
+    raw_nodes = _read("NPA_COSMOS_NODE_COUNT", "SKYPILOT_NUM_NODES")
+    raw_rank = _read("NPA_COSMOS_NODE_RANK", "SKYPILOT_NODE_RANK") or "0"
+    try:
+        nodes = int(raw_nodes) if raw_nodes else 1
+        rank = int(raw_rank)
+    except ValueError as exc:
+        raise typer.BadParameter(
+            "multi-node augment identity is not numeric "
+            f"(node count {raw_nodes!r}, rank {raw_rank!r})"
+        ) from exc
+    if nodes < 1 or not 0 <= rank < nodes:
+        raise typer.BadParameter(
+            f"multi-node augment identity is inconsistent: rank {rank} of {nodes} node(s)"
+        )
+    return rank, nodes
+
+
+def _shard_indices(count: int, *, rank: int, nodes: int) -> list[int]:
+    """Variant indices this node renders, striding so the load stays balanced.
+
+    Striding (rank, rank+nodes, ...) rather than contiguous blocks keeps every
+    node within one variant of the others when the count does not divide evenly.
+    """
+
+    if nodes <= 1:
+        return list(range(max(0, count)))
+    return list(range(rank, max(0, count), nodes))
+
+
 def _variant_parallelism(num_variants: int) -> int:
     """Resolve how many variant inferences to run concurrently (>=1).
 
@@ -293,13 +343,18 @@ def _materialize_conditioning_input(
         ) from exc
 
 
-def _persist_generated_conditioning_clip(local_input: str, input_uri: str) -> str:
+def _persist_generated_conditioning_clip(
+    local_input: str, input_uri: str, *, publish: bool = True
+) -> str:
     """Persist PAIDF's frame-derived clip so evaluation uses the exact source.
 
     Operator-side preparation already persists ``conditioning.mp4``. The legacy
     fixture path still creates ``npa-paidf-conditioning.mp4`` in the worker and
     needs it published. In both cases return the canonical URI so evaluation
     records the exact clip Cosmos consumed.
+
+    ``publish=False`` resolves the URI without writing: in a multi-node augment
+    every node derives the same clip, so only one of them uploads it.
     """
 
     path = Path(str(local_input or ""))
@@ -310,6 +365,8 @@ def _persist_generated_conditioning_clip(local_input: str, input_uri: str) -> st
         return uri
     if path.name != "npa-paidf-conditioning.mp4":
         return ""
+    if not publish:
+        return uri
     from npa.clients.storage import StorageClient
 
     return StorageClient.from_environment().upload_file(str(path), uri)
@@ -451,25 +508,38 @@ def transfer_cmd(
             # image). The per-clip layout is what data_factory curate /
             # build_run_rrd / provenance consume.
             from npa.workbench.cosmos.transfer import (
+                merge_shard_manifests,
                 publish_transfer_clip,
                 write_run_manifest,
+                write_shard_manifest,
             )
 
             combos = _all_augmentations(configs_uri) if configs_uri else []
             if not combos:
                 combos = [{}]
 
+            # Multi-node fan-out: this node renders only its stride of the sampled
+            # combos. Variant indices stay GLOBAL, so clip names remain disjoint
+            # across the gang and the merged manifest keeps the sampled order.
+            rank, node_count = _gang_shard()
+            shard = [(i, combos[i]) for i in _shard_indices(len(combos), rank=rank, nodes=node_count)]
+
             conditioning_clip_uri = _persist_generated_conditioning_clip(
-                local_input, input_uri
+                local_input,
+                input_uri,
+                # One writer for a key the whole gang would otherwise race on.
+                publish=rank == 0,
             )
 
-            parallelism = _variant_parallelism(len(combos))
+            parallelism = _variant_parallelism(len(shard))
 
-            def _render_variant(i: int, combo: dict) -> dict:
+            def _render_variant(slot: int, i: int, combo: dict) -> dict:
                 variant_run = f"{run_id}-v{i}" if run_id else f"v{i}"
                 # Pin each concurrent variant to a distinct GPU so an N-GPU pod
                 # runs N diffusions at once (sequential when parallelism == 1).
-                device = str(i % parallelism) if parallelism > 1 else None
+                # The device comes from the node-local slot, never the global
+                # variant index: rank 1 of a gang must still start at GPU 0.
+                device = str(slot % parallelism) if parallelism > 1 else None
                 result = run_cosmos_transfer(
                     run_id=variant_run,
                     spec=spec or None,
@@ -484,25 +554,25 @@ def transfer_cmd(
                 result["conditioning_clip_uri"] = conditioning_clip_uri
                 return result
 
-            # Fan the GPU-bound diffusions out across the pod's GPUs, then publish
+            # Fan the GPU-bound diffusions out across this pod's GPUs, then publish
             # sequentially in combo order (publish/S3 upload stays single-threaded).
-            transfers: list[dict] = [dict() for _ in combos]
-            if parallelism > 1 and len(combos) > 1:
+            transfers: dict[int, dict] = {}
+            if parallelism > 1 and len(shard) > 1:
                 from concurrent.futures import ThreadPoolExecutor
 
                 with ThreadPoolExecutor(max_workers=parallelism) as pool:
                     futures = {
-                        pool.submit(_render_variant, i, combo): i
-                        for i, combo in enumerate(combos)
+                        pool.submit(_render_variant, slot, i, combo): i
+                        for slot, (i, combo) in enumerate(shard)
                     }
                     for future in futures:
                         transfers[futures[future]] = future.result()
             else:
-                for i, combo in enumerate(combos):
-                    transfers[i] = _render_variant(i, combo)
+                for slot, (i, combo) in enumerate(shard):
+                    transfers[i] = _render_variant(slot, i, combo)
 
             clips: list[dict] = []
-            for i, combo in enumerate(combos):
+            for i, combo in shard:
                 clip_name = f"aug-{run_id}-{i}" if run_id else f"aug{i}"
                 clips.append(
                     publish_transfer_clip(
@@ -511,12 +581,41 @@ def transfer_cmd(
                         run_id=run_id,
                         clip_name=clip_name,
                         variables=combo,
+                        variant_index=i,
                         require_frames=True,
                     )
                 )
-            manifest = write_run_manifest(
-                clips, output_uri, run_id=run_id, variant_parallelism=parallelism
-            )
+            if node_count > 1:
+                # Each node publishes its own shard manifest; rank 0 joins them into
+                # the single run manifest the downstream stages read. A worker's
+                # payload describes its own shard -- it never claims the run's total.
+                from npa.workbench.cosmos.transfer import build_run_manifest
+
+                write_shard_manifest(
+                    clips,
+                    output_uri,
+                    run_id=run_id,
+                    rank=rank,
+                    node_count=node_count,
+                    variant_parallelism=parallelism,
+                    variant_total=len(combos),
+                )
+                manifest = (
+                    merge_shard_manifests(
+                        output_uri, run_id=run_id, node_count=node_count
+                    )
+                    if rank == 0
+                    else build_run_manifest(
+                        clips,
+                        run_id=run_id,
+                        variant_parallelism=parallelism,
+                        node_count=node_count,
+                    )
+                )
+            else:
+                manifest = write_run_manifest(
+                    clips, output_uri, run_id=run_id, variant_parallelism=parallelism
+                )
             payload["status"] = TRANSFER_MANIFEST_STATUS
             payload["output_kind"] = "video"
             payload["mode"] = TRANSFER_MANIFEST_MODE
@@ -526,6 +625,9 @@ def transfer_cmd(
             payload["variant_count"] = manifest["variant_count"]
             payload["multiply_mode"] = manifest["multiply_mode"]
             payload["variant_parallelism"] = manifest["variant_parallelism"]
+            payload["node_count"] = node_count
+            payload["node_rank"] = rank
+            payload["shard_variant_count"] = len(clips)
             payload["clips"] = manifest["clips"]
             payload["augmentation_variables"] = combos[0]
             payload["prompt"] = str((combos[0] or {}).get("prompt") or "")

--- a/npa/src/npa/orchestration/npa_workflow/deploy.py
+++ b/npa/src/npa/orchestration/npa_workflow/deploy.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, replace
 from typing import Any, Callable, Mapping
 
 from npa.orchestration.npa_workflow.errors import NpaWorkflowError
-from npa.orchestration.npa_workflow.spec import NpaWorkflowSpec
+from npa.orchestration.npa_workflow.spec import NpaWorkflowSpec, profile_num_nodes
 from npa.provisioning_preflight import (
     DEFAULT_CPU_NODES,
     DEFAULT_CPU_PLATFORM,
@@ -153,6 +153,13 @@ def parse_deploy_targets(spec: NpaWorkflowSpec) -> list[DeployTarget]:
             )
         elif not _coerce_bool(directive):
             continue
+
+        # A gang-scheduled stage needs a cluster that can actually hold the block:
+        # `num_nodes: 4` on a one-GPU-node cluster does not fail, it sits PENDING.
+        # An explicit gpuNodes directive still wins when it asks for more.
+        gang_nodes = profile_num_nodes(dict(raw), name=str(profile), config=spec.config)
+        if accelerators and gang_nodes > gpu_nodes:
+            gpu_nodes = gang_nodes
 
         targets.append(
             DeployTarget(

--- a/npa/src/npa/orchestration/npa_workflow/scheduler.py
+++ b/npa/src/npa/orchestration/npa_workflow/scheduler.py
@@ -21,15 +21,18 @@ def num_nodes_for_step(spec: NpaWorkflowSpec, step: PlanStep) -> int:
     inside it (see ``sky/utils/schemas.py`` and ``npa.burst.core.build_task_spec``). It
     lives on the resource profile in a spec because that is where per-stage shape
     belongs, and the renderer lifts it back out to the task document.
+
+    A ``{{config.*}}`` value is resolved here against the (already ``--var``-merged)
+    config, which is how a shipped blueprint's block size can be chosen at submit
+    time.
     """
 
-    raw = resources_for_step(spec, step).get("num_nodes")
-    try:
-        return max(1, int(raw)) if raw not in (None, "") else 1
-    except (TypeError, ValueError):
-        # validate_spec rejects a non-integer, so this is only reachable for a spec
-        # built in-process; be conservative rather than crashing the renderer.
-        return 1
+    from npa.orchestration.npa_workflow.spec import profile_num_nodes
+
+    profile = step.resources or "default"
+    return profile_num_nodes(
+        resources_for_step(spec, step), name=profile, config=spec.config
+    )
 
 
 def build_scheduler_task(

--- a/npa/src/npa/orchestration/npa_workflow/spec.py
+++ b/npa/src/npa/orchestration/npa_workflow/spec.py
@@ -381,40 +381,66 @@ def validate_spec(spec: NpaWorkflowSpec) -> None:
     _validate_resolvable(spec)
 
 
-def _validate_resource_profiles(spec: NpaWorkflowSpec) -> None:
-    """Validate resource-profile fields the renderer will act on.
+def profile_num_nodes(
+    profile: Any,
+    *,
+    name: str,
+    config: Any = None,
+) -> int:
+    """Return a resource profile's ``num_nodes`` (default 1), validating bounds.
 
-    ``num_nodes`` is the only one that changes the *shape* of the rendered task (a
-    multi-node gang instead of one pod), so a bad value has to fail at validate time
-    rather than at provision time.
+    The value may be a literal or a ``{{config.*}}`` token, so one blueprint can be
+    submitted with a different block size (``--var augment_nodes=4``) instead of
+    being edited. With ``config=None`` -- validate time, before ``--var`` overrides
+    are merged -- an unresolved token is accepted and re-checked once the value is
+    known; every other malformed value still fails at validate time, because
+    ``num_nodes`` changes the *shape* of the rendered task.
     """
 
-    for name, profile in spec.resources.items():
-        if not isinstance(profile, dict):
-            raise NpaWorkflowError(f"resource profile {name!r} must be a mapping")
-        raw = profile.get("num_nodes")
-        if raw in (None, ""):
-            continue
-        if isinstance(raw, bool):
-            raise NpaWorkflowError(
-                f"resource profile {name!r}: num_nodes must be an integer, not a bool"
-            )
+    if not isinstance(profile, dict):
+        raise NpaWorkflowError(f"resource profile {name!r} must be a mapping")
+    raw = profile.get("num_nodes")
+    if raw in (None, ""):
+        return 1
+    if isinstance(raw, bool):
+        raise NpaWorkflowError(
+            f"resource profile {name!r}: num_nodes must be an integer, not a bool"
+        )
+    if isinstance(raw, str) and "{{" in raw:
+        if config is None:
+            return 1
+        from npa.orchestration.npa_workflow.tokens import TokenError, resolve_tokens
+
         try:
-            value = int(raw)
-        except (TypeError, ValueError) as exc:
+            raw = resolve_tokens(raw, config=config, run={})
+        except TokenError as exc:
             raise NpaWorkflowError(
-                f"resource profile {name!r}: num_nodes must be an integer, got {raw!r}"
+                f"resource profile {name!r}: num_nodes token is unresolvable: {exc}"
             ) from exc
-        if value < 1:
-            raise NpaWorkflowError(
-                f"resource profile {name!r}: num_nodes must be >= 1, got {value}"
-            )
-        if value > MAX_PROFILE_NODES:
-            raise NpaWorkflowError(
-                f"resource profile {name!r}: num_nodes must be <= {MAX_PROFILE_NODES}, "
-                f"got {value} (a gang-scheduled block this large is almost always a typo; "
-                "it would sit PENDING rather than fail)"
-            )
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError) as exc:
+        raise NpaWorkflowError(
+            f"resource profile {name!r}: num_nodes must be an integer, got {raw!r}"
+        ) from exc
+    if value < 1:
+        raise NpaWorkflowError(
+            f"resource profile {name!r}: num_nodes must be >= 1, got {value}"
+        )
+    if value > MAX_PROFILE_NODES:
+        raise NpaWorkflowError(
+            f"resource profile {name!r}: num_nodes must be <= {MAX_PROFILE_NODES}, "
+            f"got {value} (a gang-scheduled block this large is almost always a typo; "
+            "it would sit PENDING rather than fail)"
+        )
+    return value
+
+
+def _validate_resource_profiles(spec: NpaWorkflowSpec) -> None:
+    """Validate resource-profile fields the renderer will act on."""
+
+    for name, profile in spec.resources.items():
+        profile_num_nodes(profile, name=name)
 
 
 def _validate_parallel_group(spec: NpaWorkflowSpec, state: StateSpec) -> None:

--- a/npa/src/npa/workbench/cosmos/transfer.py
+++ b/npa/src/npa/workbench/cosmos/transfer.py
@@ -44,6 +44,14 @@ TRANSFER_MANIFEST_FILENAME = "manifest.json"
 TRANSFER_MANIFEST_SCHEMA = "npa.cosmos2.transfer.v1"
 TRANSFER_MANIFEST_MODE = "cosmos_transfer2.5_gpu"
 TRANSFER_MANIFEST_STATUS = "executed"
+# Multi-node augment: each node of a gang-scheduled block publishes its own clips
+# and one shard manifest, then rank 0 merges the shards into the run manifest.
+# Shard manifests are FILES at the augment prefix root (never a subdirectory):
+# every consumer -- data_factory_stages.curate/finalize, the Cosmos Evaluator, the
+# provenance reader -- treats a subdirectory of that prefix as a clip, so a
+# `shards/` dir would be counted as a bogus variant.
+SHARD_MANIFEST_PREFIX = "manifest-rank-"
+SHARD_MANIFEST_SCHEMA = "npa.cosmos2.transfer_shard.v1"
 AUGMENTED_FRAMES_INDEX = "index.json"
 AUGMENTED_FRAMES_SCHEMA = "npa.sim2real.augmented_frames.v1"
 REFERENCE_AUGMENT_MODE = "reference_augment"
@@ -377,6 +385,7 @@ def publish_transfer_clip(
     run_id: str = "",
     clip_name: str = "",
     variables: dict[str, Any] | None = None,
+    variant_index: int = 0,
     max_frames: int = 8,
     frames_output_uri: str = "",
     require_frames: bool = False,
@@ -447,6 +456,10 @@ def publish_transfer_clip(
             "schema": TRANSFER_MANIFEST_SCHEMA,
             "mode": TRANSFER_MANIFEST_MODE,
             "clip": clip,
+            # Position of this variant in the sampled combo order. It is the same
+            # number whichever node rendered the clip, so a merged multi-node
+            # manifest can restore the single-node ordering.
+            "variant_index": int(variant_index),
             "variables": variables or {},
             "prompt": str((variables or {}).get("prompt") or ""),
             "control_spec": transfer.get("spec", ""),
@@ -462,6 +475,7 @@ def publish_transfer_clip(
 
     return {
         "clip": clip,
+        "variant_index": int(variant_index),
         "clip_base": clip_base,
         "augmented_video_uri": video_uri,
         "frame_count": len(frame_index),
@@ -478,30 +492,35 @@ def publish_transfer_clip(
     }
 
 
-def write_run_manifest(
-    clips: list[dict[str, Any]],
-    output_uri: str,
-    *,
-    run_id: str = "",
-    storage_client: Any = None,
-    variant_parallelism: int = 1,
-) -> dict[str, Any]:
-    """Write the run-level ``cosmos_augmented/manifest.json`` listing every clip
-    produced by the (possibly multi-variant) augment stage; return the manifest.
-
-    ``clips`` are the descriptors returned by :func:`publish_transfer_clip`.
-    ``variant_parallelism`` records how many GPUs the fan-out ran across (1 ==
-    sequential) so provenance can surface the multi-GPU amplification.
-    """
-
-    if not output_uri.startswith("s3://"):
-        raise ValueError(f"output_uri must be an s3:// prefix, got: {output_uri!r}")
-    from npa.clients.storage import StorageClient
+def _upload_json(client: Any, document: dict[str, Any], uri: str) -> str:
+    """Upload ``document`` as pretty-printed JSON to ``uri``."""
 
     import json as _json
     import tempfile as _tempfile
 
-    client = storage_client or StorageClient.from_environment()
+    with _tempfile.TemporaryDirectory(prefix="npa-cosmos-man-") as tmp:
+        local = Path(tmp) / Path(uri).name
+        local.write_text(
+            _json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return client.upload_file(str(local), uri)
+
+
+def build_run_manifest(
+    clips: list[dict[str, Any]],
+    *,
+    run_id: str = "",
+    variant_parallelism: int = 1,
+    node_count: int = 1,
+    shards: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return the run-level transfer manifest for ``clips`` (no I/O).
+
+    Shared by the single-node publisher (:func:`write_run_manifest`) and the
+    multi-node shard merge (:func:`merge_shard_manifests`) so both emit the same
+    document for the same set of variants.
+    """
+
     first = clips[0] if clips else {}
     frames = [f for c in clips for f in c.get("frames", [])]
     manifest = {
@@ -514,7 +533,11 @@ def write_run_manifest(
         # "multiply": one Cosmos Transfer 2.5 inference per sampled appearance
         # combo. >1 clips means the run genuinely amplified across scenarios.
         "multiply_mode": "multi-variant" if len(clips) > 1 else "single-variant",
+        # Concurrent variant renders across the whole augment block: the sum of
+        # each node's GPU fan-out, so it is the pod's GPU count on one node and
+        # the gang's total on many.
         "variant_parallelism": max(1, int(variant_parallelism or 1)),
+        "node_count": max(1, int(node_count or 1)),
         "augmented_video_uri": first.get("augmented_video_uri", ""),
         "augmented_videos": [c.get("augmented_video_uri", "") for c in clips],
         "frame_count": sum(int(c.get("frame_count", 0) or 0) for c in clips),
@@ -532,19 +555,193 @@ def write_run_manifest(
         "variants": [
             {
                 "clip": c.get("clip", ""),
+                "variant_index": int(c.get("variant_index", index) or 0),
                 "variables": c.get("variables", {}),
                 "prompt": str((c.get("variables") or {}).get("prompt") or ""),
                 "frame_count": int(c.get("frame_count", 0) or 0),
                 "augmented_video_uri": c.get("augmented_video_uri", ""),
             }
-            for c in clips
+            for index, c in enumerate(clips)
         ],
     }
-    with _tempfile.TemporaryDirectory(prefix="npa-cosmos-man-") as tmp:
-        mp = Path(tmp) / TRANSFER_MANIFEST_FILENAME
-        mp.write_text(_json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        client.upload_file(str(mp), transfer_manifest_uri_for(output_uri))
+    if shards is not None:
+        manifest["shards"] = shards
     return manifest
+
+
+def write_run_manifest(
+    clips: list[dict[str, Any]],
+    output_uri: str,
+    *,
+    run_id: str = "",
+    storage_client: Any = None,
+    variant_parallelism: int = 1,
+    node_count: int = 1,
+    shards: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Write the run-level ``cosmos_augmented/manifest.json`` listing every clip
+    produced by the (possibly multi-variant) augment stage; return the manifest.
+
+    ``clips`` are the descriptors returned by :func:`publish_transfer_clip`.
+    ``variant_parallelism`` records how many GPUs the fan-out ran across (1 ==
+    sequential) so provenance can surface the multi-GPU amplification.
+    """
+
+    if not output_uri.startswith("s3://"):
+        raise ValueError(f"output_uri must be an s3:// prefix, got: {output_uri!r}")
+    from npa.clients.storage import StorageClient
+
+    client = storage_client or StorageClient.from_environment()
+    manifest = build_run_manifest(
+        clips,
+        run_id=run_id,
+        variant_parallelism=variant_parallelism,
+        node_count=node_count,
+        shards=shards,
+    )
+    _upload_json(client, manifest, transfer_manifest_uri_for(output_uri))
+    return manifest
+
+
+def shard_manifest_uri_for(output_uri: str, rank: int) -> str:
+    """Return the shard-manifest URI one node of a gang-scheduled augment writes."""
+
+    return f"{output_uri.rstrip('/')}/{SHARD_MANIFEST_PREFIX}{int(rank)}.json"
+
+
+def write_shard_manifest(
+    clips: list[dict[str, Any]],
+    output_uri: str,
+    *,
+    run_id: str = "",
+    rank: int,
+    node_count: int,
+    variant_parallelism: int = 1,
+    variant_total: int = 0,
+    storage_client: Any = None,
+) -> dict[str, Any]:
+    """Publish ONE node's share of a multi-node augment as a shard manifest.
+
+    Every node of the gang writes its own file, so the nodes never contend for a
+    single key. ``clips`` carry their global ``variant_index``, which is what lets
+    :func:`merge_shard_manifests` restore the sampled combo order.
+    """
+
+    if not output_uri.startswith("s3://"):
+        raise ValueError(f"output_uri must be an s3:// prefix, got: {output_uri!r}")
+    from npa.clients.storage import StorageClient
+
+    client = storage_client or StorageClient.from_environment()
+    shard = {
+        "schema": SHARD_MANIFEST_SCHEMA,
+        "mode": TRANSFER_MANIFEST_MODE,
+        "status": TRANSFER_MANIFEST_STATUS,
+        "run_id": run_id,
+        "rank": int(rank),
+        "node_count": max(1, int(node_count or 1)),
+        "variant_parallelism": max(1, int(variant_parallelism or 1)),
+        "variant_total": max(0, int(variant_total or 0)),
+        "variant_count": len(clips),
+        "clips": [c.get("clip", "") for c in clips],
+        "clip_descriptors": clips,
+    }
+    _upload_json(client, shard, shard_manifest_uri_for(output_uri, rank))
+    return shard
+
+
+def merge_shard_manifests(
+    output_uri: str,
+    *,
+    run_id: str = "",
+    node_count: int,
+    storage_client: Any = None,
+    timeout_s: float = 3600.0,
+    poll_interval_s: float = 15.0,
+    sleep: Any = None,
+) -> dict[str, Any]:
+    """Wait for every node's shard manifest, then write the run manifest.
+
+    Called by rank 0 only. The gang's nodes run the same augment command
+    concurrently, so this is the join: it fetches ``manifest-rank-<k>.json`` for
+    every expected rank, orders the clips by their global variant index, and
+    writes the same ``manifest.json`` a single-node run would have produced.
+    Waiting is bounded -- a rank that never reports is a hard failure naming the
+    missing ranks, not a manifest that silently omits its variants.
+    """
+
+    import json as _json
+    import tempfile as _tempfile
+    import time as _time
+
+    if not output_uri.startswith("s3://"):
+        raise ValueError(f"output_uri must be an s3:// prefix, got: {output_uri!r}")
+    from npa.clients.storage import StorageClient
+
+    client = storage_client or StorageClient.from_environment()
+    waiter = sleep or _time.sleep
+    expected = max(1, int(node_count or 1))
+    deadline = _time.monotonic() + max(0.0, float(timeout_s))
+    shards: dict[int, dict[str, Any]] = {}
+
+    with _tempfile.TemporaryDirectory(prefix="npa-cosmos-shard-") as tmp:
+        while True:
+            for rank in range(expected):
+                if rank in shards:
+                    continue
+                # Fetch the exact key rather than listing the prefix: a bucket
+                # listing can lag behind a sibling node's upload.
+                local = Path(tmp) / f"{SHARD_MANIFEST_PREFIX}{rank}.json"
+                try:
+                    client.download_path(
+                        shard_manifest_uri_for(output_uri, rank), str(local)
+                    )
+                except Exception:  # noqa: BLE001 - a rank that is not there yet
+                    continue
+                if not local.is_file():
+                    continue
+                try:
+                    shards[rank] = _json.loads(local.read_text(encoding="utf-8"))
+                except ValueError:
+                    # A partially visible object: drop it and re-read next pass.
+                    local.unlink(missing_ok=True)
+            if len(shards) == expected:
+                break
+            if _time.monotonic() >= deadline:
+                missing = [r for r in range(expected) if r not in shards]
+                raise RuntimeError(
+                    "multi-node augment: no shard manifest from rank(s) "
+                    f"{missing} after {timeout_s:.0f}s at {output_uri}. Those nodes "
+                    "did not finish publishing their variants, so the run manifest "
+                    "would understate the fan-out."
+                )
+            waiter(max(0.1, float(poll_interval_s)))
+
+    ordered = sorted(
+        (clip for shard in shards.values() for clip in shard.get("clip_descriptors", [])),
+        key=lambda c: int(c.get("variant_index", 0) or 0),
+    )
+    return write_run_manifest(
+        ordered,
+        output_uri,
+        run_id=run_id,
+        storage_client=client,
+        variant_parallelism=sum(
+            max(1, int(shard.get("variant_parallelism", 1) or 1))
+            for shard in shards.values()
+            if int(shard.get("variant_count", 0) or 0) > 0
+        )
+        or 1,
+        node_count=expected,
+        shards=[
+            {
+                "rank": int(shard.get("rank", rank) or 0),
+                "variant_count": int(shard.get("variant_count", 0) or 0),
+                "variant_parallelism": max(1, int(shard.get("variant_parallelism", 1) or 1)),
+                "clips": list(shard.get("clips", [])),
+            }
+            for rank, shard in sorted(shards.items())
+        ],
+    )
 
 
 def publish_transfer_to_s3(
@@ -755,19 +952,25 @@ __all__ = [
     "FrameExtractionError",
     "REFERENCE_AUGMENT_MODE",
     "REFERENCE_AUGMENT_STATUS",
+    "SHARD_MANIFEST_PREFIX",
+    "SHARD_MANIFEST_SCHEMA",
     "TRANSFER_MANIFEST_FILENAME",
     "TRANSFER_MANIFEST_MODE",
     "TRANSFER_MANIFEST_SCHEMA",
     "TRANSFER_MANIFEST_STATUS",
     "augmented_frames_index_uri_for",
+    "build_run_manifest",
     "cosmos_transfer_available",
     "cosmos_transfer_repo",
     "ensure_env",
     "extract_frames",
+    "merge_shard_manifests",
     "publish_transfer_clip",
     "publish_transfer_to_s3",
     "reference_augment_frames",
     "run_cosmos_transfer",
+    "shard_manifest_uri_for",
     "transfer_manifest_uri_for",
     "write_run_manifest",
+    "write_shard_manifest",
 ]

--- a/npa/tests/orchestration/npa_workflow/test_multi_node.py
+++ b/npa/tests/orchestration/npa_workflow/test_multi_node.py
@@ -192,6 +192,102 @@ def test_a_non_mapping_resource_profile_is_rejected(tmp_path: Path) -> None:
         load_spec(path)
 
 
+TOKEN_SPEC = """\
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+metadata:
+  name: token-nodes
+config:
+  bucket: example-bucket
+  prefix: "runs/{{run.id}}/probe"
+  augment_nodes: "1"
+resources:
+  gpu:
+    cloud: kubernetes
+    accelerators: RTXPRO6000:1
+    num_nodes: "{{config.augment_nodes}}"
+    deployIfAbsent: true
+initial: augment
+states:
+  augment:
+    resources: gpu
+    run:
+      shell: "echo rank $SKYPILOT_NODE_RANK"
+    terminal: true
+"""
+
+
+def _token_spec(tmp_path: Path):
+    path = tmp_path / "token-nodes.yaml"
+    path.write_text(TOKEN_SPEC, encoding="utf-8")
+    return load_spec(path)
+
+
+def test_a_config_token_lets_submit_choose_the_block_size(tmp_path: Path) -> None:
+    """`--var augment_nodes=4` must scale a shipped blueprint without editing it."""
+
+    from npa.orchestration.npa_workflow.submit import merge_config_overrides
+
+    spec = _token_spec(tmp_path)
+    plan = build_plan(spec, run_id="probe")
+    step = next(s for s in plan.steps if s.state == "augment")
+    assert num_nodes_for_step(spec, step) == 1
+
+    scaled = merge_config_overrides(spec, {"augment_nodes": "4"})
+    assert num_nodes_for_step(scaled, step) == 4
+
+
+def test_a_config_token_resolving_to_nonsense_still_fails(tmp_path: Path) -> None:
+    from npa.orchestration.npa_workflow.submit import merge_config_overrides
+
+    spec = merge_config_overrides(_token_spec(tmp_path), {"augment_nodes": "lots"})
+    step = next(s for s in build_plan(spec, run_id="probe").steps if s.state == "augment")
+
+    with pytest.raises(NpaWorkflowError, match="must be an integer"):
+        num_nodes_for_step(spec, step)
+
+
+def test_a_gang_stage_provisions_a_cluster_that_can_hold_it(tmp_path: Path) -> None:
+    """`num_nodes: 4` against a one-GPU-node cluster does not fail; it sits PENDING."""
+
+    from npa.orchestration.npa_workflow.deploy import parse_deploy_targets
+    from npa.orchestration.npa_workflow.submit import merge_config_overrides
+
+    spec = _token_spec(tmp_path)
+    assert [t.gpu_nodes for t in parse_deploy_targets(spec)] == [1]
+
+    scaled = merge_config_overrides(spec, {"augment_nodes": "4"})
+    assert [t.gpu_nodes for t in parse_deploy_targets(scaled)] == [4]
+
+
+def test_paidf_augment_scales_from_one_pod_to_a_gang(monkeypatch: pytest.MonkeyPatch) -> None:
+    from npa.orchestration.npa_workflow.submit import merge_config_overrides
+
+    monkeypatch.setenv("NPA_SRC_S3_URI", "s3://example-bucket/prefix/npa")
+    blueprint = (
+        Path(__file__).resolve().parents[3] / "workflows" / "physical-ai-data-factory.yaml"
+    )
+    spec = load_spec(blueprint)
+
+    def _augment_task(loaded):
+        plan = build_plan(loaded, run_id="paidf", assume_decision="promote_checkpoint")
+        text = render_skypilot_yaml(
+            loaded,
+            plan,
+            run_id="paidf",
+            options=SkypilotRenderOptions(image_overrides={"*": ""}),
+        )
+        docs = [doc for doc in yaml.safe_load_all(text) if doc]
+        return next(doc for doc in docs[1:] if doc["name"].startswith("augment"))
+
+    # Shipped default: one augment pod, rendered exactly as before.
+    assert "num_nodes" not in _augment_task(spec)
+
+    gang = _augment_task(merge_config_overrides(spec, {"augment_nodes": "4"}))
+    assert gang["num_nodes"] == 4
+    assert "num_nodes" not in gang["resources"]
+
+
 def test_every_shipped_spec_still_validates() -> None:
     """The new profile validation must not reject anything already in the catalog."""
 

--- a/npa/tests/workbench/test_cosmos_transfer_multi_node.py
+++ b/npa/tests/workbench/test_cosmos_transfer_multi_node.py
@@ -1,0 +1,393 @@
+"""Multi-node augment: shard the sampled combos across a gang-scheduled block.
+
+``resources.gpu.num_nodes: N`` makes SkyPilot gang-schedule N identical pods for
+the one augment task and run the SAME command in each. Without a shard every node
+would render every variant, so these tests pin the two properties that make the
+block real work rather than N copies of it:
+
+* each rank renders only its stride of the combos, on its own GPUs; and
+* rank 0 joins the per-node shard manifests into the one ``manifest.json`` the
+  downstream stages read, or fails naming the ranks that never reported.
+
+No GPU or Cosmos runtime is touched: inference and S3 are both fakes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.cli.workbench import cosmos2
+from npa.workbench.cosmos import transfer as tx
+
+runner = CliRunner()
+
+
+class FakeStorage:
+    """In-memory stand-in for the S3 objects a gang's nodes exchange."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    def upload_file(self, local: str, uri: str) -> str:
+        self.objects[uri] = Path(local).read_bytes()
+        return uri
+
+    def download_path(self, uri: str, local_path: str) -> str:
+        if uri not in self.objects:
+            return local_path
+        dest = Path(local_path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(self.objects[uri])
+        return str(dest)
+
+
+def _clip(index: int, *, run_id: str = "run1") -> dict:
+    return {
+        "clip": f"aug-{run_id}-{index}",
+        "variant_index": index,
+        "augmented_video_uri": f"s3://bkt/{run_id}/cosmos_augmented/aug-{run_id}-{index}/augmented_video.mp4",
+        "frames_uri": f"s3://bkt/{run_id}/cosmos_augmented/aug-{run_id}-{index}/",
+        "frames": [{"frame_id": "frame-00000", "uri": "s3://bkt/f.png"}],
+        "frame_count": 1,
+        "variables": {"prompt": f"scene {index}"},
+        "video_bytes": 1000,
+        "input_conditioned": True,
+        "control": "edge",
+    }
+
+
+def test_shard_indices_stride_so_every_node_gets_a_balanced_share() -> None:
+    # 5 combos over 2 nodes: striding keeps the nodes within one variant of each
+    # other; contiguous blocks would give one node 3 and the other 2 in sequence.
+    assert cosmos2._shard_indices(5, rank=0, nodes=2) == [0, 2, 4]
+    assert cosmos2._shard_indices(5, rank=1, nodes=2) == [1, 3]
+    # Every variant is rendered exactly once across the gang.
+    covered = [i for rank in range(3) for i in cosmos2._shard_indices(7, rank=rank, nodes=3)]
+    assert sorted(covered) == list(range(7))
+    # More nodes than variants: the surplus ranks render nothing.
+    assert cosmos2._shard_indices(2, rank=3, nodes=4) == []
+    # Single node keeps the whole list, in order.
+    assert cosmos2._shard_indices(3, rank=0, nodes=1) == [0, 1, 2]
+
+
+def test_gang_shard_reads_skypilot_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NPA_COSMOS_NODE_COUNT", raising=False)
+    monkeypatch.delenv("NPA_COSMOS_NODE_RANK", raising=False)
+    monkeypatch.delenv("SKYPILOT_NUM_NODES", raising=False)
+    monkeypatch.delenv("SKYPILOT_NODE_RANK", raising=False)
+    # No gang: a single-node augment, which is the shipped default.
+    assert cosmos2._gang_shard() == (0, 1)
+
+    monkeypatch.setenv("SKYPILOT_NUM_NODES", "4")
+    monkeypatch.setenv("SKYPILOT_NODE_RANK", "2")
+    assert cosmos2._gang_shard() == (2, 4)
+
+    # An NPA override wins, so the shard is reproducible off-cluster.
+    monkeypatch.setenv("NPA_COSMOS_NODE_COUNT", "2")
+    monkeypatch.setenv("NPA_COSMOS_NODE_RANK", "1")
+    assert cosmos2._gang_shard() == (1, 2)
+
+
+@pytest.mark.parametrize(
+    ("rank", "nodes"),
+    [("4", "4"), ("-1", "2"), ("x", "2"), ("0", "0")],
+)
+def test_gang_shard_fails_closed_on_an_inconsistent_identity(
+    monkeypatch: pytest.MonkeyPatch, rank: str, nodes: str
+) -> None:
+    """Collapsing to one node would duplicate every variant on every GPU."""
+
+    monkeypatch.setenv("NPA_COSMOS_NODE_COUNT", nodes)
+    monkeypatch.setenv("NPA_COSMOS_NODE_RANK", rank)
+    with pytest.raises(cosmos2.typer.BadParameter, match="multi-node augment identity"):
+        cosmos2._gang_shard()
+
+
+def test_shard_manifests_merge_into_the_single_node_run_manifest() -> None:
+    storage = FakeStorage()
+    output_uri = "s3://bkt/run1/cosmos_augmented/"
+    # Rank 1 finishes first; the merge must still restore sampled combo order.
+    tx.write_shard_manifest(
+        [_clip(1), _clip(3)],
+        output_uri,
+        run_id="run1",
+        rank=1,
+        node_count=2,
+        variant_parallelism=2,
+        variant_total=4,
+        storage_client=storage,
+    )
+    tx.write_shard_manifest(
+        [_clip(0), _clip(2)],
+        output_uri,
+        run_id="run1",
+        rank=0,
+        node_count=2,
+        variant_parallelism=2,
+        variant_total=4,
+        storage_client=storage,
+    )
+
+    manifest = tx.merge_shard_manifests(
+        output_uri, run_id="run1", node_count=2, storage_client=storage
+    )
+
+    assert manifest["schema"] == tx.TRANSFER_MANIFEST_SCHEMA
+    assert manifest["clips"] == [
+        "aug-run1-0",
+        "aug-run1-1",
+        "aug-run1-2",
+        "aug-run1-3",
+    ]
+    assert manifest["variant_count"] == 4
+    assert manifest["multiply_mode"] == "multi-variant"
+    assert manifest["node_count"] == 2
+    # Concurrent renders across the whole block: 2 GPUs on each of 2 nodes.
+    assert manifest["variant_parallelism"] == 4
+    assert [s["rank"] for s in manifest["shards"]] == [0, 1]
+    # The join is durable: it lands on the same key a single-node run writes.
+    written = json.loads(storage.objects[tx.transfer_manifest_uri_for(output_uri)])
+    assert written["clips"] == manifest["clips"]
+    assert (
+        tx.shard_manifest_uri_for(output_uri, 1)
+        == "s3://bkt/run1/cosmos_augmented/manifest-rank-1.json"
+    )
+
+
+def test_shard_manifests_are_files_not_a_subdirectory_of_the_augment_prefix() -> None:
+    """Every consumer counts a subdir of the augment prefix as a scenario variant."""
+
+    uri = tx.shard_manifest_uri_for("s3://bkt/run1/cosmos_augmented/", 3)
+    relative = uri.split("cosmos_augmented/", 1)[1]
+    assert "/" not in relative
+
+    from npa.workflows import data_factory_stages as dfs
+
+    keys = [
+        "physical-ai-data-factory/run1/cosmos_augmented/manifest.json",
+        "physical-ai-data-factory/run1/cosmos_augmented/manifest-rank-0.json",
+        "physical-ai-data-factory/run1/cosmos_augmented/manifest-rank-1.json",
+        "physical-ai-data-factory/run1/cosmos_augmented/aug-run1-0/augmented_video.mp4",
+        "physical-ai-data-factory/run1/cosmos_augmented/aug-run1-1/augmented_video.mp4",
+    ]
+    _, prefix = dfs._split(
+        "s3://bkt/physical-ai-data-factory/run1/cosmos_augmented/"
+    )
+    rels = [k[len(prefix):] for k in keys if k.startswith(prefix)]
+    clips = sorted({r.split("/", 1)[0] for r in rels if "/" in r})
+    assert clips == ["aug-run1-0", "aug-run1-1"]
+
+
+def test_merge_waits_for_a_slow_rank_then_joins() -> None:
+    storage = FakeStorage()
+    output_uri = "s3://bkt/run1/cosmos_augmented/"
+    tx.write_shard_manifest(
+        [_clip(0)], output_uri, run_id="run1", rank=0, node_count=2,
+        variant_parallelism=1, variant_total=2, storage_client=storage,
+    )
+    waits: list[float] = []
+
+    def late_arrival(seconds: float) -> None:
+        waits.append(seconds)
+        tx.write_shard_manifest(
+            [_clip(1)], output_uri, run_id="run1", rank=1, node_count=2,
+            variant_parallelism=1, variant_total=2, storage_client=storage,
+        )
+
+    manifest = tx.merge_shard_manifests(
+        output_uri,
+        run_id="run1",
+        node_count=2,
+        storage_client=storage,
+        poll_interval_s=0.5,
+        sleep=late_arrival,
+    )
+
+    assert waits == [0.5]
+    assert manifest["clips"] == ["aug-run1-0", "aug-run1-1"]
+
+
+def test_merge_fails_naming_the_ranks_that_never_reported() -> None:
+    storage = FakeStorage()
+    output_uri = "s3://bkt/run1/cosmos_augmented/"
+    tx.write_shard_manifest(
+        [_clip(0)], output_uri, run_id="run1", rank=0, node_count=3,
+        variant_parallelism=1, variant_total=3, storage_client=storage,
+    )
+
+    with pytest.raises(RuntimeError, match=r"rank\(s\) \[1, 2\]"):
+        tx.merge_shard_manifests(
+            output_uri,
+            run_id="run1",
+            node_count=3,
+            storage_client=storage,
+            timeout_s=0,
+            sleep=lambda _s: None,
+        )
+
+    # A partial manifest is never published: an understated fan-out would look
+    # like a successful smaller run to every downstream stage.
+    assert tx.transfer_manifest_uri_for(output_uri) not in storage.objects
+
+
+def _multiply_cli(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, storage: FakeStorage
+) -> list[dict]:
+    """Wire the multiply path to fake inference/publish; return rendered variants."""
+
+    rendered: list[dict] = []
+    configs = tmp_path / "configs"
+    configs.mkdir(exist_ok=True)
+    (configs / "manifest.json").write_text(
+        json.dumps(
+            {
+                "augmentations": [
+                    {"prompt": f"scene {i}", "lighting": f"l{i}"} for i in range(4)
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(tx, "cosmos_transfer_available", lambda: True)
+    monkeypatch.setattr(cosmos2, "_materialize_input_clip", lambda *_a, **_k: "/tmp/in.mp4")
+    monkeypatch.setattr(cosmos2, "_variant_parallelism", lambda n: max(1, n))
+
+    def fake_run(**kwargs):
+        rendered.append(kwargs)
+        return {
+            "video_path": "/tmp/out.mp4",
+            "video_bytes": 1000,
+            "spec": "spec.json",
+            "input_conditioned": True,
+            "input_video": "/tmp/in.mp4",
+            "control": "edge",
+        }
+
+    def fake_publish(transfer, output_uri, **kwargs):
+        index = int(kwargs["variant_index"])
+        return _clip(index)
+
+    monkeypatch.setattr(tx, "run_cosmos_transfer", fake_run)
+    monkeypatch.setattr(tx, "publish_transfer_clip", fake_publish)
+    from npa.clients.storage import StorageClient
+
+    monkeypatch.setattr(StorageClient, "from_environment", lambda: storage)
+    return rendered
+
+
+def _invoke_multiply(configs_dir: Path) -> object:
+    return runner.invoke(
+        app,
+        [
+            "workbench",
+            "cosmos2",
+            "transfer",
+            "--input-uri",
+            "s3://bkt/run1/input/",
+            "--output-uri",
+            "s3://bkt/run1/cosmos_augmented/",
+            "--run-id",
+            "run1",
+            "--configs-uri",
+            str(configs_dir) + "/",
+            "--condition-on-input",
+            "--execute",
+        ],
+    )
+
+
+def test_a_worker_renders_only_its_stride_and_publishes_a_shard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = FakeStorage()
+    rendered = _multiply_cli(monkeypatch, tmp_path, storage)
+    monkeypatch.setenv("NPA_COSMOS_NODE_COUNT", "2")
+    monkeypatch.setenv("NPA_COSMOS_NODE_RANK", "1")
+
+    result = _invoke_multiply(tmp_path / "configs")
+
+    assert result.exit_code == 0, result.output
+    # Rank 1 of 2 renders variants 1 and 3 -- not all four.
+    assert [call["run_id"] for call in rendered] == ["run1-v1", "run1-v3"]
+    # Its GPU pins start at 0: the device index is node-local, not the global one.
+    assert sorted(call["cuda_visible_devices"] for call in rendered) == ["0", "1"]
+    shard = json.loads(
+        storage.objects["s3://bkt/run1/cosmos_augmented/manifest-rank-1.json"]
+    )
+    assert shard["schema"] == tx.SHARD_MANIFEST_SCHEMA
+    assert shard["clips"] == ["aug-run1-1", "aug-run1-3"]
+    assert shard["variant_total"] == 4
+    # A worker must not publish the run manifest; rank 0 owns that key.
+    assert "s3://bkt/run1/cosmos_augmented/manifest.json" not in storage.objects
+    payload = json.loads(result.output)
+    assert payload["node_rank"] == 1
+    assert payload["node_count"] == 2
+    assert payload["shard_variant_count"] == 2
+
+
+def test_rank_zero_merges_the_gang_into_one_run_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = FakeStorage()
+    rendered = _multiply_cli(monkeypatch, tmp_path, storage)
+    # The other node already finished and left its shard behind.
+    tx.write_shard_manifest(
+        [_clip(1), _clip(3)],
+        "s3://bkt/run1/cosmos_augmented/",
+        run_id="run1",
+        rank=1,
+        node_count=2,
+        variant_parallelism=2,
+        variant_total=4,
+        storage_client=storage,
+    )
+    monkeypatch.setenv("NPA_COSMOS_NODE_COUNT", "2")
+    monkeypatch.setenv("NPA_COSMOS_NODE_RANK", "0")
+
+    result = _invoke_multiply(tmp_path / "configs")
+
+    assert result.exit_code == 0, result.output
+    assert [call["run_id"] for call in rendered] == ["run1-v0", "run1-v2"]
+    manifest = json.loads(
+        storage.objects["s3://bkt/run1/cosmos_augmented/manifest.json"]
+    )
+    assert manifest["clips"] == [
+        "aug-run1-0",
+        "aug-run1-1",
+        "aug-run1-2",
+        "aug-run1-3",
+    ]
+    assert manifest["variant_count"] == 4
+    assert manifest["node_count"] == 2
+    payload = json.loads(result.output)
+    assert payload["variant_count"] == 4
+    assert payload["shard_variant_count"] == 2
+
+
+def test_single_node_augment_writes_no_shard_and_keeps_todays_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default path must be byte-for-byte the same artifact set as before."""
+
+    storage = FakeStorage()
+    rendered = _multiply_cli(monkeypatch, tmp_path, storage)
+    for name in ("NPA_COSMOS_NODE_COUNT", "NPA_COSMOS_NODE_RANK", "SKYPILOT_NUM_NODES", "SKYPILOT_NODE_RANK"):
+        monkeypatch.delenv(name, raising=False)
+
+    result = _invoke_multiply(tmp_path / "configs")
+
+    assert result.exit_code == 0, result.output
+    assert len(rendered) == 4
+    assert not [uri for uri in storage.objects if "manifest-rank-" in uri]
+    manifest = json.loads(
+        storage.objects["s3://bkt/run1/cosmos_augmented/manifest.json"]
+    )
+    assert manifest["variant_count"] == 4
+    assert manifest["node_count"] == 1
+    assert "shards" not in manifest

--- a/npa/workflows/physical-ai-data-factory.yaml
+++ b/npa/workflows/physical-ai-data-factory.yaml
@@ -89,6 +89,14 @@ config:
   seed_default_input: "false"
   n_augmentations: "2"            # augmented variants sampled per source video
   augment_subject: "the input robot clips"  # included in sampled Cosmos prompts
+  # Nodes in the augment block. The variants are independent diffusions, so they
+  # shard across a gang-scheduled block: each node renders its stride of the
+  # sampled combos on its own GPUs, publishes those clips plus a shard manifest,
+  # and rank 0 merges the shards into cosmos_augmented/manifest.json. Total
+  # concurrent renders = augment_nodes x GPUs per node. Raise it at submit time
+  # (`--var augment_nodes=4`) rather than editing this file; deployIfAbsent then
+  # provisions a cluster with that many GPU nodes.
+  augment_nodes: "1"
   refinement_iterations: "2"      # max evaluate/validate passes before reject
   grade_threshold: "0.75"         # min aggregate score to promote (else loop_back)
   # NPA temporal residual is advisory until a deployment calibrates its fixed
@@ -193,6 +201,12 @@ resources:
     # (auto-detected, or set NPA_COSMOS_VARIANT_PARALLELISM). N variants then run
     # in ~one variant's wall-clock instead of N x. Keep :1 for a single-GPU run.
     accelerators: RTXPRO6000:1
+    # MULTI-NODE FAN-OUT: the second axis. SkyPilot gang-schedules this many
+    # identical pods for the augment task and exports SKYPILOT_NODE_RANK /
+    # SKYPILOT_NUM_NODES into each; the augment stage shards the sampled combos by
+    # rank, so a 4-node x 4-GPU block renders 16 variants concurrently. Only the
+    # augment stage is multi-node -- the CPU/Token-Factory stages stay single pod.
+    num_nodes: "{{config.augment_nodes}}"
     # Host-side model loading/checkpoint materialization scales with the
     # multi-GPU variant fan-out. Keep enough CPU/RAM headroom for a 4-GPU
     # override instead of OOM-killing four concurrent Cosmos workers.
@@ -265,6 +279,10 @@ states:
       Stage 2b - Augment & Multiply. Cosmos Transfer 2.5 runs ONE inference per
       sampled appearance combo (config.n_augmentations), so N combos -> N scenario
       variants, each published as its own cosmos_augmented/<clip>/ dir (GPU tier).
+      The variants fan out over GPUs within a node and over nodes when
+      config.augment_nodes > 1: each node renders its stride of the combos and
+      publishes a manifest-rank-<k>.json shard, and rank 0 merges the shards into
+      the run manifest, so the fan-out is one artifact set either way.
       Appearance-only: lighting, background, color grade, surface finish -- never scene
       geometry.
       Every managed variant conditions on the prepared 93-frame

--- a/skills/workflows/physical-ai-data-factory/SKILL.md
+++ b/skills/workflows/physical-ai-data-factory/SKILL.md
@@ -76,6 +76,32 @@ Verified live: a 4-variant run on `RTXPRO6000:4` drove all 4 GPUs to 100%
 (4 distinct compute PIDs) and finished in ~14 min end-to-end; the manifest recorded
 `variant_parallelism: 4`.
 
+**Multi-node fan-out (`--var augment_nodes=N`).** GPUs-per-pod is the first axis;
+nodes are the second, and only the `augment` stage uses it. `resources.gpu` declares
+`num_nodes: "{{config.augment_nodes}}"` (default `1`), so submit chooses the block
+size without editing the blueprint — concurrent renders = `augment_nodes` × GPUs per
+node. `num_nodes` accepts a `{{config.*}}` token on any profile, resolved against the
+`--var`-merged config; `deployIfAbsent` then provisions at least that many GPU nodes,
+because a gang bigger than the cluster sits `PENDING` rather than failing.
+
+SkyPilot runs the *same* augment command in every pod of the gang, so the stage
+shards: node `k` of `N` renders variants `k, k+N, …` (striding keeps the nodes within
+one variant of each other) with node-local GPU pins, publishes those clip dirs under
+global variant indices (so clip names stay disjoint), and writes
+`cosmos_augmented/manifest-rank-<k>.json`. **Rank 0 is the join**: it waits for all N
+shards and merges them into the usual `cosmos_augmented/manifest.json` in sampled
+combo order, adding `node_count` and a per-rank `shards` block; a rank that never
+reports fails the stage by name instead of publishing an understated fan-out. Shard
+manifests are objects at the augment prefix root, never a subdirectory — every
+consumer (`curate`, `finalize`, the evaluator, provenance) treats a subdirectory
+there as a scenario variant. With `augment_nodes=1` no shard file is written and the
+artifact set is exactly what it was before.
+
+Cosmos Transfer 2.5 itself also supports `torchrun --nproc_per_node=N` context
+parallelism for *one* clip; NPA does not use it, because one-variant-per-GPU gives a
+better throughput for a multiply fan-out. A single-variant run therefore does not go
+faster on more GPUs.
+
 **Authoring from chat (agent).** The NPA chat agent can WRITE this blueprint. Ask
 it e.g. *"write me a paidf workflow: augment my robot clips and fan out 4 scenarios
 on at least 4 RTX 6000 PRO GPUs"* — the deterministic router classifies
@@ -383,7 +409,8 @@ npa workbench cosmos-curate curate-videos --input-dir ./clips --output-dir ./cur
   `publish_transfer_to_s3` uploads the real Cosmos Transfer 2.5 result in the
   **per-clip** layout the consumers require:
   `cosmos_augmented/<clip>/{augmented_video.mp4, frame-*.png, metadata.json}`
-  plus a run-level `cosmos_augmented/manifest.json`.   `curate` counts clip
+  plus a run-level `cosmos_augmented/manifest.json` (and, for a multi-node augment,
+  one `manifest-rank-<k>.json` per node beside it).   `curate` counts clip
   subdirs (not top-level files) and `build_run_rrd` reads each clip's
   `metadata.json` for its Rerun label. Producer and consumers share this shape;
 - **Real FiftyOne curation:** the `curate` stage invokes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- The PAIDF `augment` stage multiplied scenario variants across the GPUs of **one** pod, so the fan-out was capped by a single node — even though each variant is an independent Cosmos Transfer 2.5 diffusion. The engine already supported gang-scheduled `num_nodes`, but nothing connected the augment tool to it: adding nodes would have rendered every variant on every node.
- **`--var augment_nodes=N`** now gang-schedules N augment pods. `resources.gpu` declares `num_nodes: "{{config.augment_nodes}}"` (default `1`), and `num_nodes` accepts a `{{config.*}}` token on any resource profile, resolved against the `--var`-merged config — so a shipped blueprint's block size is a submit decision instead of a file edit. Bounds and error text are unchanged; a token that resolves to nonsense still fails.
- **`deployIfAbsent` sizes the cluster to the gang.** A profile asking for more nodes than the cluster has does not fail, it sits `PENDING`, so the provisioner now takes `num_nodes` as the GPU-node floor.
- **The augment stage shards and rejoins.** SkyPilot runs the same command in every pod of a gang, so node `k` of `N` renders variants `k, k+N, …` (striding keeps the nodes within one variant of each other) with node-local GPU pins and global variant indices, publishes its clip dirs, and writes `cosmos_augmented/manifest-rank-<k>.json`. Rank 0 is the join: it waits for every shard and merges them into the usual `manifest.json`, ordered by variant index, plus `node_count` and a per-rank `shards` block. A rank that never reports fails the stage by name rather than publishing a manifest that understates the fan-out.
- Shard manifests are objects at the augment prefix **root**, never a subdirectory: `curate`, `finalize`, the Cosmos Evaluator, and the provenance reader all treat a subdirectory of that prefix as a scenario variant, so a `shards/` dir would have been counted as a bogus clip. A test pins that.
- Concurrent renders are now `augment_nodes` × GPUs per node. With `augment_nodes=1` (the default) no shard file is written and the artifact set is exactly what it was before.
- Also fixed while sharding: the conditioning clip is uploaded by one rank instead of every node racing on the same key, and the per-variant GPU pin comes from the node-local slot rather than the global variant index (rank 1 must still start at GPU 0).

Not included: Cosmos Transfer 2.5's own `torchrun --nproc_per_node` context parallelism, which speeds up a *single* clip. One-variant-per-GPU gives better throughput for a multiply fan-out, so a single-variant run still does not go faster on more GPUs. The skill notes this.

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks. Full unit suite: `8846 passed, 37 skipped` (`make test` markers). New coverage in `npa/tests/workbench/test_cosmos_transfer_multi_node.py` (shard striding, fail-closed gang identity, shard/merge round-trip, slow-rank wait, missing-rank failure, worker-vs-rank-0 CLI behavior, unchanged single-node artifacts) and `npa/tests/orchestration/npa_workflow/test_multi_node.py` (token-valued `num_nodes`, cluster sizing, PAIDF renders one pod by default and a 4-node gang with `--var`).
- [x] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Skill Maintenance

- [x] I updated the relevant root `skills/` entry and `skills/index.yaml`, or this PR does not change behavior that needs skill guidance. `skills/workflows/physical-ai-data-factory/SKILL.md` gained a multi-node fan-out section next to the multi-GPU one; the deploy guide gained §6b with the artifact contract; `CHANGELOG.md` records it.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff8ff-dbb2-783b-97c4-21ac1c9c0d90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff8ff-dbb2-783b-97c4-21ac1c9c0d90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

