### PR TITLE
Harden fresh reserved-GPU setup, readiness, and smoke recovery

### DIFF
--- a/docs/orchestration/skypilot-setup.md
+++ b/docs/orchestration/skypilot-setup.md
@@ -42,8 +42,33 @@ export PATH="$(dirname "$(npa skypilot status --bin-path)"):$PATH"
 
 ```bash
 test -x "$NPA_SKYPILOT_BIN"
-npa skypilot verify
+npa skypilot verify --cluster <npa-cluster-context>
 ```
+
+Passing the NPA cluster context is important on workstations that already use
+SkyPilot with another Kubernetes cluster. NPA pins the check to that exact
+context and requires SkyPilot to report `Kubernetes: enabled`; a zero exit code
+with Kubernetes disabled is a failed verification.
+
+To prove GPU execution without creating a managed-jobs controller, use NPA's
+built-in smoke task:
+
+```bash
+npa provision-if-absent \
+  --project <project-alias> \
+  --cluster-name <npa-cluster-context> \
+  --context <npa-cluster-context> \
+  --kubeconfig <kubeconfig> \
+  --skip-s3 \
+  --sky-smoke \
+  --accelerator RTXPRO6000:1 \
+  --sky-bin "$NPA_SKYPILOT_BIN"
+```
+
+The smoke also runs when the cluster kubeconfig is already cached. Every
+SkyPilot check, launch, status poll, and cleanup remains scoped to the selected
+context, and the command succeeds only after the GPU task completes and its
+ephemeral SkyPilot cluster is removed.
 
 ## Managed-Jobs Controller
 

--- a/docs/orchestration/skypilot-setup.md
+++ b/docs/orchestration/skypilot-setup.md
@@ -48,7 +48,11 @@ npa skypilot verify --cluster <npa-cluster-context>
 Passing the NPA cluster context is important on workstations that already use
 SkyPilot with another Kubernetes cluster. NPA pins the check to that exact
 context and requires SkyPilot to report `Kubernetes: enabled`; a zero exit code
-with Kubernetes disabled is a failed verification.
+with Kubernetes disabled is a failed verification. A bare `npa skypilot verify`
+remains a legacy runtime/dependency check and does not require Kubernetes merely
+because Kubernetes is the default controller backend; `--cluster`,
+`--kubeconfig`, or an explicit `--controller-backend kubernetes` opts into the
+strict Kubernetes gate.
 
 To prove GPU execution without creating a managed-jobs controller, use NPA's
 built-in smoke task:
@@ -61,14 +65,19 @@ npa provision-if-absent \
   --kubeconfig <kubeconfig> \
   --skip-s3 \
   --sky-smoke \
-  --accelerator RTXPRO6000:1 \
   --sky-bin "$NPA_SKYPILOT_BIN"
 ```
 
-The smoke also runs when the cluster kubeconfig is already cached. Every
-SkyPilot check, launch, status poll, and cleanup remains scoped to the selected
-context, and the command succeeds only after the GPU task completes and its
-ephemeral SkyPilot cluster is removed.
+Omitting `--accelerator` makes the smoke discover a compatible GPU from the
+selected cluster; pass (for example) `--accelerator RTXPRO6000:1` to require a
+specific family. The smoke also runs when the cluster kubeconfig is already
+cached. Before either cached or fresh smoke, NPA explicitly reports and performs
+an idempotent node-label repair only for its reviewed GPU aliases, then waits for
+SkyPilot discovery. This mutation requires Kubernetes `get/list` on nodes plus
+`patch/update` when a label is absent; an RBAC failure is reported immediately.
+Every SkyPilot check, GPU discovery, launch, status poll, and cleanup remains
+scoped to the selected context, and the command succeeds only after the GPU task
+completes and its ephemeral SkyPilot cluster is removed.
 
 ## Managed-Jobs Controller
 

--- a/npa/src/npa/cli/cluster/terraform_lifecycle.py
+++ b/npa/src/npa/cli/cluster/terraform_lifecycle.py
@@ -3104,21 +3104,56 @@ def _gpus_per_node(preset: str) -> int:
 
 
 def _run_skypilot_smoke(
-    kubeconfig_path: Path, context: str, cluster_name: str, sky_gpus: str
+    kubeconfig_path: Path,
+    context: str,
+    cluster_name: str,
+    sky_gpus: str,
+    *,
+    sky_bin: str = "",
 ) -> None:
-    sky_bin = os.environ.get("NPA_SKYPILOT_BIN") or str(_DEFAULT_SKYPILOT_BIN)
-    sky = _require_bin(sky_bin)
+    executable = (
+        sky_bin or os.environ.get("NPA_SKYPILOT_BIN") or str(_DEFAULT_SKYPILOT_BIN)
+    )
+    sky = _require_bin(executable)
     env = os.environ.copy()
     env["KUBECONFIG"] = str(kubeconfig_path)
     infra = f"k8s/{context}"
-    _run_stream([sky, "check", "kubernetes"], env=env, timeout=300)
-    accelerator = sky_gpus.strip() or _detect_skypilot_gpu(sky, infra, env)
+    allowed_contexts = json.dumps([context], separators=(",", ":"))
+    check_result = _run_capture(
+        [
+            sky,
+            "check",
+            "--config",
+            f"kubernetes.allowed_contexts={allowed_contexts}",
+            "kubernetes",
+        ],
+        env=env,
+        timeout=300,
+    )
+    plain_check = re.sub(
+        r"\x1b\[[0-?]*[ -/]*[@-~]",
+        "",
+        "\n".join((check_result.stdout or "", check_result.stderr or "")),
+    )
+    if not re.search(
+        r"\bKubernetes:\s+enabled\b", plain_check, flags=re.IGNORECASE
+    ):
+        raise RuntimeError(
+            "SkyPilot returned success without enabling the exact Kubernetes context"
+        )
+    typer.echo(f"SkyPilot Kubernetes credentials verified for context {context!r}.")
+    config_override = f"kubernetes.allowed_contexts={allowed_contexts}"
+    accelerator = sky_gpus.strip() or _detect_skypilot_gpu(
+        sky, infra, env, config_override=config_override
+    )
     smoke_name = _sky_cluster_name(cluster_name)
     try:
         _run_stream(
             [
                 sky,
                 "launch",
+                "--config",
+                config_override,
                 "-c",
                 smoke_name,
                 "--infra",
@@ -3132,14 +3167,29 @@ def _run_skypilot_smoke(
             timeout=1800,
         )
     finally:
-        _run_stream([sky, "down", "--yes", smoke_name], env=env, timeout=600)
-        _wait_for_sky_down(sky, smoke_name, env)
+        _run_stream(
+            [sky, "down", "--config", config_override, "--yes", smoke_name],
+            env=env,
+            timeout=600,
+        )
+        _wait_for_sky_down(
+            sky, smoke_name, env, config_override=config_override
+        )
     typer.echo(f"SkyPilot smoke passed and {smoke_name} was removed.")
 
 
-def _detect_skypilot_gpu(sky: str, infra: str, env: dict[str, str]) -> str:
+def _detect_skypilot_gpu(
+    sky: str,
+    infra: str,
+    env: dict[str, str],
+    *,
+    config_override: str = "",
+) -> str:
+    cmd = [sky, "show-gpus", "--infra", infra, "--all"]
+    if config_override:
+        cmd[2:2] = ["--config", config_override]
     result = _run_capture(
-        [sky, "show-gpus", "--infra", infra, "--all"], env=env, timeout=300
+        cmd, env=env, timeout=300
     )
     for line in result.stdout.splitlines():
         if "RTX" not in line.upper() or "6000" not in line:
@@ -3157,10 +3207,19 @@ def _sky_cluster_name(cluster_name: str) -> str:
     return f"{normalized[:40]}-sky-smoke"
 
 
-def _wait_for_sky_down(sky: str, cluster_name: str, env: dict[str, str]) -> None:
+def _wait_for_sky_down(
+    sky: str,
+    cluster_name: str,
+    env: dict[str, str],
+    *,
+    config_override: str = "",
+) -> None:
     for _ in range(30):
+        cmd = [sky, "status", "--refresh"]
+        if config_override:
+            cmd[2:2] = ["--config", config_override]
         result = _run_capture(
-            [sky, "status", "--refresh"], env=env, timeout=120, check=False
+            cmd, env=env, timeout=120, check=False
         )
         if cluster_name not in result.stdout:
             return

--- a/npa/src/npa/cli/cluster/terraform_lifecycle.py
+++ b/npa/src/npa/cli/cluster/terraform_lifecycle.py
@@ -258,6 +258,11 @@ def up_cmd(
         "--sky-gpus",
         help="SkyPilot GPU demand for the smoke task. Defaults to auto-detecting the first Kubernetes GPU.",
     ),
+    sky_bin: str = typer.Option(
+        "",
+        "--sky-bin",
+        help="Pinned NPA SkyPilot executable override for GPU readiness and smoke.",
+    ),
     capacity_block_group: str = typer.Option(
         "",
         "--capacity-block-group",
@@ -633,7 +638,25 @@ def up_cmd(
                 f"default StorageClass {validation['default_storage_class']}"
             )
         if sky_smoke:
-            _run_skypilot_smoke(kubeconfig_path, context, cluster_name, sky_gpus)
+            from npa.orchestration.skypilot.k8s_gpu_catalog import (
+                wait_for_kubernetes_accelerators,
+            )
+
+            wait_for_kubernetes_accelerators(
+                [sky_gpus] if sky_gpus.strip() else [],
+                context=context,
+                kubeconfig=kubeconfig_path,
+                sky_bin=sky_bin or None,
+                label_known_gpus=True,
+                on_status=lambda message: typer.echo(message, err=True),
+            )
+            _run_skypilot_smoke(
+                kubeconfig_path,
+                context,
+                cluster_name,
+                sky_gpus,
+                sky_bin=sky_bin,
+            )
         _save_terraform_cluster_state(
             tfvars,
             cluster,
@@ -1546,27 +1569,73 @@ def _run_stream(
     a graceful shutdown that still persists state) and the reason is raised.
     """
     if cancel is None:
-        result = subprocess.run(
-            args,
-            cwd=cwd,
-            env=env,
-            text=True,
-            timeout=timeout,
-            check=False,
-            stdout=subprocess.PIPE if capture_output else None,
-            stderr=subprocess.PIPE if capture_output else None,
-        )
-        safe_stdout = result.stdout or ""
-        safe_stderr = result.stderr or ""
         if capture_output:
             from npa.clients.nebius import redact_nebius_output
 
-            safe_stdout = redact_nebius_output(safe_stdout)
-            safe_stderr = redact_nebius_output(safe_stderr)
-        if capture_output and safe_stdout:
-            typer.echo(safe_stdout, nl=not safe_stdout.endswith("\n"))
-        if capture_output and safe_stderr:
-            typer.echo(safe_stderr, err=True, nl=not safe_stderr.endswith("\n"))
+            process = subprocess.Popen(
+                args,
+                cwd=cwd,
+                env=env,
+                text=True,
+                bufsize=1,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            captured_stdout: list[str] = []
+            captured_stderr: list[str] = []
+
+            def drain(
+                pipe: Any, captured: list[str], *, stderr: bool
+            ) -> None:
+                if pipe is None:
+                    return
+                for line in iter(pipe.readline, ""):
+                    safe_line = redact_nebius_output(line)
+                    captured.append(safe_line)
+                    typer.echo(safe_line, err=stderr, nl=False)
+                pipe.close()
+
+            readers = [
+                threading.Thread(
+                    target=drain,
+                    args=(process.stdout, captured_stdout),
+                    kwargs={"stderr": False},
+                    daemon=True,
+                ),
+                threading.Thread(
+                    target=drain,
+                    args=(process.stderr, captured_stderr),
+                    kwargs={"stderr": True},
+                    daemon=True,
+                ),
+            ]
+            for reader in readers:
+                reader.start()
+            try:
+                returncode = process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                _stop_process(process)
+                raise
+            finally:
+                for reader in readers:
+                    reader.join(timeout=5)
+            result = subprocess.CompletedProcess(
+                args=args,
+                returncode=returncode,
+                stdout="".join(captured_stdout),
+                stderr="".join(captured_stderr),
+            )
+        else:
+            result = subprocess.run(
+                args,
+                cwd=cwd,
+                env=env,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        safe_stdout = result.stdout or ""
+        safe_stderr = result.stderr or ""
         if result.returncode != 0:
             detail = ""
             if capture_output:
@@ -3118,17 +3187,22 @@ def _run_skypilot_smoke(
     env = os.environ.copy()
     env["KUBECONFIG"] = str(kubeconfig_path)
     infra = f"k8s/{context}"
-    allowed_contexts = json.dumps([context], separators=(",", ":"))
-    check_result = _run_capture(
+    from npa.orchestration.skypilot.k8s_gpu_catalog import (
+        exact_kubernetes_context_config,
+    )
+
+    config_override = exact_kubernetes_context_config(context)
+    check_result = _run_stream(
         [
             sky,
             "check",
             "--config",
-            f"kubernetes.allowed_contexts={allowed_contexts}",
+            config_override,
             "kubernetes",
         ],
         env=env,
         timeout=300,
+        capture_output=True,
     )
     plain_check = re.sub(
         r"\x1b\[[0-?]*[ -/]*[@-~]",
@@ -3142,7 +3216,6 @@ def _run_skypilot_smoke(
             "SkyPilot returned success without enabling the exact Kubernetes context"
         )
     typer.echo(f"SkyPilot Kubernetes credentials verified for context {context!r}.")
-    config_override = f"kubernetes.allowed_contexts={allowed_contexts}"
     accelerator = sky_gpus.strip() or _detect_skypilot_gpu(
         sky, infra, env, config_override=config_override
     )

--- a/npa/src/npa/cli/cluster/terraform_lifecycle.py
+++ b/npa/src/npa/cli/cluster/terraform_lifecycle.py
@@ -207,6 +207,7 @@ def _rollback_fresh_cluster_apply(
             tenant_id=str(operation.read().get("tenant_id") or ""),
             region=str(operation.read().get("region") or ""),
             cluster_id="",
+            operation_id="",
             context_name=context,
             keep_local_state=False,
             force=True,

--- a/npa/src/npa/cli/cluster/terraform_runtime.py
+++ b/npa/src/npa/cli/cluster/terraform_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import shutil
@@ -14,6 +15,7 @@ from typing import Iterator
 
 
 _SCRATCH_MARKER = ".npa-owned.json"
+_SCRATCH_LOCK = ".npa-in-use.lock"
 _INVENTORY_NAME = "terraform-lifecycle.json"
 _LEGACY_CACHE_PARTS = ("deploy", "cluster", ".terraform")
 
@@ -37,8 +39,18 @@ def _now() -> str:
 
 
 def terraform_scratch_root() -> Path:
-    """Return the NPA-owned parent used for ephemeral Terraform data."""
+    """Return the NPA-owned parent used for active Terraform data.
 
+    The extra ``active`` level is an upgrade-safety boundary.  Older NPA cleanup
+    versions scan only the immediate children of ``terraform-data/cluster``;
+    they therefore preserve this unmarked parent instead of deleting a newer
+    run whose advisory-lock contract they do not understand.
+    """
+
+    return _legacy_terraform_scratch_root() / "active"
+
+
+def _legacy_terraform_scratch_root() -> Path:
     return Path(
         os.environ.get("NPA_CONFIG_DIR", "").strip() or (Path.home() / ".npa")
     ) / "terraform-data" / "cluster"
@@ -115,6 +127,9 @@ def isolated_terraform_data_dir(
         root.mkdir(parents=True, exist_ok=True, mode=0o700)
         root.chmod(0o700)
         scratch = Path(tempfile.mkdtemp(prefix="run-", dir=root))
+        lock_fd = os.open(scratch / _SCRATCH_LOCK, os.O_RDWR | os.O_CREAT, 0o600)
+        os.fchmod(lock_fd, 0o600)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         _write_private_json(
             scratch / _SCRATCH_MARKER,
             {
@@ -128,6 +143,11 @@ def isolated_terraform_data_dir(
             },
         )
     except OSError as exc:
+        if "lock_fd" in locals():
+            try:
+                os.close(lock_fd)
+            except OSError:
+                pass
         if "scratch" in locals():
             try:
                 shutil.rmtree(scratch)
@@ -149,7 +169,11 @@ def isolated_terraform_data_dir(
         primary_error = exc
         raise
     finally:
-        cleanup_error = _remove_owned_scratch(scratch)
+        cleanup_error = _remove_owned_scratch(scratch, held_lock_fd=lock_fd)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(lock_fd)
         try:
             root.rmdir()
             root.parent.rmdir()
@@ -170,17 +194,20 @@ def collect_terraform_residue(start: Path | None = None) -> list[TerraformResidu
     """Find exact NPA Terraform scratch and legacy source-cache residue."""
 
     found: list[TerraformResidue] = []
-    root = terraform_scratch_root()
-    if root.is_symlink() or (root.exists() and not root.is_dir()):
-        found.append(
-            TerraformResidue(
-                "Unverified Terraform scratch root",
-                root,
-                False,
-                "scratch root is not an exact NPA-owned directory",
+    current_root = terraform_scratch_root()
+    for root in (current_root, _legacy_terraform_scratch_root()):
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
+            found.append(
+                TerraformResidue(
+                    "Unverified Terraform scratch root",
+                    root,
+                    False,
+                    "scratch root is not an exact NPA-owned directory",
+                )
             )
-        )
-    elif root.is_dir():
+            continue
+        if not root.is_dir():
+            continue
         try:
             children = sorted(root.iterdir())
         except OSError as exc:
@@ -194,9 +221,17 @@ def collect_terraform_residue(start: Path | None = None) -> list[TerraformResidu
             )
         else:
             for child in children:
+                if root != current_root and child == current_root:
+                    continue
                 if _owned_scratch_marker(child):
+                    active, reason = _scratch_lock_status(child)
                     found.append(
-                        TerraformResidue("Terraform runtime scratch", child, True)
+                        TerraformResidue(
+                            "Terraform runtime scratch",
+                            child,
+                            not active,
+                            reason,
+                        )
                     )
                 else:
                     found.append(
@@ -248,14 +283,25 @@ def remove_terraform_residue(item: TerraformResidue) -> str:
     return "unsupported Terraform residue type"
 
 
-def _remove_owned_scratch(path: Path) -> str:
+def _remove_owned_scratch(path: Path, *, held_lock_fd: int | None = None) -> str:
     if not _owned_scratch_marker(path):
         return "ownership marker is missing, malformed, or mismatched"
+    lock_fd = held_lock_fd
+    if lock_fd is None:
+        lock_fd, reason = _acquire_scratch_lock(path)
+        if reason:
+            return reason
     try:
         shutil.rmtree(path)
     except OSError as exc:
         return str(exc)
-    root = terraform_scratch_root()
+    finally:
+        if lock_fd is not None and held_lock_fd is None:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            finally:
+                os.close(lock_fd)
+    root = path.parent
     try:
         root.rmdir()
         root.parent.rmdir()
@@ -264,13 +310,56 @@ def _remove_owned_scratch(path: Path) -> str:
     return ""
 
 
+def _acquire_scratch_lock(path: Path) -> tuple[int | None, str]:
+    """Acquire an existing scratch lock or explain why removal is unsafe."""
+
+    lock_path = path / _SCRATCH_LOCK
+    try:
+        descriptor = os.open(lock_path, os.O_RDWR)
+    except FileNotFoundError:
+        # Compatibility for marked scratch from versions before the lock existed.
+        return None, ""
+    except OSError as exc:
+        return None, f"scratch ownership lock could not be verified: {exc}"
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        os.close(descriptor)
+        return None, "active Terraform run holds the scratch ownership lock"
+    except OSError as exc:
+        os.close(descriptor)
+        return None, f"scratch ownership lock could not be verified: {exc}"
+    return descriptor, ""
+
+
+def _scratch_lock_status(path: Path) -> tuple[bool, str]:
+    """Return whether an owned scratch directory is in use by another process.
+
+    ``npa cleanup --full`` may run concurrently with a long Terraform apply from
+    another checkout that shares ``~/.npa``.  The ownership marker proves that a
+    directory belongs to NPA; it does not prove that deleting it is safe *now*.
+    A non-blocking advisory lock closes that gap without relying on PIDs or
+    wall-clock age.  Scratch created before this lock existed remains removable.
+    """
+
+    descriptor, reason = _acquire_scratch_lock(path)
+    if reason:
+        return True, reason
+    if descriptor is not None:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+    return False, ""
+
+
 def _owned_scratch_marker(path: Path) -> bool:
-    root = terraform_scratch_root()
+    roots = (terraform_scratch_root(), _legacy_terraform_scratch_root())
     try:
         if (
             not path.is_dir()
             or path.is_symlink()
-            or path.parent.resolve() != root.resolve()
+            or path.parent.resolve() not in {root.resolve() for root in roots}
             or not path.name.startswith("run-")
         ):
             return False

--- a/npa/src/npa/cli/skypilot/__init__.py
+++ b/npa/src/npa/cli/skypilot/__init__.py
@@ -594,10 +594,14 @@ def verify_cmd(
             "--kubeconfig is not given."
         ),
     ),
-    controller_backend: str = typer.Option(
-        "kubernetes",
+    controller_backend: str | None = typer.Option(
+        None,
         "--controller-backend",
-        help="Controller backend: kubernetes (Nebius profile optional) or nebius (required).",
+        help=(
+            "Controller backend: kubernetes (Nebius profile optional) or nebius "
+            "(required). Defaults to kubernetes without making a bare legacy "
+            "runtime check require cluster setup."
+        ),
     ),
     output_format: str = typer.Option(
         "text",
@@ -617,7 +621,8 @@ def verify_cmd(
         _fail(kubernetes_client_remedy(state.kubernetes_version))
         return
 
-    backend = controller_backend.strip().lower()
+    backend_was_explicit = controller_backend is not None
+    backend = str(controller_backend or "kubernetes").strip().lower()
     if backend not in {"kubernetes", "nebius"}:
         _fail("--controller-backend must be kubernetes or nebius")
         return
@@ -626,6 +631,9 @@ def verify_cmd(
         return
     check_env, exact_context = _verify_kube_env(
         kubeconfig=kubeconfig, cluster=cluster
+    )
+    kubernetes_required = backend == "kubernetes" and bool(
+        backend_was_explicit or kubeconfig is not None or cluster
     )
     check_cmd = [str(state.sky_bin), "check"]
     if backend == "kubernetes" and exact_context:
@@ -659,7 +667,7 @@ def verify_cmd(
     ok = (
         result.returncode == 0
         and not (profile_failure and required)
-        and (backend != "kubernetes" or kubernetes_enabled)
+        and (not kubernetes_required or kubernetes_enabled)
     )
     if profile_failure and not required:
         profile_status = "skipped_not_required"
@@ -679,6 +687,7 @@ def verify_cmd(
     payload = {
         "status": "ok" if ok else "failed",
         "controller_backend": backend,
+        "kubernetes_required": kubernetes_required,
         "kubernetes_enabled": kubernetes_enabled,
         "nebius_profile": profile_status,
         "nebius_profile_detail": detail,

--- a/npa/src/npa/cli/skypilot/__init__.py
+++ b/npa/src/npa/cli/skypilot/__init__.py
@@ -21,6 +21,7 @@ import fcntl
 
 import typer
 from rich.console import Console
+import yaml  # type: ignore[import-untyped]
 
 from npa.orchestration.skypilot._bin import REQUIRED_SKYPILOT_VERSION
 from npa.orchestration.skypilot.workflow_state import redact_text
@@ -616,13 +617,6 @@ def verify_cmd(
         _fail(kubernetes_client_remedy(state.kubernetes_version))
         return
 
-    check_env = _verify_kube_env(kubeconfig=kubeconfig, cluster=cluster)
-    result = _run_observable(
-        [str(state.sky_bin), "check"],
-        label="SkyPilot verification",
-        env=check_env,
-        emit_progress=output_format != "json",
-    )
     backend = controller_backend.strip().lower()
     if backend not in {"kubernetes", "nebius"}:
         _fail("--controller-backend must be kubernetes or nebius")
@@ -630,6 +624,25 @@ def verify_cmd(
     if output_format not in {"text", "json"}:
         _fail("--output-format must be text or json")
         return
+    check_env, exact_context = _verify_kube_env(
+        kubeconfig=kubeconfig, cluster=cluster
+    )
+    check_cmd = [str(state.sky_bin), "check"]
+    if backend == "kubernetes" and exact_context:
+        # A pre-existing SkyPilot config can restrict allowed_contexts to other
+        # clusters.  Verify the kubeconfig the operator explicitly selected,
+        # rather than silently checking that stale allowlist and returning 0
+        # with Kubernetes disabled.
+        allowed_contexts = json.dumps([exact_context], separators=(",", ":"))
+        check_cmd.extend(
+            ["--config", f"kubernetes.allowed_contexts={allowed_contexts}", "kubernetes"]
+        )
+    result = _run_observable(
+        check_cmd,
+        label="SkyPilot verification",
+        env=check_env,
+        emit_progress=output_format != "json",
+    )
     combined_lines = [
         line
         for line in "\n".join((result.stdout or "", result.stderr or "")).splitlines()
@@ -637,7 +650,17 @@ def verify_cmd(
     ]
     profile_failure = any("unable to create nebius profile" in line.lower() for line in combined_lines)
     required = backend == "nebius"
-    ok = result.returncode == 0 and not (profile_failure and required)
+    plain_output = re.sub(
+        r"\x1b\[[0-?]*[ -/]*[@-~]", "", "\n".join(combined_lines)
+    )
+    kubernetes_enabled = bool(
+        re.search(r"\bKubernetes:\s+enabled\b", plain_output, flags=re.IGNORECASE)
+    )
+    ok = (
+        result.returncode == 0
+        and not (profile_failure and required)
+        and (backend != "kubernetes" or kubernetes_enabled)
+    )
     if profile_failure and not required:
         profile_status = "skipped_not_required"
         detail = "Nebius profile skipped; not required for Kubernetes-controller mode"
@@ -656,6 +679,7 @@ def verify_cmd(
     payload = {
         "status": "ok" if ok else "failed",
         "controller_backend": backend,
+        "kubernetes_enabled": kubernetes_enabled,
         "nebius_profile": profile_status,
         "nebius_profile_detail": detail,
         "sky_check_returncode": result.returncode,
@@ -675,7 +699,7 @@ def verify_cmd(
 
 def _verify_kube_env(
     *, kubeconfig: Path | None, cluster: str | None
-) -> dict[str, str] | None:
+) -> tuple[dict[str, str] | None, str]:
     """Build the env for `sky check`, pinning KUBECONFIG when known.
 
     Without an explicit kubeconfig/cluster the behavior is unchanged (inherits
@@ -688,7 +712,7 @@ def _verify_kube_env(
 
         resolved = kubeconfig_file(cluster)
     if resolved is None:
-        return None
+        return None, str(cluster or "").strip()
     resolved = resolved.expanduser()
     if not resolved.exists():
         _fail(
@@ -697,7 +721,15 @@ def _verify_kube_env(
         )
     env = os.environ.copy()
     env["KUBECONFIG"] = str(resolved)
-    return env
+    exact_context = str(cluster or "").strip()
+    if not exact_context:
+        try:
+            payload = yaml.safe_load(resolved.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            payload = {}
+        if isinstance(payload, dict):
+            exact_context = str(payload.get("current-context") or "").strip()
+    return env, exact_context
 
 
 def bootstrap_skypilot(

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -1512,7 +1512,7 @@ def submit_cmd(
                 try:
                     submitted = submit()
                 except BaseException as exc:
-                    operation.transition("recovery-required", error=str(exc))
+                    _record_workflow_submit_failure(operation, exc)
                     raise
                 operation.transition("state-durable")
                 operation.commit()
@@ -2352,6 +2352,34 @@ def _resolve_submit_accelerators(
             overrides[accelerator] = resolution.resolved
         typer.echo(f"accelerator-resolve: {resolution.describe()}", err=True)
     return overrides
+
+
+def _record_workflow_submit_failure(operation, exc: BaseException) -> None:  # noqa: ANN001
+    """Keep recovery only when this transaction may have issued a launch.
+
+    A failed initial reconciliation has ``launch_sequence == 0``: NPA never
+    called ``sky jobs launch`` and therefore owns no workflow resource to
+    recover.  Marking that journal recovery-required blocks unrelated safe
+    project operations forever, even though no mutation occurred.
+    """
+
+    transaction = getattr(exc, "transaction", None)
+    launch_sequence = getattr(transaction, "launch_sequence", None)
+    if launch_sequence == 0:
+        operation.record_rollback(
+            attempted=False,
+            completed=True,
+            removed=[],
+            preserved=[],
+            outcomes=[],
+        )
+        operation.transition(
+            "rolled-back",
+            error=str(exc),
+            details={"error_type": type(exc).__name__, "launch_attempted": False},
+        )
+        return
+    operation.transition("recovery-required", error=str(exc))
 
 
 def _parse_submit_vars(var: list[str]) -> dict[str, str]:

--- a/npa/src/npa/cluster/api.py
+++ b/npa/src/npa/cluster/api.py
@@ -70,6 +70,7 @@ class MK8sClient:
         self,
         *,
         nebius_bin: str | None = None,
+        profile: str | None = None,
         subprocess_runner: SubprocessRunner | None = None,
         timeout: int = 900,
         retries: int = 3,
@@ -77,6 +78,7 @@ class MK8sClient:
         sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         self._nebius_bin = nebius_bin or shutil.which("nebius") or "nebius"
+        self._profile = profile
         self._runner = subprocess_runner or subprocess.run
         self._timeout = timeout
         self._retries = max(1, retries)
@@ -631,8 +633,15 @@ class MK8sClient:
         timeout: int | None = None,
     ) -> subprocess.CompletedProcess[str]:
         from npa.clients.nebius import nebius_cli_env
+        from npa.clients.nebius_auth import nebius_profile
 
-        full_args = [self._nebius_bin, *args]
+        profile = str(
+            self._profile if self._profile is not None else nebius_profile()
+        ).strip()
+        full_args = [self._nebius_bin]
+        if profile:
+            full_args.extend(["--profile", profile])
+        full_args.extend(args)
         last_result: subprocess.CompletedProcess[str] | None = None
         for attempt in range(1, self._retries + 1):
             try:

--- a/npa/src/npa/cluster/identity.py
+++ b/npa/src/npa/cluster/identity.py
@@ -358,7 +358,7 @@ def resolve_verified_cluster_identity(
             project_id=project_id,
             context=selected_context,
             cluster_id=state.cluster_id,
-            cluster_name=state.name,
+            cluster_name=state.provider_name or state.name,
             kubeconfig=saved_kubeconfig,
             endpoint=state.endpoint,
             cluster_absent=True,
@@ -374,9 +374,14 @@ def resolve_verified_cluster_identity(
         mismatches.append(f"cluster id {remote.id!r} != {state.cluster_id!r}")
     if remote.project_id and remote.project_id != project_id:
         mismatches.append(f"project id {remote.project_id!r} != {project_id!r}")
-    if remote.name and remote.name not in {state.name, selected_context}:
+    expected_provider_names = {
+        state.provider_name or state.name,
+        selected_context,
+    }
+    if remote.name and remote.name not in expected_provider_names:
         mismatches.append(
-            f"cluster name {remote.name!r} is not {state.name!r}/{selected_context!r}"
+            f"cluster name {remote.name!r} is not one of "
+            f"{sorted(expected_provider_names)!r}"
         )
     remote_host = _endpoint_host(remote.endpoint or state.endpoint)
     kube_host = _endpoint_host(kube_server)
@@ -394,7 +399,7 @@ def resolve_verified_cluster_identity(
         project_id=project_id,
         context=selected_context,
         cluster_id=state.cluster_id,
-        cluster_name=remote.name or state.name,
+        cluster_name=remote.name or state.provider_name or state.name,
         kubeconfig=saved_kubeconfig,
         endpoint=remote.endpoint or state.endpoint,
     )

--- a/npa/src/npa/cluster/state.py
+++ b/npa/src/npa/cluster/state.py
@@ -35,6 +35,10 @@ class ClusterState:
     node_group_id: str = ""
     endpoint: str = ""
     kubeconfig_path: str = ""
+    # Usually equal to ``name`` (the local kube context), but fleet contexts are
+    # deliberately prefixed for uniqueness while the provider cluster keeps the
+    # operator-authored cluster name.
+    provider_name: str = ""
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ClusterState":
@@ -55,6 +59,7 @@ class ClusterState:
                 node_group_id=str(data.get("node_group_id", "")),
                 endpoint=str(data.get("endpoint", "")),
                 kubeconfig_path=str(data.get("kubeconfig_path", "")),
+                provider_name=str(data.get("provider_name", "")),
             )
         except (KeyError, TypeError, ValueError) as exc:
             raise ClusterStateError(f"Malformed cluster state: {exc}") from exc

--- a/npa/src/npa/controller_ownership.py
+++ b/npa/src/npa/controller_ownership.py
@@ -147,7 +147,7 @@ def resolve_controller_candidate(project: str, context: str) -> ControllerOwner:
         project_alias=alias,
         project_id=environment.project_id,
         cluster_id=cluster.cluster_id,
-        cluster_name=cluster.name,
+        cluster_name=cluster.provider_name or cluster.name,
         context=context,
         context_fingerprint=digest.hexdigest(),
         operation_id=operation_id,

--- a/npa/src/npa/fleet/lifecycle.py
+++ b/npa/src/npa/fleet/lifecycle.py
@@ -45,7 +45,7 @@ from npa.cli.cluster.terraform_lifecycle import (
 from npa.cluster.gpu_driver import resolve_gpu_driver_strategy
 from npa.cluster.gpu_health import GpuHealthConfig, validate_gpu_health
 from npa.fleet.quotas import preflight_region, shortfall_message
-from npa.fleet.spec import ClusterSpec, FleetSpec, ProjectSpec
+from npa.fleet.spec import ClusterSpec, FleetSpec, NodePoolSpec, ProjectSpec
 from npa.fleet.tfvars import patch_provider_domain, provider_domain, render_tfvars
 
 logger = logging.getLogger(__name__)
@@ -351,11 +351,85 @@ def _list_projects(
 
 
 def _find_project_id(projects: list[dict[str, Any]], name: str) -> str:
-    for item in projects:
-        meta = item.get("metadata", {})
-        if meta.get("name") == name and meta.get("id"):
-            return str(meta["id"])
-    return ""
+    matches = [
+        str((item.get("metadata", {}) or {}).get("id") or "")
+        for item in projects
+        if (item.get("metadata", {}) or {}).get("name") == name
+        and (item.get("metadata", {}) or {}).get("id")
+    ]
+    if len(matches) > 1:
+        raise ValueError(
+            f"project name {name!r} is ambiguous under the selected tenant; "
+            "use an explicit project_id"
+        )
+    return matches[0] if matches else ""
+
+
+def _get_project(
+    nebius_bin: str, project_id: str, env: dict[str, str], profile: str = ""
+) -> dict[str, Any]:
+    """Return one exact provider project without exposing provider output."""
+
+    result = _run_capture(
+        [
+            *_nebius_argv(nebius_bin, profile),
+            "iam",
+            "project",
+            "get",
+            "--id",
+            project_id,
+            "--format",
+            "json",
+        ],
+        env=env,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"could not verify existing project (nebius exited {result.returncode})"
+        )
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise ValueError("could not parse existing project JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("existing project JSON is not an object")
+    return payload
+
+
+def _verify_existing_project(
+    payload: dict[str, Any],
+    *,
+    project_id: str,
+    tenant_id: str,
+    name: str,
+    region: str,
+) -> None:
+    """Fail closed unless a same-name resume has the exact requested identity."""
+
+    metadata = payload.get("metadata", {}) or {}
+    spec = payload.get("spec", {}) or {}
+    status = payload.get("status", {}) or {}
+    actual_region = str(
+        spec.get("region") or status.get("region") or metadata.get("region") or ""
+    )
+    mismatches: list[str] = []
+    if str(metadata.get("id") or "") != project_id:
+        mismatches.append("provider id does not match the listed project")
+    if str(metadata.get("name") or "") != name:
+        mismatches.append("display name changed after project listing")
+    if str(metadata.get("parent_id") or "") != tenant_id:
+        mismatches.append("project belongs to another tenant")
+    if region and actual_region != region:
+        mismatches.append(
+            f"project region {actual_region or '<unavailable>'!r} does not match "
+            f"requested region {region!r}"
+        )
+    if mismatches:
+        raise ValueError(
+            f"existing project {name!r} failed immutable identity verification: "
+            + "; ".join(mismatches)
+        )
 
 
 def _create_project(
@@ -577,6 +651,14 @@ def resolve_project_id(
     existing = _list_projects(nebius_bin, tenant_id, env, profile)
     found = _find_project_id(existing, name)
     if found:
+        verified = _get_project(nebius_bin, found, env, profile)
+        _verify_existing_project(
+            verified,
+            project_id=found,
+            tenant_id=tenant_id,
+            name=name,
+            region=region,
+        )
         _log(on_status, f"project {name!r} exists ({found})")
         return found, False
     if not create:
@@ -668,6 +750,128 @@ def _load_json_file(path: Path | None) -> dict[str, Any]:
 
 def _write_env_sidecar(install_dir: Path, data: dict[str, Any]) -> None:
     _write_json_file(install_dir / _ENV_SIDECAR, data)
+
+
+def _persist_npa_cluster_identity(
+    *,
+    context: str,
+    cluster_id: str,
+    project_id: str,
+    region: str,
+    cluster: ClusterSpec,
+    subnet_id: str,
+    kubeconfig_path: Path,
+    fleet_name: str,
+    project_key: str,
+    base_dir: Path | None = None,
+) -> None:
+    """Register a fleet cluster for project-scoped workflow/controller use."""
+
+    from npa.cluster.state import (
+        ClusterState,
+        kubeconfig_file,
+        load_cluster_state,
+        save_cluster_state,
+        utc_now_iso,
+    )
+
+    existing = load_cluster_state(context, base_dir=base_dir)
+    if existing is not None and (
+        existing.cluster_id != cluster_id or existing.project_id != project_id
+    ):
+        raise RuntimeError(
+            f"NPA cluster context {context!r} already records a different immutable "
+            "project/cluster identity; refusing to overwrite it"
+        )
+    if not kubeconfig_path.is_file():
+        raise RuntimeError(
+            "Fleet kubeconfig is unavailable; refusing to register incomplete "
+            "NPA cluster identity"
+        )
+    installed_kubeconfig = kubeconfig_file(context, base_dir=base_dir)
+    installed_kubeconfig.parent.mkdir(parents=True, exist_ok=True)
+    if kubeconfig_path.resolve() != installed_kubeconfig.resolve():
+        temporary: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=installed_kubeconfig.parent,
+                prefix=f".{installed_kubeconfig.name}.",
+                delete=False,
+            ) as handle:
+                with kubeconfig_path.open("rb") as source:
+                    shutil.copyfileobj(source, handle)
+                temporary = Path(handle.name)
+            temporary.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            os.replace(temporary, installed_kubeconfig)
+            temporary = None
+        finally:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+    else:
+        installed_kubeconfig.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    primary_pool = (
+        cluster.gpu_nodes
+        if cluster.gpu_nodes and cluster.gpu_nodes.count > 0
+        else cluster.cpu_nodes
+    )
+    state = ClusterState(
+        name=context,
+        cluster_id=cluster_id,
+        project_id=project_id,
+        region=region,
+        node_count=cluster.cpu_count() + cluster.gpu_count(),
+        node_platform=str(primary_pool.platform if primary_pool else ""),
+        node_preset=str(primary_pool.preset if primary_pool else ""),
+        k8s_version=cluster.k8s_version,
+        subnet_id=subnet_id,
+        created_at=existing.created_at if existing else utc_now_iso(),
+        last_seen_state="RUNNING",
+        last_seen_at=utc_now_iso(),
+        node_group_id=existing.node_group_id if existing else "",
+        endpoint=existing.endpoint if existing else "",
+        kubeconfig_path=str(installed_kubeconfig),
+        provider_name=cluster.name,
+    )
+    save_cluster_state(
+        state,
+        base_dir=base_dir,
+        metadata={
+            "managed_by": "npa fleet",
+            "fleet": fleet_name,
+            "project_key": project_key,
+            "event": "kubeconfig_written",
+            "updated_at": utc_now_iso(),
+            "teardown": (
+                "Run `npa fleet destroy --spec <fleet-spec.yaml> "
+                f"--only-projects {project_key} --only-clusters {cluster.name} --yes`."
+            ),
+        },
+    )
+
+
+def _remove_npa_cluster_identity(
+    *,
+    context: str,
+    cluster_id: str,
+    project_id: str,
+    base_dir: Path | None = None,
+) -> None:
+    """Remove only the exact fleet identity after authoritative cloud teardown."""
+
+    if not context:
+        return
+    from npa.cluster.state import delete_cluster_state, load_cluster_state
+
+    existing = load_cluster_state(context, base_dir=base_dir)
+    if existing is None:
+        return
+    if existing.cluster_id != cluster_id or existing.project_id != project_id:
+        raise RuntimeError(
+            f"NPA cluster context {context!r} no longer matches the fleet's immutable "
+            "project/cluster identity; local identity was preserved"
+        )
+    delete_cluster_state(context, base_dir=base_dir)
 
 
 def _load_env_sidecar(install_dir: Path) -> dict[str, str] | None:
@@ -1355,9 +1559,11 @@ def deploy_fleet(
         "k8s_training_source": str(recipe_root),
     }
 
-    # Phase 0: quota preflight, before any project is created. Regions come from
-    # the spec, so this needs no project ids -- and running it first means a
-    # quota-blocked deploy does not leave a freshly created, empty project behind.
+    # Phase 0: quota preflight, before any project is created. An exact
+    # provider-present target whose saved rendered shape still matches the spec
+    # has zero incremental demand. Everything else is conservatively treated as
+    # new capacity, so missing/stale local state can never bypass preflight or
+    # leave a newly created project behind when quota is unavailable.
     preflight_project_ids: dict[str, str] = {}
     if preflight:
         scoped: dict[str, list[ClusterSpec]] = {}
@@ -1370,6 +1576,24 @@ def deploy_fleet(
             project_has_scoped_cluster = False
             for cluster in project.clusters:
                 if only_clusters and cluster.name not in only_clusters:
+                    continue
+                if _is_verified_unchanged_target(
+                    project=project,
+                    cluster=cluster,
+                    prefix=prefix,
+                    tenant_id=tenant_id,
+                    region=region,
+                    ssh_public_key=ssh_public_key,
+                    fleet_root=fleet_root,
+                    nebius_bin=nebius_bin,
+                    profile=nebius_profile,
+                    env=cli_env,
+                ):
+                    _log(
+                        on_status,
+                        f"capacity/quota preflight: {project.key()}/{cluster.name} "
+                        "is provider-verified and unchanged; incremental demand is zero",
+                    )
                     continue
                 scoped.setdefault(region, []).append(cluster)
                 project_has_scoped_cluster = True
@@ -1545,6 +1769,174 @@ def deploy_fleet(
     return result
 
 
+def _is_verified_unchanged_target(
+    *,
+    project: ProjectSpec,
+    cluster: ClusterSpec,
+    prefix: str,
+    tenant_id: str,
+    region: str,
+    ssh_public_key: str,
+    fleet_root: Path,
+    nebius_bin: str,
+    profile: str,
+    env: dict[str, str],
+) -> bool:
+    """Prove that a target consumes no *additional* quota on this deploy."""
+
+    install_dir = fleet_root / project.key() / cluster.name
+    saved = _load_env_sidecar(install_dir) or {}
+    project_id = str(saved.get("project_id") or "")
+    cluster_id = str(saved.get("cluster_id") or "")
+    if (
+        str(saved.get("status") or "") != "deployed"
+        or not project_id
+        or not cluster_id
+        or str(saved.get("tenant_id") or "") != tenant_id
+        or str(saved.get("region") or "") != region
+        or str(saved.get("cluster_name") or "") != cluster.name
+    ):
+        return False
+    if project.project_id and project.project_id != project_id:
+        return False
+    tfvars_path = install_dir / _K8S_TRAINING_SUBDIR / "terraform.tfvars"
+    try:
+        if tfvars_path.read_text(encoding="utf-8") != render_tfvars(
+            cluster, ssh_public_key=ssh_public_key
+        ):
+            return False
+        provider_project = _get_project(nebius_bin, project_id, env, profile)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    metadata = provider_project.get("metadata", {}) or {}
+    project_spec = provider_project.get("spec", {}) or {}
+    project_status = provider_project.get("status", {}) or {}
+    provider_region = str(
+        project_spec.get("region")
+        or project_status.get("region")
+        or metadata.get("region")
+        or ""
+    )
+    expected_name = project.display_name(prefix) if project.name else ""
+    if (
+        str(metadata.get("id") or "") != project_id
+        or str(metadata.get("parent_id") or "") != tenant_id
+        or provider_region != region
+        or (expected_name and str(metadata.get("name") or "") != expected_name)
+    ):
+        return False
+
+    cluster_result = _run_capture(
+        [
+            *_nebius_argv(nebius_bin, profile),
+            "mk8s",
+            "cluster",
+            "get",
+            "--id",
+            cluster_id,
+            "--format",
+            "json",
+        ],
+        env=env,
+        check=False,
+    )
+    groups_result = _run_capture(
+        [
+            *_nebius_argv(nebius_bin, profile),
+            "mk8s",
+            "node-group",
+            "list",
+            "--parent-id",
+            cluster_id,
+            "--format",
+            "json",
+        ],
+        env=env,
+        check=False,
+    )
+    if cluster_result.returncode != 0 or groups_result.returncode != 0:
+        return False
+    try:
+        provider_cluster = json.loads(cluster_result.stdout or "{}")
+        groups_payload = json.loads(groups_result.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(provider_cluster, dict) or not isinstance(groups_payload, dict):
+        return False
+    cluster_metadata = provider_cluster.get("metadata", {}) or {}
+    cluster_status = provider_cluster.get("status", {}) or {}
+    if (
+        str(cluster_metadata.get("id") or "") != cluster_id
+        or str(cluster_metadata.get("parent_id") or "") != project_id
+        or str(cluster_metadata.get("name") or "") != cluster.name
+        or str(cluster_status.get("state") or "") != "RUNNING"
+    ):
+        return False
+    groups = groups_payload.get("items", [])
+    if not isinstance(groups, list):
+        return False
+    expected_pools = [
+        pool
+        for pool in (cluster.cpu_nodes, cluster.gpu_nodes)
+        if pool is not None and pool.count > 0
+    ]
+    if len(groups) != len(expected_pools):
+        return False
+
+    unmatched = [item for item in groups if isinstance(item, dict)]
+    if len(unmatched) != len(groups):
+        return False
+    for pool in expected_pools:
+        match_index = next(
+            (
+                index
+                for index, item in enumerate(unmatched)
+                if _provider_node_group_matches_pool(item, pool)
+            ),
+            None,
+        )
+        if match_index is None:
+            return False
+        unmatched.pop(match_index)
+    return not unmatched
+
+
+def _provider_node_group_matches_pool(
+    payload: dict[str, Any], pool: NodePoolSpec
+) -> bool:
+    """Compare one provider node-group payload with one desired pool."""
+
+    spec = payload.get("spec", {}) or {}
+    status = payload.get("status", {}) or {}
+    template = spec.get("template", {}) or {}
+    resources = template.get("resources", {}) or {}
+    reservation = template.get("reservation_policy", {}) or {}
+    reservation_ids = (
+        reservation.get("reservation_ids", []) if isinstance(reservation, dict) else []
+    )
+    try:
+        fixed_node_count = int(spec.get("fixed_node_count") or 0)
+    except (TypeError, ValueError):
+        return False
+    if (
+        str(status.get("state") or "") != "RUNNING"
+        or fixed_node_count != pool.count
+        or str(resources.get("platform") or "") != pool.platform
+        or str(resources.get("preset") or "") != pool.preset
+        or bool(template.get("preemptible"))
+    ):
+        return False
+    if pool.capacity_block_group:
+        return (
+            isinstance(reservation, dict)
+            and str(reservation.get("policy") or "") == "STRICT"
+            and reservation_ids == [pool.capacity_block_group]
+        )
+    return not reservation_ids and not (
+        isinstance(reservation, dict) and reservation.get("policy")
+    )
+
+
 def _preflight_quotas(
     nebius_bin: str,
     *,
@@ -1710,6 +2102,17 @@ def _deploy_one_cluster(
         try:
             _write_kubeconfig(
                 nebius_bin, cluster_id, kubeconfig_path, context, env, profile
+            )
+            _persist_npa_cluster_identity(
+                context=context,
+                cluster_id=cluster_id,
+                project_id=project_id,
+                region=region,
+                cluster=cluster,
+                subnet_id=subnet_id,
+                kubeconfig_path=kubeconfig_path,
+                fleet_name=spec.name,
+                project_key=project_key,
             )
         except Exception as exc:  # noqa: BLE001 - retain applied state for credential retry
             message = str(exc)
@@ -2301,7 +2704,28 @@ def _destroy_one_cluster(
         }
 
     # Terraform is the authoritative owner of all recipe resources. Only after
-    # its successful destroy may the local state be removed.
+    # its successful destroy may the exact global cluster identity and local
+    # fleet state be removed.
+    try:
+        _remove_npa_cluster_identity(
+            context=str(saved.get("context") or ""),
+            cluster_id=str(saved.get("cluster_id") or ""),
+            project_id=project_id,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        errors.append(
+            f"cloud teardown succeeded but NPA cluster identity cleanup failed: "
+            f"{type(exc).__name__}"
+        )
+        return {
+            "project_key": project.key(),
+            "cluster_name": cluster.name,
+            "status": "destroy-incomplete",
+            "errors": errors,
+            "retry_command": retry_command,
+            "install_dir": str(install_dir),
+            **log_metadata,
+        }
     try:
         shutil.rmtree(install_dir)
     except OSError as exc:

--- a/npa/src/npa/fleet/lifecycle.py
+++ b/npa/src/npa/fleet/lifecycle.py
@@ -397,6 +397,26 @@ def _get_project(
     return payload
 
 
+_PROVIDER_FIELD_MISSING = object()
+
+
+def _provider_field(
+    payload: object, *spellings: str
+) -> object:
+    """Read one provider field defensively across wire-format spellings.
+
+    Multiple spellings are accepted only when their values agree. Missing or
+    contradictory evidence stays unknown so identity/shape checks fail closed.
+    """
+
+    if not isinstance(payload, dict):
+        return _PROVIDER_FIELD_MISSING
+    values = [payload[key] for key in spellings if key in payload]
+    if not values or any(value != values[0] for value in values[1:]):
+        return _PROVIDER_FIELD_MISSING
+    return values[0]
+
+
 def _verify_existing_project(
     payload: dict[str, Any],
     *,
@@ -418,7 +438,8 @@ def _verify_existing_project(
         mismatches.append("provider id does not match the listed project")
     if str(metadata.get("name") or "") != name:
         mismatches.append("display name changed after project listing")
-    if str(metadata.get("parent_id") or "") != tenant_id:
+    parent_id = _provider_field(metadata, "parent_id", "parentId")
+    if str(parent_id if parent_id is not _PROVIDER_FIELD_MISSING else "") != tenant_id:
         mismatches.append("project belongs to another tenant")
     if region and actual_region != region:
         mismatches.append(
@@ -1818,9 +1839,15 @@ def _is_verified_unchanged_target(
         or ""
     )
     expected_name = project.display_name(prefix) if project.name else ""
+    provider_parent_id = _provider_field(metadata, "parent_id", "parentId")
     if (
         str(metadata.get("id") or "") != project_id
-        or str(metadata.get("parent_id") or "") != tenant_id
+        or str(
+            provider_parent_id
+            if provider_parent_id is not _PROVIDER_FIELD_MISSING
+            else ""
+        )
+        != tenant_id
         or provider_region != region
         or (expected_name and str(metadata.get("name") or "") != expected_name)
     ):
@@ -1865,9 +1892,17 @@ def _is_verified_unchanged_target(
         return False
     cluster_metadata = provider_cluster.get("metadata", {}) or {}
     cluster_status = provider_cluster.get("status", {}) or {}
+    cluster_parent_id = _provider_field(
+        cluster_metadata, "parent_id", "parentId"
+    )
     if (
         str(cluster_metadata.get("id") or "") != cluster_id
-        or str(cluster_metadata.get("parent_id") or "") != project_id
+        or str(
+            cluster_parent_id
+            if cluster_parent_id is not _PROVIDER_FIELD_MISSING
+            else ""
+        )
+        != project_id
         or str(cluster_metadata.get("name") or "") != cluster.name
         or str(cluster_status.get("state") or "") != "RUNNING"
     ):
@@ -1910,12 +1945,29 @@ def _provider_node_group_matches_pool(
     status = payload.get("status", {}) or {}
     template = spec.get("template", {}) or {}
     resources = template.get("resources", {}) or {}
-    reservation = template.get("reservation_policy", {}) or {}
-    reservation_ids = (
-        reservation.get("reservation_ids", []) if isinstance(reservation, dict) else []
+    reservation_value = _provider_field(
+        template, "reservation_policy", "reservationPolicy"
     )
+    if reservation_value is _PROVIDER_FIELD_MISSING:
+        reservation: dict[str, Any] = {}
+    elif isinstance(reservation_value, dict):
+        reservation = reservation_value
+    else:
+        return False
+    reservation_ids_value = _provider_field(
+        reservation, "reservation_ids", "reservationIds"
+    )
+    reservation_ids = (
+        []
+        if reservation_ids_value is _PROVIDER_FIELD_MISSING
+        else reservation_ids_value
+    )
+    fixed_node_count_value = _provider_field(
+        spec, "fixed_node_count", "fixedNodeCount"
+    )
+    preemptible = _provider_field(template, "preemptible")
     try:
-        fixed_node_count = int(spec.get("fixed_node_count") or 0)
+        fixed_node_count = int(fixed_node_count_value)
     except (TypeError, ValueError):
         return False
     if (
@@ -1923,7 +1975,9 @@ def _provider_node_group_matches_pool(
         or fixed_node_count != pool.count
         or str(resources.get("platform") or "") != pool.platform
         or str(resources.get("preset") or "") != pool.preset
-        or bool(template.get("preemptible"))
+        # Absence, relocation, or non-boolean data cannot prove an on-demand
+        # pool. Only an explicit provider boolean false is sufficient.
+        or preemptible is not False
     ):
         return False
     if pool.capacity_block_group:

--- a/npa/src/npa/orchestration/skypilot/k8s_gpu_catalog.py
+++ b/npa/src/npa/orchestration/skypilot/k8s_gpu_catalog.py
@@ -178,14 +178,29 @@ def discover_kubernetes_gpu_inventory(
             eligible_nodes += 1
             allocatable += node_allocatable
             capacity += node_capacity
-            for key, value in raw_labels.items():
-                if key in {
-                    "nvidia.com/gpu.product",
-                    "nebius.com/gpu",
-                    "node.kubernetes.io/instance-type",
-                } or "product" in key.casefold():
-                    if value:
-                        products.add(value)
+            # Report one canonical product per node. Nebius and GPU Feature
+            # Discovery can advertise two aliases for the same physical card;
+            # treating both as separate products makes a homogeneous pool look
+            # heterogeneous in CLI readiness output.
+            product = next(
+                (
+                    raw_labels.get(key, "")
+                    for key in ("nvidia.com/gpu.product", "nebius.com/gpu-name")
+                    if raw_labels.get(key)
+                ),
+                "",
+            )
+            if not product:
+                product = next(
+                    (
+                        value
+                        for key, value in sorted(raw_labels.items())
+                        if "product" in key.casefold() and value
+                    ),
+                    "",
+                )
+            if product:
+                products.add(product)
     return KubernetesGpuInventory(
         context=context,
         ready_nodes=ready_nodes,
@@ -312,7 +327,115 @@ def discover_kubernetes_gpu_catalog(
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or f"exit {result.returncode}").strip()
         raise KubernetesGpuCatalogError(f"`{' '.join(cmd)}` failed: {detail}")
-    return parse_kubernetes_gpu_catalog(output, context=context)
+    catalog = parse_kubernetes_gpu_catalog(output, context=context)
+    if catalog.is_empty and context:
+        labelled = label_known_kubernetes_gpus_for_skypilot(context=context)
+        if labelled:
+            try:
+                result = execute(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=timeout,
+                    check=False,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                raise KubernetesGpuCatalogError(
+                    f"Unable to rerun `{' '.join(cmd)}` after GPU labelling: {exc}"
+                ) from exc
+            output = "\n".join(
+                part for part in (result.stdout, result.stderr) if part
+            )
+            if result.returncode != 0:
+                detail = (
+                    result.stderr or result.stdout or f"exit {result.returncode}"
+                ).strip()
+                raise KubernetesGpuCatalogError(
+                    f"`{' '.join(cmd)}` failed after GPU labelling: {detail}"
+                )
+            catalog = parse_kubernetes_gpu_catalog(output, context=context)
+    return catalog
+
+
+_KNOWN_SKYPILOT_LABELS = {
+    "rtx6000": "rtxpro6000",
+    "rtxpro6000": "rtxpro6000",
+    "rtxpro6000blackwellserveredition": "rtxpro6000",
+    "nvidiartxpro6000blackwellserveredition": "rtxpro6000",
+}
+
+
+def _known_skypilot_label(labels: dict[str, str]) -> str:
+    for key in ("nvidia.com/gpu.product", "nebius.com/gpu-name"):
+        normalized = _normalize(labels.get(key, ""))
+        if normalized in _KNOWN_SKYPILOT_LABELS:
+            return _KNOWN_SKYPILOT_LABELS[normalized]
+    return ""
+
+
+def label_known_kubernetes_gpus_for_skypilot(
+    *,
+    context: str,
+    inventory: KubernetesGpuInventory | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> int:
+    """Add SkyPilot labels only for exact, reviewed GFD product aliases.
+
+    SkyPilot 0.12.2 treats any GFD label as "already labelled", but its GPU name
+    catalog does not yet recognize the RTX PRO 6000 Blackwell product string.
+    Its own ``sky gpus label`` therefore performs no mutation while
+    ``sky gpus list`` remains empty.  NPA bridges only explicit equivalences;
+    unknown or adjacent products remain untouched and fail closed.
+    """
+
+    exact_context = str(context or "").strip()
+    if not exact_context:
+        raise KubernetesGpuCatalogError(
+            "Refusing to label GPUs without an exact Kubernetes context"
+        )
+    observed = inventory or discover_kubernetes_gpu_inventory(context=exact_context)
+    if observed.error:
+        raise KubernetesGpuCatalogError(
+            f"Cannot label GPUs because Kubernetes inventory failed: {observed.error}"
+        )
+    execute = runner or subprocess.run
+    labelled = 0
+    for node, labels in observed.node_labels.items():
+        if labels.get("skypilot.co/accelerator"):
+            continue
+        accelerator = _known_skypilot_label(labels)
+        if not accelerator:
+            continue
+        cmd = [
+            "kubectl",
+            "--context",
+            exact_context,
+            "label",
+            "node",
+            node,
+            f"skypilot.co/accelerator={accelerator}",
+        ]
+        try:
+            result = execute(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise KubernetesGpuCatalogError(
+                "Could not add the reviewed SkyPilot accelerator label to a GPU node"
+            ) from exc
+        if result.returncode != 0:
+            raise KubernetesGpuCatalogError(
+                "Could not add the reviewed SkyPilot accelerator label to a GPU node; "
+                "the existing node labels were preserved"
+            )
+        labelled += 1
+    return labelled
 
 
 def kubernetes_allocatable_gpu_count(

--- a/npa/src/npa/orchestration/skypilot/k8s_gpu_catalog.py
+++ b/npa/src/npa/orchestration/skypilot/k8s_gpu_catalog.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 import json
+import os
+from pathlib import Path
 import re
 import subprocess
 import time
@@ -42,6 +44,48 @@ class UnsatisfiableAcceleratorError(ValueError):
 
 class PermanentlyUnsatisfiableAcceleratorError(UnsatisfiableAcceleratorError):
     """Raised when more discovery time cannot make the request schedulable."""
+
+
+Kubeconfig = str | os.PathLike[str] | None
+
+
+def exact_kubernetes_context_config(context: str) -> str:
+    """Return SkyPilot's exact single-context configuration override."""
+
+    exact_context = str(context or "").strip()
+    if not exact_context:
+        return ""
+    allowed_contexts = json.dumps([exact_context], separators=(",", ":"))
+    return f"kubernetes.allowed_contexts={allowed_contexts}"
+
+
+def _kubeconfig_env(kubeconfig: Kubeconfig) -> dict[str, str] | None:
+    if kubeconfig is None or not os.fspath(kubeconfig).strip():
+        return None
+    env = os.environ.copy()
+    env["KUBECONFIG"] = str(Path(kubeconfig).expanduser())
+    return env
+
+
+def _kubectl_failure(*, action: str, returncode: int, output: str) -> str:
+    """Classify kubectl failures without echoing raw private resource details."""
+
+    lowered = str(output or "").casefold()
+    if "forbidden" in lowered or "cannot list resource" in lowered:
+        return (
+            f"Kubernetes RBAC denied {action} in the exact context; grant the "
+            "operator get/list access to nodes and patch/update access when label "
+            "repair is requested"
+        )
+    if "unauthorized" in lowered or "authentication" in lowered:
+        return (
+            f"Kubernetes authentication failed while {action} in the exact context; "
+            "refresh the selected kubeconfig credentials"
+        )
+    return (
+        f"kubectl failed while {action} in the exact context (exit {returncode}); "
+        "verify the selected kubeconfig, context, API reachability, and node RBAC"
+    )
 
 
 @dataclass(frozen=True)
@@ -112,11 +156,14 @@ class KubernetesGpuInventory:
 def discover_kubernetes_gpu_inventory(
     *,
     context: str = "",
+    kubeconfig: Kubeconfig = None,
     runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
 ) -> KubernetesGpuInventory:
     """Read Ready/schedulable nodes, GPU quantities, and raw product labels."""
 
     cmd = ["kubectl"]
+    if kubeconfig is not None and os.fspath(kubeconfig).strip():
+        cmd.extend(["--kubeconfig", str(Path(kubeconfig).expanduser())])
     if context:
         cmd.extend(["--context", context])
     cmd.extend(["get", "nodes", "-o", "json"])
@@ -129,10 +176,22 @@ def discover_kubernetes_gpu_inventory(
             text=True,
             timeout=30,
             check=False,
+            env=_kubeconfig_env(kubeconfig),
         )
         if result.returncode != 0:
             return KubernetesGpuInventory(
-                context, 0, 0, 0, 0, (), {}, "kubectl node inventory failed"
+                context,
+                0,
+                0,
+                0,
+                0,
+                (),
+                {},
+                _kubectl_failure(
+                    action="reading GPU node inventory",
+                    returncode=result.returncode,
+                    output=result.stderr or result.stdout,
+                ),
             )
         payload = json.loads(result.stdout or "{}")
     except (OSError, ValueError, subprocess.SubprocessError):
@@ -300,6 +359,7 @@ def parse_kubernetes_gpu_catalog(
 def discover_kubernetes_gpu_catalog(
     *,
     context: str = "",
+    kubeconfig: Kubeconfig = None,
     sky_bin: SkyBin = None,
     timeout: int = DEFAULT_DISCOVERY_TIMEOUT_SECONDS,
     runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
@@ -309,6 +369,9 @@ def discover_kubernetes_gpu_catalog(
     sky_executable = str(resolve_sky_bin(sky_bin))
     infra = f"k8s/{context}" if context else "k8s"
     cmd = [sky_executable, "show-gpus", "--infra", infra]
+    config_override = exact_kubernetes_context_config(context)
+    if config_override:
+        cmd[2:2] = ["--config", config_override]
     execute = runner or subprocess.run
     try:
         result = execute(
@@ -318,6 +381,7 @@ def discover_kubernetes_gpu_catalog(
             text=True,
             timeout=timeout,
             check=False,
+            env=_kubeconfig_env(kubeconfig),
         )
     except (OSError, subprocess.SubprocessError) as exc:
         raise KubernetesGpuCatalogError(
@@ -327,35 +391,7 @@ def discover_kubernetes_gpu_catalog(
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or f"exit {result.returncode}").strip()
         raise KubernetesGpuCatalogError(f"`{' '.join(cmd)}` failed: {detail}")
-    catalog = parse_kubernetes_gpu_catalog(output, context=context)
-    if catalog.is_empty and context:
-        labelled = label_known_kubernetes_gpus_for_skypilot(context=context)
-        if labelled:
-            try:
-                result = execute(
-                    cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    timeout=timeout,
-                    check=False,
-                )
-            except (OSError, subprocess.SubprocessError) as exc:
-                raise KubernetesGpuCatalogError(
-                    f"Unable to rerun `{' '.join(cmd)}` after GPU labelling: {exc}"
-                ) from exc
-            output = "\n".join(
-                part for part in (result.stdout, result.stderr) if part
-            )
-            if result.returncode != 0:
-                detail = (
-                    result.stderr or result.stdout or f"exit {result.returncode}"
-                ).strip()
-                raise KubernetesGpuCatalogError(
-                    f"`{' '.join(cmd)}` failed after GPU labelling: {detail}"
-                )
-            catalog = parse_kubernetes_gpu_catalog(output, context=context)
-    return catalog
+    return parse_kubernetes_gpu_catalog(output, context=context)
 
 
 _KNOWN_SKYPILOT_LABELS = {
@@ -377,6 +413,7 @@ def _known_skypilot_label(labels: dict[str, str]) -> str:
 def label_known_kubernetes_gpus_for_skypilot(
     *,
     context: str,
+    kubeconfig: Kubeconfig = None,
     inventory: KubernetesGpuInventory | None = None,
     runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
 ) -> int:
@@ -394,7 +431,9 @@ def label_known_kubernetes_gpus_for_skypilot(
         raise KubernetesGpuCatalogError(
             "Refusing to label GPUs without an exact Kubernetes context"
         )
-    observed = inventory or discover_kubernetes_gpu_inventory(context=exact_context)
+    observed = inventory or discover_kubernetes_gpu_inventory(
+        context=exact_context, kubeconfig=kubeconfig
+    )
     if observed.error:
         raise KubernetesGpuCatalogError(
             f"Cannot label GPUs because Kubernetes inventory failed: {observed.error}"
@@ -409,13 +448,19 @@ def label_known_kubernetes_gpus_for_skypilot(
             continue
         cmd = [
             "kubectl",
-            "--context",
-            exact_context,
-            "label",
-            "node",
-            node,
-            f"skypilot.co/accelerator={accelerator}",
         ]
+        if kubeconfig is not None and os.fspath(kubeconfig).strip():
+            cmd.extend(["--kubeconfig", str(Path(kubeconfig).expanduser())])
+        cmd.extend(
+            [
+                "--context",
+                exact_context,
+                "label",
+                "node",
+                node,
+                f"skypilot.co/accelerator={accelerator}",
+            ]
+        )
         try:
             result = execute(
                 cmd,
@@ -424,15 +469,21 @@ def label_known_kubernetes_gpus_for_skypilot(
                 text=True,
                 timeout=30,
                 check=False,
+                env=_kubeconfig_env(kubeconfig),
             )
         except (OSError, subprocess.SubprocessError) as exc:
             raise KubernetesGpuCatalogError(
-                "Could not add the reviewed SkyPilot accelerator label to a GPU node"
+                "Could not run kubectl for the explicitly requested GPU label repair; "
+                "verify kubectl installation and the exact kubeconfig/context"
             ) from exc
         if result.returncode != 0:
             raise KubernetesGpuCatalogError(
-                "Could not add the reviewed SkyPilot accelerator label to a GPU node; "
-                "the existing node labels were preserved"
+                _kubectl_failure(
+                    action="repairing the reviewed SkyPilot GPU node label",
+                    returncode=result.returncode,
+                    output=result.stderr or result.stdout,
+                )
+                + "; existing node labels were preserved"
             )
         labelled += 1
     return labelled
@@ -441,11 +492,14 @@ def label_known_kubernetes_gpus_for_skypilot(
 def kubernetes_allocatable_gpu_count(
     *,
     context: str = "",
+    kubeconfig: Kubeconfig = None,
     runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
 ) -> int | None:
     """Return Kubernetes' allocatable GPU total, or ``None`` when unavailable."""
 
-    inventory = discover_kubernetes_gpu_inventory(context=context, runner=runner)
+    inventory = discover_kubernetes_gpu_inventory(
+        context=context, kubeconfig=kubeconfig, runner=runner
+    )
     return None if inventory.error else inventory.allocatable
 
 
@@ -453,7 +507,9 @@ def wait_for_kubernetes_accelerators(
     accelerators: list[str],
     *,
     context: str = "",
+    kubeconfig: Kubeconfig = None,
     sky_bin: SkyBin = None,
+    label_known_gpus: bool = False,
     timeout: float = DEFAULT_READINESS_TIMEOUT_SECONDS,
     poll_interval: float = DEFAULT_READINESS_POLL_SECONDS,
     discover: Callable[[], KubernetesGpuCatalog] | None = None,
@@ -465,35 +521,83 @@ def wait_for_kubernetes_accelerators(
     """Wait until both Kubernetes and SkyPilot see every requested accelerator.
 
     Kubernetes allocatable capacity is reported independently because it can be
-    healthy minutes before SkyPilot's catalog has consumed the node labels.  A
-    timeout is observational only: it never deletes or scales the cluster.
+    healthy minutes before SkyPilot's catalog has consumed the node labels.
+    Discovery is read-only by default. Setup callers may explicitly opt into the
+    narrow, idempotent known-product label repair with ``label_known_gpus=True``;
+    a timeout never deletes or scales the cluster.
     """
 
     if timeout <= 0 or poll_interval <= 0:
         raise ValueError("GPU readiness timeout and poll interval must be positive")
-    requested = [item for item in accelerators if str(item).strip()]
+    requested = [str(item).strip() for item in accelerators if str(item).strip()]
+    initial_inventory: KubernetesGpuInventory | None = None
+    if label_known_gpus:
+        if not str(context or "").strip():
+            raise KubernetesGpuCatalogError(
+                "Refusing explicit GPU label repair without an exact Kubernetes context"
+            )
+        initial_inventory = discover_kubernetes_gpu_inventory(
+            context=context, kubeconfig=kubeconfig
+        )
+        if on_status:
+            on_status(
+                "GPU label mutation requested: exact-context known-product repair "
+                "is enabled"
+            )
+        labelled = label_known_kubernetes_gpus_for_skypilot(
+            context=context,
+            kubeconfig=kubeconfig,
+            inventory=initial_inventory,
+        )
+        if on_status:
+            on_status(
+                f"GPU label mutation: added {labelled} reviewed "
+                "skypilot.co/accelerator label(s)"
+                if labelled
+                else "GPU label mutation: no label changes were required"
+            )
+        if not requested:
+            known = sorted(
+                {
+                    labels.get("skypilot.co/accelerator")
+                    or _known_skypilot_label(labels)
+                    for labels in initial_inventory.node_labels.values()
+                }
+                - {""}
+            )
+            if not known:
+                raise KubernetesGpuCatalogError(
+                    "SkyPilot smoke auto-detection found no reviewed GPU product "
+                    "mapping in the exact Kubernetes context; pass an explicit "
+                    "accelerator after confirming the node product"
+                )
+            requested = [f"{known[0]}:1"]
     if not requested:
         return {}
     get_catalog = discover or (
         lambda: discover_kubernetes_gpu_catalog(
             context=context,
+            kubeconfig=kubeconfig,
             sky_bin=sky_bin,
             timeout=max(1, min(int(timeout), DEFAULT_DISCOVERY_TIMEOUT_SECONDS)),
         )
     )
     get_allocatable = allocatable or (
-        lambda: kubernetes_allocatable_gpu_count(context=context)
+        lambda: kubernetes_allocatable_gpu_count(
+            context=context, kubeconfig=kubeconfig
+        )
     )
     deadline = monotonic() + timeout
     last_failure = "SkyPilot accelerator catalog has not been queried"
     attempt = 0
     while True:
         attempt += 1
-        inventory = (
-            discover_kubernetes_gpu_inventory(context=context)
-            if allocatable is None
-            else None
-        )
+        inventory = initial_inventory
+        initial_inventory = None
+        if inventory is None and allocatable is None:
+            inventory = discover_kubernetes_gpu_inventory(
+                context=context, kubeconfig=kubeconfig
+            )
         count = inventory.allocatable if inventory is not None and not inventory.error else get_allocatable()
         if on_status:
             shown = "unknown" if count is None else str(count)

--- a/npa/src/npa/provisioning.py
+++ b/npa/src/npa/provisioning.py
@@ -465,17 +465,6 @@ def provision_if_absent(
             )
             actions.append("k8s:validated stable GPU health and CUDA vectorAdd")
         k8s_ready = True
-        if sky_smoke and not dry_run:
-            from npa.cli.cluster.terraform_lifecycle import _run_skypilot_smoke
-
-            _run_skypilot_smoke(
-                Path(kubeconfig_path),
-                context,
-                cluster_name,
-                str(accelerator or ""),
-                sky_bin=sky_bin,
-            )
-            actions.append("sky-smoke:passed")
     elif not environment.project_id or not environment.tenant_id:
         warnings.append("project_id and tenant_id are required to ensure Kubernetes")
     elif dry_run:
@@ -525,8 +514,12 @@ def provision_if_absent(
                 context_name=context,
                 project=alias or "",
                 validate=validate,
-                sky_smoke=sky_smoke,
+                # Provisioning owns one shared cached/fresh GPU-readiness and
+                # smoke boundary below. Running smoke inside up_cmd would put
+                # the fresh path ahead of label repair and readiness.
+                sky_smoke=False,
                 sky_gpus="",
+                sky_bin=sky_bin,
                 capacity_block_group="",
                 gpu_nodes=gpu_nodes,
                 cpu_nodes=cpu_nodes,
@@ -550,15 +543,14 @@ def provision_if_absent(
         k8s_ready = True
 
     requested_accelerator = str(accelerator or "").strip()
-    if requested_accelerator and k8s_ready and not skip_k8s and not dry_run:
+    needs_gpu_setup = bool(requested_accelerator or sky_smoke)
+    if needs_gpu_setup and k8s_ready and not skip_k8s and not dry_run:
         from npa.controller_ownership import ensure_controller_owner
+        from npa.cli.cluster.terraform_lifecycle import _run_skypilot_smoke
         from npa.orchestration.skypilot.k8s_gpu_catalog import (
-            KubernetesGpuCatalogError,
             wait_for_kubernetes_accelerators,
         )
 
-        previous_kubeconfig = os.environ.get("KUBECONFIG")
-        os.environ["KUBECONFIG"] = str(kubeconfig_path)
         try:
             owner = ensure_controller_owner(alias, context)
             actions.append(
@@ -574,15 +566,28 @@ def provision_if_absent(
                     operation.heartbeat(details={"gpu_readiness": message})
 
             wait_for_kubernetes_accelerators(
-                [requested_accelerator],
+                [requested_accelerator] if requested_accelerator else [],
                 context=context,
+                kubeconfig=kubeconfig_path,
                 sky_bin=sky_bin or None,
+                label_known_gpus=True,
                 timeout=gpu_readiness_timeout,
                 poll_interval=gpu_readiness_poll_interval,
                 on_status=report_gpu_status,
             )
-        except (KubernetesGpuCatalogError, RuntimeError, ValueError) as exc:
-            gpu_readiness = "timeout"
+            if sky_smoke:
+                _run_skypilot_smoke(
+                    Path(kubeconfig_path),
+                    context,
+                    cluster_name,
+                    requested_accelerator,
+                    sky_bin=sky_bin,
+                )
+                actions.append("sky-smoke:passed")
+        except Exception as exc:  # noqa: BLE001 - return a resumable partial result
+            gpu_readiness = (
+                "timeout" if str(exc).startswith("Timed out after ") else "failed"
+            )
             warnings.append(str(exc))
             operation = current_operation()
             created_cluster = bool(
@@ -601,15 +606,16 @@ def provision_if_absent(
             )
         else:
             gpu_readiness = "ready"
-            actions.append(f"gpu:SkyPilot ready for {requested_accelerator}")
-        finally:
-            if previous_kubeconfig is None:
-                os.environ.pop("KUBECONFIG", None)
-            else:
-                os.environ["KUBECONFIG"] = previous_kubeconfig
-    elif requested_accelerator and dry_run:
+            actions.append(
+                "gpu:SkyPilot ready for "
+                + (requested_accelerator or "auto-detected smoke accelerator")
+            )
+    elif needs_gpu_setup and dry_run:
         gpu_readiness = "dry-run"
-        actions.append(f"gpu:dry-run wait for SkyPilot {requested_accelerator}")
+        actions.append(
+            "gpu:dry-run wait for SkyPilot "
+            + (requested_accelerator or "auto-detected smoke accelerator")
+        )
 
     status = "ok" if not warnings and (skip_s3 or storage_ready) else "partial"
     if dry_run:

--- a/npa/src/npa/provisioning.py
+++ b/npa/src/npa/provisioning.py
@@ -465,6 +465,17 @@ def provision_if_absent(
             )
             actions.append("k8s:validated stable GPU health and CUDA vectorAdd")
         k8s_ready = True
+        if sky_smoke and not dry_run:
+            from npa.cli.cluster.terraform_lifecycle import _run_skypilot_smoke
+
+            _run_skypilot_smoke(
+                Path(kubeconfig_path),
+                context,
+                cluster_name,
+                str(accelerator or ""),
+                sky_bin=sky_bin,
+            )
+            actions.append("sky-smoke:passed")
     elif not environment.project_id or not environment.tenant_id:
         warnings.append("project_id and tenant_id are required to ensure Kubernetes")
     elif dry_run:

--- a/npa/src/npa/provisioning_journal.py
+++ b/npa/src/npa/provisioning_journal.py
@@ -225,6 +225,38 @@ def _plan_differences(
     return differences
 
 
+_TOPOLOGY_PROGRESS_KEYS = frozenset(
+    {
+        "agent_exists",
+        "existing_cpu_nodes",
+        "existing_gpu_nodes",
+        "new_agent_instances",
+        "new_cpu_nodes",
+        "new_gpu_nodes",
+        "required_instances",
+        "required_disks",
+        "required_network_ssd_bytes",
+        "required_network_ssd_gib",
+        "required_public_ips",
+        "required_gpus",
+    }
+)
+
+
+def _immutable_plan_identity(plan: Mapping[str, Any]) -> dict[str, Any]:
+    """Return requested topology identity without provider-derived progress."""
+
+    identity = dict(plan)
+    topology = identity.get("topology")
+    if isinstance(topology, Mapping):
+        identity["topology"] = {
+            key: value
+            for key, value in topology.items()
+            if key not in _TOPOLOGY_PROGRESS_KEYS
+        }
+    return identity
+
+
 def _pid_is_alive(pid: int) -> bool:
     if pid <= 0:
         return False
@@ -1249,7 +1281,11 @@ class ProvisioningOperation:
                 "input_action",
             )
             differences = (
-                _plan_differences(existing, candidate, immutable_keys=immutable_keys)
+                _plan_differences(
+                    _immutable_plan_identity(existing),
+                    _immutable_plan_identity(candidate),
+                    immutable_keys=immutable_keys,
+                )
                 if isinstance(existing, dict)
                 else []
             )

--- a/npa/tests/cli/test_skypilot_bootstrap.py
+++ b/npa/tests/cli/test_skypilot_bootstrap.py
@@ -237,11 +237,14 @@ def _intercept_sky_check(monkeypatch: pytest.MonkeyPatch, captured: dict[str, ob
     original = skypilot_cli._run_no_raise
 
     def fake_run(cmd, *, env=None):  # noqa: ANN001 - test stub
-        if cmd[-1] == "check":
+        if "check" in cmd:
             captured["cmd"] = cmd
             captured["env"] = env
             return subprocess.CompletedProcess(
-                cmd, 0, stdout="checks passed", stderr=""
+                cmd,
+                0,
+                stdout="Kubernetes: enabled [compute]\nchecks passed",
+                stderr="",
             )
         return original(cmd, env=env)
 
@@ -265,6 +268,65 @@ def test_verify_pins_kubeconfig_from_flag(
     assert result.exit_code == 0, result.output
     assert captured["cmd"][-1] == "check"
     assert captured["env"]["KUBECONFIG"] == str(kubeconfig)
+
+
+def test_verify_scopes_existing_kubeconfig_to_its_current_context(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    kubeconfig = tmp_path / "kube.yaml"
+    kubeconfig.write_text(
+        "apiVersion: v1\ncurrent-context: fleet-exact\n", encoding="utf-8"
+    )
+    captured: dict[str, object] = {}
+    _intercept_sky_check(monkeypatch, captured)
+
+    result = runner.invoke(
+        app,
+        ["skypilot", "verify", "--path", str(venv), "--kubeconfig", str(kubeconfig)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["cmd"][-4:] == [
+        "check",
+        "--config",
+        'kubernetes.allowed_contexts=["fleet-exact"]',
+        "kubernetes",
+    ]
+
+
+def test_verify_rejects_zero_exit_when_kubernetes_is_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    original = skypilot_cli._run_no_raise
+
+    def fake_run(cmd, *, env=None):  # noqa: ANN001
+        if cmd[-1] == "check":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="Kubernetes: disabled\nNo infra to check/enabled.", stderr=""
+            )
+        return original(cmd, env=env)
+
+    monkeypatch.setattr(skypilot_cli, "_run_no_raise", fake_run)
+    result = runner.invoke(
+        app,
+        [
+            "skypilot",
+            "verify",
+            "--path",
+            str(venv),
+            "--controller-backend",
+            "kubernetes",
+            "--output-format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["status"] == "failed"
+    assert payload["kubernetes_enabled"] is False
 
 
 def test_verify_without_kubeconfig_inherits_ambient_env(
@@ -291,7 +353,10 @@ def test_verify_kubernetes_mode_marks_nebius_profile_optional(
             return subprocess.CompletedProcess(
                 cmd,
                 0,
-                stdout="Unable to create Nebius profile\nSetup completed\n",
+                stdout=(
+                    "Kubernetes: enabled [compute]\n"
+                    "Unable to create Nebius profile\nSetup completed\n"
+                ),
                 stderr="",
             )
         return original(cmd, env=env)

--- a/npa/tests/cli/test_skypilot_bootstrap.py
+++ b/npa/tests/cli/test_skypilot_bootstrap.py
@@ -329,6 +329,70 @@ def test_verify_rejects_zero_exit_when_kubernetes_is_disabled(
     assert payload["kubernetes_enabled"] is False
 
 
+def test_bare_verify_keeps_legacy_runtime_semantics_without_kubernetes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    original = skypilot_cli._run_no_raise
+
+    def fake_run(cmd, *, env=None):  # noqa: ANN001
+        if cmd[-1] == "check":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="Kubernetes: disabled\nchecks passed", stderr=""
+            )
+        return original(cmd, env=env)
+
+    monkeypatch.setattr(skypilot_cli, "_run_no_raise", fake_run)
+    result = runner.invoke(
+        app,
+        ["skypilot", "verify", "--path", str(venv), "--output-format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "ok"
+    assert payload["kubernetes_required"] is False
+    assert payload["kubernetes_enabled"] is False
+
+
+def test_verify_with_kubeconfig_requires_kubernetes_without_backend_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    venv = _fake_installed_venv(tmp_path / "sky-venv")
+    kubeconfig = tmp_path / "kube.yaml"
+    kubeconfig.write_text(
+        "apiVersion: v1\ncurrent-context: fleet-exact\n", encoding="utf-8"
+    )
+    original = skypilot_cli._run_no_raise
+
+    def fake_run(cmd, *, env=None):  # noqa: ANN001
+        if "check" in cmd:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="Kubernetes: disabled\nchecks passed", stderr=""
+            )
+        return original(cmd, env=env)
+
+    monkeypatch.setattr(skypilot_cli, "_run_no_raise", fake_run)
+    result = runner.invoke(
+        app,
+        [
+            "skypilot",
+            "verify",
+            "--path",
+            str(venv),
+            "--kubeconfig",
+            str(kubeconfig),
+            "--output-format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["kubernetes_required"] is True
+    assert payload["kubernetes_enabled"] is False
+
+
 def test_verify_without_kubeconfig_inherits_ambient_env(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/npa/tests/cli/test_submit_preflight_and_accelerators.py
+++ b/npa/tests/cli/test_submit_preflight_and_accelerators.py
@@ -20,6 +20,7 @@ from npa.orchestration.skypilot.image_bootstrap_contract import (
 )
 from npa.orchestration.skypilot.k8s_gpu_catalog import KubernetesGpuCatalog
 from npa.orchestration.skypilot.registry_preflight import ImagePullCheck
+from npa.orchestration.skypilot.workflow import SkyPilotSubmitError
 
 
 runner = CliRunner()
@@ -47,6 +48,49 @@ SPEC = {
         "done": {"terminal": True},
     },
 }
+
+
+class _RecordingOperation:
+    def __init__(self) -> None:
+        self.rollback: dict[str, object] | None = None
+        self.transitions: list[tuple[str, dict[str, object]]] = []
+
+    def record_rollback(self, **kwargs) -> None:  # noqa: ANN003
+        self.rollback = kwargs
+
+    def transition(self, phase: str, **kwargs) -> None:  # noqa: ANN003
+        self.transitions.append((phase, kwargs))
+
+
+def test_prelaunch_reconciliation_failure_does_not_leave_recovery_blocker() -> None:
+    operation = _RecordingOperation()
+    transaction = type("Transaction", (), {"launch_sequence": 0})()
+    error = SkyPilotSubmitError("controller identity mismatch", transaction=transaction)
+
+    workflow_cli._record_workflow_submit_failure(operation, error)
+
+    assert operation.rollback == {
+        "attempted": False,
+        "completed": True,
+        "removed": [],
+        "preserved": [],
+        "outcomes": [],
+    }
+    assert operation.transitions[0][0] == "rolled-back"
+    assert operation.transitions[0][1]["details"]["launch_attempted"] is False
+
+
+def test_postlaunch_failure_preserves_recovery_blocker() -> None:
+    operation = _RecordingOperation()
+    transaction = type("Transaction", (), {"launch_sequence": 1})()
+    error = SkyPilotSubmitError("launch indeterminate", transaction=transaction)
+
+    workflow_cli._record_workflow_submit_failure(operation, error)
+
+    assert operation.rollback is None
+    assert operation.transitions == [
+        ("recovery-required", {"error": "launch indeterminate"})
+    ]
 
 
 @pytest.fixture()

--- a/npa/tests/orchestration/skypilot/test_k8s_gpu_catalog.py
+++ b/npa/tests/orchestration/skypilot/test_k8s_gpu_catalog.py
@@ -201,18 +201,34 @@ def sky_bin(tmp_path):  # noqa: ANN001, ANN201 - pytest fixture
     return str(path)
 
 
-def test_discover_passes_the_context_as_an_infra_target(sky_bin: str) -> None:
+def test_discover_passes_exact_context_config_and_kubeconfig(
+    sky_bin: str, tmp_path
+) -> None:  # noqa: ANN001
     seen: dict[str, object] = {}
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
 
     def fake_run(cmd, **kwargs):  # noqa: ANN001 - test stub
         seen["cmd"] = cmd
+        seen["env"] = kwargs["env"]
         return subprocess.CompletedProcess(cmd, 0, stdout=LIVE_OUTPUT, stderr="")
 
     catalog = discover_kubernetes_gpu_catalog(
-        context="npa-rtxpro-mk8s", sky_bin=sky_bin, runner=fake_run
+        context="npa-rtxpro-mk8s",
+        kubeconfig=kubeconfig,
+        sky_bin=sky_bin,
+        runner=fake_run,
     )
 
-    assert seen["cmd"][-2:] == ["--infra", "k8s/npa-rtxpro-mk8s"]
+    assert seen["cmd"] == [
+        sky_bin,
+        "show-gpus",
+        "--config",
+        'kubernetes.allowed_contexts=["npa-rtxpro-mk8s"]',
+        "--infra",
+        "k8s/npa-rtxpro-mk8s",
+    ]
+    assert seen["env"]["KUBECONFIG"] == str(kubeconfig)
     assert set(catalog.quantities_by_accelerator) == {
         "RTXPRO-6000-BLACKWELL-SERVER-EDITION"
     }
@@ -228,29 +244,25 @@ def test_discover_surfaces_a_failing_sky_invocation(sky_bin: str) -> None:
     assert "no kube context" in str(excinfo.value)
 
 
-def test_discover_labels_known_rtxpro_when_skypilot_catalog_is_empty(
+def test_empty_discovery_is_read_only_and_never_labels_nodes(
     sky_bin: str, monkeypatch
 ) -> None:  # noqa: ANN001
-    outputs = iter(["", SINGLE_GPU_OUTPUT])
-    calls: list[list[str]] = []
-
     def fake_run(cmd, **kwargs):  # noqa: ANN001 - test stub
-        return subprocess.CompletedProcess(cmd, 0, stdout=next(outputs), stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(
         "npa.orchestration.skypilot.k8s_gpu_catalog."
         "label_known_kubernetes_gpus_for_skypilot",
-        lambda **kwargs: (calls.append([kwargs["context"]]), 1)[1],
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("catalog discovery must not mutate Kubernetes nodes")
+        ),
     )
 
     catalog = discover_kubernetes_gpu_catalog(
         context="npa-cluster", sky_bin=sky_bin, runner=fake_run
     )
 
-    assert calls == [["npa-cluster"]]
-    assert catalog.quantities_by_accelerator == {
-        "RTXPRO-6000-BLACKWELL-SERVER-EDITION": frozenset({1})
-    }
+    assert catalog.is_empty
 
 
 def test_known_rtxpro_label_is_exact_context_scoped() -> None:
@@ -292,6 +304,27 @@ def test_known_rtxpro_label_is_exact_context_scoped() -> None:
             "skypilot.co/accelerator=rtxpro6000",
         ]
     ]
+
+
+def test_known_gpu_label_rbac_failure_is_immediate_and_actionable() -> None:
+    inventory = KubernetesGpuInventory(
+        context="ctx",
+        ready_nodes=1,
+        eligible_gpu_nodes=1,
+        capacity=1,
+        allocatable=1,
+        products=("RTX6000",),
+        node_labels={"node-a": {"nebius.com/gpu-name": "RTX6000"}},
+    )
+
+    with pytest.raises(KubernetesGpuCatalogError, match="RBAC.*patch/update"):
+        label_known_kubernetes_gpus_for_skypilot(
+            context="ctx",
+            inventory=inventory,
+            runner=lambda cmd, **_kwargs: subprocess.CompletedProcess(
+                cmd, 1, stdout="", stderr="Error from server (Forbidden)"
+            ),
+        )
 
 
 def test_inventory_prefers_gfd_product_over_same_node_provider_alias() -> None:
@@ -396,6 +429,47 @@ def test_readiness_waits_after_kubernetes_allocatable_until_skypilot_labels() ->
     assert messages[-1].startswith(
         "GPU readiness: Kubernetes allocatable=1; SkyPilot discovery=ready"
     )
+
+
+def test_explicit_known_label_repair_precedes_catalog_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    inventory = KubernetesGpuInventory(
+        context="ctx",
+        ready_nodes=1,
+        eligible_gpu_nodes=1,
+        capacity=1,
+        allocatable=1,
+        products=("RTX6000",),
+        node_labels={"node-a": {"nebius.com/gpu-name": "RTX6000"}},
+    )
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.k8s_gpu_catalog."
+        "discover_kubernetes_gpu_inventory",
+        lambda **_kwargs: inventory,
+    )
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.k8s_gpu_catalog."
+        "label_known_kubernetes_gpus_for_skypilot",
+        lambda **_kwargs: (events.append("label"), 1)[1],
+    )
+
+    result = wait_for_kubernetes_accelerators(
+        [],
+        context="ctx",
+        label_known_gpus=True,
+        discover=lambda: (
+            events.append("discover"),
+            KubernetesGpuCatalog(
+                quantities_by_accelerator={"rtxpro6000": frozenset({1})}
+            ),
+        )[1],
+        monotonic=lambda: 0.0,
+    )
+
+    assert events == ["label", "discover"]
+    assert result["rtxpro6000:1"].resolved == "rtxpro6000:1"
 
 
 def test_readiness_timeout_is_clear_and_preserves_capacity() -> None:

--- a/npa/tests/orchestration/skypilot/test_k8s_gpu_catalog.py
+++ b/npa/tests/orchestration/skypilot/test_k8s_gpu_catalog.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+import json
 import subprocess
 
 import pytest
 
 from npa.orchestration.skypilot.k8s_gpu_catalog import (
+    KubernetesGpuInventory,
     KubernetesGpuCatalog,
     KubernetesGpuCatalogError,
     UnsatisfiableAcceleratorError,
     context_from_infra,
     discover_kubernetes_gpu_catalog,
+    discover_kubernetes_gpu_inventory,
+    label_known_kubernetes_gpus_for_skypilot,
     parse_kubernetes_gpu_catalog,
     resolve_kubernetes_accelerator,
     spec_accelerators,
@@ -222,6 +226,128 @@ def test_discover_surfaces_a_failing_sky_invocation(sky_bin: str) -> None:
         discover_kubernetes_gpu_catalog(sky_bin=sky_bin, runner=fake_run)
 
     assert "no kube context" in str(excinfo.value)
+
+
+def test_discover_labels_known_rtxpro_when_skypilot_catalog_is_empty(
+    sky_bin: str, monkeypatch
+) -> None:  # noqa: ANN001
+    outputs = iter(["", SINGLE_GPU_OUTPUT])
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001 - test stub
+        return subprocess.CompletedProcess(cmd, 0, stdout=next(outputs), stderr="")
+
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.k8s_gpu_catalog."
+        "label_known_kubernetes_gpus_for_skypilot",
+        lambda **kwargs: (calls.append([kwargs["context"]]), 1)[1],
+    )
+
+    catalog = discover_kubernetes_gpu_catalog(
+        context="npa-cluster", sky_bin=sky_bin, runner=fake_run
+    )
+
+    assert calls == [["npa-cluster"]]
+    assert catalog.quantities_by_accelerator == {
+        "RTXPRO-6000-BLACKWELL-SERVER-EDITION": frozenset({1})
+    }
+
+
+def test_known_rtxpro_label_is_exact_context_scoped() -> None:
+    inventory = KubernetesGpuInventory(
+        context="ctx",
+        ready_nodes=1,
+        eligible_gpu_nodes=1,
+        capacity=1,
+        allocatable=1,
+        products=("NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition",),
+        node_labels={
+            "node-a": {
+                "nvidia.com/gpu.product": (
+                    "NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition"
+                )
+            }
+        },
+    )
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001 - test stub
+        seen.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="node/node-a labelled", stderr="")
+
+    assert (
+        label_known_kubernetes_gpus_for_skypilot(
+            context="ctx", inventory=inventory, runner=fake_run
+        )
+        == 1
+    )
+    assert seen == [
+        [
+            "kubectl",
+            "--context",
+            "ctx",
+            "label",
+            "node",
+            "node-a",
+            "skypilot.co/accelerator=rtxpro6000",
+        ]
+    ]
+
+
+def test_inventory_prefers_gfd_product_over_same_node_provider_alias() -> None:
+    payload = {
+        "items": [
+            {
+                "metadata": {
+                    "name": "gpu-node",
+                    "labels": {
+                        "nvidia.com/gpu.product": "NVIDIA-RTX-PRO-6000",
+                        "nebius.com/gpu-name": "RTX6000",
+                    },
+                },
+                "spec": {},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "capacity": {"nvidia.com/gpu": "1"},
+                    "allocatable": {"nvidia.com/gpu": "1"},
+                },
+            }
+        ]
+    }
+
+    inventory = discover_kubernetes_gpu_inventory(
+        context="ctx",
+        runner=lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            [], 0, stdout=json.dumps(payload), stderr=""
+        ),
+    )
+
+    assert inventory.products == ("NVIDIA-RTX-PRO-6000",)
+    assert inventory.to_dict()["accelerator_product"] == "NVIDIA-RTX-PRO-6000"
+
+
+def test_unknown_gpu_is_never_fuzzy_labelled() -> None:
+    inventory = KubernetesGpuInventory(
+        context="ctx",
+        ready_nodes=1,
+        eligible_gpu_nodes=1,
+        capacity=1,
+        allocatable=1,
+        products=("NVIDIA-RTX-PRO-5000-Blackwell",),
+        node_labels={
+            "node-a": {"nvidia.com/gpu.product": "NVIDIA-RTX-PRO-5000-Blackwell"}
+        },
+    )
+
+    def unexpected(*args, **kwargs):  # noqa: ANN001, ANN202
+        raise AssertionError("unknown products must not be labelled")
+
+    assert (
+        label_known_kubernetes_gpus_for_skypilot(
+            context="ctx", inventory=inventory, runner=unexpected
+        )
+        == 0
+    )
 
 
 def test_spec_accelerators_reads_only_kubernetes_profiles() -> None:

--- a/npa/tests/test_provisioning.py
+++ b/npa/tests/test_provisioning.py
@@ -215,12 +215,12 @@ def test_reused_cluster_runs_requested_skypilot_smoke(
     seen: list[tuple[object, ...]] = []
     monkeypatch.setattr(
         "npa.cli.cluster.terraform_lifecycle._run_skypilot_smoke",
-        lambda *args, **kwargs: seen.append((*args, kwargs)),
+        lambda *args, **kwargs: seen.append(("smoke", *args, kwargs)),
     )
     monkeypatch.setattr(
         "npa.orchestration.skypilot.k8s_gpu_catalog."
         "wait_for_kubernetes_accelerators",
-        lambda *_args, **_kwargs: {},
+        lambda *args, **kwargs: seen.append(("readiness", *args, kwargs)) or {},
     )
 
     result = provisioning.provision_if_absent(
@@ -234,15 +234,90 @@ def test_reused_cluster_runs_requested_skypilot_smoke(
 
     assert result.status == "ok"
     assert "sky-smoke:passed" in result.actions
-    assert seen == [
-        (
-            kubeconfig,
-            "npa-cluster",
-            "npa-cluster",
-            "RTXPRO6000:1",
-            {"sky_bin": "/opt/npa/sky"},
-        )
-    ]
+    assert [item[0] for item in seen] == ["readiness", "smoke"]
+    readiness = seen[0]
+    assert readiness[1] == ["RTXPRO6000:1"]
+    assert readiness[-1]["kubeconfig"] == kubeconfig
+    assert readiness[-1]["sky_bin"] == "/opt/npa/sky"
+    assert readiness[-1]["label_known_gpus"] is True
+    assert seen[1] == (
+        "smoke",
+        kubeconfig,
+        "npa-cluster",
+        "npa-cluster",
+        "RTXPRO6000:1",
+        {"sky_bin": "/opt/npa/sky"},
+    )
+
+
+def test_fresh_cluster_uses_the_same_readiness_then_smoke_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_runtime(tmp_path, monkeypatch)
+    kubeconfig = tmp_path / "fresh-kubeconfig"
+    seen: list[tuple[str, object]] = []
+
+    def up(**kwargs):  # noqa: ANN003, ANN202
+        seen.append(("up", kwargs))
+
+    monkeypatch.setattr("npa.cli.cluster.terraform_lifecycle.up_cmd", up)
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.k8s_gpu_catalog."
+        "wait_for_kubernetes_accelerators",
+        lambda *_args, **kwargs: seen.append(("readiness", kwargs)) or {},
+    )
+    monkeypatch.setattr(
+        "npa.cli.cluster.terraform_lifecycle._run_skypilot_smoke",
+        lambda *_args, **kwargs: seen.append(("smoke", kwargs)),
+    )
+
+    result = provisioning.provision_if_absent(
+        project="proj",
+        cluster_name="npa-cluster",
+        kubeconfig=kubeconfig,
+        sky_smoke=True,
+        accelerator="RTXPRO6000:1",
+        sky_bin="/opt/npa/sky",
+    )
+
+    assert result.status == "ok"
+    assert [item[0] for item in seen] == ["up", "readiness", "smoke"]
+    up_kwargs = seen[0][1]
+    assert up_kwargs["sky_smoke"] is False
+    assert up_kwargs["sky_bin"] == "/opt/npa/sky"
+    assert seen[1][1]["label_known_gpus"] is True
+    assert seen[1][1]["sky_bin"] == "/opt/npa/sky"
+    assert seen[2][1]["sky_bin"] == "/opt/npa/sky"
+
+
+def test_cached_smoke_without_accelerator_keeps_auto_detection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_runtime(tmp_path, monkeypatch)
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    seen: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.k8s_gpu_catalog."
+        "wait_for_kubernetes_accelerators",
+        lambda accelerators, **_kwargs: seen.append(("readiness", accelerators))
+        or {},
+    )
+    monkeypatch.setattr(
+        "npa.cli.cluster.terraform_lifecycle._run_skypilot_smoke",
+        lambda *_args, **_kwargs: seen.append(("smoke", _args[3])),
+    )
+
+    result = provisioning.provision_if_absent(
+        project="proj",
+        cluster_name="npa-cluster",
+        kubeconfig=kubeconfig,
+        sky_smoke=True,
+        sky_bin="/opt/npa/sky",
+    )
+
+    assert result.status == "ok"
+    assert seen == [("readiness", []), ("smoke", "")]
 
 
 def test_reused_cluster_still_waits_for_skypilot_gpu_readiness(
@@ -258,7 +333,8 @@ def test_reused_cluster_still_waits_for_skypilot_gpu_readiness(
     def wait(accelerators, **kwargs):  # noqa: ANN001, ANN202
         seen["accelerators"] = accelerators
         seen["context"] = kwargs["context"]
-        seen["kubeconfig"] = __import__("os").environ["KUBECONFIG"]
+        seen["kubeconfig"] = str(kwargs["kubeconfig"])
+        seen["label_known_gpus"] = kwargs["label_known_gpus"]
         kwargs["on_status"]("Kubernetes allocatable=1; SkyPilot discovery=ready")
         return {}
 
@@ -279,6 +355,7 @@ def test_reused_cluster_still_waits_for_skypilot_gpu_readiness(
         "accelerators": ["RTXPRO6000:1"],
         "context": "npa-cluster",
         "kubeconfig": str(kubeconfig),
+        "label_known_gpus": True,
     }
     assert any("SkyPilot discovery=ready" in action for action in result.actions)
 
@@ -322,7 +399,7 @@ def test_green_preflight_rolls_back_only_new_cluster_on_readiness_failure(
     )
 
     assert result.status == "partial"
-    assert result.gpu_readiness == "timeout"
+    assert result.gpu_readiness == "failed"
     down.assert_called_once()
     assert down.call_args.kwargs["cluster_id"] == "cluster-created-by-test-operation"
     assert any("rollback:removed only cluster resources" in a for a in result.actions)

--- a/npa/tests/test_provisioning.py
+++ b/npa/tests/test_provisioning.py
@@ -206,6 +206,45 @@ def test_provision_if_absent_reuses_kubeconfig_and_ensures_bucket(
     assert "k8s:validated stable GPU health and CUDA vectorAdd" in result.actions
 
 
+def test_reused_cluster_runs_requested_skypilot_smoke(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write_runtime(tmp_path, monkeypatch)
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    seen: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        "npa.cli.cluster.terraform_lifecycle._run_skypilot_smoke",
+        lambda *args, **kwargs: seen.append((*args, kwargs)),
+    )
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.k8s_gpu_catalog."
+        "wait_for_kubernetes_accelerators",
+        lambda *_args, **_kwargs: {},
+    )
+
+    result = provisioning.provision_if_absent(
+        project="proj",
+        cluster_name="npa-cluster",
+        kubeconfig=kubeconfig,
+        sky_smoke=True,
+        accelerator="RTXPRO6000:1",
+        sky_bin="/opt/npa/sky",
+    )
+
+    assert result.status == "ok"
+    assert "sky-smoke:passed" in result.actions
+    assert seen == [
+        (
+            kubeconfig,
+            "npa-cluster",
+            "npa-cluster",
+            "RTXPRO6000:1",
+            {"sky_bin": "/opt/npa/sky"},
+        )
+    ]
+
+
 def test_reused_cluster_still_waits_for_skypilot_gpu_readiness(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/npa/tests/unit/test_cluster_api_mock.py
+++ b/npa/tests/unit/test_cluster_api_mock.py
@@ -48,6 +48,34 @@ def _config() -> ClusterConfig:
     )
 
 
+def test_client_passes_selected_nebius_profile_globally(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setenv("NPA_NEBIUS_PROFILE", "tenant-profile")
+
+    def run(args, **_kwargs):  # noqa: ANN001
+        calls.append(args)
+        return _result(_cluster())
+
+    client = MK8sClient(nebius_bin="nebius", subprocess_runner=run)
+    info = client.get_cluster("mk8scluster-a", project_id="project-a")
+
+    assert info.id == "mk8scluster-a"
+    assert calls == [
+        [
+            "nebius",
+            "--profile",
+            "tenant-profile",
+            "mk8s",
+            "cluster",
+            "get",
+            "--id",
+            "mk8scluster-a",
+            "--format",
+            "json",
+        ]
+    ]
+
+
 def test_create_cluster_creates_cluster_then_node_group() -> None:
     calls: list[list[str]] = []
 

--- a/npa/tests/unit/test_cluster_identity.py
+++ b/npa/tests/unit/test_cluster_identity.py
@@ -11,7 +11,12 @@ from npa.cluster.exceptions import ClusterNotFoundError
 from npa.cluster.state import ClusterState
 
 
-def _state(kubeconfig: Path, *, project_id: str = "project-a") -> ClusterState:
+def _state(
+    kubeconfig: Path,
+    *,
+    project_id: str = "project-a",
+    provider_name: str = "",
+) -> ClusterState:
     return ClusterState(
         name="npa-cluster",
         cluster_id="cluster-a",
@@ -25,6 +30,7 @@ def _state(kubeconfig: Path, *, project_id: str = "project-a") -> ClusterState:
         created_at="2026-08-06T00:00:00Z",
         endpoint="https://api.cluster.example",
         kubeconfig_path=str(kubeconfig),
+        provider_name=provider_name,
     )
 
 
@@ -105,6 +111,37 @@ def test_explicit_project_and_context_take_precedence(
     assert verified.project_alias == "selected"
     assert verified.context == "npa-cluster"
     assert client.calls == [("cluster-a", "project-a")]
+
+
+def test_provider_name_may_differ_from_unique_local_context(
+    monkeypatch, tmp_path: Path
+) -> None:  # noqa: ANN001
+    kubeconfig = tmp_path / "kubeconfig"
+    _write_kubeconfig(kubeconfig)
+    state = _state(kubeconfig, provider_name="fleet-cluster")
+    from npa.clients import config
+
+    monkeypatch.setattr(
+        config, "list_projects", lambda: {"selected": {"project_id": "project-a"}}
+    )
+    monkeypatch.setattr(config, "default_project_name", lambda: "selected")
+    monkeypatch.setattr(identity, "load_cluster_state", lambda context: state)
+    monkeypatch.setattr(identity, "existing_kubeconfig", lambda context: kubeconfig)
+    client = _Client(
+        remote=SimpleNamespace(
+            id="cluster-a",
+            project_id="project-a",
+            name="fleet-cluster",
+            endpoint="https://api.cluster.example",
+        )
+    )
+
+    verified = identity.resolve_verified_cluster_identity(
+        project="selected", context="npa-cluster", client=client
+    )
+
+    assert verified.context == "npa-cluster"
+    assert verified.cluster_name == "fleet-cluster"
 
 
 def test_context_project_mismatch_fails_before_provider_access(

--- a/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
+++ b/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -73,23 +74,37 @@ def _find_call(stream_calls: list[list[str]], *prefix: str) -> list[str] | None:
     return None
 
 
+def test_run_stream_capture_output_is_visible_and_retained(capsys) -> None:
+    result = tf_mod._run_stream(
+        [
+            sys.executable,
+            "-c",
+            "import sys; print('check-visible'); print('check-detail', file=sys.stderr)",
+        ],
+        capture_output=True,
+    )
+
+    visible = capsys.readouterr()
+    assert "check-visible" in visible.out
+    assert "check-detail" in visible.err
+    assert "check-visible" in result.stdout
+    assert "check-detail" in result.stderr
+
+
 def test_skypilot_smoke_scopes_check_and_uses_explicit_binary(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     kubeconfig = tmp_path / "kubeconfig"
     kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
-    captures: list[tuple[list[str], dict[str, str]]] = []
-    streams: list[list[str]] = []
+    streams: list[tuple[list[str], dict[str, str]]] = []
     monkeypatch.setattr(tf_mod, "_require_bin", lambda value: value)
 
-    def capture(cmd, **kwargs):  # noqa: ANN001
-        captures.append((cmd, kwargs["env"]))
-        return _completed("Kubernetes: enabled [compute]\n")
+    def stream(cmd, **kwargs):  # noqa: ANN001
+        streams.append((cmd, kwargs["env"]))
+        output = "Kubernetes: enabled [compute]\n" if cmd[1] == "check" else ""
+        return _completed(output)
 
-    monkeypatch.setattr(tf_mod, "_run_capture", capture)
-    monkeypatch.setattr(
-        tf_mod, "_run_stream", lambda cmd, **_kwargs: streams.append(cmd)
-    )
+    monkeypatch.setattr(tf_mod, "_run_stream", stream)
     monkeypatch.setattr(
         tf_mod, "_wait_for_sky_down", lambda *_args, **_kwargs: None
     )
@@ -102,23 +117,58 @@ def test_skypilot_smoke_scopes_check_and_uses_explicit_binary(
         sky_bin="/opt/npa/sky",
     )
 
-    assert captures[0][0] == [
+    assert streams[0][0] == [
         "/opt/npa/sky",
         "check",
         "--config",
         'kubernetes.allowed_contexts=["fleet-exact"]',
         "kubernetes",
     ]
-    assert captures[0][1]["KUBECONFIG"] == str(kubeconfig)
-    assert streams[0][0:2] == ["/opt/npa/sky", "launch"]
-    assert streams[0][streams[0].index("--config") + 1] == (
+    assert streams[0][1]["KUBECONFIG"] == str(kubeconfig)
+    launch = streams[1][0]
+    assert launch[0:2] == ["/opt/npa/sky", "launch"]
+    assert launch[launch.index("--config") + 1] == (
         'kubernetes.allowed_contexts=["fleet-exact"]'
     )
-    assert streams[0][streams[0].index("--gpus") + 1] == "RTXPRO6000:1"
-    assert streams[1][0:2] == ["/opt/npa/sky", "down"]
-    assert streams[1][streams[1].index("--config") + 1] == (
+    assert launch[launch.index("--gpus") + 1] == "RTXPRO6000:1"
+    down = streams[2][0]
+    assert down[0:2] == ["/opt/npa/sky", "down"]
+    assert down[down.index("--config") + 1] == (
         'kubernetes.allowed_contexts=["fleet-exact"]'
     )
+
+
+def test_skypilot_auto_detection_uses_exact_context_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[list[str]] = []
+
+    def capture(cmd, **_kwargs):  # noqa: ANN001
+        seen.append(cmd)
+        return _completed(
+            "RTXPRO-6000-BLACKWELL-SERVER-EDITION  1  1 of 1 free\n"
+        )
+
+    monkeypatch.setattr(tf_mod, "_run_capture", capture)
+    accelerator = tf_mod._detect_skypilot_gpu(
+        "/opt/npa/sky",
+        "k8s/fleet-exact",
+        {},
+        config_override='kubernetes.allowed_contexts=["fleet-exact"]',
+    )
+
+    assert accelerator == "RTXPRO-6000-BLACKWELL-SERVER-EDITION:1"
+    assert seen == [
+        [
+            "/opt/npa/sky",
+            "show-gpus",
+            "--config",
+            'kubernetes.allowed_contexts=["fleet-exact"]',
+            "--infra",
+            "k8s/fleet-exact",
+            "--all",
+        ]
+    ]
 
 
 def test_explicit_context_is_the_terraform_resource_name() -> None:
@@ -193,6 +243,7 @@ def test_up_runs_terraform_writes_kubeconfig_and_validates(
     )
     stream_calls: list[list[str]] = []
     stream_envs: list[dict[str, str]] = []
+    gpu_events: list[tuple[str, object]] = []
 
     def fake_require_bin(binary: str) -> str:
         return binary
@@ -308,6 +359,19 @@ def test_up_runs_terraform_writes_kubeconfig_and_validates(
     monkeypatch.setattr(tf_mod, "_run_stream", fake_stream)
     monkeypatch.setattr(tf_mod, "_run_capture", fake_capture)
     monkeypatch.setattr(
+        "npa.orchestration.skypilot.k8s_gpu_catalog."
+        "wait_for_kubernetes_accelerators",
+        lambda accelerators, **kwargs: gpu_events.append(
+            ("readiness", (accelerators, kwargs))
+        )
+        or {},
+    )
+    monkeypatch.setattr(
+        tf_mod,
+        "_run_skypilot_smoke",
+        lambda *args, **kwargs: gpu_events.append(("smoke", (args, kwargs))),
+    )
+    monkeypatch.setattr(
         tf_mod, "save_cluster_state", lambda state, metadata=None: saved.append(state)
     )
 
@@ -322,7 +386,11 @@ def test_up_runs_terraform_writes_kubeconfig_and_validates(
             "--gpu-health-stabilization-seconds",
             "0",
             "--skip-gpu-cuda-smoke",
-            "--skip-sky-smoke",
+            "--sky-smoke",
+            "--sky-gpus",
+            "RTXPRO6000:1",
+            "--sky-bin",
+            "/opt/npa/sky",
         ],
     )
 
@@ -347,6 +415,13 @@ def test_up_runs_terraform_writes_kubeconfig_and_validates(
     assert [state.last_seen_state for state in saved] == ["VALIDATING", "RUNNING"]
     assert saved[-1].cluster_id == "mk8scluster-a"
     assert "16 allocatable GPUs" in result.output
+    assert [event[0] for event in gpu_events] == ["readiness", "smoke"]
+    readiness_args, readiness_kwargs = gpu_events[0][1]
+    assert readiness_args == ["RTXPRO6000:1"]
+    assert readiness_kwargs["label_known_gpus"] is True
+    assert readiness_kwargs["sky_bin"] == "/opt/npa/sky"
+    _smoke_args, smoke_kwargs = gpu_events[1][1]
+    assert smoke_kwargs["sky_bin"] == "/opt/npa/sky"
 
 
 def test_inherited_topology_overrides_every_effective_terraform_input() -> None:

--- a/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
+++ b/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
@@ -645,6 +645,7 @@ def test_failed_fresh_apply_rolls_back_only_its_new_terraform_state(
     assert "provider race after network create" in result.output
     down.assert_called_once()
     assert down.call_args.kwargs["context_name"] == "cluster-a"
+    assert down.call_args.kwargs["operation_id"] == ""
 
 
 def test_validate_cluster_accepts_compute_csi_when_filestore_is_disabled(

--- a/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
+++ b/npa/tests/unit/test_cluster_terraform_lifecycle_cli.py
@@ -73,6 +73,54 @@ def _find_call(stream_calls: list[list[str]], *prefix: str) -> list[str] | None:
     return None
 
 
+def test_skypilot_smoke_scopes_check_and_uses_explicit_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    captures: list[tuple[list[str], dict[str, str]]] = []
+    streams: list[list[str]] = []
+    monkeypatch.setattr(tf_mod, "_require_bin", lambda value: value)
+
+    def capture(cmd, **kwargs):  # noqa: ANN001
+        captures.append((cmd, kwargs["env"]))
+        return _completed("Kubernetes: enabled [compute]\n")
+
+    monkeypatch.setattr(tf_mod, "_run_capture", capture)
+    monkeypatch.setattr(
+        tf_mod, "_run_stream", lambda cmd, **_kwargs: streams.append(cmd)
+    )
+    monkeypatch.setattr(
+        tf_mod, "_wait_for_sky_down", lambda *_args, **_kwargs: None
+    )
+
+    tf_mod._run_skypilot_smoke(
+        kubeconfig,
+        "fleet-exact",
+        "provider-cluster",
+        "RTXPRO6000:1",
+        sky_bin="/opt/npa/sky",
+    )
+
+    assert captures[0][0] == [
+        "/opt/npa/sky",
+        "check",
+        "--config",
+        'kubernetes.allowed_contexts=["fleet-exact"]',
+        "kubernetes",
+    ]
+    assert captures[0][1]["KUBECONFIG"] == str(kubeconfig)
+    assert streams[0][0:2] == ["/opt/npa/sky", "launch"]
+    assert streams[0][streams[0].index("--config") + 1] == (
+        'kubernetes.allowed_contexts=["fleet-exact"]'
+    )
+    assert streams[0][streams[0].index("--gpus") + 1] == "RTXPRO6000:1"
+    assert streams[1][0:2] == ["/opt/npa/sky", "down"]
+    assert streams[1][streams[1].index("--config") + 1] == (
+        'kubernetes.allowed_contexts=["fleet-exact"]'
+    )
+
+
 def test_explicit_context_is_the_terraform_resource_name() -> None:
     tfvars = {"cluster_name": "npa-cluster"}
     context = "k8s-live-unique"

--- a/npa/tests/unit/test_cluster_terraform_runtime.py
+++ b/npa/tests/unit/test_cluster_terraform_runtime.py
@@ -39,6 +39,37 @@ def test_isolated_data_cleanup_failure_stays_owned_and_reportable(
     assert not scratch.exists()
 
 
+def test_cleanup_never_removes_scratch_held_by_an_active_terraform_run(
+    tmp_path: Path,
+) -> None:
+    terraform_dir = tmp_path / "deploy" / "cluster"
+    terraform_dir.mkdir(parents=True)
+
+    with terraform_runtime.isolated_terraform_data_dir(
+        terraform_dir, "cluster-a"
+    ) as scratch:
+        assert scratch.parent.name == "active"
+        provider = scratch / "providers" / "keep"
+        provider.parent.mkdir()
+        provider.write_text("in use\n")
+
+        residue = next(
+            item
+            for item in terraform_runtime.collect_terraform_residue(start=tmp_path)
+            if item.path == scratch
+        )
+        assert not residue.removable
+        assert "active Terraform run" in residue.reason
+        assert "active Terraform run" in terraform_runtime.remove_terraform_residue(
+            terraform_runtime.TerraformResidue(
+                "Terraform runtime scratch", scratch, True
+            )
+        )
+        assert provider.read_text() == "in use\n"
+
+    assert not scratch.exists()
+
+
 def test_isolated_data_creation_failure_never_leaves_an_unowned_run_dir(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/npa/tests/unit/test_fleet_cli.py
+++ b/npa/tests/unit/test_fleet_cli.py
@@ -526,14 +526,80 @@ def test_resolve_project_id_reuses_existing_by_name(monkeypatch) -> None:
             {"metadata": {"name": "fleet1-test-a", "id": "project-found"}}
         ],
     )
+    monkeypatch.setattr(
+        lifecycle,
+        "_get_project",
+        lambda *a, **k: {
+            "metadata": {
+                "name": "fleet1-test-a",
+                "id": "project-found",
+                "parent_id": "tenant-x",
+            },
+            "spec": {"region": "us-central1"},
+        },
+    )
     project = ProjectSpec(
         name="a", clusters=[ClusterSpec(name="c", cpu_nodes=NodePoolSpec(count=1))]
     )
     pid, created = lifecycle.resolve_project_id(
-        "nebius", "tenant-x", project, prefix="fleet1-test-", create=False, env={}
+        "nebius",
+        "tenant-x",
+        project,
+        prefix="fleet1-test-",
+        create=False,
+        env={},
+        region="us-central1",
     )
     assert pid == "project-found"
     assert created is False
+
+
+def test_resolve_project_id_rejects_same_name_in_wrong_region(monkeypatch) -> None:
+    from npa.fleet import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_list_projects",
+        lambda *a, **k: [
+            {"metadata": {"name": "fleet1-test-a", "id": "project-found"}}
+        ],
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_get_project",
+        lambda *a, **k: {
+            "metadata": {
+                "name": "fleet1-test-a",
+                "id": "project-found",
+                "parent_id": "tenant-x",
+            },
+            "status": {"region": "eu-north1"},
+        },
+    )
+    project = ProjectSpec(
+        name="a", clusters=[ClusterSpec(name="c", cpu_nodes=NodePoolSpec(count=1))]
+    )
+    with pytest.raises(ValueError, match="region.*does not match"):
+        lifecycle.resolve_project_id(
+            "nebius",
+            "tenant-x",
+            project,
+            prefix="fleet1-test-",
+            create=False,
+            env={},
+            region="us-central1",
+        )
+
+
+def test_find_project_id_rejects_ambiguous_same_name() -> None:
+    from npa.fleet import lifecycle
+
+    projects = [
+        {"metadata": {"name": "same", "id": "project-a"}},
+        {"metadata": {"name": "same", "id": "project-b"}},
+    ]
+    with pytest.raises(ValueError, match="ambiguous"):
+        lifecycle._find_project_id(projects, "same")
 
 
 def test_resolve_project_id_errors_when_absent_and_no_create(monkeypatch) -> None:
@@ -905,6 +971,7 @@ def _mock_deploy_boundary(monkeypatch, *, apply_fails: bool = False):
         lambda *a, **k: {"kube_cluster": {"value": {"id": "mk8s-1"}}},
     )
     monkeypatch.setattr(L, "_write_kubeconfig", lambda *a, **k: None)
+    monkeypatch.setattr(L, "_persist_npa_cluster_identity", lambda **k: None)
     return L
 
 
@@ -934,6 +1001,10 @@ def _run_one_cluster(L, tmp_path, *, profile: str = "", cluster=None):
 
 def test_deploy_one_cluster_success_promotes_sidecar(tmp_path, monkeypatch) -> None:
     L = _mock_deploy_boundary(monkeypatch)
+    recorded = []
+    monkeypatch.setattr(
+        L, "_persist_npa_cluster_identity", lambda **kwargs: recorded.append(kwargs)
+    )
     res = _run_one_cluster(L, tmp_path)
     assert res["status"] == "deployed"
     assert res["cluster_id"] == "mk8s-1"
@@ -941,6 +1012,197 @@ def test_deploy_one_cluster_success_promotes_sidecar(tmp_path, monkeypatch) -> N
     assert sidecar["status"] == "deployed"
     assert sidecar["subnet_id"] == "subnet-1"
     assert sidecar["cluster_id"] == "mk8s-1"
+    assert len(recorded) == 1
+    assert recorded[0]["context"] == "fleet-f-a-c"
+    assert recorded[0]["cluster_id"] == "mk8s-1"
+    assert recorded[0]["project_id"] == "p1"
+
+
+def test_fleet_cluster_identity_roundtrip_and_collision_guard(tmp_path) -> None:
+    from npa.cluster.state import kubeconfig_file, load_cluster_state
+    from npa.fleet import lifecycle as L
+
+    kubeconfig = tmp_path / "source-kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n")
+    cluster = ClusterSpec(
+        name="gpu",
+        cpu_nodes=NodePoolSpec(count=1, platform="cpu-d3", preset="8vcpu-32gb"),
+        gpu_nodes=NodePoolSpec(
+            count=1, platform="gpu-rtx6000", preset="1gpu-24vcpu-218gb"
+        ),
+    )
+    kwargs = {
+        "context": "fleet-f-a-gpu",
+        "cluster_id": "cluster-1",
+        "project_id": "project-1",
+        "region": "us-central1",
+        "cluster": cluster,
+        "subnet_id": "subnet-1",
+        "kubeconfig_path": kubeconfig,
+        "fleet_name": "f",
+        "project_key": "a",
+        "base_dir": tmp_path / "clusters",
+    }
+    L._persist_npa_cluster_identity(**kwargs)
+    state = load_cluster_state("fleet-f-a-gpu", base_dir=tmp_path / "clusters")
+    assert state is not None
+    assert state.cluster_id == "cluster-1"
+    assert state.project_id == "project-1"
+    assert state.node_count == 2
+    assert state.node_platform == "gpu-rtx6000"
+    installed_kubeconfig = kubeconfig_file(
+        "fleet-f-a-gpu", base_dir=tmp_path / "clusters"
+    )
+    assert installed_kubeconfig.read_text() == "apiVersion: v1\n"
+    assert installed_kubeconfig.stat().st_mode & 0o777 == 0o600
+    assert state.kubeconfig_path == str(installed_kubeconfig)
+    assert state.provider_name == "gpu"
+
+    with pytest.raises(RuntimeError, match="different immutable"):
+        L._persist_npa_cluster_identity(**{**kwargs, "cluster_id": "cluster-2"})
+
+    L._remove_npa_cluster_identity(
+        context="fleet-f-a-gpu",
+        cluster_id="cluster-1",
+        project_id="project-1",
+        base_dir=tmp_path / "clusters",
+    )
+    assert load_cluster_state("fleet-f-a-gpu", base_dir=tmp_path / "clusters") is None
+
+
+def test_unchanged_provider_verified_target_has_zero_incremental_demand(
+    tmp_path, monkeypatch
+) -> None:
+    from npa.fleet import lifecycle as L
+
+    fleet_root = tmp_path / "f"
+    install = fleet_root / "a" / "gpu"
+    workdir = install / L._K8S_TRAINING_SUBDIR
+    workdir.mkdir(parents=True)
+    project = ProjectSpec(
+        name="a",
+        clusters=[],
+    )
+    cluster = ClusterSpec(
+        name="gpu",
+        cpu_nodes=NodePoolSpec(count=1, platform="cpu-d3", preset="8vcpu-32gb"),
+        gpu_nodes=NodePoolSpec(
+            count=1,
+            platform="gpu-rtx6000",
+            preset="1gpu-24vcpu-218gb",
+            capacity_block_group="capacityblockgroup-exact",
+        ),
+    )
+    L._write_env_sidecar(
+        install,
+        {
+            "tenant_id": "tenant-x",
+            "project_id": "project-x",
+            "region": "us-central1",
+            "cluster_name": "gpu",
+            "cluster_id": "cluster-x",
+            "status": "deployed",
+        },
+    )
+    ssh_key = "ssh-ed25519 test"
+    (workdir / "terraform.tfvars").write_text(
+        render_tfvars(cluster, ssh_public_key=ssh_key)
+    )
+    monkeypatch.setattr(
+        L,
+        "_get_project",
+        lambda *a, **k: {
+            "metadata": {
+                "id": "project-x",
+                "name": "a",
+                "parent_id": "tenant-x",
+            },
+            "spec": {"region": "us-central1"},
+        },
+    )
+
+    def provider(cmd, **kwargs):
+        if "node-group" in cmd:
+            return _Cap(
+                json.dumps(
+                    {
+                        "items": [
+                            {
+                                "spec": {
+                                    "fixed_node_count": 1,
+                                    "template": {
+                                        "resources": {
+                                            "platform": "cpu-d3",
+                                            "preset": "8vcpu-32gb",
+                                        }
+                                    },
+                                },
+                                "status": {"state": "RUNNING"},
+                            },
+                            {
+                                "spec": {
+                                    "fixed_node_count": 1,
+                                    "template": {
+                                        "resources": {
+                                            "platform": "gpu-rtx6000",
+                                            "preset": "1gpu-24vcpu-218gb",
+                                        },
+                                        "reservation_policy": {
+                                            "policy": "STRICT",
+                                            "reservation_ids": [
+                                                "capacityblockgroup-exact"
+                                            ],
+                                        },
+                                    },
+                                },
+                                "status": {"state": "RUNNING"},
+                            },
+                        ]
+                    }
+                ),
+                0,
+            )
+        return _Cap(
+            json.dumps(
+                {
+                    "metadata": {
+                        "id": "cluster-x",
+                        "name": "gpu",
+                        "parent_id": "project-x",
+                    },
+                    "status": {"state": "RUNNING"},
+                }
+            ),
+            0,
+        )
+
+    monkeypatch.setattr(L, "_run_capture", provider)
+    kwargs = {
+        "project": project,
+        "cluster": cluster,
+        "prefix": "",
+        "tenant_id": "tenant-x",
+        "region": "us-central1",
+        "ssh_public_key": ssh_key,
+        "fleet_root": fleet_root,
+        "nebius_bin": "nebius",
+        "profile": "profile-x",
+        "env": {},
+    }
+    assert L._is_verified_unchanged_target(**kwargs) is True
+
+    changed = ClusterSpec(
+        name="gpu",
+        cpu_nodes=cluster.cpu_nodes,
+        gpu_nodes=NodePoolSpec(
+            count=1,
+            platform="gpu-rtx6000",
+            preset="1gpu-24vcpu-218gb",
+            disk_size_gib=2048,
+            capacity_block_group="capacityblockgroup-exact",
+        ),
+    )
+    assert L._is_verified_unchanged_target(**{**kwargs, "cluster": changed}) is False
 
 
 def test_deploy_one_cluster_failure_leaves_sidecar_provisioning(

--- a/npa/tests/unit/test_fleet_cli.py
+++ b/npa/tests/unit/test_fleet_cli.py
@@ -533,7 +533,7 @@ def test_resolve_project_id_reuses_existing_by_name(monkeypatch) -> None:
             "metadata": {
                 "name": "fleet1-test-a",
                 "id": "project-found",
-                "parent_id": "tenant-x",
+                "parentId": "tenant-x",
             },
             "spec": {"region": "us-central1"},
         },
@@ -1115,7 +1115,7 @@ def test_unchanged_provider_verified_target_has_zero_incremental_demand(
             "metadata": {
                 "id": "project-x",
                 "name": "a",
-                "parent_id": "tenant-x",
+                "parentId": "tenant-x",
             },
             "spec": {"region": "us-central1"},
         },
@@ -1129,27 +1129,29 @@ def test_unchanged_provider_verified_target_has_zero_incremental_demand(
                         "items": [
                             {
                                 "spec": {
-                                    "fixed_node_count": 1,
+                                    "fixedNodeCount": 1,
                                     "template": {
                                         "resources": {
                                             "platform": "cpu-d3",
                                             "preset": "8vcpu-32gb",
-                                        }
+                                        },
+                                        "preemptible": False,
                                     },
                                 },
                                 "status": {"state": "RUNNING"},
                             },
                             {
                                 "spec": {
-                                    "fixed_node_count": 1,
+                                    "fixedNodeCount": 1,
                                     "template": {
                                         "resources": {
                                             "platform": "gpu-rtx6000",
                                             "preset": "1gpu-24vcpu-218gb",
                                         },
-                                        "reservation_policy": {
+                                        "preemptible": False,
+                                        "reservationPolicy": {
                                             "policy": "STRICT",
-                                            "reservation_ids": [
+                                            "reservationIds": [
                                                 "capacityblockgroup-exact"
                                             ],
                                         },
@@ -1168,7 +1170,7 @@ def test_unchanged_provider_verified_target_has_zero_incremental_demand(
                     "metadata": {
                         "id": "cluster-x",
                         "name": "gpu",
-                        "parent_id": "project-x",
+                        "parentId": "project-x",
                     },
                     "status": {"state": "RUNNING"},
                 }
@@ -1203,6 +1205,52 @@ def test_unchanged_provider_verified_target_has_zero_incremental_demand(
         ),
     )
     assert L._is_verified_unchanged_target(**{**kwargs, "cluster": changed}) is False
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        {"resources": {"platform": "cpu-d3", "preset": "8vcpu-32gb"}},
+        {
+            "resources": {"platform": "cpu-d3", "preset": "8vcpu-32gb"},
+            "preemptible": "false",
+        },
+        {
+            "resources": {"platform": "cpu-d3", "preset": "8vcpu-32gb"},
+            "preemptible": None,
+        },
+    ],
+)
+def test_node_group_match_fails_closed_without_explicit_false_preemptibility(
+    template: dict,
+) -> None:
+    from npa.fleet import lifecycle as L
+
+    payload = {
+        "spec": {"fixedNodeCount": 1, "template": template},
+        "status": {"state": "RUNNING"},
+    }
+    pool = NodePoolSpec(count=1, platform="cpu-d3", preset="8vcpu-32gb")
+
+    assert L._provider_node_group_matches_pool(payload, pool) is False
+
+
+def test_node_group_match_accepts_camel_case_with_explicit_on_demand_evidence() -> None:
+    from npa.fleet import lifecycle as L
+
+    payload = {
+        "spec": {
+            "fixedNodeCount": 1,
+            "template": {
+                "resources": {"platform": "cpu-d3", "preset": "8vcpu-32gb"},
+                "preemptible": False,
+            },
+        },
+        "status": {"state": "RUNNING"},
+    }
+    pool = NodePoolSpec(count=1, platform="cpu-d3", preset="8vcpu-32gb")
+
+    assert L._provider_node_group_matches_pool(payload, pool) is True
 
 
 def test_deploy_one_cluster_failure_leaves_sidecar_provisioning(

--- a/npa/tests/unit/test_provisioning_journal.py
+++ b/npa/tests/unit/test_provisioning_journal.py
@@ -351,6 +351,51 @@ def test_immutable_plan_conflict_names_sanitized_nested_fields(
         )
 
 
+def test_preflight_resume_allows_provider_progress_for_the_same_requested_shape(
+    journal_root: Path,
+) -> None:
+    operation = _prepare()
+    original = {
+        "project_alias": "prod",
+        "project_id": "project-a",
+        "tenant_id": "tenant-a",
+        "region": "us-central1",
+        "topology": {
+            "cluster_name": "gpu",
+            "gpu_nodes": 1,
+            "gpu_platform": "gpu-rtx6000",
+            "gpu_preset": "1gpu-24vcpu-218gb",
+            "gpu_disk_gib": 256,
+            "existing_gpu_nodes": 0,
+            "new_gpu_nodes": 1,
+            "required_instances": 1,
+            "required_disks": 1,
+            "required_network_ssd_bytes": 256 * 1024**3,
+            "required_network_ssd_gib": "256",
+            "required_gpus": 1,
+        },
+    }
+    operation.record_preflight_plan(original)
+
+    converged = {
+        **original,
+        "topology": {
+            **original["topology"],
+            "existing_gpu_nodes": 1,
+            "new_gpu_nodes": 0,
+            "required_instances": 0,
+            "required_disks": 0,
+            "required_network_ssd_bytes": 0,
+            "required_network_ssd_gib": "0",
+            "required_gpus": 0,
+        },
+    }
+    operation.record_preflight_plan(converged)
+
+    assert operation.read()["preflight_plan"] == converged
+    assert len(operation.read()["preflight_evaluations"]) == 2
+
+
 def test_authoritative_region_can_be_corrected_only_before_resource_creation(
     journal_root: Path,
 ) -> None:

--- a/skills/atomic/submit-workflow/SKILL.md
+++ b/skills/atomic/submit-workflow/SKILL.md
@@ -38,7 +38,7 @@ SkyPilot submission behavior.
 ## Live submit prerequisites (real cluster)
 
 A real `npa workbench workflow submit` (not `--plan-only`) needs, on top of a
-healthy `sky check kubernetes`:
+successful `npa skypilot verify --cluster <exact-context>`:
 
 - **Secrets via `--secret-env`** (never in the YAML): `NEBIUS_TOKEN_FACTORY_KEY`
   for Token Factory stages, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` for S3,
@@ -69,6 +69,10 @@ healthy `sky check kubernetes`:
   deadline. This is product behavior, not an operator job/time budget. A
   recovered launch proceeds in the same command; use `--resume-run <same-id>`
   only for crash/restart or a printed indeterminate/deadline recovery action.
+- A failed reconciliation with launch sequence zero created no SkyPilot job.
+  NPA records a completed no-op rollback instead of leaving a
+  `recovery-required` journal that would block unrelated project operations.
+  Any failure after a launch may have been issued remains recovery-required.
 
 - SkyPilot `envs` does not support self-referencing interpolation. The
   npa.workflow renderer resolves images and config before submit so rendered

--- a/skills/tools/fleet/SKILL.md
+++ b/skills/tools/fleet/SKILL.md
@@ -203,7 +203,10 @@ depends on it.
    pass `--yes`/`-y` for non-interactive runs. Missing projects are created via
    the `nebius` CLI unless `--no-create-projects`. Deploy runs per cluster and
    continues past a failing target (`--fail-fast` to stop); a JSON summary lists
-   deployed vs failed clusters with kube contexts.
+   deployed vs failed clusters with kube contexts. A successful kubeconfig
+   write also registers the fleet target under `~/.npa/clusters/<context>` so
+   project-scoped workflow, controller, and `provision-if-absent` commands can
+   consume it without a second manual cluster registration step.
 7. **Consume the latest recipe**: `--k8s-training-ref main` clones
    `nebius-solutions-library` and uses its `k8s-training` (or `--k8s-training-dir`
    for a local checkout). Omit both to use the repo-vendored, tested copy. NPA
@@ -252,6 +255,12 @@ Both `deploy` and `destroy` confirm before acting (bypass with `--yes`/`-y`;
   `deployed-validation-failed`; credential failures report
   `deployed-credentials-failed`. Both retain Terraform/cloud state, kubeconfig,
   and local evidence for diagnosis and an idempotent retry.
+- **Idempotent preflight is live-verified**: a repeat deploy counts an existing
+  target as zero incremental quota only when its saved tfvars still match and
+  the exact provider project, cluster, and node groups are all running with the
+  requested shapes. Reserved pools must still report non-preemptible nodes and
+  the exact `STRICT` reservation binding; stale or incomplete evidence falls
+  back to the ordinary conservative quota preflight.
 - **Region domain**: the recipe's `provider.tf` domain is patched to
   `api.nebius.cloud` for non-EU regions automatically (EU uses
   `api.eu.nebius.cloud`). If the upstream recipe drifts (renames `provider.tf`,


### PR DESCRIPTION
## Summary

This hardens the public fresh reserved-GPU setup and SkyPilot smoke path, including the seven review findings and three recovery defects exposed during live validation.

### Review fixes

1. Cached and fresh setup paths now perform reviewed known-GPU label repair and readiness before smoke; standalone `cluster up` uses the same ordering.
2. GPU discovery uses the exact Kubernetes context and dedicated kubeconfig through SkyPilot's temporary config override.
3. Provider adapters accept camelCase provider evidence (`parentId`, `fixedNodeCount`, `reservationPolicy`, and `reservationIds`) without weakening identity checks.
4. Non-preemptible verification requires explicit provider evidence; missing, moved, or malformed evidence fails closed.
5. Discovery remains read-only by default. Label mutation is explicit, status-reported, exact-context scoped, idempotent, and returns actionable RBAC/authentication failures.
6. Bare `npa skypilot verify` retains legacy semantics, while explicit Kubernetes inputs enforce Kubernetes readiness.
7. `--sky-bin` reaches cached and fresh smoke paths; no-accelerator auto-detection uses the same pinned SkyPilot binary, and `sky check` is streamed while captured for exact-context verification.

### Live-recovery hardening

- Active Terraform scratch now lives behind an upgrade-safe `active/` boundary and holds an advisory in-use lock, so concurrent NPA cleanup cannot remove provider plugins from a running apply.
- Internal fresh-apply rollback passes an explicit empty operation selector instead of allowing a Typer `OptionInfo` sentinel into path resolution.
- Provisioning-journal resume compares immutable requested topology separately from provider-derived progress, so the same operation can converge from `required=1` to `existing=1` while requested shape changes still fail closed.

## Rebase and conflict resolution

- Rebased the same branch directly onto current `main` (`5b798696`) with no merge commit.
- Integrated main's managed-driver/GPU-health contract semantically: stable GPU health and CUDA vectorAdd complete first, then exact-context label repair/readiness, then SkyPilot smoke, and only then cluster state is persisted as `RUNNING`.
- The Fleet runbook retains both GPU-health promotion semantics and strict live reservation verification for idempotent preflight.
- The final unrelated main advance reapplied all three PR commits with identical stable patch IDs.

## User and developer impact

- Fresh and cached setup now fail closed on ambiguous provider identity, reservation, placement, GPU readiness, and controller ownership.
- Operators get exact-context readiness progress and recoverable setup state instead of silent fallback, delayed submit failures, or cleanup races.
- Tests cover label mutation ordering, temporary SkyPilot config use, provider field variants, explicit non-preemptible evidence, cached/fresh smoke parity, recovery locking, and journal convergence.

## Redacted infrastructure and live-GPU evidence

- Provider-verified the existing requested project, tenant, and `us-central1` region without duplicating the project.
- Reused a provider-active compatible `gpu-rtx6000` capacity-block group.
- Created and preserved exactly one task-owned validation cluster with one Ready RTX PRO 6000 Blackwell node and one allocatable GPU.
- Provider evidence confirms one active reservation binding, `STRICT` reservation policy, RUNNING cluster/node group/instance, and regular (non-preemptible) placement. No on-demand fallback occurred.
- The unrelated pre-existing cluster and its shared managed-jobs controller were not mutated. Task-local restrictive NPA/SkyPilot state isolated the validation from that controller.

Live gates on final candidate `4ab1364c`:

1. Removed only `skypilot.co/accelerator` from the exact verified GPU node and confirmed all other labels were unchanged. The public setup path passed stable GPU health plus per-node CUDA vectorAdd, restored `rtxpro6000` before discovery, ran a real `nvidia-smi` job through SkyPilot 0.12.2, and removed the ephemeral smoke cluster.
2. Repeated `--sky-smoke` without `--accelerator`. The captured recovery command also contains no accelerator flag; the exact-context `sky show-gpus --all` path auto-detected `RTXPRO6000:1`, the real GPU job succeeded, and the ephemeral cluster/pods were removed.

## Validation

- Focused conflict/setup coverage: 312 passed.
- Final patch-identity integrity coverage, including the newest main guardrail: 317 passed.
- Ruff: passed.
- CLI docs drift: passed with the checkout-pinned NPA executable.
- Skills-index guardrail: 3 passed.
- Full guardrails: 1,857 passed, 1 skipped.
- Final serial non-E2E suite: 9,655 passed, 49 skipped, 1 xpassed; 158 warnings.
- `git diff --check`: passed.
- Final diff: 25 intended files; runtime-state, live-identifier, and sensitive-assignment scans found no additions.

## Limitations

- The preserved validation pool predates main's managed-image default and is truthfully GPU Operator-managed. Final validation therefore used the supported explicit `--gpu-driver-mode operator`; it did not roll or recreate the node group.
- The task-owned reserved cluster is intentionally left running for follow-up validation. Only ephemeral smoke resources were cleaned up.
- No PR merge is performed here.
