### PR TITLE
Fix live Soperator deployment contract

### DIFF
--- a/docs/cli/soperator.md
+++ b/docs/cli/soperator.md
@@ -10,7 +10,7 @@ Deploy and manage Nebius soperator (Slurm-on-Kubernetes) clusters.
 Options
 --help  Show this message and exit.
 Commands
-deploy  Deploy a soperator cluster from a spec (multiple presets + optional docker cache).
+deploy  Deploy or reconcile a pinned-contract Soperator cluster spec.
 destroy  Destroy an npa-managed soperator cluster by name.
 status  Show a soperator cluster's Slurm partitions/nodes via kubectl.
 ```
@@ -25,7 +25,7 @@ status  Show a soperator cluster's Slurm partitions/nodes via kubectl.
 
 | Command | Description |
 | --- | --- |
-| `deploy` | Deploy a soperator cluster from a spec (multiple presets + optional docker cache). |
+| `deploy` | Deploy or reconcile a pinned-contract Soperator cluster spec. |
 | `destroy` | Destroy an npa-managed soperator cluster by name. |
 | `status` | Show a soperator cluster's Slurm partitions/nodes via kubectl. |
 

--- a/docs/cli/soperator.md
+++ b/docs/cli/soperator.md
@@ -10,6 +10,7 @@ Deploy and manage Nebius soperator (Slurm-on-Kubernetes) clusters.
 Options
 --help  Show this message and exit.
 Commands
+plan  Show a public-safe, provider-free Soperator capacity plan.
 deploy  Deploy or reconcile a pinned-contract Soperator cluster spec.
 destroy  Destroy an npa-managed soperator cluster by name.
 status  Show a soperator cluster's Slurm partitions/nodes via kubectl.
@@ -25,6 +26,7 @@ status  Show a soperator cluster's Slurm partitions/nodes via kubectl.
 
 | Command | Description |
 | --- | --- |
+| `plan` | Show a public-safe, provider-free Soperator capacity plan. |
 | `deploy` | Deploy or reconcile a pinned-contract Soperator cluster spec. |
 | `destroy` | Destroy an npa-managed soperator cluster by name. |
 | `status` | Show a soperator cluster's Slurm partitions/nodes via kubectl. |
@@ -33,7 +35,7 @@ status  Show a soperator cluster's Slurm partitions/nodes via kubectl.
 
 ```bash
 npa soperator --help
-npa soperator deploy --help
+npa soperator plan --help
 ```
 
 Regenerate this page with `bash scripts/build_docs.sh` after changing `soperator`.

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -3960,6 +3960,9 @@ def _soperator_validate_payload(body: dict) -> dict:
 
 
 def _soperator_deploy_from_payload(body: dict) -> dict:
+    from npa.soperator.lifecycle import _validate_immutable_solutions_library_ref
+    from npa.soperator.spec import DEFAULT_SOLUTIONS_LIBRARY_REF
+
     ready, reason = _agent_npa_ready()
     if not ready:
         return {{"ok": False, "status": "blocked", "error": reason}}
@@ -3967,6 +3970,16 @@ def _soperator_deploy_from_payload(body: dict) -> dict:
     validation = _soperator_validate_payload(body)
     if not validation.get("ok"):
         return {{"ok": False, "status": "invalid", "validation": validation}}
+    try:
+        ref = _validate_immutable_solutions_library_ref(
+            str(
+                body.get("ref")
+                or body.get("solutions_library_ref")
+                or DEFAULT_SOLUTIONS_LIBRARY_REF
+            )
+        )
+    except ValueError as exc:
+        return {{"ok": False, "status": "invalid", "error": str(exc), "validation": validation}}
     if dry_run:
         return {{
             "ok": True,
@@ -3974,12 +3987,12 @@ def _soperator_deploy_from_payload(body: dict) -> dict:
             "dry_run": True,
             "validation": validation,
             "command": "npa soperator deploy --spec <validated-spec> --output json",
+            "solutions_library_ref": ref,
         }}
     timeout_minutes = int(body.get("timeout_minutes") or body.get("timeout") or 90)
     project = _agent_project_alias(str(body.get("project") or ""))
     terraform_dir_text = str(body.get("terraform_dir") or "").strip()
     terraform_dir = Path(terraform_dir_text).expanduser() if terraform_dir_text else None
-    ref = str(body.get("ref") or body.get("solutions_library_ref") or "main")
     apply_fixes = bool(body.get("apply_fixes", True))
     spec_path = _write_soperator_temp_spec(_soperator_spec_text_from_payload(body))
     try:

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -3939,6 +3939,10 @@ def _soperator_validate_payload(body: dict) -> dict:
             "apiVersion": "npa.soperator/v0.0.1",
             "name": spec.name,
             "region": spec.region,
+            "control_plane": {{
+                "system_min_size": spec.system_min_size,
+                "system_max_size": spec.effective_system_max_size(),
+            }},
             "worker_pools": [pool.name for pool in spec.workers],
             "docker_cache_pools": [pool.name for pool in spec.workers if pool.docker_cache],
             "workers": [
@@ -3948,6 +3952,8 @@ def _soperator_validate_payload(body: dict) -> dict:
                     "preset": pool.preset,
                     "size": pool.size,
                     "preemptible": pool.preemptible,
+                    "capacity_mode": pool.capacity_mode(),
+                    "reservation_selector": pool.reservation_selector_kind() or None,
                     "docker_cache": pool.docker_cache,
                 }}
                 for pool in spec.workers
@@ -3960,7 +3966,11 @@ def _soperator_validate_payload(body: dict) -> dict:
 
 
 def _soperator_deploy_from_payload(body: dict) -> dict:
-    from npa.soperator.lifecycle import _validate_immutable_solutions_library_ref
+    from npa.soperator.lifecycle import (
+        SoperatorDeploymentValidationError,
+        _validate_gpu_creation_check_timeout,
+        _validate_immutable_solutions_library_ref,
+    )
     from npa.soperator.spec import DEFAULT_SOLUTIONS_LIBRARY_REF
 
     ready, reason = _agent_npa_ready()
@@ -3980,6 +3990,14 @@ def _soperator_deploy_from_payload(body: dict) -> dict:
         )
     except ValueError as exc:
         return {{"ok": False, "status": "invalid", "error": str(exc), "validation": validation}}
+    try:
+        raw_gpu_timeout = body.get("gpu_creation_check_timeout_seconds")
+        gpu_creation_check_timeout_seconds = (
+            30 * 60 if raw_gpu_timeout is None else int(raw_gpu_timeout)
+        )
+        _validate_gpu_creation_check_timeout(gpu_creation_check_timeout_seconds)
+    except (TypeError, ValueError) as exc:
+        return {{"ok": False, "status": "invalid", "error": str(exc), "validation": validation}}
     if dry_run:
         return {{
             "ok": True,
@@ -3988,6 +4006,7 @@ def _soperator_deploy_from_payload(body: dict) -> dict:
             "validation": validation,
             "command": "npa soperator deploy --spec <validated-spec> --output json",
             "solutions_library_ref": ref,
+            "gpu_creation_check_timeout_seconds": gpu_creation_check_timeout_seconds,
         }}
     timeout_minutes = int(body.get("timeout_minutes") or body.get("timeout") or 90)
     project = _agent_project_alias(str(body.get("project") or ""))
@@ -4006,7 +4025,9 @@ def _soperator_deploy_from_payload(body: dict) -> dict:
             solutions_library_ref=ref,
             project=project or None,
             timeout_minutes=timeout_minutes,
+            gpu_creation_check_timeout_seconds=gpu_creation_check_timeout_seconds,
             apply_fixes=apply_fixes,
+            stream_terraform_output=False,
             on_status=lambda msg: None,
         )
         return {{
@@ -4015,6 +4036,14 @@ def _soperator_deploy_from_payload(body: dict) -> dict:
             "dry_run": False,
             "validation": validation,
             "result": result,
+        }}
+    except SoperatorDeploymentValidationError as exc:
+        return {{
+            "ok": False,
+            "status": "degraded-validation",
+            "error": str(exc),
+            "validation": validation,
+            "result": exc.result,
         }}
     except Exception as exc:
         return {{"ok": False, "status": "error", "error": str(exc), "validation": validation}}

--- a/npa/src/npa/cli/soperator/__init__.py
+++ b/npa/src/npa/cli/soperator/__init__.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import typer
 
+from npa.soperator.lifecycle import DEFAULT_GPU_CREATION_CHECK_TIMEOUT_SECONDS
 from npa.soperator.spec import DEFAULT_SOLUTIONS_LIBRARY_REF
 
 app = typer.Typer(
@@ -19,6 +20,44 @@ app = typer.Typer(
     help="Deploy and manage Nebius soperator (Slurm-on-Kubernetes) clusters.",
     no_args_is_help=True,
 )
+
+
+def plan_cmd(
+    spec_path: Path = typer.Option(
+        ...,
+        "--spec",
+        "-f",
+        help="Path to an npa.soperator/v0.0.1 cluster spec YAML.",
+    ),
+    output: str = typer.Option("text", "--output", help="Output format: text or json."),
+) -> None:
+    """Show a public-safe, provider-free Soperator capacity plan."""
+
+    from npa.soperator.lifecycle import plan_cluster
+    from npa.soperator.spec import SoperatorSpecError, load_spec
+
+    try:
+        result = plan_cluster(load_spec(spec_path))
+    except (SoperatorSpecError, FileNotFoundError, OSError) as exc:
+        raise typer.BadParameter(f"Invalid soperator spec: {exc}") from exc
+    if output not in {"text", "json"}:
+        raise typer.BadParameter("--output must be text or json")
+    if output == "json":
+        typer.echo(json.dumps(result, indent=2))
+        return
+    typer.echo(f"Soperator plan for '{result['name']}' ({result['region']}):")
+    typer.echo(
+        "  system autoscaling: "
+        f"{result['control_plane']['system_min_size']}.."
+        f"{result['control_plane']['system_max_size']}"
+    )
+    for worker in result["workers"]:
+        typer.echo(
+            f"  worker {worker['name']}: size={worker['size']} "
+            f"preset={worker['preset']} capacity={worker['capacity_mode']}"
+        )
+    if result["reservation_preflight"] == "required":
+        typer.echo("  reserved-capacity provider preflight: required before apply")
 
 
 def deploy_cmd(
@@ -49,6 +88,14 @@ def deploy_cmd(
         "overrides the spec, environment, and operator-home discovery.",
     ),
     timeout: int = typer.Option(90, "--timeout", help="Terraform apply timeout in minutes."),
+    gpu_creation_check_timeout: int = typer.Option(
+        DEFAULT_GPU_CREATION_CHECK_TIMEOUT_SECONDS,
+        "--gpu-creation-check-timeout",
+        min=1,
+        help="Independent end-to-end mandatory GPU gate timeout in seconds. Bounds "
+        "Slurm queueing, job wall time, and the local kubectl process; --timeout "
+        "continues to apply only to Terraform.",
+    ),
     apply_fixes: bool = typer.Option(
         True,
         "--apply-fixes/--skip-fixes",
@@ -56,11 +103,17 @@ def deploy_cmd(
         "fixes, Ubuntu userns setup, and best-effort worker recovery. Mandatory "
         "direct CUDA creation checks for GPU pools run with either setting.",
     ),
+    source_preflight_only: bool = typer.Option(
+        False,
+        "--source-preflight-only",
+        help="Reconcile/verify the pinned source and planned installation path, "
+        "then stop before Terraform initialization or provider mutation.",
+    ),
     output: str = typer.Option("text", "--output", help="Output format: text or json."),
 ) -> None:
     """Deploy or reconcile a pinned-contract Soperator cluster spec."""
 
-    from npa.soperator.lifecycle import deploy_cluster
+    from npa.soperator.lifecycle import SoperatorDeploymentValidationError, deploy_cluster
     from npa.soperator.spec import SoperatorSpecError, load_spec
 
     try:
@@ -68,18 +121,56 @@ def deploy_cmd(
     except (SoperatorSpecError, FileNotFoundError, OSError) as exc:
         raise typer.BadParameter(f"Invalid soperator spec: {exc}") from exc
 
-    result = deploy_cluster(
-        spec,
-        terraform_dir=terraform_dir,
-        solutions_library_ref=solutions_library_ref,
-        root_login_ssh_public_key_file=root_login_ssh_public_key_file,
-        project=project or None,
-        timeout_minutes=timeout,
-        apply_fixes=apply_fixes,
-        on_status=lambda msg: typer.echo(f"  - {msg}"),
-    )
+    if output not in {"text", "json"}:
+        raise typer.BadParameter("--output must be text or json")
+    json_mode = output == "json"
+    try:
+        result = deploy_cluster(
+            spec,
+            terraform_dir=terraform_dir,
+            solutions_library_ref=solutions_library_ref,
+            root_login_ssh_public_key_file=root_login_ssh_public_key_file,
+            project=project or None,
+            timeout_minutes=timeout,
+            gpu_creation_check_timeout_seconds=gpu_creation_check_timeout,
+            apply_fixes=apply_fixes,
+            source_preflight_only=source_preflight_only,
+            stream_terraform_output=not json_mode,
+            on_status=lambda msg: typer.echo(f"  - {msg}", err=json_mode),
+        )
+    except SoperatorDeploymentValidationError as exc:
+        if json_mode:
+            typer.echo(json.dumps(exc.result, indent=2))
+        else:
+            result = exc.result
+            typer.echo(
+                f"Soperator cluster '{result['name']}' was applied, but mandatory "
+                "post-apply validation failed.",
+                err=True,
+            )
+            typer.echo(f"  validation: {result['validation']['message']}", err=True)
+            typer.echo(f"  kube context: {result['kube_context']}", err=True)
+            typer.echo(f"  worker pools: {', '.join(result['worker_pools'])}", err=True)
+            typer.echo(f"  install dir: {result['install_dir']}", err=True)
+        raise typer.Exit(1) from exc
     if output == "json":
         typer.echo(json.dumps(result, indent=2))
+    elif source_preflight_only:
+        typer.echo(
+            f"Deploy source preflight passed for soperator cluster '{result['name']}'; "
+            "no provider mutation was performed."
+        )
+        for worker in result.get("workers", []):
+            verification = (
+                " (reservation not provider-verified in source-only mode)"
+                if worker["capacity_mode"] == "reserved"
+                else ""
+            )
+            typer.echo(
+                f"  worker {worker['name']} capacity: "
+                f"{worker['capacity_mode']}{verification}"
+            )
+        typer.echo(f"  install dir: {result['install_dir']}")
     else:
         typer.echo(f"Deployed soperator cluster '{result['name']}' in {result['region']}.")
         typer.echo(f"  kube context: {result['kube_context']}")
@@ -87,6 +178,10 @@ def deploy_cmd(
         if result.get("docker_cache_pools"):
             typer.echo(
                 f"  docker-cache pools (IO_M3): {', '.join(result['docker_cache_pools'])}"
+            )
+        for worker in result.get("workers", []):
+            typer.echo(
+                f"  worker {worker['name']} capacity: {worker['capacity_mode']}"
             )
         typer.echo(f"  install dir: {result['install_dir']}")
 
@@ -108,27 +203,48 @@ def destroy_cmd(
         "(only used for installs predating the env sidecar).",
     ),
     timeout: int = typer.Option(90, "--timeout", help="Terraform destroy timeout in minutes."),
+    source_preflight_only: bool = typer.Option(
+        False,
+        "--source-preflight-only",
+        help="Reconcile/verify the pinned source and installation path, then stop "
+        "before Terraform initialization or any provider deletion.",
+    ),
     force: bool = typer.Option(False, "--force", help="Skip confirmation."),
 ) -> None:
     """Destroy an npa-managed soperator cluster by name."""
 
     from npa.soperator.lifecycle import destroy_cluster
 
-    if not force and not typer.confirm(f"Destroy soperator cluster '{name}'?"):
+    if not source_preflight_only and not force and not typer.confirm(
+        f"Destroy soperator cluster '{name}'?"
+    ):
         raise typer.Exit(1)
-    destroy_cluster(
+    result = destroy_cluster(
         name,
         terraform_dir=terraform_dir,
         solutions_library_ref=solutions_library_ref,
         project=project or None,
         timeout_minutes=timeout,
+        source_preflight_only=source_preflight_only,
         on_status=lambda msg: typer.echo(f"  - {msg}"),
     )
+    if source_preflight_only:
+        assert result is not None
+        typer.echo(
+            f"Destroy source preflight passed for soperator cluster '{name}'; "
+            "no provider mutation was performed."
+        )
+        return
     typer.echo(f"Destroyed soperator cluster '{name}'.")
 
 
 def status_cmd(
     name: str = typer.Option(..., "--name", help="Cluster name."),
+    terraform_dir: Path | None = typer.Option(
+        None,
+        "--terraform-dir",
+        help="Optional authoritative solutions-library soperator recipe directory.",
+    ),
     output: str = typer.Option("text", "--output", help="Output format: text or json."),
 ) -> None:
     """Show a soperator cluster's Slurm partitions/nodes via kubectl."""
@@ -152,12 +268,36 @@ def status_cmd(
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout).strip()
         raise typer.BadParameter(f"Could not query Slurm on '{name}': {detail}")
+    from npa.soperator.lifecycle import worker_capacity_status
+
+    workers = worker_capacity_status(name, terraform_dir=terraform_dir)
+    if output not in {"text", "json"}:
+        raise typer.BadParameter("--output must be text or json")
     if output == "json":
-        typer.echo(json.dumps({"name": name, "context": context, "sinfo": proc.stdout}))
+        typer.echo(
+            json.dumps(
+                {
+                    "name": name,
+                    "context": context,
+                    "sinfo": proc.stdout,
+                    "workers": workers,
+                    "capacity_status": "applied" if workers else "unknown",
+                }
+            )
+        )
     else:
         typer.echo(proc.stdout)
+        if workers:
+            for worker in workers:
+                typer.echo(
+                    f"worker {worker['name']} capacity: {worker['capacity_mode']} "
+                    f"({worker['nodes']} node(s))"
+                )
+        else:
+            typer.echo("worker capacity: unknown (local Terraform state not found)")
 
 
+app.command("plan")(plan_cmd)
 app.command("deploy")(deploy_cmd)
 app.command("destroy")(destroy_cmd)
 app.command("status")(status_cmd)

--- a/npa/src/npa/cli/soperator/__init__.py
+++ b/npa/src/npa/cli/soperator/__init__.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import typer
 
+from npa.soperator.spec import DEFAULT_SOLUTIONS_LIBRARY_REF
+
 app = typer.Typer(
     name="soperator",
     help="Deploy and manage Nebius soperator (Slurm-on-Kubernetes) clusters.",
@@ -36,18 +38,27 @@ def deploy_cmd(
         "If omitted, the library is cloned under ~/.npa/soperator.",
     ),
     solutions_library_ref: str = typer.Option(
-        "main", "--ref", help="Git ref of nebius-solutions-library to clone when needed."
+        DEFAULT_SOLUTIONS_LIBRARY_REF,
+        "--ref",
+        help="Immutable 40-character nebius-solutions-library commit SHA.",
+    ),
+    root_login_ssh_public_key_file: Path | None = typer.Option(
+        None,
+        "--root-login-ssh-public-key-file",
+        help="Public-key file granting root SSH access on the public login node; "
+        "overrides the spec, environment, and operator-home discovery.",
     ),
     timeout: int = typer.Option(90, "--timeout", help="Terraform apply timeout in minutes."),
     apply_fixes: bool = typer.Option(
         True,
         "--apply-fixes/--skip-fixes",
-        help="Apply the post-deploy fixes (monitoring CRDs, CRD patch, scripts configmap) "
-        "the 4.1.0-stable recipe needs to reach a working Slurm.",
+        help="Apply monitoring prerequisites/repair, CRD and scripts compatibility "
+        "fixes, Ubuntu userns setup, and best-effort worker recovery. Mandatory "
+        "direct CUDA creation checks for GPU pools run with either setting.",
     ),
     output: str = typer.Option("text", "--output", help="Output format: text or json."),
 ) -> None:
-    """Deploy a soperator cluster from a spec (multiple presets + optional docker cache)."""
+    """Deploy or reconcile a pinned-contract Soperator cluster spec."""
 
     from npa.soperator.lifecycle import deploy_cluster
     from npa.soperator.spec import SoperatorSpecError, load_spec
@@ -61,6 +72,7 @@ def deploy_cmd(
         spec,
         terraform_dir=terraform_dir,
         solutions_library_ref=solutions_library_ref,
+        root_login_ssh_public_key_file=root_login_ssh_public_key_file,
         project=project or None,
         timeout_minutes=timeout,
         apply_fixes=apply_fixes,
@@ -84,7 +96,11 @@ def destroy_cmd(
     terraform_dir: Path | None = typer.Option(
         None, "--terraform-dir", help="solutions-library 'soperator' recipe dir (if not the default)."
     ),
-    solutions_library_ref: str = typer.Option("main", "--ref"),
+    solutions_library_ref: str = typer.Option(
+        DEFAULT_SOLUTIONS_LIBRARY_REF,
+        "--ref",
+        help="Immutable 40-character nebius-solutions-library commit SHA.",
+    ),
     project: str = typer.Option(
         "",
         "--project",

--- a/npa/src/npa/sdk/soperator.py
+++ b/npa/src/npa/sdk/soperator.py
@@ -12,7 +12,8 @@ Example::
     spec = SoperatorSpec(
         name="npa-soperator",
         region="us-central1",
-        ssh_public_keys=["ssh-ed25519 AAAA... me"],
+        # Explicitly grants root SSH access to the public login node.
+        root_login_ssh_public_key="ssh-ed25519 AAAA... operator",
         workers=[
             WorkerPoolSpec(name="cpu", platform="cpu-d3", preset="8vcpu-32gb", docker_cache=True),
             WorkerPoolSpec(name="gpu", platform="gpu-b200-sxm", preset="8gpu-160vcpu-1792gb",

--- a/npa/src/npa/sdk/soperator.py
+++ b/npa/src/npa/sdk/soperator.py
@@ -26,16 +26,22 @@ Example::
 from __future__ import annotations
 
 from npa.soperator.lifecycle import (
+    DeploymentValidationFailure,
+    SoperatorDeploymentValidationError,
     apply_post_deploy_fixes,
     deploy_cluster as deploy,
     destroy_cluster as destroy,
+    plan_cluster as plan,
 )
 from npa.soperator.spec import SoperatorSpec, WorkerPoolSpec, load_spec, spec_from_mapping
 
 __all__ = [
     "deploy",
     "destroy",
+    "plan",
     "apply_post_deploy_fixes",
+    "DeploymentValidationFailure",
+    "SoperatorDeploymentValidationError",
     "SoperatorSpec",
     "WorkerPoolSpec",
     "load_spec",

--- a/npa/src/npa/soperator/__init__.py
+++ b/npa/src/npa/soperator/__init__.py
@@ -4,8 +4,11 @@ This package wraps the public ``nebius/nebius-solutions-library`` soperator
 Terraform recipe. Callers describe a cluster with a small declarative spec
 (``npa.soperator/v0.0.1``) that supports **multiple worker node pools with
 different presets** and an optional per-pool **Docker/Enroot image cache disk**
-(node-local ``NETWORK_SSD_IO_M3``). The spec is rendered into the recipe's
-``terraform.tfvars`` and applied; post-deploy fixes make the cluster usable.
+(node-local ``NETWORK_SSD_IO_M3``). The spec is rendered against an immutable,
+validated upstream contract. Deploy applies idempotent monitoring, CRD,
+user-namespace, scripts, and worker repairs, then requires direct CUDA creation
+checks on every GPU worker. REST/accounting compatibility and control-plane
+sizing are validated before provider mutation.
 
 No project/tenant/registry IDs are baked in here -- they are resolved from
 ``~/.npa/config.yaml`` or explicit arguments, keeping this module public-safe.

--- a/npa/src/npa/soperator/lifecycle.py
+++ b/npa/src/npa/soperator/lifecycle.py
@@ -14,17 +14,21 @@ Reuses the terraform subprocess helpers from ``npa.cli.cluster.terraform_lifecyc
 from __future__ import annotations
 
 import base64
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
+import fcntl
 import hashlib
 import json
 import os
 import re
 import shutil
 import subprocess
+import tempfile
 import threading
 import time
+import uuid
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 from npa.cli.cluster.terraform_lifecycle import (
     _require_bin,
@@ -37,6 +41,7 @@ from npa.soperator.spec import (
     DEFAULT_SOLUTIONS_LIBRARY_REF,
     DEFAULT_SLURM_OPERATOR_VERSION,
     SoperatorSpec,
+    WorkerPoolSpec,
     validate_ssh_public_key_record,
 )
 from npa.soperator.tfvars import render_tfvars
@@ -55,6 +60,22 @@ _PROMETHEUS_CRDS = (
 _MONITORING_NAMESPACE = "monitoring-system"
 _MONITORING_RELEASE_SUFFIX = "-monitoring-dashboards"
 _ACTIVECHECKS_RELEASE_SUFFIX = "-soperator-activechecks"
+DEFAULT_GPU_CREATION_CHECK_TIMEOUT_SECONDS = 30 * 60
+_GPU_CHECK_CLEANUP_TIMEOUT_SECONDS = 30
+_SAFE_LOCAL_RECONCILIATION_REPLACEMENTS = {
+    (
+        "module.k8s.terraform_data.kubectl_cluster_context",
+        "terraform.io/builtin/terraform",
+    ),
+    (
+        "module.login_script.terraform_data.lb_service_ip",
+        "terraform.io/builtin/terraform",
+    ),
+    (
+        "module.login_script.local_file.this",
+        "registry.terraform.io/hashicorp/local",
+    ),
+}
 
 # Sidecar written next to the generated tfvars so ``destroy`` can rebuild the
 # same TF_VAR_* env the recipe requires. region/tenant/project/subnet/o11y are
@@ -66,6 +87,102 @@ _ENV_SIDECAR = ".npa-soperator-env.json"
 
 class UpstreamContractError(ValueError):
     """Raised before provider mutation when the pinned recipe contract differs."""
+
+
+class SolutionsLibraryReconciliationError(UpstreamContractError):
+    """Raised when an existing source checkout cannot be reconciled safely."""
+
+
+class ProviderReplacementPlanError(RuntimeError):
+    """Raised when a deploy plan contains an unsafe destructive action."""
+
+    def __init__(self, replacements: list[str]) -> None:
+        self.replacements = list(replacements)
+        super().__init__(
+            "Terraform planned "
+            f"{len(self.replacements)} provider or unexpected destructive action(s); "
+            "refusing to apply. The saved installation identity, Terraform state, "
+            "and live cluster were preserved"
+        )
+
+
+@dataclass(frozen=True)
+class GuardedTerraformPlan:
+    """One inspected plan plus its exact non-cloud local refresh replacements."""
+
+    path: Path
+    safe_local_replacements: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class DeploymentValidationFailure:
+    """Public-safe details for a mandatory post-apply validation failure."""
+
+    code: str
+    message: str
+    check: str
+    pool: str | None = None
+    phase: str | None = None
+    cleanup_confirmed: bool | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "status": "failed",
+            "code": self.code,
+            "check": self.check,
+            "message": self.message,
+        }
+        if self.pool is not None:
+            result["pool"] = self.pool
+        if self.phase is not None:
+            result["phase"] = self.phase
+        if self.cleanup_confirmed is not None:
+            result["cleanup_confirmed"] = self.cleanup_confirmed
+        return result
+
+
+class SoperatorDeploymentValidationError(RuntimeError):
+    """A cluster was applied but a mandatory validation gate failed.
+
+    Successful SDK calls keep returning the historical dictionary. Failed
+    post-apply validation raises this typed exception and retains the same
+    deployment metadata in :attr:`result`, clearly marked as degraded rather
+    than deployed successfully.
+    """
+
+    def __init__(
+        self,
+        deployment: dict[str, Any],
+        failure: DeploymentValidationFailure,
+    ) -> None:
+        self.deployment = dict(deployment)
+        self.failure = failure
+        self.result = {
+            **self.deployment,
+            "status": "degraded-validation",
+            "deployment_status": "applied",
+            "validation": failure.to_dict(),
+        }
+        super().__init__(failure.message)
+
+
+class GPUCreationCheckError(RuntimeError):
+    """Internal typed failure from the mandatory direct Slurm/CUDA gate."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        pool: str | None,
+        phase: str,
+        cleanup_confirmed: bool | None = None,
+        completed_checks: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.pool = pool
+        self.phase = phase
+        self.cleanup_confirmed = cleanup_confirmed
+        self.completed_checks = list(completed_checks or [])
+        super().__init__(message)
 
 
 @dataclass(frozen=True)
@@ -86,18 +203,25 @@ def _write_env_sidecar(
     subnet_id: str,
     o11y_profile: str,
 ) -> None:
-    (install_dir / _ENV_SIDECAR).write_text(
-        json.dumps(
-            {
-                "region": region,
-                "tenant_id": tenant_id,
-                "project_id": project_id,
-                "subnet_id": subnet_id,
-                "o11y_profile": o11y_profile,
-            },
-            indent=2,
+    path = install_dir / _ENV_SIDECAR
+    temporary = install_dir / f".{_ENV_SIDECAR}.{uuid.uuid4().hex}.tmp"
+    try:
+        temporary.write_text(
+            json.dumps(
+                {
+                    "region": region,
+                    "tenant_id": tenant_id,
+                    "project_id": project_id,
+                    "subnet_id": subnet_id,
+                    "o11y_profile": o11y_profile,
+                },
+                indent=2,
+            )
         )
-    )
+        temporary.chmod(0o600)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _load_env_sidecar(install_dir: Path) -> dict[str, str] | None:
@@ -106,9 +230,649 @@ def _load_env_sidecar(install_dir: Path) -> dict[str, str] | None:
         return None
     try:
         data = json.loads(path.read_text())
-    except (json.JSONDecodeError, OSError):
-        return None
-    return data if isinstance(data, dict) else None
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(
+            f"persisted Soperator installation identity at {path} is unreadable; "
+            "refusing to fall back to an ambient project"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"persisted Soperator installation identity at {path} is not an object; "
+            "refusing to fall back to an ambient project"
+        )
+    return data
+
+
+def _resolve_deploy_environment(
+    spec: SoperatorSpec,
+    recipe_dir: Path,
+    *,
+    project: str | None,
+) -> tuple[str, str, str, str | None, dict[str, str] | None]:
+    """Resolve deploy identity without drifting an existing Terraform install.
+
+    The persisted apply-time sidecar is authoritative for omitted identity
+    fields. Ambient/default project configuration is only a fallback for a new
+    install. Re-resolving an existing install against a changed default project
+    would otherwise produce a Terraform replacement plan for the whole cluster.
+    """
+
+    install_dir = recipe_dir / "installations" / spec.name
+    saved = _load_env_sidecar(install_dir)
+    explicit = {
+        "region": spec.region,
+        "tenant_id": spec.tenant_id,
+        "project_id": spec.project_id,
+        "subnet_id": spec.subnet_id,
+    }
+    if saved is not None:
+        persisted = {
+            field: str(saved.get(field) or "").strip()
+            for field in ("region", "tenant_id", "project_id", "subnet_id")
+        }
+        missing = [field for field, value in persisted.items() if not value]
+        if missing:
+            raise ValueError(
+                f"persisted identity for existing installation {spec.name!r} is "
+                f"incomplete (missing {', '.join(missing)}); refusing to resolve "
+                "replacement-sensitive fields from an ambient project"
+            )
+        for field, requested in explicit.items():
+            if requested and requested != persisted[field]:
+                raise ValueError(
+                    f"existing installation {spec.name!r} is pinned to its persisted "
+                    f"{field}; refusing a provider-replacement deploy. Restore the "
+                    "original value or deploy a distinct cluster name"
+                )
+        if project is not None:
+            configured = resolve_environment(project=project)
+            for field in ("region", "tenant_id", "project_id"):
+                requested = str(getattr(configured, field) or "")
+                if requested and requested != persisted[field]:
+                    raise ValueError(
+                        f"project {project!r} does not match the persisted {field} for "
+                        f"existing installation {spec.name!r}; refusing a provider-"
+                        "replacement deploy"
+                    )
+        return (
+            persisted["region"],
+            persisted["tenant_id"],
+            persisted["project_id"],
+            persisted["subnet_id"],
+            saved,
+        )
+
+    configured = resolve_environment(
+        project=project,
+        project_id=spec.project_id or None,
+        tenant_id=spec.tenant_id or None,
+        region=spec.region or None,
+    )
+    region = spec.region or configured.region
+    tenant_id = spec.tenant_id or configured.tenant_id
+    project_id = spec.project_id or configured.project_id
+    if not (region and tenant_id and project_id):
+        raise ValueError(
+            "region, tenant_id and project_id must be resolvable from the spec, "
+            "the existing installation sidecar, or ~/.npa config"
+        )
+    subnet_id = spec.subnet_id or None
+    return region, tenant_id, project_id, subnet_id, None
+
+
+def worker_capacity_summary(
+    spec: SoperatorSpec, *, reservations_verified: bool = False
+) -> list[dict[str, Any]]:
+    """Return public-safe worker capacity metadata for plans/results/status."""
+
+    return [
+        {
+            "name": pool.name,
+            "platform": pool.platform,
+            "preset": pool.preset,
+            "size": pool.size,
+            "capacity_mode": pool.capacity_mode(),
+            "reservation_selector": pool.reservation_selector_kind() or None,
+            "reservation_verified": (
+                reservations_verified if pool.capacity_mode() == "reserved" else None
+            ),
+        }
+        for pool in spec.workers
+    ]
+
+
+def plan_cluster(spec: SoperatorSpec) -> dict[str, Any]:
+    """Return a provider-free public plan for one declarative Soperator spec."""
+
+    spec.validate()
+    return {
+        "name": spec.name,
+        "region": spec.region or "(resolve-at-deploy)",
+        "control_plane": {
+            "system_min_size": spec.system_min_size,
+            "system_max_size": spec.effective_system_max_size(),
+        },
+        "workers": worker_capacity_summary(spec),
+        "reservation_preflight": (
+            "required"
+            if any(pool.capacity_mode() == "reserved" for pool in spec.workers)
+            else "not-required"
+        ),
+        "provider_mutation": False,
+    }
+
+
+def _status_installation_dir(
+    name: str,
+    *,
+    terraform_dir: Path | None = None,
+    work_root: Path | None = None,
+) -> Path | None:
+    """Find one existing installation without cloning or reconciling source."""
+
+    if terraform_dir is not None:
+        candidate = terraform_dir.expanduser().resolve() / "installations" / name
+        return candidate if candidate.is_dir() else None
+    root = (work_root or Path.home() / ".npa" / "soperator").expanduser()
+    candidates = [
+        root / "nebius-solutions-library" / "soperator" / "installations" / name,
+        *sorted(
+            root.glob(
+                f"nebius-solutions-library-*/soperator/installations/{name}"
+            )
+        ),
+    ]
+    existing = [candidate for candidate in candidates if candidate.is_dir()]
+    if len(existing) > 1:
+        raise ValueError(
+            f"multiple local installations exist for cluster {name!r}; pass "
+            "--terraform-dir to select the authoritative one"
+        )
+    return existing[0] if existing else None
+
+
+def worker_capacity_status(
+    name: str,
+    *,
+    terraform_dir: Path | None = None,
+    work_root: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Read applied worker capacity modes from local Terraform state."""
+
+    install_dir = _status_installation_dir(
+        name, terraform_dir=terraform_dir, work_root=work_root
+    )
+    if install_dir is None:
+        return []
+    state_path = install_dir / "terraform.tfstate"
+    if not state_path.is_file():
+        return []
+    try:
+        state = json.loads(state_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(
+            "local Terraform state is unreadable; worker capacity mode is unknown"
+        ) from exc
+    resources = state.get("resources") if isinstance(state, dict) else None
+    if not isinstance(resources, list):
+        raise ValueError(
+            "local Terraform state has no valid resource inventory; worker "
+            "capacity mode is unknown"
+        )
+    pools: dict[str, dict[str, Any]] = {}
+    for resource in resources:
+        if not isinstance(resource, dict) or resource.get("type") != "nebius_mk8s_v1_node_group":
+            continue
+        if resource.get("name") != "worker_v2":
+            continue
+        for instance in resource.get("instances") or []:
+            attributes = instance.get("attributes") if isinstance(instance, dict) else None
+            if not isinstance(attributes, dict):
+                continue
+            node_group_name = str(attributes.get("name") or "")
+            pool_name = re.sub(r"-[0-9]+$", "", node_group_name) or node_group_name
+            template = attributes.get("template") or {}
+            policy = template.get("reservation_policy") or {}
+            reservation_ids = (
+                policy.get("reservation_ids") if isinstance(policy, dict) else []
+            ) or []
+            if (
+                isinstance(policy, dict)
+                and policy.get("policy") == "STRICT"
+                and isinstance(reservation_ids, list)
+                and reservation_ids
+            ):
+                mode = "reserved"
+            elif isinstance(template, dict) and template.get("preemptible") is not None:
+                mode = "preemptible"
+            else:
+                mode = "on-demand"
+            existing = pools.get(pool_name)
+            if existing and existing["capacity_mode"] != mode:
+                raise ValueError(
+                    f"worker pool {pool_name!r} has mixed applied capacity modes"
+                )
+            entry = existing or {
+                "name": pool_name,
+                "capacity_mode": mode,
+                "node_groups": 0,
+                "nodes": 0,
+            }
+            entry["node_groups"] += 1
+            entry["nodes"] += int(attributes.get("fixed_node_count") or 0)
+            pools[pool_name] = entry
+    return [pools[key] for key in sorted(pools)]
+
+
+def _provider_json(
+    command: list[str],
+    *,
+    env: dict[str, str],
+    description: str,
+) -> dict[str, Any]:
+    """Run one read-only provider query and require an object-shaped response."""
+
+    try:
+        completed = _run_capture(
+            command,
+            env=env,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(f"{description} timed out; refusing provider mutation") from exc
+    if completed.returncode != 0 or not completed.stdout.strip():
+        raise ValueError(f"{description} failed; refusing provider mutation")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{description} returned invalid JSON; refusing provider mutation"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"{description} returned an incompatible response; refusing provider mutation"
+        )
+    return payload
+
+
+def _current_reserved_gpu_usage(install_dir: Path) -> dict[tuple[str, str], int]:
+    """Read already-applied STRICT GPU usage so deploy preflight is idempotent."""
+
+    state_path = install_dir / "terraform.tfstate"
+    if not state_path.is_file():
+        return {}
+    try:
+        state = json.loads(state_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(
+            "existing Terraform state is unreadable; reservation availability "
+            "cannot be checked safely"
+        ) from exc
+    resources = state.get("resources") if isinstance(state, dict) else None
+    if not isinstance(resources, list):
+        raise ValueError(
+            "existing Terraform state has no valid resource inventory; reservation "
+            "availability cannot be checked safely"
+        )
+    usage: dict[tuple[str, str], int] = {}
+    for resource in resources:
+        if not isinstance(resource, dict) or resource.get("type") != "nebius_mk8s_v1_node_group":
+            continue
+        if resource.get("name") != "worker_v2":
+            continue
+        for instance in resource.get("instances") or []:
+            attributes = instance.get("attributes") if isinstance(instance, dict) else None
+            if not isinstance(attributes, dict):
+                continue
+            template = attributes.get("template") or {}
+            if not isinstance(template, dict):
+                continue
+            policy = template.get("reservation_policy") or {}
+            if not isinstance(policy, dict) or policy.get("policy") != "STRICT":
+                continue
+            reservation_ids = policy.get("reservation_ids") or []
+            if not isinstance(reservation_ids, list) or len(reservation_ids) != 1:
+                raise ValueError(
+                    "existing worker reservation policy is ambiguous; refusing to "
+                    "guess available reserved capacity"
+                )
+            reservation_id = str(reservation_ids[0] or "").strip()
+            preset = str((template.get("resources") or {}).get("preset") or "")
+            try:
+                node_count = int(attributes.get("fixed_node_count") or 0)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "existing reserved worker count is invalid; refusing provider mutation"
+                ) from exc
+            if not reservation_id or node_count < 0:
+                raise ValueError(
+                    "existing worker reservation policy is incomplete; refusing "
+                    "provider mutation"
+                )
+            key = (reservation_id, preset)
+            usage[key] = usage.get(key, 0) + (
+                node_count * _gpu_count_from_preset(preset)
+            )
+    return usage
+
+
+def _resolve_reserved_worker_capacity(
+    spec: SoperatorSpec,
+    *,
+    install_dir: Path,
+    nebius_bin: str,
+    tenant_id: str,
+    project_id: str,
+    region: str,
+    env: dict[str, str],
+    on_status: Callable[[str], None] | None = None,
+) -> tuple[SoperatorSpec, list[dict[str, Any]]]:
+    """Resolve and verify every explicit STRICT capacity-block selector.
+
+    The selected project is first verified to belong to the selected tenant and
+    region. Group IDs/names are then resolved only within that tenant, checked
+    for a unique active region/platform/fabric match, and capacity-checked after
+    crediting already-applied STRICT workers from the same installation.
+    """
+
+    reserved_pools = [
+        pool for pool in spec.workers if pool.capacity_mode() == "reserved"
+    ]
+    if not reserved_pools:
+        return spec, worker_capacity_summary(spec)
+
+    project = _provider_json(
+        [nebius_bin, "iam", "project", "get", "--id", project_id, "--format", "json"],
+        env=env,
+        description="selected-project identity preflight",
+    )
+    project_metadata = project.get("metadata") or {}
+    project_status = project.get("status") or {}
+    project_spec = project.get("spec") or {}
+    if (
+        not isinstance(project_metadata, dict)
+        or str(project_metadata.get("id") or "") != project_id
+        or str(project_metadata.get("parent_id") or "") != tenant_id
+    ):
+        raise ValueError(
+            "selected project does not belong to the selected tenant; refusing "
+            "reserved-capacity provider mutation"
+        )
+    project_region = str(
+        (project_status if isinstance(project_status, dict) else {}).get("region")
+        or (project_spec if isinstance(project_spec, dict) else {}).get("region")
+        or ""
+    )
+    if project_region != region:
+        raise ValueError(
+            "selected project region does not match the Soperator region; refusing "
+            "reserved-capacity provider mutation"
+        )
+
+    inventory = _provider_json(
+        [
+            nebius_bin,
+            "capacity",
+            "capacity-block-group",
+            "list",
+            "--parent-id",
+            tenant_id,
+            "--all",
+            "--format",
+            "json",
+        ],
+        env=env,
+        description="capacity-block inventory preflight",
+    )
+    items = inventory.get("items")
+    if not isinstance(items, list):
+        raise ValueError(
+            "capacity-block inventory omitted a valid items list; refusing provider mutation"
+        )
+    from npa.fleet.quotas import parse_capacity_blocks
+
+    blocks = parse_capacity_blocks(json.dumps(inventory))
+    advice_inventory = _provider_json(
+        [
+            nebius_bin,
+            "capacity",
+            "resource-advice",
+            "list",
+            "--parent-id",
+            tenant_id,
+            "--all",
+            "--format",
+            "json",
+        ],
+        env=env,
+        description="reserved preset-availability preflight",
+    )
+    advice_items = advice_inventory.get("items")
+    if not isinstance(advice_items, list):
+        raise ValueError(
+            "reserved preset-availability preflight omitted a valid items list; "
+            "refusing provider mutation"
+        )
+    existing_usage = _current_reserved_gpu_usage(install_dir)
+    resolved_workers: list[WorkerPoolSpec] = []
+    requirements: dict[str, dict[str, Any]] = {}
+
+    for pool in spec.workers:
+        if pool.capacity_mode() != "reserved":
+            resolved_workers.append(pool)
+            continue
+        selector_kind = pool.reservation_selector_kind()
+        selector = (
+            pool.capacity_block_group
+            if selector_kind == "id"
+            else pool.capacity_block_group_name
+        )
+        if selector_kind == "id":
+            matches = [
+                item
+                for item in items
+                if isinstance(item, dict)
+                and str((item.get("metadata") or {}).get("id") or "") == selector
+            ]
+            if not matches:
+                # Distinguish a wrong-tenant ID from a missing/unreadable one
+                # without echoing the private selector in public diagnostics.
+                try:
+                    foreign = _provider_json(
+                        [
+                            nebius_bin,
+                            "capacity",
+                            "capacity-block-group",
+                            "get",
+                            "--id",
+                            selector,
+                            "--format",
+                            "json",
+                        ],
+                        env=env,
+                        description="capacity-block selector lookup",
+                    )
+                except ValueError:
+                    foreign = {}
+                foreign_parent = str((foreign.get("metadata") or {}).get("parent_id") or "")
+                reason = (
+                    "belongs to another tenant"
+                    if foreign_parent and foreign_parent != tenant_id
+                    else "was not found in the selected tenant"
+                )
+                raise ValueError(
+                    f"worker pool {pool.name!r} capacity-block ID {reason}; "
+                    "refusing provider mutation"
+                )
+        else:
+            matches = [
+                item
+                for item in items
+                if isinstance(item, dict)
+                and str((item.get("metadata") or {}).get("name") or "") == selector
+            ]
+            if not matches:
+                raise ValueError(
+                    f"worker pool {pool.name!r} capacity-block name was not found "
+                    "in the selected tenant; refusing provider mutation"
+                )
+            if len(matches) > 1:
+                raise ValueError(
+                    f"worker pool {pool.name!r} capacity-block name is ambiguous "
+                    "in the selected tenant; use its immutable ID"
+                )
+        if len(matches) != 1:
+            raise ValueError(
+                f"worker pool {pool.name!r} capacity-block selector is ambiguous; "
+                "refusing provider mutation"
+            )
+        metadata = matches[0].get("metadata") or {}
+        reservation_id = str(metadata.get("id") or "")
+        block = blocks.get(reservation_id)
+        if not reservation_id or block is None:
+            raise ValueError(
+                f"worker pool {pool.name!r} capacity-block response is incomplete; "
+                "refusing provider mutation"
+            )
+        if block["parent_id"] != tenant_id:
+            raise ValueError(
+                f"worker pool {pool.name!r} capacity block belongs to another tenant"
+            )
+        if block["state"] != "STATE_ACTIVE":
+            raise ValueError(
+                f"worker pool {pool.name!r} capacity block is not active"
+            )
+        if block["region"] != region:
+            raise ValueError(
+                f"worker pool {pool.name!r} capacity-block region does not match {region}"
+            )
+        if block["platform"] != pool.platform:
+            raise ValueError(
+                f"worker pool {pool.name!r} capacity-block platform does not match "
+                f"{pool.platform}"
+            )
+        if block["fabric"] != pool.fabric:
+            raise ValueError(
+                f"worker pool {pool.name!r} capacity-block fabric does not match "
+                f"{pool.fabric}"
+            )
+        required_gpus = pool.size * _gpu_count_from_preset(pool.preset)
+        advice_matches = [
+            item
+            for item in advice_items
+            if isinstance(item, dict)
+            and str(((item.get("spec") or {}).get("compute_instance") or {}).get("platform") or "")
+            == pool.platform
+            and str(
+                ((((item.get("spec") or {}).get("compute_instance") or {}).get("preset") or {}).get("name"))
+                or ""
+            )
+            == pool.preset
+            and str((item.get("spec") or {}).get("region") or "") == region
+            and str((item.get("spec") or {}).get("fabric") or "") == pool.fabric
+        ]
+        if len(advice_matches) != 1:
+            raise ValueError(
+                f"worker pool {pool.name!r} reserved preset availability is "
+                "missing or ambiguous; refusing provider mutation"
+            )
+        reserved_advice = (advice_matches[0].get("status") or {}).get("reserved") or {}
+        advice_is_fresh = (
+            isinstance(reserved_advice, dict)
+            and reserved_advice.get("data_state") == "DATA_STATE_FRESH"
+            and reserved_advice.get("available") is not None
+        )
+        available_nodes: int | None = None
+        if advice_is_fresh:
+            try:
+                available_nodes = int(reserved_advice["available"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"worker pool {pool.name!r} reserved preset availability is invalid; "
+                    "refusing provider mutation"
+                ) from exc
+        previous = requirements.get(reservation_id)
+        if previous and (
+            previous["platform"] != pool.platform
+            or previous["fabric"] != pool.fabric
+            or previous["preset"] != pool.preset
+        ):
+            raise ValueError(
+                "one capacity block cannot back incompatible Soperator worker pools"
+            )
+        requirement = previous or {
+            "platform": pool.platform,
+            "fabric": pool.fabric,
+            "preset": pool.preset,
+            "required_gpus": 0,
+            "required_nodes": 0,
+            "available_gpus": block["available_gpus"],
+            "available_nodes": available_nodes,
+            "pools": [],
+        }
+        requirement["required_gpus"] += required_gpus
+        requirement["required_nodes"] += pool.size
+        if requirement["available_nodes"] is None or available_nodes is None:
+            requirement["available_nodes"] = None
+        else:
+            requirement["available_nodes"] = min(
+                requirement["available_nodes"], available_nodes
+            )
+        requirement["pools"].append(pool.name)
+        requirements[reservation_id] = requirement
+        resolved_workers.append(
+            replace(pool, resolved_capacity_block_group_id=reservation_id)
+        )
+
+    for reservation_id, requirement in requirements.items():
+        available = requirement["available_gpus"]
+        if available is None:
+            raise ValueError(
+                "reserved GPU availability is unavailable; refusing provider mutation"
+            )
+        already_applied = existing_usage.get(
+            (reservation_id, requirement["preset"]), 0
+        )
+        additional = max(0, requirement["required_gpus"] - already_applied)
+        if available < additional:
+            pools = ", ".join(sorted(requirement["pools"]))
+            raise ValueError(
+                f"reserved capacity is insufficient for worker pool(s) {pools}: "
+                f"needs {additional} additional GPUs, only {available} are available; "
+                "STRICT reservation-backed workers cannot fall back to on-demand "
+                "or preemptible capacity"
+            )
+        gpus_per_node = _gpu_count_from_preset(requirement["preset"])
+        already_applied_nodes = already_applied // gpus_per_node
+        additional_nodes = max(
+            0, requirement["required_nodes"] - already_applied_nodes
+        )
+        if additional_nodes and requirement["available_nodes"] is None:
+            pools = ", ".join(sorted(requirement["pools"]))
+            raise ValueError(
+                f"worker pool(s) {pools} reserved preset availability is stale "
+                "or unavailable; refusing provider mutation"
+            )
+        if (
+            additional_nodes
+            and requirement["available_nodes"] < additional_nodes
+        ):
+            pools = ", ".join(sorted(requirement["pools"]))
+            raise ValueError(
+                f"reserved preset capacity is insufficient for worker pool(s) "
+                f"{pools}: needs {additional_nodes} additional node(s), only "
+                f"{requirement['available_nodes']} are available for preset "
+                f"{requirement['preset']}; STRICT reservation-backed workers "
+                "cannot fall back to on-demand or preemptible capacity"
+            )
+    resolved = replace(spec, workers=resolved_workers)
+    _log(
+        on_status,
+        f"reserved-capacity preflight passed: {len(reserved_pools)} worker pool(s), "
+        f"{len(requirements)} active capacity block group(s)",
+    )
+    return resolved, worker_capacity_summary(resolved, reservations_verified=True)
 
 
 def _log(on_status: Callable[[str], None] | None, message: str) -> None:
@@ -205,24 +969,6 @@ def _resolve_root_login_ssh_public_key(
     )
 
 
-def _with_resolved_ssh_public_keys(
-    spec: SoperatorSpec, *, home: Path | None = None
-) -> SoperatorSpec:
-    """Compatibility wrapper returning *spec* with its canonical root-login key."""
-
-    resolved = _resolve_root_login_ssh_public_key(spec, home=home)
-    if (
-        spec.root_login_ssh_public_key == resolved.value
-        and not spec.ssh_public_keys
-    ):
-        return spec
-    return replace(
-        spec,
-        root_login_ssh_public_key=resolved.value,
-        ssh_public_keys=[],
-    )
-
-
 def _validate_immutable_solutions_library_ref(ref: str) -> str:
     normalized = ref.strip().lower()
     if not _IMMUTABLE_GIT_REF_RE.fullmatch(normalized):
@@ -233,8 +979,183 @@ def _validate_immutable_solutions_library_ref(ref: str) -> str:
     return normalized
 
 
+@contextmanager
+def _solutions_library_lock(work_root: Path):
+    """Serialize source reconciliation without locking Terraform operations."""
+
+    work_root.mkdir(parents=True, exist_ok=True)
+    lock_path = work_root / ".solutions-library.lock"
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    os.fchmod(descriptor, 0o600)
+    try:
+        with os.fdopen(descriptor, "a+") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            yield
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    except BaseException:
+        # ``os.fdopen`` owns the descriptor once entered; close it only when an
+        # exception happened before ownership transferred.
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise
+
+
+def _git_capture(
+    git: str,
+    repo_root: Path,
+    args: list[str],
+    *,
+    timeout: int = 600,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [git, "-C", str(repo_root), *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _reconcile_existing_solutions_library_checkout(
+    repo_root: Path,
+    *,
+    ref: str,
+    git: str,
+) -> None:
+    """Move a clean legacy checkout to *ref* without touching untracked state."""
+
+    inside = _git_capture(git, repo_root, ["rev-parse", "--is-inside-work-tree"])
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        raise SolutionsLibraryReconciliationError(
+            f"existing solutions-library path {repo_root} is not a Git checkout; "
+            "move it aside only after preserving its installations/Terraform state"
+        )
+
+    head = _git_capture(git, repo_root, ["rev-parse", "HEAD"])
+    actual = head.stdout.strip().lower() if head.returncode == 0 else ""
+    symbolic_ref = _git_capture(git, repo_root, ["symbolic-ref", "-q", "HEAD"])
+    if actual == ref:
+        if symbolic_ref.returncode == 0:
+            detached = _git_capture(git, repo_root, ["checkout", "--detach", ref])
+            if detached.returncode != 0:
+                raise SolutionsLibraryReconciliationError(
+                    "the solutions-library checkout is at the pinned commit but could "
+                    "not detach from its moving branch; preserve its installation state, "
+                    "resolve the reported Git conflict, and retry"
+                )
+        # The later contract assertion accepts only pristine source plus NPA's
+        # exact idempotent patches, and rejects every other tracked mutation.
+        return
+
+    if symbolic_ref.returncode != 0 and actual:
+        raise SolutionsLibraryReconciliationError(
+            "existing solutions-library checkout is already detached at a different "
+            f"immutable commit ({actual[:12]}); retry with that installation's ref or "
+            "use a separate work root. The checkout and Terraform state were unchanged"
+        )
+
+    tracked = _git_capture(
+        git,
+        repo_root,
+        ["status", "--porcelain", "--untracked-files=no"],
+    )
+    if tracked.returncode != 0:
+        raise SolutionsLibraryReconciliationError(
+            "could not inspect the existing solutions-library checkout; no files were changed"
+        )
+    if tracked.stdout.strip():
+        raise SolutionsLibraryReconciliationError(
+            "existing solutions-library checkout has tracked changes and cannot be migrated "
+            "safely; commit, stash, or revert the tracked changes and retry. Untracked "
+            "installations/Terraform state were preserved"
+        )
+
+    present = _git_capture(git, repo_root, ["cat-file", "-e", f"{ref}^{{commit}}"])
+    if present.returncode != 0:
+        fetched = _git_capture(git, repo_root, ["fetch", "--no-tags", "origin", ref])
+        if fetched.returncode != 0:
+            raise SolutionsLibraryReconciliationError(
+                "the pinned solutions-library commit is missing from this checkout and "
+                f"`git fetch origin {ref}` failed; restore network/remote access and retry. "
+                "The checkout and all installation state were left unchanged"
+            )
+        present = _git_capture(git, repo_root, ["cat-file", "-e", f"{ref}^{{commit}}"])
+        if present.returncode != 0:
+            raise SolutionsLibraryReconciliationError(
+                "the solutions-library fetch completed but the pinned commit is still "
+                "unavailable; verify the origin remote and retry. No state was removed"
+            )
+
+    checked_out = _git_capture(git, repo_root, ["checkout", "--detach", ref])
+    if checked_out.returncode != 0:
+        raise SolutionsLibraryReconciliationError(
+            "could not check out the pinned solutions-library commit, commonly because an "
+            "untracked file conflicts with the pinned tree; move only the reported conflict "
+            "aside and retry. Installations/Terraform state were not deleted"
+        )
+    verified = _git_capture(git, repo_root, ["rev-parse", "HEAD"])
+    if verified.returncode != 0 or verified.stdout.strip().lower() != ref:
+        raise SolutionsLibraryReconciliationError(
+            "solutions-library checkout did not reach the requested immutable commit"
+        )
+
+
+def _clone_solutions_library_atomically(
+    clone_dir: Path,
+    *,
+    ref: str,
+    git: str,
+) -> None:
+    """Publish a complete checkout atomically; never expose a partial clone."""
+
+    with tempfile.TemporaryDirectory(
+        prefix=f".{clone_dir.name}.clone-",
+        dir=clone_dir.parent,
+    ) as temp_root:
+        candidate = Path(temp_root) / "checkout"
+        cloned = subprocess.run(
+            [
+                git,
+                "clone",
+                "--filter=blob:none",
+                "--no-checkout",
+                _SOLUTIONS_LIBRARY_REPO,
+                str(candidate),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=600,
+            check=False,
+        )
+        if cloned.returncode != 0:
+            raise SolutionsLibraryReconciliationError(
+                "could not clone the solutions library; restore GitHub/network access and retry"
+            )
+        present = _git_capture(git, candidate, ["cat-file", "-e", f"{ref}^{{commit}}"])
+        if present.returncode != 0:
+            fetched = _git_capture(git, candidate, ["fetch", "--no-tags", "origin", ref])
+            if fetched.returncode != 0:
+                raise SolutionsLibraryReconciliationError(
+                    "the fresh clone could not fetch the pinned solutions-library commit"
+                )
+        checked_out = _git_capture(git, candidate, ["checkout", "--detach", ref])
+        if checked_out.returncode != 0:
+            raise SolutionsLibraryReconciliationError(
+                "the fresh clone could not check out the pinned solutions-library commit"
+            )
+        if not (candidate / "soperator" / "installations" / "example").is_dir():
+            raise SolutionsLibraryReconciliationError(
+                "the pinned solutions-library checkout is missing soperator/installations/example"
+            )
+        os.replace(candidate, clone_dir)
+
+
 def _resolve_solutions_library(terraform_dir: Path | None, work_root: Path, ref: str) -> Path:
-    """Resolve a checkout of one immutable solutions-library commit."""
+    """Resolve and safely reconcile one immutable solutions-library commit."""
 
     ref = _validate_immutable_solutions_library_ref(ref)
 
@@ -245,27 +1166,41 @@ def _resolve_solutions_library(terraform_dir: Path | None, work_root: Path, ref:
                 f"{path} is not a soperator recipe dir (missing installations/example)"
             )
         return path
-    # Preserve the historical default location when it exists so an already
-    # deployed installation keeps using its Terraform state. The contract
-    # assertion immediately after resolution still requires its HEAD to equal
-    # the requested immutable commit and permits only NPA's two known patches.
-    legacy_clone = work_root / "nebius-solutions-library"
-    if (legacy_clone / "soperator" / "installations" / "example").exists():
-        return legacy_clone / "soperator"
-    clone_dir = work_root / f"nebius-solutions-library-{ref[:12]}"
-    if not (clone_dir / "soperator" / "installations" / "example").exists():
-        work_root.mkdir(parents=True, exist_ok=True)
-        git = _require_bin("git")
-        _run_stream(
-            [git, "clone", "--filter=blob:none", "--no-checkout", _SOLUTIONS_LIBRARY_REPO, str(clone_dir)],
-            timeout=600,
-        )
-        _run_stream(
-            [git, "checkout", "--detach", ref],
-            cwd=clone_dir,
-            timeout=600,
-        )
-    return clone_dir / "soperator"
+    git = _require_bin("git")
+    with _solutions_library_lock(work_root):
+        # Preserve and migrate the historical default location in place so its
+        # untracked installations, Terraform state, and operator files retain
+        # both path identity and bytes.
+        legacy_clone = work_root / "nebius-solutions-library"
+        if legacy_clone.exists():
+            _reconcile_existing_solutions_library_checkout(
+                legacy_clone,
+                ref=ref,
+                git=git,
+            )
+            recipe = legacy_clone / "soperator"
+            if not (recipe / "installations" / "example").is_dir():
+                raise SolutionsLibraryReconciliationError(
+                    "the reconciled legacy solutions-library checkout is missing "
+                    "soperator/installations/example; no state was removed"
+                )
+            return recipe
+
+        clone_dir = work_root / f"nebius-solutions-library-{ref[:12]}"
+        if clone_dir.exists():
+            _reconcile_existing_solutions_library_checkout(
+                clone_dir,
+                ref=ref,
+                git=git,
+            )
+        else:
+            _clone_solutions_library_atomically(clone_dir, ref=ref, git=git)
+        recipe = clone_dir / "soperator"
+        if not (recipe / "installations" / "example").is_dir():
+            raise SolutionsLibraryReconciliationError(
+                "the pinned solutions-library checkout is incomplete; no files were deleted"
+            )
+        return recipe
 
 
 def _nebius_cli_env() -> dict[str, str]:
@@ -344,6 +1279,80 @@ _NODECONFIGURATOR_USERNS_VALUES = (
     "                      sysctl -w net.ipv4.tcp_rmem=\"4096 131072 536870912\"\n"
     "                      sysctl -w net.ipv4.tcp_wmem=\"4096 16384 536870912\"\n"
 )
+_STABLE_KUBECTL_CONTEXT_MARKER = "# npa: refresh credentials only when the cluster id changes"
+_STABLE_LOGIN_IP_MARKER = "# npa: regenerate the login script only when its public IP changes"
+
+
+def _patch_kubectl_context_trigger_text(text: str) -> tuple[str, bool]:
+    """Remove the pinned recipe's perpetual timestamp replacement trigger."""
+
+    if _STABLE_KUBECTL_CONTEXT_MARKER in text:
+        return text, False
+    original = (
+        "  triggers_replace = [\n"
+        "    nebius_mk8s_v1_cluster.this.id,\n"
+        "    timestamp(),\n"
+        "  ]\n"
+    )
+    if text.count(original) != 1:
+        raise UpstreamContractError(
+            "pinned kubectl context trigger does not match the verified timestamp contract"
+        )
+    replacement = (
+        "  " + _STABLE_KUBECTL_CONTEXT_MARKER + "\n"
+        "  triggers_replace = [\n"
+        "    nebius_mk8s_v1_cluster.this.id,\n"
+        "  ]\n"
+    )
+    return text.replace(original, replacement, 1), True
+
+
+def _patch_login_ip_trigger_text(text: str) -> tuple[str, bool]:
+    """Key the local login script refresh to its IP, not Service metadata churn."""
+
+    if _STABLE_LOGIN_IP_MARKER in text:
+        return text, False
+    original = (
+        "  triggers_replace = [\n"
+        "    one(data.kubernetes_service_v1.slurm_login.metadata).resource_version\n"
+        "  ]\n"
+    )
+    if text.count(original) != 1:
+        raise UpstreamContractError(
+            "pinned login-script trigger does not match the verified Service contract"
+        )
+    replacement = (
+        "  " + _STABLE_LOGIN_IP_MARKER + "\n"
+        "  triggers_replace = [\n"
+        "    one(one(one(data.kubernetes_service_v1.slurm_login.status).load_balancer).ingress).ip\n"
+        "  ]\n"
+    )
+    return text.replace(original, replacement, 1), True
+
+
+def _patch_stable_local_reconciliation_triggers(recipe_dir: Path) -> bool:
+    """Stabilize two local-only resources that otherwise replace every reconcile."""
+
+    targets = (
+        (
+            recipe_dir / "modules" / "k8s" / "k8s_cluster.tf",
+            _patch_kubectl_context_trigger_text,
+        ),
+        (
+            recipe_dir / "modules" / "login" / "main.tf",
+            _patch_login_ip_trigger_text,
+        ),
+    )
+    staged: list[tuple[Path, str]] = []
+    for path, transform in targets:
+        if not path.is_file():
+            raise UpstreamContractError(f"missing pinned local reconciliation target {path}")
+        patched, target_changed = transform(path.read_text())
+        if target_changed:
+            staged.append((path, patched))
+    for path, patched in staged:
+        path.write_text(patched)
+    return bool(staged)
 
 
 def _patch_active_checks_text(text: str) -> tuple[str, bool]:
@@ -563,6 +1572,14 @@ def _assert_solutions_library_contract(
 
     patch_contracts = (
         (
+            "soperator/modules/k8s/k8s_cluster.tf",
+            _patch_kubectl_context_trigger_text,
+        ),
+        (
+            "soperator/modules/login/main.tf",
+            _patch_login_ip_trigger_text,
+        ),
+        (
             "soperator/modules/slurm/locals_active_checks.tf",
             _patch_active_checks_text,
         ),
@@ -590,6 +1607,7 @@ def _prepare_installation(recipe_dir: Path, spec: SoperatorSpec, region: str) ->
     """Create installations/<name> with the recipe files + generated tfvars."""
 
     _patch_active_checks_locals(recipe_dir)
+    _patch_stable_local_reconciliation_triggers(recipe_dir)
     if not spec.use_default_apparmor_profile:
         _patch_nodeconfigurator_userns(recipe_dir)
     example = recipe_dir / "installations" / "example"
@@ -1141,6 +2159,164 @@ def _mid_apply_fix_loop(
             time.sleep(15)
 
 
+def _run_terraform_command(
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int,
+    stream_output: bool,
+) -> None:
+    """Run Terraform while preserving a machine-readable caller's stdout."""
+
+    if stream_output:
+        _run_stream(args, cwd=cwd, env=env, timeout=timeout)
+        return
+    completed = _run_capture(
+        args,
+        cwd=cwd,
+        env=env,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        from npa.clients.nebius import redact_nebius_output
+
+        detail = redact_nebius_output(
+            _tail_diagnostic(completed.stderr, completed.stdout)
+        )
+        raise RuntimeError(
+            f"Terraform command failed ({completed.returncode}): {' '.join(args[:2])}"
+            + (f": {detail}" if detail else "")
+        )
+
+
+@contextmanager
+def _terraform_plan_without_unsafe_replacements(
+    terraform_bin: str,
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int,
+    targets: tuple[str, ...] = (),
+    on_status: Callable[[str], None] | None = None,
+) -> Iterator[GuardedTerraformPlan]:
+    """Yield a saved plan after rejecting provider/unexpected destruction.
+
+    Applying the exact inspected plan closes the gap between a safety preflight
+    and Terraform's provider mutation. Plan files can contain sensitive values,
+    so they live in an owner-only temporary directory inside the installation
+    and are removed on every exit path. The pinned recipe has three audited
+    local-only refresh resources; their exact replacement addresses/providers
+    are allowed once while every other replacement or pure delete fails closed.
+    """
+
+    phase = ", ".join(targets) if targets else "full deployment"
+    _log(on_status, f"terraform replacement guard: planning {phase}")
+    with tempfile.TemporaryDirectory(prefix=".npa-plan-", dir=cwd) as temporary:
+        temporary_path = Path(temporary)
+        temporary_path.chmod(0o700)
+        plan_path = temporary_path / "deploy.tfplan"
+        plan_command = [
+            terraform_bin,
+            "plan",
+            "-input=false",
+            "-detailed-exitcode",
+            f"-out={plan_path}",
+            *(f"-target={target}" for target in targets),
+        ]
+        try:
+            planned = _run_capture(
+                plan_command,
+                cwd=cwd,
+                env=env,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                "Terraform replacement-guard plan timed out before provider mutation"
+            ) from exc
+        if planned.returncode not in (0, 2):
+            from npa.clients.nebius import redact_nebius_output
+
+            detail = redact_nebius_output(
+                _tail_diagnostic(planned.stderr, planned.stdout)
+            )
+            raise RuntimeError(
+                f"Terraform replacement-guard plan failed ({planned.returncode}) "
+                "before provider mutation"
+                + (f": {detail}" if detail else "")
+            )
+        if not plan_path.is_file():
+            raise RuntimeError(
+                "Terraform replacement-guard plan did not produce a saved plan; "
+                "no provider mutation was attempted"
+            )
+        plan_path.chmod(0o600)
+
+        try:
+            shown = _run_capture(
+                [terraform_bin, "show", "-json", str(plan_path)],
+                cwd=cwd,
+                env=env,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                "Terraform replacement-guard plan inspection timed out before "
+                "provider mutation"
+            ) from exc
+        if shown.returncode != 0:
+            from npa.clients.nebius import redact_nebius_output
+
+            detail = redact_nebius_output(_tail_diagnostic(shown.stderr, shown.stdout))
+            raise RuntimeError(
+                "Terraform replacement-guard plan inspection failed before provider mutation"
+                + (f": {detail}" if detail else "")
+            )
+        try:
+            plan = json.loads(shown.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                "Terraform replacement-guard plan inspection returned invalid JSON; "
+                "no provider mutation was attempted"
+            ) from exc
+        resource_changes = plan.get("resource_changes", [])
+        if not isinstance(resource_changes, list):
+            raise RuntimeError(
+                "Terraform replacement-guard plan omitted a valid resource_changes list; "
+                "no provider mutation was attempted"
+            )
+        safe_local_replacements: list[str] = []
+        unsafe_destructive_actions: list[str] = []
+        for change in resource_changes:
+            if not isinstance(change, dict) or not isinstance(change.get("change"), dict):
+                continue
+            actions = change["change"].get("actions")
+            if not isinstance(actions, list) or "delete" not in actions:
+                continue
+            address = str(change.get("address") or "<unknown-resource>")
+            provider = str(change.get("provider_name") or "<unknown-provider>")
+            replacement = "create" in actions
+            if replacement and (address, provider) in _SAFE_LOCAL_RECONCILIATION_REPLACEMENTS:
+                safe_local_replacements.append(address)
+            else:
+                unsafe_destructive_actions.append(address)
+        if unsafe_destructive_actions:
+            raise ProviderReplacementPlanError(sorted(unsafe_destructive_actions))
+        _log(
+            on_status,
+            "terraform replacement guard passed: 0 provider/unexpected destructive "
+            f"actions; safe local refresh replacements={len(safe_local_replacements)}",
+        )
+        yield GuardedTerraformPlan(
+            path=plan_path,
+            safe_local_replacements=tuple(sorted(safe_local_replacements)),
+        )
+
+
 def deploy_cluster(
     spec: SoperatorSpec,
     *,
@@ -1150,12 +2326,16 @@ def deploy_cluster(
     root_login_ssh_public_key_file: Path | None = None,
     project: str | None = None,
     timeout_minutes: int = 90,
+    gpu_creation_check_timeout_seconds: int = DEFAULT_GPU_CREATION_CHECK_TIMEOUT_SECONDS,
     apply_fixes: bool = True,
+    source_preflight_only: bool = False,
+    stream_terraform_output: bool = True,
     on_status: Callable[[str], None] | None = None,
 ) -> dict[str, Any]:
     """Deploy or reconcile *spec* after pinned-contract and key preflight."""
 
     spec.validate()
+    _validate_gpu_creation_check_timeout(gpu_creation_check_timeout_seconds)
     root_login_key = _resolve_root_login_ssh_public_key(
         spec, explicit_file=root_login_ssh_public_key_file
     )
@@ -1170,31 +2350,55 @@ def deploy_cluster(
         "login-node root SSH access enabled: "
         f"source={root_login_key.source}; fingerprint={root_login_key.fingerprint}",
     )
-    envcfg = resolve_environment(
-        project=project,
-        project_id=spec.project_id or None,
-        tenant_id=spec.tenant_id or None,
-        region=spec.region or None,
-    )
-    region = spec.region or envcfg.region
-    tenant_id = spec.tenant_id or envcfg.tenant_id
-    project_id = spec.project_id or envcfg.project_id
-    if not (region and tenant_id and project_id):
-        raise ValueError(
-            "region, tenant_id and project_id must be resolvable from the spec or ~/.npa config"
-        )
-
-    terraform_bin = _require_bin(os.environ.get("NPA_TERRAFORM_BIN") or "terraform")
-    nebius_bin = _require_bin(os.environ.get("NPA_NEBIUS_BIN") or "nebius")
-
     work_root = (work_root or Path.home() / ".npa" / "soperator").expanduser()
     recipe_dir = _resolve_solutions_library(terraform_dir, work_root, solutions_library_ref)
     _assert_solutions_library_contract(recipe_dir, ref=solutions_library_ref)
     _log(on_status, f"verified solutions-library contract {solutions_library_ref[:12]}")
+    region, tenant_id, project_id, persisted_subnet_id, _saved = (
+        _resolve_deploy_environment(spec, recipe_dir, project=project)
+    )
+    if source_preflight_only:
+        result = {
+            "name": spec.name,
+            "region": region,
+            "install_dir": str(recipe_dir / "installations" / spec.name),
+            "kube_context": f"nebius-{spec.name}-slurm",
+            "worker_pools": [pool.name for pool in spec.workers],
+            "docker_cache_pools": [pool.name for pool in spec.workers if pool.docker_cache],
+            "control_plane": {
+                "system_min_size": spec.system_min_size,
+                "system_max_size": spec.effective_system_max_size(),
+            },
+            "workers": worker_capacity_summary(spec),
+            "solutions_library_ref": solutions_library_ref,
+            "status": "source-preflight-passed",
+            "provider_mutation": False,
+        }
+        _log(
+            on_status,
+            f"deploy source preflight passed: {spec.name}; provider mutation disabled",
+        )
+        return result
+
+    terraform_bin = _require_bin(os.environ.get("NPA_TERRAFORM_BIN") or "terraform")
+    nebius_bin = _require_bin(os.environ.get("NPA_NEBIUS_BIN") or "nebius")
+    install_dir = recipe_dir / "installations" / spec.name
+    spec, capacity_workers = _resolve_reserved_worker_capacity(
+        spec,
+        install_dir=install_dir,
+        nebius_bin=nebius_bin,
+        tenant_id=tenant_id,
+        project_id=project_id,
+        region=region,
+        env=_nebius_cli_env(),
+        on_status=on_status,
+    )
     install_dir = _prepare_installation(recipe_dir, spec, region)
     _log(on_status, f"Installation dir: {install_dir}")
 
-    subnet_id = spec.subnet_id or _resolve_subnet(nebius_bin, project_id, _nebius_cli_env())
+    subnet_id = persisted_subnet_id or _resolve_subnet(
+        nebius_bin, project_id, _nebius_cli_env()
+    )
     env = _soperator_tf_env(
         nebius_bin,
         region=region,
@@ -1202,19 +2406,35 @@ def deploy_cluster(
         project_id=project_id,
         subnet_id=subnet_id,
     )
-    # Persist the env the recipe requires so ``destroy`` can reconstruct it.
-    _write_env_sidecar(
-        install_dir,
-        region=region,
-        tenant_id=tenant_id,
-        project_id=project_id,
-        subnet_id=subnet_id,
-        o11y_profile=env["TF_VAR_o11y_profile"],
-    )
+    sidecar_persisted = False
+
+    def persist_identity_before_apply() -> None:
+        """Checkpoint the guarded identity immediately before provider mutation."""
+
+        nonlocal sidecar_persisted
+        if sidecar_persisted:
+            return
+        _write_env_sidecar(
+            install_dir,
+            region=region,
+            tenant_id=tenant_id,
+            project_id=project_id,
+            subnet_id=subnet_id,
+            o11y_profile=env["TF_VAR_o11y_profile"],
+        )
+        sidecar_persisted = True
 
     context = f"nebius-{spec.name}-slurm"
+    replacement_plans_checked = 0
+    safe_local_replacements_applied = 0
     _log(on_status, "terraform init")
-    _run_stream([terraform_bin, "init"], cwd=install_dir, env=env, timeout=900)
+    _run_terraform_command(
+        [terraform_bin, "init"],
+        cwd=install_dir,
+        env=env,
+        timeout=900,
+        stream_output=stream_terraform_output,
+    )
 
     if apply_fixes:
         # Two-phase apply: the soperator operator HelmRelease is reconciled inside
@@ -1226,12 +2446,26 @@ def deploy_cluster(
         # install cleanly in phase 2.
         kubectl_bin = _require_bin(os.environ.get("NPA_KUBECTL_BIN") or "kubectl")
         _log(on_status, "terraform apply (phase 1: k8s cluster + node groups)")
-        _run_stream(
-            [terraform_bin, "apply", "-target=module.k8s", "-auto-approve"],
+        with _terraform_plan_without_unsafe_replacements(
+            terraform_bin,
             cwd=install_dir,
             env=env,
             timeout=timeout_minutes * 60,
-        )
+            targets=("module.k8s",),
+            on_status=on_status,
+        ) as guarded_plan:
+            replacement_plans_checked += 1
+            safe_local_replacements_applied += len(
+                guarded_plan.safe_local_replacements
+            )
+            persist_identity_before_apply()
+            _run_terraform_command(
+                [terraform_bin, "apply", str(guarded_plan.path)],
+                cwd=install_dir,
+                env=env,
+                timeout=timeout_minutes * 60,
+                stream_output=stream_terraform_output,
+            )
         cluster_id = _terraform_cluster_id(terraform_bin, install_dir, env)
         if cluster_id:
             _log(on_status, "refreshing kube admin credentials")
@@ -1252,25 +2486,50 @@ def deploy_cluster(
             kwargs={"stop": stop, "on_status": on_status},
             daemon=True,
         )
-        fixer.start()
-        try:
-            _run_stream(
-                [terraform_bin, "apply", "-auto-approve"],
-                cwd=install_dir,
-                env=env,
-                timeout=timeout_minutes * 60,
-            )
-        finally:
-            stop.set()
-            fixer.join(timeout=10)
-    else:
-        _log(on_status, f"terraform apply ({len(spec.workers)} worker pool(s))")
-        _run_stream(
-            [terraform_bin, "apply", "-auto-approve"],
+        with _terraform_plan_without_unsafe_replacements(
+            terraform_bin,
             cwd=install_dir,
             env=env,
             timeout=timeout_minutes * 60,
-        )
+            on_status=on_status,
+        ) as guarded_plan:
+            replacement_plans_checked += 1
+            safe_local_replacements_applied += len(
+                guarded_plan.safe_local_replacements
+            )
+            fixer.start()
+            try:
+                _run_terraform_command(
+                    [terraform_bin, "apply", str(guarded_plan.path)],
+                    cwd=install_dir,
+                    env=env,
+                    timeout=timeout_minutes * 60,
+                    stream_output=stream_terraform_output,
+                )
+            finally:
+                stop.set()
+                fixer.join(timeout=10)
+    else:
+        _log(on_status, f"terraform apply ({len(spec.workers)} worker pool(s))")
+        with _terraform_plan_without_unsafe_replacements(
+            terraform_bin,
+            cwd=install_dir,
+            env=env,
+            timeout=timeout_minutes * 60,
+            on_status=on_status,
+        ) as guarded_plan:
+            replacement_plans_checked += 1
+            safe_local_replacements_applied += len(
+                guarded_plan.safe_local_replacements
+            )
+            persist_identity_before_apply()
+            _run_terraform_command(
+                [terraform_bin, "apply", str(guarded_plan.path)],
+                cwd=install_dir,
+                env=env,
+                timeout=timeout_minutes * 60,
+                stream_output=stream_terraform_output,
+            )
 
     result: dict[str, Any] = {
         "name": spec.name,
@@ -1280,6 +2539,17 @@ def deploy_cluster(
         "kube_context": context,
         "worker_pools": [p.name for p in spec.workers],
         "docker_cache_pools": [p.name for p in spec.workers if p.docker_cache],
+        "control_plane": {
+            "system_min_size": spec.system_min_size,
+            "system_max_size": spec.effective_system_max_size(),
+        },
+        "workers": capacity_workers,
+        "replacement_guard": {
+            "status": "passed",
+            "plans_checked": replacement_plans_checked,
+            "replacement_count": 0,
+            "safe_local_replacements_applied": safe_local_replacements_applied,
+        },
     }
 
     if apply_fixes:
@@ -1290,13 +2560,45 @@ def deploy_cluster(
 
     # GPU validation is a deploy contract, not an optional repair. Keep it
     # active even when an operator deliberately selects --skip-fixes.
-    kubectl_bin = _require_bin(os.environ.get("NPA_KUBECTL_BIN") or "kubectl")
-    result["gpu_creation_checks"] = _run_gpu_creation_checks(
-        spec,
-        context,
-        kubectl_bin,
-        on_status=on_status,
-    )
+    if any(pool.is_gpu() for pool in spec.workers):
+        try:
+            kubectl_bin = _require_bin(os.environ.get("NPA_KUBECTL_BIN") or "kubectl")
+            result["gpu_creation_checks"] = _run_gpu_creation_checks(
+                spec,
+                context,
+                kubectl_bin,
+                timeout_seconds=gpu_creation_check_timeout_seconds,
+                on_status=on_status,
+            )
+        except GPUCreationCheckError as exc:
+            result["gpu_creation_checks"] = exc.completed_checks
+            failure = DeploymentValidationFailure(
+                code="gpu_creation_check_failed",
+                message=str(exc),
+                check="gpu-creation",
+                pool=exc.pool,
+                phase=exc.phase,
+                cleanup_confirmed=exc.cleanup_confirmed,
+            )
+            raise SoperatorDeploymentValidationError(result, failure) from exc
+        except Exception as exc:
+            result["gpu_creation_checks"] = []
+            failure = DeploymentValidationFailure(
+                code="gpu_creation_check_failed",
+                message=f"GPU creation-check preflight failed: {exc}",
+                check="gpu-creation",
+                phase="preflight",
+            )
+            raise SoperatorDeploymentValidationError(result, failure) from exc
+    else:
+        result["gpu_creation_checks"] = []
+
+    result["status"] = "ready"
+    result["deployment_status"] = "applied"
+    result["validation"] = {
+        "status": "passed",
+        "check": "gpu-creation",
+    }
 
     return result
 
@@ -1309,18 +2611,30 @@ def destroy_cluster(
     solutions_library_ref: str = DEFAULT_SOLUTIONS_LIBRARY_REF,
     project: str | None = None,
     timeout_minutes: int = 90,
+    source_preflight_only: bool = False,
     on_status: Callable[[str], None] | None = None,
-) -> None:
+) -> dict[str, Any] | None:
     """Destroy an npa-managed soperator cluster by name."""
 
-    terraform_bin = _require_bin(os.environ.get("NPA_TERRAFORM_BIN") or "terraform")
-    nebius_bin = _require_bin(os.environ.get("NPA_NEBIUS_BIN") or "nebius")
     work_root = (work_root or Path.home() / ".npa" / "soperator").expanduser()
     recipe_dir = _resolve_solutions_library(terraform_dir, work_root, solutions_library_ref)
     _assert_solutions_library_contract(recipe_dir, ref=solutions_library_ref)
     install_dir = recipe_dir / "installations" / name
     if not install_dir.exists():
         raise ValueError(f"no installation found for cluster {name!r} at {install_dir}")
+    if source_preflight_only:
+        result = {
+            "name": name,
+            "status": "source-preflight-passed",
+            "install_dir": str(install_dir),
+            "solutions_library_ref": solutions_library_ref,
+            "provider_mutation": False,
+        }
+        _log(on_status, f"destroy source preflight passed: {name}; provider mutation disabled")
+        return result
+
+    terraform_bin = _require_bin(os.environ.get("NPA_TERRAFORM_BIN") or "terraform")
+    nebius_bin = _require_bin(os.environ.get("NPA_NEBIUS_BIN") or "nebius")
 
     # ``terraform destroy`` still parses the config, so the region/tenant/project/
     # subnet/o11y variables (passed as env at apply time, never written to
@@ -1622,12 +2936,257 @@ def _gpu_count_from_preset(preset: str) -> int:
     return int(match.group(1))
 
 
+def _validate_gpu_creation_check_timeout(timeout_seconds: int) -> int:
+    """Validate the independent end-to-end GPU creation-check budget."""
+
+    if (
+        isinstance(timeout_seconds, bool)
+        or not isinstance(timeout_seconds, int)
+        or timeout_seconds < 1
+    ):
+        raise ValueError(
+            "gpu creation-check timeout must be an integer of at least 1 second"
+        )
+    return timeout_seconds
+
+
+def _tail_diagnostic(*parts: str | bytes | None) -> str:
+    text_parts: list[str] = []
+    for part in parts:
+        if isinstance(part, bytes):
+            text_parts.append(part.decode(errors="replace"))
+        elif part:
+            text_parts.append(part)
+    return "\n".join("\n".join(text_parts).strip().splitlines()[-20:])
+
+
+def _slurm_time_limit(seconds: int) -> str:
+    """Render a Slurm wall-time value without dropping a sub-minute remainder."""
+
+    days, remainder = divmod(max(1, seconds), 24 * 60 * 60)
+    hours, remainder = divmod(remainder, 60 * 60)
+    minutes, seconds = divmod(remainder, 60)
+    clock = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+    return f"{days}-{clock}" if days else clock
+
+
+def _slurm_exec_command(
+    kubectl_bin: str,
+    context: str,
+    namespace: str,
+    pod: str,
+    container: str | None,
+    args: list[str],
+    *,
+    jailed: bool = False,
+) -> list[str]:
+    command = [
+        kubectl_bin,
+        "--context",
+        context,
+        "exec",
+        "-n",
+        namespace,
+        pod,
+    ]
+    if container:
+        command += ["-c", container]
+    command += ["--"]
+    if jailed:
+        command += ["chroot", "/mnt/jail"]
+    return [*command, *args]
+
+
+def _discover_slurm_gpu_nodes(
+    spec: SoperatorSpec,
+    context: str,
+    kubectl_bin: str,
+    namespace: str,
+    *,
+    timeout_seconds: int,
+    kube_env: dict[str, str],
+) -> dict[str, list[str]]:
+    """Discover node names from Slurm and validate their spec-pool mapping."""
+
+    command = _slurm_exec_command(
+        kubectl_bin,
+        context,
+        namespace,
+        "controller-0",
+        "slurmctld",
+        ["sinfo", "-h", "-N", "-o", "%N"],
+    )
+    try:
+        completed = _run_capture(
+            command,
+            env=kube_env,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        diagnostic = _tail_diagnostic(exc.stderr, exc.stdout)
+        raise GPUCreationCheckError(
+            "GPU creation check timed out while discovering live Slurm nodes"
+            + (f":\n{diagnostic}" if diagnostic else ""),
+            pool=None,
+            phase="node-discovery",
+        ) from exc
+    if completed.returncode != 0:
+        diagnostic = _tail_diagnostic(completed.stderr, completed.stdout)
+        raise GPUCreationCheckError(
+            "GPU creation check could not query live Slurm nodes"
+            + (f":\n{diagnostic}" if diagnostic else ""),
+            pool=None,
+            phase="node-discovery",
+        )
+
+    discovered = sorted(
+        {
+            line.strip().split()[0]
+            for line in completed.stdout.splitlines()
+            if line.strip()
+        }
+    )
+    if not discovered:
+        raise GPUCreationCheckError(
+            "GPU creation check found no nodes in live Slurm state",
+            pool=None,
+            phase="node-discovery",
+        )
+
+    mapping: dict[str, list[str]] = {}
+    for pool in (worker for worker in spec.workers if worker.is_gpu()):
+        pattern = re.compile(rf"^{re.escape(pool.name)}-[0-9]+$")
+        nodes = [node for node in discovered if pattern.fullmatch(node)]
+        if len(nodes) != pool.size:
+            shown = ", ".join(discovered)
+            raise GPUCreationCheckError(
+                f"GPU creation check cannot map pool {pool.name!r}: expected "
+                f"{pool.size} live Slurm node(s) named {pool.name}-<index>, found "
+                f"{len(nodes)}; Slurm reported: {shown}. Verify the upstream "
+                "nodeset naming contract before retrying",
+                pool=pool.name,
+                phase="node-mapping",
+            )
+        mapping[pool.name] = nodes
+    return mapping
+
+
+def _cancel_and_verify_gpu_check_job(
+    context: str,
+    kubectl_bin: str,
+    namespace: str,
+    job_name: str,
+    *,
+    kube_env: dict[str, str],
+) -> tuple[bool, str]:
+    """Cancel one uniquely named gate job and prove it left Slurm's queue."""
+
+    scancel = _slurm_exec_command(
+        kubectl_bin,
+        context,
+        namespace,
+        "login-0",
+        None,
+        ["scancel", "--name", job_name],
+        jailed=True,
+    )
+    diagnostics: list[str] = []
+    try:
+        cancelled = _run_capture(
+            scancel,
+            env=kube_env,
+            check=False,
+            timeout=_GPU_CHECK_CLEANUP_TIMEOUT_SECONDS,
+        )
+        if cancelled.returncode != 0:
+            detail = _tail_diagnostic(cancelled.stderr, cancelled.stdout)
+            if detail:
+                diagnostics.append(f"scancel: {detail}")
+    except subprocess.TimeoutExpired:
+        diagnostics.append("scancel timed out")
+
+    squeue = _slurm_exec_command(
+        kubectl_bin,
+        context,
+        namespace,
+        "login-0",
+        None,
+        ["squeue", "--noheader", "--name", job_name, "--format=%A"],
+        jailed=True,
+    )
+    deadline = time.monotonic() + _GPU_CHECK_CLEANUP_TIMEOUT_SECONDS
+    while True:
+        remaining = max(1, int(deadline - time.monotonic()))
+        try:
+            queued = _run_capture(
+                squeue,
+                env=kube_env,
+                check=False,
+                timeout=remaining,
+            )
+        except subprocess.TimeoutExpired:
+            diagnostics.append("squeue cleanup verification timed out")
+            return False, "; ".join(diagnostics)
+        if queued.returncode == 0 and not queued.stdout.strip():
+            return True, "; ".join(diagnostics)
+        if queued.returncode != 0:
+            detail = _tail_diagnostic(queued.stderr, queued.stdout)
+            diagnostics.append("could not verify Slurm queue" + (f": {detail}" if detail else ""))
+            return False, "; ".join(diagnostics)
+        if time.monotonic() >= deadline:
+            diagnostics.append(f"job {job_name} remains in Slurm after cancellation")
+            return False, "; ".join(diagnostics)
+        time.sleep(1)
+
+
+def _verify_gpu_check_job_absent(
+    context: str,
+    kubectl_bin: str,
+    namespace: str,
+    job_name: str,
+    *,
+    kube_env: dict[str, str],
+) -> bool:
+    """Allow Slurm's completion accounting to settle, then prove queue absence."""
+
+    command = _slurm_exec_command(
+        kubectl_bin,
+        context,
+        namespace,
+        "login-0",
+        None,
+        ["squeue", "--noheader", "--name", job_name, "--format=%A"],
+        jailed=True,
+    )
+    deadline = time.monotonic() + _GPU_CHECK_CLEANUP_TIMEOUT_SECONDS
+    while True:
+        remaining = max(1, int(deadline - time.monotonic()))
+        try:
+            queued = _run_capture(
+                command,
+                env=kube_env,
+                check=False,
+                timeout=remaining,
+            )
+        except subprocess.TimeoutExpired:
+            return False
+        if queued.returncode != 0:
+            return False
+        if not queued.stdout.strip():
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(1)
+
+
 def _run_gpu_creation_checks(
     spec: SoperatorSpec,
     context: str,
     kubectl_bin: str,
     *,
     namespace: str = "soperator",
+    timeout_seconds: int = DEFAULT_GPU_CREATION_CHECK_TIMEOUT_SECONDS,
     on_status: Callable[[str], None] | None = None,
 ) -> list[dict[str, Any]]:
     """Run real CUDA samples on every GPU worker through the login jail.
@@ -1642,20 +3201,49 @@ def _run_gpu_creation_checks(
     Any failed/missing node or CUDA result fails the deploy.
     """
 
+    timeout_seconds = _validate_gpu_creation_check_timeout(timeout_seconds)
     checks: list[dict[str, Any]] = []
     kube_env = _nebius_cli_env()
-    for pool in (worker for worker in spec.workers if worker.is_gpu()):
+    gpu_pools = [worker for worker in spec.workers if worker.is_gpu()]
+    if not gpu_pools:
+        return checks
+    deadline = time.monotonic() + timeout_seconds
+    node_mapping = _discover_slurm_gpu_nodes(
+        spec,
+        context,
+        kubectl_bin,
+        namespace,
+        timeout_seconds=timeout_seconds,
+        kube_env=kube_env,
+    )
+    for pool in gpu_pools:
+        remaining = int(deadline - time.monotonic())
+        if remaining < 1:
+            raise GPUCreationCheckError(
+                f"GPU creation check exceeded its {timeout_seconds}-second end-to-end "
+                f"timeout before pool {pool.name!r} could start",
+                pool=pool.name,
+                phase="queue",
+                completed_checks=checks,
+            )
         gpu_count = _gpu_count_from_preset(pool.preset)
-        nodes = [f"{pool.name}-{index}" for index in range(pool.size)]
+        nodes = node_mapping[pool.name]
         node_list = ",".join(nodes)
         task_script = f"""
 set -uo pipefail
-gpu_count=$(nvidia-smi -L | wc -l)
+if ! gpu_inventory=$(nvidia-smi -L); then
+  echo "NPA_GPU_CREATION_CHECK_RESULT host=$(hostname) status=FAIL phase=nvidia-smi-inventory"
+  exit 1
+fi
+gpu_count=$(printf '%s\n' "$gpu_inventory" | wc -l)
 if [ "$gpu_count" -ne {gpu_count} ]; then
   echo "NPA_GPU_CREATION_CHECK_RESULT host=$(hostname) status=FAIL expected_gpus={gpu_count} actual_gpus=$gpu_count"
   exit 1
 fi
-gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader | sort -u)
+if ! gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader | sort -u); then
+  echo "NPA_GPU_CREATION_CHECK_RESULT host=$(hostname) status=FAIL phase=nvidia-smi-name"
+  exit 1
+fi
 case "$gpu_name" in
   "NVIDIA H100") platform=8xH100 ;;
   "NVIDIA H200") platform=8xH200 ;;
@@ -1665,34 +3253,43 @@ case "$gpu_name" in
   *) echo "NPA_GPU_CREATION_CHECK_RESULT host=$(hostname) status=FAIL unsupported_gpu=$gpu_name"; exit 1 ;;
 esac
 echo "NPA_GPU_CREATION_CHECK_START host=$(hostname) gpu_count=$gpu_count platform=$platform"
+command_rc=0
 out=$(health-checker run -e soperator -p "$platform" \
   -n deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest \
   -f json-partial \
-  --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout)
-command_rc=$?
-status=$(printf '%s\n' "$out" | awk '/^[[:space:]]*{{/,/^[[:space:]]*}}/' | jq -r '.status // empty')
+  --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout) || command_rc=$?
+status=$(printf '%s\n' "$out" | awk '/^[[:space:]]*{{/,/^[[:space:]]*}}/' | jq -r '.status // empty') || {{
+  echo "NPA_GPU_CREATION_CHECK_RESULT host=$(hostname) status=FAIL command_rc=$command_rc phase=result-parse"
+  exit 1
+}}
 echo "NPA_GPU_CREATION_CHECK_RESULT host=$(hostname) status=$status command_rc=$command_rc"
-test "$command_rc" -eq 0
-test "$status" = PASS
+if [ "$command_rc" -ne 0 ] || [ "$status" != PASS ]; then
+  exit 1
+fi
 """.strip()
+        job_name = f"npa-gpu-check-{uuid.uuid4().hex[:12]}"
         command = [
-            kubectl_bin,
-            "--context",
-            context,
-            "exec",
-            "-n",
-            namespace,
-            "login-0",
-            "--",
-            "chroot",
-            "/mnt/jail",
+            *_slurm_exec_command(
+                kubectl_bin,
+                context,
+                namespace,
+                "login-0",
+                None,
+                [],
+                jailed=True,
+            ),
             "srun",
             "--label",
+            f"--job-name={job_name}",
             f"--nodes={pool.size}",
             f"--ntasks={pool.size}",
             "--ntasks-per-node=1",
             f"--gpus-per-node={gpu_count}",
             "--exclusive",
+            "--kill-on-bad-exit=1",
+            "--wait=10",
+            f"--immediate={remaining}",
+            f"--time={_slurm_time_limit(remaining)}",
             f"--nodelist={node_list}",
             "bash",
             "-lc",
@@ -1702,9 +3299,36 @@ test "$status" = PASS
             on_status,
             "GPU creation check: "
             f"pool={pool.name}; nodes={pool.size}; GPUs/node={gpu_count}; "
+            f"timeout={remaining}s; "
             "tests=deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest",
         )
-        completed = _run_capture(command, env=kube_env, check=False)
+        try:
+            completed = _run_capture(
+                command,
+                env=kube_env,
+                check=False,
+                timeout=remaining,
+            )
+        except subprocess.TimeoutExpired as exc:
+            cleanup_confirmed, cleanup_detail = _cancel_and_verify_gpu_check_job(
+                context,
+                kubectl_bin,
+                namespace,
+                job_name,
+                kube_env=kube_env,
+            )
+            diagnostic = _tail_diagnostic(exc.stderr, exc.stdout)
+            detail_parts = [part for part in (diagnostic, cleanup_detail) if part]
+            detail = "\n".join(detail_parts)
+            raise GPUCreationCheckError(
+                f"GPU creation check timed out after {remaining} seconds for pool "
+                f"{pool.name!r}; the queued/running Slurm job was cancelled"
+                + (f":\n{detail}" if detail else ""),
+                pool=pool.name,
+                phase="process-timeout",
+                cleanup_confirmed=cleanup_confirmed,
+                completed_checks=checks,
+            ) from exc
         passes = completed.stdout.count("NPA_GPU_CREATION_CHECK_RESULT")
         passes_with_status = completed.stdout.count("status=PASS")
         if (
@@ -1712,13 +3336,47 @@ test "$status" = PASS
             or passes != pool.size
             or passes_with_status != pool.size
         ):
-            diagnostic = "\n".join(
-                (completed.stderr or completed.stdout).strip().splitlines()[-20:]
+            cleanup_confirmed, cleanup_detail = _cancel_and_verify_gpu_check_job(
+                context,
+                kubectl_bin,
+                namespace,
+                job_name,
+                kube_env=kube_env,
             )
-            raise RuntimeError(
+            diagnostic = _tail_diagnostic(completed.stderr, completed.stdout)
+            detail_parts = [part for part in (diagnostic, cleanup_detail) if part]
+            detail = "\n".join(detail_parts)
+            raise GPUCreationCheckError(
                 f"GPU creation check failed for pool {pool.name!r} "
                 f"({passes_with_status}/{pool.size} workers reported PASS)"
-                + (f":\n{diagnostic}" if diagnostic else "")
+                + (f":\n{detail}" if detail else ""),
+                pool=pool.name,
+                phase="slurm-step",
+                cleanup_confirmed=cleanup_confirmed,
+                completed_checks=checks,
+            )
+        if not _verify_gpu_check_job_absent(
+            context,
+            kubectl_bin,
+            namespace,
+            job_name,
+            kube_env=kube_env,
+        ):
+            cleanup_confirmed, cleanup_detail = _cancel_and_verify_gpu_check_job(
+                context,
+                kubectl_bin,
+                namespace,
+                job_name,
+                kube_env=kube_env,
+            )
+            raise GPUCreationCheckError(
+                f"GPU creation check tasks passed for pool {pool.name!r}, but Slurm "
+                "still reported the gate job; cancellation was requested"
+                + (f": {cleanup_detail}" if cleanup_detail else ""),
+                pool=pool.name,
+                phase="cleanup-verification",
+                cleanup_confirmed=cleanup_confirmed,
+                completed_checks=checks,
             )
         checks.append(
             {

--- a/npa/src/npa/soperator/lifecycle.py
+++ b/npa/src/npa/soperator/lifecycle.py
@@ -1,22 +1,28 @@
-"""Deploy / destroy / status for npa-managed soperator clusters.
+"""Deploy, reconcile, destroy, and repair npa-managed Soperator clusters.
 
-Wraps the ``nebius/nebius-solutions-library`` soperator Terraform recipe and
-applies the post-deploy fixes required to make the 4.1.0 stable release usable
-(monitoring CRDs, the ``ncclInspectorPreConf`` CRD gap, the cluster-name-
-prefixed slurm-scripts configmap). Node registration helpers are best-effort.
+NPA wraps an immutable, runtime-asserted ``nebius-solutions-library`` Soperator
+Terraform contract. It applies the monitoring prerequisites, stalled-dashboard
+repair, ``ncclInspectorPreConf`` CRD compatibility patch, prefixed Slurm scripts
+configmap, Ubuntu user-namespace configuration, best-effort worker recovery,
+and direct creation-time CUDA checks needed by that contract. REST is explicit
+at the NPA surface, while runtime validation accounts for the pinned operator's
+remaining REST/accounting limitation.
 
 Reuses the terraform subprocess helpers from ``npa.cli.cluster.terraform_lifecycle``.
 """
 
 from __future__ import annotations
 
+import base64
+from dataclasses import dataclass, replace
+import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import threading
 import time
-from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 
@@ -27,10 +33,16 @@ from npa.cli.cluster.terraform_lifecycle import (
     _terraform_env,
 )
 from npa.clients.config import resolve_environment
-from npa.soperator.spec import SoperatorSpec
+from npa.soperator.spec import (
+    DEFAULT_SOLUTIONS_LIBRARY_REF,
+    DEFAULT_SLURM_OPERATOR_VERSION,
+    SoperatorSpec,
+    validate_ssh_public_key_record,
+)
 from npa.soperator.tfvars import render_tfvars
 
 _SOLUTIONS_LIBRARY_REPO = "https://github.com/nebius/nebius-solutions-library.git"
+_IMMUTABLE_GIT_REF_RE = re.compile(r"^[0-9a-f]{40}$")
 _PROMETHEUS_CRD_BASE = (
     "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/"
     "v0.76.0/example/prometheus-operator-crd"
@@ -42,6 +54,7 @@ _PROMETHEUS_CRDS = (
 )
 _MONITORING_NAMESPACE = "monitoring-system"
 _MONITORING_RELEASE_SUFFIX = "-monitoring-dashboards"
+_ACTIVECHECKS_RELEASE_SUFFIX = "-soperator-activechecks"
 
 # Sidecar written next to the generated tfvars so ``destroy`` can rebuild the
 # same TF_VAR_* env the recipe requires. region/tenant/project/subnet/o11y are
@@ -49,6 +62,19 @@ _MONITORING_RELEASE_SUFFIX = "-monitoring-dashboards"
 # later ``terraform destroy`` would fail on "No value for required variable"
 # without these.
 _ENV_SIDECAR = ".npa-soperator-env.json"
+
+
+class UpstreamContractError(ValueError):
+    """Raised before provider mutation when the pinned recipe contract differs."""
+
+
+@dataclass(frozen=True)
+class ResolvedRootLoginSSHKey:
+    """One validated public key that explicitly grants login-node root access."""
+
+    value: str
+    source: str
+    fingerprint: str
 
 
 def _write_env_sidecar(
@@ -96,36 +122,121 @@ def _api_domain(region: str) -> str:
     return "api.eu.nebius.cloud:443" if region.startswith("eu") else "api.nebius.cloud:443"
 
 
-def _with_resolved_ssh_public_keys(
-    spec: SoperatorSpec, *, home: Path | None = None
-) -> SoperatorSpec:
-    """Return *spec* with a standard operator SSH public key when omitted.
+def _root_login_key_fingerprint(value: str) -> str:
+    blob = base64.b64decode(value.split(maxsplit=2)[1], validate=True)
+    digest = base64.b64encode(hashlib.sha256(blob).digest()).decode().rstrip("=")
+    return f"SHA256:{digest}"
 
-    Current solutions-library installations require at least one login key.
-    Keep explicit spec values authoritative; otherwise mirror the repository's
-    other infrastructure lifecycles and use the first conventional local key.
-    The key is rendered only into the private installation, never logged.
-    """
 
-    if spec.ssh_public_keys:
-        return spec
-    ssh_dir = (home or Path.home()).expanduser() / ".ssh"
-    for name in ("id_ed25519.pub", "id_rsa.pub"):
-        candidate = ssh_dir / name
-        try:
-            value = candidate.read_text(encoding="utf-8").strip()
-        except OSError:
-            continue
-        if value:
-            return replace(spec, ssh_public_keys=[value])
-    raise ValueError(
-        "soperator requires at least one login SSH public key: set "
-        "ssh_public_keys in the spec or create ~/.ssh/id_ed25519.pub"
+def _read_root_login_key_file(path: Path, *, source: str) -> ResolvedRootLoginSSHKey:
+    try:
+        value = path.expanduser().read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"could not read {source} root-login SSH public-key file") from exc
+    normalized = validate_ssh_public_key_record(value)
+    return ResolvedRootLoginSSHKey(
+        value=normalized,
+        source=source,
+        fingerprint=_root_login_key_fingerprint(normalized),
     )
 
 
+def _resolve_root_login_ssh_public_key(
+    spec: SoperatorSpec,
+    *,
+    explicit_file: Path | None = None,
+    environ: dict[str, str] | None = None,
+    home: Path | None = None,
+) -> ResolvedRootLoginSSHKey:
+    """Resolve the one key granting root access to the public login node.
+
+    Precedence is: explicit CLI/SDK file, canonical or legacy spec field,
+    Soperator-specific inline environment value, Soperator-specific environment
+    file, generic ``NPA_SSH_PUBLIC_KEY`` file, then conventional operator-home
+    key discovery. Only a single OpenSSH public-key record is accepted.
+    """
+
+    if explicit_file is not None:
+        return _read_root_login_key_file(explicit_file, source="explicit argument")
+
+    explicit = spec.explicit_root_login_ssh_public_key()
+    if explicit:
+        normalized = validate_ssh_public_key_record(explicit)
+        source = (
+            "spec root_login_ssh_public_key"
+            if spec.root_login_ssh_public_key
+            else "legacy spec ssh_public_keys"
+        )
+        return ResolvedRootLoginSSHKey(
+            value=normalized,
+            source=source,
+            fingerprint=_root_login_key_fingerprint(normalized),
+        )
+
+    env = os.environ if environ is None else environ
+    inline = env.get("NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY", "").strip()
+    if inline:
+        normalized = validate_ssh_public_key_record(inline)
+        return ResolvedRootLoginSSHKey(
+            value=normalized,
+            source="NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY",
+            fingerprint=_root_login_key_fingerprint(normalized),
+        )
+
+    for env_name in (
+        "NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY_FILE",
+        "NPA_SSH_PUBLIC_KEY",
+    ):
+        configured_path = env.get(env_name, "").strip()
+        if configured_path:
+            return _read_root_login_key_file(Path(configured_path), source=env_name)
+
+    ssh_dir = (home or Path.home()).expanduser() / ".ssh"
+    for name in ("id_ed25519.pub", "id_rsa.pub", "id_ecdsa.pub"):
+        candidate = ssh_dir / name
+        if candidate.is_file():
+            return _read_root_login_key_file(candidate, source=f"operator default {name}")
+    raise ValueError(
+        "soperator login-node root access requires one SSH public key: set "
+        "root_login_ssh_public_key in the spec, pass "
+        "--root-login-ssh-public-key-file, set "
+        "NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY[_FILE], or create "
+        "~/.ssh/id_ed25519.pub"
+    )
+
+
+def _with_resolved_ssh_public_keys(
+    spec: SoperatorSpec, *, home: Path | None = None
+) -> SoperatorSpec:
+    """Compatibility wrapper returning *spec* with its canonical root-login key."""
+
+    resolved = _resolve_root_login_ssh_public_key(spec, home=home)
+    if (
+        spec.root_login_ssh_public_key == resolved.value
+        and not spec.ssh_public_keys
+    ):
+        return spec
+    return replace(
+        spec,
+        root_login_ssh_public_key=resolved.value,
+        ssh_public_keys=[],
+    )
+
+
+def _validate_immutable_solutions_library_ref(ref: str) -> str:
+    normalized = ref.strip().lower()
+    if not _IMMUTABLE_GIT_REF_RE.fullmatch(normalized):
+        raise ValueError(
+            "solutions_library_ref must be an immutable 40-character commit SHA; "
+            "branches and moving tags are not accepted"
+        )
+    return normalized
+
+
 def _resolve_solutions_library(terraform_dir: Path | None, work_root: Path, ref: str) -> Path:
-    """Return the soperator recipe dir, cloning the solutions-library if needed."""
+    """Resolve a checkout of one immutable solutions-library commit."""
+
+    ref = _validate_immutable_solutions_library_ref(ref)
 
     if terraform_dir is not None:
         path = terraform_dir.expanduser().resolve()
@@ -134,12 +245,24 @@ def _resolve_solutions_library(terraform_dir: Path | None, work_root: Path, ref:
                 f"{path} is not a soperator recipe dir (missing installations/example)"
             )
         return path
-    clone_dir = work_root / "nebius-solutions-library"
+    # Preserve the historical default location when it exists so an already
+    # deployed installation keeps using its Terraform state. The contract
+    # assertion immediately after resolution still requires its HEAD to equal
+    # the requested immutable commit and permits only NPA's two known patches.
+    legacy_clone = work_root / "nebius-solutions-library"
+    if (legacy_clone / "soperator" / "installations" / "example").exists():
+        return legacy_clone / "soperator"
+    clone_dir = work_root / f"nebius-solutions-library-{ref[:12]}"
     if not (clone_dir / "soperator" / "installations" / "example").exists():
         work_root.mkdir(parents=True, exist_ok=True)
         git = _require_bin("git")
         _run_stream(
-            [git, "clone", "--depth", "1", "--branch", ref, _SOLUTIONS_LIBRARY_REPO, str(clone_dir)],
+            [git, "clone", "--filter=blob:none", "--no-checkout", _SOLUTIONS_LIBRARY_REPO, str(clone_dir)],
+            timeout=600,
+        )
+        _run_stream(
+            [git, "checkout", "--detach", ref],
+            cwd=clone_dir,
             timeout=600,
         )
     return clone_dir / "soperator"
@@ -157,6 +280,10 @@ def _nebius_cli_env() -> dict[str, str]:
     """
 
     env = os.environ.copy()
+    if env.get("NPA_NEBIUS_PROFILE", "").strip() and not env.get(
+        "NEBIUS_PROFILE", ""
+    ).strip():
+        env["NEBIUS_PROFILE"] = env["NPA_NEBIUS_PROFILE"].strip()
     reuse = env.get("NPA_REUSE_IAM_TOKEN", "").strip().lower() in {
         "1",
         "true",
@@ -219,6 +346,22 @@ _NODECONFIGURATOR_USERNS_VALUES = (
 )
 
 
+def _patch_active_checks_text(text: str) -> tuple[str, bool]:
+    if _ESSENTIAL_HEALTHY_NODES_MARKER in text:
+        return text, False
+    marker = "    essential = {\n"
+    idx = text.find(marker)
+    if idx == -1:
+        raise UpstreamContractError(
+            "pinned active-checks contract lacks the essential scope"
+        )
+    insert_at = idx + len(marker)
+    return (
+        text[:insert_at] + _ESSENTIAL_HEALTHY_NODES_OVERRIDE + text[insert_at:],
+        True,
+    )
+
+
 def _patch_active_checks_locals(recipe_dir: Path) -> bool:
     """Ensure the ``essential`` active-checks scope skips ``ensure-healthy-nodes``.
 
@@ -238,22 +381,84 @@ def _patch_active_checks_locals(recipe_dir: Path) -> bool:
     if not locals_tf.exists():
         return False
     text = locals_tf.read_text()
-    if _ESSENTIAL_HEALTHY_NODES_MARKER in text:
-        return False
-    marker = "    essential = {\n"
-    idx = text.find(marker)
-    if idx == -1:
-        return False
-    insert_at = idx + len(marker)
-    patched = text[:insert_at] + _ESSENTIAL_HEALTHY_NODES_OVERRIDE + text[insert_at:]
-    locals_tf.write_text(patched)
-    return True
+    patched, changed = _patch_active_checks_text(text)
+    if changed:
+        locals_tf.write_text(patched)
+    return changed
+
+
+def _yaml_mapping_block_bounds(text: str, key: str) -> tuple[int, int, int]:
+    """Return byte bounds and indentation for one YAML mapping block.
+
+    The Terraform template is YAML with interpolation expressions; parsing it as
+    ordinary YAML is unreliable. Indentation is nevertheless structural, so a
+    bounded mapping walk prevents a missing child from matching a later chart.
+    """
+
+    lines = text.splitlines(keepends=True)
+    offsets: list[int] = []
+    offset = 0
+    matches: list[tuple[int, int]] = []
+    for index, line in enumerate(lines):
+        offsets.append(offset)
+        stripped = line.lstrip(" ")
+        indent = len(line) - len(stripped)
+        if stripped.rstrip("\r\n") == f"{key}:":
+            matches.append((index, indent))
+        offset += len(line)
+    if len(matches) != 1:
+        raise UpstreamContractError(
+            f"pinned Helm template must contain exactly one {key!r} mapping; "
+            f"found {len(matches)}"
+        )
+    start_index, indent = matches[0]
+    end_index = len(lines)
+    for index in range(start_index + 1, len(lines)):
+        stripped = lines[index].strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("%{"):
+            continue
+        candidate = lines[index].lstrip(" ")
+        candidate_indent = len(lines[index]) - len(candidate)
+        if candidate_indent <= indent:
+            end_index = index
+            break
+    start = offsets[start_index]
+    end = offsets[end_index] if end_index < len(offsets) else len(text)
+    return start, end, indent
+
+
+def _patch_nodeconfigurator_text(text: str) -> tuple[str, bool]:
+    section_start, section_end, section_indent = _yaml_mapping_block_bounds(
+        text, "nodeConfigurator"
+    )
+    section = text[section_start:section_end]
+    marker_inside = _NODECONFIGURATOR_USERNS_MARKER in section
+    marker_anywhere = _NODECONFIGURATOR_USERNS_MARKER in text
+    if marker_anywhere and not marker_inside:
+        raise UpstreamContractError(
+            "nodeConfigurator user-namespace marker exists outside its chart block"
+        )
+    if marker_inside:
+        return text, False
+
+    values_line = " " * (section_indent + 2) + "values:\n"
+    matches = [match.start() for match in re.finditer(re.escape(values_line), section)]
+    if len(matches) != 1:
+        raise UpstreamContractError(
+            "pinned nodeConfigurator block must contain its own values: mapping; "
+            "refusing to inject into a sibling chart"
+        )
+    insert_at = section_start + matches[0] + len(values_line)
+    return (
+        text[:insert_at] + _NODECONFIGURATOR_USERNS_VALUES + text[insert_at:],
+        True,
+    )
 
 
 def _patch_nodeconfigurator_userns(recipe_dir: Path) -> bool:
     """Teach the upstream node configurator about Ubuntu's AppArmor userns gate.
 
-    The 4.1.0 chart enables ``kernel.unprivileged_userns_clone`` but Ubuntu's
+    The verified chart enables ``kernel.unprivileged_userns_clone`` but Ubuntu's
     newer host images independently deny unprivileged user namespaces through
     ``kernel.apparmor_restrict_unprivileged_userns``. Enroot/Pyxis image startup
     then fails even though the worker container itself is AppArmor-unconfined.
@@ -272,25 +477,121 @@ def _patch_nodeconfigurator_userns(recipe_dir: Path) -> bool:
     if not template.exists():
         return False
     text = template.read_text()
-    if _NODECONFIGURATOR_USERNS_MARKER in text:
-        return False
-    section = text.find("          nodeConfigurator:\n")
-    if section == -1:
-        return False
-    marker = "            values:\n"
-    insert_at = text.find(marker, section)
-    if insert_at == -1:
-        return False
-    insert_at += len(marker)
-    template.write_text(text[:insert_at] + _NODECONFIGURATOR_USERNS_VALUES + text[insert_at:])
-    return True
+    patched, changed = _patch_nodeconfigurator_text(text)
+    if changed:
+        template.write_text(patched)
+    return changed
+
+
+def _git_checkout_text(repo_root: Path, ref: str, relative_path: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{ref}:{relative_path}"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise UpstreamContractError(
+            f"could not read {relative_path} from solutions-library {ref[:12]}"
+        )
+    return proc.stdout
+
+
+def _assert_solutions_library_contract(
+    recipe_dir: Path,
+    *,
+    ref: str,
+) -> None:
+    """Assert the complete pinned source/mutation contract before cloud writes."""
+
+    ref = _validate_immutable_solutions_library_ref(ref)
+    repo_root = recipe_dir.parent
+    head = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if head.returncode != 0 or head.stdout.strip().lower() != ref:
+        actual = head.stdout.strip()[:12] if head.returncode == 0 else "not-a-git-checkout"
+        raise UpstreamContractError(
+            f"solutions-library checkout mismatch: expected {ref[:12]}, got {actual}"
+        )
+
+    critical_fragments = {
+        "soperator/installations/example/terraform.tfvars": (
+            f'slurm_operator_version = "{DEFAULT_SLURM_OPERATOR_VERSION}"',
+            "k8s_version = 1.34",
+            "node_group_version = 72",
+        ),
+        "soperator/installations/example/main.tf": (
+            "rest_enabled                    = var.slurm_rest_enabled",
+            "accounting_enabled              = var.accounting_enabled",
+            "sizing_tier_override = module.sizing.sizing_tier",
+        ),
+        "soperator/installations/example/variables.tf": (
+            'variable "slurm_rest_enabled"',
+            'variable "accounting_enabled"',
+            'variable "sizing_tier_override"',
+        ),
+        "soperator/modules/sizing_tier/main.tf": (
+            'var.worker_count < 10 ? "XS"',
+            'var.worker_count < 100 ? "S"',
+            'var.worker_count < 500 ? "M"',
+            'var.worker_count < 2000 ? "L" : "XL"',
+            'L  = "32vcpu-128gb"',
+            'XL = "64vcpu-256gb"',
+        ),
+    }
+    for relative, fragments in critical_fragments.items():
+        pristine = _git_checkout_text(repo_root, ref, relative)
+        current_path = repo_root / relative
+        try:
+            current = current_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise UpstreamContractError(f"missing pinned contract file {relative}") from exc
+        if current != pristine:
+            raise UpstreamContractError(
+                f"unexpected local mutation in pinned contract file {relative}"
+            )
+        missing = [fragment for fragment in fragments if fragment not in current]
+        if missing:
+            raise UpstreamContractError(
+                f"pinned runtime contract is incompatible in {relative}: "
+                f"missing {missing[0]!r}"
+            )
+
+    patch_contracts = (
+        (
+            "soperator/modules/slurm/locals_active_checks.tf",
+            _patch_active_checks_text,
+        ),
+        (
+            "soperator/modules/slurm/templates/helm_values/"
+            "terraform_fluxcd_values.yaml.tftpl",
+            _patch_nodeconfigurator_text,
+        ),
+    )
+    for relative, transform in patch_contracts:
+        pristine = _git_checkout_text(repo_root, ref, relative)
+        expected_patched, _ = transform(pristine)
+        current_path = repo_root / relative
+        try:
+            current = current_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise UpstreamContractError(f"missing pinned patch target {relative}") from exc
+        if current not in (pristine, expected_patched):
+            raise UpstreamContractError(
+                f"unexpected local mutation in pinned patch target {relative}"
+            )
 
 
 def _prepare_installation(recipe_dir: Path, spec: SoperatorSpec, region: str) -> Path:
     """Create installations/<name> with the recipe files + generated tfvars."""
 
     _patch_active_checks_locals(recipe_dir)
-    _patch_nodeconfigurator_userns(recipe_dir)
+    if not spec.use_default_apparmor_profile:
+        _patch_nodeconfigurator_userns(recipe_dir)
     example = recipe_dir / "installations" / "example"
     install_dir = recipe_dir / "installations" / spec.name
     install_dir.mkdir(parents=True, exist_ok=True)
@@ -321,13 +622,21 @@ def _soperator_tf_env(
     project_id: str,
     subnet_id: str,
 ) -> dict[str, str]:
-    env = _terraform_env(nebius_bin)
+    profile = (
+        os.environ.get("NPA_NEBIUS_PROFILE", "").strip()
+        or os.environ.get("NEBIUS_PROFILE", "").strip()
+    )
+    env = _terraform_env(nebius_bin, profile=profile)
+    if profile:
+        # Terraform local-exec and kubeconfig generation invoke the bare CLI;
+        # keep them on the same explicitly selected cross-tenant principal.
+        env["NEBIUS_PROFILE"] = profile
     env["TF_VAR_region"] = region
     env["TF_VAR_iam_tenant_id"] = tenant_id
     env["TF_VAR_iam_project_id"] = project_id
     # o11y is disabled in tfvars, but the variables are required to parse.
     env["TF_VAR_o11y_iam_tenant_id"] = tenant_id
-    env["TF_VAR_o11y_profile"] = os.environ.get("NPA_NEBIUS_PROFILE", "") or "default"
+    env["TF_VAR_o11y_profile"] = profile or "default"
     env["TF_VAR_vpc_subnet_id"] = subnet_id
     return env
 
@@ -382,9 +691,16 @@ def _refresh_kube_credentials(
 ) -> None:
     """Write an admin kubeconfig context for the cluster (recipe writes a limited SA)."""
 
+    argv = [nebius_bin]
+    profile = (
+        env.get("NPA_NEBIUS_PROFILE", "").strip()
+        or env.get("NEBIUS_PROFILE", "").strip()
+    )
+    if profile:
+        argv.extend(["--profile", profile])
     _run_capture(
         [
-            nebius_bin, "mk8s", "cluster", "get-credentials",
+            *argv, "mk8s", "cluster", "get-credentials",
             "--id", cluster_id, "--external", "--force", "--context-name", context,
         ],
         env=env,
@@ -455,7 +771,7 @@ def _ensure_monitoring_namespace(
 ) -> None:
     """Ensure the namespace required by the unconditional dashboards chart.
 
-    Soperator 4.1.0 still reconciles monitoring dashboards when observability is
+    The pinned Soperator contract still reconciles monitoring dashboards when observability is
     disabled, but that mode does not create ``monitoring-system``.  Creating the
     namespace is idempotent and lets Flux install the chart instead of leaving a
     permanently failed HelmRelease in an otherwise healthy cluster.
@@ -615,6 +931,107 @@ def _reset_stalled_monitoring_releases(
     return reset
 
 
+def _abort_superseded_activechecks_upgrade(
+    kubectl_bin: str,
+    context: str,
+    *,
+    namespace: str = "soperator",
+    env: dict[str, str] | None = None,
+) -> list[str]:
+    """Unblock a newer ActiveChecks generation from an older Helm action.
+
+    An upgrade can remain in its generated ``wait-for-active-checks`` hook when
+    an old REST-backed generation cannot observe Slurm job status. Flux cannot
+    start an already-rendered newer generation until that action exits. Only
+    when ``lastAttemptedGeneration`` is older than metadata.generation and the
+    release is actively Progressing, delete the Helm-owned hook Job and request
+    a reset/reconcile. Current-generation installs are never interrupted.
+    """
+
+    kube_env = env or _nebius_cli_env()
+    listed = _run_capture(
+        [
+            kubectl_bin,
+            "--context",
+            context,
+            "-n",
+            "flux-system",
+            "get",
+            "helmreleases",
+            "-o",
+            "json",
+        ],
+        env=kube_env,
+        check=False,
+    )
+    if listed.returncode != 0:
+        return []
+    try:
+        items = json.loads(listed.stdout or "{}").get("items", [])
+    except (AttributeError, json.JSONDecodeError):
+        return []
+
+    reset: list[str] = []
+    for item in items:
+        metadata = item.get("metadata") or {}
+        status = item.get("status") or {}
+        name = str(metadata.get("name") or "")
+        generation = int(metadata.get("generation") or 0)
+        attempted = int(status.get("lastAttemptedGeneration") or 0)
+        progressing = any(
+            condition.get("type") == "Reconciling"
+            and condition.get("status") == "True"
+            and condition.get("reason") == "Progressing"
+            for condition in (status.get("conditions") or [])
+        )
+        if (
+            not name.endswith(_ACTIVECHECKS_RELEASE_SUFFIX)
+            or not progressing
+            or attempted <= 0
+            or attempted >= generation
+        ):
+            continue
+        deleted = _run_capture(
+            [
+                kubectl_bin,
+                "--context",
+                context,
+                "-n",
+                namespace,
+                "delete",
+                "job",
+                "wait-for-active-checks",
+                "--ignore-not-found=true",
+                "--wait=false",
+            ],
+            env=kube_env,
+            check=False,
+        )
+        if deleted.returncode != 0:
+            continue
+        token = str(time.time_ns())
+        annotated = _run_capture(
+            [
+                kubectl_bin,
+                "--context",
+                context,
+                "-n",
+                "flux-system",
+                "annotate",
+                "helmrelease",
+                name,
+                f"reconcile.fluxcd.io/requestedAt={token}",
+                f"reconcile.fluxcd.io/resetAt={token}",
+                "--overwrite",
+            ],
+            env=kube_env,
+            check=False,
+        )
+        if annotated.returncode == 0:
+            reset.append(name)
+    return reset
+
+
 def _patch_slurmcluster_crd(kubectl_bin: str, context: str) -> bool:
     """Patch the SlurmCluster CRD to accept plugStackConfig.ncclInspectorPreConf.
 
@@ -729,16 +1146,30 @@ def deploy_cluster(
     *,
     terraform_dir: Path | None = None,
     work_root: Path | None = None,
-    solutions_library_ref: str = "main",
+    solutions_library_ref: str = DEFAULT_SOLUTIONS_LIBRARY_REF,
+    root_login_ssh_public_key_file: Path | None = None,
     project: str | None = None,
     timeout_minutes: int = 90,
     apply_fixes: bool = True,
     on_status: Callable[[str], None] | None = None,
 ) -> dict[str, Any]:
-    """Deploy a soperator cluster described by *spec*. Returns cluster metadata."""
+    """Deploy or reconcile *spec* after pinned-contract and key preflight."""
 
-    spec = _with_resolved_ssh_public_keys(spec)
     spec.validate()
+    root_login_key = _resolve_root_login_ssh_public_key(
+        spec, explicit_file=root_login_ssh_public_key_file
+    )
+    spec = replace(
+        spec,
+        root_login_ssh_public_key=root_login_key.value,
+        ssh_public_keys=[],
+    )
+    spec.validate()
+    _log(
+        on_status,
+        "login-node root SSH access enabled: "
+        f"source={root_login_key.source}; fingerprint={root_login_key.fingerprint}",
+    )
     envcfg = resolve_environment(
         project=project,
         project_id=spec.project_id or None,
@@ -758,6 +1189,8 @@ def deploy_cluster(
 
     work_root = (work_root or Path.home() / ".npa" / "soperator").expanduser()
     recipe_dir = _resolve_solutions_library(terraform_dir, work_root, solutions_library_ref)
+    _assert_solutions_library_contract(recipe_dir, ref=solutions_library_ref)
+    _log(on_status, f"verified solutions-library contract {solutions_library_ref[:12]}")
     install_dir = _prepare_installation(recipe_dir, spec, region)
     _log(on_status, f"Installation dir: {install_dir}")
 
@@ -851,8 +1284,19 @@ def deploy_cluster(
 
     if apply_fixes:
         kubectl_bin = _require_bin(os.environ.get("NPA_KUBECTL_BIN") or "kubectl")
-        apply_post_deploy_fixes(context, kubectl_bin, on_status=on_status)
+        warnings = apply_post_deploy_fixes(context, kubectl_bin, on_status=on_status)
         result["post_deploy_fixes"] = "applied"
+        result["post_deploy_fix_warnings"] = warnings
+
+    # GPU validation is a deploy contract, not an optional repair. Keep it
+    # active even when an operator deliberately selects --skip-fixes.
+    kubectl_bin = _require_bin(os.environ.get("NPA_KUBECTL_BIN") or "kubectl")
+    result["gpu_creation_checks"] = _run_gpu_creation_checks(
+        spec,
+        context,
+        kubectl_bin,
+        on_status=on_status,
+    )
 
     return result
 
@@ -862,7 +1306,7 @@ def destroy_cluster(
     *,
     terraform_dir: Path | None = None,
     work_root: Path | None = None,
-    solutions_library_ref: str = "main",
+    solutions_library_ref: str = DEFAULT_SOLUTIONS_LIBRARY_REF,
     project: str | None = None,
     timeout_minutes: int = 90,
     on_status: Callable[[str], None] | None = None,
@@ -873,6 +1317,7 @@ def destroy_cluster(
     nebius_bin = _require_bin(os.environ.get("NPA_NEBIUS_BIN") or "nebius")
     work_root = (work_root or Path.home() / ".npa" / "soperator").expanduser()
     recipe_dir = _resolve_solutions_library(terraform_dir, work_root, solutions_library_ref)
+    _assert_solutions_library_contract(recipe_dir, ref=solutions_library_ref)
     install_dir = recipe_dir / "installations" / name
     if not install_dir.exists():
         raise ValueError(f"no installation found for cluster {name!r} at {install_dir}")
@@ -1069,17 +1514,37 @@ def apply_post_deploy_fixes(
     namespace: str = "soperator",
     on_status: Callable[[str], None] | None = None,
     timeout_minutes: int = 20,
-) -> None:
-    """Apply the fixes the 4.1.0-stable recipe needs to reach a working Slurm.
+) -> list[str]:
+    """Apply idempotent repairs after a successful Terraform reconciliation.
 
-    1. Install prometheus-operator CRDs (operator chart needs ServiceMonitor even
-       when telemetry is off).
-    2. Patch the SlurmCluster CRD to accept ``plugStackConfig.ncclInspectorPreConf``.
-    3. Create the cluster-name-prefixed ``<ns>-slurm-scripts`` configmap the
-       nodesets chart mounts (chart naming skew).
+    Monitoring namespace/CRD/dashboard repair is best-effort here: RBAC or a
+    transient Flux error is retained in the returned diagnostics but cannot turn
+    an already healthy Terraform apply into a reported deploy failure. A
+    superseded ActiveChecks wait hook is reset only when its attempted generation
+    is older than the desired generation. The CRD and scripts compatibility
+    fixes remain polled/best-effort, followed by worker address/RESUME recovery.
+    Returns non-secret warning strings.
     """
 
-    _install_monitoring_crds(kubectl_bin, context, on_status=on_status)
+    warnings: list[str] = []
+    try:
+        _install_monitoring_crds(kubectl_bin, context, on_status=on_status)
+    except RuntimeError as exc:
+        warning = f"monitoring repair skipped after successful apply: {exc}"
+        warnings.append(warning)
+        _log(on_status, f"post-deploy warning: {warning}")
+
+    reset_activechecks = _abort_superseded_activechecks_upgrade(
+        kubectl_bin,
+        context,
+        namespace=namespace,
+    )
+    if reset_activechecks:
+        _log(
+            on_status,
+            "post-deploy: aborted a superseded ActiveChecks Helm action so "
+            "the newer generation can reconcile",
+        )
 
     _log(on_status, "post-deploy: patching SlurmCluster CRD + ensuring scripts configmap")
     deadline = time.monotonic() + timeout_minutes * 60
@@ -1097,7 +1562,8 @@ def apply_post_deploy_fixes(
         _log(on_status, "post-deploy: slurm-scripts configmap not present yet; skipped")
 
     _register_slurm_workers(kubectl_bin, context, namespace, on_status=on_status)
-    _log(on_status, "post-deploy: fixes applied")
+    _log(on_status, "post-deploy: fixes applied" + (" with warnings" if warnings else ""))
+    return warnings
 
 
 def _register_slurm_workers(
@@ -1108,12 +1574,11 @@ def _register_slurm_workers(
     on_status: Callable[[str], None] | None = None,
     wait_minutes: int = 10,
 ) -> None:
-    """Best-effort: bring DOWN worker nodes to IDLE (soperator 4.1.0 slurmrestd gap).
+    """Best-effort: bring DOWN worker nodes to IDLE after registration races.
 
-    In 4.1.0-stable the operator doesn't deploy slurmrestd, so soperator's
-    dynamic-node registration can leave workers DOWN/not-responding with slurmctld
-    resolving the bare short name. Set the FQDN NodeAddr and RESUME any node that
-    isn't idle. Idempotent and non-fatal.
+    Dynamic-node registration can race worker readiness and leave slurmctld
+    resolving a bare short name. Set
+    the FQDN NodeAddr and RESUME any node that is down. Idempotent and non-fatal.
     """
 
     kube_env = _nebius_cli_env()
@@ -1144,3 +1609,130 @@ def _register_slurm_workers(
             slurmctl(["scontrol", "update", f"NodeName={node}", "State=RESUME"])
         _log(on_status, f"post-deploy: registered worker node(s): {', '.join(sorted(set(down)))}")
         time.sleep(15)
+
+
+def _gpu_count_from_preset(preset: str) -> int:
+    """Return the leading GPU count from an upstream GPU preset name."""
+
+    match = re.match(r"^([1-9][0-9]*)gpu-", preset)
+    if match is None:
+        raise RuntimeError(
+            f"GPU creation check cannot derive a GPU count from preset {preset!r}"
+        )
+    return int(match.group(1))
+
+
+def _run_gpu_creation_checks(
+    spec: SoperatorSpec,
+    context: str,
+    kubectl_bin: str,
+    *,
+    namespace: str = "soperator",
+    on_status: Callable[[str], None] | None = None,
+) -> list[dict[str, Any]]:
+    """Run real CUDA samples on every GPU worker through the login jail.
+
+    The pinned 4.1.6 Terraform surface exposes REST separately from accounting,
+    but the exact operator implementation skips REST reconciliation when
+    accounting is disabled. Its REST-backed ActiveCheck controller therefore
+    cannot provide creation-time GPU validation for that combination. This
+    direct Slurm check is the safe runtime contract: one exclusive task per
+    worker receives every GPU on that worker and requires deviceQuery,
+    vectorAdd, simpleMultiGPU, and p2pBandwidthLatencyTest to all report PASS.
+    Any failed/missing node or CUDA result fails the deploy.
+    """
+
+    checks: list[dict[str, Any]] = []
+    kube_env = _nebius_cli_env()
+    for pool in (worker for worker in spec.workers if worker.is_gpu()):
+        gpu_count = _gpu_count_from_preset(pool.preset)
+        nodes = [f"{pool.name}-{index}" for index in range(pool.size)]
+        node_list = ",".join(nodes)
+        task_script = f"""
+set -uo pipefail
+gpu_count=$(nvidia-smi -L | wc -l)
+if [ "$gpu_count" -ne {gpu_count} ]; then
+  echo "NPA_GPU_CREATION_CHECK_RESULT host=$(hostname) status=FAIL expected_gpus={gpu_count} actual_gpus=$gpu_count"
+  exit 1
+fi
+gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader | sort -u)
+case "$gpu_name" in
+  "NVIDIA H100") platform=8xH100 ;;
+  "NVIDIA H200") platform=8xH200 ;;
+  "NVIDIA B200") platform=8xB200 ;;
+  "NVIDIA B300") platform=8xB300 ;;
+  "NVIDIA GB300") platform=4xGB300 ;;
+  *) echo "NPA_GPU_CREATION_CHECK_RESULT host=$(hostname) status=FAIL unsupported_gpu=$gpu_name"; exit 1 ;;
+esac
+echo "NPA_GPU_CREATION_CHECK_START host=$(hostname) gpu_count=$gpu_count platform=$platform"
+out=$(health-checker run -e soperator -p "$platform" \
+  -n deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest \
+  -f json-partial \
+  --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout)
+command_rc=$?
+status=$(printf '%s\n' "$out" | awk '/^[[:space:]]*{{/,/^[[:space:]]*}}/' | jq -r '.status // empty')
+echo "NPA_GPU_CREATION_CHECK_RESULT host=$(hostname) status=$status command_rc=$command_rc"
+test "$command_rc" -eq 0
+test "$status" = PASS
+""".strip()
+        command = [
+            kubectl_bin,
+            "--context",
+            context,
+            "exec",
+            "-n",
+            namespace,
+            "login-0",
+            "--",
+            "chroot",
+            "/mnt/jail",
+            "srun",
+            "--label",
+            f"--nodes={pool.size}",
+            f"--ntasks={pool.size}",
+            "--ntasks-per-node=1",
+            f"--gpus-per-node={gpu_count}",
+            "--exclusive",
+            f"--nodelist={node_list}",
+            "bash",
+            "-lc",
+            task_script,
+        ]
+        _log(
+            on_status,
+            "GPU creation check: "
+            f"pool={pool.name}; nodes={pool.size}; GPUs/node={gpu_count}; "
+            "tests=deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest",
+        )
+        completed = _run_capture(command, env=kube_env, check=False)
+        passes = completed.stdout.count("NPA_GPU_CREATION_CHECK_RESULT")
+        passes_with_status = completed.stdout.count("status=PASS")
+        if (
+            completed.returncode != 0
+            or passes != pool.size
+            or passes_with_status != pool.size
+        ):
+            diagnostic = "\n".join(
+                (completed.stderr or completed.stdout).strip().splitlines()[-20:]
+            )
+            raise RuntimeError(
+                f"GPU creation check failed for pool {pool.name!r} "
+                f"({passes_with_status}/{pool.size} workers reported PASS)"
+                + (f":\n{diagnostic}" if diagnostic else "")
+            )
+        checks.append(
+            {
+                "pool": pool.name,
+                "nodes": pool.size,
+                "gpus_per_node": gpu_count,
+                "tests": [
+                    "deviceQuery",
+                    "vectorAdd",
+                    "simpleMultiGPU",
+                    "p2pBandwidthLatencyTest",
+                ],
+                "status": "PASS",
+            }
+        )
+        _log(on_status, f"GPU creation check passed: pool={pool.name}; workers={pool.size}")
+    return checks

--- a/npa/src/npa/soperator/lifecycle.py
+++ b/npa/src/npa/soperator/lifecycle.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import threading
 import time
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 
@@ -39,6 +40,8 @@ _PROMETHEUS_CRDS = (
     "monitoring.coreos.com_podmonitors.yaml",
     "monitoring.coreos.com_probes.yaml",
 )
+_MONITORING_NAMESPACE = "monitoring-system"
+_MONITORING_RELEASE_SUFFIX = "-monitoring-dashboards"
 
 # Sidecar written next to the generated tfvars so ``destroy`` can rebuild the
 # same TF_VAR_* env the recipe requires. region/tenant/project/subnet/o11y are
@@ -91,6 +94,34 @@ def _api_domain(region: str) -> str:
     """Nebius API domain for a region (the recipe hardcodes the EU domain)."""
 
     return "api.eu.nebius.cloud:443" if region.startswith("eu") else "api.nebius.cloud:443"
+
+
+def _with_resolved_ssh_public_keys(
+    spec: SoperatorSpec, *, home: Path | None = None
+) -> SoperatorSpec:
+    """Return *spec* with a standard operator SSH public key when omitted.
+
+    Current solutions-library installations require at least one login key.
+    Keep explicit spec values authoritative; otherwise mirror the repository's
+    other infrastructure lifecycles and use the first conventional local key.
+    The key is rendered only into the private installation, never logged.
+    """
+
+    if spec.ssh_public_keys:
+        return spec
+    ssh_dir = (home or Path.home()).expanduser() / ".ssh"
+    for name in ("id_ed25519.pub", "id_rsa.pub"):
+        candidate = ssh_dir / name
+        try:
+            value = candidate.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if value:
+            return replace(spec, ssh_public_keys=[value])
+    raise ValueError(
+        "soperator requires at least one login SSH public key: set "
+        "ssh_public_keys in the spec or create ~/.ssh/id_ed25519.pub"
+    )
 
 
 def _resolve_solutions_library(terraform_dir: Path | None, work_root: Path, ref: str) -> Path:
@@ -159,6 +190,33 @@ _ESSENTIAL_HEALTHY_NODES_OVERRIDE = (
     "        runAfterCreation = false\n"
     "      }\n"
 )
+_NODECONFIGURATOR_USERNS_MARKER = "# npa: allow Enroot user namespaces on Ubuntu hosts"
+_NODECONFIGURATOR_USERNS_VALUES = (
+    "              " + _NODECONFIGURATOR_USERNS_MARKER + "\n"
+    "              # Preserve the chart's complete default init-container list; Helm\n"
+    "              # replaces arrays rather than merging individual list entries.\n"
+    "              initContainers:\n"
+    "                - name: node-sysctl-params\n"
+    "                  image: cr.eu-north1.nebius.cloud/soperator/busybox\n"
+    "                  securityContext:\n"
+    "                    privileged: true\n"
+    "                    runAsUser: 0\n"
+    "                    runAsGroup: 0\n"
+    "                    readOnlyRootFilesystem: false\n"
+    "                    allowPrivilegeEscalation: true\n"
+    "                  command:\n"
+    "                    - /bin/sh\n"
+    "                    - -c\n"
+    "                    - |-\n"
+    "                      sysctl -w kernel.unprivileged_userns_clone=1\n"
+    "                      if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && [ \"${apparmor_enabled}\" = \"false\" ]; then\n"
+    "                        sysctl -w kernel.apparmor_restrict_unprivileged_userns=0\n"
+    "                      fi\n"
+    "                      sysctl -w net.core.rmem_max=536870912\n"
+    "                      sysctl -w net.core.wmem_max=536870912\n"
+    "                      sysctl -w net.ipv4.tcp_rmem=\"4096 131072 536870912\"\n"
+    "                      sysctl -w net.ipv4.tcp_wmem=\"4096 16384 536870912\"\n"
+)
 
 
 def _patch_active_checks_locals(recipe_dir: Path) -> bool:
@@ -192,10 +250,47 @@ def _patch_active_checks_locals(recipe_dir: Path) -> bool:
     return True
 
 
+def _patch_nodeconfigurator_userns(recipe_dir: Path) -> bool:
+    """Teach the upstream node configurator about Ubuntu's AppArmor userns gate.
+
+    The 4.1.0 chart enables ``kernel.unprivileged_userns_clone`` but Ubuntu's
+    newer host images independently deny unprivileged user namespaces through
+    ``kernel.apparmor_restrict_unprivileged_userns``. Enroot/Pyxis image startup
+    then fails even though the worker container itself is AppArmor-unconfined.
+    Override the chart's full init-container list and disable the second gate
+    only when Soperator's default AppArmor profile is intentionally disabled.
+    """
+
+    template = (
+        recipe_dir
+        / "modules"
+        / "slurm"
+        / "templates"
+        / "helm_values"
+        / "terraform_fluxcd_values.yaml.tftpl"
+    )
+    if not template.exists():
+        return False
+    text = template.read_text()
+    if _NODECONFIGURATOR_USERNS_MARKER in text:
+        return False
+    section = text.find("          nodeConfigurator:\n")
+    if section == -1:
+        return False
+    marker = "            values:\n"
+    insert_at = text.find(marker, section)
+    if insert_at == -1:
+        return False
+    insert_at += len(marker)
+    template.write_text(text[:insert_at] + _NODECONFIGURATOR_USERNS_VALUES + text[insert_at:])
+    return True
+
+
 def _prepare_installation(recipe_dir: Path, spec: SoperatorSpec, region: str) -> Path:
     """Create installations/<name> with the recipe files + generated tfvars."""
 
     _patch_active_checks_locals(recipe_dir)
+    _patch_nodeconfigurator_userns(recipe_dir)
     example = recipe_dir / "installations" / "example"
     install_dir = recipe_dir / "installations" / spec.name
     install_dir.mkdir(parents=True, exist_ok=True)
@@ -315,6 +410,7 @@ def _install_monitoring_crds(
     """
 
     kube_env = _nebius_cli_env()
+    _ensure_monitoring_namespace(kubectl_bin, context, env=kube_env)
     _log(on_status, "installing prometheus-operator CRDs (ServiceMonitor/PodMonitor/Probe)")
     for crd in _PROMETHEUS_CRDS:
         last: subprocess.CompletedProcess[str] | None = None
@@ -349,6 +445,174 @@ def _install_monitoring_crds(
             "prometheus-operator ServiceMonitor CRD not present after install"
             + (f": {detail}" if detail else "")
         )
+    reset = _reset_stalled_monitoring_releases(kubectl_bin, context, env=kube_env)
+    if reset:
+        _log(on_status, f"reset {reset} stalled monitoring HelmRelease(s)")
+
+
+def _ensure_monitoring_namespace(
+    kubectl_bin: str, context: str, *, env: dict[str, str] | None = None
+) -> None:
+    """Ensure the namespace required by the unconditional dashboards chart.
+
+    Soperator 4.1.0 still reconciles monitoring dashboards when observability is
+    disabled, but that mode does not create ``monitoring-system``.  Creating the
+    namespace is idempotent and lets Flux install the chart instead of leaving a
+    permanently failed HelmRelease in an otherwise healthy cluster.
+    """
+
+    kube_env = env or _nebius_cli_env()
+    get = _run_capture(
+        [
+            kubectl_bin,
+            "--context",
+            context,
+            "get",
+            "namespace",
+            _MONITORING_NAMESPACE,
+            "-o",
+            "name",
+        ],
+        env=kube_env,
+        check=False,
+    )
+    if get.returncode == 0 and get.stdout.strip():
+        return
+    create = _run_capture(
+        [
+            kubectl_bin,
+            "--context",
+            context,
+            "create",
+            "namespace",
+            _MONITORING_NAMESPACE,
+        ],
+        env=kube_env,
+        check=False,
+    )
+    if create.returncode == 0:
+        return
+
+    # Another reconciler may create the namespace between our read and write.
+    # Confirm the desired end state before treating a failed create as fatal.
+    confirm = _run_capture(
+        [
+            kubectl_bin,
+            "--context",
+            context,
+            "get",
+            "namespace",
+            _MONITORING_NAMESPACE,
+            "-o",
+            "name",
+        ],
+        env=kube_env,
+        check=False,
+    )
+    if confirm.returncode == 0 and confirm.stdout.strip():
+        return
+
+    detail = (create.stderr or create.stdout).strip()
+    raise RuntimeError(
+        f"failed to ensure {_MONITORING_NAMESPACE} namespace"
+        + (f": {detail}" if detail else "")
+    )
+
+
+def _reset_stalled_monitoring_releases(
+    kubectl_bin: str, context: str, *, env: dict[str, str] | None = None
+) -> int:
+    """Reset failed dashboards releases after repairing their prerequisites.
+
+    Flux stops retrying a HelmRelease after its remediation budget is exhausted.
+    A rerun of NPA can therefore repair ``monitoring-system`` and the CRDs yet
+    remain blocked on the old failure. Flux's paired ``requestedAt``/``resetAt``
+    annotations reset that counter. Clean installs have no HelmRelease at this
+    point, and healthy releases are left untouched.
+    """
+
+    kube_env = env or _nebius_cli_env()
+    listed = _run_capture(
+        [
+            kubectl_bin,
+            "--context",
+            context,
+            "-n",
+            "flux-system",
+            "get",
+            "helmreleases",
+            "-o",
+            "json",
+        ],
+        env=kube_env,
+        check=False,
+    )
+    if listed.returncode != 0:
+        raw_detail = (listed.stderr or listed.stdout).strip()
+        detail = raw_detail.lower()
+        if (
+            "not found" in detail
+            or "doesn't have a resource type" in detail
+            or "the server could not find the requested resource" in detail
+        ):
+            return 0
+        raise RuntimeError(
+            "failed to inspect monitoring HelmReleases"
+            + (f": {raw_detail}" if raw_detail else "")
+        )
+
+    try:
+        payload = json.loads(listed.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("failed to inspect monitoring HelmReleases: invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("failed to inspect monitoring HelmReleases: invalid JSON object")
+
+    reset = 0
+    for item in payload.get("items") or []:
+        metadata = item.get("metadata") or {}
+        name = str(metadata.get("name") or "")
+        if not name.endswith(_MONITORING_RELEASE_SUFFIX):
+            continue
+        conditions = (item.get("status") or {}).get("conditions") or []
+        stalled = any(
+            condition.get("status") == "True" and condition.get("type") == "Stalled"
+            for condition in conditions
+        )
+        retries_exhausted = any(
+            condition.get("type") == "Ready"
+            and condition.get("status") == "False"
+            and condition.get("reason") == "RetriesExceeded"
+            for condition in conditions
+        )
+        if not (stalled or retries_exhausted):
+            continue
+        token = str(time.time_ns())
+        annotated = _run_capture(
+            [
+                kubectl_bin,
+                "--context",
+                context,
+                "-n",
+                "flux-system",
+                "annotate",
+                "helmrelease",
+                name,
+                f"reconcile.fluxcd.io/requestedAt={token}",
+                f"reconcile.fluxcd.io/resetAt={token}",
+                "--overwrite",
+            ],
+            env=kube_env,
+            check=False,
+        )
+        if annotated.returncode != 0:
+            detail = (annotated.stderr or annotated.stdout).strip()
+            raise RuntimeError(
+                f"failed to reset monitoring HelmRelease {name}"
+                + (f": {detail}" if detail else "")
+            )
+        reset += 1
+    return reset
 
 
 def _patch_slurmcluster_crd(kubectl_bin: str, context: str) -> bool:
@@ -473,6 +737,7 @@ def deploy_cluster(
 ) -> dict[str, Any]:
     """Deploy a soperator cluster described by *spec*. Returns cluster metadata."""
 
+    spec = _with_resolved_ssh_public_keys(spec)
     spec.validate()
     envcfg = resolve_environment(
         project=project,

--- a/npa/src/npa/soperator/lifecycle.py
+++ b/npa/src/npa/soperator/lifecycle.py
@@ -1049,7 +1049,7 @@ def _patch_slurmcluster_crd(kubectl_bin: str, context: str) -> bool:
     )
     if got.returncode != 0 or not got.stdout.strip():
         return False
-    _run_capture(
+    patched = _run_capture(
         [kubectl_bin, "--context", context, "patch", "crd",
          "slurmclusters.slurm.nebius.ai", "--type=json", "-p",
          '[{"op":"add","path":"/spec/versions/0/schema/openAPIV3Schema/'
@@ -1058,7 +1058,7 @@ def _patch_slurmcluster_crd(kubectl_bin: str, context: str) -> bool:
         env=kube_env,
         check=False,
     )
-    return True
+    return patched.returncode == 0
 
 
 def _ensure_scripts_configmap(kubectl_bin: str, context: str, namespace: str) -> bool:
@@ -1091,14 +1091,14 @@ def _ensure_scripts_configmap(kubectl_bin: str, context: str, namespace: str) ->
     except json.JSONDecodeError:
         return False
     cm["metadata"] = {"name": target, "namespace": namespace}
-    subprocess.run(
+    applied = subprocess.run(
         [kubectl_bin, "--context", context, "apply", "-f", "-"],
         input=json.dumps(cm),
         text=True,
         env=kube_env,
         check=False,
     )
-    return True
+    return applied.returncode == 0
 
 
 def _mid_apply_fix_loop(

--- a/npa/src/npa/soperator/spec.py
+++ b/npa/src/npa/soperator/spec.py
@@ -11,26 +11,120 @@ node-local Docker/Enroot image cache per pool.
 
 from __future__ import annotations
 
+import base64
+import binascii
 from dataclasses import dataclass, field
 from pathlib import Path
+import re
 from typing import Any
 
 import yaml
 
 API_VERSION = "npa.soperator/v0.0.1"
+DEFAULT_SOLUTIONS_LIBRARY_REF = "7046fb3c68314a940cdb47ff5c4fd23c01a6711e"
+DEFAULT_SLURM_OPERATOR_VERSION = "4.1.6"
+DEFAULT_K8S_VERSION = "1.34"
+DEFAULT_NODE_GROUP_VERSION = "72"
 
-# Minimum sufficient cpu-d3 presets per soperator node role.  The current
-# sizing-tier recipe places the XS system and controller components on 16-vCPU
-# nodes; smaller historical presets no longer have enough allocatable capacity.
-_MIN_PRESET = {
-    "system": "16vcpu-64gb",
-    "controller": "16vcpu-64gb",
-    "login": "16vcpu-64gb",
+# Mirrors modules/sizing_tier/main.tf at DEFAULT_SOLUTIONS_LIBRARY_REF. Keeping
+# this small table in NPA lets an unsafe explicit override fail before cloning,
+# Terraform initialization, or any provider mutation. Omitted presets are still
+# resolved by the pinned upstream module, which remains the source of truth.
+_SIZING_BOUNDARIES = ((10, "XS"), (100, "S"), (500, "M"), (2000, "L"))
+_MIN_PRESET_BY_ROLE_AND_TIER = {
+    "system": {
+        "XS": "16vcpu-64gb",
+        "S": "16vcpu-64gb",
+        "M": "16vcpu-64gb",
+        "L": "32vcpu-128gb",
+        "XL": "64vcpu-256gb",
+    },
+    "controller": {tier: "16vcpu-64gb" for tier in ("XS", "S", "M", "L", "XL")},
+    "accounting": {
+        "XS": "8vcpu-32gb",
+        "S": "8vcpu-32gb",
+        "M": "8vcpu-32gb",
+        "L": "16vcpu-64gb",
+        "XL": "32vcpu-128gb",
+    },
+    "login": {tier: "16vcpu-64gb" for tier in ("XS", "S", "M", "L", "XL")},
 }
+_CPU_D3_PRESET_RANK = {
+    "4vcpu-16gb": 4,
+    "8vcpu-32gb": 8,
+    "16vcpu-64gb": 16,
+    "32vcpu-128gb": 32,
+    "64vcpu-256gb": 64,
+    "128vcpu-512gb": 128,
+}
+_OPERATOR_VERSION_RE = re.compile(r"^[1-9][0-9]*\.[0-9]+\.[0-9]+$")
+_VERIFIED_OPERATOR_VERSIONS = frozenset({"4.1.6", "4.1.7"})
+_VERIFIED_USERNS_OPERATOR_VERSIONS = frozenset({DEFAULT_SLURM_OPERATOR_VERSION})
+_SSH_KEY_TYPE_RE = re.compile(
+    r"^(?:ssh-(?:ed25519|rsa)|ecdsa-sha2-nistp(?:256|384|521)|"
+    r"sk-(?:ssh-ed25519|ecdsa-sha2-nistp256)@openssh\.com)$"
+)
 
 
 class SoperatorSpecError(ValueError):
     """Raised when a soperator spec is missing required fields or malformed."""
+
+
+def sizing_tier_for_worker_count(worker_count: int) -> str:
+    """Return the pinned upstream sizing tier for *worker_count*."""
+
+    for upper_bound, tier in _SIZING_BOUNDARIES:
+        if worker_count < upper_bound:
+            return tier
+    return "XL"
+
+
+def _validate_role_preset(role: str, preset: str | None, tier: str) -> None:
+    """Reject explicit cpu-d3 presets smaller than the pinned tier requires."""
+
+    if preset is None:
+        return
+    actual_rank = _CPU_D3_PRESET_RANK.get(preset)
+    if actual_rank is None:
+        accepted = ", ".join(_CPU_D3_PRESET_RANK)
+        raise SoperatorSpecError(
+            f"control_plane.{role}.preset {preset!r} is not a supported cpu-d3 "
+            f"preset; expected one of: {accepted}"
+        )
+    required = _MIN_PRESET_BY_ROLE_AND_TIER[role][tier]
+    if actual_rank < _CPU_D3_PRESET_RANK[required]:
+        raise SoperatorSpecError(
+            f"control_plane.{role}.preset {preset!r} is insufficient for {tier} "
+            f"sizing ({role} requires at least {required}); omit the preset to "
+            "use the pinned upstream sizing tier"
+        )
+
+
+def validate_ssh_public_key_record(value: str) -> str:
+    """Validate and normalize one OpenSSH public-key record.
+
+    Options, blank records, private-key blocks, and multiple newline-delimited
+    keys are rejected. The optional comment may contain spaces.
+    """
+
+    normalized = value.strip()
+    if not normalized or "\n" in normalized or "\r" in normalized:
+        raise SoperatorSpecError(
+            "root login SSH key must be exactly one non-empty public-key record"
+        )
+    fields = normalized.split(maxsplit=2)
+    if len(fields) < 2 or not _SSH_KEY_TYPE_RE.fullmatch(fields[0]):
+        raise SoperatorSpecError(
+            "root login SSH key must start with a supported OpenSSH key type "
+            "and contain one base64 key blob"
+        )
+    try:
+        decoded = base64.b64decode(fields[1], validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise SoperatorSpecError("root login SSH key has an invalid base64 blob") from exc
+    if not decoded:
+        raise SoperatorSpecError("root login SSH key has an empty key blob")
+    return normalized
 
 
 @dataclass
@@ -95,48 +189,126 @@ class SoperatorSpec:
     tenant_id: str = ""
     project_id: str = ""
     subnet_id: str = ""
+    # Existing positional field retained as a one-record compatibility alias.
     ssh_public_keys: list[str] = field(default_factory=list)
 
-    # Control-plane sizing (minimal defaults that fit the sufficiency map).
+    # Omitted system/controller/accounting presets are derived from the pinned
+    # upstream XS..XL sizing tier. Explicit values are checked against that tier.
     system_min_size: int = 3  # recipe minimum is 3
-    system_preset: str = _MIN_PRESET["system"]
-    controller_preset: str = _MIN_PRESET["controller"]
-    login_preset: str = _MIN_PRESET["login"]
+    system_preset: str | None = None
+    controller_preset: str | None = None
+    login_preset: str = "16vcpu-64gb"
 
     workers: list[WorkerPoolSpec] = field(default_factory=list)
 
     # Toggles that keep the deploy small and working out of the box.
     accounting: bool = False
     telemetry: bool = False
-    # Custom AppArmor profile is not loaded by SPO in the 4.1.0 stable build;
+    # Custom AppArmor profile is not loaded by the verified chart contract;
     # unconfined (use_default_apparmor_profile=false) keeps login/worker sshd
     # starting. Default off for reliability; opt in if your build loads it.
     use_default_apparmor_profile: bool = False
     jail_size_gib: int = 512
-    slurm_operator_version: str = "4.1.0"
-    # Keep these explicit because the upstream recipe intentionally has no
-    # node_group_version default.  They must advance together when the tested
-    # solutions-library contract advances.
-    k8s_version: str = "1.34"
-    node_group_version: str = "72"
+    slurm_operator_version: str = DEFAULT_SLURM_OPERATOR_VERSION
+    # These defaults are part of the immutable solutions-library contract.
+    k8s_version: str = DEFAULT_K8S_VERSION
+    node_group_version: str = DEFAULT_NODE_GROUP_VERSION
+
+    # New fields are declared last so existing positional SDK construction keeps
+    # its historical meaning. The canonical key name makes the root grant clear.
+    root_login_ssh_public_key: str = ""
+    system_max_size: int | None = None  # omitted -> max(min_size, upstream example's 24)
+    accounting_preset: str | None = None
+    # ``None`` preserves the historical default (follow accounting) while an
+    # explicit bool makes the public contract independent. The pinned 4.1.6
+    # operator still cannot reconcile REST without accounting; NPA therefore
+    # performs its own direct GPU creation check when accounting is disabled.
+    slurm_rest_enabled: bool | None = None
+
+    def explicit_root_login_ssh_public_key(self) -> str:
+        """Return the canonical or legacy explicit root-login key, if supplied."""
+
+        if self.root_login_ssh_public_key:
+            return self.root_login_ssh_public_key
+        return self.ssh_public_keys[0] if self.ssh_public_keys else ""
+
+    def effective_slurm_rest_enabled(self) -> bool:
+        """Resolve the backward-compatible REST default independently."""
+
+        if self.slurm_rest_enabled is None:
+            return self.accounting
+        return self.slurm_rest_enabled
 
     def validate(self) -> None:
         if not self.name or not self.name.replace("-", "").isalnum():
             raise SoperatorSpecError(f"cluster name must be alphanumeric/dash: {self.name!r}")
         if self.system_min_size < 3:
             raise SoperatorSpecError("system_min_size must be >= 3 (recipe rule)")
+        if self.system_max_size is not None and self.system_max_size < self.system_min_size:
+            raise SoperatorSpecError(
+                "control_plane.system.max_size must be >= min_size"
+            )
         if not self.workers:
             raise SoperatorSpecError("at least one worker pool is required")
         if not self.k8s_version or not self.node_group_version:
             raise SoperatorSpecError(
                 "k8s_version and node_group_version must both be non-empty"
             )
+        if not _OPERATOR_VERSION_RE.fullmatch(self.slurm_operator_version):
+            raise SoperatorSpecError(
+                "slurm_operator_version must be an explicit semantic version "
+                "such as '4.1.6'"
+            )
+        if self.slurm_operator_version not in _VERIFIED_OPERATOR_VERSIONS:
+            supported = ", ".join(sorted(_VERIFIED_OPERATOR_VERSIONS))
+            raise SoperatorSpecError(
+                "slurm_operator_version is outside the pinned runtime contract; "
+                f"verified overrides are: {supported}"
+            )
+        if (
+            not self.use_default_apparmor_profile
+            and self.slurm_operator_version not in _VERIFIED_USERNS_OPERATOR_VERSIONS
+        ):
+            raise SoperatorSpecError(
+                "the unconfined Enroot/Pyxis user-namespace override is verified only "
+                f"with slurm_operator_version {DEFAULT_SLURM_OPERATOR_VERSION}; use "
+                "that version or explicitly enable use_default_apparmor_profile for "
+                "a separately validated chart"
+            )
+        if self.root_login_ssh_public_key and self.ssh_public_keys:
+            raise SoperatorSpecError(
+                "set only root_login_ssh_public_key; ssh_public_keys is its legacy alias"
+            )
+        if len(self.ssh_public_keys) > 1:
+            raise SoperatorSpecError(
+                "ssh_public_keys accepts exactly one root-login public-key record; "
+                "use root_login_ssh_public_key"
+            )
+        explicit_root_key = self.explicit_root_login_ssh_public_key()
+        if explicit_root_key:
+            validate_ssh_public_key_record(explicit_root_key)
         seen: set[str] = set()
         for pool in self.workers:
             pool.validate()
             if pool.name in seen:
                 raise SoperatorSpecError(f"duplicate worker pool name: {pool.name}")
             seen.add(pool.name)
+
+        worker_count = sum(pool.size for pool in self.workers)
+        tier = sizing_tier_for_worker_count(worker_count)
+        _validate_role_preset("system", self.system_preset, tier)
+        _validate_role_preset("controller", self.controller_preset, tier)
+        if self.accounting:
+            _validate_role_preset("accounting", self.accounting_preset, tier)
+        _validate_role_preset("login", self.login_preset, tier)
+        if self.effective_slurm_rest_enabled() and not self.accounting:
+            raise SoperatorSpecError(
+                "slurm_rest_enabled=true requires accounting=true with the pinned "
+                f"Slurm operator {self.slurm_operator_version} runtime contract; the "
+                "verified controller skips REST reconciliation "
+                "without an accounting database. GPU creation checks do not require "
+                "accounting because NPA runs them directly through the login-node jail"
+            )
 
 
 def spec_from_mapping(data: dict[str, Any]) -> SoperatorSpec:
@@ -174,25 +346,53 @@ def spec_from_mapping(data: dict[str, Any]) -> SoperatorSpec:
 
     control = data.get("control_plane") or {}
     system = control.get("system") or {}
+    controller = control.get("controller") or {}
+    accounting_control = control.get("accounting") or {}
+    login = control.get("login") or {}
+
+    legacy_keys = data.get("ssh_public_keys") or []
+    if not isinstance(legacy_keys, list):
+        raise SoperatorSpecError("ssh_public_keys must be a list")
+    rest_value = data.get("slurm_rest_enabled")
+    if rest_value is not None and not isinstance(rest_value, bool):
+        raise SoperatorSpecError("slurm_rest_enabled must be a boolean when set")
     spec = SoperatorSpec(
         name=str(data.get("name", "")),
         region=str(data.get("region", "")),
         tenant_id=str(data.get("tenant_id", "")),
         project_id=str(data.get("project_id", "")),
         subnet_id=str(data.get("subnet_id", "")),
-        ssh_public_keys=list(data.get("ssh_public_keys") or []),
+        root_login_ssh_public_key=str(data.get("root_login_ssh_public_key", "") or ""),
+        ssh_public_keys=[str(key) for key in legacy_keys],
         system_min_size=int(system.get("min_size", 3)),
-        system_preset=str(system.get("preset", _MIN_PRESET["system"])),
-        controller_preset=str((control.get("controller") or {}).get("preset", _MIN_PRESET["controller"])),
-        login_preset=str((control.get("login") or {}).get("preset", _MIN_PRESET["login"])),
+        system_max_size=(
+            int(system["max_size"]) if system.get("max_size") is not None else None
+        ),
+        system_preset=(str(system["preset"]) if system.get("preset") is not None else None),
+        controller_preset=(
+            str(controller["preset"]) if controller.get("preset") is not None else None
+        ),
+        accounting_preset=(
+            str(accounting_control["preset"])
+            if accounting_control.get("preset") is not None
+            else None
+        ),
+        login_preset=str(login.get("preset", "16vcpu-64gb")),
         workers=workers,
         accounting=bool(data.get("accounting", False)),
+        slurm_rest_enabled=(
+            rest_value if rest_value is not None else None
+        ),
         telemetry=bool(data.get("telemetry", False)),
         use_default_apparmor_profile=bool(data.get("use_default_apparmor_profile", False)),
         jail_size_gib=int(data.get("jail_size_gib", 512)),
-        slurm_operator_version=str(data.get("slurm_operator_version", "4.1.0")),
-        k8s_version=str(data.get("k8s_version", "1.34")),
-        node_group_version=str(data.get("node_group_version", "72")),
+        slurm_operator_version=str(
+            data.get("slurm_operator_version", DEFAULT_SLURM_OPERATOR_VERSION)
+        ),
+        k8s_version=str(data.get("k8s_version", DEFAULT_K8S_VERSION)),
+        node_group_version=str(
+            data.get("node_group_version", DEFAULT_NODE_GROUP_VERSION)
+        ),
     )
     return spec
 

--- a/npa/src/npa/soperator/spec.py
+++ b/npa/src/npa/soperator/spec.py
@@ -145,9 +145,37 @@ class WorkerPoolSpec:
     docker_cache: bool = False
     docker_cache_gib: int = 372  # must be divisible by 93 for IO_M3 (keep IO_M3 quota modest)
     docker_cache_disk_type: str = "NETWORK_SSD_IO_M3"
+    # Reserved-capacity selectors are runtime inputs. ``capacity_block_group``
+    # matches the fleet contract and accepts an immutable group ID;
+    # ``capacity_block_group_name`` is resolved to exactly one tenant-owned
+    # group before Terraform is rendered. Live selector values must not be
+    # committed in public examples.
+    capacity_block_group: str = ""
+    capacity_block_group_name: str = ""
+    # Populated only by the provider preflight for name-based selectors. It is
+    # deliberately absent from YAML parsing and public plan/status output.
+    resolved_capacity_block_group_id: str = field(
+        default="", repr=False, compare=False
+    )
 
     def is_gpu(self) -> bool:
         return self.platform.startswith("gpu-")
+
+    def capacity_mode(self) -> str:
+        """Return the public worker-capacity mode without exposing selectors."""
+
+        if self.capacity_block_group or self.capacity_block_group_name:
+            return "reserved"
+        return "preemptible" if self.preemptible else "on-demand"
+
+    def reservation_selector_kind(self) -> str:
+        """Return the configured selector kind, never its private value."""
+
+        if self.capacity_block_group:
+            return "id"
+        if self.capacity_block_group_name:
+            return "name"
+        return ""
 
     def validate(self) -> None:
         if not self.name or not self.name.replace("-", "").isalnum():
@@ -168,6 +196,21 @@ class WorkerPoolSpec:
         if not self.is_gpu() and self.fabric:
             raise SoperatorSpecError(
                 f"worker pool {self.name}: CPU preset must not set 'fabric'"
+            )
+        if self.capacity_block_group and self.capacity_block_group_name:
+            raise SoperatorSpecError(
+                f"worker pool {self.name}: set only one of capacity_block_group "
+                "or capacity_block_group_name"
+            )
+        if self.capacity_mode() == "reserved" and not self.is_gpu():
+            raise SoperatorSpecError(
+                f"worker pool {self.name}: reserved capacity selectors are valid "
+                "only for GPU worker pools"
+            )
+        if self.capacity_mode() == "reserved" and self.preemptible:
+            raise SoperatorSpecError(
+                f"worker pool {self.name}: reserved capacity is mutually exclusive "
+                "with preemptible=true; disable preemptibility to use a capacity block"
             )
         if self.docker_cache and self.docker_cache_gib % 93 != 0:
             raise SoperatorSpecError(
@@ -217,7 +260,10 @@ class SoperatorSpec:
     # New fields are declared last so existing positional SDK construction keeps
     # its historical meaning. The canonical key name makes the root grant clear.
     root_login_ssh_public_key: str = ""
-    system_max_size: int | None = None  # omitted -> max(min_size, upstream example's 24)
+    # Compatibility migration: the old NPA renderer fixed max_size to min_size.
+    # Omission now preserves the pinned upstream autoscaling ceiling of 24 while
+    # explicit values remain available for operator-controlled capacity/cost.
+    system_max_size: int | None = None
     accounting_preset: str | None = None
     # ``None`` preserves the historical default (follow accounting) while an
     # explicit bool makes the public contract independent. The pinned 4.1.6
@@ -238,6 +284,13 @@ class SoperatorSpec:
         if self.slurm_rest_enabled is None:
             return self.accounting
         return self.slurm_rest_enabled
+
+    def effective_system_max_size(self) -> int:
+        """Return the rendered autoscaling ceiling (visible in plans/results)."""
+
+        if self.system_max_size is not None:
+            return self.system_max_size
+        return max(self.system_min_size, 24)
 
     def validate(self) -> None:
         if not self.name or not self.name.replace("-", "").isalnum():
@@ -261,9 +314,19 @@ class SoperatorSpec:
             )
         if self.slurm_operator_version not in _VERIFIED_OPERATOR_VERSIONS:
             supported = ", ".join(sorted(_VERIFIED_OPERATOR_VERSIONS))
+            if self.slurm_operator_version == "4.1.0":
+                raise SoperatorSpecError(
+                    "slurm_operator_version 4.1.0 is no longer verified; replace it "
+                    f"with {DEFAULT_SLURM_OPERATOR_VERSION} for the default unconfined "
+                    "Enroot/Pyxis setup. Version 4.1.7 is accepted only with "
+                    "use_default_apparmor_profile=true after separately validating that "
+                    "profile on the nodes; 4.1.0 is not safe to re-enable"
+                )
             raise SoperatorSpecError(
                 "slurm_operator_version is outside the pinned runtime contract; "
-                f"verified overrides are: {supported}"
+                f"use {DEFAULT_SLURM_OPERATOR_VERSION} for the default unconfined "
+                f"Enroot/Pyxis setup; verified overrides are: {supported} (4.1.7 "
+                "requires use_default_apparmor_profile=true)"
             )
         if (
             not self.use_default_apparmor_profile
@@ -341,6 +404,12 @@ def spec_from_mapping(data: dict[str, Any]) -> SoperatorSpec:
                 docker_cache_disk_type=str(
                     entry.get("docker_cache_disk_type", "NETWORK_SSD_IO_M3")
                 ),
+                capacity_block_group=str(
+                    entry.get("capacity_block_group", "") or ""
+                ).strip(),
+                capacity_block_group_name=str(
+                    entry.get("capacity_block_group_name", "") or ""
+                ).strip(),
             )
         )
 

--- a/npa/src/npa/soperator/spec.py
+++ b/npa/src/npa/soperator/spec.py
@@ -19,11 +19,12 @@ import yaml
 
 API_VERSION = "npa.soperator/v0.0.1"
 
-# Minimum sufficient cpu-d3 presets per soperator node role (from the recipe's
-# available_resources sufficiency map): system>=8, controller>=4, login>=16.
+# Minimum sufficient cpu-d3 presets per soperator node role.  The current
+# sizing-tier recipe places the XS system and controller components on 16-vCPU
+# nodes; smaller historical presets no longer have enough allocatable capacity.
 _MIN_PRESET = {
-    "system": "8vcpu-32gb",
-    "controller": "4vcpu-16gb",
+    "system": "16vcpu-64gb",
+    "controller": "16vcpu-64gb",
     "login": "16vcpu-64gb",
 }
 
@@ -113,6 +114,11 @@ class SoperatorSpec:
     use_default_apparmor_profile: bool = False
     jail_size_gib: int = 512
     slurm_operator_version: str = "4.1.0"
+    # Keep these explicit because the upstream recipe intentionally has no
+    # node_group_version default.  They must advance together when the tested
+    # solutions-library contract advances.
+    k8s_version: str = "1.34"
+    node_group_version: str = "72"
 
     def validate(self) -> None:
         if not self.name or not self.name.replace("-", "").isalnum():
@@ -121,6 +127,10 @@ class SoperatorSpec:
             raise SoperatorSpecError("system_min_size must be >= 3 (recipe rule)")
         if not self.workers:
             raise SoperatorSpecError("at least one worker pool is required")
+        if not self.k8s_version or not self.node_group_version:
+            raise SoperatorSpecError(
+                "k8s_version and node_group_version must both be non-empty"
+            )
         seen: set[str] = set()
         for pool in self.workers:
             pool.validate()
@@ -181,6 +191,8 @@ def spec_from_mapping(data: dict[str, Any]) -> SoperatorSpec:
         use_default_apparmor_profile=bool(data.get("use_default_apparmor_profile", False)),
         jail_size_gib=int(data.get("jail_size_gib", 512)),
         slurm_operator_version=str(data.get("slurm_operator_version", "4.1.0")),
+        k8s_version=str(data.get("k8s_version", "1.34")),
+        node_group_version=str(data.get("node_group_version", "72")),
     )
     return spec
 

--- a/npa/src/npa/soperator/tfvars.py
+++ b/npa/src/npa/soperator/tfvars.py
@@ -22,13 +22,31 @@ def _bool(value: bool) -> str:
 
 
 def _tfstr(value: str) -> str:
-    """Render a Terraform/HCL string with JSON and template escaping."""
+    """Render a Terraform/HCL string with single-pass template escaping."""
 
     # HCL quoted strings still evaluate ${...} interpolation and %{...}
-    # directives after JSON-compatible escaping. Doubling their introducers is
-    # Terraform's literal form and prevents a public-key comment (or any other
-    # user-controlled string) from changing the generated expression.
-    escaped = value.replace("${", "$${").replace("%{", "%%{")
+    # directives after JSON-compatible escaping. Scan once so literal forms that
+    # are already escaped ($${...} / %%{...}) remain unchanged instead of
+    # becoming $$${...} / %%%{...} and changing Terraform template semantics.
+    escaped_parts: list[str] = []
+    index = 0
+    while index < len(value):
+        if value.startswith("$${", index):
+            escaped_parts.append("$${")
+            index += 3
+        elif value.startswith("${", index):
+            escaped_parts.append("$${")
+            index += 2
+        elif value.startswith("%%{", index):
+            escaped_parts.append("%%{")
+            index += 3
+        elif value.startswith("%{", index):
+            escaped_parts.append("%%{")
+            index += 2
+        else:
+            escaped_parts.append(value[index])
+            index += 1
+    escaped = "".join(escaped_parts)
     return json.dumps(escaped, ensure_ascii=True)
 
 
@@ -57,7 +75,24 @@ def _render_worker(pool: WorkerPoolSpec) -> str:
         lines.append("    gpu_cluster = {")
         lines.append(f"      infiniband_fabric = {_tfstr(pool.fabric)}")
         lines.append("    }")
+    reservation_id = (
+        pool.resolved_capacity_block_group_id or pool.capacity_block_group
+    )
+    if pool.capacity_block_group_name and not reservation_id:
+        raise ValueError(
+            f"worker pool {pool.name}: capacity block name must be provider-resolved "
+            "before rendering Terraform"
+        )
     lines.append(f"    preemptible = {'{}' if pool.preemptible else 'null'}")
+    if reservation_id:
+        # STRICT is the only safe reservation policy for an explicit capacity
+        # block. AUTO could silently fall back to ordinary on-demand capacity.
+        lines.append("    reservation_policy = {")
+        lines.append('      policy          = "STRICT"')
+        lines.append(f"      reservation_ids = [{_tfstr(reservation_id)}]")
+        lines.append("    }")
+    else:
+        lines.append("    reservation_policy = null")
     lines.append("    features = null")
     lines.append("    create_partition = null")
     lines.append("    ephemeral_nodes                = false")
@@ -183,7 +218,7 @@ slurm_partition_config_type = "default"
 # --- Nodes ---
 slurm_nodeset_system = {{
   min_size = {spec.system_min_size}
-  max_size = {spec.system_max_size or max(spec.system_min_size, 24)}
+  max_size = {spec.effective_system_max_size()}
   resource = {{
     platform = "cpu-d3"
     preset   = {_nullable_tfstr(spec.system_preset)}

--- a/npa/src/npa/soperator/tfvars.py
+++ b/npa/src/npa/soperator/tfvars.py
@@ -5,10 +5,14 @@ every nodeset must be set explicitly. This renderer produces a minimal, working
 tfvars: a trimmed control plane, one worker nodeset per spec pool (mixed presets
 supported), optional per-pool node-local Docker/Enroot image cache
 (``NETWORK_SSD_IO_M3``), NFS-in-k8s, accounting/telemetry/backups off by
-default, and ``use_default_apparmor_profile`` wired from the spec.
+default, REST resolved through the pinned operator compatibility contract,
+upstream-derived control-plane sizing, and ``use_default_apparmor_profile``
+wired from the spec. Mandatory direct GPU creation checks live in the lifecycle.
 """
 
 from __future__ import annotations
+
+import json
 
 from npa.soperator.spec import SoperatorSpec, WorkerPoolSpec
 
@@ -17,17 +21,32 @@ def _bool(value: bool) -> str:
     return "true" if value else "false"
 
 
+def _tfstr(value: str) -> str:
+    """Render a Terraform/HCL string with JSON and template escaping."""
+
+    # HCL quoted strings still evaluate ${...} interpolation and %{...}
+    # directives after JSON-compatible escaping. Doubling their introducers is
+    # Terraform's literal form and prevents a public-key comment (or any other
+    # user-controlled string) from changing the generated expression.
+    escaped = value.replace("${", "$${").replace("%{", "%%{")
+    return json.dumps(escaped, ensure_ascii=True)
+
+
+def _nullable_tfstr(value: str | None) -> str:
+    return "null" if value is None else _tfstr(value)
+
+
 def _render_worker(pool: WorkerPoolSpec) -> str:
     lines: list[str] = []
     lines.append("  {")
-    lines.append(f'    name = "{pool.name}"')
+    lines.append(f"    name = {_tfstr(pool.name)}")
     lines.append(f"    size = {pool.size}")
     lines.append("    autoscaling = {")
     lines.append("      enabled = false")
     lines.append("    }")
     lines.append("    resource = {")
-    lines.append(f'      platform = "{pool.platform}"')
-    lines.append(f'      preset   = "{pool.preset}"')
+    lines.append(f"      platform = {_tfstr(pool.platform)}")
+    lines.append(f"      preset   = {_tfstr(pool.preset)}")
     lines.append("    }")
     lines.append("    boot_disk = {")
     lines.append('      type                 = "NETWORK_SSD"')
@@ -36,7 +55,7 @@ def _render_worker(pool: WorkerPoolSpec) -> str:
     lines.append("    }")
     if pool.is_gpu():
         lines.append("    gpu_cluster = {")
-        lines.append(f'      infiniband_fabric = "{pool.fabric}"')
+        lines.append(f"      infiniband_fabric = {_tfstr(pool.fabric)}")
         lines.append("    }")
     lines.append(f"    preemptible = {'{}' if pool.preemptible else 'null'}")
     lines.append("    features = null")
@@ -56,7 +75,7 @@ def _render_worker(pool: WorkerPoolSpec) -> str:
         lines.append("      spec = {")
         lines.append(f"        size_gibibytes  = {pool.docker_cache_gib}")
         lines.append('        filesystem_type = "ext4"')
-        lines.append(f'        disk_type       = "{pool.docker_cache_disk_type}"')
+        lines.append(f"        disk_type       = {_tfstr(pool.docker_cache_disk_type)}")
         lines.append("      }")
         lines.append("    }")
     else:
@@ -71,7 +90,8 @@ def render_tfvars(spec: SoperatorSpec) -> str:
     """Return the full ``terraform.tfvars`` content for *spec*."""
 
     workers_block = "\n".join(_render_worker(p) for p in spec.workers)
-    ssh_keys = "\n".join(f'  "{key}",' for key in spec.ssh_public_keys)
+    root_login_key = spec.explicit_root_login_ssh_public_key()
+    ssh_keys = f"  {_tfstr(root_login_key)}," if root_login_key else ""
     telemetry = _bool(spec.telemetry)
     # ActiveChecks in the "dev" scope run NCCL all-reduce + InfiniBand + GPU perf
     # jobs that Error on a CPU-only cluster, hanging wait_for_soperator_activechecks_hr
@@ -79,13 +99,16 @@ def render_tfvars(spec: SoperatorSpec) -> str:
     # (variables.tf validation rejects ""), so on CPU-only clusters use "essential",
     # which sets runAfterCreation=false for every GPU/NCCL/IB/perf check and only
     # runs CPU-safe checks (ssh-check, etc.).
-    # Soperator 4.1 skips slurmrestd unless accounting is enabled, while its
-    # GPU bootstrap checks require that REST service to observe submitted Slurm
-    # jobs. Selecting those checks with accounting disabled leaves Terraform's
-    # activechecks HelmRelease waiting forever. Keep the full dev checks only
-    # when their REST dependency can exist.
+    # The pinned Terraform surface exposes REST independently, but its 4.1.6
+    # operator skips REST reconciliation without accounting. Only select the
+    # REST-backed dev checks for the runnable combination. NPA performs direct
+    # login-jail CUDA creation checks for every GPU pool, including accounting-
+    # disabled clusters, so essential scope no longer means zero GPU validation.
+    rest_enabled = spec.effective_slurm_rest_enabled()
     active_checks_scope = (
-        "dev" if spec.accounting and any(p.is_gpu() for p in spec.workers) else "essential"
+        "dev"
+        if rest_enabled and spec.accounting and any(p.is_gpu() for p in spec.workers)
+        else "essential"
     )
     # filestore_accounting must be non-null only when accounting is enabled, but
     # slurm_nodeset_accounting's variable validation dereferences it even when
@@ -104,7 +127,7 @@ def render_tfvars(spec: SoperatorSpec) -> str:
 
     return f"""# Generated by `npa soperator deploy` from an npa.soperator/v0.0.1 spec.
 # Cluster: {spec.name}
-company_name = "{spec.name}"
+company_name = {_tfstr(spec.name)}
 production   = false
 
 # --- Storage ---
@@ -138,7 +161,7 @@ nfs_in_k8s = {{
 }}
 
 # --- Slurm ---
-slurm_operator_version = "{spec.slurm_operator_version}"
+slurm_operator_version = {_tfstr(spec.slurm_operator_version)}
 slurm_operator_stable  = true
 
 slurm_nodesets_partitions = [
@@ -160,10 +183,10 @@ slurm_partition_config_type = "default"
 # --- Nodes ---
 slurm_nodeset_system = {{
   min_size = {spec.system_min_size}
-  max_size = {spec.system_min_size}
+  max_size = {spec.system_max_size or max(spec.system_min_size, 24)}
   resource = {{
     platform = "cpu-d3"
-    preset   = "{spec.system_preset}"
+    preset   = {_nullable_tfstr(spec.system_preset)}
   }}
   boot_disk = {{
     type                 = "NETWORK_SSD"
@@ -176,7 +199,7 @@ slurm_nodeset_controller = {{
   size = 1
   resource = {{
     platform = "cpu-d3"
-    preset   = "{spec.controller_preset}"
+    preset   = {_nullable_tfstr(spec.controller_preset)}
   }}
   boot_disk = {{
     type                 = "NETWORK_SSD"
@@ -195,7 +218,7 @@ slurm_nodeset_login = {{
   size = 1
   resource = {{
     platform = "cpu-d3"
-    preset   = "{spec.login_preset}"
+    preset   = {_tfstr(spec.login_preset)}
   }}
   boot_disk = {{
     type                 = "NETWORK_SSD"
@@ -209,7 +232,7 @@ slurm_nodeset_login = {{
 slurm_nodeset_accounting = {{
   resource = {{
     platform = "cpu-d3"
-    preset   = "16vcpu-64gb"
+    preset   = {_nullable_tfstr(spec.accounting_preset)}
   }}
   boot_disk = {{
     type                 = "NETWORK_SSD"
@@ -239,7 +262,7 @@ soperator_notifier   = {{ enabled = false }}
 nccl_inspector_profiling = {{ enabled = false }}
 
 accounting_enabled = {_bool(spec.accounting)}
-slurm_rest_enabled = {_bool(spec.accounting)}
+slurm_rest_enabled = {_bool(rest_enabled)}
 
 backups_enabled           = "force_disable"
 backups_password          = "unused-backups-disabled"
@@ -248,14 +271,15 @@ backups_prune_schedule    = "@daily-random"
 backups_retention         = {{ keepDaily = 7 }}
 cleanup_bucket_on_destroy = false
 
-k8s_version        = "{spec.k8s_version}"
-node_group_version = "{spec.node_group_version}"
+k8s_version        = {_tfstr(spec.k8s_version)}
+node_group_version = {_tfstr(spec.node_group_version)}
 nvidia_config_lines = [
   "options nvidia NVreg_RestrictProfilingToAdminUsers=0",
   "options nvidia NVreg_EnableStreamMemOPs=1",
 ]
 
-# Custom localhost AppArmor profile is not loaded by SPO in 4.1.0-stable; use
-# unconfined so login/worker sshd start. Overridable via the spec.
+# With the verified chart contract, NPA configures the Ubuntu user-namespace
+# sysctls when this is false so Enroot/Pyxis can run unconfined. Overrides are
+# version-gated by spec validation.
 use_default_apparmor_profile = {_bool(spec.use_default_apparmor_profile)}
 """

--- a/npa/src/npa/soperator/tfvars.py
+++ b/npa/src/npa/soperator/tfvars.py
@@ -79,7 +79,14 @@ def render_tfvars(spec: SoperatorSpec) -> str:
     # (variables.tf validation rejects ""), so on CPU-only clusters use "essential",
     # which sets runAfterCreation=false for every GPU/NCCL/IB/perf check and only
     # runs CPU-safe checks (ssh-check, etc.).
-    active_checks_scope = "dev" if any(p.is_gpu() for p in spec.workers) else "essential"
+    # Soperator 4.1 skips slurmrestd unless accounting is enabled, while its
+    # GPU bootstrap checks require that REST service to observe submitted Slurm
+    # jobs. Selecting those checks with accounting disabled leaves Terraform's
+    # activechecks HelmRelease waiting forever. Keep the full dev checks only
+    # when their REST dependency can exist.
+    active_checks_scope = (
+        "dev" if spec.accounting and any(p.is_gpu() for p in spec.workers) else "essential"
+    )
     # filestore_accounting must be non-null only when accounting is enabled, but
     # slurm_nodeset_accounting's variable validation dereferences it even when
     # disabled -- so always provide a valid accounting nodeset object.
@@ -165,39 +172,6 @@ slurm_nodeset_system = {{
   }}
 }}
 
-# Trimmed so the operator stack fits small (>=8vcpu) system nodes.
-system_resources = {{
-  rest = {{
-    cpu_cores                   = 3
-    memory_gibibytes            = 8
-    ephemeral_storage_gibibytes = 5
-  }}
-  exporter = {{
-    cpu_cores                   = 1
-    memory_gibibytes            = 4
-    ephemeral_storage_gibibytes = 2
-  }}
-  mariadb = {{
-    cpu_cores                   = 2
-    memory_gibibytes            = 6
-    ephemeral_storage_gibibytes = 32
-  }}
-  node_configurator = {{
-    requests = {{ cpu_cores = 0.5, memory_gibibytes = 0.25 }}
-    limits   = {{ memory_gibibytes = 0.25 }}
-  }}
-  slurm_operator = {{
-    requests = {{ cpu_cores = 1, memory_gibibytes = 4 }}
-    limits   = {{ memory_gibibytes = 4 }}
-  }}
-  slurm_checks = {{
-    requests = {{ cpu_cores = 1, memory_gibibytes = 4 }}
-    limits   = {{ memory_gibibytes = 4 }}
-  }}
-  kruise_daemon = {{ cpu_cores = 1, memory_gibibytes = 4 }}
-  dcgm_exporter = {{ cpu_cores = 0.05, memory_gibibytes = 0.5 }}
-}}
-
 slurm_nodeset_controller = {{
   size = 1
   resource = {{
@@ -265,6 +239,7 @@ soperator_notifier   = {{ enabled = false }}
 nccl_inspector_profiling = {{ enabled = false }}
 
 accounting_enabled = {_bool(spec.accounting)}
+slurm_rest_enabled = {_bool(spec.accounting)}
 
 backups_enabled           = "force_disable"
 backups_password          = "unused-backups-disabled"
@@ -273,7 +248,8 @@ backups_prune_schedule    = "@daily-random"
 backups_retention         = {{ keepDaily = 7 }}
 cleanup_bucket_on_destroy = false
 
-k8s_version = 1.33
+k8s_version        = "{spec.k8s_version}"
+node_group_version = "{spec.node_group_version}"
 nvidia_config_lines = [
   "options nvidia NVreg_RestrictProfilingToAdminUsers=0",
   "options nvidia NVreg_EnableStreamMemOPs=1",

--- a/npa/tests/cli/test_agent_workflow.py
+++ b/npa/tests/cli/test_agent_workflow.py
@@ -922,6 +922,8 @@ def test_bootstrap_embeds_workflow_endpoints() -> None:
     assert "pip install -e" in source
     assert "deploy/cluster" in source
     assert "_soperator_deploy_from_payload" in source
+    assert "DEFAULT_SOLUTIONS_LIBRARY_REF" in source
+    assert "_validate_immutable_solutions_library_ref" in source
     assert '@app.get("/workflows/draft")' in source
     assert "workflowYaml" in bundled
     assert "validateWorkflowYaml" in bundled

--- a/npa/tests/cli/test_agent_workflow.py
+++ b/npa/tests/cli/test_agent_workflow.py
@@ -924,6 +924,13 @@ def test_bootstrap_embeds_workflow_endpoints() -> None:
     assert "_soperator_deploy_from_payload" in source
     assert "DEFAULT_SOLUTIONS_LIBRARY_REF" in source
     assert "_validate_immutable_solutions_library_ref" in source
+    assert "SoperatorDeploymentValidationError" in source
+    assert '"status": "degraded-validation"' in source
+    assert "gpu_creation_check_timeout_seconds" in source
+    assert "_validate_gpu_creation_check_timeout" in source
+    assert '"system_max_size": spec.effective_system_max_size()' in source
+    assert '"capacity_mode": pool.capacity_mode()' in source
+    assert '"reservation_selector": pool.reservation_selector_kind() or None' in source
     assert '@app.get("/workflows/draft")' in source
     assert "workflowYaml" in bundled
     assert "validateWorkflowYaml" in bundled

--- a/npa/tests/unit/test_soperator_cli.py
+++ b/npa/tests/unit/test_soperator_cli.py
@@ -7,8 +7,14 @@ lifecycle at the call site for the deploy path.
 
 from __future__ import annotations
 
+from contextlib import contextmanager, nullcontext
+import hashlib
 import json
+from pathlib import Path
+import shutil
+import subprocess
 import textwrap
+import threading
 
 import pytest
 from typer.testing import CliRunner
@@ -23,7 +29,7 @@ from npa.soperator.spec import (
     load_spec,
     sizing_tier_for_worker_count,
 )
-from npa.soperator.tfvars import render_tfvars
+from npa.soperator.tfvars import _tfstr, render_tfvars
 
 runner = CliRunner()
 
@@ -62,8 +68,9 @@ def test_deploy_help_documents_spec_and_fixes() -> None:
     assert result.exit_code == 0
     assert "--spec" in result.output
     assert "--apply-fixes" in result.output
-    assert "--root-login-ssh-pub" in result.output
-    assert DEFAULT_SOLUTIONS_LIBRARY_REF[:20] in result.output
+    # Rich truncates long option names to the available terminal column width.
+    assert "--root-login-ss" in result.output
+    assert DEFAULT_SOLUTIONS_LIBRARY_REF[:12] in result.output
 
 
 def test_spec_multiple_presets_and_docker_cache() -> None:
@@ -300,8 +307,10 @@ def test_accounting_preset_boundaries_when_accounting_enabled(
 
 def test_system_max_size_preserves_upstream_autoscaling_and_validates_override() -> None:
     spec = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
+    assert spec.effective_system_max_size() == 24
     assert "max_size = 24" in render_tfvars(spec)
     spec.system_min_size = 25
+    assert spec.effective_system_max_size() == 25
     assert "max_size = 25" in render_tfvars(spec)
     spec.system_max_size = 24
     with pytest.raises(SoperatorSpecError, match="max_size must be >= min_size"):
@@ -309,35 +318,33 @@ def test_system_max_size_preserves_upstream_autoscaling_and_validates_override()
 
 
 def test_resolve_login_ssh_key_from_operator_home(tmp_path) -> None:
-    from npa.soperator.lifecycle import _with_resolved_ssh_public_keys
+    from npa.soperator.lifecycle import _resolve_root_login_ssh_public_key
 
     ssh_dir = tmp_path / ".ssh"
     ssh_dir.mkdir()
     (ssh_dir / "id_ed25519.pub").write_text("ssh-ed25519 AAAA operator\n")
     original = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
 
-    resolved = _with_resolved_ssh_public_keys(original, home=tmp_path)
+    resolved = _resolve_root_login_ssh_public_key(original, home=tmp_path)
 
-    assert resolved.root_login_ssh_public_key == "ssh-ed25519 AAAA operator"
-    assert resolved.ssh_public_keys == []
+    assert resolved.value == "ssh-ed25519 AAAA operator"
     assert original.ssh_public_keys == []
 
 
 def test_explicit_login_ssh_key_wins_and_missing_fallback_fails(tmp_path) -> None:
-    from npa.soperator.lifecycle import _with_resolved_ssh_public_keys
+    from npa.soperator.lifecycle import _resolve_root_login_ssh_public_key
 
     explicit = SoperatorSpec(
         name="c",
         workers=[WorkerPoolSpec(name="w")],
         ssh_public_keys=["ssh-rsa AAAA explicit"],
     )
-    resolved = _with_resolved_ssh_public_keys(explicit, home=tmp_path)
-    assert resolved.root_login_ssh_public_key == "ssh-rsa AAAA explicit"
-    assert resolved.ssh_public_keys == []
+    resolved = _resolve_root_login_ssh_public_key(explicit, home=tmp_path)
+    assert resolved.value == "ssh-rsa AAAA explicit"
 
     missing = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
     with pytest.raises(ValueError, match="root access requires one SSH public key"):
-        _with_resolved_ssh_public_keys(missing, home=tmp_path)
+        _resolve_root_login_ssh_public_key(missing, home=tmp_path)
 
 
 def test_root_login_ssh_key_precedence_and_nonstandard_ci_path(tmp_path) -> None:
@@ -420,8 +427,38 @@ def test_legacy_root_login_key_alias_accepts_one_record_only() -> None:
         spec.validate()
 
 
+def test_tfstr_single_pass_preserves_literals_and_terraform_parses_value(tmp_path) -> None:
+    value = (
+        'mixed-$-${live}-$${literal}-%{if true}-%%{literal}-"quoted"-'
+        '\\path-雪-ssh-comment'
+    )
+    rendered = _tfstr(value)
+    assert "$${live}" in rendered
+    assert "$${literal}" in rendered
+    assert "$$${literal}" not in rendered
+    assert "%%{if true}" in rendered
+    assert "%%{literal}" in rendered
+    assert "%%%{literal}" not in rendered
+
+    terraform = shutil.which("terraform")
+    if terraform is None:
+        pytest.skip("terraform is required to validate generated HCL")
+    parsed = subprocess.run(
+        [terraform, f"-chdir={tmp_path}", "console"],
+        input=f"jsonencode({rendered})\n",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert parsed.returncode == 0, parsed.stderr
+    # terraform console returns a Terraform string containing JSON text.
+    expected_value = value.replace("$${", "${").replace("%%{", "%{")
+    assert json.loads(json.loads(parsed.stdout)) == expected_value
+
+
 def test_root_login_ssh_key_hcl_rendering_escapes_comment_safely() -> None:
-    key = 'ssh-ed25519 AAAA ci-${var.bad}-%{if true}-"quoted"-\\path'
+    key = 'ssh-ed25519 AAAA ci-${var.bad}-$${literal}-%{if true}-%%{literal}-"quoted"-\\path-雪'
     spec = SoperatorSpec(
         name="c",
         workers=[WorkerPoolSpec(name="w")],
@@ -431,10 +468,10 @@ def test_root_login_ssh_key_hcl_rendering_escapes_comment_safely() -> None:
     rendered = render_tfvars(spec)
     assert "${var.bad}" not in rendered.replace("$${var.bad}", "")
     assert "%{if true}" not in rendered.replace("%%{if true}", "")
-    assert (
-        '  "ssh-ed25519 AAAA ci-$${var.bad}-%%{if true}-\\"quoted\\"-\\\\path",'
-        in rendered
-    )
+    assert "$${literal}" in rendered
+    assert "$$${literal}" not in rendered
+    assert "%%{literal}" in rendered
+    assert "%%%{literal}" not in rendered
 
 
 def test_operator_override_validation_and_verified_userns_contract() -> None:
@@ -454,7 +491,14 @@ def test_operator_override_validation_and_verified_userns_contract() -> None:
     spec.validate()  # explicit newer chart is possible when the pinned sysctl override is unused
 
     spec.slurm_operator_version = "4.2.0"
-    with pytest.raises(SoperatorSpecError, match="outside the pinned runtime contract"):
+    with pytest.raises(SoperatorSpecError, match="use 4.1.6"):
+        spec.validate()
+
+    spec.slurm_operator_version = "4.1.0"
+    with pytest.raises(
+        SoperatorSpecError,
+        match="4.1.0 is no longer verified; replace it with 4.1.6",
+    ):
         spec.validate()
 
 
@@ -476,16 +520,741 @@ def test_solutions_library_ref_requires_immutable_commit() -> None:
         _validate_immutable_solutions_library_ref("main")
 
 
-def test_solutions_library_resolution_preserves_legacy_install_state(tmp_path) -> None:
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def _legacy_shallow_checkout(tmp_path: Path) -> tuple[Path, str, Path, str]:
+    """Create a moving-main shallow clone whose pinned commit is not local."""
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    _git(remote, "init", "-b", "main")
+    _git(remote, "config", "user.email", "tests@example.invalid")
+    _git(remote, "config", "user.name", "NPA tests")
+    example = remote / "soperator" / "installations" / "example"
+    example.mkdir(parents=True)
+    (example / "main.tf").write_text("# pinned\n")
+    (remote / "README.md").write_text("pinned\n")
+    (remote / "PINNED_ONLY.md").write_text("tracked at the pin\n")
+    _git(remote, "add", ".")
+    _git(remote, "commit", "-m", "pinned")
+    pinned = _git(remote, "rev-parse", "HEAD").stdout.strip()
+    (remote / "README.md").write_text("moving main\n")
+    _git(remote, "rm", "PINNED_ONLY.md")
+    _git(remote, "commit", "-am", "moving main")
+
+    work_root = tmp_path / "work"
+    work_root.mkdir()
+    legacy = work_root / "nebius-solutions-library"
+    subprocess.run(
+        ["git", "clone", "--depth=1", f"file://{remote}", str(legacy)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    sentinel = legacy / "soperator" / "installations" / "live" / "terraform.tfstate"
+    sentinel.parent.mkdir(parents=True)
+    sentinel.write_bytes(b'{{"serial":7,"owner":"operator"}}\n')
+    digest = hashlib.sha256(sentinel.read_bytes()).hexdigest()
+    missing = subprocess.run(
+        ["git", "-C", str(legacy), "cat-file", "-e", f"{pinned}^{{commit}}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert missing.returncode != 0
+    return work_root, pinned, sentinel, digest
+
+
+def test_solutions_library_reconciles_shallow_legacy_and_preserves_state(tmp_path) -> None:
     from npa.soperator.lifecycle import _resolve_solutions_library
 
-    recipe = tmp_path / "nebius-solutions-library" / "soperator"
-    (recipe / "installations" / "example").mkdir(parents=True)
+    work_root, pinned, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    recipe = _resolve_solutions_library(None, work_root, pinned)
 
-    assert (
-        _resolve_solutions_library(None, tmp_path, DEFAULT_SOLUTIONS_LIBRARY_REF)
-        == recipe
+    assert recipe == work_root / "nebius-solutions-library" / "soperator"
+    assert _git(recipe.parent, "rev-parse", "HEAD").stdout.strip() == pinned
+    detached = subprocess.run(
+        ["git", "-C", str(recipe.parent), "symbolic-ref", "-q", "HEAD"],
+        check=False,
     )
+    assert detached.returncode != 0
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+
+
+def test_solutions_library_detaches_attached_shallow_pin_and_preserves_state(tmp_path) -> None:
+    from npa.soperator.lifecycle import _resolve_solutions_library
+
+    work_root, _older_pin, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    legacy = work_root / "nebius-solutions-library"
+    attached_head = _git(legacy, "rev-parse", "HEAD").stdout.strip()
+    assert _git(legacy, "symbolic-ref", "-q", "HEAD").stdout.strip() == "refs/heads/main"
+
+    recipe = _resolve_solutions_library(None, work_root, attached_head)
+
+    assert _git(recipe.parent, "rev-parse", "HEAD").stdout.strip() == attached_head
+    detached = subprocess.run(
+        ["git", "-C", str(recipe.parent), "symbolic-ref", "-q", "HEAD"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert detached.returncode != 0
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+
+
+def test_solutions_library_cached_pin_is_idempotent_offline(tmp_path) -> None:
+    from npa.soperator.lifecycle import _resolve_solutions_library
+
+    work_root, pinned, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    recipe = _resolve_solutions_library(None, work_root, pinned)
+    _git(recipe.parent, "remote", "set-url", "origin", str(tmp_path / "offline"))
+
+    assert _resolve_solutions_library(None, work_root, pinned) == recipe
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+
+
+def test_solutions_library_detached_pin_cannot_race_to_another_ref(tmp_path) -> None:
+    from npa.soperator.lifecycle import (
+        SolutionsLibraryReconciliationError,
+        _resolve_solutions_library,
+    )
+
+    work_root, pinned, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    recipe = _resolve_solutions_library(None, work_root, pinned)
+    moving_main = _git(
+        recipe.parent, "ls-remote", "origin", "refs/heads/main"
+    ).stdout.split()[0]
+
+    with pytest.raises(SolutionsLibraryReconciliationError, match="already detached"):
+        _resolve_solutions_library(None, work_root, moving_main)
+    assert _git(recipe.parent, "rev-parse", "HEAD").stdout.strip() == pinned
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+
+
+def test_solutions_library_missing_pin_offline_is_actionable_and_preserves_state(
+    tmp_path,
+) -> None:
+    from npa.soperator.lifecycle import (
+        SolutionsLibraryReconciliationError,
+        _resolve_solutions_library,
+    )
+
+    work_root, pinned, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    legacy = work_root / "nebius-solutions-library"
+    _git(legacy, "remote", "set-url", "origin", str(tmp_path / "offline"))
+
+    with pytest.raises(SolutionsLibraryReconciliationError, match="fetch origin"):
+        _resolve_solutions_library(None, work_root, pinned)
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+    assert _git(legacy, "rev-parse", "HEAD").stdout.strip() != pinned
+
+
+def test_solutions_library_dirty_checkout_fails_without_touching_state(tmp_path) -> None:
+    from npa.soperator.lifecycle import (
+        SolutionsLibraryReconciliationError,
+        _resolve_solutions_library,
+    )
+
+    work_root, pinned, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    legacy = work_root / "nebius-solutions-library"
+    (legacy / "README.md").write_text("operator edit\n")
+
+    with pytest.raises(SolutionsLibraryReconciliationError, match="tracked changes"):
+        _resolve_solutions_library(None, work_root, pinned)
+    assert (legacy / "README.md").read_text() == "operator edit\n"
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+
+
+def test_solutions_library_untracked_checkout_conflict_preserves_state(tmp_path) -> None:
+    from npa.soperator.lifecycle import (
+        SolutionsLibraryReconciliationError,
+        _resolve_solutions_library,
+    )
+
+    work_root, pinned, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    legacy = work_root / "nebius-solutions-library"
+    conflict = legacy / "PINNED_ONLY.md"
+    conflict.write_text("operator-owned untracked bytes\n")
+    head_before = _git(legacy, "rev-parse", "HEAD").stdout.strip()
+
+    with pytest.raises(SolutionsLibraryReconciliationError, match="untracked file conflicts"):
+        _resolve_solutions_library(None, work_root, pinned)
+
+    assert _git(legacy, "rev-parse", "HEAD").stdout.strip() == head_before
+    assert conflict.read_text() == "operator-owned untracked bytes\n"
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+
+
+def test_solutions_library_concurrent_reconciliation_is_serial_and_idempotent(tmp_path) -> None:
+    from npa.soperator.lifecycle import _resolve_solutions_library
+
+    work_root, pinned, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    barrier = threading.Barrier(4)
+    recipes: list[Path] = []
+    errors: list[BaseException] = []
+
+    def resolve() -> None:
+        try:
+            barrier.wait()
+            recipes.append(_resolve_solutions_library(None, work_root, pinned))
+        except BaseException as exc:  # surfaced by the assertions below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=resolve) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors
+    assert len(recipes) == 4
+    assert len(set(recipes)) == 1
+    assert _git(recipes[0].parent, "rev-parse", "HEAD").stdout.strip() == pinned
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+
+
+def test_fresh_solutions_library_clone_is_published_atomically(tmp_path, monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    legacy_root, pinned, _sentinel, _digest = _legacy_shallow_checkout(tmp_path / "source")
+    origin = _git(
+        legacy_root / "nebius-solutions-library", "remote", "get-url", "origin"
+    ).stdout.strip()
+    fresh_root = tmp_path / "fresh"
+    monkeypatch.setattr(lifecycle, "_SOLUTIONS_LIBRARY_REPO", origin)
+
+    recipe = lifecycle._resolve_solutions_library(None, fresh_root, pinned)
+
+    assert recipe == fresh_root / f"nebius-solutions-library-{pinned[:12]}" / "soperator"
+    assert _git(recipe.parent, "rev-parse", "HEAD").stdout.strip() == pinned
+    assert not list(fresh_root.glob(".*.clone-*"))
+
+
+def test_deploy_path_reconciles_legacy_source_before_provider_mutation(
+    tmp_path, monkeypatch
+) -> None:
+    from types import SimpleNamespace
+
+    from npa.soperator import lifecycle
+
+    work_root, pinned, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    seen: dict[str, Path] = {}
+
+    def assert_contract(recipe: Path, *, ref: str) -> None:
+        seen["recipe"] = recipe
+        assert ref == pinned
+
+    monkeypatch.setattr(
+        lifecycle,
+        "resolve_environment",
+        lambda **kwargs: SimpleNamespace(
+            region="us-central1", tenant_id="tenant", project_id="project"
+        ),
+    )
+    required_bins: list[str] = []
+    monkeypatch.setattr(
+        lifecycle,
+        "_require_bin",
+        lambda name: required_bins.append(name) or name,
+    )
+    monkeypatch.setattr(lifecycle, "_assert_solutions_library_contract", assert_contract)
+    monkeypatch.setattr(
+        lifecycle,
+        "_prepare_installation",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("provider boundary crossed")),
+    )
+    spec = SoperatorSpec(
+        name="cluster",
+        region="us-central1",
+        tenant_id="tenant",
+        project_id="project",
+        root_login_ssh_public_key="ssh-ed25519 AAAA operator",
+        workers=[WorkerPoolSpec(name="cpu")],
+    )
+
+    result = lifecycle.deploy_cluster(
+        spec,
+        work_root=work_root,
+        solutions_library_ref=pinned,
+        source_preflight_only=True,
+    )
+
+    assert seen["recipe"] == work_root / "nebius-solutions-library" / "soperator"
+    assert _git(seen["recipe"].parent, "rev-parse", "HEAD").stdout.strip() == pinned
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+    assert required_bins == ["git"]
+    assert result["status"] == "source-preflight-passed"
+    assert result["provider_mutation"] is False
+    assert result["control_plane"]["system_max_size"] == 24
+
+
+def test_destroy_source_preflight_reconciles_without_provider_calls(tmp_path, monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    work_root, pinned, sentinel, digest = _legacy_shallow_checkout(tmp_path)
+    install = work_root / "nebius-solutions-library" / "soperator" / "installations" / "live"
+    monkeypatch.setattr(lifecycle, "_assert_solutions_library_contract", lambda *a, **k: None)
+    required_bins: list[str] = []
+    monkeypatch.setattr(
+        lifecycle,
+        "_require_bin",
+        lambda name: required_bins.append(name) or name,
+    )
+
+    result = lifecycle.destroy_cluster(
+        "live",
+        work_root=work_root,
+        solutions_library_ref=pinned,
+        source_preflight_only=True,
+    )
+
+    assert result == {
+        "name": "live",
+        "status": "source-preflight-passed",
+        "install_dir": str(install),
+        "solutions_library_ref": pinned,
+        "provider_mutation": False,
+    }
+    assert required_bins == ["git"]
+    assert _git(install.parents[2], "rev-parse", "HEAD").stdout.strip() == pinned
+    assert hashlib.sha256(sentinel.read_bytes()).hexdigest() == digest
+
+
+def test_existing_deploy_uses_persisted_identity_not_changed_default(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    recipe = tmp_path / "soperator"
+    install = recipe / "installations" / "live"
+    install.mkdir(parents=True)
+    lifecycle._write_env_sidecar(
+        install,
+        region="us-central1",
+        tenant_id="tenant-live",
+        project_id="project-live",
+        subnet_id="subnet-live",
+        o11y_profile="live",
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "resolve_environment",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("ambient project resolution must not run")
+        ),
+    )
+    spec = SoperatorSpec(
+        name="live",
+        region="us-central1",
+        root_login_ssh_public_key="ssh-ed25519 AAAA operator",
+        workers=[WorkerPoolSpec(name="cpu")],
+    )
+
+    resolved = lifecycle._resolve_deploy_environment(spec, recipe, project=None)
+
+    assert resolved[:4] == (
+        "us-central1",
+        "tenant-live",
+        "project-live",
+        "subnet-live",
+    )
+    assert resolved[4] == json.loads((install / ".npa-soperator-env.json").read_text())
+    assert (install / ".npa-soperator-env.json").stat().st_mode & 0o777 == 0o600
+    assert not list(install.glob("..npa-soperator-env.json.*.tmp"))
+
+
+@pytest.mark.parametrize("payload", ["not-json", "[]", '{"region":"us-central1"}'])
+def test_existing_deploy_fails_closed_on_invalid_persisted_identity(
+    tmp_path, monkeypatch, payload: str
+) -> None:
+    from npa.soperator import lifecycle
+
+    recipe = tmp_path / "soperator"
+    install = recipe / "installations" / "live"
+    install.mkdir(parents=True)
+    sidecar = install / ".npa-soperator-env.json"
+    sidecar.write_text(payload)
+    monkeypatch.setattr(
+        lifecycle,
+        "resolve_environment",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("ambient project resolution must not run")
+        ),
+    )
+    spec = SoperatorSpec(
+        name="live",
+        region="us-central1",
+        root_login_ssh_public_key="ssh-ed25519 AAAA operator",
+        workers=[WorkerPoolSpec(name="cpu")],
+    )
+
+    with pytest.raises(ValueError, match="persisted.*identity|persisted identity"):
+        lifecycle._resolve_deploy_environment(spec, recipe, project=None)
+
+    assert sidecar.read_text() == payload
+
+
+def test_env_sidecar_atomic_failure_preserves_previous_bytes(tmp_path, monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    install = tmp_path / "install"
+    install.mkdir()
+    sidecar = install / ".npa-soperator-env.json"
+    original = b'{"project_id":"original"}\n'
+    sidecar.write_bytes(original)
+    monkeypatch.setattr(
+        lifecycle.os,
+        "replace",
+        lambda *args: (_ for _ in ()).throw(OSError("simulated replace failure")),
+    )
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        lifecycle._write_env_sidecar(
+            install,
+            region="us-central1",
+            tenant_id="tenant",
+            project_id="project",
+            subnet_id="subnet",
+            o11y_profile="profile",
+        )
+
+    assert sidecar.read_bytes() == original
+    assert not list(install.glob("..npa-soperator-env.json.*.tmp"))
+
+
+def test_terraform_replacement_guard_blocks_plan_and_removes_private_plan(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    def fake_capture(command, **kwargs):
+        if "plan" in command:
+            plan_path = Path(next(arg.removeprefix("-out=") for arg in command if arg.startswith("-out=")))
+            plan_path.write_bytes(b"private plan")
+            return _Done(returncode=2)
+        if "show" in command:
+            return _Done(
+                stdout=json.dumps(
+                    {
+                        "resource_changes": [
+                            {
+                                "address": "module.k8s.nebius_mk8s_v1_cluster.this",
+                                "change": {"actions": ["delete", "create"]},
+                            }
+                        ]
+                    }
+                )
+            )
+        raise AssertionError(command)
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    with pytest.raises(
+        lifecycle.ProviderReplacementPlanError,
+        match="1 provider or unexpected destructive action.*refusing to apply",
+    ) as caught:
+        with lifecycle._terraform_plan_without_unsafe_replacements(
+            "terraform", cwd=tmp_path, env={}, timeout=30
+        ):
+            raise AssertionError("replacement plan must never be yielded")
+
+    assert caught.value.replacements == ["module.k8s.nebius_mk8s_v1_cluster.this"]
+    assert not list(tmp_path.glob(".npa-plan-*"))
+
+
+def test_terraform_replacement_guard_yields_exact_owner_only_saved_plan(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    calls: list[list[str]] = []
+
+    def fake_capture(command, **kwargs):
+        calls.append(command)
+        if "plan" in command:
+            plan_path = Path(next(arg.removeprefix("-out=") for arg in command if arg.startswith("-out=")))
+            plan_path.write_bytes(b"private plan")
+            return _Done(returncode=2)
+        if "show" in command:
+            return _Done(
+                stdout=json.dumps(
+                    {
+                        "resource_changes": [
+                            {
+                                "address": "module.k8s.safe_update",
+                                "change": {"actions": ["update"]},
+                            }
+                        ]
+                    }
+                )
+            )
+        raise AssertionError(command)
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    with lifecycle._terraform_plan_without_unsafe_replacements(
+        "terraform",
+        cwd=tmp_path,
+        env={},
+        timeout=30,
+        targets=("module.k8s",),
+    ) as guarded_plan:
+        assert guarded_plan.path.is_file()
+        assert guarded_plan.path.stat().st_mode & 0o777 == 0o600
+        assert guarded_plan.safe_local_replacements == ()
+        assert "-target=module.k8s" in calls[0]
+        yielded_path = guarded_plan.path
+
+    assert not yielded_path.exists()
+    assert not list(tmp_path.glob(".npa-plan-*"))
+
+
+def test_terraform_replacement_guard_allows_only_audited_local_refreshes(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    resource_changes = [
+        {
+            "address": address,
+            "provider_name": provider,
+            "change": {"actions": ["delete", "create"]},
+        }
+        for address, provider in lifecycle._SAFE_LOCAL_RECONCILIATION_REPLACEMENTS
+    ]
+
+    def fake_capture(command, **kwargs):
+        if "plan" in command:
+            plan_path = Path(
+                next(arg.removeprefix("-out=") for arg in command if arg.startswith("-out="))
+            )
+            plan_path.write_bytes(b"private plan")
+            return _Done(returncode=2)
+        if "show" in command:
+            return _Done(stdout=json.dumps({"resource_changes": resource_changes}))
+        raise AssertionError(command)
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    with lifecycle._terraform_plan_without_unsafe_replacements(
+        "terraform", cwd=tmp_path, env={}, timeout=30
+    ) as guarded_plan:
+        assert guarded_plan.safe_local_replacements == tuple(
+            sorted(address for address, _provider in lifecycle._SAFE_LOCAL_RECONCILIATION_REPLACEMENTS)
+        )
+
+
+@pytest.mark.parametrize(
+    ("address", "provider", "actions"),
+    [
+        (
+            "module.k8s.terraform_data.kubectl_cluster_context",
+            "registry.terraform.io/hashicorp/local",
+            ["delete", "create"],
+        ),
+        (
+            "module.login_script.local_file.this",
+            "registry.terraform.io/hashicorp/local",
+            ["delete"],
+        ),
+        (
+            "module.k8s.nebius_mk8s_v1_cluster.this",
+            "terraform-provider-nebius.storage.nebius.cloud/nebius/nebius",
+            ["delete", "create"],
+        ),
+    ],
+)
+def test_terraform_replacement_guard_blocks_wrong_provider_or_delete(
+    tmp_path, monkeypatch, address: str, provider: str, actions: list[str]
+) -> None:
+    from npa.soperator import lifecycle
+
+    def fake_capture(command, **kwargs):
+        if "plan" in command:
+            plan_path = Path(
+                next(arg.removeprefix("-out=") for arg in command if arg.startswith("-out="))
+            )
+            plan_path.write_bytes(b"private plan")
+            return _Done(returncode=2)
+        if "show" in command:
+            return _Done(
+                stdout=json.dumps(
+                    {
+                        "resource_changes": [
+                            {
+                                "address": address,
+                                "provider_name": provider,
+                                "change": {"actions": actions},
+                            }
+                        ]
+                    }
+                )
+            )
+        raise AssertionError(command)
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    with pytest.raises(lifecycle.ProviderReplacementPlanError) as caught:
+        with lifecycle._terraform_plan_without_unsafe_replacements(
+            "terraform", cwd=tmp_path, env={}, timeout=30
+        ):
+            raise AssertionError("unsafe plan must never be yielded")
+
+    assert caught.value.replacements == [address]
+    assert not list(tmp_path.glob(".npa-plan-*"))
+
+
+def test_replacement_guard_stops_before_sidecar_overwrite_or_apply(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    recipe = tmp_path / "soperator"
+    (recipe / "installations" / "example").mkdir(parents=True)
+    install = recipe / "installations" / "live"
+    install.mkdir()
+    lifecycle._write_env_sidecar(
+        install,
+        region="us-central1",
+        tenant_id="tenant",
+        project_id="project",
+        subnet_id="subnet",
+        o11y_profile="profile",
+    )
+    sidecar = install / ".npa-soperator-env.json"
+    original = sidecar.read_bytes()
+    commands: list[list[str]] = []
+    monkeypatch.setattr(lifecycle, "_require_bin", lambda name: name)
+    monkeypatch.setattr(lifecycle, "_assert_solutions_library_contract", lambda *a, **k: None)
+    monkeypatch.setattr(lifecycle, "_prepare_installation", lambda *a, **k: install)
+    monkeypatch.setattr(lifecycle, "_resolve_subnet", lambda *a, **k: "subnet")
+    monkeypatch.setattr(
+        lifecycle,
+        "_soperator_tf_env",
+        lambda *a, **k: {"TF_VAR_o11y_profile": "profile"},
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_terraform_command",
+        lambda command, **kwargs: commands.append(command),
+    )
+
+    @contextmanager
+    def reject_plan(*args, **kwargs):
+        raise lifecycle.ProviderReplacementPlanError(["module.k8s.cluster"])
+        yield Path("unreachable")
+
+    monkeypatch.setattr(
+        lifecycle, "_terraform_plan_without_unsafe_replacements", reject_plan
+    )
+    spec = SoperatorSpec(
+        name="live",
+        region="us-central1",
+        root_login_ssh_public_key="ssh-ed25519 AAAA operator",
+        workers=[WorkerPoolSpec(name="cpu")],
+    )
+
+    with pytest.raises(lifecycle.ProviderReplacementPlanError):
+        lifecycle.deploy_cluster(spec, terraform_dir=recipe, apply_fixes=False)
+
+    assert commands == [["terraform", "init"]]
+    assert sidecar.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("project_id", "project-other"),
+        ("tenant_id", "tenant-other"),
+        ("subnet_id", "subnet-other"),
+    ],
+)
+def test_existing_deploy_rejects_provider_identity_replacement(
+    tmp_path, monkeypatch, field: str, value: str
+) -> None:
+    from types import SimpleNamespace
+
+    from npa.soperator import lifecycle
+
+    recipe = tmp_path / "soperator"
+    install = recipe / "installations" / "live"
+    install.mkdir(parents=True)
+    lifecycle._write_env_sidecar(
+        install,
+        region="us-central1",
+        tenant_id="tenant-live",
+        project_id="project-live",
+        subnet_id="subnet-live",
+        o11y_profile="live",
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "resolve_environment",
+        lambda **kwargs: SimpleNamespace(
+            region="us-central1",
+            tenant_id="tenant-live",
+            project_id="project-live",
+        ),
+    )
+    kwargs = {field: value}
+    spec = SoperatorSpec(
+        name="live",
+        region="us-central1",
+        root_login_ssh_public_key="ssh-ed25519 AAAA operator",
+        workers=[WorkerPoolSpec(name="cpu")],
+        **kwargs,
+    )
+
+    with pytest.raises(ValueError, match="refusing a provider-replacement deploy"):
+        lifecycle._resolve_deploy_environment(spec, recipe, project=None)
+
+
+def test_existing_deploy_rejects_mismatched_explicit_project_alias(
+    tmp_path, monkeypatch
+) -> None:
+    from types import SimpleNamespace
+
+    from npa.soperator import lifecycle
+
+    recipe = tmp_path / "soperator"
+    install = recipe / "installations" / "live"
+    install.mkdir(parents=True)
+    lifecycle._write_env_sidecar(
+        install,
+        region="us-central1",
+        tenant_id="tenant-live",
+        project_id="project-live",
+        subnet_id="subnet-live",
+        o11y_profile="live",
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "resolve_environment",
+        lambda **kwargs: SimpleNamespace(
+            region="us-central1",
+            tenant_id="tenant-other",
+            project_id="project-other",
+        ),
+    )
+    spec = SoperatorSpec(
+        name="live",
+        region="us-central1",
+        root_login_ssh_public_key="ssh-ed25519 AAAA operator",
+        workers=[WorkerPoolSpec(name="cpu")],
+    )
+
+    with pytest.raises(ValueError, match="does not match the persisted"):
+        lifecycle._resolve_deploy_environment(spec, recipe, project="other")
 
 
 def test_render_tfvars_cpu_only_disables_image_disk() -> None:
@@ -804,6 +1573,10 @@ def test_direct_gpu_creation_check_uses_every_worker_and_gpu(monkeypatch) -> Non
 
     def fake_capture(cmd, **kwargs):
         calls.append(cmd)
+        if "sinfo" in cmd:
+            return _Done(stdout="gpu-7\ngpu-3\ncpu-0\n")
+        if "squeue" in cmd:
+            return _Done(stdout="")
         return _Done(
             stdout=(
                 "0: NPA_GPU_CREATION_CHECK_RESULT host=gpu-0 status=PASS command_rc=0\n"
@@ -825,7 +1598,9 @@ def test_direct_gpu_creation_check_uses_every_worker_and_gpu(monkeypatch) -> Non
         ],
     )
 
-    checks = lifecycle._run_gpu_creation_checks(spec, "ctx", "kubectl")
+    checks = lifecycle._run_gpu_creation_checks(
+        spec, "ctx", "kubectl", timeout_seconds=123
+    )
 
     assert checks == [{
         "pool": "gpu",
@@ -839,26 +1614,34 @@ def test_direct_gpu_creation_check_uses_every_worker_and_gpu(monkeypatch) -> Non
         ],
         "status": "PASS",
     }]
-    command = calls[0]
+    command = next(call for call in calls if "srun" in call)
     assert "--nodes=2" in command
     assert "--ntasks=2" in command
     assert "--gpus-per-node=8" in command
-    assert "--nodelist=gpu-0,gpu-1" in command
+    assert "--nodelist=gpu-3,gpu-7" in command
+    immediate = int(next(arg.split("=", 1)[1] for arg in command if arg.startswith("--immediate=")))
+    assert 1 <= immediate <= 123
+    assert f"--time={lifecycle._slurm_time_limit(immediate)}" in command
+    assert "--kill-on-bad-exit=1" in command
     task_script = command[-1]
     assert "health-checker run" in task_script
     assert "deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest" in task_script
+    assert 'if [ "$command_rc" -ne 0 ] || [ "$status" != PASS ]' in task_script
 
 
 def test_direct_gpu_creation_check_fails_on_missing_worker_pass(monkeypatch) -> None:
     from npa.soperator import lifecycle
 
-    monkeypatch.setattr(
-        lifecycle,
-        "_run_capture",
-        lambda *a, **k: _Done(
+    def fake_capture(cmd, **kwargs):
+        if "sinfo" in cmd:
+            return _Done(stdout="gpu-0\ngpu-1\n")
+        if "squeue" in cmd or "scancel" in cmd:
+            return _Done(stdout="")
+        return _Done(
             stdout="0: NPA_GPU_CREATION_CHECK_RESULT host=gpu-0 status=PASS command_rc=0\n"
-        ),
-    )
+        )
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
     spec = SoperatorSpec(
         name="c",
         workers=[
@@ -872,8 +1655,9 @@ def test_direct_gpu_creation_check_fails_on_missing_worker_pass(monkeypatch) -> 
         ],
     )
 
-    with pytest.raises(RuntimeError, match="1/2 workers reported PASS"):
+    with pytest.raises(lifecycle.GPUCreationCheckError, match="1/2 workers reported PASS") as caught:
         lifecycle._run_gpu_creation_checks(spec, "ctx", "kubectl")
+    assert caught.value.cleanup_confirmed is True
 
 
 def test_direct_gpu_creation_check_is_noop_for_cpu_cluster(monkeypatch) -> None:
@@ -887,6 +1671,399 @@ def test_direct_gpu_creation_check_is_noop_for_cpu_cluster(monkeypatch) -> None:
     spec = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="cpu")])
 
     assert lifecycle._run_gpu_creation_checks(spec, "ctx", "kubectl") == []
+
+
+def _gpu_creation_spec(*, size: int = 2) -> SoperatorSpec:
+    return SoperatorSpec(
+        name="c",
+        workers=[
+            WorkerPoolSpec(
+                name="gpu",
+                platform="gpu-b200-sxm",
+                preset="8gpu-160vcpu-1792gb",
+                size=size,
+                fabric="us-central1-b",
+            )
+        ],
+    )
+
+
+def test_gpu_creation_check_rejects_invalid_timeout_before_slurm(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected Slurm call")),
+    )
+    with pytest.raises(ValueError, match="at least 1 second"):
+        lifecycle._run_gpu_creation_checks(
+            _gpu_creation_spec(), "ctx", "kubectl", timeout_seconds=0
+        )
+
+
+def test_deploy_rejects_invalid_gpu_timeout_before_source_or_provider(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_resolve_root_login_ssh_public_key",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("SSH/source/provider preflight should not start")
+        ),
+    )
+    spec = _gpu_creation_spec()
+    with pytest.raises(ValueError, match="at least 1 second"):
+        lifecycle.deploy_cluster(spec, gpu_creation_check_timeout_seconds=0)
+
+
+def test_gpu_creation_check_requires_live_slurm_pool_cardinality(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        lambda cmd, **kwargs: _Done(stdout="renamed-worker-a\nrenamed-worker-b\n"),
+    )
+    with pytest.raises(
+        lifecycle.GPUCreationCheckError,
+        match="cannot map pool 'gpu'.*expected 2.*found 0",
+    ) as caught:
+        lifecycle._run_gpu_creation_checks(_gpu_creation_spec(), "ctx", "kubectl")
+    assert caught.value.phase == "node-mapping"
+
+
+def test_gpu_creation_check_process_timeout_cancels_and_verifies_queue(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_capture(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if "sinfo" in cmd:
+            return _Done(stdout="gpu-0\ngpu-1\n")
+        if "srun" in cmd:
+            raise subprocess.TimeoutExpired(
+                cmd,
+                kwargs["timeout"],
+                output="srun: job queued and waiting for resources\n",
+            )
+        if "scancel" in cmd or "squeue" in cmd:
+            return _Done(stdout="")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    with pytest.raises(
+        lifecycle.GPUCreationCheckError,
+        match="timed out after .* queued/running Slurm job was cancelled",
+    ) as caught:
+        lifecycle._run_gpu_creation_checks(
+            _gpu_creation_spec(), "ctx", "kubectl", timeout_seconds=17
+        )
+
+    assert caught.value.phase == "process-timeout"
+    assert caught.value.cleanup_confirmed is True
+    srun_call, srun_kwargs = next(item for item in calls if "srun" in item[0])
+    assert 0 < srun_kwargs["timeout"] <= 17
+    assert any(arg.startswith("--immediate=") for arg in srun_call)
+    assert any(arg.startswith("--time=") for arg in srun_call)
+    assert any("scancel" in command for command, _ in calls)
+    assert any("squeue" in command for command, _ in calls)
+
+
+def test_gpu_creation_check_queue_failure_is_nonzero_and_cleaned(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    calls: list[list[str]] = []
+
+    def fake_capture(cmd, **kwargs):
+        calls.append(cmd)
+        if "sinfo" in cmd:
+            return _Done(stdout="gpu-0\ngpu-1\n")
+        if "srun" in cmd:
+            return _Done(
+                stderr="srun: Requested nodes are unavailable; unable to allocate resources",
+                returncode=1,
+            )
+        if "scancel" in cmd or "squeue" in cmd:
+            return _Done(stdout="")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    with pytest.raises(
+        lifecycle.GPUCreationCheckError,
+        match="0/2 workers reported PASS",
+    ) as caught:
+        lifecycle._run_gpu_creation_checks(
+            _gpu_creation_spec(), "ctx", "kubectl", timeout_seconds=30
+        )
+    assert caught.value.cleanup_confirmed is True
+    assert "Requested nodes are unavailable" in str(caught.value)
+    assert any("scancel" in command for command in calls)
+
+
+def test_gpu_creation_check_success_requires_no_remaining_slurm_job(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    def fake_capture(cmd, **kwargs):
+        if "sinfo" in cmd:
+            return _Done(stdout="gpu-0\ngpu-1\n")
+        if "srun" in cmd:
+            return _Done(
+                stdout=(
+                    "0: NPA_GPU_CREATION_CHECK_RESULT host=gpu-0 status=PASS command_rc=0\n"
+                    "1: NPA_GPU_CREATION_CHECK_RESULT host=gpu-1 status=PASS command_rc=0\n"
+                )
+            )
+        if "squeue" in cmd:
+            return _Done(stdout="")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+    checks = lifecycle._run_gpu_creation_checks(
+        _gpu_creation_spec(), "ctx", "kubectl", timeout_seconds=60
+    )
+    assert checks[0]["status"] == "PASS"
+
+
+def test_gpu_creation_check_success_tolerates_slurm_completion_race(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    squeue_calls = 0
+
+    def fake_capture(cmd, **kwargs):
+        nonlocal squeue_calls
+        if "sinfo" in cmd:
+            return _Done(stdout="gpu-0\ngpu-1\n")
+        if "srun" in cmd:
+            return _Done(
+                stdout=(
+                    "0: NPA_GPU_CREATION_CHECK_RESULT host=gpu-0 status=PASS command_rc=0\n"
+                    "1: NPA_GPU_CREATION_CHECK_RESULT host=gpu-1 status=PASS command_rc=0\n"
+                )
+            )
+        if "squeue" in cmd:
+            squeue_calls += 1
+            return _Done(stdout="72\n" if squeue_calls == 1 else "")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+    monkeypatch.setattr(lifecycle.time, "sleep", lambda _seconds: None)
+
+    checks = lifecycle._run_gpu_creation_checks(
+        _gpu_creation_spec(), "ctx", "kubectl", timeout_seconds=60
+    )
+
+    assert checks[0]["status"] == "PASS"
+    assert squeue_calls == 2
+
+
+def _degraded_deployment_result(lifecycle) -> dict:
+    failure = lifecycle.DeploymentValidationFailure(
+        code="gpu_creation_check_failed",
+        message="GPU creation check timed out after 17 seconds for pool 'gpu'",
+        check="gpu-creation",
+        pool="gpu",
+        phase="process-timeout",
+        cleanup_confirmed=True,
+    )
+    error = lifecycle.SoperatorDeploymentValidationError(
+        {
+            "name": "c",
+            "region": "us-central1",
+            "project_id": "project",
+            "install_dir": "/safe/installations/c",
+            "kube_context": "nebius-c-slurm",
+            "worker_pools": ["gpu"],
+            "docker_cache_pools": [],
+            "control_plane": {"system_min_size": 3, "system_max_size": 24},
+            "gpu_creation_checks": [],
+        },
+        failure,
+    )
+    return error.result
+
+
+def test_sdk_typed_degraded_validation_retains_deploy_metadata(tmp_path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from npa.sdk import soperator as sdk
+    from npa.soperator import lifecycle
+
+    recipe = tmp_path / "soperator"
+    (recipe / "installations" / "example").mkdir(parents=True)
+    install = recipe / "installations" / "c"
+    install.mkdir()
+    monkeypatch.setattr(
+        lifecycle,
+        "resolve_environment",
+        lambda **kwargs: SimpleNamespace(
+            region="us-central1", tenant_id="tenant", project_id="project"
+        ),
+    )
+    monkeypatch.setattr(lifecycle, "_require_bin", lambda name: name)
+    monkeypatch.setattr(lifecycle, "_resolve_solutions_library", lambda *a, **k: recipe)
+    monkeypatch.setattr(lifecycle, "_assert_solutions_library_contract", lambda *a, **k: None)
+    monkeypatch.setattr(lifecycle, "_prepare_installation", lambda *a, **k: install)
+    monkeypatch.setattr(lifecycle, "_resolve_subnet", lambda *a, **k: "subnet")
+    monkeypatch.setattr(
+        lifecycle,
+        "_soperator_tf_env",
+        lambda *a, **k: {"TF_VAR_o11y_profile": "profile"},
+    )
+    terraform_commands: list[list[str]] = []
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_terraform_command",
+        lambda command, **kwargs: terraform_commands.append(command),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_terraform_plan_without_unsafe_replacements",
+        lambda *a, **k: nullcontext(
+            lifecycle.GuardedTerraformPlan(install / "guarded.tfplan")
+        ),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_gpu_creation_checks",
+        lambda *a, **k: (_ for _ in ()).throw(
+            lifecycle.GPUCreationCheckError(
+                "GPU creation check timed out after 17 seconds for pool 'gpu'",
+                pool="gpu",
+                phase="process-timeout",
+                cleanup_confirmed=True,
+            )
+        ),
+    )
+    spec = _gpu_creation_spec(size=2)
+    spec.region = "us-central1"
+    spec.tenant_id = "tenant"
+    spec.project_id = "project"
+    spec.root_login_ssh_public_key = "ssh-ed25519 AAAA operator"
+
+    with pytest.raises(lifecycle.SoperatorDeploymentValidationError) as caught:
+        sdk.deploy(
+            spec,
+            terraform_dir=recipe,
+            apply_fixes=False,
+            gpu_creation_check_timeout_seconds=17,
+        )
+
+    result = caught.value.result
+    assert terraform_commands == [
+        ["terraform", "init"],
+        ["terraform", "apply", str(install / "guarded.tfplan")],
+    ]
+    assert result["status"] == "degraded-validation"
+    assert result["deployment_status"] == "applied"
+    assert result["install_dir"] == str(install)
+    assert result["kube_context"] == "nebius-c-slurm"
+    assert result["worker_pools"] == ["gpu"]
+    assert result["control_plane"]["system_max_size"] == 24
+    assert result["replacement_guard"] == {
+        "status": "passed",
+        "plans_checked": 1,
+        "replacement_count": 0,
+        "safe_local_replacements_applied": 0,
+    }
+    assert result["validation"] == {
+        "status": "failed",
+        "code": "gpu_creation_check_failed",
+        "check": "gpu-creation",
+        "message": "GPU creation check timed out after 17 seconds for pool 'gpu'",
+        "pool": "gpu",
+        "phase": "process-timeout",
+        "cleanup_confirmed": True,
+    }
+
+
+@pytest.mark.parametrize("output", ["text", "json"])
+def test_cli_degraded_validation_exits_nonzero_with_metadata(
+    tmp_path, monkeypatch, output: str
+) -> None:
+    from npa.soperator import lifecycle
+
+    spec_path = tmp_path / "cluster.yaml"
+    spec_path.write_text(
+        textwrap.dedent(
+            """
+            apiVersion: npa.soperator/v0.0.1
+            name: c
+            region: us-central1
+            tenant_id: tenant
+            project_id: project
+            root_login_ssh_public_key: ssh-ed25519 AAAA operator
+            workers:
+              - name: gpu
+                platform: gpu-b200-sxm
+                preset: 8gpu-160vcpu-1792gb
+                size: 2
+                fabric: us-central1-b
+            """
+        )
+    )
+    result_payload = _degraded_deployment_result(lifecycle)
+    failure = lifecycle.DeploymentValidationFailure(
+        code="gpu_creation_check_failed",
+        message=result_payload["validation"]["message"],
+        check="gpu-creation",
+        pool="gpu",
+        phase="process-timeout",
+        cleanup_confirmed=True,
+    )
+    error = lifecycle.SoperatorDeploymentValidationError(result_payload, failure)
+    seen_kwargs: dict = {}
+
+    def fail_deploy(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        raise error
+
+    monkeypatch.setattr(lifecycle, "deploy_cluster", fail_deploy)
+
+    invoked = runner.invoke(
+        app,
+        ["soperator", "deploy", "--spec", str(spec_path), "--output", output],
+    )
+
+    assert invoked.exit_code == 1
+    assert seen_kwargs["stream_terraform_output"] is (output != "json")
+    if output == "json":
+        parsed = json.loads(invoked.stdout)
+        assert parsed["status"] == "degraded-validation"
+        assert parsed["install_dir"] == "/safe/installations/c"
+        assert parsed["validation"]["cleanup_confirmed"] is True
+    else:
+        assert "was applied, but mandatory post-apply validation failed" in invoked.output
+        assert "nebius-c-slurm" in invoked.output
+        assert "/safe/installations/c" in invoked.output
+        assert "Deployed soperator cluster" not in invoked.output
+
+
+def test_json_mode_terraform_runner_captures_child_output(monkeypatch, tmp_path, capsys) -> None:
+    from npa.soperator import lifecycle
+
+    seen: dict = {}
+
+    def fake_capture(args, **kwargs):
+        seen["args"] = args
+        seen.update(kwargs)
+        return _Done(stdout="terraform progress that must not reach JSON stdout\n")
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+    lifecycle._run_terraform_command(
+        ["terraform", "apply"],
+        cwd=tmp_path,
+        env={},
+        timeout=42,
+        stream_output=False,
+    )
+
+    assert capsys.readouterr().out == ""
+    assert seen["timeout"] == 42
+    assert seen["check"] is False
 
 
 def test_superseded_activechecks_upgrade_aborts_only_old_hook(monkeypatch) -> None:
@@ -1353,6 +2530,70 @@ def test_patch_active_checks_locals_missing_file(tmp_path) -> None:
     assert lifecycle._patch_active_checks_locals(tmp_path) is False
 
 
+def _write_local_reconciliation_targets(tmp_path: Path) -> tuple[Path, Path]:
+    kubectl_context = tmp_path / "modules" / "k8s" / "k8s_cluster.tf"
+    login = tmp_path / "modules" / "login" / "main.tf"
+    kubectl_context.parent.mkdir(parents=True)
+    login.parent.mkdir(parents=True)
+    kubectl_context.write_text(
+        'resource "terraform_data" "kubectl_cluster_context" {\n'
+        "  triggers_replace = [\n"
+        "    nebius_mk8s_v1_cluster.this.id,\n"
+        "    timestamp(),\n"
+        "  ]\n"
+        "}\n"
+    )
+    login.write_text(
+        'resource "terraform_data" "lb_service_ip" {\n'
+        "  triggers_replace = [\n"
+        "    one(data.kubernetes_service_v1.slurm_login.metadata).resource_version\n"
+        "  ]\n"
+        "\n"
+        "  input = one(one(one(data.kubernetes_service_v1.slurm_login.status)."
+        "load_balancer).ingress).ip\n"
+        "}\n"
+    )
+    return kubectl_context, login
+
+
+def test_patch_local_reconciliation_triggers_is_stable_and_idempotent(tmp_path) -> None:
+    from npa.soperator import lifecycle
+
+    kubectl_context, login = _write_local_reconciliation_targets(tmp_path)
+
+    assert lifecycle._patch_stable_local_reconciliation_triggers(tmp_path) is True
+    kubectl_patched = kubectl_context.read_text()
+    login_patched = login.read_text()
+    assert "timestamp()" not in kubectl_patched
+    assert "resource_version" not in login_patched
+    assert "nebius_mk8s_v1_cluster.this.id" in kubectl_patched
+    assert (
+        "one(one(one(data.kubernetes_service_v1.slurm_login.status)."
+        "load_balancer).ingress).ip" in login_patched
+    )
+
+    assert lifecycle._patch_stable_local_reconciliation_triggers(tmp_path) is False
+    assert kubectl_context.read_text() == kubectl_patched
+    assert login.read_text() == login_patched
+
+
+def test_patch_local_reconciliation_triggers_fails_closed_before_any_write(
+    tmp_path,
+) -> None:
+    from npa.soperator import lifecycle
+
+    kubectl_context, login = _write_local_reconciliation_targets(tmp_path)
+    kubectl_original = kubectl_context.read_bytes()
+    login.write_text(login.read_text().replace("resource_version", "generation"))
+    login_original = login.read_bytes()
+
+    with pytest.raises(lifecycle.UpstreamContractError, match="login-script trigger"):
+        lifecycle._patch_stable_local_reconciliation_triggers(tmp_path)
+
+    assert kubectl_context.read_bytes() == kubectl_original
+    assert login.read_bytes() == login_original
+
+
 def test_patch_nodeconfigurator_allows_enroot_userns_and_is_idempotent(
     tmp_path,
 ) -> None:
@@ -1475,3 +2716,627 @@ def test_patch_nodeconfigurator_missing_template_is_safe(tmp_path) -> None:
     from npa.soperator import lifecycle
 
     assert lifecycle._patch_nodeconfigurator_userns(tmp_path) is False
+
+
+def _reserved_worker(**overrides) -> WorkerPoolSpec:
+    values = {
+        "name": "gpu",
+        "platform": "gpu-b200-sxm",
+        "preset": "8gpu-160vcpu-1792gb",
+        "size": 2,
+        "fabric": "us-central1-b",
+        "capacity_block_group": "capacityblockgroup-test",
+    }
+    values.update(overrides)
+    return WorkerPoolSpec(**values)
+
+
+def _capacity_group(
+    *,
+    reservation_id: str = "capacityblockgroup-test",
+    name: str = "reserved-b200-test",
+    tenant_id: str = "tenant-test",
+    state: str = "STATE_ACTIVE",
+    region: str = "us-central1",
+    platform: str = "gpu-b200-sxm",
+    fabric: str = "us-central1-b",
+    limit: int = 40,
+    usage: int = 8,
+) -> dict:
+    return {
+        "metadata": {
+            "id": reservation_id,
+            "name": name,
+            "parent_id": tenant_id,
+        },
+        "status": {
+            "state": state,
+            "region": region,
+            "current_limit": str(limit),
+            "usage": str(usage),
+            "resource_affinity": {
+                "compute_v1": {"platform": platform, "fabric": fabric}
+            },
+        },
+    }
+
+
+def _reserved_provider_capture(
+    groups: list[dict],
+    *,
+    project_tenant="tenant-test",
+    project_region="us-central1",
+    advice_available: int | None = None,
+    advice_data_state: str = "DATA_STATE_FRESH",
+):
+    def capture(command, **kwargs):
+        if command[1:4] == ["iam", "project", "get"]:
+            return _Done(
+                stdout=json.dumps(
+                    {
+                        "metadata": {
+                            "id": "project-test",
+                            "parent_id": project_tenant,
+                        },
+                        "status": {"region": project_region},
+                    }
+                )
+            )
+        if command[1:4] == ["capacity", "capacity-block-group", "list"]:
+            return _Done(stdout=json.dumps({"items": groups}))
+        if command[1:4] == ["capacity", "resource-advice", "list"]:
+            available_gpus = 0
+            if groups:
+                status = groups[0]["status"]
+                available_gpus = int(status["current_limit"]) - int(status["usage"])
+            return _Done(
+                stdout=json.dumps(
+                    {
+                        "items": [
+                            {
+                                "spec": {
+                                    "region": "us-central1",
+                                    "fabric": "us-central1-b",
+                                    "compute_instance": {
+                                        "platform": "gpu-b200-sxm",
+                                        "preset": {
+                                            "name": "8gpu-160vcpu-1792gb",
+                                            "resources": {"gpu_count": 8},
+                                        },
+                                    },
+                                },
+                                "status": {
+                                    "reserved": {
+                                        "data_state": advice_data_state,
+                                        "available": (
+                                            available_gpus // 8
+                                            if advice_available is None
+                                            else advice_available
+                                        ),
+                                    }
+                                },
+                            }
+                        ]
+                    }
+                )
+            )
+        if command[1:4] == ["capacity", "capacity-block-group", "get"]:
+            return _Done(returncode=1, stderr="not found")
+        raise AssertionError(command)
+
+    return capture
+
+
+def test_reserved_capacity_spec_modes_and_mutual_exclusion() -> None:
+    reserved = _reserved_worker()
+    assert reserved.capacity_mode() == "reserved"
+    assert reserved.reservation_selector_kind() == "id"
+    reserved.validate()
+    assert WorkerPoolSpec(name="cpu").capacity_mode() == "on-demand"
+    assert WorkerPoolSpec(name="cpu", preemptible=True).capacity_mode() == "preemptible"
+
+    with pytest.raises(SoperatorSpecError, match="mutually exclusive"):
+        _reserved_worker(preemptible=True).validate()
+    with pytest.raises(SoperatorSpecError, match="set only one"):
+        _reserved_worker(capacity_block_group_name="reserved-b200-test").validate()
+    with pytest.raises(SoperatorSpecError, match="only for GPU"):
+        WorkerPoolSpec(
+            name="cpu", capacity_block_group="capacityblockgroup-test"
+        ).validate()
+
+
+def test_reserved_capacity_sdk_and_positional_compatibility() -> None:
+    from npa.sdk import soperator as sdk
+    from npa.soperator import lifecycle
+
+    # Reservation fields were appended, so the historical positional SDK
+    # constructor retains exactly the same field mapping.
+    worker = WorkerPoolSpec(
+        "gpu",
+        "gpu-b200-sxm",
+        "8gpu-160vcpu-1792gb",
+        2,
+        512,
+        "us-central1-b",
+        False,
+        True,
+        372,
+        "NETWORK_SSD_IO_M3",
+    )
+    assert worker.capacity_mode() == "on-demand"
+    assert worker.docker_cache is True
+    assert worker.capacity_block_group == ""
+    assert sdk.plan is lifecycle.plan_cluster
+    assert sdk.SoperatorDeploymentValidationError is (
+        lifecycle.SoperatorDeploymentValidationError
+    )
+
+
+def test_reserved_capacity_spec_parses_id_or_name_without_exposing_values() -> None:
+    from npa.soperator.lifecycle import plan_cluster
+
+    spec = spec_from_mapping(
+        {
+            "apiVersion": "npa.soperator/v0.0.1",
+            "name": "c",
+            "workers": [
+                {
+                    "name": "gpu",
+                    "platform": "gpu-b200-sxm",
+                    "preset": "8gpu-160vcpu-1792gb",
+                    "fabric": "us-central1-b",
+                    "capacity_block_group_name": " reserved-b200-test ",
+                }
+            ],
+        }
+    )
+    spec.validate()
+    assert spec.workers[0].capacity_block_group_name == "reserved-b200-test"
+    plan = plan_cluster(spec)
+    assert plan["workers"][0]["capacity_mode"] == "reserved"
+    assert plan["workers"][0]["reservation_selector"] == "name"
+    assert plan["workers"][0]["reservation_verified"] is False
+    assert "reserved-b200-test" not in json.dumps(plan)
+
+
+def test_reserved_capacity_tfvars_render_exact_strict_upstream_contract() -> None:
+    spec = SoperatorSpec(name="c", workers=[_reserved_worker()])
+    rendered = render_tfvars(spec)
+    assert "preemptible = null" in rendered
+    assert 'policy          = "STRICT"' in rendered
+    assert 'reservation_ids = ["capacityblockgroup-test"]' in rendered
+    assert "AUTO" not in rendered
+
+    named = _reserved_worker(
+        capacity_block_group="", capacity_block_group_name="reserved-b200-test"
+    )
+    with pytest.raises(ValueError, match="provider-resolved"):
+        render_tfvars(SoperatorSpec(name="c", workers=[named]))
+
+
+def test_soperator_plan_cli_distinguishes_capacity_modes_without_selectors(
+    tmp_path,
+) -> None:
+    spec_path = tmp_path / "cluster.yaml"
+    spec_path.write_text(
+        textwrap.dedent(
+            """
+            apiVersion: npa.soperator/v0.0.1
+            name: c
+            workers:
+              - name: ondemand
+              - name: spot
+                preemptible: true
+              - name: reserved
+                platform: gpu-b200-sxm
+                preset: 8gpu-160vcpu-1792gb
+                fabric: us-central1-b
+                capacity_block_group_name: reserved-b200-test
+            """
+        )
+    )
+    result = runner.invoke(
+        app,
+        ["soperator", "plan", "--spec", str(spec_path), "--output", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert [worker["capacity_mode"] for worker in payload["workers"]] == [
+        "on-demand",
+        "preemptible",
+        "reserved",
+    ]
+    assert "reserved-b200-test" not in result.stdout
+
+
+def test_reserved_capacity_name_preflight_resolves_and_verifies_without_echoing_id(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    group = _capacity_group(usage=8)
+    monkeypatch.setattr(
+        lifecycle, "_run_capture", _reserved_provider_capture([group])
+    )
+    worker = _reserved_worker(
+        capacity_block_group="", capacity_block_group_name="reserved-b200-test"
+    )
+    spec = SoperatorSpec(name="c", workers=[worker])
+
+    resolved, summary = lifecycle._resolve_reserved_worker_capacity(
+        spec,
+        install_dir=tmp_path,
+        nebius_bin="nebius",
+        tenant_id="tenant-test",
+        project_id="project-test",
+        region="us-central1",
+        env={},
+    )
+
+    assert resolved.workers[0].resolved_capacity_block_group_id == (
+        "capacityblockgroup-test"
+    )
+    assert summary[0]["capacity_mode"] == "reserved"
+    assert summary[0]["reservation_verified"] is True
+    assert "capacityblockgroup-test" not in json.dumps(summary)
+
+
+@pytest.mark.parametrize(
+    ("group_overrides", "message"),
+    [
+        ({"tenant_id": "tenant-other"}, "belongs to another tenant"),
+        ({"state": "STATE_INACTIVE"}, "not active"),
+        ({"region": "eu-north1"}, "region does not match"),
+        ({"platform": "gpu-h200-sxm"}, "platform does not match"),
+        ({"fabric": "us-central1-a"}, "fabric does not match"),
+        ({"limit": 40, "usage": 32}, "insufficient"),
+    ],
+)
+def test_reserved_capacity_preflight_fails_closed_on_incompatible_or_insufficient(
+    tmp_path, monkeypatch, group_overrides: dict, message: str
+) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        _reserved_provider_capture([_capacity_group(**group_overrides)]),
+    )
+    with pytest.raises(ValueError, match=message):
+        lifecycle._resolve_reserved_worker_capacity(
+            SoperatorSpec(name="c", workers=[_reserved_worker()]),
+            install_dir=tmp_path,
+            nebius_bin="nebius",
+            tenant_id="tenant-test",
+            project_id="project-test",
+            region="us-central1",
+            env={},
+        )
+
+
+def test_reserved_capacity_preflight_rejects_wrong_project_tenant(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        _reserved_provider_capture(
+            [_capacity_group()], project_tenant="tenant-other"
+        ),
+    )
+    with pytest.raises(ValueError, match="project does not belong"):
+        lifecycle._resolve_reserved_worker_capacity(
+            SoperatorSpec(name="c", workers=[_reserved_worker()]),
+            install_dir=tmp_path,
+            nebius_bin="nebius",
+            tenant_id="tenant-test",
+            project_id="project-test",
+            region="us-central1",
+            env={},
+        )
+
+
+def test_reserved_capacity_preflight_rejects_wrong_project_region(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        _reserved_provider_capture(
+            [_capacity_group()], project_region="eu-north1"
+        ),
+    )
+    with pytest.raises(ValueError, match="project region does not match"):
+        lifecycle._resolve_reserved_worker_capacity(
+            SoperatorSpec(name="c", workers=[_reserved_worker()]),
+            install_dir=tmp_path,
+            nebius_bin="nebius",
+            tenant_id="tenant-test",
+            project_id="project-test",
+            region="us-central1",
+            env={},
+        )
+
+
+@pytest.mark.parametrize(
+    ("available", "data_state", "message"),
+    [
+        (1, "DATA_STATE_FRESH", "reserved preset capacity is insufficient"),
+        (2, "DATA_STATE_STALE", "availability is stale or unavailable"),
+    ],
+)
+def test_reserved_capacity_preflight_fails_closed_on_preset_availability(
+    tmp_path,
+    monkeypatch,
+    available: int,
+    data_state: str,
+    message: str,
+) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        _reserved_provider_capture(
+            [_capacity_group(limit=40, usage=8)],
+            advice_available=available,
+            advice_data_state=data_state,
+        ),
+    )
+    with pytest.raises(ValueError, match=message):
+        lifecycle._resolve_reserved_worker_capacity(
+            SoperatorSpec(name="c", workers=[_reserved_worker()]),
+            install_dir=tmp_path,
+            nebius_bin="nebius",
+            tenant_id="tenant-test",
+            project_id="project-test",
+            region="us-central1",
+            env={},
+        )
+
+
+def test_reserved_capacity_preflight_refuses_unreadable_authorization(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        lambda *args, **kwargs: _Done(returncode=1, stderr="permission denied"),
+    )
+    with pytest.raises(ValueError, match="identity preflight failed"):
+        lifecycle._resolve_reserved_worker_capacity(
+            SoperatorSpec(name="c", workers=[_reserved_worker()]),
+            install_dir=tmp_path,
+            nebius_bin="nebius",
+            tenant_id="tenant-test",
+            project_id="project-test",
+            region="us-central1",
+            env={},
+        )
+
+
+def test_reserved_capacity_name_preflight_rejects_missing_and_ambiguous(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    worker = _reserved_worker(
+        capacity_block_group="", capacity_block_group_name="reserved-b200-test"
+    )
+    spec = SoperatorSpec(name="c", workers=[worker])
+    monkeypatch.setattr(
+        lifecycle, "_run_capture", _reserved_provider_capture([])
+    )
+    with pytest.raises(ValueError, match="name was not found"):
+        lifecycle._resolve_reserved_worker_capacity(
+            spec,
+            install_dir=tmp_path,
+            nebius_bin="nebius",
+            tenant_id="tenant-test",
+            project_id="project-test",
+            region="us-central1",
+            env={},
+        )
+
+    duplicate = _capacity_group(reservation_id="capacityblockgroup-test-2")
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        _reserved_provider_capture([_capacity_group(), duplicate]),
+    )
+    with pytest.raises(ValueError, match="name is ambiguous"):
+        lifecycle._resolve_reserved_worker_capacity(
+            spec,
+            install_dir=tmp_path,
+            nebius_bin="nebius",
+            tenant_id="tenant-test",
+            project_id="project-test",
+            region="us-central1",
+            env={},
+        )
+
+
+def test_reserved_capacity_preflight_credits_already_applied_strict_workers(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    (tmp_path / "terraform.tfstate").write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "type": "nebius_mk8s_v1_node_group",
+                        "name": "worker_v2",
+                        "instances": [
+                            {
+                                "attributes": {
+                                    "name": "gpu-0",
+                                    "fixed_node_count": 2,
+                                    "template": {
+                                        "resources": {
+                                            "preset": "8gpu-160vcpu-1792gb"
+                                        },
+                                        "reservation_policy": {
+                                            "policy": "STRICT",
+                                            "reservation_ids": [
+                                                "capacityblockgroup-test"
+                                            ],
+                                        },
+                                    },
+                                }
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        _reserved_provider_capture(
+            [_capacity_group(limit=48, usage=40)],
+            advice_data_state="DATA_STATE_UNAVAILABLE",
+        ),
+    )
+
+    resolved, summary = lifecycle._resolve_reserved_worker_capacity(
+        SoperatorSpec(name="c", workers=[_reserved_worker()]),
+        install_dir=tmp_path,
+        nebius_bin="nebius",
+        tenant_id="tenant-test",
+        project_id="project-test",
+        region="us-central1",
+        env={},
+    )
+    assert resolved.workers[0].capacity_mode() == "reserved"
+    assert summary[0]["reservation_verified"] is True
+
+    with pytest.raises(ValueError, match="availability is stale or unavailable"):
+        lifecycle._resolve_reserved_worker_capacity(
+            SoperatorSpec(name="c", workers=[_reserved_worker(size=3)]),
+            install_dir=tmp_path,
+            nebius_bin="nebius",
+            tenant_id="tenant-test",
+            project_id="project-test",
+            region="us-central1",
+            env={},
+        )
+
+
+def test_worker_capacity_status_reads_applied_modes_without_ids(tmp_path) -> None:
+    from npa.soperator import lifecycle
+
+    recipe = tmp_path / "soperator"
+    install = recipe / "installations" / "c"
+    install.mkdir(parents=True)
+    instances = []
+    for name, preemptible, reservation_policy in [
+        ("ondemand-0", None, None),
+        ("spot-0", {}, None),
+        (
+            "reserved-0",
+            None,
+            {
+                "policy": "STRICT",
+                "reservation_ids": ["capacityblockgroup-test"],
+            },
+        ),
+    ]:
+        instances.append(
+            {
+                "attributes": {
+                    "name": name,
+                    "fixed_node_count": 1,
+                    "template": {
+                        "preemptible": preemptible,
+                        "reservation_policy": reservation_policy,
+                    },
+                }
+            }
+        )
+    (install / "terraform.tfstate").write_text(
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "type": "nebius_mk8s_v1_node_group",
+                        "name": "worker_v2",
+                        "instances": instances,
+                    }
+                ]
+            }
+        )
+    )
+
+    status = lifecycle.worker_capacity_status("c", terraform_dir=recipe)
+    assert {item["name"]: item["capacity_mode"] for item in status} == {
+        "ondemand": "on-demand",
+        "reserved": "reserved",
+        "spot": "preemptible",
+    }
+    assert "capacityblockgroup-test" not in json.dumps(status)
+
+
+def test_deploy_reservation_failure_stops_before_render_init_or_provider_mutation(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.soperator import lifecycle
+
+    recipe = tmp_path / "soperator"
+    (recipe / "installations" / "example").mkdir(parents=True)
+    monkeypatch.setattr(lifecycle, "_require_bin", lambda name: name)
+    monkeypatch.setattr(
+        lifecycle, "_resolve_solutions_library", lambda *args, **kwargs: recipe
+    )
+    monkeypatch.setattr(
+        lifecycle, "_assert_solutions_library_contract", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_resolve_deploy_environment",
+        lambda *args, **kwargs: (
+            "us-central1",
+            "tenant-test",
+            "project-test",
+            "subnet-test",
+            {},
+        ),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_resolve_reserved_worker_capacity",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            ValueError("reserved capacity is insufficient")
+        ),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_prepare_installation",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("tfvars rendering must not start")
+        ),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_terraform_command",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("terraform must not start")
+        ),
+    )
+    spec = SoperatorSpec(
+        name="c",
+        region="us-central1",
+        root_login_ssh_public_key="ssh-ed25519 AAAA operator",
+        workers=[_reserved_worker()],
+    )
+
+    with pytest.raises(ValueError, match="reserved capacity is insufficient"):
+        lifecycle.deploy_cluster(spec, terraform_dir=recipe)

--- a/npa/tests/unit/test_soperator_cli.py
+++ b/npa/tests/unit/test_soperator_cli.py
@@ -15,7 +15,14 @@ from typer.testing import CliRunner
 
 from npa.cli.main import app
 from npa.soperator import spec_from_mapping
-from npa.soperator.spec import SoperatorSpec, SoperatorSpecError, WorkerPoolSpec, load_spec
+from npa.soperator.spec import (
+    DEFAULT_SOLUTIONS_LIBRARY_REF,
+    SoperatorSpec,
+    SoperatorSpecError,
+    WorkerPoolSpec,
+    load_spec,
+    sizing_tier_for_worker_count,
+)
 from npa.soperator.tfvars import render_tfvars
 
 runner = CliRunner()
@@ -55,6 +62,8 @@ def test_deploy_help_documents_spec_and_fixes() -> None:
     assert result.exit_code == 0
     assert "--spec" in result.output
     assert "--apply-fixes" in result.output
+    assert "--root-login-ssh-pub" in result.output
+    assert DEFAULT_SOLUTIONS_LIBRARY_REF[:20] in result.output
 
 
 def test_spec_multiple_presets_and_docker_cache() -> None:
@@ -65,6 +74,26 @@ def test_spec_multiple_presets_and_docker_cache() -> None:
     assert spec.workers[1].platform == "gpu-b200-sxm"
     assert spec.workers[1].preemptible is True
     assert all(w.docker_cache for w in spec.workers)
+
+
+def test_existing_positional_sdk_fields_keep_their_meaning() -> None:
+    spec = SoperatorSpec(
+        "c",
+        "us-central1",
+        "tenant",
+        "project",
+        "subnet",
+        ["ssh-ed25519 AAAA legacy"],
+        3,
+        "16vcpu-64gb",
+        "16vcpu-64gb",
+        "16vcpu-64gb",
+        [WorkerPoolSpec(name="w")],
+    )
+    spec.validate()
+    assert spec.ssh_public_keys == ["ssh-ed25519 AAAA legacy"]
+    assert spec.system_min_size == 3
+    assert spec.workers[0].name == "w"
 
 
 def test_gpu_pool_requires_fabric() -> None:
@@ -108,22 +137,70 @@ def test_render_tfvars_emits_multi_preset_and_io_m3_cache() -> None:
     assert "accounting_enabled = false" in tf
     assert 'active_checks_scope    = "essential"' in tf
     assert "slurm_rest_enabled = false" in tf
-    # Current upstream main requires an explicit node-group bundle version and
-    # replaced the old root-level system_resources input with sizing tiers.
+    # The pinned upstream contract requires an explicit node-group bundle and
+    # resolves omitted control-plane presets from its worker-count sizing tier.
     assert 'k8s_version        = "1.34"' in tf
     assert 'node_group_version = "72"' in tf
+    assert 'slurm_operator_version = "4.1.6"' in tf
+    assert "max_size = 24" in tf
+    assert tf.count("preset   = null") >= 2
     assert "system_resources =" not in tf
 
 
-def test_gpu_bootstrap_checks_require_accounting_backed_rest_api() -> None:
+@pytest.mark.parametrize("gpu", [False, True])
+@pytest.mark.parametrize("accounting", [False, True])
+def test_rest_and_accounting_are_independent_for_cpu_gpu_combinations(
+    gpu: bool, accounting: bool
+) -> None:
     data = _base_spec_mapping()
+    data["accounting"] = accounting
+    if not gpu:
+        data["workers"] = [data["workers"][0]]
+
+    spec = spec_from_mapping(data)
+    spec.validate()
+    tf = render_tfvars(spec)
+
+    assert f"accounting_enabled = {str(accounting).lower()}" in tf
+    # Omission is backward-compatible: REST follows accounting. GPU validation
+    # remains mandatory through NPA's direct login-jail creation check when the
+    # pinned operator cannot provide its REST-backed ActiveChecks.
+    assert f"slurm_rest_enabled = {str(accounting).lower()}" in tf
+    expected_scope = "dev" if gpu and accounting else "essential"
+    assert f'active_checks_scope    = "{expected_scope}"' in tf
+
+
+def test_gpu_cluster_allows_rest_disable_without_losing_direct_creation_check() -> None:
+    data = _base_spec_mapping()
+    data["accounting"] = False
+    data["slurm_rest_enabled"] = False
+
+    spec = spec_from_mapping(data)
+    spec.validate()
+    tf = render_tfvars(spec)
+    assert "accounting_enabled = false" in tf
+    assert "slurm_rest_enabled = false" in tf
+    assert 'active_checks_scope    = "essential"' in tf
+
+
+def test_explicit_rest_contract_rejects_operator_unsupported_no_accounting() -> None:
+    data = _base_spec_mapping()
+    data["accounting"] = False
+    data["slurm_rest_enabled"] = True
+
+    with pytest.raises(SoperatorSpecError, match="controller skips REST reconciliation"):
+        spec_from_mapping(data).validate()
+
+    # The toggles remain independent in the accepted direction: accounting can
+    # be enabled while REST is explicitly disabled.
     data["accounting"] = True
-
-    tf = render_tfvars(spec_from_mapping(data))
-
+    data["slurm_rest_enabled"] = False
+    spec = spec_from_mapping(data)
+    spec.validate()
+    tf = render_tfvars(spec)
     assert "accounting_enabled = true" in tf
-    assert "slurm_rest_enabled = true" in tf
-    assert 'active_checks_scope    = "dev"' in tf
+    assert "slurm_rest_enabled = false" in tf
+    assert 'active_checks_scope    = "essential"' in tf
 
 
 def test_k8s_and_node_group_versions_parse_and_must_be_non_empty() -> None:
@@ -144,9 +221,91 @@ def test_k8s_and_node_group_versions_parse_and_must_be_non_empty() -> None:
 
 def test_current_sizing_tier_control_plane_defaults() -> None:
     spec = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
-    assert spec.system_preset == "16vcpu-64gb"
-    assert spec.controller_preset == "16vcpu-64gb"
+    assert spec.system_preset is None
+    assert spec.controller_preset is None
+    assert spec.accounting_preset is None
     assert spec.login_preset == "16vcpu-64gb"
+
+
+@pytest.mark.parametrize(
+    ("worker_count", "expected_tier"),
+    [
+        (9, "XS"),
+        (10, "S"),
+        (99, "S"),
+        (100, "M"),
+        (499, "M"),
+        (500, "L"),
+        (1999, "L"),
+        (2000, "XL"),
+    ],
+)
+def test_sizing_tier_threshold_boundaries(worker_count: int, expected_tier: str) -> None:
+    assert sizing_tier_for_worker_count(worker_count) == expected_tier
+
+
+@pytest.mark.parametrize(
+    ("worker_count", "rejected", "accepted"),
+    [
+        (1, "8vcpu-32gb", "16vcpu-64gb"),
+        (499, "8vcpu-32gb", "16vcpu-64gb"),
+        (500, "16vcpu-64gb", "32vcpu-128gb"),
+        (2000, "32vcpu-128gb", "64vcpu-256gb"),
+    ],
+)
+def test_system_preset_rejected_and_accepted_at_every_capacity_boundary(
+    worker_count: int, rejected: str, accepted: str
+) -> None:
+    workers = [WorkerPoolSpec(name="w", size=worker_count)]
+    with pytest.raises(SoperatorSpecError, match="control_plane.system.preset"):
+        SoperatorSpec(name="c", workers=workers, system_preset=rejected).validate()
+    SoperatorSpec(name="c", workers=workers, system_preset=accepted).validate()
+
+
+@pytest.mark.parametrize("role", ["controller", "login"])
+def test_controller_and_login_actual_minimum_preset(role: str) -> None:
+    kwargs = {f"{role}_preset": "8vcpu-32gb"}
+    with pytest.raises(SoperatorSpecError, match=rf"control_plane.{role}.preset"):
+        SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")], **kwargs).validate()
+    kwargs[f"{role}_preset"] = "16vcpu-64gb"
+    SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")], **kwargs).validate()
+
+
+@pytest.mark.parametrize(
+    ("worker_count", "rejected", "accepted"),
+    [
+        (499, "4vcpu-16gb", "8vcpu-32gb"),
+        (500, "8vcpu-32gb", "16vcpu-64gb"),
+        (2000, "16vcpu-64gb", "32vcpu-128gb"),
+    ],
+)
+def test_accounting_preset_boundaries_when_accounting_enabled(
+    worker_count: int, rejected: str, accepted: str
+) -> None:
+    workers = [WorkerPoolSpec(name="w", size=worker_count)]
+    with pytest.raises(SoperatorSpecError, match="control_plane.accounting.preset"):
+        SoperatorSpec(
+            name="c",
+            workers=workers,
+            accounting=True,
+            accounting_preset=rejected,
+        ).validate()
+    SoperatorSpec(
+        name="c",
+        workers=workers,
+        accounting=True,
+        accounting_preset=accepted,
+    ).validate()
+
+
+def test_system_max_size_preserves_upstream_autoscaling_and_validates_override() -> None:
+    spec = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
+    assert "max_size = 24" in render_tfvars(spec)
+    spec.system_min_size = 25
+    assert "max_size = 25" in render_tfvars(spec)
+    spec.system_max_size = 24
+    with pytest.raises(SoperatorSpecError, match="max_size must be >= min_size"):
+        spec.validate()
 
 
 def test_resolve_login_ssh_key_from_operator_home(tmp_path) -> None:
@@ -159,7 +318,8 @@ def test_resolve_login_ssh_key_from_operator_home(tmp_path) -> None:
 
     resolved = _with_resolved_ssh_public_keys(original, home=tmp_path)
 
-    assert resolved.ssh_public_keys == ["ssh-ed25519 AAAA operator"]
+    assert resolved.root_login_ssh_public_key == "ssh-ed25519 AAAA operator"
+    assert resolved.ssh_public_keys == []
     assert original.ssh_public_keys == []
 
 
@@ -171,11 +331,161 @@ def test_explicit_login_ssh_key_wins_and_missing_fallback_fails(tmp_path) -> Non
         workers=[WorkerPoolSpec(name="w")],
         ssh_public_keys=["ssh-rsa AAAA explicit"],
     )
-    assert _with_resolved_ssh_public_keys(explicit, home=tmp_path) is explicit
+    resolved = _with_resolved_ssh_public_keys(explicit, home=tmp_path)
+    assert resolved.root_login_ssh_public_key == "ssh-rsa AAAA explicit"
+    assert resolved.ssh_public_keys == []
 
     missing = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
-    with pytest.raises(ValueError, match="requires at least one login SSH public key"):
+    with pytest.raises(ValueError, match="root access requires one SSH public key"):
         _with_resolved_ssh_public_keys(missing, home=tmp_path)
+
+
+def test_root_login_ssh_key_precedence_and_nonstandard_ci_path(tmp_path) -> None:
+    from npa.soperator.lifecycle import _resolve_root_login_ssh_public_key
+
+    explicit_file = tmp_path / "ci" / "operator.pub"
+    explicit_file.parent.mkdir()
+    explicit_file.write_text("ssh-ed25519 AAAA explicit-file\n")
+    env_file = tmp_path / "env.pub"
+    env_file.write_text("ssh-ed25519 AAAA env-file\n")
+    home_key = tmp_path / ".ssh" / "id_ed25519.pub"
+    home_key.parent.mkdir()
+    home_key.write_text("ssh-ed25519 AAAA home\n")
+    env = {
+        "NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY": "ssh-ed25519 AAAA env-inline",
+        "NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY_FILE": str(env_file),
+    }
+    spec = SoperatorSpec(
+        name="c",
+        workers=[WorkerPoolSpec(name="w")],
+        root_login_ssh_public_key="ssh-ed25519 AAAA spec",
+    )
+
+    resolved = _resolve_root_login_ssh_public_key(
+        spec, explicit_file=explicit_file, environ=env, home=tmp_path
+    )
+    assert resolved.value.endswith("explicit-file")
+    assert resolved.source == "explicit argument"
+    assert resolved.fingerprint.startswith("SHA256:")
+
+    resolved = _resolve_root_login_ssh_public_key(spec, environ=env, home=tmp_path)
+    assert resolved.value.endswith("spec")
+    assert resolved.source == "spec root_login_ssh_public_key"
+
+    empty_spec = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
+    resolved = _resolve_root_login_ssh_public_key(empty_spec, environ=env, home=tmp_path)
+    assert resolved.value.endswith("env-inline")
+    assert resolved.source == "NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY"
+
+    env.pop("NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY")
+    resolved = _resolve_root_login_ssh_public_key(empty_spec, environ=env, home=tmp_path)
+    assert resolved.value.endswith("env-file")
+    assert resolved.source == "NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY_FILE"
+
+    resolved = _resolve_root_login_ssh_public_key(empty_spec, environ={}, home=tmp_path)
+    assert resolved.value.endswith("home")
+    assert resolved.source == "operator default id_ed25519.pub"
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    [
+        "",
+        "command=x ssh-ed25519 AAAA comment",
+        "ssh-ed25519 not-base64! comment",
+        "ssh-ed25519 AAAA one\nssh-ed25519 AAAA two",
+    ],
+)
+def test_root_login_ssh_key_rejects_invalid_or_multiple_records(bad_key: str) -> None:
+    spec = SoperatorSpec(
+        name="c",
+        workers=[WorkerPoolSpec(name="w")],
+        root_login_ssh_public_key=bad_key,
+    )
+    if not bad_key:
+        # Empty means omitted and is resolved later by the deploy environment.
+        spec.validate()
+    else:
+        with pytest.raises(SoperatorSpecError, match="root login SSH key"):
+            spec.validate()
+
+
+def test_legacy_root_login_key_alias_accepts_one_record_only() -> None:
+    spec = SoperatorSpec(
+        name="c",
+        workers=[WorkerPoolSpec(name="w")],
+        ssh_public_keys=["ssh-ed25519 AAAA one", "ssh-ed25519 AAAA two"],
+    )
+    with pytest.raises(SoperatorSpecError, match="exactly one"):
+        spec.validate()
+
+
+def test_root_login_ssh_key_hcl_rendering_escapes_comment_safely() -> None:
+    key = 'ssh-ed25519 AAAA ci-${var.bad}-%{if true}-"quoted"-\\path'
+    spec = SoperatorSpec(
+        name="c",
+        workers=[WorkerPoolSpec(name="w")],
+        root_login_ssh_public_key=key,
+    )
+    spec.validate()
+    rendered = render_tfvars(spec)
+    assert "${var.bad}" not in rendered.replace("$${var.bad}", "")
+    assert "%{if true}" not in rendered.replace("%%{if true}", "")
+    assert (
+        '  "ssh-ed25519 AAAA ci-$${var.bad}-%%{if true}-\\"quoted\\"-\\\\path",'
+        in rendered
+    )
+
+
+def test_operator_override_validation_and_verified_userns_contract() -> None:
+    spec = SoperatorSpec(
+        name="c",
+        workers=[WorkerPoolSpec(name="w")],
+        slurm_operator_version="latest",
+    )
+    with pytest.raises(SoperatorSpecError, match="semantic version"):
+        spec.validate()
+
+    spec.slurm_operator_version = "4.1.7"
+    with pytest.raises(SoperatorSpecError, match="user-namespace override is verified only"):
+        spec.validate()
+
+    spec.use_default_apparmor_profile = True
+    spec.validate()  # explicit newer chart is possible when the pinned sysctl override is unused
+
+    spec.slurm_operator_version = "4.2.0"
+    with pytest.raises(SoperatorSpecError, match="outside the pinned runtime contract"):
+        spec.validate()
+
+
+def test_rest_contract_rejects_string_boolean() -> None:
+    data = _base_spec_mapping()
+    data["slurm_rest_enabled"] = "false"
+
+    with pytest.raises(SoperatorSpecError, match="must be a boolean"):
+        spec_from_mapping(data)
+
+
+def test_solutions_library_ref_requires_immutable_commit() -> None:
+    from npa.soperator.lifecycle import _validate_immutable_solutions_library_ref
+
+    assert _validate_immutable_solutions_library_ref(DEFAULT_SOLUTIONS_LIBRARY_REF) == (
+        DEFAULT_SOLUTIONS_LIBRARY_REF
+    )
+    with pytest.raises(ValueError, match="immutable 40-character"):
+        _validate_immutable_solutions_library_ref("main")
+
+
+def test_solutions_library_resolution_preserves_legacy_install_state(tmp_path) -> None:
+    from npa.soperator.lifecycle import _resolve_solutions_library
+
+    recipe = tmp_path / "nebius-solutions-library" / "soperator"
+    (recipe / "installations" / "example").mkdir(parents=True)
+
+    assert (
+        _resolve_solutions_library(None, tmp_path, DEFAULT_SOLUTIONS_LIBRARY_REF)
+        == recipe
+    )
 
 
 def test_render_tfvars_cpu_only_disables_image_disk() -> None:
@@ -237,9 +547,10 @@ def test_destroy_reconstructs_tf_var_env_from_sidecar(tmp_path, monkeypatch) -> 
     )
 
     monkeypatch.setattr(lifecycle, "_require_bin", lambda name: name)
+    monkeypatch.setattr(lifecycle, "_assert_solutions_library_contract", lambda *a, **k: None)
     # _soperator_tf_env -> _terraform_env mints a real IAM token via the `nebius`
     # CLI; stub it so the destroy tests never touch real infra (CI has no nebius).
-    monkeypatch.setattr(lifecycle, "_terraform_env", lambda nebius_bin: {})
+    monkeypatch.setattr(lifecycle, "_terraform_env", lambda nebius_bin, **kwargs: {})
     captured: dict[str, dict[str, str]] = {}
 
     class _Done:
@@ -301,9 +612,10 @@ def test_destroy_deletes_orphaned_vpc_allocation(tmp_path, monkeypatch) -> None:
     )
 
     monkeypatch.setattr(lifecycle, "_require_bin", lambda name: name)
+    monkeypatch.setattr(lifecycle, "_assert_solutions_library_contract", lambda *a, **k: None)
     # _soperator_tf_env -> _terraform_env mints a real IAM token via the `nebius`
     # CLI; stub it so the destroy tests never touch real infra (CI has no nebius).
-    monkeypatch.setattr(lifecycle, "_terraform_env", lambda nebius_bin: {})
+    monkeypatch.setattr(lifecycle, "_terraform_env", lambda nebius_bin, **kwargs: {})
     deleted: list[str] = []
 
     class _Done:
@@ -362,9 +674,10 @@ def test_destroy_deletes_orphaned_filesystems(tmp_path, monkeypatch) -> None:
     )
 
     monkeypatch.setattr(lifecycle, "_require_bin", lambda name: name)
+    monkeypatch.setattr(lifecycle, "_assert_solutions_library_contract", lambda *a, **k: None)
     # _soperator_tf_env -> _terraform_env mints a real IAM token via the `nebius`
     # CLI; stub it so the destroy tests never touch real infra (CI has no nebius).
-    monkeypatch.setattr(lifecycle, "_terraform_env", lambda nebius_bin: {})
+    monkeypatch.setattr(lifecycle, "_terraform_env", lambda nebius_bin, **kwargs: {})
     deleted: list[str] = []
 
     class _Done:
@@ -419,11 +732,223 @@ def test_nebius_cli_env_keeps_token_when_reuse_opt_in(monkeypatch) -> None:
     assert lifecycle._nebius_cli_env()["NEBIUS_IAM_TOKEN"] == "ci-injected-token"
 
 
+def test_soperator_terraform_token_uses_explicit_nebius_profile(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setenv("NPA_NEBIUS_PROFILE", "cross-tenant-profile")
+    seen: dict[str, str] = {}
+
+    def fake_tf_env(nebius_bin, *, profile=""):
+        seen["profile"] = profile
+        return {}
+
+    monkeypatch.setattr(lifecycle, "_terraform_env", fake_tf_env)
+    env = lifecycle._soperator_tf_env(
+        "nebius",
+        region="us-central1",
+        tenant_id="tenant",
+        project_id="project",
+        subnet_id="subnet",
+    )
+
+    assert seen["profile"] == "cross-tenant-profile"
+    assert env["TF_VAR_o11y_profile"] == "cross-tenant-profile"
+    assert env["NEBIUS_PROFILE"] == "cross-tenant-profile"
+    assert lifecycle._nebius_cli_env()["NEBIUS_PROFILE"] == "cross-tenant-profile"
+
+
+def test_kube_credential_refresh_pins_selected_nebius_profile(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        lambda cmd, **kwargs: calls.append(cmd) or _Done(),
+    )
+
+    lifecycle._refresh_kube_credentials(
+        "nebius",
+        "cluster-id",
+        "context",
+        {"NPA_NEBIUS_PROFILE": "cross-tenant-profile"},
+    )
+
+    assert calls == [[
+        "nebius",
+        "--profile",
+        "cross-tenant-profile",
+        "mk8s",
+        "cluster",
+        "get-credentials",
+        "--id",
+        "cluster-id",
+        "--external",
+        "--force",
+        "--context-name",
+        "context",
+    ]]
+
+
 class _Done:
     def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
         self.stdout = stdout
         self.stderr = stderr
         self.returncode = returncode
+
+
+def test_direct_gpu_creation_check_uses_every_worker_and_gpu(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    calls: list[list[str]] = []
+
+    def fake_capture(cmd, **kwargs):
+        calls.append(cmd)
+        return _Done(
+            stdout=(
+                "0: NPA_GPU_CREATION_CHECK_RESULT host=gpu-0 status=PASS command_rc=0\n"
+                "1: NPA_GPU_CREATION_CHECK_RESULT host=gpu-1 status=PASS command_rc=0\n"
+            )
+        )
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+    spec = SoperatorSpec(
+        name="c",
+        workers=[
+            WorkerPoolSpec(
+                name="gpu",
+                platform="gpu-b200-sxm",
+                preset="8gpu-160vcpu-1792gb",
+                size=2,
+                fabric="us-central1-b",
+            )
+        ],
+    )
+
+    checks = lifecycle._run_gpu_creation_checks(spec, "ctx", "kubectl")
+
+    assert checks == [{
+        "pool": "gpu",
+        "nodes": 2,
+        "gpus_per_node": 8,
+        "tests": [
+            "deviceQuery",
+            "vectorAdd",
+            "simpleMultiGPU",
+            "p2pBandwidthLatencyTest",
+        ],
+        "status": "PASS",
+    }]
+    command = calls[0]
+    assert "--nodes=2" in command
+    assert "--ntasks=2" in command
+    assert "--gpus-per-node=8" in command
+    assert "--nodelist=gpu-0,gpu-1" in command
+    task_script = command[-1]
+    assert "health-checker run" in task_script
+    assert "deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest" in task_script
+
+
+def test_direct_gpu_creation_check_fails_on_missing_worker_pass(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        lambda *a, **k: _Done(
+            stdout="0: NPA_GPU_CREATION_CHECK_RESULT host=gpu-0 status=PASS command_rc=0\n"
+        ),
+    )
+    spec = SoperatorSpec(
+        name="c",
+        workers=[
+            WorkerPoolSpec(
+                name="gpu",
+                platform="gpu-b200-sxm",
+                preset="8gpu-160vcpu-1792gb",
+                size=2,
+                fabric="us-central1-b",
+            )
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="1/2 workers reported PASS"):
+        lifecycle._run_gpu_creation_checks(spec, "ctx", "kubectl")
+
+
+def test_direct_gpu_creation_check_is_noop_for_cpu_cluster(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_run_capture",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("unexpected kubectl")),
+    )
+    spec = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="cpu")])
+
+    assert lifecycle._run_gpu_creation_checks(spec, "ctx", "kubectl") == []
+
+
+def test_superseded_activechecks_upgrade_aborts_only_old_hook(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    calls: list[list[str]] = []
+    releases = {
+        "items": [
+            {
+                "metadata": {
+                    "name": "stack-soperator-activechecks",
+                    "generation": 4,
+                },
+                "status": {
+                    "lastAttemptedGeneration": 3,
+                    "conditions": [
+                        {
+                            "type": "Reconciling",
+                            "status": "True",
+                            "reason": "Progressing",
+                        }
+                    ],
+                },
+            },
+            {
+                "metadata": {
+                    "name": "current-soperator-activechecks",
+                    "generation": 7,
+                },
+                "status": {
+                    "lastAttemptedGeneration": 7,
+                    "conditions": [
+                        {
+                            "type": "Reconciling",
+                            "status": "True",
+                            "reason": "Progressing",
+                        }
+                    ],
+                },
+            },
+        ]
+    }
+
+    def fake_capture(cmd, **kwargs):
+        calls.append(cmd)
+        if "get" in cmd and "helmreleases" in cmd:
+            return _Done(stdout=json.dumps(releases))
+        return _Done(stdout="ok")
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+    monkeypatch.setattr(lifecycle.time, "time_ns", lambda: 42)
+
+    reset = lifecycle._abort_superseded_activechecks_upgrade("kubectl", "ctx")
+
+    assert reset == ["stack-soperator-activechecks"]
+    deletes = [cmd for cmd in calls if "delete" in cmd]
+    assert len(deletes) == 1
+    assert "wait-for-active-checks" in deletes[0]
+    annotations = [cmd for cmd in calls if "annotate" in cmd]
+    assert len(annotations) == 1
+    assert "stack-soperator-activechecks" in annotations[0]
+    assert "current-soperator-activechecks" not in annotations[0]
 
 
 def test_install_monitoring_crds_strips_token_and_verifies(monkeypatch) -> None:
@@ -676,6 +1201,55 @@ def test_install_monitoring_crds_raises_when_crd_absent(monkeypatch) -> None:
         lifecycle._install_monitoring_crds("kubectl", "ctx")
 
 
+@pytest.mark.parametrize(
+    "detail",
+    [
+        "failed to inspect monitoring HelmReleases: Forbidden",
+        "failed to reset monitoring HelmRelease: transient server error",
+    ],
+)
+def test_post_deploy_monitoring_repair_failure_is_best_effort(
+    monkeypatch, detail: str
+) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_install_monitoring_crds",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(detail)),
+    )
+    monkeypatch.setattr(lifecycle, "_patch_slurmcluster_crd", lambda *a, **k: True)
+    monkeypatch.setattr(lifecycle, "_ensure_scripts_configmap", lambda *a, **k: True)
+    monkeypatch.setattr(lifecycle, "_register_slurm_workers", lambda *a, **k: None)
+    monkeypatch.setattr(
+        lifecycle, "_abort_superseded_activechecks_upgrade", lambda *a, **k: []
+    )
+    messages: list[str] = []
+
+    warnings = lifecycle.apply_post_deploy_fixes(
+        "ctx", "kubectl", on_status=messages.append
+    )
+
+    assert warnings == [f"monitoring repair skipped after successful apply: {detail}"]
+    assert any("post-deploy warning" in message for message in messages)
+
+
+def test_post_deploy_monitoring_repair_clean_install_returns_no_warnings(
+    monkeypatch,
+) -> None:
+    from npa.soperator import lifecycle
+
+    monkeypatch.setattr(lifecycle, "_install_monitoring_crds", lambda *a, **k: None)
+    monkeypatch.setattr(lifecycle, "_patch_slurmcluster_crd", lambda *a, **k: True)
+    monkeypatch.setattr(lifecycle, "_ensure_scripts_configmap", lambda *a, **k: True)
+    monkeypatch.setattr(lifecycle, "_register_slurm_workers", lambda *a, **k: None)
+    monkeypatch.setattr(
+        lifecycle, "_abort_superseded_activechecks_upgrade", lambda *a, **k: []
+    )
+
+    assert lifecycle.apply_post_deploy_fixes("ctx", "kubectl") == []
+
+
 def _write_recipe_locals(tmp_path, essential_body: str):
     """Write a minimal locals_active_checks.tf with an ``essential`` scope."""
 
@@ -774,6 +1348,88 @@ def test_patch_nodeconfigurator_allows_enroot_userns_and_is_idempotent(
     assert lifecycle._patch_nodeconfigurator_userns(tmp_path) is False
     assert template.read_text() == patched
     assert patched.count("# npa: allow Enroot user namespaces on Ubuntu hosts") == 1
+
+
+def test_patch_nodeconfigurator_missing_own_values_refuses_sibling_chart(
+    tmp_path,
+) -> None:
+    from npa.soperator import lifecycle
+
+    template = (
+        tmp_path
+        / "modules"
+        / "slurm"
+        / "templates"
+        / "helm_values"
+        / "terraform_fluxcd_values.yaml.tftpl"
+    )
+    template.parent.mkdir(parents=True)
+    original = (
+        "        fluxcd:\n"
+        "          nodeConfigurator:\n"
+        "            enabled: true\n"
+        "          siblingChart:\n"
+        "            enabled: true\n"
+        "            values:\n"
+        "              resources: {}\n"
+    )
+    template.write_text(original)
+
+    with pytest.raises(lifecycle.UpstreamContractError, match="its own values"):
+        lifecycle._patch_nodeconfigurator_userns(tmp_path)
+
+    assert template.read_text() == original
+    assert "privileged: true" not in template.read_text()
+
+
+def test_contract_assertion_stops_before_installation_or_cloud_mutation(
+    tmp_path, monkeypatch
+) -> None:
+    from types import SimpleNamespace
+
+    from npa.soperator import lifecycle
+
+    spec = SoperatorSpec(
+        name="c",
+        region="us-central1",
+        tenant_id="tenant",
+        project_id="project",
+        workers=[WorkerPoolSpec(name="w")],
+        root_login_ssh_public_key="ssh-ed25519 AAAA operator",
+    )
+    recipe = tmp_path / "soperator"
+    (recipe / "installations" / "example").mkdir(parents=True)
+    monkeypatch.setattr(lifecycle, "resolve_environment", lambda **k: SimpleNamespace(
+        region="us-central1", tenant_id="tenant", project_id="project"
+    ))
+    monkeypatch.setattr(lifecycle, "_require_bin", lambda name: name)
+    monkeypatch.setattr(lifecycle, "_resolve_solutions_library", lambda *a, **k: recipe)
+    monkeypatch.setattr(
+        lifecycle,
+        "_assert_solutions_library_contract",
+        lambda *a, **k: (_ for _ in ()).throw(
+            lifecycle.UpstreamContractError("incompatible pinned contract")
+        ),
+    )
+    prepared = False
+    provider_read = False
+
+    def prepare(*args, **kwargs):
+        nonlocal prepared
+        prepared = True
+
+    def resolve_subnet(*args, **kwargs):
+        nonlocal provider_read
+        provider_read = True
+
+    monkeypatch.setattr(lifecycle, "_prepare_installation", prepare)
+    monkeypatch.setattr(lifecycle, "_resolve_subnet", resolve_subnet)
+
+    with pytest.raises(lifecycle.UpstreamContractError, match="incompatible"):
+        lifecycle.deploy_cluster(spec, work_root=tmp_path)
+
+    assert prepared is False
+    assert provider_read is False
 
 
 def test_patch_nodeconfigurator_missing_template_is_safe(tmp_path) -> None:

--- a/npa/tests/unit/test_soperator_cli.py
+++ b/npa/tests/unit/test_soperator_cli.py
@@ -1250,6 +1250,45 @@ def test_post_deploy_monitoring_repair_clean_install_returns_no_warnings(
     assert lifecycle.apply_post_deploy_fixes("ctx", "kubectl") == []
 
 
+def test_slurmcluster_crd_patch_reports_kubernetes_write_failure(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    def fake_capture(cmd, *, cwd=None, env=None, timeout=None, check=True):
+        if "get" in cmd:
+            return _Done(stdout="slurmclusters.slurm.nebius.ai")
+        assert "patch" in cmd
+        return _Done(stderr="Forbidden", returncode=1)
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    assert lifecycle._patch_slurmcluster_crd("kubectl", "ctx") is False
+
+
+def test_scripts_configmap_reports_kubernetes_write_failure(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    source = {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "slurm-scripts"},
+        "data": {"entrypoint.sh": "#!/bin/sh"},
+    }
+
+    def fake_capture(cmd, *, cwd=None, env=None, timeout=None, check=True):
+        if "soperator-slurm-scripts" in cmd:
+            return _Done(stderr="NotFound", returncode=1)
+        return _Done(stdout=json.dumps(source))
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+    monkeypatch.setattr(
+        lifecycle.subprocess,
+        "run",
+        lambda *args, **kwargs: _Done(stderr="Forbidden", returncode=1),
+    )
+
+    assert lifecycle._ensure_scripts_configmap("kubectl", "ctx", "soperator") is False
+
+
 def _write_recipe_locals(tmp_path, essential_body: str):
     """Write a minimal locals_active_checks.tf with an ``essential`` scope."""
 

--- a/npa/tests/unit/test_soperator_cli.py
+++ b/npa/tests/unit/test_soperator_cli.py
@@ -106,6 +106,76 @@ def test_render_tfvars_emits_multi_preset_and_io_m3_cache() -> None:
     # AppArmor default off (unconfined) and accounting/telemetry off.
     assert "use_default_apparmor_profile = false" in tf
     assert "accounting_enabled = false" in tf
+    assert 'active_checks_scope    = "essential"' in tf
+    assert "slurm_rest_enabled = false" in tf
+    # Current upstream main requires an explicit node-group bundle version and
+    # replaced the old root-level system_resources input with sizing tiers.
+    assert 'k8s_version        = "1.34"' in tf
+    assert 'node_group_version = "72"' in tf
+    assert "system_resources =" not in tf
+
+
+def test_gpu_bootstrap_checks_require_accounting_backed_rest_api() -> None:
+    data = _base_spec_mapping()
+    data["accounting"] = True
+
+    tf = render_tfvars(spec_from_mapping(data))
+
+    assert "accounting_enabled = true" in tf
+    assert "slurm_rest_enabled = true" in tf
+    assert 'active_checks_scope    = "dev"' in tf
+
+
+def test_k8s_and_node_group_versions_parse_and_must_be_non_empty() -> None:
+    data = _base_spec_mapping()
+    data["k8s_version"] = "1.35"
+    data["node_group_version"] = "80"
+    spec = spec_from_mapping(data)
+    spec.validate()
+    assert spec.k8s_version == "1.35"
+    assert spec.node_group_version == "80"
+    assert 'k8s_version        = "1.35"' in render_tfvars(spec)
+    assert 'node_group_version = "80"' in render_tfvars(spec)
+
+    spec.node_group_version = ""
+    with pytest.raises(SoperatorSpecError, match="must both be non-empty"):
+        spec.validate()
+
+
+def test_current_sizing_tier_control_plane_defaults() -> None:
+    spec = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
+    assert spec.system_preset == "16vcpu-64gb"
+    assert spec.controller_preset == "16vcpu-64gb"
+    assert spec.login_preset == "16vcpu-64gb"
+
+
+def test_resolve_login_ssh_key_from_operator_home(tmp_path) -> None:
+    from npa.soperator.lifecycle import _with_resolved_ssh_public_keys
+
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "id_ed25519.pub").write_text("ssh-ed25519 AAAA operator\n")
+    original = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
+
+    resolved = _with_resolved_ssh_public_keys(original, home=tmp_path)
+
+    assert resolved.ssh_public_keys == ["ssh-ed25519 AAAA operator"]
+    assert original.ssh_public_keys == []
+
+
+def test_explicit_login_ssh_key_wins_and_missing_fallback_fails(tmp_path) -> None:
+    from npa.soperator.lifecycle import _with_resolved_ssh_public_keys
+
+    explicit = SoperatorSpec(
+        name="c",
+        workers=[WorkerPoolSpec(name="w")],
+        ssh_public_keys=["ssh-rsa AAAA explicit"],
+    )
+    assert _with_resolved_ssh_public_keys(explicit, home=tmp_path) is explicit
+
+    missing = SoperatorSpec(name="c", workers=[WorkerPoolSpec(name="w")])
+    with pytest.raises(ValueError, match="requires at least one login SSH public key"):
+        _with_resolved_ssh_public_keys(missing, home=tmp_path)
 
 
 def test_render_tfvars_cpu_only_disables_image_disk() -> None:
@@ -367,6 +437,8 @@ def test_install_monitoring_crds_strips_token_and_verifies(monkeypatch) -> None:
 
     def fake_capture(cmd, *, cwd=None, env=None, timeout=None, check=True):
         seen_envs.append(dict(env or {}))
+        if "helmreleases" in cmd:
+            return _Done(stdout='{"items": []}')
         if "get" in cmd and "crd" in cmd:
             return _Done(stdout="customresourcedefinition.apiextensions.k8s.io/"
                                 "servicemonitors.monitoring.coreos.com\n")
@@ -380,6 +452,194 @@ def test_install_monitoring_crds_strips_token_and_verifies(monkeypatch) -> None:
     # call must run without it so the plugin mints a fresh credential.
     assert seen_envs, "expected kubectl to be invoked"
     assert all("NEBIUS_IAM_TOKEN" not in e for e in seen_envs)
+
+
+def test_monitoring_prerequisites_create_namespace_when_telemetry_is_off(
+    monkeypatch,
+) -> None:
+    from npa.soperator import lifecycle
+
+    calls: list[list[str]] = []
+
+    def fake_capture(cmd, *, cwd=None, env=None, timeout=None, check=True):
+        calls.append(cmd)
+        if "helmreleases" in cmd:
+            return _Done(stdout='{"items": []}')
+        if "get" in cmd and "namespace" in cmd:
+            return _Done(stderr="NotFound", returncode=1)
+        if "get" in cmd and "crd" in cmd:
+            return _Done(stdout="servicemonitors.monitoring.coreos.com")
+        return _Done(stdout="created")
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    lifecycle._install_monitoring_crds("kubectl", "ctx")
+
+    assert [
+        "kubectl",
+        "--context",
+        "ctx",
+        "create",
+        "namespace",
+        "monitoring-system",
+    ] in calls
+
+
+def test_monitoring_namespace_creation_failure_is_actionable(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    def fake_capture(cmd, *, cwd=None, env=None, timeout=None, check=True):
+        if "get" in cmd and "namespace" in cmd:
+            return _Done(stderr="NotFound", returncode=1)
+        if "create" in cmd and "namespace" in cmd:
+            return _Done(stderr="Forbidden", returncode=1)
+        return _Done(stdout="")
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    with pytest.raises(RuntimeError, match="failed to ensure monitoring-system"):
+        lifecycle._install_monitoring_crds("kubectl", "ctx")
+
+
+def test_monitoring_namespace_creation_race_accepts_existing_namespace(
+    monkeypatch,
+) -> None:
+    from npa.soperator import lifecycle
+
+    namespace_reads = 0
+
+    def fake_capture(cmd, *, cwd=None, env=None, timeout=None, check=True):
+        nonlocal namespace_reads
+        if "helmreleases" in cmd:
+            return _Done(stdout='{"items": []}')
+        if "get" in cmd and "namespace" in cmd:
+            namespace_reads += 1
+            if namespace_reads == 1:
+                return _Done(stderr="NotFound", returncode=1)
+            return _Done(stdout="namespace/monitoring-system")
+        if "create" in cmd and "namespace" in cmd:
+            return _Done(stderr="AlreadyExists", returncode=1)
+        if "get" in cmd and "crd" in cmd:
+            return _Done(stdout="servicemonitors.monitoring.coreos.com")
+        return _Done(stdout="created")
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    lifecycle._install_monitoring_crds("kubectl", "ctx")
+    assert namespace_reads == 2
+
+
+def test_monitoring_prerequisites_reset_only_stalled_dashboard_release(
+    monkeypatch,
+) -> None:
+    from npa.soperator import lifecycle
+
+    calls: list[list[str]] = []
+    releases = {
+        "items": [
+            {
+                "metadata": {"name": "stack-monitoring-dashboards"},
+                "status": {
+                    "conditions": [
+                        {
+                            "type": "Ready",
+                            "status": "False",
+                            "reason": "RetriesExceeded",
+                        }
+                    ]
+                },
+            },
+            {
+                "metadata": {"name": "healthy-monitoring-dashboards"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}]
+                },
+            },
+            {
+                "metadata": {"name": "progressing-monitoring-dashboards"},
+                "status": {
+                    "conditions": [
+                        {
+                            "type": "Ready",
+                            "status": "Unknown",
+                            "reason": "Progressing",
+                        }
+                    ]
+                },
+            },
+            {"metadata": {"name": "unrelated"}},
+        ]
+    }
+
+    def fake_capture(cmd, *, cwd=None, env=None, timeout=None, check=True):
+        calls.append(cmd)
+        if "namespace" in cmd:
+            return _Done(stdout="namespace/monitoring-system")
+        if "helmreleases" in cmd:
+            return _Done(stdout=json.dumps(releases))
+        if "get" in cmd and "crd" in cmd:
+            return _Done(stdout="established")
+        return _Done(stdout="ok")
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+    monkeypatch.setattr(lifecycle.time, "time_ns", lambda: 1234)
+
+    lifecycle._install_monitoring_crds("kubectl", "ctx")
+
+    annotation_calls = [cmd for cmd in calls if "annotate" in cmd]
+    assert annotation_calls == [
+        [
+            "kubectl",
+            "--context",
+            "ctx",
+            "-n",
+            "flux-system",
+            "annotate",
+            "helmrelease",
+            "stack-monitoring-dashboards",
+            "reconcile.fluxcd.io/requestedAt=1234",
+            "reconcile.fluxcd.io/resetAt=1234",
+            "--overwrite",
+        ]
+    ]
+
+
+def test_monitoring_release_inspection_failure_is_actionable(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    def fake_capture(cmd, *, cwd=None, env=None, timeout=None, check=True):
+        if "namespace" in cmd:
+            return _Done(stdout="namespace/monitoring-system")
+        if "helmreleases" in cmd:
+            return _Done(stderr="Forbidden", returncode=1)
+        if "get" in cmd and "crd" in cmd:
+            return _Done(stdout="established")
+        return _Done(stdout="ok")
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    with pytest.raises(RuntimeError, match="failed to inspect monitoring HelmReleases"):
+        lifecycle._install_monitoring_crds("kubectl", "ctx")
+
+
+def test_monitoring_release_inspection_allows_clean_pre_flux_install(monkeypatch) -> None:
+    from npa.soperator import lifecycle
+
+    def fake_capture(cmd, *, cwd=None, env=None, timeout=None, check=True):
+        if "namespace" in cmd:
+            return _Done(stdout="namespace/monitoring-system")
+        if "helmreleases" in cmd:
+            return _Done(
+                stderr='the server doesn\'t have a resource type "helmreleases"',
+                returncode=1,
+            )
+        if "get" in cmd and "crd" in cmd:
+            return _Done(stdout="established")
+        return _Done(stdout="ok")
+
+    monkeypatch.setattr(lifecycle, "_run_capture", fake_capture)
+
+    lifecycle._install_monitoring_crds("kubectl", "ctx")
 
 
 def test_install_monitoring_crds_raises_on_failure(monkeypatch) -> None:
@@ -478,3 +738,45 @@ def test_patch_active_checks_locals_missing_file(tmp_path) -> None:
 
     # No modules/slurm/locals_active_checks.tf -> no-op, no crash.
     assert lifecycle._patch_active_checks_locals(tmp_path) is False
+
+
+def test_patch_nodeconfigurator_allows_enroot_userns_and_is_idempotent(
+    tmp_path,
+) -> None:
+    from npa.soperator import lifecycle
+
+    template = (
+        tmp_path
+        / "modules"
+        / "slurm"
+        / "templates"
+        / "helm_values"
+        / "terraform_fluxcd_values.yaml.tftpl"
+    )
+    template.parent.mkdir(parents=True)
+    template.write_text(
+        "        fluxcd:\n"
+        "          nodeConfigurator:\n"
+        "            enabled: true\n"
+        "            values:\n"
+        "              resources: {}\n"
+        "          anotherRelease:\n"
+    )
+
+    assert lifecycle._patch_nodeconfigurator_userns(tmp_path) is True
+    patched = template.read_text()
+    assert "sysctl -w kernel.unprivileged_userns_clone=1" in patched
+    assert "sysctl -w kernel.apparmor_restrict_unprivileged_userns=0" in patched
+    assert '[ "${apparmor_enabled}" = "false" ]' in patched
+    assert "sysctl -w net.core.rmem_max=536870912" in patched
+    assert patched.index("initContainers:") < patched.index("resources: {}")
+
+    assert lifecycle._patch_nodeconfigurator_userns(tmp_path) is False
+    assert template.read_text() == patched
+    assert patched.count("# npa: allow Enroot user namespaces on Ubuntu hosts") == 1
+
+
+def test_patch_nodeconfigurator_missing_template_is_safe(tmp_path) -> None:
+    from npa.soperator import lifecycle
+
+    assert lifecycle._patch_nodeconfigurator_userns(tmp_path) is False

--- a/skills/tools/soperator/SKILL.md
+++ b/skills/tools/soperator/SKILL.md
@@ -30,8 +30,8 @@ apiVersion: npa.soperator/v0.0.1
 name: npasop                 # company_name; kube context = nebius-<name>-slurm
 region: us-central1          # or resolved from ~/.npa config
 control_plane:
-  system: { min_size: 3, preset: 8vcpu-32gb }   # min_size >= 3 (recipe rule)
-  controller: { preset: 8vcpu-32gb }
+  system: { min_size: 3, preset: 16vcpu-64gb }  # min_size >= 3; XS sizing-tier floor
+  controller: { preset: 16vcpu-64gb }           # current sizing-tier floor
   login: { preset: 16vcpu-64gb }                 # login needs >= 16vcpu (sufficiency)
 workers:
   - name: cpu8
@@ -46,13 +46,17 @@ workers:
     fabric: us-central1-b       # required for GPU presets; 1-GPU can't cluster
     preemptible: true           # on-demand GPU quota is often 0; preemptible works
     docker_cache: true
+k8s_version: "1.34"
+node_group_version: "72"     # required by current solutions-library main
 ```
 
 ## Procedure
 
 1. Keep committed files public-safe: never hardcode project/tenant/registry IDs
    or SSH keys in the skill or spec templates. The spec resolves region/tenant/
-   project from `~/.npa/config.yaml` when its fields are empty.
+   project from `~/.npa/config.yaml` when its fields are empty. If
+   `ssh_public_keys` is omitted, deploy uses `~/.ssh/id_ed25519.pub` (then
+   `id_rsa.pub`); it fails before Terraform when neither exists.
 2. **Preflight quotas** (the deploy hits these in order; raise before applying):
    - `compute.instance.count` — ~7 instances for a 2-pool cluster.
    - `compute.instance.non-gpu.vcpu` — sum of all node vCPUs.
@@ -63,11 +67,19 @@ workers:
 3. Deploy: `npa soperator deploy --spec cluster.yaml --terraform-dir <solutions-lib>/soperator`
    (omit `--terraform-dir` to clone the library). Requires terraform >= 1.12
    (set `NPA_TERRAFORM_BIN` if the system terraform is older).
+   The current recipe requires a Kubernetes node-group bundle version; keep
+   `k8s_version` and `node_group_version` aligned with its example installation.
 4. `--apply-fixes` (default) applies the 4.1.0-stable post-deploy fixes:
-   prometheus-operator CRDs (operator chart needs ServiceMonitor even with
-   telemetry off), the `plugStackConfig.ncclInspectorPreConf` CRD
-   preserve-unknown-fields patch, and the cluster-name-prefixed
-   `<ns>-slurm-scripts` configmap.
+   the `monitoring-system` namespace and prometheus-operator CRDs (charts need
+   both even with telemetry off), recovery for a dashboards HelmRelease whose
+   remediation retries were exhausted before those prerequisites existed, the
+   `plugStackConfig.ncclInspectorPreConf` CRD preserve-unknown-fields patch, and
+   the cluster-name-prefixed `<ns>-slurm-scripts` configmap. For the default
+   unconfined worker profile, NPA also extends the node configurator's sysctls so
+   Ubuntu's AppArmor user-namespace gate does not block Enroot/Pyxis jobs.
+   Accounting-disabled clusters use the `essential` active-check scope because
+   Soperator does not create the REST service required by its Slurm GPU checks
+   without accounting; accounting-enabled GPU clusters keep the `dev` scope.
 5. Verify: `npa soperator status --name <name>` runs `sinfo` on the controller.
 
 ## Gotchas

--- a/skills/tools/soperator/SKILL.md
+++ b/skills/tools/soperator/SKILL.md
@@ -15,8 +15,8 @@ declarative spec, so customers get a working Slurm cluster without hand-editing
 the recipe's large tfvars.
 
 Three-tier contract:
-- **CLI**: `npa soperator deploy --spec <cluster.yaml>`, `npa soperator status --name <n>`, `npa soperator destroy --name <n>`.
-- **SDK**: `npa.sdk.soperator.deploy(spec)` / `destroy(name)` with `SoperatorSpec` / `WorkerPoolSpec`.
+- **CLI**: `npa soperator plan|deploy --spec <cluster.yaml>`, `npa soperator status --name <n>`, `npa soperator destroy --name <n>`.
+- **SDK**: `npa.sdk.soperator.plan(spec)` / `deploy(spec)` / `destroy(name)` with `SoperatorSpec` / `WorkerPoolSpec`.
 - **YAML / agent**: `apiVersion: npa.soperator/v0.0.1` spec; workflow `toolRef: infra.soperator.deploy`.
 
 ## Spec (npa.soperator/v0.0.1)
@@ -45,6 +45,10 @@ workers:
     size: 2
     fabric: us-central1-b       # required for GPU presets; 1-GPU can't cluster
     preemptible: true           # on-demand GPU quota is often 0; preemptible works
+    # For reserved capacity, set preemptible: false and exactly one runtime
+    # selector. Never commit a live ID/name:
+    # capacity_block_group: <capacity-block-group-id>
+    # capacity_block_group_name: <unique-capacity-block-group-name>
     docker_cache: true
 accounting: false
 # omitted REST preserves the legacy default (follows accounting); GPU checks still run directly
@@ -65,14 +69,32 @@ node_group_version: "72"
    `id_ecdsa.pub`. NPA validates one OpenSSH record and logs only its source and
    SHA256 fingerprint. The legacy one-element `ssh_public_keys` list remains
    accepted; multiple records fail early.
-2. **Preflight quotas** (the deploy hits these in order; raise before applying):
+2. Plan with `npa soperator plan --spec cluster.yaml`. The public-safe output
+   labels every worker pool as `on-demand`, `preemptible`, or `reserved` without
+   echoing reservation selectors. Applied `status` output reads local Terraform
+   state and reports the same capacity modes.
+3. **Preflight quotas** (the deploy hits these in order; raise before applying):
    - `compute.instance.count` — ~7 instances for a 2-pool cluster.
    - `compute.instance.non-gpu.vcpu` — sum of all node vCPUs.
    - `compute.disk.count` — boot disks + one IO_M3 cache disk per docker-cache pool + NFS PVC (~10).
    - `compute.disk.size.network-ssd-io-m3` — NFS PVC + docker-cache disks.
    - GPU on-demand quota is commonly 0; use `preemptible: true` for GPU pools.
    Read with `nebius quotas quota-allowance get-by-name --parent-id <tenant> --region <region> --name <quota>`.
-3. Deploy: `npa soperator deploy --spec cluster.yaml --terraform-dir <solutions-lib>/soperator`
+4. **Bind reserved B200 capacity explicitly when required.** Set exactly one
+   per-pool selector: `capacity_block_group` for an immutable ID (fleet-compatible)
+   or `capacity_block_group_name` for an exact tenant-scoped name. Reserved pools
+   must be GPU pools with `preemptible: false`. Before Terraform rendering,
+   deploy verifies the selected project belongs to the selected tenant/region,
+   resolves names uniquely, and requires the group to be tenant-owned, active,
+   region/platform/fabric-compatible, and large enough for the additional GPUs.
+   Existing applied STRICT workers are credited so idempotent reconciles do not
+   demand duplicate capacity. Missing, cross-tenant, inactive, ambiguous,
+   incompatible, unreadable, or insufficient reservations fail before provider
+   mutation. The renderer passes the exact upstream contract:
+   `reservation_policy = { policy = "STRICT", reservation_ids = [...] }` and
+   never combines it with `preemptible`. `AUTO` is not accepted because it can
+   fall back to on-demand capacity.
+5. Deploy: `npa soperator deploy --spec cluster.yaml --terraform-dir <solutions-lib>/soperator`
    (omit `--terraform-dir` to clone the library). The default source is immutable
    solutions-library commit `7046fb3c68314a940cdb47ff5c4fd23c01a6711e`, not
    moving `main`; `--ref` accepts only a full commit SHA. Before any provider
@@ -80,13 +102,33 @@ node_group_version: "72"
    inputs, template patch targets, example Slurm chart `4.1.6`, Kubernetes
    `1.34`, and node bundle `72`. Requires terraform >= 1.12 (set
    `NPA_TERRAFORM_BIN` if the system terraform is older).
-4. Control-plane sizing follows the pinned upstream worker-count tiers:
+   Existing default checkouts, including legacy shallow clones on moving
+   `main`, are reconciled in place under a filesystem lock: NPA fetches the
+   exact missing commit and checks it out detached while preserving untracked
+   installations, Terraform state, and operator-owned files. Tracked changes
+   or conflicting untracked paths fail with recovery guidance; NPA never
+   deletes or recreates an installation to repair source. Destroy uses the
+   same resolver. `deploy --source-preflight-only` and
+   `destroy --source-preflight-only` exercise their real source/install
+   boundaries without Terraform initialization or provider mutation/deletion.
+   For an existing installation, its owner-only environment sidecar is the
+   authoritative project/tenant/region/subnet identity; an ambient default can
+   never override it, and an incomplete/corrupt sidecar fails closed. Sidecar
+   replacement is atomic. Before each deploy apply, NPA saves a Terraform plan,
+   inspects its machine-readable actions, refuses every provider replacement,
+   pure delete, and unexpected destructive action, and applies only that exact
+   inspected plan. The immutable source patch stabilizes the cluster-context
+   and login-IP triggers. During its one-time migration, only the three exact
+   audited local-only refresh resources may replace; subsequent plans contain
+   zero replacements. The sidecar is checkpointed only after the guard passes
+   and immediately before provider mutation.
+6. Control-plane sizing follows the pinned upstream worker-count tiers:
    XS `<10`, S `<100`, M `<500`, L `<2000`, XL `>=2000`. Omitted system,
    controller, and accounting presets inherit the tier. Explicit presets remain
    compatible when large enough; NPA rejects component-specific undersizing
    before clone/apply (system minimums: 16/16/16/32/64 vCPU across XS..XL).
    The system nodeset defaults to autoscaling from `min_size` through 24.
-5. REST and accounting are explicit but the verified runtime has an important
+7. REST and accounting are explicit but the verified runtime has an important
    boundary: although the pinned Terraform module accepts the switches
    independently, the exact Slurm operator `4.1.6` implementation skips REST
    reconciliation without an accounting database. Omitted REST therefore keeps
@@ -98,7 +140,7 @@ node_group_version: "72"
    requires `deviceQuery`, `vectorAdd`, `simpleMultiGPU`, and
    `p2pBandwidthLatencyTest` to report `PASS`. Accounting+REST GPU specs may also
    use the upstream `dev` ActiveChecks; all other specs use `essential`.
-6. `--apply-fixes` (default) applies the pinned-contract fixes:
+8. `--apply-fixes` (default) applies the pinned-contract fixes:
    the `monitoring-system` namespace and prometheus-operator CRDs (charts need
    both even with telemetry off), recovery for a dashboards HelmRelease whose
    remediation retries were exhausted before those prerequisites existed, the
@@ -116,8 +158,37 @@ node_group_version: "72"
    turn an otherwise healthy Terraform reconciliation into a failed deploy.
    The direct GPU creation check is a required validation, not a best-effort
    repair; it still runs with `--skip-fixes`, and a missing node/GPU or failed
-   CUDA result fails deployment.
-7. Verify: `npa soperator status --name <name>` runs `sinfo` on the controller.
+   CUDA result fails deployment. Its independent
+   `--gpu-creation-check-timeout` defaults to 1,800 seconds and bounds the
+   whole gate, Slurm queue wait (`srun --immediate`), Slurm wall time, and the
+   local kubectl process. The deploy `--timeout` remains Terraform-only and is
+   never silently reused for GPU validation. Timed-out/failed gate jobs are
+   cancelled by a unique name and verified absent from `squeue`. If the
+   Terraform apply created/reconciled the cluster but this gate fails, the SDK
+   raises `SoperatorDeploymentValidationError` with a public-safe `result`;
+   text/JSON CLI output retains the install directory, kube context, and pool
+   metadata, reports `degraded-validation`, and exits nonzero.
+9. Verify: `npa soperator status --name <name>` runs `sinfo` on the controller
+   and reports each applied worker pool's capacity mode without reservation IDs.
+
+## Compatibility and migration
+
+- **Slurm operator 4.1.0:** this former default is rejected because it is not in
+  the verified runtime contract. Replace it with `4.1.6` for the default
+  unconfined Enroot/Pyxis setup. `4.1.7` is accepted only with
+  `use_default_apparmor_profile: true` after separately validating that loaded
+  profile on the nodes. Do not re-enable `4.1.0`.
+- **System autoscaling ceiling:** older NPA output fixed
+  `control_plane.system.max_size` to `min_size`. Omission now renders the pinned
+  upstream maximum of **24** (or `min_size` when it is greater than 24), which
+  can increase capacity and cost if autoscaling is exercised. Set an explicit
+  `control_plane.system.max_size` to retain a reviewed lower ceiling, provided
+  it is at least `min_size`. Rendered tfvars, deploy results, and agent
+  validation/dry-run output expose the effective numeric maximum.
+- **Immutable source migration:** default legacy clones are upgraded in place;
+  preserve a clean tracked checkout and keep installations/state untracked.
+  Offline migration works once the pinned object has been fetched. If it is
+  missing, restore access to the checkout's `origin` and retry.
 
 ## Gotchas
 
@@ -140,6 +211,7 @@ node_group_version: "72"
 ## Verify
 
 ```bash
+npa soperator plan --help
 npa soperator deploy --help
 npa/.venv/bin/python -m pytest npa/tests/unit/test_soperator_cli.py -q
 ```

--- a/skills/tools/soperator/SKILL.md
+++ b/skills/tools/soperator/SKILL.md
@@ -30,8 +30,8 @@ apiVersion: npa.soperator/v0.0.1
 name: npasop                 # company_name; kube context = nebius-<name>-slurm
 region: us-central1          # or resolved from ~/.npa config
 control_plane:
-  system: { min_size: 3, preset: 16vcpu-64gb }  # min_size >= 3; XS sizing-tier floor
-  controller: { preset: 16vcpu-64gb }           # current sizing-tier floor
+  system: { min_size: 3, max_size: 24 }         # preset omitted: derive XS..XL upstream
+  controller: {}                                # preset omitted: derive with same tier
   login: { preset: 16vcpu-64gb }                 # login needs >= 16vcpu (sufficiency)
 workers:
   - name: cpu8
@@ -46,17 +46,25 @@ workers:
     fabric: us-central1-b       # required for GPU presets; 1-GPU can't cluster
     preemptible: true           # on-demand GPU quota is often 0; preemptible works
     docker_cache: true
+accounting: false
+# omitted REST preserves the legacy default (follows accounting); GPU checks still run directly
+slurm_operator_version: "4.1.6"
 k8s_version: "1.34"
-node_group_version: "72"     # required by current solutions-library main
+node_group_version: "72"
 ```
 
 ## Procedure
 
 1. Keep committed files public-safe: never hardcode project/tenant/registry IDs
    or SSH keys in the skill or spec templates. The spec resolves region/tenant/
-   project from `~/.npa/config.yaml` when its fields are empty. If
-   `ssh_public_keys` is omitted, deploy uses `~/.ssh/id_ed25519.pub` (then
-   `id_rsa.pub`); it fails before Terraform when neither exists.
+   project from `~/.npa/config.yaml` when its fields are empty. Login access is
+   deliberately named as a root grant: one `root_login_ssh_public_key` record,
+   `--root-login-ssh-public-key-file`,
+   `NPA_SOPERATOR_ROOT_LOGIN_SSH_PUBLIC_KEY[_FILE]`, the compatible
+   `NPA_SSH_PUBLIC_KEY` path, then `~/.ssh/id_ed25519.pub` / `id_rsa.pub` /
+   `id_ecdsa.pub`. NPA validates one OpenSSH record and logs only its source and
+   SHA256 fingerprint. The legacy one-element `ssh_public_keys` list remains
+   accepted; multiple records fail early.
 2. **Preflight quotas** (the deploy hits these in order; raise before applying):
    - `compute.instance.count` — ~7 instances for a 2-pool cluster.
    - `compute.instance.non-gpu.vcpu` — sum of all node vCPUs.
@@ -65,32 +73,63 @@ node_group_version: "72"     # required by current solutions-library main
    - GPU on-demand quota is commonly 0; use `preemptible: true` for GPU pools.
    Read with `nebius quotas quota-allowance get-by-name --parent-id <tenant> --region <region> --name <quota>`.
 3. Deploy: `npa soperator deploy --spec cluster.yaml --terraform-dir <solutions-lib>/soperator`
-   (omit `--terraform-dir` to clone the library). Requires terraform >= 1.12
-   (set `NPA_TERRAFORM_BIN` if the system terraform is older).
-   The current recipe requires a Kubernetes node-group bundle version; keep
-   `k8s_version` and `node_group_version` aligned with its example installation.
-4. `--apply-fixes` (default) applies the 4.1.0-stable post-deploy fixes:
+   (omit `--terraform-dir` to clone the library). The default source is immutable
+   solutions-library commit `7046fb3c68314a940cdb47ff5c4fd23c01a6711e`, not
+   moving `main`; `--ref` accepts only a full commit SHA. Before any provider
+   mutation NPA verifies the checkout SHA, sizing thresholds, REST/accounting
+   inputs, template patch targets, example Slurm chart `4.1.6`, Kubernetes
+   `1.34`, and node bundle `72`. Requires terraform >= 1.12 (set
+   `NPA_TERRAFORM_BIN` if the system terraform is older).
+4. Control-plane sizing follows the pinned upstream worker-count tiers:
+   XS `<10`, S `<100`, M `<500`, L `<2000`, XL `>=2000`. Omitted system,
+   controller, and accounting presets inherit the tier. Explicit presets remain
+   compatible when large enough; NPA rejects component-specific undersizing
+   before clone/apply (system minimums: 16/16/16/32/64 vCPU across XS..XL).
+   The system nodeset defaults to autoscaling from `min_size` through 24.
+5. REST and accounting are explicit but the verified runtime has an important
+   boundary: although the pinned Terraform module accepts the switches
+   independently, the exact Slurm operator `4.1.6` implementation skips REST
+   reconciliation without an accounting database. Omitted REST therefore keeps
+   the compatible legacy default (it follows accounting), explicit
+   `slurm_rest_enabled: false` is accepted, and explicit REST-on/accounting-off
+   fails before mutation with an actionable error. This does **not** remove GPU
+   creation validation: after every deploy NPA submits an exclusive Slurm step
+   through the login-node jail on every GPU worker, allocates every GPU, and
+   requires `deviceQuery`, `vectorAdd`, `simpleMultiGPU`, and
+   `p2pBandwidthLatencyTest` to report `PASS`. Accounting+REST GPU specs may also
+   use the upstream `dev` ActiveChecks; all other specs use `essential`.
+6. `--apply-fixes` (default) applies the pinned-contract fixes:
    the `monitoring-system` namespace and prometheus-operator CRDs (charts need
    both even with telemetry off), recovery for a dashboards HelmRelease whose
    remediation retries were exhausted before those prerequisites existed, the
    `plugStackConfig.ncclInspectorPreConf` CRD preserve-unknown-fields patch, and
-   the cluster-name-prefixed `<ns>-slurm-scripts` configmap. For the default
+   the cluster-name-prefixed `<ns>-slurm-scripts` configmap. If a previous
+   ActiveChecks Helm generation is demonstrably still Progressing while a newer
+   generation is pending, NPA removes only the superseded Helm-owned wait hook
+   and requests reconciliation; current-generation installs are never
+   interrupted. For the default
    unconfined worker profile, NPA also extends the node configurator's sysctls so
-   Ubuntu's AppArmor user-namespace gate does not block Enroot/Pyxis jobs.
-   Accounting-disabled clusters use the `essential` active-check scope because
-   Soperator does not create the REST service required by its Slurm GPU checks
-   without accounting; accounting-enabled GPU clusters keep the `dev` scope.
-5. Verify: `npa soperator status --name <name>` runs `sinfo` on the controller.
+   Ubuntu's AppArmor user-namespace gate does not block Enroot/Pyxis jobs. The
+   template mutation is indentation-bounded to `nodeConfigurator.values` and is
+   tied to the verified chart contract. Post-apply monitoring repair is
+   best-effort: RBAC/transient failures are returned as diagnostics and do not
+   turn an otherwise healthy Terraform reconciliation into a failed deploy.
+   The direct GPU creation check is a required validation, not a best-effort
+   repair; it still runs with `--skip-fixes`, and a missing node/GPU or failed
+   CUDA result fails deployment.
+7. Verify: `npa soperator status --name <name>` runs `sinfo` on the controller.
 
 ## Gotchas
 
-- **AppArmor**: the custom localhost profile is not loaded by SPO in 4.1.0-stable;
+- **AppArmor**: the custom localhost profile is not loaded by the verified chart;
   the spec defaults `use_default_apparmor_profile: false` (unconfined) so
-  login/worker sshd start. Do not flip it on unless your build loads the profile.
-- **Worker registration is not fully automatic** in 4.1.0-stable: slurmrestd
-  (the `rest` nodeset) is not deployed by the operator, so soperator's dynamic-
-  node registration can stall. If `sinfo` shows 0 nodes with the worker pod
-  Running, on the controller run: `scontrol update NodeName=<w> NodeAddr=<w>.soperator-nodeset-svc.soperator.svc.cluster.local State=RESUME`.
+  login/worker sshd start. Non-default chart versions are permitted only when the
+  userns override is not needed (`use_default_apparmor_profile: true`); the
+  explicit override allowlist is currently `4.1.6` and `4.1.7`.
+- **Worker registration can race readiness.** Post-deploy
+  repair sets the nodeset-service FQDN and resumes down nodes. If diagnosing by
+  hand, the equivalent is `scontrol update NodeName=<w>
+  NodeAddr=<w>.soperator-nodeset-svc.soperator.svc.cluster.local State=RESUME`.
 - **Region domain**: the recipe hardcodes the EU API domain; the deploy patches
   it to `api.nebius.cloud` for non-EU regions automatically.
 - **Job I/O**: submit from the login node chrooted into `/mnt/jail`; write batch


### PR DESCRIPTION
## Summary

- add reserved-capacity selectors to the public Soperator spec, CLI, SDK, and agent contract, with exact group resolution, tenant/project/region/platform/fabric validation, whole-node availability checks, and strict reservation-policy rendering
- make reserved and preemptible capacity mutually exclusive while preserving on-demand compatibility and public-safe plan/status output
- bound GPU creation checks, Slurm waits, and subprocess execution; report progress; cancel timed-out jobs; verify cleanup; and retain install, kube-context, pool, and validation metadata in typed degraded results
- harden lifecycle behavior with persisted deployment identity, atomic sidecars/sentinels, guarded replacement plans, fail-fast workload commands, live Slurm discovery, and single-pass HCL escaping
- safely reconcile legacy shallow solutions-library checkouts without changing the selected installation or Terraform state bytes
- document the compatibility, cost, reservation, timeout, cleanup, and migration behavior

## Why

Soperator worker reconciliation previously lacked an end-to-end public contract for strict reserved capacity and could leave an operator without enough diagnostic context when post-apply validation timed out. This change makes the capacity choice explicit and fail-closed, prevents accidental fallback to preemptible capacity, rejects unexpected replacement/destructive plans, and makes timeout recovery observable and verifiable.

## Validation

- focused Soperator and agent tests: 265 passed
- complete guardrail suite: 1,891 passed, 1 skipped
- complete non-e2e suite, parallel: 9,857 passed, 48 skipped, 1 xpassed
- complete non-e2e suite, serial: 9,857 passed, 48 skipped, 1 xpassed
- Ruff passed for all touched Python files
- generated CLI documentation is current; `git diff --check` passed
- pinned Terraform 1.13.3 initialization and validation passed with zero errors/warnings
- strict reservation HCL and mutual-exclusion paths are covered by focused tests and the live zero-drift plan
- confidentiality guardrail and gitleaks scans passed

## Live reserved-capacity proof

- revalidated the preserved deployment identity, Terraform lineage, Kubernetes context, empty Slurm queue, bound PVCs, and intact 2 TiB filesystem before mutation
- verified an active compatible reservation group with at least two whole eight-GPU allocations available and no competing task-owned apply/lock
- inspected an authorized plan containing only one in-place GPU worker node-group capacity-policy update, with no destructive action or protected-resource replacement
- reconciled to exactly two running eight-GPU B200 workers (16 GPUs total), both non-preemptible and using strict nonempty reservations from the verified group; confirmed the expected tenant/project/region/fabric and no extra task-owned GPU worker
- confirmed all Kubernetes nodes Ready, both Slurm nodes idle after testing, all PVCs Bound, the filesystem intact, and a final guarded Terraform plan at zero drift

## Timeout and cleanup proof

A deliberately blocked validation job exercised the bounded failure path. The command exited nonzero with a typed `process-timeout` result while retaining deployment/install/kube/pool/validation metadata. The validation job and blocker were cancelled, cleanup was confirmed, the Slurm queue returned empty, and no provider resource changed.

## Two-node CUDA proof

The final Slurm workload completed successfully across both nodes and all 16 GPUs:

- 16 ranks ran across two nodes, eight ranks per node, with exactly one CUDA device visible to each rank
- all 16 `vectorAdd` checks passed
- the 16-rank cross-node NCCL all-reduce completed with the expected result and zero mismatches
- NCCL sustained about 249-250 GB/s algorithm bandwidth and 468-469 GB/s bus bandwidth in the proof run
- a shared-filesystem write/read checksum passed across nodes
- the job exited successfully and the provider, Kubernetes, and Slurm layers were clean afterward

## Preservation and limitations

- Terraform lineage, sidecar/sentinel identity, the filesystem/PVC data, and protected control-plane/system/login resources were preserved
- deploy/destroy source-only reconciliation left the legacy installation and state-file hash manifest byte-identical
- reserved-capacity provisioning fails closed when the exact compatible group or whole-node availability cannot be proven; a no-scale reconciliation may credit only the deployment's already-verified strict allocations
- no private deployment identifiers, specifications, credentials, kubeconfigs, state, logs, or artifacts are included in this PR
