### PR TITLE
Audit public container catalog and add maintenance skill

### DIFF
--- a/docs/workbench/container-image-catalog.md
+++ b/docs/workbench/container-image-catalog.md
@@ -14,10 +14,10 @@ docker pull "${NPA_REGISTRY}/npa-retargeting:0.1.1"
 ```
 
 The catalog was verified against the public GHCR tag and OCI manifest APIs on
-2026-08-11. Every repository and tag below resolved. **Built** is the UTC build
-date of the newest listed variant; reproducible images that intentionally zero
-their OCI `created` field use the timestamp in the immutable tag and
-`npa.build_ts` label.
+2026-08-14. Every repository and tag below resolved anonymously. **Built** is
+the UTC build date of the newest listed variant; reproducible images that
+intentionally zero their OCI `created` field use the timestamp in the immutable
+tag and `npa.build_ts` label.
 
 Prefer a full timestamped tag when selecting a hardware-specific variant. OCI
 tags can be moved, so resolve and retain the manifest digest as well when strict
@@ -32,12 +32,9 @@ Rows are ordered by **Built** date, then by friendly name.
 | LeRobot Policy Server 0.1.1 | `npa-lerobot-policy` | `0.1.1` | 2026-07-10 | Serves a trained LeRobot policy over HTTP for closed-loop inference (default `lerobot/diffusion_pusht`). This is the BYO-policy contract endpoint called by other workflow stages. |
 | BDD100K Detection Training | `npa-detection-training` | `bdd100k-golden-eval-smoke-20260614T210000Z` | 2026-07-22 | Object-detector train/eval service on port 8790 with torchvision detectors and COCO metrics. It provides the re-label and measurement stage in the data-factory loop. |
 | Lichtblick 1.26.0 | `npa-lichtblick` | `1.26.0` | 2026-07-23 | Fully open-source (MPL-2.0), Foxglove-compatible MCAP/ROS log viewer served by Caddy on port 8080. No account or proprietary component is required. |
-| FiftyOne 1.15.0.post1 (Voxel51) | `npa-fiftyone` | `1.15.0.post1` | 2026-08-13 | Dataset curation and visualization UI on port 5151, including uniqueness, similarity, and embedding visualization. Bundles a `mongod` binary so FiftyOne can launch its own metadata database. |
 | GR00T N1.7-3B | `npa-groot` | `0.1.0` | 2026-08-01 | NVIDIA Isaac-GR00T humanoid foundation-model inference using `nvidia/GR00T-N1.7-3B`; weights are pulled at runtime with the operator's Hugging Face token. GR00T inference itself does not require Isaac or EULA acceptance. |
 | Isaac Lab 2.3.2 (Isaac Sim 5.1) | `npa-isaac-lab` | `2.3.2.post1` | 2026-08-01 | Isaac Lab RL simulation. Contains no NVIDIA Isaac bytes: Isaac Sim and Isaac Lab are fetched from `pypi.nvidia.com` on first use under the operator's EULA. Isaac startup requires `OMNI_KIT_ACCEPT_EULA=YES` and `ISAACSIM_ACCEPT_EULA=YES`; expect an approximately 4.5 GB first-run download. |
 | Cosmos 1.0 Diffusion 7B (Predict) | `npa-cosmos` | `1.0.9`, `cu128-torch27-sm100-1.0.9-20260803T002017Z` | 2026-08-03 | Cosmos world-model generation with `Cosmos-1.0-Diffusion-7B-Text2World`, plus the default self-hosted VLM image for workflows. Uses Torch 2.7 and CUDA 12.8 with flash-attn, NATTEN, and Transformer Engine. |
-| Cosmos Curator 0.1.2 | `npa-cosmos-curate` | `0.1.2-skypilot-v1-20260813T164700Z` | 2026-08-13 | Runs real `cosmos-curate` stages in process: download, fixed-stride extraction, clip transcode, motion-vector decode, motion filtering, and clip writing. GPU-stage models are fetched at runtime with the operator's Hugging Face token. |
-| Cosmos Evaluator 0.1.2 | `npa-cosmos-evaluator` | `0.1.2-skypilot-v1-20260813T164700Z` | 2026-08-13 | Runs the upstream `HallucinationProcessor` quality gate on generated video using classical computer vision and no weights. Attribute verification calls an OpenAI-compatible endpoint; the LFS/EULA-gated obstacle checker is deliberately not fetched. |
 | Cosmos Reason 2 / Predict 2.5 (3.0.1) | `npa-cosmos3-reason` | `3.0.1-genuine-sm120`, `cuda13-b300-3.0.1-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | VLM reasoning over video/images with `Cosmos-Reason2-8B` or `Cosmos-Reason2-2B`, serving as a judge/critic stage. Also wires Predict 2.5, Transfer 2.5, and Cosmos-Guardrail1 model IDs on a Blackwell-capable CUDA 13 base. |
 | Cosmos Transfer 2.5 | `npa-cosmos2-transfer` | `2.5.1-skypilot-ready-20260801T053000Z` | 2026-08-03 | Cosmos Transfer 2.5 Sim2Real video augmentation, built from source at an immutable commit with hash-locked dependencies. Gated weights are fetched at runtime with `HF_TOKEN`; baked-byte scans are a release gate. |
 | Foxglove Embed SDK 0.58.0 | `npa-foxglove-embed` | `0.58.0` | 2026-08-03 | Static host for the pinned `@foxglove/embed` browser SDK (MIT) and shared NPA glue module used by the agent UI, on port 8099. Serves operator-mounted MCAP/bag recordings with CORS and byte ranges; the Foxglove app is not redistributed. |
@@ -45,16 +42,23 @@ Rows are ordered by **Built** date, then by friendly name.
 | LanceDB 0.30.3 + CLIP | `npa-lancedb` | `0.30.3`, `cuda13-b300-0.30.3-sm80-sm90-sm100-sm103-sm120-20260803T031514Z` | 2026-08-03 | CLIP embedding and LanceDB vector service on port 8686: the query index behind dataset-of-record search. It uses a thin FastAPI layer on the shared CUDA/PyTorch base. |
 | LeRobot 0.5.1 | `npa-lerobot` | `0.5.1`, `cuda13-b300-0.5.1-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Hugging Face LeRobot training/evaluation service on port 8080 for manipulation policies. Includes CUDA and MuJoCo/EGL headless rendering; checkpoints and job state live on mounted volumes. |
 | LeRobot VLM-RL 0.1.1 | `npa-lerobot-vlm-rl` | `0.1.1`, `cuda13-b300-0.1.1-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | RL loop in which a VLM supplies reward or shaping signals for LeRobot policies. It is built on the Genesis image so simulation and policy execution share one container. |
-| Sim2Real Control 0.1.2 | `npa-sim2real-control` | `0.1.2` | 2026-08-11 | Private/runtime CPU stage adapter for the compositional Sim2Real workflow. It bakes exact NPA source into site-packages path discovery, a pinned S3 dependency closure, and the non-root SkyPilot Kubernetes bootstrap prerequisites on digest-pinned Python slim with snapshot-pinned Debian packages; it contains no CUDA, simulator, model, or trainer runtime. Built from `sim2real-control/Dockerfile`. |
 | Sim2Real EnvGen 0.1.2 | `npa-envgen` | `0.1.2`, `cuda13-b300-0.1.2-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Generates randomized Sim2Real environments and scenes on the Genesis base. Exact-source workflow builds also bake the snapshot-pinned non-root SkyPilot Kubernetes bootstrap closure (`sudo`, SSH, and rsync); this is required before a standard workflow task can start. It is the parent image for BYO policy containers and is built from `sim2real-envgen/Dockerfile`. |
 | Sim2Real Loop Eval 0.1.3 | `npa-loop-eval` | `0.1.3-genuine-sm120`, `cuda13-b300-0.1.3-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Batched closed-loop policy evaluation in Genesis (default 16 environments and 240 steps), providing the scoring stage of the Sim2Real loop. Exact-source workflow builds bake the same snapshot-pinned non-root SkyPilot Kubernetes bootstrap closure as EnvGen so Stage 14 can start without a privileged or moving bootstrap image. Built from `sim2real-eval/Dockerfile`; the tool key is `loop-eval`. |
 | Sim2Real Reference Policy 0.1.2 | `npa-reference-policy` | `0.1.2`, `cuda13-b300-0.1.2-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Reference BYO-compatible Sim2Real action policy and worked example of the policy-container contract. Includes the policy functional smoke for comparison with custom images. |
 | SONIC (GR00T-WholeBodyControl) | `npa-sonic` | `0.1.2` (L40S), `cuda13-b300-0.1.2-k8s-runtime-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Whole-body humanoid locomotion training and evaluation using `gear_sonic` (Apache-2.0 at a pinned commit). Isaac is fetched on first use; NVIDIA Open Model License weights are downloaded at runtime and are never baked into the image. |
 | Cosmos 3 (`cosmos-framework` 1.2.2) | `npa-cosmos3` | `1.2.2-cu130`, `1.2.2-cu130-r2` | 2026-08-08 | Cosmos 3 omni-model generation: text-to-image, image-to-image, text-to-video, image-to-video, and video-to-video. Contains OpenMDW-1.1 source and a CUDA 13 venv only; checkpoints, Wan VAE, and guardrails download at runtime. |
 | Wan 2.2 TI2V-5B | `npa-wan2-2` | historical accepted tag: `2.2-ti2v5b-rtfetch-cu128-20260809T011658Z-r7`; current unpublished closure: Torch 2.13.0/CUDA 13.0/NCCL 2.29.7 | 2026-08-09 | Wan 2.2 text/image-to-video generation from Apache-2.0 source on an OSS dependency base. CUDA PyTorch, `nvidia-*` wheels, models, and tokenizers are runtime-fetched after operator acceptance. The listed tag carries the prior live evidence; the security-fixed closure requires new single- and four-GPU qualification before any tag publication or promotion. |
+| Cosmos Curator 0.1.2 | `npa-cosmos-curate` | `0.1.2-skypilot-v1-20260813T164700Z` | 2026-08-13 | Runs real `cosmos-curate` stages in process: download, fixed-stride extraction, clip transcode, motion-vector decode, motion filtering, and clip writing. GPU-stage models are fetched at runtime with the operator's Hugging Face token. |
+| Cosmos Evaluator 0.1.2 | `npa-cosmos-evaluator` | `0.1.2-skypilot-v1-20260813T164700Z` | 2026-08-13 | Runs the upstream `HallucinationProcessor` quality gate on generated video using classical computer vision and no weights. Attribute verification calls an OpenAI-compatible endpoint; the LFS/EULA-gated obstacle checker is deliberately not fetched. |
+| FiftyOne 1.15.0.post1 (Voxel51) | `npa-fiftyone` | `1.15.0.post1` | 2026-08-13 | Dataset curation and visualization UI on port 5151, including uniqueness, similarity, and embedding visualization. Bundles a `mongod` binary so FiftyOne can launch its own metadata database. |
 
 ## Intentionally not published as separate images
 
+- **`npa-sim2real-control`** is an internal workflow artifact, not a public-mirror
+  tool. Its packaging contract permits redistribution, but it has no entry in
+  `CONTAINER_IMAGE_NAMES` and is therefore outside `publicly_publishable_tools()`;
+  anonymous resolution of `npa-sim2real-control:0.1.2` was denied during the
+  2026-08-14 audit. Eligibility is not evidence of publication.
 - **`npa-cosmos3-serving`** is `restricted` and build-your-own only. Its pinned
   vLLM-Omni base embeds a runtime under NVIDIA's Deep Learning Container License;
   the thin wrapper and anonymous GHCR distribution do not establish that
@@ -74,6 +78,9 @@ timestamped Kubernetes pin declares `root` because its build sets
 `NPA_RUNTIME_USER=root`. Capability descriptions are cross-checked against the
 corresponding Dockerfiles, packaging contracts, golden evaluations, and workflow
 integrations on `main`.
+
+Maintainers should use `skills/atomic/audit-container-docs/SKILL.md` to repeat
+the repository-inventory and anonymous-registry audit after container changes.
 
 This catalog does not imply that every image supports every GPU. Use the
 [B300 validation matrix](../b300-validation-matrix.md) when choosing a

--- a/npa/tests/guardrails/test_audit_container_docs_skill.py
+++ b/npa/tests/guardrails/test_audit_container_docs_skill.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+from npa.deploy.images import (
+    CONTAINER_IMAGE_NAMES,
+    public_mirror_tag_for_tool,
+    publicly_publishable_tools,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CATALOG = REPO_ROOT / "docs/workbench/container-image-catalog.md"
+SKILL = REPO_ROOT / "skills/atomic/audit-container-docs/SKILL.md"
+
+
+def _catalog_rows() -> dict[str, str]:
+    rows: dict[str, str] = {}
+    for line in CATALOG.read_text().splitlines():
+        if not line.startswith("| ") or "`npa-" not in line:
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        match = re.fullmatch(r"`(npa-[^`]+)`", cells[1])
+        assert match, line
+        image = match.group(1)
+        assert image not in rows, f"duplicate public catalog row for {image}"
+        rows[image] = cells[2]
+    return rows
+
+
+def test_public_catalog_matches_the_repository_publish_inventory() -> None:
+    rows = _catalog_rows()
+    tools = publicly_publishable_tools()
+    expected_images = {CONTAINER_IMAGE_NAMES[tool] for tool in tools}
+
+    assert set(rows) == expected_images
+    for tool in tools:
+        image = CONTAINER_IMAGE_NAMES[tool]
+        assert f"`{public_mirror_tag_for_tool(tool)}`" in rows[image], (
+            f"{image} catalog row does not contain the current public-mirror pin"
+        )
+
+
+def test_skill_names_each_authoritative_inventory_layer() -> None:
+    text = SKILL.read_text()
+    for required in (
+        "npa/docker/workbench/packaging-contract.yaml",
+        "npa/src/npa/deploy/images.py",
+        "npa/pyproject.toml",
+        "npa/src/npa/deploy/*_image_manifest.json",
+        "npa/src/npa/deploy/publish_public.py",
+        "publicly_publishable_tools()",
+        "docker buildx imagetools inspect",
+    ):
+        assert required in text

--- a/skills/atomic/audit-container-docs/SKILL.md
+++ b/skills/atomic/audit-container-docs/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: audit-container-docs
+description: Audit and update NPA container-image catalogs and related container documentation when images are added, removed, renamed, retagged, republished, reclassified, or materially changed. Use for docs/workbench/container-image-catalog.md drift, public-mirror inventory checks, and container documentation reviews.
+---
+
+# Audit Container Documentation
+
+Separate repository intent from registry state. An image can have a Dockerfile,
+be eligible for redistribution, or exist in a private registry without being in
+the public mirror inventory. State only the layer that the evidence proves.
+
+## Read The Authoritative Sources
+
+Read `AGENTS.md`, `skills/index.yaml`, and the applicable image/tool skills first.
+Use these sources for distinct facts:
+
+- `npa/docker/workbench/packaging-contract.yaml`: built-image inventory,
+  packaging tier, ports, security exceptions, and redistribution eligibility.
+- `npa/src/npa/deploy/images.py`: canonical tool-to-image names, restricted
+  tools, public-mirror membership, and tag-resolution exceptions.
+- `npa/pyproject.toml` `[tool.npa.supported-tools]`: default immutable image pins.
+- `npa/src/npa/deploy/*_image_manifest.json`: variant-specific pins and evidence
+  for SONIC, Wan, LeRobot, and any future manifest-backed tool.
+- `npa/docker/workbench/<image>/Dockerfile*`, build scripts, lock files, and
+  redistribution records: what an image actually contains and does.
+- `npa/src/npa/deploy/publish_public.py`: exact public source-to-target plan.
+- Golden evaluations, CLI/SDK code, and workflow specs: capability and runtime
+  integration. Do not infer capabilities from an image name alone.
+- Anonymous registry manifest/config inspection: what is publicly pullable now.
+  Treat this as volatile observed state, not a replacement for repository intent.
+
+Do not treat every Dockerfile or every `redistribution: public` entry as a public
+catalog row. `public` means eligible to redistribute; public-mirror membership is
+the intersection selected by `publicly_publishable_tools()` and its resolved pin.
+
+## Run The Audit
+
+1. Preserve unrelated dirty-tree changes and inspect the diff from the relevant
+   base. Search recent changes to Dockerfiles, packaging contracts, image maps,
+   manifests, supported-tool pins, workflows, and container docs.
+2. Print the repository's current public plan from the installed checkout:
+
+   ```bash
+   npa/.venv/bin/python - <<'PY'
+   from npa.deploy.images import CONTAINER_IMAGE_NAMES, public_mirror_tag_for_tool, publicly_publishable_tools
+
+   for tool in publicly_publishable_tools():
+       print(tool, CONTAINER_IMAGE_NAMES[tool], public_mirror_tag_for_tool(tool), sep="\t")
+   PY
+   ```
+
+3. Compare that output with the public catalog. Require one row per public-plan
+   image and require each row to include its current resolved pin. Keep additional
+   aliases or historical tags only when the registry still resolves them and the
+   text explains why they remain useful.
+4. Compare the packaging-contract keys with Dockerfile directories and the public
+   plan. Classify differences: internal/derived variants, restricted build-your-own
+   images, unregistered artifacts, or actual drift. Never silently force the sets
+   to match.
+5. Verify every documented public reference anonymously. Prefer the complete
+   publisher check for current pins, then inspect any extra documented tags:
+
+   ```bash
+   npa/.venv/bin/python -m npa.deploy.publish_public \
+     --target ghcr.io/nebius/nebius-physical-ai --verify-public
+   docker buildx imagetools inspect \
+     ghcr.io/nebius/nebius-physical-ai/<image>:<tag>
+   ```
+
+   Record the UTC verification date only after all retained rows resolve. A 401 or
+   403 is not proof that a tag is absent; it proves anonymous pull was not verified.
+   Describe that limitation precisely.
+6. Inspect OCI config and labels before changing build dates, users, entrypoints,
+   ports, digests, or architecture claims. Use an immutable tag timestamp or
+   `npa.build_ts` only when the reproducible image intentionally clears `created`.
+7. Update affected documentation together: the public catalog, container
+   packaging/security docs, tool skills, workflow docs, and release records only
+   where the changed source or observed registry state supplies evidence. Preserve
+   the distinction among built, supported, publishable, published, and validated.
+
+## Validate The Result
+
+Run the skill validator, catalog/index guardrails, and documentation drift check:
+
+```bash
+npa/.venv/bin/python \
+  ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py \
+  skills/atomic/audit-container-docs
+npa/.venv/bin/python -m pytest \
+  npa/tests/guardrails/test_audit_container_docs_skill.py \
+  npa/tests/guardrails/test_skills_index.py -q
+PATH="$PWD/npa/.venv/bin:$PATH" scripts/build_docs.sh --check
+```
+
+When container sources or resolver code changed, also run the affected Docker,
+deploy, golden-eval, and workflow tests plus the full non-E2E suite required by
+`skills/atomic/testing-conventions/SKILL.md`. Documentation must report registry
+checks numerically and must not claim live capability validation from unit tests.

--- a/skills/atomic/audit-container-docs/agents/openai.yaml
+++ b/skills/atomic/audit-container-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit Container Docs"
+  short_description: "Audit image catalogs against source and registry"
+  default_prompt: "Use $audit-container-docs to audit and update the workbench container documentation."

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -64,6 +64,17 @@ skills:
         path: npa/src/npa/deploy/sonic_image_manifest.json
       - type: file_exists
         path: npa/docker/workbench/packaging-contract.yaml
+  - name: audit-container-docs
+    category: atomic
+    when_to_use: "Audit or update container-image catalogs and related container documentation after images are added, removed, renamed, retagged, republished, reclassified, or materially changed."
+    path: skills/atomic/audit-container-docs/SKILL.md
+    smoke:
+      - type: file_exists
+        path: docs/workbench/container-image-catalog.md
+      - type: file_exists
+        path: npa/docker/workbench/packaging-contract.yaml
+      - type: file_exists
+        path: npa/src/npa/deploy/images.py
   - name: cosmos3-codebase-nav
     category: atomic
     when_to_use: "Navigate NPA Cosmos3 integration and upstream Cosmos framework files."


### PR DESCRIPTION
## What changed

- Re-audited the public Workbench image catalog against the repository publish inventory and anonymous GHCR manifests.
- Removed `npa-sim2real-control:0.1.2` from the public table because it is outside `CONTAINER_IMAGE_NAMES` / `publicly_publishable_tools()` and anonymous GHCR resolution is denied.
- Reordered catalog rows by the documented build-date ordering and refreshed the anonymous verification date.
- Added the indexed `audit-container-docs` atomic skill with authoritative sources, a repeatable repository/registry audit, and validation guidance.
- Added a guardrail that keeps catalog rows and current pins synchronized with the public publish inventory.

## Why

The catalog conflated redistribution eligibility and an internal workflow artifact with anonymous public-mirror membership. Container documentation needs a durable audit process so additions, removals, renames, retags, classifications, and material image changes do not silently drift.

## Impact

Maintainers now have an agent skill for evidence-based container documentation updates. The catalog accurately exposes 24 current public-plan images, while Sim2Real Control is documented as internal rather than anonymously pullable. The new test fails if a public-plan image row is missing, extra, duplicated, or lacks its current mirror pin.

## Validation

- Skill `quick_validate`: passed.
- Catalog/skills guardrails: 5 passed.
- Independent forward audit: 24 current pins and 11 retained aliases anonymously resolved; excluded Sim2Real Control returned GHCR 403; 333 focused packaging/publishing/guardrail tests passed.
- `scripts/build_docs.sh --check`: passed.
- Full non-live suite: 9,598 passed, 37 skipped, 12 deselected, 1 xpassed.
- Targeted Ruff check for the new Python test: passed.

## Limitations

Repository-wide `make lint` still reports three pre-existing unused imports in untouched files: `npa/docker/workbench/sonic/mujoco_eval.py`, `npa/examples/isaac_franka_token_factory_reason.py`, and `npa/scripts/run_byof_datagen.py`. This PR does not alter those unrelated files. Registry verification is a 2026-08-14 point-in-time observation; the skill requires it to be repeated for future catalog updates.