### PR TITLE
Agent UI: select one bucket at a time

### DIFF
--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -665,34 +665,39 @@ def _resolve_deploy_storage_credentials(
             candidate["nebius_secret_key"] = configured_secret_key
             return candidate
 
-    shared = load_credentials(environ={})
-    shared_bucket = str(shared.s3_bucket or "").strip()
-    shared_prefix = ""
-    if shared_bucket.startswith("s3://"):
-        rest = shared_bucket[len("s3://") :]
-        shared_bucket, _sep, shared_prefix = rest.partition("/")
-        shared_prefix = shared_prefix.strip("/")
-    shared_endpoint = str(
-        shared.s3_endpoint or f"https://storage.{region}.nebius.cloud"
-    ).strip()
-    shared_access_key = str(shared.s3_access_key_id or "").strip()
-    shared_secret_key = str(shared.s3_secret_access_key or "").strip()
-    if shared_bucket and _storage_credentials_allow_writes(
-        bucket=shared_bucket,
-        endpoint=shared_endpoint,
-        access_key=shared_access_key,
-        secret_key=shared_secret_key,
-        region=region,
-        prefix=shared_prefix,
-    ):
-        if emit_status:
-            typer.echo("  Using health-verified shared artifact storage credentials.")
-        candidate["s3_bucket"] = shared_bucket
-        candidate["s3_prefix"] = shared_prefix
-        candidate["s3_endpoint"] = shared_endpoint
-        candidate["nebius_api_key"] = shared_access_key
-        candidate["nebius_secret_key"] = shared_secret_key
-        return candidate
+    # Never record a host-level shared bucket as an explicit project's remote
+    # backend; keep immutable journal ownership exact.
+    if not project_name:
+        shared = load_credentials(environ={})
+        shared_bucket = str(shared.s3_bucket or "").strip()
+        shared_prefix = ""
+        if shared_bucket.startswith("s3://"):
+            rest = shared_bucket[len("s3://") :]
+            shared_bucket, _sep, shared_prefix = rest.partition("/")
+            shared_prefix = shared_prefix.strip("/")
+        shared_endpoint = str(
+            shared.s3_endpoint or f"https://storage.{region}.nebius.cloud"
+        ).strip()
+        shared_access_key = str(shared.s3_access_key_id or "").strip()
+        shared_secret_key = str(shared.s3_secret_access_key or "").strip()
+        if shared_bucket and _storage_credentials_allow_writes(
+            bucket=shared_bucket,
+            endpoint=shared_endpoint,
+            access_key=shared_access_key,
+            secret_key=shared_secret_key,
+            region=region,
+            prefix=shared_prefix,
+        ):
+            if emit_status:
+                typer.echo(
+                    "  Using health-verified shared artifact storage credentials."
+                )
+            candidate["s3_bucket"] = shared_bucket
+            candidate["s3_prefix"] = shared_prefix
+            candidate["s3_endpoint"] = shared_endpoint
+            candidate["nebius_api_key"] = shared_access_key
+            candidate["nebius_secret_key"] = shared_secret_key
+            return candidate
 
     bucket = str(candidate.get("s3_bucket", "")).strip()
     endpoint = str(candidate.get("s3_endpoint", "")).strip()

--- a/npa/src/npa/cli/agent_ui.html
+++ b/npa/src/npa/cli/agent_ui.html
@@ -195,6 +195,12 @@
       .access-project-picker {
         display: grid;
         gap: 5px;
+        max-width: 720px;
+      }
+      .access-picker-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
         margin-top: 12px;
         max-width: 720px;
       }
@@ -273,6 +279,7 @@
       .access-action-run-copy { min-width: 0; overflow-wrap: anywhere; }
       .access-errors { margin-top: 8px; color: var(--danger-text); font-size: 12px; }
       @media (max-width: 760px) {
+        .access-picker-grid { grid-template-columns: 1fr; }
         .access-capabilities { grid-template-columns: 1fr; }
         .access-action-run { align-items: flex-start; flex-direction: column; }
       }
@@ -1967,12 +1974,21 @@
             </div>
           </div>
           <div id="agentAccessSummary" class="access-summary" aria-live="polite"></div>
-          <div class="access-project-picker">
-            <label for="agentAccessProjectSelect">Project</label>
-            <select id="agentAccessProjectSelect" aria-describedby="agentAccessProjectHint" disabled>
-              <option value="">Loading projects…</option>
-            </select>
-            <span id="agentAccessProjectHint" class="hint">Choose a project to inspect its effective read access and available actions.</span>
+          <div class="access-picker-grid">
+            <div class="access-project-picker">
+              <label for="agentAccessProjectSelect">Project</label>
+              <select id="agentAccessProjectSelect" aria-describedby="agentAccessProjectHint" disabled>
+                <option value="">Loading projects…</option>
+              </select>
+              <span id="agentAccessProjectHint" class="hint">Choose a project to inspect its effective read access.</span>
+            </div>
+            <div class="access-project-picker">
+              <label for="agentAccessBucketSelect">Bucket</label>
+              <select id="agentAccessBucketSelect" aria-describedby="agentAccessBucketHint" disabled>
+                <option value="">Loading buckets…</option>
+              </select>
+              <span id="agentAccessBucketHint" class="hint">Choose one bucket to inspect its available actions.</span>
+            </div>
           </div>
           <div id="agentAccessProjects" class="access-projects" aria-live="polite"></div>
           <div id="agentAccessErrors" class="access-errors" role="status"></div>
@@ -2641,6 +2657,7 @@
       let accessRefreshController = null;
       let selectedAccessResource = null;
       let selectedAccessProjectId = storedAccessProjectId();
+      let selectedAccessBucketName = "";
       let currentAccessReport = null;
       function accessSelectionFromButton(button) {
         return {
@@ -2869,6 +2886,54 @@
         }
         return false;
       }
+      function selectedAccessProject() {
+        return sortedAccessProjects(currentAccessReport).find(
+          (item) => String((item && item.id) || "") === selectedAccessProjectId,
+        ) || null;
+      }
+      function accessProjectResources(project) {
+        return Array.isArray(project && project.resources) ? project.resources : [];
+      }
+      function setAccessBucketPlaceholder(message) {
+        const picker = document.getElementById("agentAccessBucketSelect");
+        if (!picker) return;
+        picker.replaceChildren();
+        const option = document.createElement("option");
+        option.value = "";
+        option.textContent = message;
+        picker.appendChild(option);
+        picker.value = "";
+        picker.disabled = true;
+      }
+      function populateAccessBucketPicker(project, retainSelection) {
+        const picker = document.getElementById("agentAccessBucketSelect");
+        const resources = accessProjectResources(project);
+        if (!picker) {
+          selectedAccessBucketName = resources.length
+            ? String((resources[0] && resources[0].name) || "")
+            : "";
+          return;
+        }
+        picker.replaceChildren();
+        resources.forEach((resource) => {
+          const option = document.createElement("option");
+          const bucket = String((resource && resource.name) || "unnamed bucket");
+          option.value = bucket;
+          option.textContent = bucket;
+          picker.appendChild(option);
+        });
+        picker.disabled = !resources.length;
+        if (!resources.length) {
+          setAccessBucketPlaceholder(project ? "No buckets available" : "Select a project first");
+          selectedAccessBucketName = "";
+          return;
+        }
+        const retained = retainSelection && resources.some(
+          (resource) => String((resource && resource.name) || "unnamed bucket") === selectedAccessBucketName,
+        ) ? selectedAccessBucketName : "";
+        selectedAccessBucketName = retained || String((resources[0] && resources[0].name) || "unnamed bucket");
+        picker.value = selectedAccessBucketName;
+      }
       function renderSelectedAccessProject() {
         const projectsHost = document.getElementById("agentAccessProjects");
         if (!projectsHost) return;
@@ -2886,7 +2951,11 @@
         const readScope = capabilities.artifact_read || {};
         const submit = capabilities.workflow_submission || {};
         const storageDiscovery = capabilities.storage_resource_discovery || {};
-        const resources = Array.isArray(project && project.resources) ? project.resources : [];
+        const resources = accessProjectResources(project);
+        const selectedResourceIndex = resources.findIndex(
+          (resource) => String((resource && resource.name) || "unnamed bucket") === selectedAccessBucketName,
+        );
+        const selectedResource = selectedResourceIndex >= 0 ? resources[selectedResourceIndex] : null;
         const projectId = String(project.id || "");
         const projectName = String(project.name || projectId || "project");
         const scopeHtml = (label, capability) => {
@@ -2895,7 +2964,9 @@
             escapeHtml(accessStatusLabel(capStatus)) + "</strong> — " +
             escapeHtml(String(capability.reason || "No capability reason was reported.")) + "</div>";
         };
-        const resourceHtml = resources.length ? resources.map((resource, resourceIndex) => {
+        const resourceHtml = selectedResource ? (() => {
+          const resource = selectedResource;
+          const resourceIndex = selectedResourceIndex;
           const caps = (resource && resource.capabilities) || {};
           const list = caps.artifact_discovery || {};
           const read = caps.artifact_read || {};
@@ -2915,13 +2986,13 @@
               '<span id="' + reasonId + '" class="access-capability-reason">' +
               escapeHtml(String(capability.reason || "No capability reason was reported.")) + "</span></div>";
           };
-          return '<div class="access-resource">' +
+          return '<div class="access-resource" data-selected-bucket="' + escapeHtml(bucket) + '">' +
             '<div class="access-resource-head"><span class="pill">object storage</span><code>' + escapeHtml(bucket) + "</code></div>" +
             '<div class="access-capabilities">' +
             capabilityHtml("List", list, "list", "List artifacts") +
             capabilityHtml("Read", read, "read", "Browse / preview") +
             "</div></div>";
-        }).join("") : '<div class="access-resource-empty"><strong>No searchable artifact bucket.</strong> <span class="hint">' +
+        })() : '<div class="access-resource-empty"><strong>No searchable artifact bucket.</strong> <span class="hint">' +
           escapeHtml(String(storageDiscovery.reason || discovery.reason || "No object-storage resource was returned for this project.")) +
           "</span></div>";
         projectsHost.innerHTML = '<article class="access-project access-project-detail" data-project-id="' + escapeHtml(projectId) + '">' +
@@ -2942,12 +3013,28 @@
         const requested = String(projectId || "").trim();
         const selected = projects.find((item) => String((item && item.id) || "") === requested);
         if (!selected) return false;
-        if (selectedAccessProjectId !== requested && !opts.renderOnly) {
+        const projectChanged = selectedAccessProjectId !== requested;
+        if (projectChanged && !opts.renderOnly) {
           cancelAccessAction(true);
         }
         selectedAccessProjectId = requested;
         persistAccessProjectId(requested);
         const picker = document.getElementById("agentAccessProjectSelect");
+        if (picker && picker.value !== requested) picker.value = requested;
+        populateAccessBucketPicker(selected, !projectChanged);
+        renderSelectedAccessProject();
+        return true;
+      }
+      function selectAccessBucket(bucketName) {
+        const requested = String(bucketName || "").trim();
+        const project = selectedAccessProject();
+        const selected = accessProjectResources(project).find(
+          (resource) => String((resource && resource.name) || "unnamed bucket") === requested,
+        );
+        if (!selected) return false;
+        if (selectedAccessBucketName !== requested) cancelAccessAction(true);
+        selectedAccessBucketName = requested;
+        const picker = document.getElementById("agentAccessBucketSelect");
         if (picker && picker.value !== requested) picker.value = requested;
         renderSelectedAccessProject();
         return true;
@@ -3002,6 +3089,12 @@
             option.setAttribute("data-project-id", projectId);
             picker.appendChild(option);
           });
+          if (!projects.length) {
+            const option = document.createElement("option");
+            option.value = "";
+            option.textContent = "No projects available";
+            picker.appendChild(option);
+          }
           picker.disabled = !projects.length;
         }
         const deploymentId = String(identity.deployment_project_id || "");
@@ -3015,7 +3108,9 @@
         if (nextSelection) selectAccessProject(nextSelection, { renderOnly: true });
         else {
           selectedAccessProjectId = "";
+          selectedAccessBucketName = "";
           persistAccessProjectId("");
+          setAccessBucketPlaceholder("Select a project first");
           renderSelectedAccessProject();
         }
         const errors = Array.isArray(report && report.errors) ? report.errors : [];
@@ -3060,6 +3155,18 @@
           }
           if (errorsHost) {
             errorsHost.textContent = "Access refresh failed. Existing project-scoped operations are unchanged; retry refresh for current diagnostics.";
+          }
+          if (!currentAccessReport) {
+            const projectPicker = document.getElementById("agentAccessProjectSelect");
+            if (projectPicker) {
+              projectPicker.replaceChildren();
+              const option = document.createElement("option");
+              option.value = "";
+              option.textContent = "Projects unavailable";
+              projectPicker.appendChild(option);
+              projectPicker.disabled = true;
+            }
+            setAccessBucketPlaceholder("Buckets unavailable");
           }
           throw err;
         } finally {
@@ -3308,6 +3415,13 @@
           accessProjectSelect.addEventListener("change", (event) => {
             const value = String((event.target && event.target.value) || "");
             selectAccessProject(value);
+          });
+        }
+        const accessBucketSelect = document.getElementById("agentAccessBucketSelect");
+        if (accessBucketSelect) {
+          accessBucketSelect.addEventListener("change", (event) => {
+            const value = String((event.target && event.target.value) || "");
+            selectAccessBucket(value);
           });
         }
         const accessPanel = document.getElementById("agentAccessPanel");

--- a/npa/tests/browser/cypress/e2e/agent_mocked.cy.js
+++ b/npa/tests/browser/cypress/e2e/agent_mocked.cy.js
@@ -342,7 +342,7 @@ describe("NPA agent UI with mocked APIs", () => {
     cy.get("#artifactRefreshRuns").should("be.enabled").and("have.attr", "aria-busy", "false");
   });
 
-  it("selects one escaped project detail at a time and preserves the stable project ID", () => {
+  it("selects one escaped project and bucket detail at a time", () => {
     const projectCapabilities = (artifactStatus, artifactReason, readStatus, readReason, submitStatus, submitReason) => ({
       project_metadata: { status: "available", reason: "Project identity was returned by tenant discovery." },
       storage_resource_discovery: { status: "available", reason: "Object storage resources visible in this project were listed." },
@@ -411,7 +411,10 @@ describe("NPA agent UI with mocked APIs", () => {
         deployment_project: true,
         status: "available",
         capabilities: projectCapabilities("available", "At least one project bucket is searchable.", "available", "Artifact object reads were verified.", "available", "Workflow submission remains scoped to the deployment project."),
-        resources: [resource("resource-a", "project-artifacts")],
+        resources: [
+          resource("resource-a", "project-artifacts"),
+          resource("resource-a-archive", "archive-artifacts"),
+        ],
       },
       {
         id: "project-c",
@@ -456,6 +459,7 @@ describe("NPA agent UI with mocked APIs", () => {
     cy.wait("@selectorAccess");
 
     cy.get('label[for="agentAccessProjectSelect"]').should("contain.text", "Project");
+    cy.get('label[for="agentAccessBucketSelect"]').should("contain.text", "Bucket");
     cy.get("#agentAccessProjectSelect")
       .should("have.prop", "tagName", "SELECT")
       .and("be.enabled")
@@ -475,11 +479,25 @@ describe("NPA agent UI with mocked APIs", () => {
       .and("contain.text", "Project Alpha")
       .and("contain.text", "project-a")
       .and("contain.text", "deployment project");
+    cy.get("#agentAccessBucketSelect")
+      .should("have.prop", "tagName", "SELECT")
+      .and("be.enabled")
+      .and("have.attr", "aria-describedby", "agentAccessBucketHint")
+      .and("have.value", "project-artifacts");
+    cy.get("#agentAccessBucketSelect option").should("have.length", 2);
+    cy.get("#agentAccessProjects .access-resource").should("have.length", 1)
+      .and("contain.text", "project-artifacts")
+      .and("not.contain.text", "archive-artifacts");
+    cy.get("#agentAccessBucketSelect").select("archive-artifacts");
+    cy.get("#agentAccessProjects .access-resource").should("have.length", 1)
+      .and("contain.text", "archive-artifacts")
+      .and("not.contain.text", "project-artifacts");
     cy.get("#agentAccessPanel").should(($panel) => {
       expect($panel.text()).not.to.match(/\bpartial\b/i);
     });
 
     cy.get("#agentAccessProjectSelect").select("project-b");
+    cy.get("#agentAccessBucketSelect").should("have.value", "foreign-artifacts");
     cy.get("#agentAccessProjects .access-project-detail").should("have.length", 1)
       .and("contain.text", "Foreign Project")
       .and("contain.text", "foreign-artifacts")
@@ -489,7 +507,18 @@ describe("NPA agent UI with mocked APIs", () => {
       .should("have.attr", "data-project-id", "project-b")
       .and("have.attr", "data-resource-bucket", "foreign-artifacts");
 
+    cy.get("#agentAccessProjectSelect").select("project-a");
+    cy.get("#agentAccessBucketSelect").should("have.value", "project-artifacts");
+    cy.get("#agentAccessProjects .access-resource")
+      .should("contain.text", "project-artifacts")
+      .and("not.contain.text", "archive-artifacts");
+
     cy.get("#agentAccessProjectSelect").select("project-c");
+    cy.get("#agentAccessBucketSelect")
+      .should("be.disabled")
+      .and("have.value", "")
+      .find("option")
+      .should("have.text", "No buckets available");
     cy.get("#agentAccessProjects .access-project-detail").should("have.length", 1)
       .and("contain.text", "No searchable artifact bucket.")
       .and("contain.text", "No Bucket")
@@ -497,6 +526,7 @@ describe("NPA agent UI with mocked APIs", () => {
     cy.get("#agentAccessProjects button[data-access-action]").should("not.exist");
 
     cy.get("#agentAccessProjectSelect").select("project-d");
+    cy.get("#agentAccessBucketSelect").should("be.enabled").and("have.value", "empty-artifacts");
     cy.get("#agentAccessProjects .access-project-detail").should("have.length", 1)
       .and("contain.text", "Empty Bucket")
       .and("contain.text", "empty-artifacts")
@@ -522,6 +552,7 @@ describe("NPA agent UI with mocked APIs", () => {
       ]);
     });
     cy.get("#agentAccessProjectSelect").invoke("val", hostileProjectId).trigger("change");
+    cy.get("#agentAccessBucketSelect").should("have.value", hostileBucket);
     cy.get("#agentAccessProjects .access-project-detail").should("have.length", 1)
       .and("contain.text", hostileProjectId)
       .and("contain.text", hostileBucket)
@@ -529,9 +560,16 @@ describe("NPA agent UI with mocked APIs", () => {
     cy.get("#agentAccessPanel").find("script, img, svg").should("not.exist");
     cy.window().its("__npaXss").should("not.exist");
     cy.get("#agentAccessProjectSelect").focus().should("be.focused");
+    cy.get("#agentAccessBucketSelect").focus().should("be.focused");
 
     cy.viewport(375, 667);
     cy.get("#agentAccessProjectSelect").should("be.visible").then(($select) => {
+      const selectRect = $select[0].getBoundingClientRect();
+      const panelRect = $select[0].closest("#agentAccessPanel").getBoundingClientRect();
+      expect(selectRect.left).to.be.at.least(panelRect.left);
+      expect(selectRect.right).to.be.at.most(panelRect.right + 1);
+    });
+    cy.get("#agentAccessBucketSelect").should("be.visible").then(($select) => {
       const selectRect = $select[0].getBoundingClientRect();
       const panelRect = $select[0].closest("#agentAccessPanel").getBoundingClientRect();
       expect(selectRect.left).to.be.at.least(panelRect.left);
@@ -596,14 +634,16 @@ describe("NPA agent UI with mocked APIs", () => {
 
   it("disables denied and unavailable access actions with visible reasons", () => {
     for (const bucket of ["denied-artifacts", "unavailable-artifacts"]) {
+      cy.get("#agentAccessBucketSelect").select(bucket);
       cy.get(`#agentAccessProjects [data-resource-bucket="${bucket}"]`).each(($button) => {
         expect($button[0].tagName).to.eq("BUTTON");
         expect($button).to.be.disabled;
         expect($button.attr("aria-describedby")).to.be.a("string").and.not.be.empty;
       });
     }
-    cy.get("#agentAccessProjects").should("contain.text", "Permission denied while listing objects.");
     cy.get("#agentAccessProjects").should("contain.text", "Object reads could not be verified.");
+    cy.get("#agentAccessBucketSelect").select("denied-artifacts");
+    cy.get("#agentAccessProjects").should("contain.text", "Permission denied while listing objects.");
   });
 
   it("shows busy/error feedback and blocks stale resource responses", () => {
@@ -639,6 +679,7 @@ describe("NPA agent UI with mocked APIs", () => {
     cy.get("#agentAccessActionResult")
       .should("have.attr", "aria-busy", "true")
       .and("contain.text", "Querying the selected project and bucket");
+    cy.get("#agentAccessBucketSelect").select("archive-artifacts");
     cy.get('#agentAccessProjects button[data-access-action="list"][data-resource-bucket="archive-artifacts"]').click();
     cy.wait("@scopedAccessRuns");
     cy.get("#agentAccessActionResult", { timeout: 3000 })
@@ -652,6 +693,7 @@ describe("NPA agent UI with mocked APIs", () => {
       statusCode: 502,
       body: { ok: false, error: "Scoped list probe failed." },
     }).as("failedAccessRuns");
+    cy.get("#agentAccessBucketSelect").select("project-artifacts");
     cy.get('#agentAccessProjects button[data-access-action="list"][data-resource-bucket="project-artifacts"]').click();
     cy.wait("@failedAccessRuns");
     cy.get("#agentAccessActionResult")
@@ -680,6 +722,26 @@ describe("NPA agent UI with mocked APIs", () => {
     cy.wait(800);
     cy.get("#agentAccessActionResult").should("have.attr", "hidden");
     cy.get("#agentAccessActionResult").should("not.contain.text", "must-not-render-after-refresh");
+  });
+
+  it("preserves the selected bucket when an access refresh fails", () => {
+    cy.get("#agentAccessBucketSelect").select("archive-artifacts");
+    cy.get("#agentAccessProjects .access-resource").should("contain.text", "archive-artifacts");
+    cy.intercept("GET", "/api/access?refresh=true", {
+      statusCode: 503,
+      body: { ok: false, error: "Access inventory is temporarily unavailable." },
+    }).as("failedAccessRefresh");
+
+    cy.get("#agentAccessRefresh").click();
+    cy.wait("@failedAccessRefresh");
+    cy.get("#agentAccessStatus").should("have.text", "Access unavailable");
+    cy.get("#agentAccessErrors").should("contain.text", "Existing project-scoped operations are unchanged");
+    cy.get("#agentAccessProjectSelect").should("have.value", "project-a");
+    cy.get("#agentAccessBucketSelect").should("be.enabled").and("have.value", "archive-artifacts");
+    cy.get("#agentAccessProjects .access-resource")
+      .should("have.length", 1)
+      .and("contain.text", "archive-artifacts")
+      .and("not.contain.text", "project-artifacts");
   });
 
   it("opens a JSON-only run through Read and renders useful content", () => {

--- a/npa/tests/browser/cypress/support/e2e.js
+++ b/npa/tests/browser/cypress/support/e2e.js
@@ -406,6 +406,7 @@ const STATIC_BUTTON_IDS = [
 
 const FIELD_IDS = [
   "agentAccessProjectSelect",
+  "agentAccessBucketSelect",
   "chatSessionSelect",
   "chatModel",
   "chatLog",

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -895,6 +895,58 @@ def test_resolve_deploy_storage_credentials_falls_back_to_shared(monkeypatch) ->
     assert resolved["nebius_api_key"] == "ak-shared"
 
 
+def test_resolve_deploy_storage_credentials_rejects_shared_for_explicit_project(
+    monkeypatch,
+) -> None:
+    from npa.cli.agent import (
+        AgentStorageCredentialError,
+        _resolve_deploy_storage_credentials,
+    )
+
+    monkeypatch.setattr(
+        "npa.cli.agent.resolve_project_storage",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            checkpoint_bucket="s3://project-bucket/",
+            endpoint_url="https://storage.us-central1.nebius.cloud",
+            aws_access_key_id="ak-project",
+            aws_secret_access_key="sk-project",
+        ),
+    )
+    monkeypatch.setattr(
+        "npa.cli.agent.resolve_terraform_state",
+        lambda _project: SimpleNamespace(
+            bucket="state-bucket",
+            endpoint="https://storage.us-central1.nebius.cloud",
+            access_key="ak-state",
+            secret_key="sk-state",
+        ),
+    )
+    monkeypatch.setattr(
+        "npa.cli.agent._storage_credentials_allow_writes",
+        lambda **kwargs: kwargs["bucket"] == "shared-bucket",
+    )
+
+    def _shared_credentials_must_not_be_loaded(**_kwargs):
+        raise AssertionError("explicit-project deploy consulted shared credentials")
+
+    monkeypatch.setattr(
+        "npa.clients.credentials.load_credentials",
+        _shared_credentials_must_not_be_loaded,
+    )
+
+    with pytest.raises(AgentStorageCredentialError):
+        _resolve_deploy_storage_credentials(
+            region="us-central1",
+            project_alias="target-project",
+            bootstrap_creds={
+                "s3_bucket": "bootstrap-bucket",
+                "s3_endpoint": "https://storage.us-central1.nebius.cloud",
+                "nebius_api_key": "ak-bootstrap",
+                "nebius_secret_key": "sk-bootstrap",
+            },
+        )
+
+
 def test_resolve_deploy_storage_credentials_prefers_saved_project_state(
     monkeypatch,
 ) -> None:

--- a/npa/tests/cli/test_agent_access.py
+++ b/npa/tests/cli/test_agent_access.py
@@ -274,6 +274,8 @@ def test_access_model_is_embedded_with_api_ui_and_read_boundary() -> None:
     assert 'id="agentAccessPanel"' in ui_source
     assert 'id="agentAccessProjectSelect"' in ui_source
     assert 'for="agentAccessProjectSelect"' in ui_source
+    assert 'id="agentAccessBucketSelect"' in ui_source
+    assert 'for="agentAccessBucketSelect"' in ui_source
     assert 'apiJson("/api/access"' in ui_source
     assert 'data-access-action="' in ui_source
     assert 'data-capability-status="' in ui_source
@@ -292,6 +294,9 @@ def test_access_model_is_embedded_with_api_ui_and_read_boundary() -> None:
         in ui_source
     )
     assert "const nextSelection = retained || deployment" in ui_source
+    assert "populateAccessBucketPicker(selected, !projectChanged)" in ui_source
+    assert "function selectAccessBucket(bucketName)" in ui_source
+    assert 'data-selected-bucket="' in ui_source
     assert "No searchable artifact bucket." in ui_source
 
 


### PR DESCRIPTION
## What changed

- Added an accessible bucket dropdown beside the existing project dropdown in the Agent access panel.
- Rendered only the selected bucket's capabilities and actions instead of every bucket in the project.
- Kept the current bucket on same-project access refreshes when it is still available; project changes rebuild the choices and select that project's first reported bucket so stale cross-project selection cannot survive.
- Added explicit loading, empty, unavailable, and refresh-error behavior.
- Expanded focused mocked-browser and source-contract coverage for selection defaults, project changes, one-bucket rendering, accessibility, mobile layout, stale requests, empty projects, and refresh failures.
- Fixed a blocker found by live deployment: explicit-project deploys no longer adopt a writable shared bucket as their immutable Terraform backend.

## Why

Projects with many object-storage buckets could make the Main tab excessively tall and difficult to scan. A project-scoped bucket dropdown keeps the panel compact while preserving the existing artifact list/read actions and capability diagnostics.

The deployment fix keeps storage/backend ownership aligned with the selected project.

## User and developer impact

Users inspect and act on one bucket at a time. The project selector still prefers the retained project, then the deployment project, then the first sorted project. Within a project, the first reported bucket is the default; a valid selection survives access refreshes but resets when the project changes. The Agent access API contract is unchanged.

Explicit-project Agent deployment now fails closed instead of falling back to unrelated shared storage.

## Validation

- Fresh CPU Agent deployment in an operator-owned project: preflight 8/8 passed and fresh setup completed.
- Required live smoke: healthy JSON status; HTTPS, authenticated `/api/models`, authenticated `/api/chat`, and deployed UI all returned 200; bucket selector and single-selection markers were present.
- `npa agent verify-live`: 26 passed; 3 unrelated mature-suite cases remain failing (Soperator validation and two workflow-generation expectations). Required deploy smoke is green.
- Focused agent and skill-index tests — 221 passed.
- Full non-E2E suite with xdist — 10,369 passed, 49 skipped, 1 xpassed.
- Mocked Cypress Agent UI suite — passed.
- Ruff, monolith-size ratchet, diff whitespace, and repository confidentiality scans passed. The local gitleaks binary was unavailable; the PR gitleaks check remains authoritative.

## Limitations

- Bucket selection is page-local rather than persisted across reloads; reloads consistently return to the selected project's first reported bucket.
