### PR TITLE
docs: remove no-GPU quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,6 @@ npa --version
 npa workbench health preflight
 ```
 
-### Get a first result without a GPU
-
-[Nebius Token Factory](https://tokenfactory.nebius.com/) only needs a
-`NEBIUS_TOKEN_FACTORY_KEY`, which you can add during `npa configure`.
-
-```bash
-npa workbench token-factory verify
-printf 'Explain sim-to-real transfer in one sentence.\n' > /tmp/prompts.txt
-npa workbench token-factory generate \
-  --input-path /tmp/prompts.txt \
-  --output-path /tmp/tf-generations.jsonl \
-  --output json
-```
-
-Next: [run the full quickstart](docs/quickstart.md) or
-[pick a robot tutorial](docs/workbench/guides/README.md).
-
 ## Pick a robot
 
 | Tutorial | Stack |


### PR DESCRIPTION
## What changed

Removed the root README section titled “Get a first result without a GPU,” including its Token Factory example and follow-up links.

## Why

The no-GPU first-result section is no longer intended to appear in the repository landing page.

## Impact

The README now moves directly from installation verification to the robot tutorial selection. Runtime behavior is unchanged.

## Validation

- Confirmed the removed heading no longer appears in the root README.
- Ran `git diff --check`.
- Verified the branch changes only the root `README.md` and only removes the requested section.

## Limitations

Documentation-only change; no runtime test suite was required.
