### PR TITLE
PAIDF and Sim2Real: fail fast on onboarding prerequisites

### DIFF
--- a/docs/workbench/getting-started.md
+++ b/docs/workbench/getting-started.md
@@ -233,26 +233,12 @@ projects are configured.
 
 ## First Sim-To-Real Run
 
-After the gates above pass, submit the staged VLM-to-RL loop:
-
-```bash
-npa workbench workflow submit \
-  npa/workflows/workbench/npa-workflows/sim2real.yaml \
-  --run-id <run-id> \
-  --var NPA_SIM2REAL_BUCKET=<your-bucket> \
-  --var NPA_SIM2REAL_TRIGGER_DATASET_URI=s3://<your-bucket>/<trigger-prefix>/
-```
-
-The command prints the run ID, wall-clock time, task-success metric, checkpoint
-URI, report URI, Rerun URI, and `cluster_absent=True` after teardown. The first
-proof checkpoint path has this structure:
-
-```bash
-s3://${NPA_S3_BUCKET}/sim-to-real/<run-id>/checkpoints/policy/
-```
-
-Continue with [guides/sim2real-workflow.md](guides/sim2real-workflow.md) for the
-exact output format and override options.
+The production loop has gated models, Isaac runtime terms/cache, private images,
+Kueue objects, and a dedicated CPU scheduling requirement. Follow the
+[compositional Sim2Real operator runbook](guides/sim2real-workflow.md) in order;
+it is the authoritative copy-paste path from access checks through durable
+submit and resume. Do not adapt the older environment-variable examples: the
+canonical `npa.workflow` uses lower-case `--var` config keys.
 
 ## First BYOF Run
 

--- a/docs/workbench/guides/physical-ai-data-factory-deploy.md
+++ b/docs/workbench/guides/physical-ai-data-factory-deploy.md
@@ -22,13 +22,14 @@ tool — every stage is an existing workbench tool or a real `run.shell` step.
 
 ## Run PAIDF with a coding agent
 
-First [configure and authenticate the Nebius CLI](https://docs.nebius.com/cli/configure)
-for the target project. Create a [Token Factory project API
-key](https://docs.tokenfactory.nebius.com/quickstart), a [Hugging Face read
-token](https://huggingface.co/docs/hub/en/security-tokens), and an [NGC Personal
-API Key](https://docs.nvidia.com/ngc/latest/ngc-user-guide.html#generating-ngc-api-keys)
-with NGC Catalog access. Save each value alone in a file outside this repository
-and run `chmod 600 <file>`; give the agent paths, never secret values.
+First [authenticate the Nebius CLI](https://docs.nebius.com/cli/configure).
+Create a [Token Factory key](https://docs.tokenfactory.nebius.com/quickstart)
+and a [Hugging Face read token](https://huggingface.co/docs/hub/en/security-tokens)
+whose account has accepted the
+[Cosmos Transfer 2.5 terms](https://huggingface.co/nvidia/Cosmos-Transfer2.5-2B).
+Save each value alone in a `chmod 600` file outside the repository; give the
+agent file paths, never secret values. NGC is not required when using the public
+GHCR images in this runbook.
 
 Copy this prompt into your coding agent from the repository root:
 
@@ -47,7 +48,6 @@ Project: <project-id>
 Region: <region>
 Token Factory key file: </absolute/path/token-factory-key>
 Hugging Face token file: </absolute/path/hf-token>
-NGC API key file: </absolute/path/ngc-api-key>
 
 Never print secrets or copy them into the repository, logs, or shell history.
 Use NPA commands, continue autonomously, and report blockers and usability gaps
@@ -90,6 +90,7 @@ REGISTRY="$NPA_REGISTRY"
 RUN_ID="$(npa workbench workflow prepare-run "$SPEC" --project "$PROJECT")"
 
 npa workbench health preflight
+npa workbench health access --capability paidf
 npa provision-if-absent --project "$PROJECT" \
   --cpu-nodes 1 --cpu-platform cpu-d3 --cpu-preset 8vcpu-32gb \
   --gpu-nodes 1 --gpu-platform gpu-rtx6000 \
@@ -109,15 +110,13 @@ npa workbench workflow plan-spec "$SPEC" --run-id "$RUN_ID" \
   --var bucket="$BUCKET" \
   --var n_augmentations=1 --json
 
-# With GHCR this uses the Registry v2 anonymous token flow. With a configured
-# private registry it uses the matching configured credentials and submit also
-# refreshes the Kubernetes imagePullSecret before launch.
+# Proves manifest pulls. GHCR is anonymous; for a private Nebius registry,
+# submit also refreshes the Kubernetes imagePullSecret before launch.
 npa workbench workflow preflight-images "$SPEC" \
   --project "$PROJECT" --registry "$REGISTRY"
 
-# Source staging is automatic, content-addressed, verified, and persisted. Each
-# --secret-env NAME is resolved from the current environment first, then the
-# selected project's NPA credentials; a missing value fails before setup.
+# Source staging is automatic and content-addressed. Each secret name resolves
+# from the environment or project store; a missing gate fails before GPU launch.
 npa workbench workflow submit "$SPEC" \
   --project "$PROJECT" --registry "$REGISTRY" \
   --run-id "$RUN_ID" --runtime --auto-load \
@@ -138,6 +137,19 @@ npa workbench workflow status "$RUN_ID" --project "$PROJECT" \
 npa workbench workflow logs "$MANIFEST_URI" --project "$PROJECT" --stage augment
 npa workbench workflow load-artifact "$RUN_ID" --project "$PROJECT" # idempotent retry only
 ```
+
+The sequence has five fail-fast gates:
+
+| Gate | Success |
+| --- | --- |
+| Credentials | S3 and Token Factory checks pass |
+| Model terms | Cosmos Transfer reports `HF access ok` |
+| Cluster | one CPU node fits the controller plus a PAIDF CPU stage; one GPU node fits Transfer |
+| Images | every manifest is pullable; private Nebius credentials refresh `npa-nebius-registry` |
+| Submit secrets | Token Factory, S3, and `HF_TOKEN` are forwarded without entering YAML |
+
+Stop at the first nonzero command; it prints the remedy. Detailed recovery is
+below.
 
 For a pre-authenticated service-account/federation profile with known IDs, the
 prompt-free equivalent is:

--- a/docs/workbench/guides/physical-ai-data-factory-deploy.md
+++ b/docs/workbench/guides/physical-ai-data-factory-deploy.md
@@ -622,8 +622,8 @@ No extra flag is the production starter path. To replace it, add exactly one of:
 --seed-fixture  # developers/tests only: explicitly synthetic geometry
 ```
 
-Local and S3 replacements must be decodable H.264 MP4s. Validation and staging
-happen before automatic provisioning. Conflicts, missing media, unsupported
+Local and S3 replacements must be decodable H.264 MP4s. Kubernetes placement is
+checked before input or source staging. Conflicts, missing media, unsupported
 codec/container/shape, checksum mismatch, or an unavailable object fail with an
 actionable error and never fall back to shapes. `NPA_PAIDF_OFFLINE=1` permits
 only a verified cache hit. A committed run input is immutable, so a repeated
@@ -702,7 +702,8 @@ npa workbench workflow submit "$SPEC" \
   --assume-decision promote_checkpoint \
   --secret-env NEBIUS_TOKEN_FACTORY_KEY \
   --secret-env AWS_ACCESS_KEY_ID \
-  --secret-env AWS_SECRET_ACCESS_KEY
+  --secret-env AWS_SECRET_ACCESS_KEY \
+  --secret-env HF_TOKEN
 ```
 
 When no valid `NPA_SRC_S3_URI` or image override is supplied, real submit

--- a/docs/workbench/guides/physical-ai-data-factory.md
+++ b/docs/workbench/guides/physical-ai-data-factory.md
@@ -306,10 +306,12 @@ that optional handoff. Submit checks prerequisites up front and prints anything
 still missing in a single list; the
 [deploy runbook](physical-ai-data-factory-deploy.md) has the full ordered
 quickstart (`configure` → `skypilot bootstrap` → `provision-if-absent` → submit).
-The PAIDF submit preflight also requires one schedulable non-GPU node for the
-2 vCPU/8 GiB SkyPilot controller plus a 4 vCPU/16 GiB CPU stage, verifies the
-gated Cosmos Transfer repository with the forwarded `HF_TOKEN`, and reuses the
-generic image-pull check/secret refresh for the selected registry.
+The PAIDF submit preflight also requires one Ready, schedulable, appropriately
+untainted node with 6 CPU and 24 GiB allocatable for the SkyPilot controller and
+one CPU stage. A qualifying GPU node is valid because the CPU profile has no
+GPU exclusion. The check uses the exact submission context before S3/input/source
+mutation, verifies gated Cosmos Transfer access with the forwarded `HF_TOKEN`,
+and reuses the generic image-pull check/secret refresh.
 
 Monitor an exact run using NPA alone:
 

--- a/docs/workbench/guides/physical-ai-data-factory.md
+++ b/docs/workbench/guides/physical-ai-data-factory.md
@@ -277,6 +277,10 @@ NPA_SRC_S3_URI=s3://<your-bucket>/npa-src/npa/ \
 ## Submit (real run)
 
 ```bash
+SPEC=npa/workflows/workbench/npa-workflows/physical-ai-data-factory.yaml
+npa workbench health access --capability paidf
+npa workbench workflow preflight-images "$SPEC" \
+  --project <alias> --registry <registry>
 RUN_ID="$(npa workbench workflow prepare-run "$SPEC" --project <alias>)"
 npa workbench workflow submit "$SPEC" \
   --project <alias> --run-id "$RUN_ID" \
@@ -286,7 +290,8 @@ npa workbench workflow submit "$SPEC" \
   --infra k8s/<your-kube-context> \
   --secret-env NEBIUS_TOKEN_FACTORY_KEY \
   --secret-env AWS_ACCESS_KEY_ID \
-  --secret-env AWS_SECRET_ACCESS_KEY
+  --secret-env AWS_SECRET_ACCESS_KEY \
+  --secret-env HF_TOKEN
 ```
 
 `--var bucket=` points `config.bucket` at the artifact bucket your NPA agent
@@ -301,6 +306,10 @@ that optional handoff. Submit checks prerequisites up front and prints anything
 still missing in a single list; the
 [deploy runbook](physical-ai-data-factory-deploy.md) has the full ordered
 quickstart (`configure` → `skypilot bootstrap` → `provision-if-absent` → submit).
+The PAIDF submit preflight also requires one schedulable non-GPU node for the
+2 vCPU/8 GiB SkyPilot controller plus a 4 vCPU/16 GiB CPU stage, verifies the
+gated Cosmos Transfer repository with the forwarded `HF_TOKEN`, and reuses the
+generic image-pull check/secret refresh for the selected registry.
 
 Monitor an exact run using NPA alone:
 

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -69,7 +69,7 @@ selected project's private NPA credential store; never put values in YAML.
 
 ## 3. Add a schedulable CPU pool before GPU work
 
-SkyPilot's Kubernetes jobs controller needs 4 vCPU/16 GiB. Sim2Real CPU states
+SkyPilot's Kubernetes jobs controller requests 2 vCPU/8 GiB. Sim2Real CPU states
 request 8 vCPU/32 GiB and deliberately use the small
 `npa-sim2real-control` image. Give them a Ready, untainted, non-GPU node so they
 do not contend with RT-core workers:

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -71,8 +71,9 @@ selected project's private NPA credential store; never put values in YAML.
 
 SkyPilot's Kubernetes jobs controller requests 2 vCPU/8 GiB. Sim2Real CPU states
 request 8 vCPU/32 GiB and deliberately use the small
-`npa-sim2real-control` image. Give them a Ready, untainted, non-GPU node so they
-do not contend with RT-core workers:
+`npa-sim2real-control` image. Give them a Ready, schedulable, appropriately
+untainted node with enough allocatable CPU and memory. It may also advertise GPUs;
+the CPU profile has no GPU exclusion:
 
 ```bash
 npa/.venv/bin/npa cluster node-group add-cpu \
@@ -86,7 +87,7 @@ npa/.venv/bin/npa cluster node-group add-cpu \
 kubectl get nodes -o custom-columns=NAME:.metadata.name,READY:.status.conditions[-1].status,CPU:.status.allocatable.cpu,MEMORY:.status.allocatable.memory,GPU:.status.allocatable.nvidia\.com/gpu
 ```
 
-Expected: at least one Ready row with roughly 16 CPU, 64 GiB memory, and no GPU.
+Expected: at least one Ready row with roughly 16 CPU and 64 GiB memory.
 The larger preset is intentional: Kubernetes reserves part of nominal node
 capacity, so an `8vcpu-32gb` node cannot fit a pod that requests the full
 8 vCPU/32 GiB profile. A separate `8vcpu-32gb` pool is sufficient for the

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -1,91 +1,249 @@
-# Compositional Sim2Real workflow
+# Compositional Sim2Real operator runbook
 
-The single canonical operator spec is
-[`npa/workflows/workbench/npa-workflows/sim2real.yaml`](../../../npa/workflows/workbench/npa-workflows/sim2real.yaml), beside the Physical AI Data Factory spec. It is a normal
-`npa.workflow/v0.0.1` graph. The normal planner renders each state into a
-SkyPilot task, the normal runtime persists its S3 ledger, and `--resume`
-reconciles completed or in-flight waves. There is no Sim2Real detector bypass,
-driver pod, or hidden sibling-Job controller on this path.
+This is the onboarding source of truth for the canonical 14-stage workflow:
+[`sim2real.yaml`](../../../npa/workflows/workbench/npa-workflows/sim2real.yaml).
+Complete the gates in order. A production submit repeats the decisive S3,
+model-access, cluster-object, immutable-image, and image-pull checks before it
+creates a run or launches work.
 
-## What the graph executes
+## 1. Accept the exact third-party terms
 
-The visible states preserve the canonical 14-stage contract:
+The runtime downloads three gated checkpoints under the operator's Hugging Face
+account. Sign in, review the NVIDIA Open Model License, and request/accept access
+on all three pages:
 
-1. validate the task-aligned Isaac trigger and seed manifest;
-2. consume the asset, task, robot, camera, and strict-success contract;
-3. run real input-conditioned Cosmos Transfer 2.5;
-4. generate raw environment shards in parallel GPU tasks;
-5. curate and seal disjoint train, validation, and untouched gold sets;
-6. publish the explicit token/scenario handoff;
-7. execute real Isaac policy rollouts with primary/side/overhead cameras;
-8. execute real Cosmos Reason2 and Reason3 lanes in parallel;
-9. merge bounded temporal signals, run genuine BYO Isaac RSL-RL PPO, and use
-   only validation scenarios for checkpoint selection;
-10. load that exact checkpoint for real Isaac evaluation on untouched gold;
-11. record the unchanged strict 5 cm stable-placement metric and loop decision;
-12. record the external physical-validation boundary as `SEAM`, never `WORKS`;
-13. persist the retrigger/loop record; and
-14. publish the final report, Rerun recording, and MCAP recording.
+- [`nvidia/Cosmos-Transfer2.5-2B`](https://huggingface.co/nvidia/Cosmos-Transfer2.5-2B)
+- [`nvidia/Cosmos-Reason2-8B`](https://huggingface.co/nvidia/Cosmos-Reason2-8B)
+- [`nvidia/Cosmos-Reason2-2B`](https://huggingface.co/nvidia/Cosmos-Reason2-2B)
 
-Policy quality is reported honestly but is not a workflow-plumbing success
-gate. Long 3x3 PPO-500 efficacy studies are post-merge work. A reduced 1x1 run
-may lower counts to prove every real boundary and artifact handoff, while the
-strict metric and sealed gold contract remain unchanged.
+Isaac runtime warming and execution additionally require the operator to review
+the [NVIDIA Omniverse terms](https://docs.omniverse.nvidia.com/usd/latest/common/NVIDIA_Omniverse_License_Agreement.html),
+[Isaac Sim additional licenses](https://docs.isaacsim.omniverse.nvidia.com/latest/common/licenses.html),
+and [NVIDIA Software License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-software-license-agreement/).
+The repository never supplies consent: the cache warmer and workflow must receive
+both `OMNI_KIT_ACCEPT_EULA=YES` and `ISAACSIM_ACCEPT_EULA=YES` from the operator.
 
-## Required operator inputs
-
-The committed spec is tenant-neutral. At submission, set the S3 bucket/trigger,
-six registry-qualified immutable images, and the prewarmed Isaac cache PVC.
-The image adapters require `NPA_TASK_IMAGE` to contain `@sha256:` and attest the
-image source SHA. Isaac also verifies its read-only content-addressed runtime
-cache before simulator startup. The operator must also pass explicit NVIDIA
-acceptance through `omni_kit_accept_eula` and `isaacsim_accept_eula`; both
-committed defaults are empty. The inline Isaac adapter validates both values
-before starting Kit, so the workflow never accepts terms on the operator's
-behalf and never falls through to an interactive prompt in an unattended Job.
-
-`controller_image` is the digest-pinned, CPU-only `npa-sim2real-control` image
-built from `npa/docker/workbench/sim2real-control/Dockerfile`. It deliberately
-contains no Genesis, Isaac, CUDA, or trainer runtime; using a GPU solution image
-for CPU bookkeeping is unsupported because its cold pull can exhaust a CPU
-node before Stage 1. It does contain the non-root SkyPilot Kubernetes bootstrap
-prerequisites, which are part of the schedulable-image contract and are tested
-through the same standard runtime path used live. Its exact source is installed
-as a site-packages path as well as exported through `PYTHONPATH`, because the
-SkyPilot setup login shell is allowed to rebuild its environment. Transfer,
-EnvGen, Reason, Isaac, and visualization each retain their own immutable image
-at the corresponding workflow boundary.
-
-SkyPilot 0.12.2 still performs its Kubernetes bootstrap through passwordless
-`sudo`. For this CPU-only, ephemeral task image the task pod is the security
-boundary; the finite exception and prohibited service/public-ingress uses are
-enforced in `packaging-contract.yaml`. Separately, the Isaac cache warmer and
-the retained standalone BYO Isaac Job builders run as uid/gid 1000 (the warmer
-uses an fsGroup-owned PVC); none of the Sim2Real Isaac paths may override
-`runAsUser: 0`.
+Create a read token and verify the same token can access every Sim2Real model:
 
 ```bash
-SPEC=npa/workflows/workbench/npa-workflows/sim2real.yaml
+export HF_TOKEN='<hugging-face-read-token>'
+npa/.venv/bin/npa configure --no-interactive --save-env-credentials
+npa/.venv/bin/npa workbench health access --capability sim2real
+```
 
-npa/.venv/bin/npa workbench workflow validate-spec "$SPEC"
-npa/.venv/bin/npa workbench workflow plan-spec "$SPEC" --waves \
-  --run-id <run-id>
+Expected: three `HF access ok` lines and a zero exit status. A `401` means the
+token is invalid or did not reach the check; a `403` means the account has not
+accepted access or a fine-grained token omits that repository. See
+[Hugging Face setup](../huggingface-token.md). `NGC_API_KEY` is not required by
+the submitted runtime when all six images are already in the selected registry;
+it may be required by a separate image-build/source-fetch path.
 
-npa/.venv/bin/npa workbench workflow submit "$SPEC" \
-  --runtime \
-  --run-id <run-id> \
-  --resume \
-  --max-wait-seconds 0 \
-  --var bucket=<bucket> \
-  --var trigger_uri=s3://<bucket>/<task-aligned-trigger>/ \
-  --var seed_manifest_uri=s3://<bucket>/<task-aligned-trigger>/dataset-manifest.json \
-  --var controller_image=<registry/controller@sha256:...> \
-  --var transfer_image=<registry/transfer@sha256:...> \
-  --var envgen_image=<registry/envgen@sha256:...> \
-  --var reason_image=<registry/reason@sha256:...> \
-  --var isaac_image=<registry/isaac@sha256:...> \
-  --var viewer_image=<registry/viewer@sha256:...> \
-  --var isaac_cache_pvc=<pvc> \
+## 2. Configure Nebius, storage, Kubernetes, and SkyPilot
+
+Start with the shared [quickstart](../../quickstart.md) and
+[Kubernetes setup](../kubernetes.md). Resolve the project once, ensure S3 and
+the cluster, select the exact kube context, and bootstrap the pinned SkyPilot:
+
+```bash
+export NPA_PROJECT='<configured-project-alias>'
+export NPA_CLUSTER='<cluster-name>'
+
+npa/.venv/bin/npa configure --show
+npa/.venv/bin/npa provision-if-absent --project "${NPA_PROJECT}" --dry-run --output-format json
+npa/.venv/bin/npa provision-if-absent --project "${NPA_PROJECT}"
+export KUBECONFIG="${HOME}/.npa/clusters/${NPA_CLUSTER}/kubeconfig"
+npa/.venv/bin/npa skypilot bootstrap
+export NPA_SKYPILOT_BIN="$(npa/.venv/bin/npa skypilot status --bin-path)"
+"${NPA_SKYPILOT_BIN}" check kubernetes
+```
+
+Expected: the dry run names the intended S3/Kubernetes actions without changing
+them; the real command converges them; `sky check` reports Kubernetes enabled.
+If the kubeconfig path differs, use the path printed by `npa cluster status`.
+Clear stale ambient bearer tokens if authentication disagrees with the Nebius
+CLI: `unset NEBIUS_IAM_TOKEN NPA_NEBIUS_IAM_TOKEN`.
+
+The workflow runtime needs its storage credentials inside every wave. Request
+their propagation explicitly at submit time even when values come from the
+selected project's private NPA credential store; never put values in YAML.
+
+## 3. Add a schedulable CPU pool before GPU work
+
+SkyPilot's Kubernetes jobs controller needs 4 vCPU/16 GiB. Sim2Real CPU states
+request 8 vCPU/32 GiB and deliberately use the small
+`npa-sim2real-control` image. Give them a Ready, untainted, non-GPU node so they
+do not contend with RT-core workers:
+
+```bash
+npa/.venv/bin/npa cluster node-group add-cpu \
+  --cluster-name "${NPA_CLUSTER}" \
+  --name sim2real-cpu \
+  --platform cpu-e2 \
+  --preset 16vcpu-64gb \
+  --node-count 1 \
+  --wait
+
+kubectl get nodes -o custom-columns=NAME:.metadata.name,READY:.status.conditions[-1].status,CPU:.status.allocatable.cpu,MEMORY:.status.allocatable.memory,GPU:.status.allocatable.nvidia\.com/gpu
+```
+
+Expected: at least one Ready row with roughly 16 CPU, 64 GiB memory, and no GPU.
+The larger preset is intentional: Kubernetes reserves part of nominal node
+capacity, so an `8vcpu-32gb` node cannot fit a pod that requests the full
+8 vCPU/32 GiB profile. A separate `8vcpu-32gb` pool is sufficient for the
+controller alone, but not for the canonical Sim2Real CPU states.
+If the preflight reports no fitting CPU node, remove `NoSchedule`/`NoExecute`
+taints that the tasks do not tolerate or add/resize this pool.
+
+## 4. Create Kueue admission objects and warm Isaac once
+
+The canonical defaults name the `sim2real-gpu` LocalQueue and
+`sim2real-production` PriorityClass. Create the queue objects with quotas that
+cover the cluster's actual concurrent GPU, CPU, and memory requests; the helper
+generates the exact repository-owned schemas:
+
+```bash
+export NPA_GPU_PRODUCT='<exact nvidia.com/gpu.product label from kubectl get nodes>'
+export NPA_GPU_QUOTA='<concurrent GPU count>'
+export NPA_CPU_QUOTA='<aggregate CPU quota, for example 64>'
+export NPA_MEMORY_QUOTA='<aggregate memory quota, for example 512Gi>'
+
+npa/.venv/bin/python - <<'PY' | kubectl apply -f -
+import os
+import yaml
+from npa.workflows.sim2real.job_scheduling import kueue_queue_manifests
+
+docs = kueue_queue_manifests(
+    namespace="default",
+    gpu_product=os.environ["NPA_GPU_PRODUCT"],
+    gpu_quota=int(os.environ["NPA_GPU_QUOTA"]),
+    cpu_quota=os.environ["NPA_CPU_QUOTA"],
+    memory_quota=os.environ["NPA_MEMORY_QUOTA"],
+)
+print(yaml.safe_dump_all(docs, sort_keys=False))
+PY
+
+kubectl get localqueue.kueue.x-k8s.io sim2real-gpu -n default
+kubectl get priorityclass sim2real-production
+```
+
+Expected: both `get` commands return their named object. Missing Kueue CRDs mean
+Kueue must be installed first; a queue with insufficient CPU or memory quota can
+leave a GPU Job suspended even when a GPU is free.
+
+Choose the digest-pinned Isaac image now, then warm a shared RWX cache. The
+template is the authoritative PVC/security/bootstrap contract:
+
+```bash
+export NPA_ISAAC_IMAGE='<registry>/npa-isaac-lab@sha256:<64-hex>'
+sed "s|image: cr.us-central1.nebius.cloud/<your-registry-id>/npa-isaac-lab@sha256:<64-hex-digest>|image: ${NPA_ISAAC_IMAGE}|" \
+  npa/docker/workbench/common/warm-isaac-cache.yaml | kubectl apply -f -
+kubectl wait --for=condition=complete job/npa-warm-isaac-cache --timeout=-1s
+kubectl logs job/npa-warm-isaac-cache
+kubectl get pvc npa-isaac-cache -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,MODES:.status.accessModes
+```
+
+Expected: the Job completes, its log ends with a successful bootstrap, and the
+PVC is `Bound` with `RWX`. Exit 78 means one of the two EULA values was absent;
+image pull failures are handled in the next gate. See
+[runtime-fetch packaging](../container-packaging.md#nvidia-isaac--omniverse-runtime-fetch-images).
+
+## 5. Build/push once and prove the exact image pulls
+
+The workflow does not copy images into the configured registry. Build/push the
+runtime images using the repository scripts, or use already validated images
+from your private registry. Never submit tags: resolve and retain immutable
+`@sha256:` references for these six config keys:
+
+| Config key | Required image |
+| --- | --- |
+| `controller_image` | `npa-sim2real-control` |
+| `transfer_image` | `npa-cosmos2-transfer` |
+| `envgen_image` | `npa-envgen` |
+| `reason_image` | `npa-cosmos3-reason` |
+| `isaac_image` | `npa-isaac-lab` (same bytes used to warm the cache) |
+| `viewer_image` | `npa-rerun-viewer` |
+
+Relevant build entrypoints are
+`npa/docker/workbench/sim2real-build.sh`,
+`npa/docker/workbench/cosmos2-transfer/build.sh`, and
+`npa/docker/workbench/isaac-lab/build.sh`. Follow
+[build and push](../container-packaging.md) when images are absent.
+
+Put the six references in shell variables, then reproduce the actual manifest
+pulls with the same config used by submit:
+
+```bash
+export CONTROLLER_IMAGE='<registry>/npa-sim2real-control@sha256:<64-hex>'
+export TRANSFER_IMAGE='<registry>/npa-cosmos2-transfer@sha256:<64-hex>'
+export ENVGEN_IMAGE='<registry>/npa-envgen@sha256:<64-hex>'
+export REASON_IMAGE='<registry>/npa-cosmos3-reason@sha256:<64-hex>'
+export ISAAC_IMAGE="${NPA_ISAAC_IMAGE}"
+export VIEWER_IMAGE='<registry>/npa-rerun-viewer@sha256:<64-hex>'
+export SPEC=npa/workflows/workbench/npa-workflows/sim2real.yaml
+
+npa/.venv/bin/npa workbench workflow preflight-images "${SPEC}" \
+  --project "${NPA_PROJECT}" \
+  --infra "k8s/${NPA_CLUSTER}" \
+  --assume-decision promote_checkpoint \
+  --var controller_image="${CONTROLLER_IMAGE}" \
+  --var transfer_image="${TRANSFER_IMAGE}" \
+  --var envgen_image="${ENVGEN_IMAGE}" \
+  --var reason_image="${REASON_IMAGE}" \
+  --var isaac_image="${ISAAC_IMAGE}" \
+  --var viewer_image="${VIEWER_IMAGE}"
+```
+
+Expected: every image is pullable and bootstrap-compatible. `not_found` means
+build/push the printed image; `forbidden` means fix registry IAM. A real submit
+also refreshes `default/npa-nebius-registry` with a fresh short-lived Nebius IAM
+credential and refuses to launch if that Kubernetes pull-secret update fails.
+Do not hand-create a long-lived registry token. See
+[registry troubleshooting](../troubleshooting/known-footguns.md#registry-pull-secret-expires-silently).
+
+## 6. Validate, plan, and submit
+
+Set a real bucket and task-aligned seed prefix. The trigger prefix and its
+`dataset-manifest.json` must already be readable; customer data contracts are in
+[Sim2Real customer assets](sim2real-customer-assets.md).
+
+```bash
+export RUN_ID="sim2real-$(date -u +%Y%m%dT%H%M%SZ)"
+export NPA_BUCKET='<bucket-name>'
+
+npa/.venv/bin/npa workbench workflow validate-spec "${SPEC}" --json
+npa/.venv/bin/npa workbench workflow plan-spec "${SPEC}" \
+  --run-id "${RUN_ID}" --waves --assume-decision promote_checkpoint \
+  --var bucket="${NPA_BUCKET}" \
+  --var controller_image="${CONTROLLER_IMAGE}" \
+  --var transfer_image="${TRANSFER_IMAGE}" \
+  --var envgen_image="${ENVGEN_IMAGE}" \
+  --var reason_image="${REASON_IMAGE}" \
+  --var isaac_image="${ISAAC_IMAGE}" \
+  --var viewer_image="${VIEWER_IMAGE}" \
+  --var isaac_cache_pvc=npa-isaac-cache \
+  --var omni_kit_accept_eula=YES \
+  --var isaacsim_accept_eula=YES
+```
+
+Expected: validation reports valid, and the wave plan shows the 14-stage graph
+with Stage 4 and Stage 8 parallel waves. Then submit through the durable runtime:
+
+```bash
+npa/.venv/bin/npa workbench workflow submit "${SPEC}" \
+  --project "${NPA_PROJECT}" \
+  --infra "k8s/${NPA_CLUSTER}" \
+  --runtime --resume --max-wait-seconds 0 \
+  --run-id "${RUN_ID}" \
+  --var bucket="${NPA_BUCKET}" \
+  --var trigger_uri="s3://${NPA_BUCKET}/sim2real-triggers/${RUN_ID}/" \
+  --var seed_manifest_uri="s3://${NPA_BUCKET}/sim2real-triggers/${RUN_ID}/dataset-manifest.json" \
+  --var controller_image="${CONTROLLER_IMAGE}" \
+  --var transfer_image="${TRANSFER_IMAGE}" \
+  --var envgen_image="${ENVGEN_IMAGE}" \
+  --var reason_image="${REASON_IMAGE}" \
+  --var isaac_image="${ISAAC_IMAGE}" \
+  --var viewer_image="${VIEWER_IMAGE}" \
+  --var isaac_cache_pvc=npa-isaac-cache \
   --var omni_kit_accept_eula=YES \
   --var isaacsim_accept_eula=YES \
   --secret-env AWS_ACCESS_KEY_ID \
@@ -93,27 +251,32 @@ npa/.venv/bin/npa workbench workflow submit "$SPEC" \
   --secret-env HF_TOKEN
 ```
 
-Use `--var outer_iterations=1 --var inner_iterations=1` and reduced scenario/PPO
-values for the merge-proof ladder. Omit those overrides for production-size
-defaults. `--max-wait-seconds 0` deliberately means no arbitrary per-wave
-deadline; managed-job state and the S3 runtime ledger remain observable.
+Before any launch, submit now fails with one consolidated prerequisite report if
+the required secret propagation, three gated model probes, CPU node, cache PVC,
+Kueue queue, PriorityClass, S3 write probe, immutable images, or image pulls are
+not ready. `--skip-preflight` is an expert escape hatch and is not part of this
+runbook.
 
-## Durable evidence
+For a reduced plumbing proof, add `--var outer_iterations=1 --var
+inner_iterations=1` and deliberately chosen smaller scenario/PPO values. Do not
+change the strict 5 cm metric or sealed gold contract. Do not add arbitrary run
+deadlines; `--max-wait-seconds 0` keeps durable status in
+`s3://<bucket>/sim2real/<run-id>/npa-workflow/runtime.json`.
 
-The runtime ledger is
-`s3://<bucket>/sim2real/<run-id>/npa-workflow/runtime.json`. Stage outputs are
-explicit S3 inputs to the next state. Each stage publishes a canonical
-`components/stage_XX.json` pointer backed by an immutable
-`components/history/stage_XX/<content-sha256>.json` record. Restarting at the
-Stage 8/9 barrier or during Stage 14 reuses successful output only after the
-runtime validates its declared artifacts.
+## Resume and verify
 
-Final artifacts are:
+```bash
+npa/.venv/bin/npa workbench workflow status "${RUN_ID}" --project "${NPA_PROJECT}" --watch
+# after an operator/controller restart:
+npa/.venv/bin/npa workbench workflow submit "${SPEC}" \
+  --project "${NPA_PROJECT}" --infra "k8s/${NPA_CLUSTER}" \
+  --runtime --resume-run "${RUN_ID}" --max-wait-seconds 0 \
+  <the same --var and --secret-env arguments>
+```
 
-- `reports/sim2real-report.json`
-- `reports/sim2real.rrd`
-- `reports/sim2real.mcap`
-- the exact selected checkpoint and validation/gold lineage named by the report.
-
-See [the architecture/resume contract](../../architecture/sim2real-compositional-workflow.md)
-for execution ownership and compatibility details.
+Completion must include `reports/sim2real-report.json`, non-empty
+`reports/sim2real.rrd` and `reports/sim2real.mcap`, the selected checkpoint, and
+exact validation/gold lineage. Pipeline completion proves orchestration, not
+policy efficacy; report the measured strict success without weakening it. The
+[architecture/resume contract](../../architecture/sim2real-compositional-workflow.md)
+defines the 14 ComponentRecords and restart audit.

--- a/docs/workbench/huggingface-token.md
+++ b/docs/workbench/huggingface-token.md
@@ -27,7 +27,9 @@ while signed in and click **Agree and access repository**. The workbench's gated
 models include, among others:
 
 - <https://huggingface.co/nvidia/GR00T-N1.7-3B>
+- <https://huggingface.co/nvidia/Cosmos-Transfer2.5-2B>
 - <https://huggingface.co/nvidia/Cosmos-Reason2-2B>
+- <https://huggingface.co/nvidia/Cosmos-Reason2-8B>
 - <https://huggingface.co/nvidia/Cosmos-Reason1-7B>
 - <https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct> (only needed if you
   self-host it; Nebius Token Factory serves it hosted with no HF gating)

--- a/docs/workbench/huggingface-token.md
+++ b/docs/workbench/huggingface-token.md
@@ -70,6 +70,7 @@ variable → `~/.npa/credentials.yaml`.
 
 ```bash
 npa workbench health access          # checks HF (and NGC) access to gated models
+npa workbench health access --capability paidf    # Cosmos Transfer only
 # or, credentials-presence only (no network):
 npa workbench health preflight --offline
 ```

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -704,6 +704,7 @@ def submit_cmd(
     registry_auth_plan = None
     deploy_targets = []
     resolved_deploy_plans: dict[str, Any] = {}
+    paidf_kubernetes_checked = False
     source_action = "not-required"
     planned_source_uri = ""
     if is_npa_spec:
@@ -872,6 +873,24 @@ def submit_cmd(
                 requires_npa_source=requires_npa_source,
                 source_staging_planned=stage_source_planned,
             )
+            if not plan_only and is_paidf_spec:
+                from npa.clients.huggingface import validate_hf_access
+                from npa.orchestration.npa_workflow.paidf_preflight import (
+                    static_prerequisites as paidf_static_prerequisites,
+                )
+
+                missing.extend(
+                    paidf_static_prerequisites(
+                        requested_secret_envs=secret_env,
+                        secret_values=extra_env,
+                        hf_validator=validate_hf_access,
+                    )
+                )
+                if infra_context and _adopt_npa_kubeconfig(infra_context):
+                    missing.extend(
+                        _paidf_kubernetes_prerequisites_for_submit(infra_context)
+                    )
+                    paidf_kubernetes_checked = True
             if not plan_only and workflow_identity == "sim2real":
                 from npa.clients.huggingface import validate_hf_access
                 from npa.clients.kube import run_kubectl
@@ -1151,6 +1170,28 @@ def submit_cmd(
                 verify_controller_owner(project, infra_context)
             except ClusterOwnerIdentityMismatchError as exc:
                 _fail(str(exc))
+                return
+        if (
+            is_paidf_spec
+            and not paidf_kubernetes_checked
+            and not skip_preflight
+            and not plan_only
+        ):
+            placement_context = infra_context or next(
+                (
+                    target.resolved_context
+                    for target in deploy_targets
+                    if target.cloud.strip().lower() in {"k8s", "kubernetes"}
+                ),
+                "",
+            )
+            if placement_context:
+                _adopt_npa_kubeconfig(placement_context)
+            paidf_missing = _paidf_kubernetes_prerequisites_for_submit(
+                placement_context
+            )
+            if paidf_missing:
+                _fail_missing_prerequisites(yaml_path, paidf_missing)
                 return
         npa_render_options = SkypilotRenderOptions(
             registry=_resolve_submit_registry(registry, project),
@@ -2583,6 +2624,29 @@ def _infra_kube_context(infra: str) -> str:
     if kind.strip().lower() not in {"k8s", "kubernetes"}:
         return ""
     return context.strip()
+
+
+def _paidf_kubernetes_prerequisites_for_submit(
+    context: str,
+) -> list[tuple[str, str]]:
+    """Run PAIDF's placement check with the exact submit kube context."""
+
+    from npa.clients.kube import run_kubectl
+    from npa.orchestration.npa_workflow.paidf_preflight import (
+        kubernetes_prerequisites,
+    )
+
+    kubeconfig = os.environ.get("KUBECONFIG", "")
+
+    def _run(args: list[str]):
+        return run_kubectl(
+            args,
+            context=context,
+            kubeconfig=kubeconfig,
+            timeout=30,
+        )
+
+    return kubernetes_prerequisites(runner=_run)
 
 
 def _available_kube_contexts() -> list[str] | None:

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -704,7 +704,6 @@ def submit_cmd(
     registry_auth_plan = None
     deploy_targets = []
     resolved_deploy_plans: dict[str, Any] = {}
-    paidf_kubernetes_checked = False
     source_action = "not-required"
     planned_source_uri = ""
     if is_npa_spec:
@@ -717,6 +716,39 @@ def submit_cmd(
         # its cluster kubeconfigs outside ~/.kube/config, so a context it
         # provisioned looks missing until KUBECONFIG points at it.
         infra_context = _infra_kube_context(infra)
+        from npa.orchestration.npa_workflow.deploy import (
+            bind_deploy_targets_to_submit,
+            parse_deploy_targets,
+        )
+
+        try:
+            deploy_targets = bind_deploy_targets_to_submit(
+                parse_deploy_targets(load_spec(yaml_path)),
+                project=project,
+                infra=infra,
+            )
+        except Exception as exc:  # noqa: BLE001 - fail before any mutation
+            _fail(f"deployIfAbsent target resolution failed: {exc}")
+            return
+        if is_paidf_spec and not infra_context:
+            declared_contexts = sorted(
+                {
+                    target.resolved_context
+                    for target in deploy_targets
+                    if target.cloud.strip().lower() in {"k8s", "kubernetes"}
+                    and target.resolved_context
+                }
+            )
+            if len(declared_contexts) != 1:
+                _fail(
+                    "PAIDF Kubernetes target cannot be resolved safely without "
+                    "--infra: expected exactly one Kubernetes deployIfAbsent context, "
+                    f"found {declared_contexts or 'none'}. Pass --infra k8s/<context>; "
+                    "no S3 input or source was written."
+                )
+                return
+            infra_context = declared_contexts[0]
+            infra = f"k8s/{infra_context}"
         if infra_context and not plan_only:
             _adopt_npa_kubeconfig(infra_context)
         image_value_for_source = str(image or "").strip().lower()
@@ -836,20 +868,10 @@ def submit_cmd(
         # temporary mutation.
         if deploy_if_absent:
             from npa.orchestration.npa_workflow.deploy import (
-                bind_deploy_targets_to_submit,
-                parse_deploy_targets,
                 plan_infra_present,
-            )
-            from npa.orchestration.npa_workflow.spec import (
-                load_spec as _load_deploy_spec,
             )
 
             try:
-                deploy_targets = bind_deploy_targets_to_submit(
-                    parse_deploy_targets(_load_deploy_spec(yaml_path)),
-                    project=project,
-                    infra=infra,
-                )
                 resolved_deploy_plans = plan_infra_present(
                     deploy_targets, mutation=not plan_only
                 )
@@ -872,6 +894,7 @@ def submit_cmd(
                 ),
                 requires_npa_source=requires_npa_source,
                 source_staging_planned=stage_source_planned,
+                probe_storage=False,
             )
             if not plan_only and is_paidf_spec:
                 from npa.clients.huggingface import validate_hf_access
@@ -886,11 +909,6 @@ def submit_cmd(
                         hf_validator=validate_hf_access,
                     )
                 )
-                if infra_context and _adopt_npa_kubeconfig(infra_context):
-                    missing.extend(
-                        _paidf_kubernetes_prerequisites_for_submit(infra_context)
-                    )
-                    paidf_kubernetes_checked = True
             if not plan_only and workflow_identity == "sim2real":
                 from npa.clients.huggingface import validate_hf_access
                 from npa.clients.kube import run_kubectl
@@ -907,13 +925,12 @@ def submit_cmd(
                         hf_validator=validate_hf_access,
                     )
                 )
-                context = _infra_kube_context(infra)
                 kubeconfig = os.environ.get("KUBECONFIG", "")
 
                 def _run_sim2real_kubectl(args: list[str]):
                     return run_kubectl(
                         args,
-                        context=context,
+                        context=infra_context,
                         kubeconfig=kubeconfig,
                         timeout=30,
                     )
@@ -950,11 +967,115 @@ def submit_cmd(
             enabled=preflight_images and not plan_only,
             infra=infra,
         )
+
+        # Provision/adopt the exact submission target before any writable-S3
+        # probe, PAIDF input upload, or NPA source staging. PAIDF derives
+        # ``infra`` from its sole deployIfAbsent context when the caller omits it,
+        # so kubectl and SkyPilot can never diverge onto an ambient context.
+        if deploy_if_absent and deploy_targets:
+            from npa.orchestration.npa_workflow.deploy import ensure_infra_present
+
+            try:
+                if not plan_only:
+                    records = ensure_infra_present(
+                        deploy_targets,
+                        dry_run=False,
+                        gpu_readiness_timeout=gpu_readiness_timeout,
+                        gpu_readiness_poll_interval=gpu_readiness_poll_interval,
+                        sky_bin=sky_bin,
+                        resolved_plans=resolved_deploy_plans,
+                    )
+                else:
+                    records = [
+                        {
+                            "profile": next(
+                                target.profile
+                                for target in deploy_targets
+                                if target.resolved_context == context
+                            ),
+                            "status": plan.decision,
+                            "context": context,
+                            "actions": [],
+                            "warnings": list(plan.reasons),
+                            "topology": plan.topology.to_dict(),
+                            "quotas": [quota.to_dict() for quota in plan.quotas],
+                        }
+                        for context, plan in resolved_deploy_plans.items()
+                    ]
+                for record in records:
+                    typer.echo(
+                        "deployIfAbsent["
+                        f"{record['profile']}]: {record['status']} "
+                        f"context={record['context']} "
+                        f"actions={','.join(record['actions']) or 'none'}",
+                        err=True,
+                    )
+                    for warning in record.get("warnings", []) or []:
+                        typer.echo(
+                            f"deployIfAbsent[{record['profile']}]: warning: {warning}",
+                            err=True,
+                        )
+            except NpaWorkflowError as exc:
+                _fail(str(exc))
+                return
+
+        if infra_context and not plan_only and not _adopt_npa_kubeconfig(infra_context):
+            _fail(
+                f"Kube context {infra_context!r} (submission target {infra!r}) is not "
+                "available in KUBECONFIG or under "
+                f"~/.npa/clusters/{infra_context}/. Provision it with `npa "
+                "provision-if-absent --project <alias>`, or pass "
+                "--infra k8s/<context> for an available context; no S3 input or source "
+                "was written."
+            )
+            return
+        if infra_context and not plan_only:
+            from npa.controller_ownership import (
+                ClusterOwnerIdentityMismatchError,
+                bind_controller_owner,
+                resolve_controller_candidate,
+                verify_controller_owner,
+            )
+
+            try:
+                if bind_controller is True:
+                    bind_controller_owner(
+                        resolve_controller_candidate(project, infra_context)
+                    )
+                verify_controller_owner(project, infra_context)
+            except ClusterOwnerIdentityMismatchError as exc:
+                _fail(str(exc))
+                return
+
+        if not skip_preflight and not plan_only:
+            post_infra_missing: list[tuple[str, str]] = []
+            if is_paidf_spec:
+                post_infra_missing.extend(
+                    _paidf_kubernetes_prerequisites_for_submit(infra_context)
+                )
+            if post_infra_missing:
+                _fail_missing_prerequisites(yaml_path, post_infra_missing)
+                return
+            storage_missing = _submit_storage_prerequisites(
+                spec_config,
+                requires_s3=_spec_requires_s3(yaml_path),
+                s3_endpoint=submit_credentials.endpoint_url,
+                s3_access_key_id=getattr(
+                    submit_credentials, "access_key_id", ""
+                ),
+                s3_secret_access_key=getattr(
+                    submit_credentials, "secret_access_key", ""
+                ),
+            )
+            if storage_missing:
+                _fail_missing_prerequisites(yaml_path, storage_missing)
+                return
+
         if not plan_only:
             # Establish the exact run and current-schema no-launch evidence
-            # before PAIDF input/source staging or deployIfAbsent can mutate
-            # storage/paid infrastructure. Status can therefore prove
-            # NOT_SUBMITTED locally if any later prerequisite fails.
+            # before PAIDF input/source staging mutates storage. Infrastructure
+            # is already resolved and placement-checked above. Status can
+            # therefore prove NOT_SUBMITTED if a later staging step fails.
             try:
                 persisted_identity = prepare_run(
                     project=project,
@@ -1089,110 +1210,6 @@ def submit_cmd(
             image_overrides["*"] = image_value
         image_overrides.update(specific_image_overrides)
 
-        if deploy_if_absent and deploy_targets:
-            from npa.orchestration.npa_workflow.deploy import (
-                ensure_infra_present,
-            )
-
-            try:
-                if not plan_only:
-                    records = ensure_infra_present(
-                        deploy_targets,
-                        dry_run=False,
-                        gpu_readiness_timeout=gpu_readiness_timeout,
-                        gpu_readiness_poll_interval=gpu_readiness_poll_interval,
-                        sky_bin=sky_bin,
-                        resolved_plans=resolved_deploy_plans,
-                    )
-                else:
-                    records = [
-                        {
-                            "profile": next(
-                                target.profile
-                                for target in deploy_targets
-                                if target.resolved_context == context
-                            ),
-                            "status": plan.decision,
-                            "context": context,
-                            "actions": [],
-                            "warnings": list(plan.reasons),
-                            "topology": plan.topology.to_dict(),
-                            "quotas": [quota.to_dict() for quota in plan.quotas],
-                        }
-                        for context, plan in resolved_deploy_plans.items()
-                    ]
-                for record in records:
-                    typer.echo(
-                        "deployIfAbsent["
-                        f"{record['profile']}]: {record['status']} "
-                        f"context={record['context']} "
-                        f"actions={','.join(record['actions']) or 'none'}",
-                        err=True,
-                    )
-                    # A `partial` outcome (no project_id, no bucket, ...) used to
-                    # print its status with the reason dropped, and the submit
-                    # carried on into a launch that could not work.
-                    for warning in record.get("warnings", []) or []:
-                        typer.echo(
-                            f"deployIfAbsent[{record['profile']}]: warning: {warning}",
-                            err=True,
-                        )
-            except NpaWorkflowError as exc:
-                _fail(str(exc))
-                return
-
-        # Provisioning may have just created the context (or failed to). Either way
-        # the launch cannot work without it, so stop here with the remedy rather
-        # than deep inside `sky jobs launch`.
-        if infra_context and not plan_only and not _adopt_npa_kubeconfig(infra_context):
-            _fail(
-                f"Kube context {infra_context!r} (from --infra {infra!r}) is not available: "
-                "it is not in your kubeconfig and npa has no kubeconfig for it under "
-                f"~/.npa/clusters/{infra_context}/. Provision the cluster with "
-                "`npa provision-if-absent --project <alias>` (check its output for "
-                "warnings), or point KUBECONFIG at the cluster you want and pass a "
-                "context from `kubectl config get-contexts`."
-            )
-            return
-        if infra_context and not plan_only:
-            from npa.controller_ownership import (
-                ClusterOwnerIdentityMismatchError,
-                bind_controller_owner,
-                resolve_controller_candidate,
-                verify_controller_owner,
-            )
-
-            try:
-                if bind_controller is True:
-                    bind_controller_owner(
-                        resolve_controller_candidate(project, infra_context)
-                    )
-                verify_controller_owner(project, infra_context)
-            except ClusterOwnerIdentityMismatchError as exc:
-                _fail(str(exc))
-                return
-        if (
-            is_paidf_spec
-            and not paidf_kubernetes_checked
-            and not skip_preflight
-            and not plan_only
-        ):
-            placement_context = infra_context or next(
-                (
-                    target.resolved_context
-                    for target in deploy_targets
-                    if target.cloud.strip().lower() in {"k8s", "kubernetes"}
-                ),
-                "",
-            )
-            if placement_context:
-                _adopt_npa_kubeconfig(placement_context)
-            paidf_missing = _paidf_kubernetes_prerequisites_for_submit(
-                placement_context
-            )
-            if paidf_missing:
-                _fail_missing_prerequisites(yaml_path, paidf_missing)
-                return
         npa_render_options = SkypilotRenderOptions(
             registry=_resolve_submit_registry(registry, project),
             image_overrides=image_overrides,
@@ -2783,6 +2800,7 @@ def _submit_prerequisites(
     s3_secret_access_key: str = "",
     requires_npa_source: bool = True,
     source_staging_planned: bool = False,
+    probe_storage: bool = True,
 ) -> list[tuple[str, str]]:
     """Return ``[(missing, remedy)]`` for an npa.workflow submit.
 
@@ -2842,28 +2860,16 @@ def _submit_prerequisites(
             )
         )
 
-    if not plan_only and requires_s3 and not _is_placeholder_bucket(bucket):
-        from npa.clients.storage_validation import (
-            StorageCapabilityProfile,
-            probe_storage_write,
-        )
-
-        probe = probe_storage_write(
-            bucket=bucket,
-            endpoint_url=s3_endpoint,
-            access_key_id=s3_access_key_id,
-            secret_access_key=s3_secret_access_key,
-            profile=StorageCapabilityProfile.WORKFLOW_SUBMISSION,
-        )
-        if not probe.ok:
-            missing.append(
-                (
-                    f"writable S3 for this workflow ({probe.summary})",
-                    "run `npa provision-if-absent --project <alias> --skip-k8s`, "
-                    "then retry; this append-only preflight uses a unique object and "
-                    "does not require DeleteObject",
-                )
+    if probe_storage and not plan_only:
+        missing.extend(
+            _submit_storage_prerequisites(
+                spec_config,
+                requires_s3=requires_s3,
+                s3_endpoint=s3_endpoint,
+                s3_access_key_id=s3_access_key_id,
+                s3_secret_access_key=s3_secret_access_key,
             )
+        )
 
     # Catch an `--infra k8s/<context>` that names a context the kubeconfig does
     # not define, up front. Otherwise `sky jobs launch` fails late with a long
@@ -2888,6 +2894,43 @@ def _submit_prerequisites(
                 )
             )
     return missing
+
+
+def _submit_storage_prerequisites(
+    spec_config: Mapping[str, Any],
+    *,
+    requires_s3: bool,
+    s3_endpoint: str,
+    s3_access_key_id: str,
+    s3_secret_access_key: str,
+) -> list[tuple[str, str]]:
+    """Run the cleaned writable-storage probe at its explicit mutation boundary."""
+
+    bucket = str((spec_config or {}).get("bucket", "") or "")
+    if not requires_s3 or _is_placeholder_bucket(bucket):
+        return []
+    from npa.clients.storage_validation import (
+        StorageCapabilityProfile,
+        probe_storage_write,
+    )
+
+    probe = probe_storage_write(
+        bucket=bucket,
+        endpoint_url=s3_endpoint,
+        access_key_id=s3_access_key_id,
+        secret_access_key=s3_secret_access_key,
+        profile=StorageCapabilityProfile.WORKFLOW_SUBMISSION,
+    )
+    if probe.ok:
+        return []
+    return [
+        (
+            f"writable S3 for this workflow ({probe.summary})",
+            "run `npa provision-if-absent --project <alias> --skip-k8s`, then "
+            "retry; this append-only preflight uses a unique object and does not "
+            "require DeleteObject",
+        )
+    ]
 
 
 def _fail_missing_prerequisites(

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -71,7 +71,9 @@ def nebius_registry_hosts(rendered_yaml: str) -> list[str]:
     )
 
 
-def _refresh_kubernetes_pull_secrets(rendered_path: Path) -> None:
+def _refresh_kubernetes_pull_secrets(
+    rendered_path: Path, *, k8s_context: str = "", kubeconfig: str = ""
+) -> None:
     """Refresh the cluster's Nebius registry pull secret before launching.
 
     Kubernetes pulls private images with an ``imagePullSecret``, and the Nebius
@@ -111,6 +113,8 @@ def _refresh_kubernetes_pull_secrets(rendered_path: Path) -> None:
             registry_servers=hosts,
             username=username,
             token=password,
+            kubeconfig=kubeconfig,
+            k8s_context=k8s_context,
         )
     except Exception as exc:
         raise RuntimeError(
@@ -868,6 +872,39 @@ def submit_cmd(
                 requires_npa_source=requires_npa_source,
                 source_staging_planned=stage_source_planned,
             )
+            if not plan_only and workflow_identity == "sim2real":
+                from npa.clients.huggingface import validate_hf_access
+                from npa.clients.kube import run_kubectl
+                from npa.orchestration.npa_workflow.sim2real_preflight import (
+                    kubernetes_prerequisites,
+                    static_prerequisites,
+                )
+
+                missing.extend(
+                    static_prerequisites(
+                        spec_config,
+                        requested_secret_envs=secret_env,
+                        secret_values=extra_env,
+                        hf_validator=validate_hf_access,
+                    )
+                )
+                context = _infra_kube_context(infra)
+                kubeconfig = os.environ.get("KUBECONFIG", "")
+
+                def _run_sim2real_kubectl(args: list[str]):
+                    return run_kubectl(
+                        args,
+                        context=context,
+                        kubeconfig=kubeconfig,
+                        timeout=30,
+                    )
+
+                missing.extend(
+                    kubernetes_prerequisites(
+                        spec_config,
+                        runner=_run_sim2real_kubectl,
+                    )
+                )
             if missing:
                 _fail_missing_prerequisites(yaml_path, missing)
                 return
@@ -1150,7 +1187,11 @@ def submit_cmd(
                     config_overrides=substitutions,
                     render_options=npa_render_options,
                 )
-                _refresh_kubernetes_pull_secrets(registry_auth_plan.skypilot_yaml_path)
+                _refresh_kubernetes_pull_secrets(
+                    registry_auth_plan.skypilot_yaml_path,
+                    k8s_context=infra_context,
+                    kubeconfig=os.environ.get("KUBECONFIG", ""),
+                )
             except NpaWorkflowError as exc:
                 _fail(str(exc))
                 return
@@ -1311,7 +1352,11 @@ def submit_cmd(
             return
 
         if refresh_registry_secret:
-            _refresh_kubernetes_pull_secrets(prepared_npa.skypilot_yaml_path)
+            _refresh_kubernetes_pull_secrets(
+                prepared_npa.skypilot_yaml_path,
+                k8s_context=infra_context,
+                kubeconfig=os.environ.get("KUBECONFIG", ""),
+            )
 
         # Skip SkyPilot-path materializers; npa.workflow already planned.
         materializer = ""
@@ -5734,6 +5779,11 @@ def run_spec_cmd(
 @app.command("preflight-images")
 def preflight_images_cmd(
     yaml_path: Path = typer.Argument(help="npa.workflow spec path."),
+    var: list[str] = typer.Option(
+        [],
+        "--var",
+        help="Workflow config override as KEY=VALUE (same as submit --var).",
+    ),
     registry: str = typer.Option("", "--registry", help="Container registry override."),
     project: str = typer.Option(
         "",
@@ -5768,6 +5818,7 @@ def preflight_images_cmd(
     """
 
     from npa.orchestration.npa_workflow import build_plan
+    from npa.orchestration.npa_workflow.submit import merge_config_overrides
     from npa.orchestration.npa_workflow.skypilot_render import (
         SkypilotRenderOptions,
         plan_image_pull_secrets,
@@ -5777,7 +5828,9 @@ def preflight_images_cmd(
         check_image_pulls_with_credentials,
     )
 
-    spec = _load_npa_workflow(yaml_path)
+    spec = merge_config_overrides(
+        _load_npa_workflow(yaml_path), _parse_submit_vars(var)
+    )
     image_overrides: dict[str, str] = {}
     if image.strip():
         image_overrides["*"] = image.strip()

--- a/npa/src/npa/orchestration/npa_workflow/kubernetes_prerequisites.py
+++ b/npa/src/npa/orchestration/npa_workflow/kubernetes_prerequisites.py
@@ -1,0 +1,65 @@
+"""Shared Kubernetes placement parsing for workflow submit preflights."""
+
+from __future__ import annotations
+
+import json
+import re
+
+
+def cpu_millicores(value: object) -> int:
+    raw = str(value or "").strip()
+    try:
+        return int(raw[:-1]) if raw.endswith("m") else int(float(raw) * 1000)
+    except ValueError:
+        return 0
+
+
+def memory_bytes(value: object) -> int:
+    raw = str(value or "").strip()
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([KMGTPE]i?|)", raw)
+    if not match:
+        return 0
+    number = float(match.group(1))
+    suffix = match.group(2)
+    if not suffix:
+        return int(number)
+    powers = {letter: index for index, letter in enumerate("KMGTPE", 1)}
+    return int(number * ((1024 if suffix.endswith("i") else 1000) ** powers[suffix[0]]))
+
+
+def ready_schedulable_cpu_nodes(
+    nodes_json: str,
+    *,
+    minimum_cpu_millicores: int,
+    minimum_memory_bytes: int,
+) -> list[str]:
+    """Return Ready, untainted non-GPU nodes with the requested capacity."""
+
+    try:
+        items = (json.loads(nodes_json) or {}).get("items") or []
+    except (TypeError, json.JSONDecodeError):
+        return []
+    ready: list[str] = []
+    for node in items:
+        spec = node.get("spec") or {}
+        status = node.get("status") or {}
+        allocatable = status.get("allocatable") or {}
+        conditions = status.get("conditions") or []
+        is_ready = any(
+            item.get("type") == "Ready" and str(item.get("status")).lower() == "true"
+            for item in conditions
+        )
+        blocking_taint = any(
+            str(item.get("effect") or "") in {"NoSchedule", "NoExecute"}
+            for item in (spec.get("taints") or [])
+        )
+        if (
+            is_ready
+            and not spec.get("unschedulable", False)
+            and not blocking_taint
+            and cpu_millicores(allocatable.get("cpu")) >= minimum_cpu_millicores
+            and memory_bytes(allocatable.get("memory")) >= minimum_memory_bytes
+            and cpu_millicores(allocatable.get("nvidia.com/gpu")) == 0
+        ):
+            ready.append(str((node.get("metadata") or {}).get("name") or "<unnamed>"))
+    return ready

--- a/npa/src/npa/orchestration/npa_workflow/kubernetes_prerequisites.py
+++ b/npa/src/npa/orchestration/npa_workflow/kubernetes_prerequisites.py
@@ -4,27 +4,76 @@ from __future__ import annotations
 
 import json
 import re
+from decimal import Decimal, InvalidOperation
+
+
+_QUANTITY_RE = re.compile(
+    r"([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+))"
+    r"(?:(Ki|Mi|Gi|Ti|Pi|Ei)|([numkKMGTPE])|([eE][+-]?[0-9]+))?"
+)
+
+
+def _decimal_quantity(value: object) -> Decimal | None:
+    """Parse the numeric value of a Kubernetes resource quantity."""
+
+    raw = str(value or "").strip()
+    match = _QUANTITY_RE.fullmatch(raw)
+    if not match:
+        return None
+    try:
+        number = Decimal(match.group(1))
+        binary_suffix, decimal_suffix, exponent_suffix = match.groups()[1:]
+        if binary_suffix:
+            power = "KMGTPE".index(binary_suffix[0]) + 1
+            return number * (Decimal(1024) ** power)
+        if decimal_suffix:
+            powers = {
+                "n": -9,
+                "u": -6,
+                "m": -3,
+                "k": 3,
+                "K": 3,
+                "M": 6,
+                "G": 9,
+                "T": 12,
+                "P": 15,
+                "E": 18,
+            }
+            return number * (Decimal(10) ** powers[decimal_suffix])
+        if exponent_suffix:
+            return number * (Decimal(10) ** int(exponent_suffix[1:]))
+        return number
+    except (InvalidOperation, ValueError):
+        return None
 
 
 def cpu_millicores(value: object) -> int:
-    raw = str(value or "").strip()
-    try:
-        return int(raw[:-1]) if raw.endswith("m") else int(float(raw) * 1000)
-    except ValueError:
-        return 0
+    parsed = _decimal_quantity(value)
+    return max(0, int(parsed * 1000)) if parsed is not None else 0
 
 
 def memory_bytes(value: object) -> int:
-    raw = str(value or "").strip()
-    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([KMGTPE]i?|)", raw)
-    if not match:
+    parsed = _decimal_quantity(value)
+    return max(0, int(parsed)) if parsed is not None else 0
+
+
+def integer_resource(value: object) -> int:
+    """Parse an integer-valued Kubernetes extended resource such as a GPU."""
+
+    parsed = _decimal_quantity(value)
+    if parsed is None or parsed < 0 or parsed != parsed.to_integral_value():
         return 0
-    number = float(match.group(1))
-    suffix = match.group(2)
-    if not suffix:
-        return int(number)
-    powers = {letter: index for index, letter in enumerate("KMGTPE", 1)}
-    return int(number * ((1024 if suffix.endswith("i") else 1000) ** powers[suffix[0]]))
+    return int(parsed)
+
+
+def format_cpu_memory_requirement(
+    cpu_millicores_required: int, memory_bytes_required: int
+) -> str:
+    """Render the exact threshold constants with Kubernetes resource names."""
+
+    cpu = Decimal(cpu_millicores_required) / 1000
+    memory_gib = Decimal(memory_bytes_required) / (1024**3)
+    return f"{cpu:g} CPU / {memory_gib:g} GiB allocatable"
 
 
 def ready_schedulable_cpu_nodes(
@@ -33,7 +82,7 @@ def ready_schedulable_cpu_nodes(
     minimum_cpu_millicores: int,
     minimum_memory_bytes: int,
 ) -> list[str]:
-    """Return Ready, untainted non-GPU nodes with the requested capacity."""
+    """Return Ready, schedulable nodes with the requested CPU and memory."""
 
     try:
         items = (json.loads(nodes_json) or {}).get("items") or []
@@ -59,7 +108,6 @@ def ready_schedulable_cpu_nodes(
             and not blocking_taint
             and cpu_millicores(allocatable.get("cpu")) >= minimum_cpu_millicores
             and memory_bytes(allocatable.get("memory")) >= minimum_memory_bytes
-            and cpu_millicores(allocatable.get("nvidia.com/gpu")) == 0
         ):
             ready.append(str((node.get("metadata") or {}).get("name") or "<unnamed>"))
     return ready

--- a/npa/src/npa/orchestration/npa_workflow/paidf_preflight.py
+++ b/npa/src/npa/orchestration/npa_workflow/paidf_preflight.py
@@ -1,0 +1,96 @@
+"""Fail-fast prerequisites for the Physical AI Data Factory workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from npa.orchestration.npa_workflow.kubernetes_prerequisites import (
+    ready_schedulable_cpu_nodes,
+)
+from npa.orchestration.skypilot.controller import (
+    DEFAULT_K8S_CONTROLLER_CPUS,
+    DEFAULT_K8S_CONTROLLER_MEMORY_GB,
+)
+
+
+Issue = tuple[str, str]
+_REQUIRED_SECRET_ENVS = (
+    "NEBIUS_TOKEN_FACTORY_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "HF_TOKEN",
+)
+_TRANSFER_REPO = "nvidia/Cosmos-Transfer2.5-2B"
+_PAIDF_CPU_MILLICORES = (4 + DEFAULT_K8S_CONTROLLER_CPUS) * 1000
+_PAIDF_MEMORY_BYTES = (16 + DEFAULT_K8S_CONTROLLER_MEMORY_GB) * 1024**3
+
+
+def static_prerequisites(
+    *,
+    requested_secret_envs: Sequence[str],
+    secret_values: Mapping[str, str],
+    hf_validator: Callable[[str, str], Any],
+) -> list[Issue]:
+    """Validate runtime secret forwarding and gated Transfer access."""
+
+    issues: list[Issue] = []
+    requested = {str(name).strip() for name in requested_secret_envs}
+    not_forwarded = [name for name in _REQUIRED_SECRET_ENVS if name not in requested]
+    if not_forwarded:
+        issues.append(
+            (
+                "PAIDF runtime credentials are not forwarded with --secret-env: "
+                + ", ".join(not_forwarded),
+                "add `--secret-env NEBIUS_TOKEN_FACTORY_KEY --secret-env "
+                "AWS_ACCESS_KEY_ID --secret-env AWS_SECRET_ACCESS_KEY --secret-env "
+                "HF_TOKEN`; values resolve from the environment or the selected "
+                "project's NPA credential store",
+            )
+        )
+
+    hf_token = str(secret_values.get("HF_TOKEN") or "").strip()
+    if hf_token:
+        result = hf_validator(hf_token, _TRANSFER_REPO)
+        if not getattr(result, "ok", False):
+            detail = str(getattr(result, "error", "") or "access not verified")
+            issues.append(
+                (
+                    f"Hugging Face access failed for {_TRANSFER_REPO} ({detail})",
+                    f"accept the NVIDIA model terms at https://huggingface.co/{_TRANSFER_REPO}, "
+                    "then run `npa workbench health access --capability paidf`",
+                )
+            )
+    return issues
+
+
+def _ready_schedulable_cpu_nodes(nodes_json: str) -> list[str]:
+    return ready_schedulable_cpu_nodes(
+        nodes_json,
+        minimum_cpu_millicores=_PAIDF_CPU_MILLICORES,
+        minimum_memory_bytes=_PAIDF_MEMORY_BYTES,
+    )
+
+
+def kubernetes_prerequisites(*, runner: Callable[[list[str]], Any]) -> list[Issue]:
+    """Validate the CPU placement shared by PAIDF stages and its controller."""
+
+    nodes = runner(["get", "nodes", "-o", "json"])
+    if getattr(nodes, "returncode", 1) != 0:
+        return [
+            (
+                "Kubernetes nodes cannot be listed for PAIDF CPU/GPU placement",
+                "refresh the selected kube context and grant read access to nodes; "
+                "run `kubectl get nodes -o wide`",
+            )
+        ]
+    if _ready_schedulable_cpu_nodes(str(getattr(nodes, "stdout", ""))):
+        return []
+    return [
+        (
+            "no Ready, untainted, non-GPU node can fit the PAIDF CPU stage plus "
+            "SkyPilot controller (6 vCPU / 24 GiB allocatable)",
+            "provision at least one CPU node (recommended: cpu-d3/8vcpu-32gb), "
+            "wait for Ready, then rerun `kubectl get nodes -o json`",
+        )
+    ]

--- a/npa/src/npa/orchestration/npa_workflow/paidf_preflight.py
+++ b/npa/src/npa/orchestration/npa_workflow/paidf_preflight.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from npa.orchestration.npa_workflow.kubernetes_prerequisites import (
+    format_cpu_memory_requirement,
     ready_schedulable_cpu_nodes,
 )
 from npa.orchestration.skypilot.controller import (
@@ -24,6 +25,12 @@ _REQUIRED_SECRET_ENVS = (
 _TRANSFER_REPO = "nvidia/Cosmos-Transfer2.5-2B"
 _PAIDF_CPU_MILLICORES = (4 + DEFAULT_K8S_CONTROLLER_CPUS) * 1000
 _PAIDF_MEMORY_BYTES = (16 + DEFAULT_K8S_CONTROLLER_MEMORY_GB) * 1024**3
+
+
+def cpu_placement_requirement() -> str:
+    return format_cpu_memory_requirement(
+        _PAIDF_CPU_MILLICORES, _PAIDF_MEMORY_BYTES
+    )
 
 
 def static_prerequisites(
@@ -88,9 +95,10 @@ def kubernetes_prerequisites(*, runner: Callable[[list[str]], Any]) -> list[Issu
         return []
     return [
         (
-            "no Ready, untainted, non-GPU node can fit the PAIDF CPU stage plus "
-            "SkyPilot controller (6 vCPU / 24 GiB allocatable)",
-            "provision at least one CPU node (recommended: cpu-d3/8vcpu-32gb), "
-            "wait for Ready, then rerun `kubectl get nodes -o json`",
+            "no Ready, schedulable, appropriately untainted node can fit the "
+            f"PAIDF CPU stage plus SkyPilot controller ({cpu_placement_requirement()})",
+            "provide a node with sufficient allocatable CPU and memory (the default "
+            "cpu-d3/8vcpu-32gb preset is sufficient), wait for Ready, then rerun "
+            "`kubectl get nodes -o json` on the selected context",
         )
     ]

--- a/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
+++ b/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
@@ -7,6 +7,14 @@ import json
 import re
 from typing import Any
 
+from npa.orchestration.npa_workflow.kubernetes_prerequisites import (
+    ready_schedulable_cpu_nodes,
+)
+from npa.orchestration.skypilot.controller import (
+    DEFAULT_K8S_CONTROLLER_CPUS,
+    DEFAULT_K8S_CONTROLLER_MEMORY_GB,
+)
+
 
 Issue = tuple[str, str]
 _ACCEPTED_EULA_VALUES = frozenset({"1", "TRUE", "Y", "YES"})
@@ -121,58 +129,13 @@ def static_prerequisites(
     return issues
 
 
-def _cpu_millicores(value: object) -> int:
-    raw = str(value or "").strip()
-    try:
-        return int(raw[:-1]) if raw.endswith("m") else int(float(raw) * 1000)
-    except ValueError:
-        return 0
-
-
-def _memory_bytes(value: object) -> int:
-    raw = str(value or "").strip()
-    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([KMGTPE]i?|)", raw)
-    if not match:
-        return 0
-    number = float(match.group(1))
-    suffix = match.group(2)
-    if not suffix:
-        return int(number)
-    powers = {letter: index for index, letter in enumerate("KMGTPE", 1)}
-    return int(number * ((1024 if suffix.endswith("i") else 1000) ** powers[suffix[0]]))
-
-
 def _ready_schedulable_cpu_nodes(nodes_json: str) -> list[str]:
-    """Return non-GPU nodes able to host the 8 CPU / 32 GiB Sim2Real profile."""
-
-    try:
-        items = (json.loads(nodes_json) or {}).get("items") or []
-    except (TypeError, json.JSONDecodeError):
-        return []
-    ready: list[str] = []
-    for node in items:
-        spec = node.get("spec") or {}
-        status = node.get("status") or {}
-        allocatable = status.get("allocatable") or {}
-        conditions = status.get("conditions") or []
-        is_ready = any(
-            item.get("type") == "Ready" and str(item.get("status")).lower() == "true"
-            for item in conditions
-        )
-        blocking_taint = any(
-            str(item.get("effect") or "") in {"NoSchedule", "NoExecute"}
-            for item in (spec.get("taints") or [])
-        )
-        if (
-            is_ready
-            and not spec.get("unschedulable", False)
-            and not blocking_taint
-            and _cpu_millicores(allocatable.get("cpu")) >= 8000
-            and _memory_bytes(allocatable.get("memory")) >= 32 * 1024**3
-            and _cpu_millicores(allocatable.get("nvidia.com/gpu")) == 0
-        ):
-            ready.append(str((node.get("metadata") or {}).get("name") or "<unnamed>"))
-    return ready
+    """Return nodes able to host one CPU stage and the SkyPilot controller."""
+    return ready_schedulable_cpu_nodes(
+        nodes_json,
+        minimum_cpu_millicores=(8 + DEFAULT_K8S_CONTROLLER_CPUS) * 1000,
+        minimum_memory_bytes=(32 + DEFAULT_K8S_CONTROLLER_MEMORY_GB) * 1024**3,
+    )
 
 
 def kubernetes_prerequisites(
@@ -196,8 +159,8 @@ def kubernetes_prerequisites(
     elif not _ready_schedulable_cpu_nodes(str(getattr(nodes, "stdout", ""))):
         issues.append(
             (
-                "no Ready, untainted, non-GPU node can fit the Sim2Real 8 vCPU / "
-                "32 GiB CPU profile (and the 4 vCPU / 16 GiB SkyPilot controller)",
+                "no Ready, untainted, non-GPU node can fit the Sim2Real CPU stage "
+                "plus SkyPilot controller (10 vCPU / 40 GiB allocatable)",
                 "add a dedicated CPU node pool such as cpu-e2/16vcpu-64gb (the "
                 "8vcpu-32gb nominal preset loses capacity to Kubernetes reserve), wait for "
                 "Ready, then rerun `kubectl get nodes -o json`",

--- a/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
+++ b/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
@@ -8,6 +8,7 @@ import re
 from typing import Any
 
 from npa.orchestration.npa_workflow.kubernetes_prerequisites import (
+    format_cpu_memory_requirement,
     ready_schedulable_cpu_nodes,
 )
 from npa.orchestration.skypilot.controller import (
@@ -32,6 +33,14 @@ _REQUIRED_SECRET_ENVS = (
     "HF_TOKEN",
 )
 _DIGEST_IMAGE = re.compile(r"^[^/\s]+/.+@sha256:[0-9a-fA-F]{64}$")
+_SIM2REAL_CPU_MILLICORES = (8 + DEFAULT_K8S_CONTROLLER_CPUS) * 1000
+_SIM2REAL_MEMORY_BYTES = (32 + DEFAULT_K8S_CONTROLLER_MEMORY_GB) * 1024**3
+
+
+def cpu_placement_requirement() -> str:
+    return format_cpu_memory_requirement(
+        _SIM2REAL_CPU_MILLICORES, _SIM2REAL_MEMORY_BYTES
+    )
 
 
 def static_prerequisites(
@@ -133,8 +142,8 @@ def _ready_schedulable_cpu_nodes(nodes_json: str) -> list[str]:
     """Return nodes able to host one CPU stage and the SkyPilot controller."""
     return ready_schedulable_cpu_nodes(
         nodes_json,
-        minimum_cpu_millicores=(8 + DEFAULT_K8S_CONTROLLER_CPUS) * 1000,
-        minimum_memory_bytes=(32 + DEFAULT_K8S_CONTROLLER_MEMORY_GB) * 1024**3,
+        minimum_cpu_millicores=_SIM2REAL_CPU_MILLICORES,
+        minimum_memory_bytes=_SIM2REAL_MEMORY_BYTES,
     )
 
 
@@ -159,11 +168,13 @@ def kubernetes_prerequisites(
     elif not _ready_schedulable_cpu_nodes(str(getattr(nodes, "stdout", ""))):
         issues.append(
             (
-                "no Ready, untainted, non-GPU node can fit the Sim2Real CPU stage "
-                "plus SkyPilot controller (10 vCPU / 40 GiB allocatable)",
-                "add a dedicated CPU node pool such as cpu-e2/16vcpu-64gb (the "
+                "no Ready, schedulable, appropriately untainted node can fit the "
+                "Sim2Real CPU stage plus SkyPilot controller "
+                f"({cpu_placement_requirement()})",
+                "provide a node with sufficient allocatable CPU and memory, such as "
+                "cpu-e2/16vcpu-64gb (the "
                 "8vcpu-32gb nominal preset loses capacity to Kubernetes reserve), wait for "
-                "Ready, then rerun `kubectl get nodes -o json`",
+                "Ready, then rerun `kubectl get nodes -o json` on the selected context",
             )
         )
 

--- a/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
+++ b/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
@@ -1,0 +1,254 @@
+"""Fail-fast prerequisites for the canonical compositional Sim2Real workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+import json
+import re
+from typing import Any
+
+
+Issue = tuple[str, str]
+_ACCEPTED_EULA_VALUES = frozenset({"1", "TRUE", "Y", "YES"})
+_IMAGE_KEYS = (
+    "controller_image",
+    "transfer_image",
+    "envgen_image",
+    "reason_image",
+    "isaac_image",
+    "viewer_image",
+)
+_REQUIRED_SECRET_ENVS = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "HF_TOKEN",
+)
+_DIGEST_IMAGE = re.compile(r"^[^/\s]+/.+@sha256:[0-9a-fA-F]{64}$")
+
+
+def static_prerequisites(
+    config: Mapping[str, Any],
+    *,
+    requested_secret_envs: Sequence[str],
+    secret_values: Mapping[str, str],
+    hf_validator: Callable[[str, str], Any],
+) -> list[Issue]:
+    """Validate immutable inputs, consent, secret forwarding, and gated access."""
+
+    issues: list[Issue] = []
+    invalid_images = [
+        key
+        for key in _IMAGE_KEYS
+        if not _DIGEST_IMAGE.fullmatch(str(config.get(key) or "").strip())
+    ]
+    if invalid_images:
+        issues.append(
+            (
+                "Sim2Real image inputs are missing or not registry-qualified immutable "
+                f"digests: {', '.join(invalid_images)}",
+                "set every listed --var to <registry>/<repository>@sha256:<64-hex>; "
+                "run `npa workbench workflow preflight-images <spec> --var ...` to "
+                "verify the exact bytes",
+            )
+        )
+
+    pvc = str(config.get("isaac_cache_pvc") or "").strip()
+    if not pvc:
+        issues.append(
+            (
+                "config.isaac_cache_pvc is empty",
+                "create and warm the shared Isaac cache from "
+                "npa/docker/workbench/common/warm-isaac-cache.yaml, then pass "
+                "--var isaac_cache_pvc=<bound-rwx-pvc>",
+            )
+        )
+
+    invalid_eulas = [
+        key
+        for key in ("omni_kit_accept_eula", "isaacsim_accept_eula")
+        if str(config.get(key) or "").strip().upper() not in _ACCEPTED_EULA_VALUES
+    ]
+    if invalid_eulas:
+        issues.append(
+            (
+                "explicit NVIDIA Isaac/Omniverse acceptance is missing: "
+                + ", ".join(invalid_eulas),
+                "after reviewing the linked NVIDIA terms, pass "
+                "--var omni_kit_accept_eula=YES --var isaacsim_accept_eula=YES",
+            )
+        )
+
+    requested = {str(name).strip() for name in requested_secret_envs}
+    not_forwarded = [name for name in _REQUIRED_SECRET_ENVS if name not in requested]
+    if not_forwarded:
+        issues.append(
+            (
+                "required runtime credentials are not forwarded with --secret-env: "
+                + ", ".join(not_forwarded),
+                "add `--secret-env AWS_ACCESS_KEY_ID --secret-env "
+                "AWS_SECRET_ACCESS_KEY --secret-env HF_TOKEN`; values resolve from the "
+                "environment or the selected project's NPA credential store",
+            )
+        )
+
+    hf_token = str(secret_values.get("HF_TOKEN") or "").strip()
+    if hf_token:
+        repos = list(
+            dict.fromkeys(
+                [
+                    "nvidia/Cosmos-Transfer2.5-2B",
+                    str(config.get("reason2_model") or "").strip(),
+                    str(config.get("reason3_model") or "").strip(),
+                ]
+            )
+        )
+        denied: list[str] = []
+        for repo in (item for item in repos if item):
+            result = hf_validator(hf_token, repo)
+            if not getattr(result, "ok", False):
+                detail = str(getattr(result, "error", "") or "access not verified")
+                denied.append(f"{repo} ({detail})")
+        if denied:
+            issues.append(
+                (
+                    "Hugging Face access failed for required runtime model(s): "
+                    + "; ".join(denied),
+                    "accept each model's terms while signed in to the account that owns "
+                    "HF_TOKEN, then run `npa workbench health access --capability "
+                    "sim2real` until all three repositories PASS",
+                )
+            )
+    return issues
+
+
+def _cpu_millicores(value: object) -> int:
+    raw = str(value or "").strip()
+    try:
+        return int(raw[:-1]) if raw.endswith("m") else int(float(raw) * 1000)
+    except ValueError:
+        return 0
+
+
+def _memory_bytes(value: object) -> int:
+    raw = str(value or "").strip()
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([KMGTPE]i?|)", raw)
+    if not match:
+        return 0
+    number = float(match.group(1))
+    suffix = match.group(2)
+    if not suffix:
+        return int(number)
+    powers = {letter: index for index, letter in enumerate("KMGTPE", 1)}
+    return int(number * ((1024 if suffix.endswith("i") else 1000) ** powers[suffix[0]]))
+
+
+def _ready_schedulable_cpu_nodes(nodes_json: str) -> list[str]:
+    """Return non-GPU nodes able to host the 8 CPU / 32 GiB Sim2Real profile."""
+
+    try:
+        items = (json.loads(nodes_json) or {}).get("items") or []
+    except (TypeError, json.JSONDecodeError):
+        return []
+    ready: list[str] = []
+    for node in items:
+        spec = node.get("spec") or {}
+        status = node.get("status") or {}
+        allocatable = status.get("allocatable") or {}
+        conditions = status.get("conditions") or []
+        is_ready = any(
+            item.get("type") == "Ready" and str(item.get("status")).lower() == "true"
+            for item in conditions
+        )
+        blocking_taint = any(
+            str(item.get("effect") or "") in {"NoSchedule", "NoExecute"}
+            for item in (spec.get("taints") or [])
+        )
+        if (
+            is_ready
+            and not spec.get("unschedulable", False)
+            and not blocking_taint
+            and _cpu_millicores(allocatable.get("cpu")) >= 8000
+            and _memory_bytes(allocatable.get("memory")) >= 32 * 1024**3
+            and _cpu_millicores(allocatable.get("nvidia.com/gpu")) == 0
+        ):
+            ready.append(str((node.get("metadata") or {}).get("name") or "<unnamed>"))
+    return ready
+
+
+def kubernetes_prerequisites(
+    config: Mapping[str, Any],
+    *,
+    runner: Callable[[list[str]], Any],
+    namespace: str = "default",
+) -> list[Issue]:
+    """Validate cluster objects the real Sim2Real/SkyPilot path consumes."""
+
+    issues: list[Issue] = []
+    nodes = runner(["get", "nodes", "-o", "json"])
+    if getattr(nodes, "returncode", 1) != 0:
+        issues.append(
+            (
+                "Kubernetes nodes cannot be listed for Sim2Real CPU/GPU placement",
+                "refresh the selected kube context and grant read access to nodes; run "
+                "`kubectl get nodes -o wide`",
+            )
+        )
+    elif not _ready_schedulable_cpu_nodes(str(getattr(nodes, "stdout", ""))):
+        issues.append(
+            (
+                "no Ready, untainted, non-GPU node can fit the Sim2Real 8 vCPU / "
+                "32 GiB CPU profile (and the 4 vCPU / 16 GiB SkyPilot controller)",
+                "add a dedicated CPU node pool such as cpu-e2/16vcpu-64gb (the "
+                "8vcpu-32gb nominal preset loses capacity to Kubernetes reserve), wait for "
+                "Ready, then rerun `kubectl get nodes -o json`",
+            )
+        )
+
+    pvc_name = str(config.get("isaac_cache_pvc") or "").strip()
+    if pvc_name:
+        pvc_result = runner(["get", "pvc", pvc_name, "-n", namespace, "-o", "json"])
+        pvc: dict[str, Any] = {}
+        if getattr(pvc_result, "returncode", 1) == 0:
+            try:
+                pvc = json.loads(str(getattr(pvc_result, "stdout", ""))) or {}
+            except json.JSONDecodeError:
+                pvc = {}
+        modes = set((pvc.get("spec") or {}).get("accessModes") or [])
+        if (
+            (pvc.get("status") or {}).get("phase") != "Bound"
+            or "ReadWriteMany" not in modes
+        ):
+            issues.append(
+                (
+                    f"Isaac cache PVC {pvc_name!r} is missing or is not Bound ReadWriteMany "
+                    f"in namespace {namespace!r}",
+                    "apply npa/docker/workbench/common/warm-isaac-cache.yaml with the "
+                    "selected immutable Isaac image, wait for the warm Job to complete, "
+                    "and pass that PVC name",
+                )
+            )
+
+    queue = str(config.get("gpu_queue") or "").strip()
+    if queue:
+        result = runner(["get", "localqueue.kueue.x-k8s.io", queue, "-n", namespace, "-o", "json"])
+        if getattr(result, "returncode", 1) != 0:
+            issues.append(
+                (
+                    f"Kueue LocalQueue {queue!r} is not readable in namespace {namespace!r}",
+                    "install/configure Kueue and apply the Sim2Real ResourceFlavor, "
+                    "ClusterQueue, and LocalQueue before submission",
+                )
+            )
+
+    priority = str(config.get("gpu_priority_class") or "").strip()
+    if priority:
+        result = runner(["get", "priorityclass.scheduling.k8s.io", priority, "-o", "json"])
+        if getattr(result, "returncode", 1) != 0:
+            issues.append(
+                (
+                    f"PriorityClass {priority!r} is not readable",
+                    "create the Sim2Real PriorityClass before submission (the canonical "
+                    "default is sim2real-production)",
+                )
+            )
+    return issues

--- a/npa/src/npa/workbench/model_access.py
+++ b/npa/src/npa/workbench/model_access.py
@@ -57,6 +57,7 @@ class GatedAsset:
 # Face before the token can download them.
 WORKBENCH_ASSETS: tuple[GatedAsset, ...] = (
     GatedAsset("nvidia/GR00T-N1.7-3B", HF, ("groot",), True),
+    GatedAsset("nvidia/Cosmos-Transfer2.5-2B", HF, ("sim2real",), True),
     GatedAsset("nvidia/Cosmos-Reason2-2B", HF, ("groot", "sim2real"), True),
     GatedAsset("nvidia/Cosmos-Reason2-8B", HF, ("sim2real",), True),
     GatedAsset("nvidia/Cosmos-Reason1-7B", HF, ("cosmos",), True),

--- a/npa/src/npa/workbench/model_access.py
+++ b/npa/src/npa/workbench/model_access.py
@@ -57,7 +57,7 @@ class GatedAsset:
 # Face before the token can download them.
 WORKBENCH_ASSETS: tuple[GatedAsset, ...] = (
     GatedAsset("nvidia/GR00T-N1.7-3B", HF, ("groot",), True),
-    GatedAsset("nvidia/Cosmos-Transfer2.5-2B", HF, ("sim2real",), True),
+    GatedAsset("nvidia/Cosmos-Transfer2.5-2B", HF, ("paidf", "sim2real"), True),
     GatedAsset("nvidia/Cosmos-Reason2-2B", HF, ("groot", "sim2real"), True),
     GatedAsset("nvidia/Cosmos-Reason2-8B", HF, ("sim2real",), True),
     GatedAsset("nvidia/Cosmos-Reason1-7B", HF, ("cosmos",), True),

--- a/npa/tests/cli/test_workflow_runtime_cli.py
+++ b/npa/tests/cli/test_workflow_runtime_cli.py
@@ -305,7 +305,7 @@ def test_submit_runtime_refreshes_pull_secret_before_driver(
 
     events: list[tuple[str, str]] = []
 
-    def refresh(rendered_path: Path) -> None:
+    def refresh(rendered_path: Path, **_kwargs) -> None:
         events.append(("refresh", rendered_path.name))
 
     monkeypatch.setattr(

--- a/npa/tests/cli/test_workflow_submit_preflight.py
+++ b/npa/tests/cli/test_workflow_submit_preflight.py
@@ -141,6 +141,38 @@ def test_sim2real_submit_collects_pipeline_prerequisites_before_image_or_launch(
     launch.assert_not_called()
 
 
+def test_paidf_submit_collects_runtime_prerequisites_before_image_or_launch(
+    mocker,
+) -> None:
+    image_preflight = mocker.patch(
+        "npa.cli.workbench.workflow._preflight_submit_images"
+    )
+    launch = mocker.patch("npa.orchestration.skypilot.workflow.submit_workflow")
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(SPEC),
+            "--run-id",
+            "paidf-cold-start",
+            "--no-deploy-if-absent",
+            "--var",
+            "bucket=real-bucket",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "missing prerequisites" in result.output
+    assert "PAIDF runtime credentials" in result.output
+    assert "NEBIUS_TOKEN_FACTORY_KEY" in result.output
+    assert "HF_TOKEN" in result.output
+    image_preflight.assert_not_called()
+    launch.assert_not_called()
+
+
 def test_submit_preflight_clears_as_prerequisites_are_met(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/npa/tests/cli/test_workflow_submit_preflight.py
+++ b/npa/tests/cli/test_workflow_submit_preflight.py
@@ -101,6 +101,46 @@ def test_submit_preflight_does_not_reach_skypilot(mocker) -> None:
     submit_workflow.assert_not_called()
 
 
+def test_sim2real_submit_collects_pipeline_prerequisites_before_image_or_launch(
+    monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
+    from subprocess import CompletedProcess
+
+    image_preflight = mocker.patch(
+        "npa.cli.workbench.workflow._preflight_submit_images"
+    )
+    launch = mocker.patch("npa.orchestration.skypilot.workflow.submit_workflow")
+    monkeypatch.setattr(
+        "npa.clients.kube.run_kubectl",
+        lambda *args, **kwargs: CompletedProcess(args, 1, stdout="", stderr="NotFound"),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(SIM2REAL_SPEC),
+            "--run-id",
+            "sim2real-cold-start",
+            "--no-deploy-if-absent",
+            "--var",
+            "bucket=real-bucket",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "missing prerequisites" in result.output
+    assert "controller_image" in result.output
+    assert "AWS_ACCESS_KEY_ID" in result.output
+    assert "no Ready" not in result.output  # node listing itself failed
+    assert "Kubernetes nodes cannot be listed" in result.output
+    assert "config.isaac_cache_pvc is empty" in result.output
+    image_preflight.assert_not_called()
+    launch.assert_not_called()
+
+
 def test_submit_preflight_clears_as_prerequisites_are_met(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -384,6 +424,43 @@ def test_config_pinned_resource_images_satisfy_the_npa_source_requirement() -> N
         )
         is False
     )
+
+
+def test_preflight_images_accepts_the_same_config_vars_as_submit(mocker) -> None:
+    """An empty canonical image input must be overridable before pull probes."""
+    digest_image = f"cr.example.invalid/npa@sha256:{'a' * 64}"
+    checks = mocker.patch(
+        "npa.orchestration.skypilot.registry_preflight.check_image_pulls_with_credentials",
+        return_value=[],
+    )
+    mocker.patch(
+        "npa.cli.workbench.workflow._preflight_image_bootstrap_contracts",
+        return_value=[],
+    )
+    args = [
+        "workbench",
+        "workflow",
+        "preflight-images",
+        str(SIM2REAL_SPEC),
+        "--assume-decision",
+        "promote_checkpoint",
+    ]
+    for name in (
+        "controller_image",
+        "transfer_image",
+        "envgen_image",
+        "reason_image",
+        "isaac_image",
+        "viewer_image",
+    ):
+        args.extend(["--var", f"{name}={digest_image}"])
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 0, result.output
+    checked_images = checks.call_args.args[0]
+    assert checked_images
+    assert set(checked_images) == {digest_image}
 
 
 def test_image_none_automatically_plans_npa_source_staging() -> None:

--- a/npa/tests/cli/test_workflow_submit_preflight.py
+++ b/npa/tests/cli/test_workflow_submit_preflight.py
@@ -173,6 +173,160 @@ def test_paidf_submit_collects_runtime_prerequisites_before_image_or_launch(
     launch.assert_not_called()
 
 
+def test_paidf_kubernetes_helper_propagates_context_and_kubeconfig(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from subprocess import CompletedProcess
+
+    from npa.cli.workbench.workflow import (
+        _paidf_kubernetes_prerequisites_for_submit,
+    )
+
+    calls = []
+
+    def run(args, **kwargs):
+        calls.append((args, kwargs))
+        return CompletedProcess(args, 1, stdout="", stderr="Forbidden")
+
+    monkeypatch.setenv("KUBECONFIG", "/tmp/review-kubeconfig")
+    monkeypatch.setattr("npa.clients.kube.run_kubectl", run)
+
+    issues = _paidf_kubernetes_prerequisites_for_submit("paidf-review")
+
+    assert issues
+    assert calls == [
+        (
+            ["get", "nodes", "-o", "json"],
+            {
+                "context": "paidf-review",
+                "kubeconfig": "/tmp/review-kubeconfig",
+                "timeout": 30,
+            },
+        )
+    ]
+
+
+def test_paidf_placement_fails_before_storage_or_staging_without_explicit_infra(
+    monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
+    from types import SimpleNamespace
+
+    for name in (
+        "NEBIUS_TOKEN_FACTORY_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "HF_TOKEN",
+    ):
+        monkeypatch.setenv(name, "redacted")
+    monkeypatch.setenv("NPA_SKYPILOT_BIN", "/bin/true")
+    monkeypatch.setattr(
+        "npa.clients.huggingface.validate_hf_access",
+        lambda *_args, **_kwargs: SimpleNamespace(ok=True),
+    )
+    monkeypatch.setattr(
+        "npa.cli.workbench.workflow._available_kube_contexts",
+        lambda: ["npa-cluster"],
+    )
+    monkeypatch.setattr(
+        "npa.cli.workbench.workflow._adopt_npa_kubeconfig", lambda _context: True
+    )
+    monkeypatch.setattr(
+        "npa.controller_ownership.verify_controller_owner", lambda *_args: None
+    )
+    placement = mocker.patch(
+        "npa.cli.workbench.workflow._paidf_kubernetes_prerequisites_for_submit",
+        return_value=[("placement blocked", "resize the selected node")],
+    )
+    mocker.patch(
+        "npa.cli.workbench.workflow._preflight_submit_images", return_value={}
+    )
+    storage = mocker.patch("npa.clients.storage_validation.probe_storage_write")
+    prepare_input = mocker.patch(
+        "npa.workflows.data_factory_input.prepare_paidf_input"
+    )
+    stage_source = mocker.patch(
+        "npa.orchestration.npa_workflow.src_staging.stage_npa_source"
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(SPEC),
+            "--run-id",
+            "paidf-placement-order",
+            "--no-deploy-if-absent",
+            "--var",
+            "bucket=real-bucket",
+            "--assume-decision",
+            "promote_checkpoint",
+            "--secret-env",
+            "NEBIUS_TOKEN_FACTORY_KEY",
+            "--secret-env",
+            "AWS_ACCESS_KEY_ID",
+            "--secret-env",
+            "AWS_SECRET_ACCESS_KEY",
+            "--secret-env",
+            "HF_TOKEN",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "placement blocked" in result.output
+    placement.assert_called_once_with("npa-cluster")
+    storage.assert_not_called()
+    prepare_input.assert_not_called()
+    stage_source.assert_not_called()
+
+
+def test_sim2real_submit_propagates_explicit_kubernetes_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from subprocess import CompletedProcess
+
+    calls = []
+
+    def run(args, **kwargs):
+        calls.append((args, kwargs))
+        return CompletedProcess(args, 1, stdout="", stderr="NotFound")
+
+    monkeypatch.setenv("KUBECONFIG", "/tmp/sim2real-kubeconfig")
+    monkeypatch.setattr(
+        "npa.cli.workbench.workflow._adopt_npa_kubeconfig", lambda _context: True
+    )
+    monkeypatch.setattr(
+        "npa.cli.workbench.workflow._available_kube_contexts",
+        lambda: ["sim2real-review"],
+    )
+    monkeypatch.setattr("npa.clients.kube.run_kubectl", run)
+
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(SIM2REAL_SPEC),
+            "--run-id",
+            "sim2real-context",
+            "--no-deploy-if-absent",
+            "--infra",
+            "k8s/sim2real-review",
+            "--var",
+            "bucket=real-bucket",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert calls
+    assert all(call[1]["context"] == "sim2real-review" for call in calls)
+    assert all(
+        call[1]["kubeconfig"] == "/tmp/sim2real-kubeconfig" for call in calls
+    )
+
+
 def test_submit_preflight_clears_as_prerequisites_are_met(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/npa/tests/guardrails/test_default_cluster_fits_quickstart.py
+++ b/npa/tests/guardrails/test_default_cluster_fits_quickstart.py
@@ -181,3 +181,19 @@ def test_paidf_self_provisioning_keeps_the_controller_cpu_node_explicit() -> Non
         "gpuPlatform": "gpu-rtx6000",
         "gpuPreset": "1gpu-24vcpu-218gb",
     }
+
+
+def test_paidf_declared_cpu_preset_clears_the_allocatable_preflight_threshold() -> None:
+    """The self-provisioned preset cannot deadlock its own placement gate."""
+
+    from npa.orchestration.npa_workflow.paidf_preflight import (
+        _PAIDF_CPU_MILLICORES,
+        _PAIDF_MEMORY_BYTES,
+    )
+
+    spec = yaml.safe_load(QUICKSTART_SPEC.read_text(encoding="utf-8"))
+    preset = spec["resources"]["gpu"]["deployIfAbsent"]["cpuPreset"]
+    vcpu, memory_gib = _preset_capacity(preset)
+
+    assert int((vcpu - CPU_RESERVE) * 1000) >= _PAIDF_CPU_MILLICORES
+    assert int((memory_gib - MEMORY_RESERVE_GIB) * 1024**3) >= _PAIDF_MEMORY_BYTES

--- a/npa/tests/guardrails/test_default_cluster_fits_quickstart.py
+++ b/npa/tests/guardrails/test_default_cluster_fits_quickstart.py
@@ -168,3 +168,16 @@ def test_npa_and_terraform_agree_on_the_default_cpu_preset() -> None:
     from npa.cluster.config import DEFAULT_CPU_NODE_GROUP_PRESET
 
     assert _terraform_default("cpu_nodes_preset") == DEFAULT_CPU_NODE_GROUP_PRESET
+
+
+def test_paidf_self_provisioning_keeps_the_controller_cpu_node_explicit() -> None:
+    spec = yaml.safe_load(QUICKSTART_SPEC.read_text(encoding="utf-8"))
+    directive = spec["resources"]["gpu"]["deployIfAbsent"]
+    assert directive == {
+        "cpuNodes": 1,
+        "cpuPlatform": "cpu-d3",
+        "cpuPreset": "8vcpu-32gb",
+        "gpuNodes": 1,
+        "gpuPlatform": "gpu-rtx6000",
+        "gpuPreset": "1gpu-24vcpu-218gb",
+    }

--- a/npa/tests/orchestration/npa_workflow/test_kubernetes_prerequisites.py
+++ b/npa/tests/orchestration/npa_workflow/test_kubernetes_prerequisites.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+
+from npa.orchestration.npa_workflow.kubernetes_prerequisites import (
+    cpu_millicores,
+    integer_resource,
+    memory_bytes,
+    ready_schedulable_cpu_nodes,
+)
+
+
+def _node_document(*, spec=None, conditions=None) -> str:
+    return json.dumps(
+        {
+            "items": [
+                {
+                    "metadata": {"name": "worker"},
+                    "spec": spec or {},
+                    "status": {
+                        "allocatable": {
+                            "cpu": "6",
+                            "memory": "129e6",
+                            "nvidia.com/gpu": "4",
+                        },
+                        "conditions": conditions
+                        if conditions is not None
+                        else [{"type": "Ready", "status": "True"}],
+                    },
+                }
+            ]
+        }
+    )
+
+
+def test_kubernetes_quantities_keep_resource_types_distinct() -> None:
+    assert cpu_millicores("5900m") == 5900
+    assert memory_bytes("129e6") == 129_000_000
+    assert memory_bytes("24Gi") == 24 * 1024**3
+    assert integer_resource("4") == 4
+    assert integer_resource("4e0") == 4
+    assert integer_resource("1500m") == 0
+
+
+def test_shared_placement_accepts_gpu_nodes_and_rejects_scheduler_blockers() -> None:
+    required = dict(
+        minimum_cpu_millicores=6000,
+        minimum_memory_bytes=129_000_000,
+    )
+    assert ready_schedulable_cpu_nodes(_node_document(), **required) == ["worker"]
+    assert (
+        ready_schedulable_cpu_nodes(
+            _node_document(spec={"unschedulable": True}), **required
+        )
+        == []
+    )
+    assert (
+        ready_schedulable_cpu_nodes(
+            _node_document(spec={"taints": [{"effect": "NoExecute"}]}),
+            **required,
+        )
+        == []
+    )
+    assert (
+        ready_schedulable_cpu_nodes(
+            _node_document(conditions=[{"type": "Ready", "status": "False"}]),
+            **required,
+        )
+        == []
+    )

--- a/npa/tests/orchestration/npa_workflow/test_paidf_preflight.py
+++ b/npa/tests/orchestration/npa_workflow/test_paidf_preflight.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from npa.orchestration.npa_workflow.paidf_preflight import (
+    _ready_schedulable_cpu_nodes,
+    kubernetes_prerequisites,
+    static_prerequisites,
+)
+
+
+def _nodes(*, cpu="6", memory="24Gi", gpu="0", taints=None):
+    return json.dumps(
+        {
+            "items": [
+                {
+                    "metadata": {"name": "cpu-0"},
+                    "spec": {"taints": taints or []},
+                    "status": {
+                        "allocatable": {
+                            "cpu": cpu,
+                            "memory": memory,
+                            "nvidia.com/gpu": gpu,
+                        },
+                        "conditions": [{"type": "Ready", "status": "True"}],
+                    },
+                }
+            ]
+        }
+    )
+
+
+def test_static_preflight_checks_all_runtime_secrets_and_transfer_access():
+    checked = []
+
+    def validate(_token, repo):
+        checked.append(repo)
+        return SimpleNamespace(ok=False, error="403 gated")
+
+    issues = static_prerequisites(
+        requested_secret_envs=["HF_TOKEN"],
+        secret_values={"HF_TOKEN": "redacted"},
+        hf_validator=validate,
+    )
+
+    assert checked == ["nvidia/Cosmos-Transfer2.5-2B"]
+    rendered = "\n".join(item for item, _ in issues)
+    assert "NEBIUS_TOKEN_FACTORY_KEY" in rendered
+    assert "AWS_ACCESS_KEY_ID" in rendered
+    assert "AWS_SECRET_ACCESS_KEY" in rendered
+    assert "Cosmos-Transfer2.5-2B" in rendered
+    assert "--capability paidf" in "\n".join(remedy for _, remedy in issues)
+
+
+def test_static_preflight_passes_with_forwarded_secrets_and_gated_access():
+    names = [
+        "NEBIUS_TOKEN_FACTORY_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "HF_TOKEN",
+    ]
+    assert (
+        static_prerequisites(
+            requested_secret_envs=names,
+            secret_values={"HF_TOKEN": "redacted"},
+            hf_validator=lambda _token, _repo: SimpleNamespace(ok=True),
+        )
+        == []
+    )
+
+
+def test_cpu_node_parser_budgets_controller_and_one_paidf_cpu_stage():
+    assert _ready_schedulable_cpu_nodes(_nodes()) == ["cpu-0"]
+    assert _ready_schedulable_cpu_nodes(_nodes(cpu="5900m")) == []
+    assert _ready_schedulable_cpu_nodes(_nodes(memory="23Gi")) == []
+    assert _ready_schedulable_cpu_nodes(_nodes(gpu="1")) == []
+    assert _ready_schedulable_cpu_nodes(
+        _nodes(taints=[{"key": "dedicated", "effect": "NoSchedule"}])
+    ) == []
+
+
+def test_kubernetes_preflight_reports_cpu_placement_or_api_failure():
+    def ready(_args):
+        return SimpleNamespace(returncode=0, stdout=_nodes(), stderr="")
+
+    assert kubernetes_prerequisites(runner=ready) == []
+
+    def too_small(_args):
+        return SimpleNamespace(returncode=0, stdout=_nodes(cpu="4"), stderr="")
+
+    issue, remedy = kubernetes_prerequisites(runner=too_small)[0]
+    assert "6 vCPU / 24 GiB" in issue
+    assert "8vcpu-32gb" in remedy
+
+    def unavailable(_args):
+        return SimpleNamespace(returncode=1, stdout="", stderr="Forbidden")
+
+    assert "cannot be listed" in kubernetes_prerequisites(runner=unavailable)[0][0]

--- a/npa/tests/orchestration/npa_workflow/test_paidf_preflight.py
+++ b/npa/tests/orchestration/npa_workflow/test_paidf_preflight.py
@@ -72,9 +72,9 @@ def test_static_preflight_passes_with_forwarded_secrets_and_gated_access():
 
 def test_cpu_node_parser_budgets_controller_and_one_paidf_cpu_stage():
     assert _ready_schedulable_cpu_nodes(_nodes()) == ["cpu-0"]
+    assert _ready_schedulable_cpu_nodes(_nodes(gpu="4")) == ["cpu-0"]
     assert _ready_schedulable_cpu_nodes(_nodes(cpu="5900m")) == []
     assert _ready_schedulable_cpu_nodes(_nodes(memory="23Gi")) == []
-    assert _ready_schedulable_cpu_nodes(_nodes(gpu="1")) == []
     assert _ready_schedulable_cpu_nodes(
         _nodes(taints=[{"key": "dedicated", "effect": "NoSchedule"}])
     ) == []
@@ -90,7 +90,7 @@ def test_kubernetes_preflight_reports_cpu_placement_or_api_failure():
         return SimpleNamespace(returncode=0, stdout=_nodes(cpu="4"), stderr="")
 
     issue, remedy = kubernetes_prerequisites(runner=too_small)[0]
-    assert "6 vCPU / 24 GiB" in issue
+    assert "6 CPU / 24 GiB" in issue
     assert "8vcpu-32gb" in remedy
 
     def unavailable(_args):

--- a/npa/tests/orchestration/npa_workflow/test_registry_pull_secret_refresh.py
+++ b/npa/tests/orchestration/npa_workflow/test_registry_pull_secret_refresh.py
@@ -73,18 +73,29 @@ def test_every_host_lands_in_one_apply(
     host by host would leave only the last host authenticated.
     """
 
-    calls: list[tuple[str, tuple[str, ...]]] = []
+    calls: list[dict[str, object]] = []
     monkeypatch.setattr(
         "npa.workflows.sim2real.registry_auth.ensure_nebius_registry_pull_secret",
-        lambda *, registry_server="", registry_servers=(), **kwargs: calls.append(
-            (registry_server, tuple(registry_servers))
-        ),
+        lambda **kwargs: calls.append(kwargs),
     )
     rendered = tmp_path / "workflow.yaml"
     rendered.write_text(RENDERED, encoding="utf-8")
 
-    _refresh_kubernetes_pull_secrets(rendered)
-    assert calls == [("", ("cr.eu-north1.nebius.cloud", "cr.us-central1.nebius.cloud"))]
+    _refresh_kubernetes_pull_secrets(
+        rendered, k8s_context="target", kubeconfig="/tmp/target-kubeconfig"
+    )
+    assert calls == [
+        {
+            "registry_servers": [
+                "cr.eu-north1.nebius.cloud",
+                "cr.us-central1.nebius.cloud",
+            ],
+            "username": "iam",
+            "token": "test-token",
+            "kubeconfig": "/tmp/target-kubeconfig",
+            "k8s_context": "target",
+        }
+    ]
 
 
 def test_the_applied_secret_authenticates_every_host(

--- a/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
+++ b/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
@@ -73,7 +73,7 @@ def test_static_preflight_rejects_mutable_images_and_missing_eula_before_launch(
     assert "omni_kit_accept_eula" in rendered
 
 
-def _nodes(*, cpu="8", memory="32Gi", gpu="0", taints=None):
+def _nodes(*, cpu="10", memory="40Gi", gpu="0", taints=None):
     return json.dumps(
         {
             "items": [
@@ -96,8 +96,8 @@ def _nodes(*, cpu="8", memory="32Gi", gpu="0", taints=None):
 
 def test_cpu_node_parser_requires_the_real_schedulable_profile():
     assert _ready_schedulable_cpu_nodes(_nodes()) == ["cpu-0"]
-    assert _ready_schedulable_cpu_nodes(_nodes(cpu="7500m")) == []
-    assert _ready_schedulable_cpu_nodes(_nodes(memory="31Gi")) == []
+    assert _ready_schedulable_cpu_nodes(_nodes(cpu="9500m")) == []
+    assert _ready_schedulable_cpu_nodes(_nodes(memory="39Gi")) == []
     assert _ready_schedulable_cpu_nodes(_nodes(gpu="1")) == []
     assert _ready_schedulable_cpu_nodes(
         _nodes(taints=[{"key": "dedicated", "effect": "NoSchedule"}])

--- a/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
+++ b/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
@@ -96,9 +96,9 @@ def _nodes(*, cpu="10", memory="40Gi", gpu="0", taints=None):
 
 def test_cpu_node_parser_requires_the_real_schedulable_profile():
     assert _ready_schedulable_cpu_nodes(_nodes()) == ["cpu-0"]
+    assert _ready_schedulable_cpu_nodes(_nodes(gpu="8")) == ["cpu-0"]
     assert _ready_schedulable_cpu_nodes(_nodes(cpu="9500m")) == []
     assert _ready_schedulable_cpu_nodes(_nodes(memory="39Gi")) == []
-    assert _ready_schedulable_cpu_nodes(_nodes(gpu="1")) == []
     assert _ready_schedulable_cpu_nodes(
         _nodes(taints=[{"key": "dedicated", "effect": "NoSchedule"}])
     ) == []

--- a/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
+++ b/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from npa.orchestration.npa_workflow.sim2real_preflight import (
+    _ready_schedulable_cpu_nodes,
+    kubernetes_prerequisites,
+    static_prerequisites,
+)
+
+
+def _config(**overrides):
+    digest = f"cr.eu-north1.nebius.cloud/registry/image@sha256:{'a' * 64}"
+    config = {
+        "controller_image": digest,
+        "transfer_image": digest,
+        "envgen_image": digest,
+        "reason_image": digest,
+        "isaac_image": digest,
+        "viewer_image": digest,
+        "isaac_cache_pvc": "npa-isaac-cache",
+        "omni_kit_accept_eula": "YES",
+        "isaacsim_accept_eula": "YES",
+        "reason2_model": "nvidia/Cosmos-Reason2-8B",
+        "reason3_model": "nvidia/Cosmos-Reason2-2B",
+        "gpu_queue": "sim2real-gpu",
+        "gpu_priority_class": "sim2real-production",
+    }
+    config.update(overrides)
+    return config
+
+
+def test_static_preflight_checks_all_three_gated_models_and_secret_forwarding():
+    checked = []
+
+    def validate(_token, repo):
+        checked.append(repo)
+        return SimpleNamespace(ok=repo != "nvidia/Cosmos-Transfer2.5-2B", error="403")
+
+    issues = static_prerequisites(
+        _config(),
+        requested_secret_envs=["HF_TOKEN"],
+        secret_values={"HF_TOKEN": "redacted"},
+        hf_validator=validate,
+    )
+
+    assert checked == [
+        "nvidia/Cosmos-Transfer2.5-2B",
+        "nvidia/Cosmos-Reason2-8B",
+        "nvidia/Cosmos-Reason2-2B",
+    ]
+    rendered = "\n".join(item for item, _ in issues)
+    assert "Cosmos-Transfer2.5-2B" in rendered
+    assert "AWS_ACCESS_KEY_ID" in rendered
+    assert "AWS_SECRET_ACCESS_KEY" in rendered
+
+
+def test_static_preflight_rejects_mutable_images_and_missing_eula_before_launch():
+    issues = static_prerequisites(
+        _config(controller_image="registry/image:latest", omni_kit_accept_eula=""),
+        requested_secret_envs=[
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "HF_TOKEN",
+        ],
+        secret_values={"HF_TOKEN": "redacted"},
+        hf_validator=lambda _token, repo: SimpleNamespace(ok=True, repo=repo),
+    )
+
+    rendered = "\n".join(item for item, _ in issues)
+    assert "controller_image" in rendered
+    assert "omni_kit_accept_eula" in rendered
+
+
+def _nodes(*, cpu="8", memory="32Gi", gpu="0", taints=None):
+    return json.dumps(
+        {
+            "items": [
+                {
+                    "metadata": {"name": "cpu-0"},
+                    "spec": {"taints": taints or []},
+                    "status": {
+                        "allocatable": {
+                            "cpu": cpu,
+                            "memory": memory,
+                            "nvidia.com/gpu": gpu,
+                        },
+                        "conditions": [{"type": "Ready", "status": "True"}],
+                    },
+                }
+            ]
+        }
+    )
+
+
+def test_cpu_node_parser_requires_the_real_schedulable_profile():
+    assert _ready_schedulable_cpu_nodes(_nodes()) == ["cpu-0"]
+    assert _ready_schedulable_cpu_nodes(_nodes(cpu="7500m")) == []
+    assert _ready_schedulable_cpu_nodes(_nodes(memory="31Gi")) == []
+    assert _ready_schedulable_cpu_nodes(_nodes(gpu="1")) == []
+    assert _ready_schedulable_cpu_nodes(
+        _nodes(taints=[{"key": "dedicated", "effect": "NoSchedule"}])
+    ) == []
+
+
+def test_kubernetes_preflight_parses_nodes_pvc_queue_and_priority_class():
+    calls = []
+
+    def run(args):
+        calls.append(args)
+        if args[:2] == ["get", "nodes"]:
+            return SimpleNamespace(returncode=0, stdout=_nodes(), stderr="")
+        if args[:2] == ["get", "pvc"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "spec": {"accessModes": ["ReadWriteMany"]},
+                        "status": {"phase": "Bound"},
+                    }
+                ),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+    assert kubernetes_prerequisites(_config(), runner=run) == []
+    assert [call[:2] for call in calls] == [
+        ["get", "nodes"],
+        ["get", "pvc"],
+        ["get", "localqueue.kueue.x-k8s.io"],
+        ["get", "priorityclass.scheduling.k8s.io"],
+    ]
+
+
+def test_kubernetes_preflight_reports_every_missing_cluster_object_together():
+    def run(args):
+        if args[:2] == ["get", "nodes"]:
+            return SimpleNamespace(returncode=0, stdout=_nodes(cpu="4"), stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="NotFound")
+
+    issues = kubernetes_prerequisites(_config(), runner=run)
+    rendered = "\n".join(item for item, _ in issues)
+    assert "no Ready" in rendered
+    assert "Isaac cache PVC" in rendered
+    assert "LocalQueue" in rendered
+    assert "PriorityClass" in rendered

--- a/npa/tests/orchestration/npa_workflow/test_src_staging.py
+++ b/npa/tests/orchestration/npa_workflow/test_src_staging.py
@@ -530,6 +530,10 @@ def test_real_submit_persists_no_submit_ledger_before_source_staging(
         side_effect=RuntimeError("stop during staging"),
     )
     mocker.patch("npa.cli.workbench.workflow._submit_prerequisites", return_value=[])
+    mocker.patch(
+        "npa.orchestration.npa_workflow.paidf_preflight.static_prerequisites",
+        return_value=[],
+    )
     mocker.patch("npa.cli.workbench.workflow._preflight_submit_images")
     mocker.patch(
         "npa.workflows.data_factory_input.prepare_paidf_input",
@@ -588,6 +592,10 @@ def test_source_upload_failure_preserves_durable_no_submit_ledger(
     spec = PAIDF_SPEC
     monkeypatch.delenv("NPA_SRC_S3_URI", raising=False)
     mocker.patch("npa.cli.workbench.workflow._submit_prerequisites", return_value=[])
+    mocker.patch(
+        "npa.orchestration.npa_workflow.paidf_preflight.static_prerequisites",
+        return_value=[],
+    )
     mocker.patch("npa.cli.workbench.workflow._preflight_submit_images")
     mocker.patch(
         "npa.orchestration.npa_workflow.src_staging.stage_npa_source",
@@ -645,6 +653,10 @@ def test_input_preflight_failure_prevents_source_upload_after_durable_ledger(
     spec = PAIDF_SPEC
     monkeypatch.delenv("NPA_SRC_S3_URI", raising=False)
     mocker.patch("npa.cli.workbench.workflow._submit_prerequisites", return_value=[])
+    mocker.patch(
+        "npa.orchestration.npa_workflow.paidf_preflight.static_prerequisites",
+        return_value=[],
+    )
     mocker.patch("npa.cli.workbench.workflow._preflight_submit_images")
     stage = mocker.patch("npa.cli.workbench.workflow._stage_npa_src_for_submit")
     mocker.patch(

--- a/npa/tests/orchestration/npa_workflow/test_src_staging.py
+++ b/npa/tests/orchestration/npa_workflow/test_src_staging.py
@@ -32,6 +32,22 @@ PAIDF_SPEC = (
 )
 
 
+def _mock_paidf_submit_boundaries(mocker) -> None:
+    """Keep staging tests explicit about earlier Kubernetes/storage gates."""
+
+    mocker.patch(
+        "npa.cli.workbench.workflow._adopt_npa_kubeconfig", return_value=True
+    )
+    mocker.patch(
+        "npa.cli.workbench.workflow._paidf_kubernetes_prerequisites_for_submit",
+        return_value=[],
+    )
+    mocker.patch(
+        "npa.cli.workbench.workflow._submit_storage_prerequisites", return_value=[]
+    )
+    mocker.patch("npa.controller_ownership.verify_controller_owner")
+
+
 class FakeStorageClient:
     def __init__(self) -> None:
         self.uploads: list[tuple[str, str]] = []
@@ -523,6 +539,7 @@ def test_real_submit_persists_no_submit_ledger_before_source_staging(
     from npa.workflows.data_factory_input import PreparedPaidfInput
 
     spec = PAIDF_SPEC
+    _mock_paidf_submit_boundaries(mocker)
     monkeypatch.delenv("NPA_SRC_S3_URI", raising=False)
     monkeypatch.delenv("NPA_E2E_NPA_SRC_S3_URI", raising=False)
     stage = mocker.patch(
@@ -590,6 +607,7 @@ def test_source_upload_failure_preserves_durable_no_submit_ledger(
     from npa.orchestration.npa_workflow.first_run_state import RunPreparation
 
     spec = PAIDF_SPEC
+    _mock_paidf_submit_boundaries(mocker)
     monkeypatch.delenv("NPA_SRC_S3_URI", raising=False)
     mocker.patch("npa.cli.workbench.workflow._submit_prerequisites", return_value=[])
     mocker.patch(
@@ -651,6 +669,7 @@ def test_input_preflight_failure_prevents_source_upload_after_durable_ledger(
     from npa.workflows.data_factory_input import PaidfInputError
 
     spec = PAIDF_SPEC
+    _mock_paidf_submit_boundaries(mocker)
     monkeypatch.delenv("NPA_SRC_S3_URI", raising=False)
     mocker.patch("npa.cli.workbench.workflow._submit_prerequisites", return_value=[])
     mocker.patch(

--- a/npa/tests/workbench/test_model_access.py
+++ b/npa/tests/workbench/test_model_access.py
@@ -52,7 +52,7 @@ def test_hf_model_url() -> None:
 
 def test_all_capabilities_includes_core_tools() -> None:
     caps = all_capabilities()
-    for expected in ("groot", "cosmos", "sim2real", "vlm_eval"):
+    for expected in ("groot", "cosmos", "paidf", "sim2real", "vlm_eval"):
         assert expected in caps
 
 
@@ -63,6 +63,12 @@ def test_assets_for_filters_by_capability() -> None:
     # 'all' / None returns the full catalog.
     assert assets_for(None) == WORKBENCH_ASSETS
     assert assets_for([]) == WORKBENCH_ASSETS
+
+
+def test_paidf_access_is_scoped_to_the_gated_transfer_model() -> None:
+    assets = assets_for(["paidf"])
+    assert [asset.repo for asset in assets] == ["nvidia/Cosmos-Transfer2.5-2B"]
+    assert all(asset.gated for asset in assets)
 
 
 def test_hf_gated_warns_without_token() -> None:

--- a/npa/workflows/workbench/npa-workflows/physical-ai-data-factory.yaml
+++ b/npa/workflows/workbench/npa-workflows/physical-ai-data-factory.yaml
@@ -204,7 +204,15 @@ resources:
     # blueprint-specific command. `npa provision-if-absent` beforehand is still
     # fine, and `--no-deploy-if-absent` opts out. The GPU quota gate in
     # `npa cluster up` refuses before spending anything when quota is short.
-    deployIfAbsent: true
+    deployIfAbsent:
+      # One CPU node is mandatory: it hosts the 2 CPU / 8 GiB SkyPilot jobs
+      # controller alongside each 4 CPU / 16 GiB PAIDF CPU stage.
+      cpuNodes: 1
+      cpuPlatform: cpu-d3
+      cpuPreset: 8vcpu-32gb
+      gpuNodes: 1
+      gpuPlatform: gpu-rtx6000
+      gpuPreset: 1gpu-24vcpu-218gb
   cpu:
     cloud: kubernetes
     # The same cluster serves both profiles, so only the GPU one declares

--- a/npa/workflows/workbench/sim2real/README.md
+++ b/npa/workflows/workbench/sim2real/README.md
@@ -1,6 +1,12 @@
 # Sim2Real workflow
 
-Use the single canonical spec:
+Use the single canonical spec and complete the operator runbook before submit:
+
+- [onboarding, preflight, submit, and remediation](../../../../docs/workbench/guides/sim2real-workflow.md)
+- [data and customer-asset contracts](../../../../docs/workbench/guides/sim2real-customer-assets.md)
+- [architecture and durable resume](../../../../docs/architecture/sim2real-compositional-workflow.md)
+
+Configured operators submit through the standard durable runtime:
 
 ```bash
 npa workbench workflow submit \
@@ -13,7 +19,12 @@ npa workbench workflow submit \
   --var reason_image=<immutable-ref> \
   --var isaac_image=<immutable-ref> \
   --var viewer_image=<immutable-ref> \
-  --var isaac_cache_pvc=<pvc>
+  --var isaac_cache_pvc=<bound-rwx-pvc> \
+  --var omni_kit_accept_eula=YES \
+  --var isaacsim_accept_eula=YES \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY \
+  --secret-env HF_TOKEN
 ```
 
 The YAML exposes all 14 stages and runs through the standard workflow runtime.
@@ -36,5 +47,7 @@ The legacy `npa.workflows.sim2real` controller modules have a finite compatibili
 window for archived callers and artifacts. They are lazy, are not called by the
 canonical workflow, and cannot materialize or submit its retired controller.
 
-See `docs/workbench/guides/sim2real-workflow.md` for preflight, reduced proof,
-resume, monitoring, and evidence-audit commands.
+The submit path fails before launch when storage, secret propagation, gated
+model access, the dedicated CPU capacity, Kueue/PriorityClass, Isaac cache PVC,
+immutable images, or real image pulls are not ready. The linked runbook gives
+copy-paste setup, expected results, and remediation without duplicating it here.

--- a/skills/workflows/physical-ai-data-factory/SKILL.md
+++ b/skills/workflows/physical-ai-data-factory/SKILL.md
@@ -238,9 +238,12 @@ npa workbench workflow plan-spec "$SPEC" --run-id demo \
   --assume-decision promote_checkpoint --var bucket=<bucket> --json
 
 # Prerequisites, in order, on a fresh machine/account:
+npa workbench health preflight
+npa workbench health access --capability paidf   # Cosmos Transfer gate must PASS
 npa skypilot bootstrap                          # persists skypilot.sky_bin
 npa provision-if-absent --project <alias> --cluster-name <context> \
-  --accelerator RTXPRO6000:1                    # creates + atomically binds exact owner
+  --cpu-nodes 1 --cpu-preset 8vcpu-32gb \
+  --accelerator RTXPRO6000:1                    # CPU hosts controller + CPU stages
 # Submit stages missing/outdated content-addressed NPA source automatically.
 # `stage-src` or submit `--stage-src` remains the explicit force/restage path.
 
@@ -262,10 +265,12 @@ explicitly synthetic developer/test input.
 The one-variant override keeps the first real run decisive; omit it for the
 spec's default two-variant multiply or raise it with the requested GPU count.
 
-`submit` runs a prerequisite check first and reports **every** missing item at
-once (SkyPilot CLI, npa source for image-less steps, placeholder bucket) with
-the command that fixes each. `--plan-only` skips the runtime-only checks;
-`--skip-preflight` bypasses them.
+`submit` reports missing prerequisites together: SkyPilot, source staging,
+bucket/S3, the four forwarded runtime secrets, gated Cosmos Transfer access,
+and a Ready non-GPU node with 6 vCPU/24 GiB allocatable for one PAIDF CPU stage
+plus the SkyPilot controller. Image preflight proves each selected manifest;
+private Nebius pulls refresh the Kubernetes secret before launch. `--plan-only`
+skips runtime-only checks; `--skip-preflight` bypasses them.
 
 The immutable infrastructure plan also checks boot-disk count and
 `compute.disk.size.network-ssd` byte capacity before any mutation. The shipped

--- a/skills/workflows/physical-ai-data-factory/SKILL.md
+++ b/skills/workflows/physical-ai-data-factory/SKILL.md
@@ -267,8 +267,9 @@ spec's default two-variant multiply or raise it with the requested GPU count.
 
 `submit` reports missing prerequisites together: SkyPilot, source staging,
 bucket/S3, the four forwarded runtime secrets, gated Cosmos Transfer access,
-and a Ready non-GPU node with 6 vCPU/24 GiB allocatable for one PAIDF CPU stage
-plus the SkyPilot controller. Image preflight proves each selected manifest;
+and a Ready, schedulable, appropriately untainted node with 6 CPU/24 GiB
+allocatable for one PAIDF CPU stage plus the SkyPilot controller. A qualifying
+GPU node is valid. Image preflight proves each selected manifest;
 private Nebius pulls refresh the Kubernetes secret before launch. `--plan-only`
 skips runtime-only checks; `--skip-preflight` bypasses them.
 


### PR DESCRIPTION
## What changed

- PAIDF and Sim2Real now accept any Ready, schedulable, appropriately untainted node with enough allocatable CPU and memory; GPU-capable nodes are no longer rejected when the CPU profiles impose no GPU exclusion.
- Kubernetes quantities now support exponent-form memory (for example `129e6`) and integer extended resources use a dedicated parser. Capacity diagnostics are rendered from the threshold constants and use Kubernetes CPU/GiB terminology.
- PAIDF resolves an explicit `--infra` context or its sole declared `deployIfAbsent` context, pins submission to that same target, and runs provisioning/adoption plus placement before the writable-S3 probe, input upload, or source staging. Missing/ambiguous targets fail early.
- Submit-path tests cover PAIDF Kubernetes invocation, kubeconfig/context propagation, mutation ordering, explicit staging boundaries, and matching Sim2Real propagation. The 4-GPU PAIDF example now forwards `HF_TOKEN`.
- Sim2Real immutable-image, EULA, gated-model, PVC, Kueue LocalQueue, PriorityClass, and CPU-placement checks are newly enforced at submit time.

## Why and impact

The previous gate rejected otherwise schedulable GPU-only clusters and PAIDF could mutate S3 before checking placement, sometimes through an ambient kubectl context. Fresh runs now fail early against the exact submission target with concise remedies, while the default PAIDF `cpu-d3/8vcpu-32gb` controller preset remains schedulable.

## Validation

- Full non-E2E suite: `9648 passed, 49 skipped, 1 xpassed, 0 failed`.
- Workflow/docs/guardrails: `2028 passed, 1 skipped`; docs generation, Ruff, and `git diff --check` passed.
- Focused PAIDF/Sim2Real submit, parser, staging, image/model, EULA, registry, and preset tests: `276 passed, 1 skipped`.
- Exact spec validation/planning: PAIDF valid with 11 planned steps; Sim2Real valid with 24 planned steps.
- Plan-only live wrapper: 166 renderer/smoke tests passed and the PAIDF matrix case passed. The generic Sim2Real matrix lacks its required six project-local immutable images; the exact submit path with six digest inputs passed as `PLANNED` with 24 steps and `NOT_SUBMITTED`.
- Authenticated model access: PAIDF Cosmos Transfer PASS; all three required Sim2Real NVIDIA repositories PASS. The public `lerobot/pusht` metadata probe retains its non-blocking HTTP 404 warning.
- Live Kubernetes evidence from explicit context `openpi-b200-8gpu` using `kubectl get nodes -o json`: the Ready, schedulable, untainted `cpu-d3/8vcpu-32gb` node advertises `7900m` CPU and `32238476Ki` memory, above PAIDF's `6000m`/`25165824Ki` threshold. The live 8-GPU B200 node also qualifies PAIDF and Sim2Real, proving GPU nodes are accepted.

## Limitations

- No costly GPU workflow was launched; workflow graphs and real component toolRefs are unchanged.
- A complete canonical Sim2Real launch still requires operator-supplied immutable component digests, a warmed Isaac RWX PVC, queue/priority objects, task-aligned trigger data, and accepted NVIDIA terms.
