### PR TITLE
Fleet: fail closed on quota and stabilize B200 provisioning

### DIFF
--- a/deploy/cluster/main.tf
+++ b/deploy/cluster/main.tf
@@ -6,6 +6,14 @@ locals {
   create_subnet        = trimspace(var.subnet_id) == ""
   subnet_id            = local.create_subnet ? nebius_vpc_v1_subnet.cluster[0].id : var.subnet_id
   capacity_block_group = trimspace(var.capacity_block_group)
+  b200_driverfull_platforms = toset([
+    "gpu-b200-sxm",
+    "gpu-b200-sxm-a",
+  ])
+  gpu_nodes_driverfull_image = contains(
+    local.b200_driverfull_platforms,
+    lower(trimspace(var.gpu_nodes_platform)),
+  )
   gpu_reservation_policy = local.capacity_block_group == "" ? null : {
     policy          = "STRICT"
     reservation_ids = [local.capacity_block_group]
@@ -54,7 +62,7 @@ module "k8s_training" {
   gpu_nodes_preset                = var.gpu_nodes_preset
   gpu_nodes_reservation_policy    = local.gpu_reservation_policy
   gpu_disk_size                   = var.gpu_disk_size
-  gpu_nodes_driverfull_image      = false
+  gpu_nodes_driverfull_image      = local.gpu_nodes_driverfull_image
   enable_gpu_cluster              = var.enable_gpu_cluster
   infiniband_fabric               = var.infiniband_fabric
   custom_driver                   = false

--- a/deploy/cluster/vendor/nebius-solutions-library/k8s-training/filesystem-csi-validation/01-verify-node-filesystem-mounts.sh
+++ b/deploy/cluster/vendor/nebius-solutions-library/k8s-training/filesystem-csi-validation/01-verify-node-filesystem-mounts.sh
@@ -113,7 +113,6 @@ for node in "${NODES_TO_CHECK[@]}"; do
   output_file="$(mktemp)"
   if kubectl debug -n "${TEST_NAMESPACE}" "${node}" \
     --attach=true \
-    --quiet \
     --image="${DEBUG_IMAGE}" \
     --profile=sysadmin -- \
     chroot /host sh -lc "

--- a/npa/src/npa/fleet/lifecycle.py
+++ b/npa/src/npa/fleet/lifecycle.py
@@ -55,6 +55,9 @@ _MODULES_SUBDIR = "modules"
 # copy (deploy/cluster/vendor + the single-cluster wrapper) so a fleet run from an
 # installed package doesn't silently drift onto upstream ``main`` HEAD.
 _PINNED_LIBRARY_REF = "main-v2026-05-25+local-cluster-patches"
+_FILESYSTEM_VERIFIER = (
+    Path("filesystem-csi-validation") / "01-verify-node-filesystem-mounts.sh"
+)
 _ENV_SIDECAR = ".npa-fleet-env.json"
 _PROJECT_NETWORK_STATE = ".npa-fleet-network.json"
 _FLEET_STATE = "fleet-state.json"
@@ -322,6 +325,7 @@ def _list_projects(
             "list",
             "--parent-id",
             tenant_id,
+            "--all",
             "--format",
             "json",
         ],
@@ -705,6 +709,19 @@ def _prepare_install_dir(
     if modules_dst.exists():
         shutil.rmtree(modules_dst, ignore_errors=True)
     shutil.copytree(recipe_root / _MODULES_SUBDIR, modules_dst)
+
+    # kubectl 1.36's `debug --quiet` suppresses both attached verifier output and
+    # the generated debugger-pod name. That defeats success-evidence checking and
+    # cleanup. Apply this compatibility shim to the materialized recipe so local,
+    # ref-cloned, package-fallback, and vendored sources all receive the fix.
+    verifier = workdir / _FILESYSTEM_VERIFIER
+    if verifier.is_file():
+        original = verifier.read_text()
+        patched = re.sub(r"(?m)^[ \t]*--quiet[ \t]*\\\n", "", original)
+        patched = patched.replace("kubectl debug --quiet ", "kubectl debug ")
+        if patched != original:
+            verifier.write_text(patched)
+            _log(on_status, "patched filesystem verifier for kubectl debug output")
 
     provider_tf = workdir / "provider.tf"
     if provider_tf.exists():
@@ -1312,21 +1329,50 @@ def deploy_fleet(
     # Phase 0: quota preflight, before any project is created. Regions come from
     # the spec, so this needs no project ids -- and running it first means a
     # quota-blocked deploy does not leave a freshly created, empty project behind.
+    preflight_project_ids: dict[str, str] = {}
     if preflight:
         scoped: dict[str, list[ClusterSpec]] = {}
+        new_projects_by_region: dict[str, int] = {}
+        scoped_projects: list[tuple[ProjectSpec, str]] = []
         for project in spec.projects:
             if not _project_in_scope(project, only_projects, prefix):
                 continue
             region = project.region or fleet_region
+            project_has_scoped_cluster = False
             for cluster in project.clusters:
                 if only_clusters and cluster.name not in only_clusters:
                     continue
                 scoped.setdefault(region, []).append(cluster)
+                project_has_scoped_cluster = True
+            if project_has_scoped_cluster:
+                scoped_projects.append((project, region))
+
+        named_projects = [
+            project for project, _region in scoped_projects if not project.project_id
+        ]
+        existing_projects = (
+            _list_projects(nebius_bin, tenant_id, cli_env, nebius_profile)
+            if named_projects
+            else []
+        )
+        for project, region in scoped_projects:
+            if project.project_id:
+                continue
+            name = project.display_name(prefix)
+            found = _find_project_id(existing_projects, name)
+            if found:
+                preflight_project_ids[project.key()] = found
+                _log(on_status, f"project {name!r} exists ({found})")
+            else:
+                new_projects_by_region[region] = (
+                    new_projects_by_region.get(region, 0) + 1
+                )
         if scoped:
             _preflight_quotas(
                 nebius_bin,
                 tenant_id=tenant_id,
                 by_region=scoped,
+                new_projects_by_region=new_projects_by_region,
                 env=cli_env,
                 profile=nebius_profile,
                 on_status=on_status,
@@ -1347,17 +1393,21 @@ def deploy_fleet(
             continue
         region = project.region or fleet_region
         try:
-            project_id, created = resolve_project_id(
-                nebius_bin,
-                tenant_id,
-                project,
-                prefix=prefix,
-                create=create_projects,
-                env=cli_env,
-                region=region,
-                profile=nebius_profile,
-                on_status=on_status,
-            )
+            if project.key() in preflight_project_ids:
+                project_id = preflight_project_ids[project.key()]
+                created = False
+            else:
+                project_id, created = resolve_project_id(
+                    nebius_bin,
+                    tenant_id,
+                    project,
+                    prefix=prefix,
+                    create=create_projects,
+                    env=cli_env,
+                    region=region,
+                    profile=nebius_profile,
+                    on_status=on_status,
+                )
             shared_subnet_id = ""
             if any(not cluster.subnet_id for cluster in scoped_clusters):
                 shared_subnet_id, _created_network_id = ensure_subnet(
@@ -1471,6 +1521,7 @@ def _preflight_quotas(
     *,
     tenant_id: str,
     by_region: dict[str, list[ClusterSpec]],
+    new_projects_by_region: dict[str, int],
     env: dict[str, str],
     profile: str,
     on_status: Callable[[str], None] | None,
@@ -1488,6 +1539,7 @@ def _preflight_quotas(
             tenant_id=tenant_id,
             region=region,
             clusters=clusters,
+            new_projects=new_projects_by_region.get(region, 0),
             env=env,
             profile=profile,
             run_capture=_run_capture,

--- a/npa/src/npa/fleet/quotas.py
+++ b/npa/src/npa/fleet/quotas.py
@@ -15,7 +15,9 @@ only subdivide the tenant allowance, so the tenant is the meaningful container
 to check.
 
 Only read APIs are used (``nebius capacity capacity-block-group list`` and
-``nebius quotas quota-allowance list``).
+``nebius quotas quota-allowance list``). Quota evidence is fail-closed: an
+unreadable, incomplete, malformed, or unpaged allowance response is not proof
+that a deployment fits.
 """
 
 from __future__ import annotations
@@ -33,6 +35,16 @@ _CPU_DISK_GIB = 128
 _FILESYSTEM_SIZE_QUOTA = "compute.filesystem.size.network-ssd"
 _FILESYSTEM_SIZE_UNIT = "byte"
 _BYTE_QUOTAS = {_FILESYSTEM_SIZE_QUOTA, "compute.disk.size.network-ssd"}
+_VCPU_QUOTAS = {"compute.instance.non-gpu.vcpu"}
+_OPTIONAL_UNADVERTISED_QUOTAS = frozenset(
+    {
+        "vpc.network.count",
+        "vpc.subnet.count",
+        "vpc.pool.count",
+        "vpc.routetable.count",
+        "vpc.route.count",
+    }
+)
 
 # GPU quotas are keyed by accelerator family, not by the platform name:
 # platform "gpu-h200-sxm" consumes "compute.instance.gpu.h200".
@@ -281,7 +293,9 @@ def reservation_shortfall_message(shortfalls: list[ReservationShortfall]) -> str
     )
 
 
-def required_quotas(clusters: Iterable[ClusterSpec]) -> dict[str, int]:
+def required_quotas(
+    clusters: Iterable[ClusterSpec], *, new_projects: int = 0
+) -> dict[str, int]:
     """Aggregate the tenant quota amounts *clusters* need in one region.
 
     GPU-node vCPUs are deliberately not added to ``compute.instance.non-gpu.vcpu``
@@ -298,6 +312,11 @@ def required_quotas(clusters: Iterable[ClusterSpec]) -> dict[str, int]:
         cpu, gpu = cluster.cpu_nodes, cluster.gpu_nodes
         nodes = cluster.cpu_count() + cluster.gpu_count()
         add("mk8s.cluster.count", 1)
+        # Every private worker consumes two tenant VPC allocations: its /32
+        # address plus the delegated pod alias range. The managed control plane
+        # endpoint is service-owned and consumes neither a tenant allocation nor
+        # public-address quota; worker public IPs are disabled by the recipe.
+        add("vpc.allocation.count", 2 * nodes)
         # Managed control-plane etcd is service-owned: it consumes control-plane
         # IP allocations, but not the tenant's Compute VM or disk quotas. Only
         # node-group VMs and their explicitly rendered boot disks count here.
@@ -327,69 +346,237 @@ def required_quotas(clusters: Iterable[ClusterSpec]) -> dict[str, int]:
         if cluster.enable_filestore and not cluster.existing_filestore:
             add("compute.filesystem.count", 1)
             add(_FILESYSTEM_SIZE_QUOTA, cluster.filestore_disk_size_gibibytes * _GIB)
+    # A create-on-demand project needs one default/owned topology before the
+    # recipe can run. Live inventory contains private and public project pools,
+    # plus the network's default route table and egress route.
+    add("vpc.network.count", new_projects)
+    add("vpc.subnet.count", new_projects)
+    add("vpc.pool.count", 2 * new_projects)
+    add("vpc.routetable.count", new_projects)
+    add("vpc.route.count", new_projects)
     return needed
 
 
-def parse_allowances(payload: str, region: str) -> dict[str, dict[str, Any]]:
-    """Index ``quota-allowance list`` JSON by quota name for *region*.
+def _quota_units(name: str) -> frozenset[str]:
+    """Return explicitly supported wire units for one required quota."""
 
-    An allowance with an unset ``limit`` means "no limit at this container"
-    (project allowances are usually unset and draw on the tenant pool), so those
-    entries are skipped rather than read as a limit of zero.
+    if name in _BYTE_QUOTAS:
+        return frozenset({_FILESYSTEM_SIZE_UNIT})
+    if name in _VCPU_QUOTAS:
+        # Current tenant payloads use count; older/catalog-specific payloads use
+        # the semantically equivalent vcpu label.
+        return frozenset({"count", "vcpu"})
+    if name.startswith("compute.instance.gpu."):
+        return frozenset({"count", "gpu"})
+    return frozenset({"count"})
+
+
+def _parse_uint(value: Any, *, field: str) -> int:
+    """Parse a protobuf uint64 JSON value without truncating floats/bools."""
+
+    if isinstance(value, bool):
+        raise ValueError(f"{field} is not an unsigned integer")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str) and value.strip().isdigit():
+        parsed = int(value.strip())
+    else:
+        raise ValueError(f"{field} is not an unsigned integer")
+    if parsed < 0:
+        raise ValueError(f"{field} is negative")
+    return parsed
+
+
+def _finite_allowance(name: str, item: dict[str, Any]) -> dict[str, Any]:
+    """Interpret one finite allowance, raising when capacity is not provable."""
+
+    spec = item["spec"]
+    status = item.get("status")
+    try:
+        parsed_limit = _parse_uint(spec["limit"], field="limit")
+        if not isinstance(status, dict):
+            raise ValueError("finite allowance has no status mapping")
+        state = str(status.get("state") or "")
+        if state and state != "STATE_ACTIVE":
+            raise ValueError(f"allowance state is not active: {state}")
+        unit = str(status.get("unit") or "").strip().lower()
+        compatible_units = _quota_units(name)
+        if unit not in compatible_units:
+            expected = ", ".join(sorted(compatible_units))
+            raise ValueError(
+                f"quota {name!r} reported incompatible unit {unit!r}; "
+                f"expected one of: {expected}"
+            )
+
+        raw_usage = status.get("usage")
+        if raw_usage not in (None, ""):
+            usage = _parse_uint(raw_usage, field="usage")
+            available = max(0, parsed_limit - usage)
+            usage_source = "exact"
+        elif status.get("usage_percentage") not in (None, ""):
+            fraction = Decimal(str(status["usage_percentage"]))
+            # The API defines this as a 0..1 fraction, but explicitly permits
+            # values above 1 when consumption exceeds the allowance.
+            if not fraction.is_finite() or fraction < 0:
+                raise ValueError("usage_percentage is not a non-negative fraction")
+            available = max(
+                0,
+                int(
+                    (
+                        Decimal(parsed_limit) * (Decimal(1) - fraction)
+                    ).to_integral_value(rounding=ROUND_FLOOR)
+                ),
+            )
+            usage = max(0, parsed_limit - available)
+            usage_source = "fraction"
+        elif status.get("usage_state") == "USAGE_STATE_NOT_USED":
+            usage = 0
+            available = parsed_limit
+            usage_source = "not-used"
+        else:
+            raise ValueError(
+                "finite allowance has no usage, usage_percentage, or not-used state"
+            )
+    except (InvalidOperation, KeyError, TypeError, ValueError) as exc:
+        if isinstance(exc, ValueError) and "incompatible unit" in str(exc):
+            raise
+        raise ValueError(f"quota {name!r} has unusable capacity evidence") from exc
+    return {
+        "limit": parsed_limit,
+        "available": available,
+        "unit": unit,
+        "unlimited": False,
+        "usage": usage,
+        "usage_source": usage_source,
+    }
+
+
+def _unlimited_allowance(name: str, item: dict[str, Any]) -> dict[str, Any]:
+    """Interpret an allowance whose optional API ``limit`` field is omitted."""
+
+    status = item.get("status")
+    if status is not None and not isinstance(status, dict):
+        raise ValueError(f"quota {name!r} has a non-mapping status")
+    state = str((status or {}).get("state") or "")
+    if state and state != "STATE_ACTIVE":
+        raise ValueError(f"quota {name!r} allowance state is not active: {state}")
+    unit = str((status or {}).get("unit") or "").strip().lower()
+    if unit and unit not in _quota_units(name):
+        expected = ", ".join(sorted(_quota_units(name)))
+        raise ValueError(
+            f"quota {name!r} reported incompatible unit {unit!r}; "
+            f"expected one of: {expected}"
+        )
+    return {
+        "limit": None,
+        "available": None,
+        "unit": unit,
+        "unlimited": True,
+        "usage_source": "unlimited",
+    }
+
+
+def _select_allowance(
+    name: str,
+    candidates: list[tuple[str, dict[str, Any]]],
+    *,
+    container_id: str,
+) -> dict[str, Any] | None:
+    """Select one deterministic allowance for the requested container scope."""
+
+    if container_id:
+        authoritative = [item for parent, item in candidates if parent == container_id]
+        if authoritative:
+            selected = authoritative
+            # A finite legacy/unscoped candidate alongside an authoritative
+            # unlimited record is contradictory rather than proof of infinity.
+            if all(item["spec"].get("limit") is None for item in selected) and any(
+                not parent and item["spec"].get("limit") is not None
+                for parent, item in candidates
+            ):
+                raise ValueError(
+                    f"quota {name!r} has ambiguous scoped/unscoped candidates"
+                )
+        else:
+            # Older fixtures/clients may omit parent metadata. They are usable
+            # only when no explicitly scoped target allowance was returned.
+            selected = [item for parent, item in candidates if not parent]
+    else:
+        selected = [item for _parent, item in candidates]
+    if not selected:
+        return None
+
+    finite = [item for item in selected if item["spec"].get("limit") is not None]
+    if finite:
+        parsed = [_finite_allowance(name, item) for item in finite]
+        first = parsed[0]
+        if any(candidate != first for candidate in parsed[1:]):
+            raise ValueError(f"quota {name!r} has ambiguous finite candidates")
+        return first
+    parsed_unlimited = [_unlimited_allowance(name, item) for item in selected]
+    units = {candidate["unit"] for candidate in parsed_unlimited if candidate["unit"]}
+    if len(units) > 1:
+        raise ValueError(f"quota {name!r} has ambiguous unlimited candidates")
+    result = parsed_unlimited[0]
+    result["unit"] = next(iter(units), "")
+    return result
+
+
+def parse_allowances(
+    payload: str,
+    region: str,
+    required: Iterable[str] | None = None,
+    *,
+    container_id: str = "",
+) -> dict[str, dict[str, Any]]:
+    """Select and index allowances for *region* and the requested container.
+
+    ``QuotaAllowanceSpec.limit`` is optional. An omitted limit is treated as
+    unlimited only after scope selection proves that the record belongs to the
+    requested tenant (or is the sole legacy unscoped evidence). A concrete limit
+    always beats an unscoped unlimited collision, independent of response order.
     """
 
+    required_names = set(required or ())
     try:
-        items = json.loads(payload or "{}").get("items", [])
-    except json.JSONDecodeError:
-        return {}
-    indexed: dict[str, dict[str, Any]] = {}
-    for item in items if isinstance(items, list) else []:
-        meta = item.get("metadata", {}) or {}
-        spec = item.get("spec", {}) or {}
+        document = json.loads(payload or "{}")
+    except json.JSONDecodeError as exc:
+        raise ValueError("could not parse quota allowance JSON") from exc
+    if not isinstance(document, dict) or not isinstance(document.get("items"), list):
+        raise ValueError("quota allowance JSON has a non-list 'items' field")
+    if document.get("next_page_token"):
+        raise ValueError("quota allowance JSON is incomplete after paginated read")
+
+    grouped: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+    for item in document["items"]:
+        if not isinstance(item, dict):
+            raise ValueError("quota allowance JSON contains a non-mapping item")
+        meta = item.get("metadata")
+        spec = item.get("spec")
+        if not isinstance(meta, dict) or not isinstance(spec, dict):
+            raise ValueError("quota allowance has non-mapping metadata or spec")
         name = str(meta.get("name") or "")
         if not name or str(spec.get("region") or "") != region:
             continue
-        limit = spec.get("limit")
-        if limit is None:
+        if required_names and name not in required_names:
             continue
-        status = item.get("status", {}) or {}
-        unit = str(status.get("unit") or "")
-        if name in _BYTE_QUOTAS and unit != _FILESYSTEM_SIZE_UNIT:
-            raise ValueError(
-                f"quota {name!r} reported unit {unit!r}; expected {_FILESYSTEM_SIZE_UNIT!r}"
-            )
-        try:
-            parsed_limit = int(limit)
-            available = parsed_limit
-            raw_usage = status.get("usage")
-            if raw_usage not in (None, ""):
-                available = max(0, parsed_limit - int(raw_usage))
-            elif status.get("usage_percentage") not in (None, ""):
-                fraction = Decimal(str(status["usage_percentage"]))
-                # Authoritative live quota wire data uses a 0..1 fraction (0.10
-                # means 10%), despite the field name. Fail closed on drift.
-                if fraction < 0 or fraction > 1:
-                    raise ValueError(
-                        f"quota {name!r} reported unexpected usage_percentage "
-                        f"{status['usage_percentage']!r}; expected a 0..1 fraction"
-                    )
-                available = max(
-                    0,
-                    int(
-                        (
-                            Decimal(parsed_limit) * (Decimal(1) - fraction)
-                        ).to_integral_value(rounding=ROUND_FLOOR)
-                    ),
-                )
-            indexed[name] = {
-                "limit": parsed_limit,
-                "available": available,
-                "unit": unit,
-            }
-        except (InvalidOperation, TypeError, ValueError):
-            if name == _FILESYSTEM_SIZE_QUOTA:
-                raise
-            continue
+        scope_values = {
+            str(meta.get(field) or "")
+            for field in ("parent_id", "container_id")
+            if meta.get(field)
+        }
+        if len(scope_values) > 1:
+            raise ValueError(f"quota {name!r} has conflicting container metadata")
+        parent_id = next(iter(scope_values), "")
+        grouped.setdefault(name, []).append((parent_id, item))
+
+    indexed: dict[str, dict[str, Any]] = {}
+    for name in sorted(grouped):
+        selected = _select_allowance(
+            name, grouped[name], container_id=container_id
+        )
+        if selected is not None:
+            indexed[name] = selected
     return indexed
 
 
@@ -405,9 +592,11 @@ def find_shortfalls(
     shortfalls: list[QuotaShortfall] = []
     for name, required in sorted(needed.items()):
         allowance = allowances.get(name)
-        if allowance is None:  # not advertised for this region -> nothing to assert
+        if allowance is None:
             continue
-        available = allowance.get("available", allowance["limit"])
+        if allowance.get("unlimited"):
+            continue
+        available = allowance["available"]
         if required > available:
             shortfalls.append(
                 QuotaShortfall(
@@ -441,6 +630,7 @@ def preflight_region(
     region: str,
     clusters: Iterable[ClusterSpec],
     env: dict[str, str],
+    new_projects: int = 0,
     profile: str = "",
     run_capture: Callable[..., Any],
     nebius_argv: Callable[[str, str], list[str]],
@@ -448,11 +638,9 @@ def preflight_region(
 ) -> list[QuotaShortfall]:
     """Check one region's tenant allowances against *clusters*' requirements.
 
-    Returns quota shortfalls (empty when the fleet fits). A quota API that cannot
-    be read is reported and treated as "no shortfall": losing the quota check
-    must not block a deploy that would otherwise succeed. In contrast, an
-    unreadable or incompatible explicitly bound capacity block raises: STRICT
-    reservation safety must not be silently bypassed.
+    Returns quota shortfalls (empty when the fleet fits). Unreadable, incomplete,
+    or malformed capacity/quota evidence raises before project creation. A
+    preflight that cannot prove remaining capacity must not authorize mutation.
     """
 
     clusters = list(clusters)
@@ -496,7 +684,7 @@ def preflight_region(
                 "capacity block group(s); ordinary GPU quota excluded"
             )
 
-    needed = required_quotas(clusters)
+    needed = required_quotas(clusters, new_projects=new_projects)
     if not needed:
         return []
     result = run_capture(
@@ -507,6 +695,7 @@ def preflight_region(
             "list",
             "--parent-id",
             tenant_id,
+            "--all",
             "--format",
             "json",
         ],
@@ -518,18 +707,43 @@ def preflight_region(
         getattr(result, "returncode", 1) != 0
         or not (getattr(result, "stdout", "") or "").strip()
     ):
-        if on_status is not None:
+        raise ValueError(
+            f"could not read tenant quota allowances for {region}; refusing to "
+            "create projects or resources without capacity evidence"
+        )
+    allowances = parse_allowances(
+        result.stdout, region, required=needed, container_id=tenant_id
+    )
+    missing = sorted(set(needed) - set(allowances))
+    required_missing = [
+        name for name in missing if name not in _OPTIONAL_UNADVERTISED_QUOTAS
+    ]
+    if required_missing:
+        raise ValueError(
+            f"tenant quota response for {region} omitted required allowances: "
+            f"{', '.join(required_missing)}"
+        )
+    if on_status is not None:
+        for name in missing:
             on_status(
-                f"WARNING: could not read tenant quota allowances for {region}; "
-                "skipping quota preflight"
+                f"quota {name} [{region}]: unadvertised optional quota in completed "
+                "tenant catalog; treating it as not quota-controlled in this region"
             )
-        return []
-    allowances = parse_allowances(result.stdout, region)
-    if not allowances:
-        if on_status is not None:
-            on_status(
-                f"WARNING: no quota allowances reported for region {region}; "
-                "skipping quota preflight"
-            )
-        return []
+        for name, required_amount in sorted(needed.items()):
+            if name not in allowances:
+                continue
+            allowance = allowances[name]
+            unit = f" {allowance['unit']}" if allowance["unit"] else ""
+            if allowance.get("unlimited"):
+                on_status(
+                    f"quota {name} [{region}]: needs {required_amount}{unit}; "
+                    "tenant allowance is unlimited"
+                )
+            else:
+                on_status(
+                    f"quota {name} [{region}]: needs {required_amount}{unit}; "
+                    f"{allowance['available']} available from limit "
+                    f"{allowance['limit']} (usage evidence: "
+                    f"{allowance['usage_source']})"
+                )
     return find_shortfalls(needed, allowances, region)

--- a/npa/src/npa/fleet/tfvars.py
+++ b/npa/src/npa/fleet/tfvars.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from npa.fleet.spec import ClusterSpec
 
 _EU_DOMAIN = "api.eu.nebius.cloud:443"
+_B200_DRIVERFULL_PLATFORMS = frozenset({"gpu-b200-sxm", "gpu-b200-sxm-a"})
 
 
 def provider_domain(region: str) -> str:
@@ -24,6 +25,12 @@ def patch_provider_domain(provider_tf: str, region: str) -> str:
     """Patch the recipe's hardcoded EU provider domain for *region*."""
 
     return provider_tf.replace(_EU_DOMAIN, provider_domain(region))
+
+
+def managed_gpu_driverfull_image(platform: str) -> bool:
+    """Whether *platform* requires Nebius's managed CUDA driver-full image."""
+
+    return platform.strip().lower() in _B200_DRIVERFULL_PLATFORMS
 
 
 def _tfstr(value: str) -> str:
@@ -58,7 +65,17 @@ def render_tfvars(cluster: ClusterSpec, *, ssh_public_key: str = "") -> str:
     lines.append("gpu_nodes_preemptible        = false")
     lines.append('mig_strategy                 = "none"')
     lines.append("custom_driver                = false")
-    lines.append("gpu_nodes_driverfull_image   = false")
+    # Nebius exposes an authoritative CUDA 13 driver-full image for B200. It
+    # starts the NVLink fabric stack before kubelet advertises GPUs, avoiding a
+    # live race observed with the marketplace GPU Operator where its driver pod
+    # and Network Operator install/reload host components concurrently and CUDA
+    # remains SYSTEM_NOT_READY. The recipe installs only the provider device
+    # plugin when this is true.
+    managed_gpu_drivers = bool(gpu and managed_gpu_driverfull_image(gpu.platform))
+    lines.append(
+        "gpu_nodes_driverfull_image   = "
+        f"{'true' if managed_gpu_drivers else 'false'}"
+    )
 
     cpu_count = cpu.count if cpu else 0
     lines.append(f"cpu_nodes_fixed_count = {cpu_count}")

--- a/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
+++ b/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
@@ -11,6 +11,17 @@ from npa.cli.cluster import app
 from npa.cli.cluster import terraform_lifecycle as tf_mod
 
 
+def test_cluster_terraform_uses_managed_driver_image_for_b200_platforms_only() -> None:
+    main_tf = (
+        Path(__file__).resolve().parents[3] / "deploy" / "cluster" / "main.tf"
+    ).read_text()
+
+    assert '"gpu-b200-sxm"' in main_tf
+    assert '"gpu-b200-sxm-a"' in main_tf
+    assert "gpu_nodes_driverfull_image      = local.gpu_nodes_driverfull_image" in main_tf
+    assert "gpu_nodes_driverfull_image      = false" not in main_tf
+
+
 runner = CliRunner()
 _REAL_WHOLE_PATH_PREFLIGHT = tf_mod._preflight_whole_path_capacity
 

--- a/npa/tests/unit/test_fleet_cli.py
+++ b/npa/tests/unit/test_fleet_cli.py
@@ -289,6 +289,9 @@ def test_vendored_filestore_contract_matches_official_guide() -> None:
     assert main_tf.count("filestore_mount_tag  = local.filestore.mount_tag") == 2
     assert 'filestore_mount_tag  = "data"' in egress_tf
     assert 'grep -Fq \\' in mount_validation
+    # kubectl 1.36 suppresses attached output and the created pod name under
+    # --quiet, defeating both evidence checking and debugger-pod cleanup.
+    assert "--quiet" not in mount_validation
     assert "completed without the required shared-filesystem success evidence" in (
         mount_validation
     )
@@ -318,6 +321,44 @@ def test_render_tfvars_capacity_block_is_strict() -> None:
         'gpu_nodes_reservation_policy = { policy = "STRICT", '
         'reservation_ids = ["capacityblockgroup-test"] }' in tf
     )
+
+
+def test_render_tfvars_b200_uses_managed_driver_image() -> None:
+    b200 = render_tfvars(
+        ClusterSpec(
+            name="b200",
+            gpu_nodes=NodePoolSpec(
+                count=2, platform="gpu-b200-sxm", preset="8gpu-160vcpu-1792gb"
+            ),
+            enable_gpu_cluster=True,
+            infiniband_fabric="us-central1-b",
+        )
+    )
+    assert "gpu_nodes_driverfull_image   = true" in b200
+
+    b200_alias = render_tfvars(
+        ClusterSpec(
+            name="b200-alias",
+            gpu_nodes=NodePoolSpec(
+                count=1, platform="gpu-b200-sxm-a", preset="8gpu-160vcpu-1792gb"
+            ),
+            enable_gpu_cluster=True,
+            infiniband_fabric="ramon",
+        )
+    )
+    assert "gpu_nodes_driverfull_image   = true" in b200_alias
+
+    h200 = render_tfvars(
+        ClusterSpec(
+            name="h200",
+            gpu_nodes=NodePoolSpec(
+                count=1, platform="gpu-h200-sxm", preset="8gpu-128vcpu-1600gb"
+            ),
+            enable_gpu_cluster=True,
+            infiniband_fabric="us-central1-a",
+        )
+    )
+    assert "gpu_nodes_driverfull_image   = false" in h200
 
 
 def test_patch_provider_domain_region_aware() -> None:
@@ -747,6 +788,80 @@ def test_prepare_install_dir_warns_when_provider_domain_not_matched(tmp_path) ->
     assert any("not patched" in m for m in msgs)
 
 
+def _add_quiet_filesystem_verifier(recipe_root: Path) -> Path:
+    verifier = (
+        recipe_root
+        / "k8s-training"
+        / "filesystem-csi-validation"
+        / "01-verify-node-filesystem-mounts.sh"
+    )
+    verifier.parent.mkdir(parents=True, exist_ok=True)
+    verifier.write_text(
+        "#!/usr/bin/env bash\n"
+        "kubectl debug node/test \\\n"
+        "  --attach=true \\\n"
+        "  --quiet \\\n"
+        "  --image=ubuntu -- true\n"
+    )
+    return verifier
+
+
+def test_prepare_install_dir_patches_external_recipe_debug_quiet(tmp_path) -> None:
+    from npa.fleet import lifecycle as L
+
+    root = _fake_recipe(
+        tmp_path, 'provider "nebius" { domain = "api.eu.nebius.cloud:443" }\n'
+    )
+    source = _add_quiet_filesystem_verifier(root)
+    workdir = L._prepare_install_dir(
+        tmp_path / "install",
+        recipe_root=L._resolve_recipe_root(
+            root, ref=None, work_root=tmp_path / "clones", on_status=None
+        ),
+        region="us-central1",
+        cluster=ClusterSpec(name="c", cpu_nodes=NodePoolSpec(count=1)),
+        ssh_public_key="k",
+    )
+    installed = (
+        workdir
+        / "filesystem-csi-validation"
+        / "01-verify-node-filesystem-mounts.sh"
+    )
+    assert "--quiet" in source.read_text()
+    assert "--quiet" not in installed.read_text()
+
+
+def test_prepare_install_dir_patches_fetched_recipe_debug_quiet(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.fleet import lifecycle as L
+
+    def clone(args, **_kwargs):
+        clone_root = Path(args[-1])
+        (clone_root / "k8s-training").mkdir(parents=True)
+        (clone_root / "modules").mkdir()
+        (clone_root / "k8s-training" / "variables.tf").write_text("")
+        _add_quiet_filesystem_verifier(clone_root)
+
+    monkeypatch.setattr(L, "_require_bin", lambda name: name)
+    monkeypatch.setattr(L, "_run_stream", clone)
+    root = L._resolve_recipe_root(
+        None, ref="upstream-test", work_root=tmp_path / "fetch", on_status=None
+    )
+    workdir = L._prepare_install_dir(
+        tmp_path / "install",
+        recipe_root=root,
+        region="us-central1",
+        cluster=ClusterSpec(name="c", cpu_nodes=NodePoolSpec(count=1)),
+        ssh_public_key="k",
+    )
+    assert "--quiet" not in (
+        workdir
+        / "filesystem-csi-validation"
+        / "01-verify-node-filesystem-mounts.sh"
+    ).read_text()
+
+
 # --------------------------------------------------------------------------- #
 # _deploy_one_cluster sidecar status transitions (mocked)
 # --------------------------------------------------------------------------- #
@@ -1052,7 +1167,10 @@ def test_deploy_only_clusters_targets_a_single_cluster(tmp_path, monkeypatch) ->
 
     monkeypatch.setattr(L, "_deploy_one_cluster", fake_one)
     res = L.deploy_fleet(
-        _two_cluster_project_spec(), work_root=tmp_path, only_clusters=["c2"]
+        _two_cluster_project_spec(),
+        work_root=tmp_path,
+        only_clusters=["c2"],
+        preflight=False,
     )
     assert built == ["c2"]  # only the targeted cluster is (re)deployed
     assert res["deployed"] == 1
@@ -1074,9 +1192,11 @@ def _mock_deploy_fleet_boundary(monkeypatch, tmp_path):
     monkeypatch.setattr(L, "_resolve_ssh_public_key", lambda *a, **k: "k")
     monkeypatch.setattr(L, "_resolve_recipe_root", lambda *a, **k: tmp_path / "recipe")
     monkeypatch.setattr(L, "_nebius_cli_env", lambda: {})
+    monkeypatch.setattr(L, "_list_projects", lambda *a, **k: [])
     monkeypatch.setattr(L, "resolve_project_id", lambda *a, **k: ("proj-1", False))
     monkeypatch.setattr(L, "ensure_subnet", lambda *a, **k: ("subnet-1", ""))
-    # No quota API in unit tests: an unreadable allowance list skips the preflight.
+    # Tests outside the preflight section opt out explicitly when this generic
+    # boundary does not model the quota API.
     monkeypatch.setattr(L, "_run_capture", lambda *a, **k: _Cap("", 1))
     return L
 
@@ -1109,7 +1229,12 @@ def test_deploy_fleet_parallel_runs_all_targets_and_prewarms_once(
         }
 
     monkeypatch.setattr(L, "_deploy_one_cluster", fake_one)
-    res = L.deploy_fleet(_two_cluster_project_spec(), work_root=tmp_path, concurrency=2)
+    res = L.deploy_fleet(
+        _two_cluster_project_spec(),
+        work_root=tmp_path,
+        concurrency=2,
+        preflight=False,
+    )
     assert sorted(ran) == ["c1", "c2"]  # both targets applied
     assert res["deployed"] == 2
     assert prewarm["n"] == 1  # plugin cache pre-warmed exactly once for parallel
@@ -1137,7 +1262,12 @@ def test_deploy_fleet_sequential_skips_prewarm_and_streams(
         }
 
     monkeypatch.setattr(L, "_deploy_one_cluster", fake_one)
-    L.deploy_fleet(_two_cluster_project_spec(), work_root=tmp_path, concurrency=1)
+    L.deploy_fleet(
+        _two_cluster_project_spec(),
+        work_root=tmp_path,
+        concurrency=1,
+        preflight=False,
+    )
     assert prewarm["n"] == 0  # no pre-warm when sequential
     assert log_paths == [None, None]  # sequential -> stream to stdout, no log file
 
@@ -1312,11 +1442,13 @@ def test_deploy_fleet_cli_profile_overrides_spec(tmp_path, monkeypatch) -> None:
             )
         ],
     )
-    res = L.deploy_fleet(spec, work_root=tmp_path)
+    res = L.deploy_fleet(spec, work_root=tmp_path, preflight=False)
     assert seen == ["from-spec"]
     assert res["profile"] == "from-spec"
     seen.clear()
-    res = L.deploy_fleet(spec, work_root=tmp_path, profile="from-cli")
+    res = L.deploy_fleet(
+        spec, work_root=tmp_path, profile="from-cli", preflight=False
+    )
     assert seen == ["from-cli"]
     assert res["profile"] == "from-cli"
 
@@ -1804,12 +1936,46 @@ def test_fleet_deploy_toolref_is_non_interactive() -> None:
 # --------------------------------------------------------------------------- #
 # tenant quota preflight (mk8s accepts node groups it cannot fill)
 # --------------------------------------------------------------------------- #
-def _allowance(name: str, region: str, limit, unit: str = "count") -> dict:
+def _allowance(
+    name: str,
+    region: str,
+    limit,
+    unit: str = "count",
+    *,
+    parent_id: str = "",
+) -> dict:
+    metadata = {"name": name}
+    if parent_id:
+        metadata["parent_id"] = parent_id
     return {
-        "metadata": {"name": name},
+        "metadata": metadata,
         "spec": {"region": region, "limit": limit},
-        "status": {"unit": unit},
+        "status": {"unit": unit, "usage_percentage": "0.00"},
     }
+
+
+def _complete_allowances(*overrides: dict) -> str:
+    """Return sufficient evidence for every quota in the RTX fleet fixture."""
+
+    defaults = [
+        _allowance("mk8s.cluster.count", "us-central1", 100),
+        _allowance("compute.instance.count", "us-central1", 100),
+        _allowance("compute.disk.count", "us-central1", 100),
+        _allowance(
+            "compute.disk.size.network-ssd", "us-central1", 100 * 1024**4, "byte"
+        ),
+        _allowance("compute.instance.non-gpu.vcpu", "us-central1", 1000),
+        _allowance("compute.instance.gpu.rtx6000", "us-central1", 100),
+        _allowance("vpc.allocation.count", "us-central1", 1000),
+        _allowance("vpc.network.count", "us-central1", 100),
+        _allowance("vpc.pool.count", "us-central1", 100),
+        _allowance("vpc.route.count", "us-central1", 100),
+        _allowance("vpc.routetable.count", "us-central1", 100),
+        _allowance("vpc.subnet.count", "us-central1", 100),
+    ]
+    indexed = {item["metadata"]["name"]: item for item in defaults}
+    indexed.update({item["metadata"]["name"]: item for item in overrides})
+    return json.dumps({"items": list(indexed.values())})
 
 
 def _capacity_block(
@@ -1873,7 +2039,17 @@ def test_required_quotas_counts_nodes_vcpu_gpus_and_filesystem() -> None:
     assert needed["compute.filesystem.count"] == 1
     assert needed["compute.filesystem.size.network-ssd"] == 2048 * 1024**3
     assert needed["mk8s.cluster.count"] == 1
+    assert needed["vpc.allocation.count"] == 8
     assert "compute.gpucluster.count" not in needed
+
+    with_project_topology = required_quotas(
+        [ClusterSpec(name="cpu", cpu_nodes=NodePoolSpec(count=1))], new_projects=1
+    )
+    assert with_project_topology["vpc.network.count"] == 1
+    assert with_project_topology["vpc.pool.count"] == 2
+    assert with_project_topology["vpc.route.count"] == 1
+    assert with_project_topology["vpc.routetable.count"] == 1
+    assert with_project_topology["vpc.subnet.count"] == 1
 
 
 def test_required_quotas_excludes_managed_control_plane_compute_resources() -> None:
@@ -2013,7 +2189,7 @@ def test_reservation_capacity_parser_treats_live_usage_percentage_as_fraction() 
     assert exact["capacityblockgroup-test"]["available_gpus"] == 40
 
 
-def test_parse_allowances_filters_region_and_skips_unset_limits() -> None:
+def test_parse_allowances_filters_region_and_preserves_unlimited() -> None:
     from npa.fleet.quotas import parse_allowances
 
     payload = json.dumps(
@@ -2028,7 +2204,269 @@ def test_parse_allowances_filters_region_and_skips_unset_limits() -> None:
     )
     parsed = parse_allowances(payload, "us-central1")
     assert parsed["compute.instance.count"]["limit"] == 10
-    assert "compute.instance.gpu.rtx6000" not in parsed
+    assert parsed["compute.instance.gpu.rtx6000"]["unlimited"] is True
+
+
+@pytest.mark.parametrize("tenant_first", [True, False])
+def test_parse_allowances_tenant_finite_cannot_be_shadowed_by_project_unlimited(
+    tenant_first: bool,
+) -> None:
+    from npa.fleet.quotas import find_shortfalls, parse_allowances
+
+    tenant = _allowance(
+        "compute.disk.count",
+        "us-central1",
+        3,
+        parent_id="tenant-test",
+    )
+    project = _allowance(
+        "compute.disk.count",
+        "us-central1",
+        None,
+        parent_id="project-test",
+    )
+    project.pop("status")  # Unlimited wire entries may omit status entirely.
+    items = [tenant, project] if tenant_first else [project, tenant]
+
+    parsed = parse_allowances(
+        json.dumps({"items": items}),
+        "us-central1",
+        required={"compute.disk.count"},
+        container_id="tenant-test",
+    )
+
+    assert parsed["compute.disk.count"]["unlimited"] is False
+    assert parsed["compute.disk.count"]["limit"] == 3
+    assert len(
+        find_shortfalls(
+            {"compute.disk.count": 4}, parsed, "us-central1"
+        )
+    ) == 1
+
+
+@pytest.mark.parametrize("unlimited_first", [True, False])
+def test_parse_allowances_unscoped_finite_wins_concrete_unlimited_collision(
+    unlimited_first: bool,
+) -> None:
+    from npa.fleet.quotas import parse_allowances
+
+    finite = _allowance("compute.instance.count", "us-central1", 8)
+    unlimited = _allowance("compute.instance.count", "us-central1", None)
+    unlimited.pop("status")
+    items = [unlimited, finite] if unlimited_first else [finite, unlimited]
+
+    parsed = parse_allowances(json.dumps({"items": items}), "us-central1")
+
+    assert parsed["compute.instance.count"]["limit"] == 8
+    assert parsed["compute.instance.count"]["unlimited"] is False
+
+
+def test_parse_allowances_authoritative_tenant_scope_beats_project_finite() -> None:
+    from npa.fleet.quotas import parse_allowances
+
+    tenant = _allowance(
+        "compute.instance.count",
+        "us-central1",
+        None,
+        parent_id="tenant-test",
+    )
+    tenant.pop("status")
+    project = _allowance(
+        "compute.instance.count",
+        "us-central1",
+        0,
+        parent_id="project-test",
+    )
+
+    parsed = parse_allowances(
+        json.dumps({"items": [project, tenant]}),
+        "us-central1",
+        container_id="tenant-test",
+    )
+
+    assert parsed["compute.instance.count"]["unlimited"] is True
+
+
+def test_parse_allowances_duplicate_finite_candidates_are_deterministic_or_fail_closed() -> (
+    None
+):
+    from npa.fleet.quotas import parse_allowances
+
+    first = _allowance(
+        "compute.instance.count", "us-central1", 10, parent_id="tenant-test"
+    )
+    duplicate = json.loads(json.dumps(first))
+    parsed = parse_allowances(
+        json.dumps({"items": [duplicate, first]}),
+        "us-central1",
+        container_id="tenant-test",
+    )
+    assert parsed["compute.instance.count"]["limit"] == 10
+
+    conflicting = _allowance(
+        "compute.instance.count", "us-central1", 11, parent_id="tenant-test"
+    )
+    with pytest.raises(ValueError, match="ambiguous finite candidates"):
+        parse_allowances(
+            json.dumps({"items": [first, conflicting]}),
+            "us-central1",
+            container_id="tenant-test",
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "unit"),
+    [
+        ("compute.disk.size.network-ssd", "byte"),
+        ("compute.disk.count", "count"),
+        ("compute.instance.non-gpu.vcpu", "vcpu"),
+        ("compute.instance.non-gpu.vcpu", "count"),
+        ("compute.instance.gpu.b200", "gpu"),
+        ("compute.instance.gpu.b200", "count"),
+    ],
+)
+def test_parse_allowances_accepts_only_known_compatible_units(
+    name: str, unit: str
+) -> None:
+    from npa.fleet.quotas import parse_allowances
+
+    parsed = parse_allowances(
+        json.dumps({"items": [_allowance(name, "us-central1", 10, unit)]}),
+        "us-central1",
+    )
+    assert parsed[name]["unit"] == unit
+
+
+@pytest.mark.parametrize(
+    ("name", "unit"),
+    [
+        ("compute.disk.size.network-ssd", "gibibyte"),
+        ("compute.disk.count", "vcpu"),
+        ("compute.instance.non-gpu.vcpu", "byte"),
+        ("compute.instance.gpu.b200", "vcpu"),
+    ],
+)
+def test_parse_allowances_rejects_incompatible_units(name: str, unit: str) -> None:
+    from npa.fleet.quotas import parse_allowances
+
+    with pytest.raises(ValueError, match="incompatible unit"):
+        parse_allowances(
+            json.dumps({"items": [_allowance(name, "us-central1", 10, unit)]}),
+            "us-central1",
+        )
+
+
+def test_parse_allowances_unlimited_may_omit_status_but_finite_may_not() -> None:
+    from npa.fleet.quotas import parse_allowances
+
+    unlimited = _allowance("compute.instance.count", "us-central1", None)
+    unlimited.pop("status")
+    parsed = parse_allowances(json.dumps({"items": [unlimited]}), "us-central1")
+    assert parsed["compute.instance.count"]["unlimited"] is True
+
+    finite = _allowance("compute.instance.count", "us-central1", 10)
+    finite.pop("status")
+    with pytest.raises(ValueError, match="unusable capacity evidence"):
+        parse_allowances(json.dumps({"items": [finite]}), "us-central1")
+
+
+@pytest.mark.parametrize("missing_status_first", [True, False])
+def test_parse_allowances_duplicate_unlimited_candidates_are_deterministic(
+    missing_status_first: bool,
+) -> None:
+    from npa.fleet.quotas import parse_allowances
+
+    without_status = _allowance("compute.instance.count", "us-central1", None)
+    without_status.pop("status")
+    with_status = _allowance("compute.instance.count", "us-central1", None)
+    items = (
+        [without_status, with_status]
+        if missing_status_first
+        else [with_status, without_status]
+    )
+
+    parsed = parse_allowances(json.dumps({"items": items}), "us-central1")
+
+    assert parsed["compute.instance.count"]["unlimited"] is True
+    assert parsed["compute.instance.count"]["unit"] == "count"
+
+    with_status["status"]["unit"] = "byte"
+    with pytest.raises(ValueError, match="incompatible unit"):
+        parse_allowances(
+            json.dumps({"items": [without_status, with_status]}), "us-central1"
+        )
+
+
+def test_parse_allowances_finite_status_variations_remain_fail_closed() -> None:
+    from npa.fleet.quotas import parse_allowances
+
+    not_used = _allowance("compute.instance.count", "us-central1", 10)
+    not_used["status"] = {
+        "unit": "count",
+        "usage_state": "USAGE_STATE_NOT_USED",
+    }
+    parsed = parse_allowances(json.dumps({"items": [not_used]}), "us-central1")
+    assert parsed["compute.instance.count"]["available"] == 10
+    assert parsed["compute.instance.count"]["usage_source"] == "not-used"
+
+    over_limit = _allowance("compute.instance.count", "us-central1", 10)
+    over_limit["status"]["usage_percentage"] = "1.25"
+    parsed = parse_allowances(json.dumps({"items": [over_limit]}), "us-central1")
+    assert parsed["compute.instance.count"]["available"] == 0
+
+    no_usage = _allowance("compute.instance.count", "us-central1", 10)
+    no_usage["status"] = {"unit": "count"}
+    with pytest.raises(ValueError, match="unusable capacity evidence"):
+        parse_allowances(json.dumps({"items": [no_usage]}), "us-central1")
+
+    frozen = _allowance("compute.instance.count", "us-central1", 10)
+    frozen["status"]["state"] = "STATE_FROZEN"
+    with pytest.raises(ValueError, match="unusable capacity evidence"):
+        parse_allowances(json.dumps({"items": [frozen]}), "us-central1")
+
+
+@pytest.mark.parametrize(
+    "broken",
+    [
+        {"metadata": {"name": "compute.instance.count"}, "spec": []},
+        {
+            "metadata": {"name": "compute.instance.count"},
+            "spec": {"region": "us-central1", "limit": 1.5},
+            "status": {"unit": "count", "usage": 0},
+        },
+        {
+            "metadata": {"name": "compute.instance.count"},
+            "spec": {"region": "us-central1", "limit": 10},
+            "status": "active",
+        },
+    ],
+)
+def test_parse_allowances_rejects_malformed_relevant_candidates(broken: dict) -> None:
+    from npa.fleet.quotas import parse_allowances
+
+    with pytest.raises(ValueError):
+        parse_allowances(
+            json.dumps({"items": [broken]}),
+            "us-central1",
+            required={"compute.instance.count"},
+        )
+
+
+def test_parse_allowances_rejects_incomplete_paginated_response() -> None:
+    from npa.fleet.quotas import parse_allowances
+
+    with pytest.raises(ValueError, match="incomplete after paginated read"):
+        parse_allowances(
+            json.dumps(
+                {
+                    "items": [
+                        _allowance("compute.instance.count", "us-central1", 10)
+                    ],
+                    "next_page_token": "still-more",
+                }
+            ),
+            "us-central1",
+        )
 
 
 def test_find_shortfalls_flags_zero_limit_and_ignores_unadvertised() -> None:
@@ -2065,6 +2503,9 @@ def test_gpu_family_maps_platform_to_quota_family() -> None:
 
 def _preflight_boundary(monkeypatch, tmp_path, allowances_json: str, *, rc: int = 0):
     L = _mock_deploy_fleet_boundary(monkeypatch, tmp_path)
+    if rc == 0:
+        supplied = json.loads(allowances_json or "{}").get("items", [])
+        allowances_json = _complete_allowances(*supplied)
     monkeypatch.setattr(L, "_run_capture", lambda *a, **k: _Cap(allowances_json, rc))
     deployed: list[str] = []
     monkeypatch.setattr(
@@ -2123,13 +2564,7 @@ def _reserved_preflight_boundary(
         if "capacity-block-group" in args:
             return _Cap(capacity_payload, rc)
         return _Cap(
-            json.dumps(
-                {
-                    "items": [
-                        _allowance("compute.instance.gpu.rtx6000", "us-central1", "0")
-                    ]
-                }
-            ),
+            _complete_allowances(),
             0,
         )
 
@@ -2163,7 +2598,9 @@ def test_reserved_preflight_uses_capacity_and_ignores_public_gpu_quota(
     )
     assert deployed == ["c"]
     assert any("capacity-block-group" in call for call in calls)
+    assert any("quota-allowance" in call and "--all" in call for call in calls)
     assert any("ordinary GPU quota excluded" in message for message in messages)
+    assert any("compute.disk.count" in message for message in messages)
 
 
 def test_reserved_preflight_fails_closed_when_block_unreadable_or_too_small(
@@ -2191,6 +2628,29 @@ def test_deploy_preflight_blocks_on_zero_gpu_quota(tmp_path, monkeypatch) -> Non
     assert deployed == []  # nothing applied
 
 
+def test_deploy_preflight_blocks_when_four_workers_have_only_three_disk_slots(
+    tmp_path, monkeypatch
+) -> None:
+    disk_allowance = _allowance("compute.disk.count", "us-central1", "25")
+    disk_allowance["status"]["usage"] = "22"
+    L, deployed = _preflight_boundary(
+        monkeypatch,
+        tmp_path,
+        json.dumps({"items": [disk_allowance]}),
+    )
+    spec = _rtx_cluster_spec()
+    spec.projects[0].clusters[0].cpu_nodes = NodePoolSpec(
+        count=2, platform="cpu-d3", preset="16vcpu-64gb"
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"compute\.disk\.count .*needs 4 count, 3 available.*limit 25",
+    ):
+        L.deploy_fleet(spec, work_root=tmp_path)
+    assert deployed == []
+
+
 def test_deploy_no_preflight_skips_the_check(tmp_path, monkeypatch) -> None:
     payload = json.dumps(
         {"items": [_allowance("compute.instance.gpu.rtx6000", "us-central1", "0")]}
@@ -2211,17 +2671,100 @@ def test_deploy_preflight_passes_when_quota_is_sufficient(
     assert deployed == ["c"]
 
 
-def test_deploy_preflight_unreadable_quota_api_does_not_block(
+def test_deploy_preflight_unreadable_quota_api_fails_closed(
     tmp_path, monkeypatch
 ) -> None:
-    # Losing the preflight (no quota read permission) must not block a deploy.
+    # Losing the preflight is not proof of capacity and must block mutation.
     L, deployed = _preflight_boundary(monkeypatch, tmp_path, "", rc=1)
-    msgs: list[str] = []
-    L.deploy_fleet(
-        _rtx_cluster_spec(), work_root=tmp_path, on_status=lambda m: msgs.append(m)
+    with pytest.raises(ValueError, match="refusing to create projects"):
+        L.deploy_fleet(_rtx_cluster_spec(), work_root=tmp_path)
+    assert deployed == []
+
+
+def test_deploy_preflight_missing_required_allowance_fails_closed(
+    tmp_path, monkeypatch
+) -> None:
+    L = _mock_deploy_fleet_boundary(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        L,
+        "_run_capture",
+        lambda *a, **k: _Cap(
+            json.dumps(
+                {
+                    "items": [
+                        _allowance(
+                            "compute.instance.gpu.rtx6000", "us-central1", 100
+                        )
+                    ]
+                }
+            ),
+            0,
+        ),
     )
-    assert deployed == ["c"]
-    assert any("skipping quota preflight" in m for m in msgs)
+    with pytest.raises(ValueError, match="omitted required allowances"):
+        L.deploy_fleet(_rtx_cluster_spec(), work_root=tmp_path)
+
+
+def test_preflight_allows_only_explicit_optional_unadvertised_topology_quotas() -> (
+    None
+):
+    from npa.fleet.quotas import preflight_region, required_quotas
+
+    cluster = ClusterSpec(
+        name="cpu",
+        cpu_nodes=NodePoolSpec(count=1, platform="cpu-d3", preset="4vcpu-16gb"),
+    )
+    needed = required_quotas([cluster], new_projects=1)
+    optional = {
+        "vpc.network.count",
+        "vpc.subnet.count",
+        "vpc.pool.count",
+        "vpc.routetable.count",
+        "vpc.route.count",
+    }
+    items = [
+        _allowance(
+            name,
+            "us-central1",
+            10 * 1024**4 if name == "compute.disk.size.network-ssd" else 100,
+            "byte" if name == "compute.disk.size.network-ssd" else "count",
+            parent_id="tenant-test",
+        )
+        for name in sorted(set(needed) - optional)
+    ]
+    messages: list[str] = []
+    shortfalls = preflight_region(
+        nebius_bin="nebius",
+        tenant_id="tenant-test",
+        region="us-central1",
+        clusters=[cluster],
+        env={},
+        new_projects=1,
+        run_capture=lambda *a, **k: _Cap(json.dumps({"items": items})),
+        nebius_argv=lambda binary, profile: [binary],
+        on_status=messages.append,
+    )
+    assert shortfalls == []
+    assert sum("unadvertised optional quota" in message for message in messages) == 5
+
+    missing_core = [
+        item
+        for item in items
+        if item["metadata"]["name"] != "compute.instance.count"
+    ]
+    with pytest.raises(ValueError, match="omitted required allowances"):
+        preflight_region(
+            nebius_bin="nebius",
+            tenant_id="tenant-test",
+            region="us-central1",
+            clusters=[cluster],
+            env={},
+            new_projects=1,
+            run_capture=lambda *a, **k: _Cap(
+                json.dumps({"items": missing_core})
+            ),
+            nebius_argv=lambda binary, profile: [binary],
+        )
 
 
 def test_preflight_runs_before_any_project_is_created(tmp_path, monkeypatch) -> None:
@@ -2246,12 +2789,8 @@ def test_preflight_runs_before_any_project_is_created(tmp_path, monkeypatch) -> 
         L,
         "_run_capture",
         lambda *a, **k: _Cap(
-            json.dumps(
-                {
-                    "items": [
-                        _allowance("compute.instance.gpu.rtx6000", "us-central1", "0")
-                    ]
-                }
+            _complete_allowances(
+                _allowance("compute.instance.gpu.rtx6000", "us-central1", "0")
             ),
             0,
         ),
@@ -2260,6 +2799,133 @@ def test_preflight_runs_before_any_project_is_created(tmp_path, monkeypatch) -> 
     with pytest.raises(ValueError, match="quota is too low"):
         L.deploy_fleet(_rtx_cluster_spec(), work_root=tmp_path)
     assert resolved == []  # no project touched
+
+
+def _project_quota_accounting_boundary(monkeypatch, tmp_path, projects):
+    L = _mock_deploy_fleet_boundary(monkeypatch, tmp_path)
+    list_calls: list[str] = []
+    preflight_calls: list[dict[str, int]] = []
+    resolve_calls: list[str] = []
+    deployed: list[str] = []
+
+    def list_projects(*_args, **_kwargs):
+        list_calls.append("list")
+        if isinstance(projects, BaseException):
+            raise projects
+        return projects
+
+    monkeypatch.setattr(L, "_list_projects", list_projects)
+    monkeypatch.setattr(
+        L,
+        "_preflight_quotas",
+        lambda *a, **k: preflight_calls.append(dict(k["new_projects_by_region"])),
+    )
+
+    def resolve(_binary, _tenant, project, **_kwargs):
+        resolve_calls.append(project.key())
+        return f"resolved-{project.key()}", not bool(project.project_id)
+
+    monkeypatch.setattr(L, "resolve_project_id", resolve)
+    monkeypatch.setattr(
+        L,
+        "_deploy_one_cluster",
+        lambda **k: (
+            deployed.append(k["project"].key()),
+            {
+                "project_key": k["project"].key(),
+                "cluster_name": k["cluster"].name,
+                "status": "deployed",
+            },
+        )[1],
+    )
+    return L, list_calls, preflight_calls, resolve_calls, deployed
+
+
+def test_preflight_project_accounting_existing_named_and_genuinely_new(
+    tmp_path, monkeypatch
+) -> None:
+    existing_spec = _rtx_cluster_spec()
+    existing_name = existing_spec.projects[0].display_name(
+        existing_spec.project_prefix
+    )
+    L, list_calls, preflight_calls, resolve_calls, deployed = (
+        _project_quota_accounting_boundary(
+            monkeypatch,
+            tmp_path,
+            [{"metadata": {"name": existing_name, "id": "project-existing"}}],
+        )
+    )
+    L.deploy_fleet(existing_spec, work_root=tmp_path)
+    assert list_calls == ["list"]
+    assert preflight_calls == [{}]
+    assert resolve_calls == []
+    assert deployed == ["a"]
+
+    new_root = tmp_path / "new"
+    L, list_calls, preflight_calls, resolve_calls, deployed = (
+        _project_quota_accounting_boundary(monkeypatch, new_root, [])
+    )
+    L.deploy_fleet(_rtx_cluster_spec(), work_root=new_root)
+    assert list_calls == ["list"]
+    assert preflight_calls == [{"us-central1": 1}]
+    assert resolve_calls == ["a"]
+    assert deployed == ["a"]
+
+
+def test_preflight_project_accounting_explicit_id_and_mixed_projects(
+    tmp_path, monkeypatch
+) -> None:
+    cluster = ClusterSpec(
+        name="c", cpu_nodes=NodePoolSpec(count=1, preset="4vcpu-16gb")
+    )
+    explicit_only = FleetSpec(
+        name="f",
+        region="us-central1",
+        projects=[ProjectSpec(project_id="project-explicit", clusters=[cluster])],
+    )
+    L, list_calls, preflight_calls, _resolve_calls, _deployed = (
+        _project_quota_accounting_boundary(monkeypatch, tmp_path / "explicit", [])
+    )
+    L.deploy_fleet(explicit_only, work_root=tmp_path / "explicit")
+    assert list_calls == []
+    assert preflight_calls == [{}]
+
+    mixed = FleetSpec(
+        name="mixed",
+        region="us-central1",
+        projects=[
+            ProjectSpec(name="existing", clusters=[cluster]),
+            ProjectSpec(name="new", region="eu-north1", clusters=[cluster]),
+            ProjectSpec(project_id="project-explicit", clusters=[cluster]),
+        ],
+    )
+    L, list_calls, preflight_calls, resolve_calls, deployed = (
+        _project_quota_accounting_boundary(
+            monkeypatch,
+            tmp_path / "mixed",
+            [{"metadata": {"name": "existing", "id": "project-existing"}}],
+        )
+    )
+    L.deploy_fleet(mixed, work_root=tmp_path / "mixed")
+    assert list_calls == ["list"]
+    assert preflight_calls == [{"eu-north1": 1}]
+    assert resolve_calls == ["new", "project-explicit"]
+    assert sorted(deployed) == ["existing", "new", "project-explicit"]
+
+
+def test_preflight_project_lookup_failure_cannot_undercount(
+    tmp_path, monkeypatch
+) -> None:
+    L, _list_calls, preflight_calls, resolve_calls, deployed = (
+        _project_quota_accounting_boundary(
+            monkeypatch, tmp_path, RuntimeError("project inventory unavailable")
+        )
+    )
+    with pytest.raises(RuntimeError, match="project inventory unavailable"):
+        L.deploy_fleet(_rtx_cluster_spec(), work_root=tmp_path)
+    assert preflight_calls == []
+    assert resolve_calls == []
+    assert deployed == []
 
 
 def test_plan_resolves_tenant_from_named_profile(monkeypatch) -> None:
@@ -2417,7 +3083,12 @@ def test_parallel_deploy_resolves_one_project_subnet_before_workers(
             },
         )[1],
     )
-    L.deploy_fleet(_two_cluster_project_spec(), work_root=tmp_path, concurrency=2)
+    L.deploy_fleet(
+        _two_cluster_project_spec(),
+        work_root=tmp_path,
+        concurrency=2,
+        preflight=False,
+    )
     assert calls == [tmp_path / "f" / "a" / L._PROJECT_NETWORK_STATE]
     assert sorted(seen) == [("c1", "shared-subnet"), ("c2", "shared-subnet")]
 
@@ -2442,7 +3113,7 @@ def test_explicit_subnet_override_bypasses_shared_project_subnet(
             },
         )[1],
     )
-    L.deploy_fleet(spec, work_root=tmp_path)
+    L.deploy_fleet(spec, work_root=tmp_path, preflight=False)
     assert seen == {"c1": "explicit-subnet", "c2": "shared-subnet"}
 
 
@@ -2634,7 +3305,7 @@ def test_quota_filesystem_byte_unit_usage_and_drift() -> None:
     drift = _allowance(
         "compute.filesystem.size.network-ssd", "us-central1", 1, "gibibyte"
     )
-    with pytest.raises(ValueError, match="expected 'byte'"):
+    with pytest.raises(ValueError, match="expected.*byte"):
         parse_allowances(json.dumps({"items": [drift]}), "us-central1")
 
 

--- a/skills/tools/fleet/SKILL.md
+++ b/skills/tools/fleet/SKILL.md
@@ -109,6 +109,11 @@ depends on it.
    valid on fabric-capable 8-GPU SXM presets. Single-GPU presets (e.g. RTX PRO
    6000 `1gpu-24vcpu-218gb`) auto-set `enable_gpu_cluster=false`; set it `true`
    only with an 8-GPU preset **and** `infiniband_fabric`.
+   B200 pools (`gpu-b200-sxm` and the recipe/API alias `gpu-b200-sxm-a`)
+   automatically use Nebius's `cuda13.0` driver-full node image and the provider
+   device plugin. This is the supported Managed Kubernetes path and prevents
+   the pod-managed GPU driver from racing the Network Operator while the NVLink
+   fabric is initialized. The same rule applies to `npa cluster up` and fleet.
 4. **Bind reserved GPU capacity explicitly when required.** Set
    `gpu_nodes.capacity_block_group` to a runtime-supplied Capacity Block Group
    ID. Fleet renders `gpu_nodes_reservation_policy = { policy = "STRICT", ... }`,
@@ -141,16 +146,42 @@ depends on it.
    frequently **0**), `compute.disk.count`/`compute.disk.size.network-ssd`,
    `compute.gpucluster.count` when `enable_gpu_cluster`, and
    `compute.filesystem.count` + `compute.filesystem.size.network-ssd` when
-   `enable_filestore`. List them all at once with
-   `nebius --profile <p> quotas quota-allowance list --parent-id <tenant> --format json`
+   `enable_filestore`. Each private worker consumes two
+   `vpc.allocation.count` slots (its private address and pod alias range); the
+   managed control-plane endpoint is service-owned. A create-on-demand project
+   additionally needs one `vpc.network.count`, one `vpc.subnet.count`, two
+   `vpc.pool.count`, one `vpc.routetable.count`, and one `vpc.route.count`.
+   List them all at once with
+   `nebius --profile <p> quotas quota-allowance list --parent-id <tenant> --all --format json`
    (each item carries `metadata.name`, `spec.region`, `spec.limit`).
 
    `deploy` does this automatically (`--preflight`, on by default) and refuses to
    apply when a capacity block or tenant limit cannot cover the in-scope
-   clusters; `--no-preflight` attempts it anyway. Ordinary quota checks subtract
-   exact usage when reported, otherwise the live wire's 0..1 fractional
-   `status.usage_percentage`. Filesystem size is byte-valued and must report
-   `status.unit: byte`; an incompatible/missing unit fails closed.
+   clusters; `--no-preflight` attempts it anyway. Before calculating
+   creation-only VPC requirements, preflight lists projects once and reuses an
+   existing immutable project ID when a name already exists. An unreadable
+   project inventory fails closed rather than assuming the project exists.
+
+   The allowance read is paged to completion and selects records whose
+   `metadata.parent_id` is the requested tenant. A project/unset allowance can
+   never shadow a finite tenant allowance; duplicate finite evidence must agree
+   exactly. Older unscoped records are a fallback only when no authoritative
+   tenant record exists. Required finite allowances fail closed when their
+   limit, unit, state, or consumption evidence cannot be interpreted. Exact
+   usage wins; otherwise the API's fractional `status.usage_percentage` is used
+   (values above 1 mean over-limit), and `USAGE_STATE_NOT_USED` is accepted as
+   zero consumption. Disk/filesystem sizes require `byte`; vCPU and GPU quotas
+   accept only their explicit compatible `count`/`vcpu` and `count`/`gpu` units.
+   A selected unlimited allowance may omit status because no arithmetic is
+   required.
+
+   The five creation-topology allowances (`vpc.network.count`,
+   `vpc.subnet.count`, `vpc.pool.count`, `vpc.routetable.count`, and
+   `vpc.route.count`) are optional catalog entries: when absent from a completed,
+   readable regional tenant catalog, preflight reports them as unadvertised and
+   does not reject the region. If any is advertised with a finite limit, it is
+   checked strictly. All compute, disk, mk8s, allocation, GPU-cluster, and
+   filesystem allowances required by the selected shape remain mandatory.
 
    Project-level allowances only *subdivide* the tenant allowance, so a tenant
    limit of 0 cannot be worked around by creating a project quota: raising a
@@ -166,7 +197,11 @@ depends on it.
    deployed vs failed clusters with kube contexts.
 7. **Consume the latest recipe**: `--k8s-training-ref main` clones
    `nebius-solutions-library` and uses its `k8s-training` (or `--k8s-training-dir`
-   for a local checkout). Omit both to use the repo-vendored, tested copy.
+   for a local checkout). Omit both to use the repo-vendored, tested copy. NPA
+   applies its compatibility preparation after materializing every source,
+   including the package-only pinned-ref fallback; currently this removes
+   `kubectl debug --quiet` from the filesystem verifier because kubectl 1.36
+   otherwise hides both required success evidence and the debugger-pod name.
 8. **Status / teardown**: `npa fleet status --spec fleet.yaml`; `npa fleet
    destroy --spec fleet.yaml` (prompts; `--yes`/`-y` or `--force` to skip).
 


### PR DESCRIPTION
## Summary

- Make fleet quota preflight select the requested tenant allowance deterministically, so project-scoped or unset records cannot shadow finite tenant limits.
- Keep finite allowances fail-closed across supported API unit/status variations, while permitting selected unlimited allowances to omit status.
- Treat only the five VPC creation-topology catalog entries as optional when absent from a complete tenant catalog; all shape/resource allowances remain mandatory and all advertised finite entries remain strictly checked.
- Resolve existing named projects before creation-only quota accounting and reuse the resolved immutable ID during deployment.
- Enable the managed CUDA driver-full image for the recipe-supported B200 platform names in both fleet rendering and `npa cluster up` Terraform.
- Apply the kubectl 1.36 filesystem-verifier compatibility patch after materializing every supported recipe source, including vendored, local-directory, fetched-ref, and package fallback paths.
- Remove stale/redundant quota parsing fallbacks while preserving fail-closed behavior.

## Quota semantics

The implementation follows the quota API's optional `spec.limit`, resource `metadata.parent_id`, exact `status.usage`, fractional `status.usage_percentage` (including over-limit values above 1), and usage-state fields. Byte quotas require `byte`; vCPU and GPU quantities accept only their explicit compatible count/vCPU/GPU units. Duplicate finite evidence must agree exactly, and incomplete pagination, ambiguous candidates, malformed finite records, unknown units, or missing finite consumption evidence stop preflight.

Absent optional topology entries are observable in status output. This is distinct from missing required compute, disk, MK8s, GPU-cluster, allocation, or filesystem entries, which still fail closed.

## Validation

- Focused fleet/quota/cluster lifecycle matrix: `199 passed`.
- PR218 integrated lifecycle, deploy, and reachability suites: `102 passed`.
- Guardrails: `1852 passed, 1 skipped`.
- Required full parallel non-E2E command: `9469 passed, 48 skipped, 1 xpassed`; 9 unrelated cleanup/CLI/provisioning/adapter cases timed out under shared-host I/O contention and all 9 passed unchanged in an immediate serial rerun.
- Ruff on changed Python, shell syntax, Terraform format, docs drift, and `git diff --check`: pass.
- Terraform 1.15.8 isolated `init -backend=false` and `validate`: pass.
- GitHub checks on the pushed head: all six pass (`docs-drift`, `gitleaks`, `guardrails`, `ruff`, `scan`, and Python 3.12 tests).

## Read-only live evidence

- A completed tenant allowance read used the documented parent-scoped paginated API shape; current finite records used `byte` and `count`, and exact usage parsed successfully.
- The exact existing B200 shape selected every required allowance and correctly reported the current network-SSD disk shortfall from existing consumption; a minimal CPU shape reported no shortfalls.
- The existing managed Kubernetes cluster and both node groups remain running and ready, with the B200 group retaining managed GPU settings and strict reservation binding.
- No infrastructure mutation was attempted.
