### PR TITLE
Harden LeRobot release pre-flight checks

### DIFF
--- a/docs/workbench/lerobot-version-support-audit-20260813.md
+++ b/docs/workbench/lerobot-version-support-audit-20260813.md
@@ -92,7 +92,7 @@ break: extras became mandatory for dataset/training deps, `eval_freq` became
 
 Checked against the 0.5.1, 0.6.0, and 0.6.1 wheels:
 
-- **Import surface: 19/19 bindings resolve in 0.6.1**, unchanged all the way
+- **Import surface: 19/19 bindings resolve statically in 0.6.1**, unchanged all the way
   back from 0.5.1. `lerobot.types` is not imported anywhere in this repo — the
   module is not referenced anywhere else in the tree — so 0.6.1's one breaking
   change is a no-op here.
@@ -297,7 +297,7 @@ contract rather than reading it:
 
 | Claim | Result |
 |---|---|
-| 19/19 bindings resolve | all 19 **import** for real, including `DiffusionPolicy` and `SmolVLAPolicy` |
+| 19/19 bindings import at runtime | all 19 **import** for real, including `DiffusionPolicy` and `SmolVLAPolicy` |
 | `env_eval_freq` replaces `eval_freq` | `lerobot-train --help` offers `--env_eval_freq`, and no longer `--eval_freq` |
 | `--policy.path` still works | accepted — parsing reaches a Hub lookup, while a bogus `--policy.x` is rejected as unrecognized. It is absent from `--help` because draccus resolves the path alias before argument parsing, which is easy to misread as a break |
 | adapters need no migration | a dataset written by `npa/adapter/sim_to_lerobot.py` loads under 0.6.1 `LeRobotDataset`, with video frames decoded and the expected `observation.state` / `action` / `observation.images.*` keys |

--- a/docs/workbench/lerobot-version-support-audit-20260813.md
+++ b/docs/workbench/lerobot-version-support-audit-20260813.md
@@ -94,8 +94,8 @@ Checked against the 0.5.1, 0.6.0, and 0.6.1 wheels:
 
 - **Import surface: 19/19 bindings resolve in 0.6.1**, unchanged all the way
   back from 0.5.1. `lerobot.types` is not imported anywhere in this repo — the
-  only reference is an archived work log — so 0.6.1's one breaking change is a
-  no-op here.
+  module is not referenced anywhere else in the tree — so 0.6.1's one breaking
+  change is a no-op here.
 - **Signatures are additive only.** `make_pre_post_processors` gained
   `pretrained_revision` and `EpisodeAwareSampler` gained `seed` /
   `absolute_to_relative_idx` (both in 0.6.0); `LeRobotDataset.__init__` gained

--- a/npa/scripts/audit_lerobot_release.py
+++ b/npa/scripts/audit_lerobot_release.py
@@ -45,9 +45,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CACHE_DIR = REPO_ROOT / ".tmp-lerobot-wheels"
@@ -56,7 +57,11 @@ PYPI_JSON = "https://pypi.org/pypi/lerobot/{version}/json"
 # ── The surface this repo binds to ──────────────────────────────────────────
 # (module, symbol, call-site provenance). symbol=None checks the module only.
 IMPORT_SURFACE: tuple[tuple[str, str | None, str], ...] = (
-    ("lerobot.datasets.lerobot_dataset", "LeRobotDataset", "npa/workflows/lerobot_dataset.py"),
+    (
+        "lerobot.datasets.lerobot_dataset",
+        "LeRobotDataset",
+        "npa/workflows/lerobot_dataset.py, npa/demo/generate_observation.py",
+    ),
     ("lerobot.datasets", "LeRobotDataset", "npa/setup/install_lerobot.sh"),
     ("lerobot.datasets.factory", "make_dataset", "research/lerobot-deploy/training/profile_train.py"),
     ("lerobot.datasets.sampler", "EpisodeAwareSampler", "research/lerobot-deploy/training/profile_train.py"),
@@ -211,17 +216,46 @@ def _top_level_names(path: Path) -> set[str]:
         tree = _parse(path)
     except SyntaxError:
         return names
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            names.add(node.name)
-        elif isinstance(node, ast.Assign):
-            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            names.add(node.target.id)
-        elif isinstance(node, ast.ImportFrom):
-            names.update(a.asname or a.name for a in node.names)
-        elif isinstance(node, ast.Import):
-            names.update(a.asname or a.name.split(".")[0] for a in node.names)
+
+    def is_type_checking(test: ast.expr) -> bool:
+        return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+            isinstance(test, ast.Attribute)
+            and isinstance(test.value, ast.Name)
+            and test.value.id == "typing"
+            and test.attr == "TYPE_CHECKING"
+        )
+
+    def catches_import_error(handler: ast.ExceptHandler) -> bool:
+        error = handler.type
+        return (isinstance(error, ast.Name) and error.id == "ImportError") or (
+            isinstance(error, ast.Tuple)
+            and any(isinstance(item, ast.Name) and item.id == "ImportError" for item in error.elts)
+        )
+
+    def collect(statements: list[ast.stmt]) -> None:
+        for node in statements:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                names.add(node.name)
+            elif isinstance(node, ast.Assign):
+                names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                names.add(node.target.id)
+            elif isinstance(node, ast.ImportFrom):
+                names.update(a.asname or a.name for a in node.names)
+            elif isinstance(node, ast.Import):
+                names.update(a.asname or a.name.split(".")[0] for a in node.names)
+            elif isinstance(node, ast.If) and is_type_checking(node.test):
+                collect(node.body)
+                collect(node.orelse)
+            elif isinstance(node, ast.Try):
+                import_handlers = [handler for handler in node.handlers if catches_import_error(handler)]
+                if import_handlers:
+                    collect(node.body)
+                    collect(node.orelse)
+                    for handler in import_handlers:
+                        collect(handler.body)
+
+    collect(tree.body)
     return names
 
 
@@ -273,21 +307,33 @@ def _dataclass_fields(root: Path, relpath: str, cls_name: str) -> set[str]:
     return set()
 
 
-def _dist_info(root: Path) -> Path:
-    return next(root.glob("lerobot-*.dist-info"))
+def _dist_info(root: Path) -> Path | None:
+    return next(root.glob("lerobot-*.dist-info"), None)
 
 
 def _declared_bounds(root: Path) -> dict[str, str]:
-    """First declared specifier per dependency we care about."""
+    """Intersection of applicable specifiers for dependencies we care about."""
 
-    bounds: dict[str, str] = {}
-    for line in (_dist_info(root) / "METADATA").read_text(encoding="utf-8").splitlines():
-        if not line.startswith("Requires-Dist:"):
+    collected: dict[str, list[str]] = {}
+    per_extra, base = _extra_requirements(root)
+    applicable = [
+        *(req for req in base if req.marker is None or req.marker.evaluate()),
+        *(
+            req
+            for extra, requirements in per_extra.items()
+            for req in requirements
+            if req.marker is None or req.marker.evaluate({"extra": extra})
+        ),
+    ]
+    for req in applicable:
+        package = canonicalize_name(req.name)
+        if package not in {"torch", "torchvision", "diffusers", "torchcodec"}:
             continue
-        req = Requirement(line.split(":", 1)[1].strip())
-        if req.name in {"torch", "torchvision", "diffusers", "torchcodec"}:
-            bounds.setdefault(req.name, str(req.specifier))
-    return bounds
+        collected.setdefault(package, []).append(str(req.specifier))
+    return {
+        package: str(SpecifierSet(",".join(specifier for specifier in specifiers if specifier)))
+        for package, specifiers in collected.items()
+    }
 
 
 def _extra_requirements(root: Path) -> tuple[dict[str, list[Requirement]], list[Requirement]]:
@@ -295,7 +341,13 @@ def _extra_requirements(root: Path) -> tuple[dict[str, list[Requirement]], list[
 
     per_extra: dict[str, list[Requirement]] = {}
     base: list[Requirement] = []
-    for line in (_dist_info(root) / "METADATA").read_text(encoding="utf-8").splitlines():
+    dist_info = _dist_info(root)
+    if dist_info is None:
+        return per_extra, base
+    metadata = dist_info / "METADATA"
+    if not metadata.exists():
+        return per_extra, base
+    for line in metadata.read_text(encoding="utf-8").splitlines():
         if not line.startswith("Requires-Dist:"):
             continue
         req = Requirement(line.split(":", 1)[1].strip())
@@ -365,7 +417,10 @@ def _require_package_gates(root: Path, relpath: str) -> list[tuple[str, str]]:
 
 
 def _entry_points(root: Path) -> set[str]:
-    path = _dist_info(root) / "entry_points.txt"
+    dist_info = _dist_info(root)
+    if dist_info is None:
+        return set()
+    path = dist_info / "entry_points.txt"
     if not path.exists():
         return set()
     return {
@@ -376,7 +431,10 @@ def _entry_points(root: Path) -> set[str]:
 
 
 def _requires_python(root: Path) -> str:
-    for line in (_dist_info(root) / "METADATA").read_text(encoding="utf-8").splitlines():
+    dist_info = _dist_info(root)
+    if dist_info is None:
+        return ""
+    for line in (dist_info / "METADATA").read_text(encoding="utf-8").splitlines():
         if line.startswith("Requires-Python:"):
             return line.split(":", 1)[1].strip()
     return ""
@@ -387,18 +445,33 @@ def _requires_python(root: Path) -> str:
 
 def check_imports(root: Path, report: Report) -> None:
     missing = []
+    lazy = []
     for module, symbol, provenance in IMPORT_SURFACE:
         path = _module_file(root, module)
         if path is None:
             missing.append(f"{module} (module gone) <- {provenance}")
-        elif symbol and symbol not in _top_level_names(path):
-            missing.append(f"{module}:{symbol} (symbol gone) <- {provenance}")
+        elif symbol:
+            names = _top_level_names(path)
+            if symbol not in names:
+                if "__getattr__" in names:
+                    lazy.append(
+                        f"{module}:{symbol} (lazily re-exported, could not verify statically)"
+                        f" <- {provenance}"
+                    )
+                else:
+                    missing.append(f"{module}:{symbol} (symbol gone) <- {provenance}")
     total = len(IMPORT_SURFACE)
+    resolved = total - len(missing) - len(lazy)
+    detail = f"{resolved}/{total} bindings resolve statically"
+    if lazy:
+        detail += "; lazy: " + ", ".join(lazy)
+    if missing:
+        detail += "; missing: " + ", ".join(missing)
     report.add(
         "import-surface",
-        not missing,
-        f"{total - len(missing)}/{total} bindings resolve"
-        + ("; missing: " + ", ".join(missing) if missing else ""),
+        not missing and not lazy,
+        detail,
+        warn=bool(lazy) and not missing,
     )
 
 
@@ -530,7 +603,12 @@ def check_cli_flags(root: Path, report: Report, manifest_entry: dict[str, Any] |
 def _pin_floor(spec: str) -> str:
     """Lowest version a pin like ``torch==2.12.1`` or ``diffusers>=0.38.0`` allows."""
 
-    return spec.split("==")[-1].split(">=")[-1].strip()
+    parsed: SpecifierSet = Requirement(spec).specifier
+    specifiers = list(parsed)
+    if len(specifiers) != 1 or specifiers[0].operator not in {"==", ">="}:
+        raise ValueError("expected one == or >= specifier")
+    Version(specifiers[0].version)
+    return specifiers[0].version
 
 
 def _conflicts(pins: dict[str, str], bounds: dict[str, str]) -> list[str]:
@@ -569,11 +647,19 @@ def check_dependency_bounds(
         )
         return
 
-    pins = {
-        package: _pin_floor(str(manifest_entry[key]))
-        for key, package in MANIFEST_PIN_KEYS.items()
-        if manifest_entry.get(key)
-    }
+    pins: dict[str, str] = {}
+    invalid_pins: list[str] = []
+    for key, package in MANIFEST_PIN_KEYS.items():
+        value = manifest_entry.get(key)
+        if not value:
+            continue
+        try:
+            pins[package] = _pin_floor(str(value))
+        except (InvalidRequirement, InvalidVersion, ValueError) as exc:
+            invalid_pins.append(f"{key}={value!r} is not a supported pin ({exc})")
+    if invalid_pins:
+        report.add("manifest torch pins", False, "; ".join(invalid_pins))
+        return
     if not pins:
         report.add(
             "manifest torch pins",
@@ -605,6 +691,14 @@ def audit(version: str, cache_dir: Path, *, offline: bool) -> Report:
     root = fetch_wheel(version, cache_dir, offline=offline)
     manifest_entry = load_manifest_entry(version)
     report = Report(version=version)
+    dist_info = _dist_info(root)
+    if dist_info is None or not (dist_info / "METADATA").exists():
+        report.add(
+            "wheel-metadata",
+            False,
+            f"no complete lerobot-*.dist-info/METADATA found under {root}",
+        )
+        return report
     check_imports(root, report)
     check_signatures(root, report)
     check_entry_points(root, report)
@@ -649,8 +743,15 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
-    print(f"\nPASS: lerobot {candidate.version} satisfies this repo's static LeRobot surface.")
-    print("Static pre-flight only -- a real GPU train+eval smoke is still the merge gate.")
+    summary_stream = sys.stderr if args.json else sys.stdout
+    print(
+        f"\nPASS: lerobot {candidate.version} satisfies this repo's static LeRobot surface.",
+        file=summary_stream,
+    )
+    print(
+        "Static pre-flight only -- a real GPU train+eval smoke is still the merge gate.",
+        file=summary_stream,
+    )
     return 0
 
 

--- a/npa/scripts/audit_lerobot_release.py
+++ b/npa/scripts/audit_lerobot_release.py
@@ -25,6 +25,10 @@ removed symbol, dropped parameter, renamed CLI flag, changed dataset
 pin this repo forces. It cannot prove runtime behaviour. A real GPU train+eval
 smoke (``npa.smoke.test_lerobot_functional``) remains the merge gate.
 
+Dependency markers are evaluated for the B300 image target (Linux x86_64), not
+the workstation running the audit. Python-version markers retain the audit
+interpreter's values because the inspected wheel and audit context supply them.
+
 The surface below is a reviewed list with call-site provenance, not a scrape.
 When a new call site starts using LeRobot, add it here too.
 """
@@ -45,6 +49,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import packaging.markers as packaging_markers
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
@@ -56,30 +61,116 @@ PYPI_JSON = "https://pypi.org/pypi/lerobot/{version}/json"
 
 # ── The surface this repo binds to ──────────────────────────────────────────
 # (module, symbol, call-site provenance). symbol=None checks the module only.
-IMPORT_SURFACE: tuple[tuple[str, str | None, str], ...] = (
+IMPORT_SURFACE: tuple[tuple[str, str | None, tuple[str, ...]], ...] = (
     (
         "lerobot.datasets.lerobot_dataset",
         "LeRobotDataset",
-        "npa/workflows/lerobot_dataset.py, npa/demo/generate_observation.py",
+        (
+            "npa/demo/generate_observation.py",
+            "npa/src/npa/workflows/lerobot_dataset.py",
+        ),
     ),
-    ("lerobot.datasets", "LeRobotDataset", "npa/setup/install_lerobot.sh"),
-    ("lerobot.datasets.factory", "make_dataset", "research/lerobot-deploy/training/profile_train.py"),
-    ("lerobot.datasets.sampler", "EpisodeAwareSampler", "research/lerobot-deploy/training/profile_train.py"),
-    ("lerobot.configs.policies", "PreTrainedConfig", "npa/server/app.py, npa/genesis/eval_student.py"),
-    ("lerobot.configs.train", "TrainPipelineConfig", "research/lerobot-deploy/training/profile_train.py"),
-    ("lerobot.configs.default", "DatasetConfig", "research/lerobot-deploy/training/profile_train.py"),
-    ("lerobot.configs.default", "EvalConfig", "research/lerobot-deploy/training/profile_train.py"),
-    ("lerobot.configs.default", "WandBConfig", "research/lerobot-deploy/training/profile_train.py"),
-    ("lerobot.policies.factory", "make_policy", "npa/server/app.py"),
-    ("lerobot.policies.factory", "make_pre_post_processors", "npa/server/app.py, npa/genesis/eval_student.py"),
-    ("lerobot.policies.utils", "prepare_observation_for_inference", "npa/server/app.py"),
-    ("lerobot.policies.act.modeling_act", "ACTPolicy", "npa/genesis/eval_student.py"),
-    ("lerobot.policies.act.configuration_act", "ACTConfig", "npa/smoke/test_lerobot_env.py"),
-    ("lerobot.policies.diffusion.modeling_diffusion", "DiffusionPolicy", "npa/genesis/eval_student.py"),
-    ("lerobot.policies.smolvla.modeling_smolvla", "SmolVLAPolicy", "npa/genesis/eval_student.py"),
-    ("lerobot.optim.factory", "make_optimizer_and_scheduler", "research/lerobot-deploy/training/profile_train.py"),
-    ("lerobot.utils.device_utils", "get_safe_torch_device", "npa/server/app.py"),
-    ("lerobot.envs.configs", "EnvConfig", "npa/server/app.py"),
+    (
+        "lerobot.datasets",
+        "LeRobotDataset",
+        ("npa/src/npa/setup/install_lerobot.sh",),
+    ),
+    (
+        "lerobot.datasets.factory",
+        "make_dataset",
+        ("research/lerobot-deploy/training/profile_train.py",),
+    ),
+    (
+        "lerobot.datasets.sampler",
+        "EpisodeAwareSampler",
+        ("research/lerobot-deploy/training/profile_train.py",),
+    ),
+    (
+        "lerobot.configs.policies",
+        "PreTrainedConfig",
+        (
+            "npa/src/npa/genesis/eval_student.py",
+            "npa/src/npa/server/app.py",
+            "research/lerobot-deploy/training/profile_train.py",
+        ),
+    ),
+    (
+        "lerobot.configs.train",
+        "TrainPipelineConfig",
+        ("research/lerobot-deploy/training/profile_train.py",),
+    ),
+    (
+        "lerobot.configs.default",
+        "DatasetConfig",
+        ("research/lerobot-deploy/training/profile_train.py",),
+    ),
+    (
+        "lerobot.configs.default",
+        "EvalConfig",
+        ("research/lerobot-deploy/training/profile_train.py",),
+    ),
+    (
+        "lerobot.configs.default",
+        "WandBConfig",
+        ("research/lerobot-deploy/training/profile_train.py",),
+    ),
+    (
+        "lerobot.policies.factory",
+        "make_policy",
+        (
+            "npa/src/npa/server/app.py",
+            "research/lerobot-deploy/training/profile_train.py",
+        ),
+    ),
+    (
+        "lerobot.policies.factory",
+        "make_pre_post_processors",
+        (
+            "npa/src/npa/genesis/eval_student.py",
+            "npa/src/npa/server/app.py",
+            "research/lerobot-deploy/training/profile_train.py",
+        ),
+    ),
+    (
+        "lerobot.policies.utils",
+        "prepare_observation_for_inference",
+        ("npa/src/npa/server/app.py",),
+    ),
+    (
+        "lerobot.policies.act.modeling_act",
+        "ACTPolicy",
+        ("npa/src/npa/genesis/eval_student.py",),
+    ),
+    (
+        "lerobot.policies.act.configuration_act",
+        "ACTConfig",
+        ("npa/src/npa/smoke/test_lerobot_env.py",),
+    ),
+    (
+        "lerobot.policies.diffusion.modeling_diffusion",
+        "DiffusionPolicy",
+        ("npa/src/npa/genesis/eval_student.py",),
+    ),
+    (
+        "lerobot.policies.smolvla.modeling_smolvla",
+        "SmolVLAPolicy",
+        ("npa/src/npa/genesis/eval_student.py",),
+    ),
+    (
+        "lerobot.optim.factory",
+        "make_optimizer_and_scheduler",
+        ("research/lerobot-deploy/training/profile_train.py",),
+    ),
+    (
+        "lerobot.utils.device_utils",
+        "get_safe_torch_device",
+        ("npa/src/npa/server/app.py",),
+    ),
+    (
+        "lerobot.envs.configs",
+        "EnvConfig",
+        ("npa/src/npa/server/app.py",),
+    ),
 )
 
 # Parameters this repo passes by keyword. Upstream may append parameters freely;
@@ -159,6 +250,10 @@ class Report:
     def failed(self) -> list[dict[str, Any]]:
         return [c for c in self.checks if c["status"] == "FAIL"]
 
+    @property
+    def warnings(self) -> list[dict[str, Any]]:
+        return [c for c in self.checks if c["status"] == "WARN"]
+
 
 # ── Wheel acquisition ───────────────────────────────────────────────────────
 
@@ -209,7 +304,7 @@ def _parse(path: Path) -> ast.Module:
 
 
 def _top_level_names(path: Path) -> set[str]:
-    """Names a module defines or re-exports (import-from counts as re-export)."""
+    """Names bound in module scope, including conditional control-flow suites."""
 
     names: set[str] = set()
     try:
@@ -217,43 +312,79 @@ def _top_level_names(path: Path) -> set[str]:
     except SyntaxError:
         return names
 
-    def is_type_checking(test: ast.expr) -> bool:
-        return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
-            isinstance(test, ast.Attribute)
-            and isinstance(test.value, ast.Name)
-            and test.value.id == "typing"
-            and test.attr == "TYPE_CHECKING"
-        )
+    try_nodes = (ast.Try,)
+    if hasattr(ast, "TryStar"):
+        try_nodes += (ast.TryStar,)
 
-    def catches_import_error(handler: ast.ExceptHandler) -> bool:
-        error = handler.type
-        return (isinstance(error, ast.Name) and error.id == "ImportError") or (
-            isinstance(error, ast.Tuple)
-            and any(isinstance(item, ast.Name) and item.id == "ImportError" for item in error.elts)
-        )
+    def collect_target(target: ast.AST | None) -> None:
+        if isinstance(target, ast.Name):
+            names.add(target.id)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for element in target.elts:
+                collect_target(element)
+        elif isinstance(target, ast.Starred):
+            collect_target(target.value)
+        elif isinstance(target, ast.MatchAs):
+            collect_target(target.pattern)
+            if target.name:
+                names.add(target.name)
+        elif isinstance(target, ast.MatchStar):
+            if target.name:
+                names.add(target.name)
+        elif isinstance(target, ast.MatchMapping):
+            for pattern in target.patterns:
+                collect_target(pattern)
+            if target.rest:
+                names.add(target.rest)
+        elif isinstance(target, ast.MatchSequence):
+            for pattern in target.patterns:
+                collect_target(pattern)
+        elif isinstance(target, ast.MatchClass):
+            for pattern in (*target.patterns, *target.kwd_patterns):
+                collect_target(pattern)
+        elif isinstance(target, ast.MatchOr):
+            for pattern in target.patterns:
+                collect_target(pattern)
 
     def collect(statements: list[ast.stmt]) -> None:
         for node in statements:
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                # The definition itself is module-scoped; its body is a new
+                # lexical scope and must never contribute exports.
                 names.add(node.name)
             elif isinstance(node, ast.Assign):
-                names.update(t.id for t in node.targets if isinstance(t, ast.Name))
-            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-                names.add(node.target.id)
+                for target in node.targets:
+                    collect_target(target)
+            elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+                collect_target(node.target)
             elif isinstance(node, ast.ImportFrom):
                 names.update(a.asname or a.name for a in node.names)
             elif isinstance(node, ast.Import):
                 names.update(a.asname or a.name.split(".")[0] for a in node.names)
-            elif isinstance(node, ast.If) and is_type_checking(node.test):
+            elif isinstance(node, ast.If):
                 collect(node.body)
                 collect(node.orelse)
-            elif isinstance(node, ast.Try):
-                import_handlers = [handler for handler in node.handlers if catches_import_error(handler)]
-                if import_handlers:
-                    collect(node.body)
-                    collect(node.orelse)
-                    for handler in import_handlers:
-                        collect(handler.body)
+            elif isinstance(node, try_nodes):
+                collect(node.body)
+                collect(node.orelse)
+                collect(node.finalbody)
+                for handler in node.handlers:
+                    collect(handler.body)
+            elif isinstance(node, (ast.With, ast.AsyncWith)):
+                for item in node.items:
+                    collect_target(item.optional_vars)
+                collect(node.body)
+            elif isinstance(node, (ast.For, ast.AsyncFor)):
+                collect_target(node.target)
+                collect(node.body)
+                collect(node.orelse)
+            elif isinstance(node, ast.While):
+                collect(node.body)
+                collect(node.orelse)
+            elif isinstance(node, ast.Match):
+                for case in node.cases:
+                    collect_target(case.pattern)
+                    collect(case.body)
 
     collect(tree.body)
     return names
@@ -311,18 +442,41 @@ def _dist_info(root: Path) -> Path | None:
     return next(root.glob("lerobot-*.dist-info"), None)
 
 
-def _declared_bounds(root: Path) -> dict[str, str]:
-    """Intersection of applicable specifiers for dependencies we care about."""
+def _target_marker_environment(*, extra: str = "") -> dict[str, str]:
+    """PEP 508 environment for the Linux x86_64 B300 image target."""
+
+    environment = packaging_markers.default_environment()
+    environment.update(
+        {
+            "extra": extra,
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_system": "Linux",
+            "sys_platform": "linux",
+        }
+    )
+    return environment
+
+
+def _marker_applies(requirement: Requirement, *, extra: str = "") -> bool:
+    return requirement.marker is None or requirement.marker.evaluate(
+        _target_marker_environment(extra=extra)
+    )
+
+
+def _declared_bounds(root: Path, extras: Iterable[str]) -> dict[str, str]:
+    """Intersection of target-applicable bounds from extras the image installs."""
 
     collected: dict[str, list[str]] = {}
     per_extra, base = _extra_requirements(root)
+    active_extras, _ = _extra_closure(per_extra, base, extras)
     applicable = [
-        *(req for req in base if req.marker is None or req.marker.evaluate()),
+        *(req for req in base if _marker_applies(req)),
         *(
             req
-            for extra, requirements in per_extra.items()
-            for req in requirements
-            if req.marker is None or req.marker.evaluate({"extra": extra})
+            for extra in active_extras
+            for req in per_extra.get(extra, [])
+            if _marker_applies(req, extra=extra)
         ),
     ]
     for req in applicable:
@@ -354,22 +508,25 @@ def _extra_requirements(root: Path) -> tuple[dict[str, list[Requirement]], list[
         extras = re.findall(r'extra\s*==\s*[\'"]([^\'"]+)[\'"]', str(req.marker or ""))
         if extras:
             for extra in extras:
-                per_extra.setdefault(extra, []).append(req)
+                per_extra.setdefault(canonicalize_name(extra), []).append(req)
         else:
             base.append(req)
     return per_extra, base
 
 
-def _extra_closure(root: Path, extras: Iterable[str]) -> set[str]:
-    """Distributions installed by ``pip install lerobot[<extras>]``.
+def _extra_closure(
+    per_extra: dict[str, list[Requirement]],
+    base: list[Requirement],
+    extras: Iterable[str],
+) -> tuple[set[str], set[str]]:
+    """Active extras and distributions from ``pip install lerobot[<extras>]``.
 
     Extras reference each other (``training`` -> ``dataset``, ``diffusion`` ->
     ``diffusers-dep``), so this walks the self-referential graph to a fixpoint.
     """
 
-    per_extra, base = _extra_requirements(root)
-    provided = {canonicalize_name(req.name) for req in base}
-    queue = list(extras)
+    provided = {canonicalize_name(req.name) for req in base if _marker_applies(req)}
+    queue = [canonicalize_name(extra) for extra in extras]
     seen: set[str] = set()
     while queue:
         extra = queue.pop()
@@ -377,11 +534,13 @@ def _extra_closure(root: Path, extras: Iterable[str]) -> set[str]:
             continue
         seen.add(extra)
         for req in per_extra.get(extra, []):
+            if not _marker_applies(req, extra=extra):
+                continue
             if canonicalize_name(req.name) == "lerobot":
-                queue.extend(req.extras)
+                queue.extend(canonicalize_name(nested) for nested in req.extras)
             else:
                 provided.add(canonicalize_name(req.name))
-    return provided
+    return seen, provided
 
 
 def _require_package_gates(root: Path, relpath: str) -> list[tuple[str, str]]:
@@ -447,19 +606,20 @@ def check_imports(root: Path, report: Report) -> None:
     missing = []
     lazy = []
     for module, symbol, provenance in IMPORT_SURFACE:
+        provenance_text = ", ".join(provenance)
         path = _module_file(root, module)
         if path is None:
-            missing.append(f"{module} (module gone) <- {provenance}")
+            missing.append(f"{module} (module gone) <- {provenance_text}")
         elif symbol:
             names = _top_level_names(path)
             if symbol not in names:
                 if "__getattr__" in names:
                     lazy.append(
                         f"{module}:{symbol} (lazily re-exported, could not verify statically)"
-                        f" <- {provenance}"
+                        f" <- {provenance_text}"
                     )
                 else:
-                    missing.append(f"{module}:{symbol} (symbol gone) <- {provenance}")
+                    missing.append(f"{module}:{symbol} (symbol gone) <- {provenance_text}")
     total = len(IMPORT_SURFACE)
     resolved = total - len(missing) - len(lazy)
     detail = f"{resolved}/{total} bindings resolve statically"
@@ -507,6 +667,16 @@ def check_entry_points(root: Path, report: Report) -> None:
     report.add("available-entry-points", True, ", ".join(extra) or "none")
 
 
+def _manifest_extras(manifest_entry: dict[str, Any] | None) -> list[str]:
+    if manifest_entry is None:
+        return []
+    return [
+        extra.strip()
+        for extra in str(manifest_entry.get("pip_extras", "")).split(",")
+        if extra.strip()
+    ]
+
+
 def check_policy_extras(root: Path, report: Report, manifest_entry: dict[str, Any] | None) -> None:
     """Do the manifest's extras actually let every policy we use be constructed?"""
 
@@ -518,8 +688,9 @@ def check_policy_extras(root: Path, report: Report, manifest_entry: dict[str, An
         )
         return
 
-    declared = [e.strip() for e in str(manifest_entry.get("pip_extras", "")).split(",") if e.strip()]
-    provided = _extra_closure(root, declared)
+    declared = _manifest_extras(manifest_entry)
+    per_extra, base = _extra_requirements(root)
+    _, provided = _extra_closure(per_extra, base, declared)
 
     problems: list[str] = []
     satisfied: list[str] = []
@@ -625,7 +796,7 @@ def _conflicts(pins: dict[str, str], bounds: dict[str, str]) -> list[str]:
 def check_dependency_bounds(
     root: Path, report: Report, manifest_entry: dict[str, Any] | None
 ) -> None:
-    bounds = _declared_bounds(root)
+    bounds = _declared_bounds(root, _manifest_extras(manifest_entry))
     report.add("requires-python", True, _requires_python(root) or "unspecified")
     report.add("declared-bounds", True, ", ".join(f"{k}{v}" for k, v in sorted(bounds.items())))
 
@@ -744,10 +915,17 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
     summary_stream = sys.stderr if args.json else sys.stdout
-    print(
-        f"\nPASS: lerobot {candidate.version} satisfies this repo's static LeRobot surface.",
-        file=summary_stream,
-    )
+    if candidate.warnings:
+        print(
+            f"\nWARN: {len(candidate.warnings)} non-blocking unverifiable finding(s)"
+            f" for lerobot {candidate.version}; no blocking findings.",
+            file=summary_stream,
+        )
+    else:
+        print(
+            f"\nPASS: lerobot {candidate.version} satisfies this repo's static LeRobot surface.",
+            file=summary_stream,
+        )
     print(
         "Static pre-flight only -- a real GPU train+eval smoke is still the merge gate.",
         file=summary_stream,

--- a/npa/tests/scripts/test_audit_lerobot_release.py
+++ b/npa/tests/scripts/test_audit_lerobot_release.py
@@ -17,6 +17,7 @@ import shutil
 import sys
 from pathlib import Path
 
+import packaging.markers as packaging_markers
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -149,6 +150,83 @@ def test_symbol_nested_inside_a_function_is_not_a_module_export(monkeypatch, whe
     assert _status(report, "import-surface") == "FAIL"
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        "try:\n"
+        "    from backend import get_safe_torch_device\n"
+        "except ModuleNotFoundError:\n"
+        "    from fallback import get_safe_torch_device\n",
+        "try:\n"
+        "    from backend import get_safe_torch_device\n"
+        "except Exception:\n"
+        "    from fallback import get_safe_torch_device\n",
+        "if sys.version_info >= (3, 12):\n"
+        "    from backend import get_safe_torch_device\n",
+        "try:\n"
+        "    from backend import get_safe_torch_device\n"
+        "finally:\n"
+        "    cleaned_up = True\n",
+        pytest.param(
+            "try:\n"
+            "    from backend import get_safe_torch_device\n"
+            "except* Exception:\n"
+            "    from fallback import get_safe_torch_device\n",
+            id="try-star",
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 11),
+                reason="except* syntax requires Python 3.11",
+            ),
+        ),
+        "with import_context():\n"
+        "    from backend import get_safe_torch_device\n",
+        "for backend in backends:\n"
+        "    from backend import get_safe_torch_device\n",
+        "while select_backend():\n"
+        "    from backend import get_safe_torch_device\n",
+        "match backend_name:\n"
+        "    case _:\n"
+        "        from backend import get_safe_torch_device\n",
+    ],
+    ids=[
+        "module-not-found-error",
+        "broad-exception",
+        "version-if",
+        "try-finally",
+        "try-star",
+        "with",
+        "for",
+        "while",
+        "match",
+    ],
+)
+def test_module_scope_conditional_exports_are_found(monkeypatch, wheel, source):
+    (wheel / "lerobot/utils/device_utils.py").write_text(source, encoding="utf-8")
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "import-surface") == "PASS"
+
+
+def _make_device_export_lazy(wheel: Path) -> None:
+    (wheel / "lerobot/utils/device_utils.py").write_text(
+        "def __getattr__(name):\n"
+        "    if name == 'get_safe_torch_device':\n"
+        "        return load_device_helper()\n"
+        "    raise AttributeError(name)\n",
+        encoding="utf-8",
+    )
+
+
+def test_lazy_getattr_export_is_an_unverifiable_warning(monkeypatch, wheel):
+    _make_device_export_lazy(wheel)
+    report = _run(monkeypatch, wheel)
+    check = next(c for c in report.checks if c["check"] == "import-surface")
+
+    assert check["status"] == "WARN"
+    assert "lazily re-exported" in check["detail"]
+    assert "could not verify statically" in check["detail"]
+    assert "symbol gone" not in check["detail"]
+
+
 def test_dropped_keyword_parameter_is_caught(monkeypatch, wheel):
     # `env_cfg` is passed by keyword from npa/server/app.py.
     (wheel / "lerobot/policies/factory.py").write_text(
@@ -239,6 +317,74 @@ def test_marker_gated_requirement_is_not_applied_unconditionally(monkeypatch, wh
     assert _status(report, "b300-image torch stack") == "PASS"
 
 
+def test_marker_evaluation_uses_x86_64_linux_image_not_aarch64_host(
+    monkeypatch, wheel
+):
+    metadata = wheel / "lerobot-9.9.9.dist-info" / "METADATA"
+    metadata.write_text(
+        metadata.read_text(encoding="utf-8").replace(
+            "Requires-Dist: torch<2.12.0,>=2.7",
+            'Requires-Dist: torch==2.5.0; platform_machine == "aarch64"\n'
+            "Requires-Dist: torch<2.12.0,>=2.7",
+        ),
+        encoding="utf-8",
+    )
+    aarch64_host = packaging_markers.default_environment()
+    aarch64_host.update(
+        {
+            "os_name": "posix",
+            "platform_machine": "aarch64",
+            "platform_system": "Linux",
+            "sys_platform": "linux",
+        }
+    )
+    monkeypatch.setattr(
+        packaging_markers,
+        "default_environment",
+        lambda: aarch64_host.copy(),
+    )
+
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "b300-image torch stack") == "PASS"
+
+
+def test_uninstalled_extra_does_not_constrain_image_pins(monkeypatch, wheel):
+    metadata = wheel / "lerobot-9.9.9.dist-info" / "METADATA"
+    metadata.write_text(
+        metadata.read_text(encoding="utf-8")
+        + 'Requires-Dist: torch==2.7.1; extra == "jetson"\n',
+        encoding="utf-8",
+    )
+
+    report = _run(monkeypatch, wheel, manifest={"pip_extras": "training,evaluation"})
+    assert _status(report, "b300-image torch stack") == "PASS"
+
+
+def test_installed_extra_still_constrains_image_pins(monkeypatch, wheel):
+    metadata = wheel / "lerobot-9.9.9.dist-info" / "METADATA"
+    metadata.write_text(
+        metadata.read_text(encoding="utf-8")
+        + 'Requires-Dist: torch==2.7.1; extra == "jetson"\n',
+        encoding="utf-8",
+    )
+
+    report = _run(monkeypatch, wheel, manifest={"pip_extras": "jetson"})
+    assert _status(report, "b300-image torch stack") == "FAIL"
+
+
+def test_transitively_installed_extra_constrains_image_pins(monkeypatch, wheel):
+    metadata = wheel / "lerobot-9.9.9.dist-info" / "METADATA"
+    metadata.write_text(
+        metadata.read_text(encoding="utf-8")
+        + 'Requires-Dist: lerobot[jetson]; extra == "hardware"\n'
+        + 'Requires-Dist: torch==2.7.1; extra == "jetson"\n',
+        encoding="utf-8",
+    )
+
+    report = _run(monkeypatch, wheel, manifest={"pip_extras": "hardware"})
+    assert _status(report, "b300-image torch stack") == "FAIL"
+
+
 @pytest.mark.parametrize(
     "pin",
     ["torch<2.11.0", "torch~=2.9.0", "torch!=2.10.0", "torch>=2.7,<2.11"],
@@ -250,7 +396,11 @@ def test_pin_floor_handles_every_specifier_form(monkeypatch, wheel, pin):
 
 def test_lower_bound_pin_below_declared_ceiling_is_caught(monkeypatch, wheel):
     # `diffusers>=0.30.0` floors below the declared >=0.38.0 floor.
-    report = _run(monkeypatch, wheel, manifest={"diffusers_pin": "diffusers>=0.30.0"})
+    report = _run(
+        monkeypatch,
+        wheel,
+        manifest={"diffusers_pin": "diffusers>=0.30.0", "pip_extras": "diffusion"},
+    )
     assert _status(report, "manifest torch pins") == "FAIL"
 
 
@@ -297,7 +447,9 @@ def test_ungated_policy_needs_no_extra(monkeypatch, wheel):
 def test_missing_dist_info_is_a_check_failure_not_a_traceback(monkeypatch, wheel):
     shutil.rmtree(wheel / "lerobot-9.9.9.dist-info")
     report = _run(monkeypatch, wheel)
-    assert report.failed
+    assert [(check["check"], check["status"]) for check in report.checks] == [
+        ("wheel-metadata", "FAIL")
+    ]
 
 
 def test_json_mode_stdout_is_pure_json(monkeypatch, wheel, capsys):
@@ -309,8 +461,52 @@ def test_json_mode_stdout_is_pure_json(monkeypatch, wheel, capsys):
     assert payload[0]["version"] == "9.9.9"
 
 
+def test_lazy_warning_human_summary_is_honest_and_non_blocking(
+    monkeypatch, wheel, capsys
+):
+    _make_device_export_lazy(wheel)
+    monkeypatch.setattr(audit_mod, "fetch_wheel", lambda *a, **k: wheel)
+    monkeypatch.setattr(
+        audit_mod,
+        "load_manifest_entry",
+        lambda version: {"pip_extras": "", "train_env_eval_flag": "env_eval_freq"},
+    )
+
+    assert audit_mod.main(["9.9.9", "--offline"]) == 0
+    captured = capsys.readouterr()
+    assert "[WARN] import-surface" in captured.out
+    assert "WARN: 1 non-blocking unverifiable finding(s)" in captured.out
+    assert "PASS: lerobot 9.9.9 satisfies" not in captured.out
+    assert captured.err == ""
+
+
+def test_lazy_warning_json_stdout_is_pure_and_summary_is_on_stderr(
+    monkeypatch, wheel, capsys
+):
+    _make_device_export_lazy(wheel)
+    monkeypatch.setattr(audit_mod, "fetch_wheel", lambda *a, **k: wheel)
+    monkeypatch.setattr(
+        audit_mod,
+        "load_manifest_entry",
+        lambda version: {"pip_extras": "", "train_env_eval_flag": "env_eval_freq"},
+    )
+
+    assert audit_mod.main(["9.9.9", "--offline", "--json"]) == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    import_check = next(c for c in payload[0]["checks"] if c["check"] == "import-surface")
+    assert import_check["status"] == "WARN"
+    assert "WARN: 1 non-blocking unverifiable finding(s)" in captured.err
+    assert "PASS: lerobot 9.9.9 satisfies" not in captured.err
+
+
 def test_import_surface_covers_every_static_lerobot_import():
-    covered = {(module, symbol) for module, symbol, _ in audit_mod.IMPORT_SURFACE}
+    covered: dict[tuple[str, str | None], set[str]] = {}
+    for module, symbol, provenance in audit_mod.IMPORT_SURFACE:
+        assert isinstance(provenance, tuple), (
+            f"{module}:{symbol} provenance must be a tuple of repository-relative paths"
+        )
+        covered.setdefault((module, symbol), set()).update(provenance)
     imports: dict[tuple[str, str | None], set[str]] = {}
 
     for root in (REPO_ROOT / "npa/src", REPO_ROOT / "npa/demo", REPO_ROOT / "research"):
@@ -327,8 +523,16 @@ def test_import_surface_covers_every_static_lerobot_import():
                         if alias.name == "lerobot" or alias.name.startswith("lerobot."):
                             imports.setdefault((alias.name, None), set()).add(relative)
 
-    missing = {binding: paths for binding, paths in imports.items() if binding not in covered}
-    assert missing == {}
+    missing_bindings = {
+        binding: paths for binding, paths in imports.items() if binding not in covered
+    }
+    missing_provenance = {
+        binding: paths - covered.get(binding, set())
+        for binding, paths in imports.items()
+        if paths - covered.get(binding, set())
+    }
+    assert missing_bindings == {}
+    assert missing_provenance == {}
 
 
 def test_b300_image_pins_match_the_dockerfile():

--- a/npa/tests/scripts/test_audit_lerobot_release.py
+++ b/npa/tests/scripts/test_audit_lerobot_release.py
@@ -9,8 +9,11 @@ inspection, which is all the script does — it never imports LeRobot.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
+import re
+import shutil
 import sys
 from pathlib import Path
 
@@ -134,6 +137,18 @@ def test_removed_symbol_is_caught(monkeypatch, wheel):
     assert _status(report, "import-surface") == "FAIL"
 
 
+def test_symbol_nested_inside_a_function_is_not_a_module_export(monkeypatch, wheel):
+    path = wheel / "lerobot/utils/device_utils.py"
+    path.write_text(
+        "def device_factory():\n"
+        "    def get_safe_torch_device(): ...\n"
+        "    return get_safe_torch_device\n",
+        encoding="utf-8",
+    )
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "import-surface") == "FAIL"
+
+
 def test_dropped_keyword_parameter_is_caught(monkeypatch, wheel):
     # `env_cfg` is passed by keyword from npa/server/app.py.
     (wheel / "lerobot/policies/factory.py").write_text(
@@ -197,6 +212,42 @@ def test_forced_torch_pin_inside_declared_bounds_passes(monkeypatch, wheel):
     assert _status(report, "manifest torch pins") == "PASS"
 
 
+def test_bare_requires_dist_does_not_disable_pin_check(monkeypatch, wheel):
+    metadata = wheel / "lerobot-9.9.9.dist-info" / "METADATA"
+    metadata.write_text(
+        metadata.read_text(encoding="utf-8").replace(
+            "Requires-Dist: torch<2.12.0,>=2.7",
+            "Requires-Dist: torch\nRequires-Dist: torch<2.12.0,>=2.7",
+        ),
+        encoding="utf-8",
+    )
+    report = _run(monkeypatch, wheel, manifest={"torch_pin": "torch==99.0.0"})
+    assert _status(report, "manifest torch pins") == "FAIL"
+
+
+def test_marker_gated_requirement_is_not_applied_unconditionally(monkeypatch, wheel):
+    metadata = wheel / "lerobot-9.9.9.dist-info" / "METADATA"
+    metadata.write_text(
+        metadata.read_text(encoding="utf-8").replace(
+            "Requires-Dist: torch<2.12.0,>=2.7",
+            'Requires-Dist: torch==2.5.0; platform_machine == "aarch64"\n'
+            "Requires-Dist: torch<2.12.0,>=2.7",
+        ),
+        encoding="utf-8",
+    )
+    report = _run(monkeypatch, wheel)
+    assert _status(report, "b300-image torch stack") == "PASS"
+
+
+@pytest.mark.parametrize(
+    "pin",
+    ["torch<2.11.0", "torch~=2.9.0", "torch!=2.10.0", "torch>=2.7,<2.11"],
+)
+def test_pin_floor_handles_every_specifier_form(monkeypatch, wheel, pin):
+    report = _run(monkeypatch, wheel, manifest={"torch_pin": pin})
+    assert _status(report, "manifest torch pins") == "FAIL"
+
+
 def test_lower_bound_pin_below_declared_ceiling_is_caught(monkeypatch, wheel):
     # `diffusers>=0.30.0` floors below the declared >=0.38.0 floor.
     report = _run(monkeypatch, wheel, manifest={"diffusers_pin": "diffusers>=0.30.0"})
@@ -241,6 +292,56 @@ def test_ungated_policy_needs_no_extra(monkeypatch, wheel):
     # ACT declares no require_package gate, so a bare install can construct it.
     report = _run(monkeypatch, wheel, manifest={"pip_extras": "pusht"})
     assert _status(report, "policy-extras") == "PASS"
+
+
+def test_missing_dist_info_is_a_check_failure_not_a_traceback(monkeypatch, wheel):
+    shutil.rmtree(wheel / "lerobot-9.9.9.dist-info")
+    report = _run(monkeypatch, wheel)
+    assert report.failed
+
+
+def test_json_mode_stdout_is_pure_json(monkeypatch, wheel, capsys):
+    monkeypatch.setattr(audit_mod, "fetch_wheel", lambda *a, **k: wheel)
+    monkeypatch.setattr(audit_mod, "load_manifest_entry", lambda version: None)
+
+    assert audit_mod.main(["9.9.9", "--offline", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["version"] == "9.9.9"
+
+
+def test_import_surface_covers_every_static_lerobot_import():
+    covered = {(module, symbol) for module, symbol, _ in audit_mod.IMPORT_SURFACE}
+    imports: dict[tuple[str, str | None], set[str]] = {}
+
+    for root in (REPO_ROOT / "npa/src", REPO_ROOT / "npa/demo", REPO_ROOT / "research"):
+        for path in root.rglob("*.py"):
+            relative = path.relative_to(REPO_ROOT).as_posix()
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if isinstance(node, ast.ImportFrom) and node.module and (
+                    node.module == "lerobot" or node.module.startswith("lerobot.")
+                ):
+                    for alias in node.names:
+                        imports.setdefault((node.module, alias.name), set()).add(relative)
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name == "lerobot" or alias.name.startswith("lerobot."):
+                            imports.setdefault((alias.name, None), set()).add(relative)
+
+    missing = {binding: paths for binding, paths in imports.items() if binding not in covered}
+    assert missing == {}
+
+
+def test_b300_image_pins_match_the_dockerfile():
+    dockerfile = (REPO_ROOT / "npa/docker/workbench/lerobot/Dockerfile.b300").read_text(
+        encoding="utf-8"
+    )
+    found = {}
+    for package in audit_mod.B300_IMAGE_PINS:
+        matches = re.findall(rf"(?<![\w-]){re.escape(package)}==([\w.+-]+)", dockerfile)
+        assert len(matches) == 1, f"expected one {package} pin, found {matches}"
+        found[package] = matches[0]
+
+    assert found == audit_mod.B300_IMAGE_PINS
 
 
 def test_repo_manifest_versions_are_all_auditable():


### PR DESCRIPTION
## What changed

This keeps `audit_lerobot_release.py` a manually run triage tool while closing the original missed-break cases and the follow-up false failures/reporting gaps.

- Dependency bounds now intersect all applicable specifiers, parse manifest pins safely, and use only the manifest's installed `pip_extras` plus their transitive LeRobot-extra closure. Constraints from uninstalled extras such as `jetson` no longer poison the B300 verdict, while installed and transitively installed extras still constrain it.
- PEP 508 markers are evaluated for the B300 image target (`Linux` / `x86_64`) instead of the auditing workstation. Python marker values continue to come from the wheel/audit interpreter context.
- Module export inspection traverses module-scope `if`, `try` / `except` / `else` / `finally`, `TryStar`, `with`, `for`, `while`, and `match` suites without descending into functions, classes, lambdas, comprehensions, or other nested lexical scopes. This covers `ModuleNotFoundError`, broad fallback handlers, version-gated imports, and `try/finally` without restoring broad `ast.walk` behavior.
- PEP 562 `__getattr__`-only exports remain non-blocking `WARN` results. Human and JSON modes now summarize those warnings honestly, retain exit code 0, and keep JSON stdout pure by writing its human summary to stderr.
- Missing wheel metadata produces a named `wheel-metadata` failure, unsupported manifest pin forms produce a check row rather than a traceback, and static import coverage now validates structured call-site provenance as well as `(module, symbol)` membership.
- The audit document now distinguishes the static `19/19 bindings resolve statically` result from the separate runtime import check.

The synthetic-wheel tests monkeypatch `fetch_wheel`, do not import LeRobot, and do not use network access.

## Reproductions before the follow-up fix

Focused regressions were added first and run against PR head `ab308d7`:

- Module-scope exports under `except ModuleNotFoundError`, `except Exception`, version-gated `if`, `try/finally`, `TryStar`, `with`, `for`, `while`, and `match` were falsely reported missing.
- A simulated aarch64 auditing host applied an aarch64-only torch marker to the x86_64 B300 image check.
- `Requires-Dist: torch==2.7.1; extra == "jetson"` failed the B300 stack even when the manifest did not install `jetson`.
- A lazy `__getattr__` export produced a `WARN` row but both human and JSON summaries claimed unqualified `PASS`.
- The static-import guard checked binding membership but not whether every call-site path was credited by the reviewed table.

Red result: **14 failed, 31 passed**. The existing closure regression continued to fail the synthetic import-surface check, proving the implementation did not return to broad nested-scope traversal.

## Why and impact

The pre-flight no longer reports conditional module exports as removed, intersects constraints from extras the repository never installs, or varies the B300 verdict with the operator's host architecture. A release with only a lazy export is explicitly unverifiable rather than statically satisfied, without turning this manual triage tool into a blocking gate.

The original PR also catches metadata ordering, unsupported pin syntax, incomplete wheel caches, closure-only names, invalid JSON output, and LeRobot policy extras that import successfully but fail during policy construction.

## Validation

Rebased onto current `main` SHA `1e8acb921aa953c1e2ce018bcbc6417611768a16` with no conflicts and no content changes; the two rebased commits remain patch-equivalent to the original PR commits.

- Focused checker suite: **44 passed, 1 skipped** locally. The skip is the `TryStar` syntax case under the repository venv's Python 3.10; Python 3.12 CI exercises it.
- Guardrails: **1852 passed, 1 skipped** locally. Current main includes the upstream root-README contract repair from `58f3f5137338f0efaf32341bd15e20ba108b1c55`; the previously failing README-related guardrails pass.
- Repository-configured Ruff on both changed Python files: passed.
- `git diff --check`: passed.
- Full `make test`: **9497 passed, 37 skipped, 12 deselected, 1 xpassed, 7 failed** locally. All seven failures are unrelated cleanup/provisioning tests caused by current main's full-suite collection importing `npa.controller_ownership.CONFIG_PATH` before the autouse fixture repoints the operator config. The identical seven failures reproduce from an archive of unmodified current main (**7 failed, 1 passed** with the collection trigger); no PR file participates in them. This PR therefore remains draft under the required-validation policy.
- Published-wheel audits from the original validation remain: **0.6.0 PASS**, **0.6.1 PASS**; **0.5.1 exits 1 only for the existing documented manifest torch/torchvision/diffusers pin conflict**. No manifest, Dockerfile, image, or runtime data was changed here.
- Fresh final-head CI on `99cdc68832f4a80758b52a23ad868a15c2962201`: Python 3.12, guardrails, Ruff, docs-drift, scan, and gitleaks all completed successfully.

## 0.6.0 artifact follow-up

The unchanged pull artifact remains tracked in #284. Maintainers still need to rebuild and repush 0.6.0, construct Diffusion Policy on a real GPU, validate through `npa/scripts/validate_blackwell_image.sh`, and record the resulting tag and digest. This PR intentionally does not build or push an image.

## Limitations and deferred follow-ups

- This remains **manual triage, not a CI or merge gate**. Static AST/wheel inspection cannot prove runtime behavior; the real GPU train+eval smoke remains the gate.
- PEP 562 lazy exports cannot be proven without importing LeRobot, so they remain non-blocking `WARN` results with exit code 0.
- Deferred unchanged: `check_signatures` treats `**kwargs` as unconditional success; a renamed keyword can be silently ignored and should probably warn.
- Deferred unchanged: informational `available-entry-points`, `requires-python`, and `declared-bounds` rows are emitted as `PASS` and inflate the all-PASS count even though they cannot fail.
