### PR TITLE
skills: add 11 agent skills for npa/workbench deployment and daily use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ The source of truth is `skills/index.yaml`. The tree is organized as:
 - `skills/tools/vlm-eval/SKILL.md`: score rollouts with a VLM and turn the score into a gate — `run` vs `loop`, rubric/threshold benchmark sweeps, backend selection, and judging against a plan an earlier stage wrote.
 - `skills/tools/golden-eval/SKILL.md`: prove a container image actually works — per-container hello-world manifest, dry-run/local/serverless tiers, batch runs, and the offline manifest validation that gates CI.
 - `skills/tools/burst/SKILL.md`: one gang-scheduled multi-node GPU job with torchrun rendezvous, deliberately not a workflow surface.
+- `skills/tools/gpu-cluster-provisioning/SKILL.md`: managed-image vs GPU-Operator driver strategy (operator mode is unsafe on NVSwitch), the post-apply health gates (fabric, CUDA vectorAdd, stability window), accelerator-name discovery, and triage for nodes whose GPUs do not work.
 - `skills/tools/detection-training/SKILL.md`: Faster R-CNN detectors trained from LanceDB materialized views (BDD100K failure-mode slices).
 - `skills/tools/artifact-viz-share/SKILL.md`: sim demos → LeRobotDataset → `.rrd`/MP4, and time-boxed presigned Rerun share links.
 - `skills/tools/fleet/SKILL.md`: deploy a fleet of Nebius Managed Kubernetes (k8s-training) clusters across one or many projects in a tenant from an `npa.fleet/v0.0.1` spec — identical and/or custom clusters, create-on-demand projects, and a k8s-training source that can consume the latest upstream recipe.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,16 @@ The source of truth is `skills/index.yaml`. The tree is organized as:
 - `skills/atomic/`: reusable actions and review conventions such as GPU selection, workflow submission, testing conventions, image build/push, Cosmos3 setup/troubleshooting, and agent visual feedback (Describe this).
 - `skills/atomic/agent-visual-feedback/SKILL.md`: Describe-this multimodal feedback for Rerun / video / image / data viewers.
 - `skills/tools/`: concrete workbench and platform tools such as LeRobot, FiftyOne, Genesis, Isaac Lab, Cosmos, LanceDB, GR00T, SONIC, MJLab, Retargeting, SkyPilot, Scenario Gen, Dataset-of-record, Fleet, and Nebius infra.
+- `skills/workflows/first-run-setup/SKILL.md`: zero to a first verified result on a fresh machine or new project — an ordered, gated path (install → configure → credential preflight → cheapest-proof workload → validate spec → provision → image pullability → submit) with a stop condition at every step.
+- `skills/atomic/health-preflight/SKILL.md`: there is no `npa doctor` — prove HF/NGC/S3/Token Factory credentials and gated-model access with `npa workbench health preflight` / `access` before spending GPU time.
+- `skills/atomic/debug-failed-run/SKILL.md`: triage a run that failed, hung, or produced no artifacts — status and pod-level reason, stage logs, S3 evidence, image pullability, scheduling, and the resume-vs-cancel decision.
+- `skills/atomic/teardown-and-cost/SKILL.md`: stop spend safely — cancel-before-destroy ordering, cloud versus local state, and the orphan audit for leaked clusters, agent VMs, controllers, buckets, and cross-project fleets.
+- `skills/tools/token-factory/SKILL.md`: zero-GPU hosted inference (captioning, batch generation, Cosmos physical-AI reasoning) — the cheapest tier that produces a real artifact, with no cluster and no provisioning.
+- `skills/tools/vlm-eval/SKILL.md`: score rollouts with a VLM and turn the score into a gate — `run` vs `loop`, rubric/threshold benchmark sweeps, backend selection, and judging against a plan an earlier stage wrote.
+- `skills/tools/golden-eval/SKILL.md`: prove a container image actually works — per-container hello-world manifest, dry-run/local/serverless tiers, batch runs, and the offline manifest validation that gates CI.
+- `skills/tools/burst/SKILL.md`: one gang-scheduled multi-node GPU job with torchrun rendezvous, deliberately not a workflow surface.
+- `skills/tools/detection-training/SKILL.md`: Faster R-CNN detectors trained from LanceDB materialized views (BDD100K failure-mode slices).
+- `skills/tools/artifact-viz-share/SKILL.md`: sim demos → LeRobotDataset → `.rrd`/MP4, and time-boxed presigned Rerun share links.
 - `skills/tools/fleet/SKILL.md`: deploy a fleet of Nebius Managed Kubernetes (k8s-training) clusters across one or many projects in a tenant from an `npa.fleet/v0.0.1` spec — identical and/or custom clusters, create-on-demand projects, and a k8s-training source that can consume the latest upstream recipe.
 - `skills/tools/scenario-gen/SKILL.md`: adversarial scenario generation — an RL adversary that maximizes failures of a policy-under-test, scenario ranking, and the adversarial-scenario-hardening workflow.
 - `skills/tools/dataset/SKILL.md`: dataset-of-record — ingest, validate, curate, and query production sensor data as a versioned, lineage-tracked dataset (FiftyOne curation + LanceDB query index).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,9 @@ making architecture, review, or domain judgments.
  and the offline manifest validation that gates CI.
 - `skills/tools/burst/SKILL.md`: one gang-scheduled multi-node GPU job with
  torchrun rendezvous, deliberately not a workflow surface.
+- `skills/tools/gpu-cluster-provisioning/SKILL.md`: managed-image vs GPU-Operator
+ driver strategy (operator mode is unsafe on NVSwitch), the post-apply health
+ gates, accelerator-name discovery, and triage for nodes whose GPUs do not work.
 - `skills/tools/detection-training/SKILL.md`: Faster R-CNN detectors trained from
  LanceDB materialized views (BDD100K failure-mode slices).
 - `skills/tools/artifact-viz-share/SKILL.md`: sim demos → LeRobotDataset →

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,19 @@ making architecture, review, or domain judgments.
   expectations.
 - `skills/atomic/architecture/SKILL.md`: platform architecture and validation
  state.
+- `skills/workflows/first-run-setup/SKILL.md`: zero to a first verified result on
+ a fresh machine or new project — an ordered, gated path (install → configure →
+ credential preflight → cheapest-proof workload → validate spec → provision →
+ image pullability → submit), with a stop condition at every step.
+- `skills/atomic/health-preflight/SKILL.md`: there is no `npa doctor` — prove
+ HF/NGC/S3/Token Factory credentials and gated-model access with
+ `npa workbench health preflight` / `access` before spending GPU time.
+- `skills/atomic/debug-failed-run/SKILL.md`: triage a run that failed, hung, or
+ produced no artifacts — status and pod-level reason, stage logs, S3 evidence,
+ image pullability, scheduling, and the resume-vs-cancel decision.
+- `skills/atomic/teardown-and-cost/SKILL.md`: stop spend safely — the mandatory
+ cancel-before-destroy ordering, cloud versus local state, and the orphan audit
+ for leaked clusters, agent VMs, controllers, buckets, and cross-project fleets.
 - `skills/atomic/agent-development/SKILL.md`: build, enhance, or test the NPA
  chat agent backend (grounded-first routing, cost-aware Token Factory model
  selection, embedded-backend mechanism, cheap-token test tiers).
@@ -37,6 +50,21 @@ making architecture, review, or domain judgments.
  (k8s-training) clusters across one or many projects in a tenant from an
  `npa.fleet/v0.0.1` spec — identical and/or custom clusters, create-on-demand
  projects, and a k8s-training source that can consume the latest upstream recipe.
+- `skills/tools/token-factory/SKILL.md`: zero-GPU hosted inference (captioning,
+ batch generation, Cosmos physical-AI reasoning) — the cheapest tier that
+ produces a real artifact, with no cluster and no provisioning.
+- `skills/tools/vlm-eval/SKILL.md`: score rollouts with a VLM and turn the score
+ into a gate — `run` vs `loop`, rubric/threshold benchmark sweeps, backend
+ selection, and judging against a plan an earlier stage wrote.
+- `skills/tools/golden-eval/SKILL.md`: prove a container image actually works —
+ per-container hello-world manifest, dry-run/local/serverless tiers, batch runs,
+ and the offline manifest validation that gates CI.
+- `skills/tools/burst/SKILL.md`: one gang-scheduled multi-node GPU job with
+ torchrun rendezvous, deliberately not a workflow surface.
+- `skills/tools/detection-training/SKILL.md`: Faster R-CNN detectors trained from
+ LanceDB materialized views (BDD100K failure-mode slices).
+- `skills/tools/artifact-viz-share/SKILL.md`: sim demos → LeRobotDataset →
+ `.rrd`/MP4, and time-boxed presigned Rerun share links.
 - `skills/tools/mjlab/SKILL.md`: MJLab locomotion evaluation and SONIC checkpoint
  scoring.
 - `skills/tools/retargeting/SKILL.md`: motion retargeting in SONIC locomotion

--- a/skills/atomic/debug-failed-run/SKILL.md
+++ b/skills/atomic/debug-failed-run/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: debug-failed-run
+description: Use when a workflow run failed, hung, or produced no artifacts — an ordered triage from run id to root cause across status, stage logs, S3 evidence, pod-level reasons, and the resume-vs-cancel decision.
+---
+
+# Debug a failed workflow run
+
+Start from the run id and work outward. Every step below is read-only until the
+final decision, so none of it costs GPU time or destroys the evidence you need.
+
+## 0. Find the run id
+
+```bash
+npa workbench workflow list --project <alias> --limit 50 --json
+```
+
+Runs are durable S3 objects, so this works after the controller, the cluster, or
+your shell is gone. If you only have an S3 prefix, every command below accepts an
+`s3://` run prefix wherever it accepts a run id.
+
+## 1. Status first — it names the failure class
+
+```bash
+npa workbench workflow status <run-id> --project <alias> --json
+```
+
+This is the single most informative command, because **for a PENDING job it
+reports the pod-level reason** rather than just "pending". That distinction is
+the whole triage:
+
+- `PENDING` + `ImagePullBackOff` → registry problem, go to step 4. The job will
+  never fail on its own; Kubernetes retries pulls forever.
+- `PENDING` + `Unschedulable` → capacity or accelerator-name problem, step 5.
+- `FAILED` → the payload ran and exited non-zero, step 3.
+- `FAILED_STARTUP` → the controller itself failed identically several times
+  (threshold `--startup-failure-threshold`, default 3). This is infrastructure,
+  not your payload.
+
+Add `--watch --interval 10` to follow a run to a terminal state. Use `--cached`
+only when the live controller is unreachable: its output is explicitly marked
+CACHED and is **not automation-trustworthy** — never gate a decision on it.
+
+## 2. Enumerate what the run actually produced
+
+```bash
+npa workbench workflow artifacts <run-id> --project <alias> --json
+npa workbench workflow artifacts <run-id> --stage <stage-name> --json
+```
+
+Compare produced artifacts against the stages the spec declares. The first stage
+with no outputs is where to look, and it is often earlier than the stage that
+reported the error. A stage that "succeeded" with a zero-byte or missing declared
+output is a real failure that the exit code missed.
+
+## 3. Read the failing stage's logs
+
+```bash
+npa workbench workflow logs <run-id> --stage <stage-name>
+npa workbench workflow logs <run-id> --stage <stage-name> --follow   # live job
+npa workbench workflow logs <run-id> --stage <stage-name> --cached   # S3 only
+```
+
+`--follow` tails live SkyPilot logs and needs the controller; `--cached` reads
+persisted object-storage evidence only and never queries the controller, which is
+what you want for a post-mortem on a torn-down run. `--json` emits the log-source
+contract so you can see *which* source answered — worth checking before you
+conclude "there are no logs", because an empty live tail and an unread S3 object
+look identical otherwise.
+
+## 4. Registry and image problems (the most common stall)
+
+A `403` from the registry does not fail the job, it stalls it. Listing a
+repository's tags is a *different permission* from pulling it, so a `200` on
+`/v2/<repo>/tags/list` proves nothing.
+
+```bash
+npa workbench workflow preflight-images <spec.yaml> --project <alias> --json
+```
+
+This reproduces the exact manifest fetch a worker performs, with the credentials
+the run injects, and reports each image `ok` / `not_found` / `forbidden`.
+
+- `not_found` → the image was never built and pushed into *this* project's
+  registry. Nothing mirrors workbench images into a registry created by
+  `npa configure`; see `skills/atomic/build-and-push-image/SKILL.md`.
+- `forbidden` → Nebius IAM registry tokens expire. Refresh the pull secret in the
+  namespace that owns the pod rather than hand-minting per run; the canonical
+  helper is `npa.clients.nebius_auth.mint_nebius_iam_token` and, for Kubernetes,
+  `npa.workflows.sim2real.registry_auth.ensure_registry_pull_secret_for_images`.
+
+## 5. Scheduling problems
+
+```bash
+npa workbench workflow gpus --cluster <name> --json
+npa workbench workflow gpus --cluster <name> --spec <spec.yaml> --json
+```
+
+Two distinct causes present identically as `FAILED_PRECHECKS` or "cluster does
+not contain any instances satisfying the request" — neither is a capacity
+shortage:
+
+- **Accelerator name mismatch.** Kubernetes names GPUs after node labels, and the
+  name changes while the NVIDIA GPU operator is still labelling nodes. Submit
+  remaps this automatically; `--no-resolve-accelerators` disables the remap.
+- **`NAME:N` needs N GPUs on one node.** SkyPilot places all GPUs of a task on a
+  single node, so `NAME:2` can never schedule across 2 nodes × 1 GPU. `gpus`
+  prints the requestable quantity per node.
+
+## 6. When the run looks fine but the controller does not
+
+```bash
+npa skypilot status --project <alias> --context <context>
+npa skypilot verify --cluster <name> --output-format json
+```
+
+A silent multi-minute submit is usually the pinned Kubernetes client, not your
+spec: SkyPilot 0.12.2 does not cap the client version and client 36+ makes every
+`pod_config` fail validation, so the controller retries forever.
+`npa skypilot bootstrap` pins a working client and repairs an existing venv.
+
+## Decide: resume, re-load, cancel, or fix config
+
+- **Resume** when the failure was transport/capacity/preemption and the completed
+  waves are valid. Submit with `--resume-run <same-id>`; the runtime adopts
+  complete waves from declared S3 outputs and resubmits only incomplete work.
+  Never resume to paper over a bad input — you will inherit the bad artifacts.
+- **Re-load artifacts only** when every stage succeeded and only the final
+  artifact load failed. This never relaunches stages:
+
+  ```bash
+  npa workbench workflow load-artifact <run-id> --project <alias> --json
+  ```
+
+- **Cancel** when the run is wedged and you want the capacity back. Cancel is
+  repeat-safe: a planned or staged run that never launched is a successful no-op.
+
+  ```bash
+  npa workbench workflow cancel <run-id> --project <alias> --json
+  ```
+
+- **Fix config and start a fresh run** for anything the run itself cannot repair:
+  wrong bucket, wrong registry, missing gated-model acceptance, wrong GPU shape.
+
+Always cancel before tearing down shared infrastructure; see
+`skills/atomic/teardown-and-cost/SKILL.md` for the ordering.
+
+## Post-mortem across runs
+
+Once a run is triaged, ingest it so the next failure is comparable rather than
+re-investigated from scratch:
+
+```bash
+npa workbench insights ingest-run --input-path <run-prefix> --output-path <store>
+npa workbench insights compare --input-path <store> \
+  --base-run <last-good> --candidate-run <failed>
+```
+
+Ingestion is non-invasive — it scans the run prefix for schemas the tools already
+emit, so nothing needed to be instrumented in advance. See
+`skills/tools/insights/SKILL.md`.
+
+## Gotchas
+
+- **A green pipeline is not a good result.** Completion proves the graph ran, not
+  that the policy or dataset is any good. Read the measured metric, and never
+  weaken a threshold to turn a run green.
+- **Do not diagnose with raw `sky` commands.** Cancelling or relaunching by name
+  bypasses the transactional launch reconciliation and can orphan or duplicate a
+  managed job. Use the `npa` commands, which adopt one immutable job ID.
+- **`--cached` output is evidence, not truth.** It is last-known state; a run can
+  have moved on or died since.
+- **Check the obvious config mismatch before deep triage.** `npa configure --show`
+  against the run's actual bucket/registry catches a surprising share of "the
+  cluster is broken" reports.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/atomic/health-preflight/SKILL.md
+++ b/skills/atomic/health-preflight/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: health-preflight
+description: Use before any deploy, image build, or GPU submit to prove credentials and gated-model access up front with `npa workbench health preflight` and `npa workbench health access`, instead of discovering a missing token mid-run.
+---
+
+# Health preflight (the doctor before you spend)
+
+There is no `npa doctor`. The readiness surface is `npa workbench health`, and it
+has exactly two public commands. Run them before anything that costs GPU time or
+provisions cloud resources.
+
+```bash
+npa workbench health preflight --json
+npa workbench health access --json
+```
+
+Both exit non-zero on any FAIL. That is the point: they are gates, not reports.
+Use `--warn-only` only when you deliberately want the report without the gate
+(for example while collecting a status snapshot), never to make a red run green.
+
+## What each command answers
+
+`preflight` answers *"do I hold the credentials nearly every workbench tool
+needs?"* — one PASS/WARN/FAIL/SKIP row per check over Hugging Face, NGC, S3, and
+Token Factory:
+
+```bash
+npa workbench health preflight --checks all
+npa workbench health preflight --checks s3,token_factory
+npa workbench health preflight --offline    # presence only, no network probes
+```
+
+Valid `--checks` values are `all`, `hf`, `ngc`, `s3`, `token_factory`; the
+default is `hf,ngc,s3,token_factory`.
+
+`access` answers the different and more specific question *"is my token actually
+entitled to the gated models this capability pulls?"* Holding an HF token is not
+the same as having accepted a model's license.
+
+```bash
+npa workbench health access --capability all
+npa workbench health access --capability cosmos3,groot
+```
+
+Capabilities: `all`, `cosmos`, `cosmos3`, `cosmos3-serving`, `groot`, `lerobot`,
+`nurec`, `paidf`, `sim2real`, `sonic`, `token_factory`, `vlm_eval`.
+
+For anything still gated, `access` prints the exact "Agree and access
+repository" URL. **Hugging Face gated licenses must be accepted interactively on
+the model page** — there is no API that accepts them for you, so no amount of
+retrying or re-tokenizing will clear a gate. Open the printed URL, accept, then
+re-run. `scripts/accept-model-access.sh` collects the URLs for a batch.
+
+## Ordering: preflight before provisioning, not after
+
+The recurring cold-start failure this prevents is a mid-run stop after you have
+already paid for a cluster. Run the checks in this order:
+
+1. `npa configure --show` — confirm the project stanza, bucket, and endpoint you
+   think you are using are the ones on disk.
+2. `npa workbench health preflight` — credentials exist and authenticate.
+3. `npa workbench health access --capability <the one you will run>` — gated
+   model entitlements for that capability only; `all` is slower and reports
+   failures you do not care about today.
+4. Only then `npa provision-if-absent`, `npa cluster up`, or
+   `npa workbench workflow submit`.
+
+Image pullability is a *separate* gate that health does not cover; see
+`npa workbench workflow preflight-images <spec.yaml>` in
+`skills/atomic/submit-workflow/SKILL.md`. A green health report with an
+unpullable image still hangs in `ImagePullBackOff`.
+
+## Persisting credentials you already hold
+
+If the tokens are in your environment but not in `~/.npa/credentials.yaml`,
+persist them instead of re-exporting them in every shell:
+
+```bash
+npa workbench health access --save-env-credentials
+npa configure --save-env-credentials
+```
+
+Both perform an atomic `0600` write and never print the values. This is the fix
+for "it worked in my shell but the submit could not resolve the secret": submit
+resolves each requested secret from the explicit process environment first, then
+the selected project's configured NPA credentials.
+
+## Hidden sim2real check
+
+`npa workbench health sim2real` exists but is hidden, and is specific to the
+14-stage Sim2Real graph rather than general readiness. It adds cluster-shaped
+checks (`config`, `coherence`, `s3`, `registry`, `tokens`, `cluster`) including
+schedulable GPU count and kube-context pinning:
+
+```bash
+npa workbench health sim2real --checks all --json
+```
+
+Use it from `skills/workflows/sim2real-operate/SKILL.md`, not as the generic
+preflight. Its cluster check counts schedulable `nvidia.com/gpu` but does not yet
+match the *requested GPU product* against available node products, so it can pass
+on a cluster that has GPUs of the wrong kind for your spec. Confirm the product
+with `npa workbench workflow gpus --cluster <name>`.
+
+## Gotchas
+
+- **`--offline` proves presence, not validity.** It skips the live HF/S3/Token
+  Factory probes. An expired-but-present token passes offline and fails the
+  moment a stage pulls. Use offline only where there is genuinely no egress.
+- **A SKIP is not a PASS.** Checks skip when the corresponding capability is not
+  configured. If you are about to run a Cosmos stage and the NGC row says SKIP,
+  you have not verified anything about NGC.
+- **`preflight` does not check Kubernetes or SkyPilot.** Cluster readiness is
+  `npa skypilot verify --cluster <exact-context>` and `npa cluster status`;
+  registry pullability is `workflow preflight-images`. Three separate gates,
+  three separate commands.
+- **Stale `NEBIUS_IAM_TOKEN` defeats provider calls even when health is green.**
+  The Nebius provider prefers an ambient (often expired) token over the fresh CLI
+  token. `unset NEBIUS_IAM_TOKEN NPA_NEBIUS_IAM_TOKEN` before provisioning or
+  submitting.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/atomic/health-preflight/SKILL.md
+++ b/skills/atomic/health-preflight/SKILL.md
@@ -70,6 +70,22 @@ Image pullability is a *separate* gate that health does not cover; see
 `skills/atomic/submit-workflow/SKILL.md`. A green health report with an
 unpullable image still hangs in `ImagePullBackOff`.
 
+**A green `s3` row does not mean the submit can write.** The `s3` check lists
+the configured project bucket; `submit` runs a stricter one that puts a unique
+object into the bucket the *workflow* resolves, which is a different bucket
+whenever `NPA_S3_BUCKET` or `AWS_ENDPOINT_URL` is set in the environment. The
+two disagreeing looks like a passing preflight followed by:
+
+```
+Error: Cannot submit <spec>.yaml: missing prerequisites:
+  - writable S3 for this workflow (S3 write permission was denied.)
+```
+
+Believe the submit, not the preflight row: it is the check closer to the write
+you are about to do. Reconcile the endpoint and bucket the workflow sees with
+the ones `npa configure --show` reports before reaching for the printed
+`npa provision-if-absent --project <alias> --skip-k8s` fix.
+
 ## Persisting credentials you already hold
 
 If the tokens are in your environment but not in `~/.npa/credentials.yaml`,

--- a/skills/atomic/teardown-and-cost/SKILL.md
+++ b/skills/atomic/teardown-and-cost/SKILL.md
@@ -57,7 +57,7 @@ Confusing these two wastes time and money in opposite directions.
 | `npa cluster down` | Yes | Terraform-managed cluster and its nodes |
 | `npa agent destroy` | Yes | Agent VM and its resources |
 | `npa storage bucket delete` | Yes | Contents and versions included |
-| `npa destroy --delete-project` | Yes | Ownership-gated, opt-in |
+| `npa destroy --all --delete-project --yes` | Yes | Ownership-gated; all three flags required |
 
 `npa cleanup` never deletes cloud resources. It *reports* what teardown left
 behind and prints the ordered runbook, which makes it the right first command

--- a/skills/atomic/teardown-and-cost/SKILL.md
+++ b/skills/atomic/teardown-and-cost/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: teardown-and-cost
+description: Use to stop spend safely and audit orphaned resources — the mandatory cancel-before-destroy ordering, which npa commands touch cloud versus local state, and how to find leaked clusters, agent VMs, controllers, and buckets.
+---
+
+# Teardown and cost hygiene
+
+There is no `npa cost` and no `npa quota` command. Spend control here is
+procedural: run things in an order that cannot orphan resources, and audit for
+residue afterwards. The single most expensive mistake is destroying
+infrastructure while managed jobs are still running, which leaves jobs billing
+against resources nothing is tracking any more.
+
+## The ordering is not optional
+
+Cancel workloads, then remove the things that host them, outermost last:
+
+```bash
+npa workbench workflow cancel <run-id> --project <alias> --json   # every run
+npa agent destroy --project <alias> --name <name> --yes
+npa skypilot cleanup-controller --project <alias> --context <context> --yes
+npa cluster down --project <alias> --force
+npa storage bucket delete --project <alias> --yes --wait
+npa storage service-account delete --project <alias> --dry-run
+npa storage service-account delete --project <alias> --yes
+npa configure --forget-project <alias>
+npa cleanup --full --yes --project <alias>
+```
+
+Cancel is repeat-safe — a run that never launched is a successful no-op — so
+there is no reason to skip it. `cleanup-controller` refuses while managed jobs
+are in progress and retries that specific refusal after the queue drains; treat
+the refusal as correct, not as something to force.
+
+Deleting the project itself is separately opt-in and stays retained by default:
+
+```bash
+npa destroy --project <alias> --all --json          # plan only
+npa destroy --project <alias> --all --yes           # execute, project retained
+npa destroy --project <alias> --all --delete-project --yes --json
+```
+
+`npa destroy --all` without `--delete-project --yes` never deletes the project.
+Full details of the ownership gating live in `skills/tools/nebius-infra/SKILL.md`;
+this skill is the operational ordering and the audit.
+
+## What is cloud spend and what is only local clutter
+
+Confusing these two wastes time and money in opposite directions.
+
+| Command | Touches cloud spend | Notes |
+|---|---|---|
+| `npa cleanup` | No | Local caches and state only, even with `--yes` |
+| `npa cleanup --full --yes` | No | Also removes saved HF/Token Factory/NGC creds; read-only IAM verification |
+| `npa workbench workflow cancel` | Yes — stops it | Repeat-safe |
+| `npa skypilot cleanup-controller` | Yes | Shared; drains first |
+| `npa cluster down` | Yes | Terraform-managed cluster and its nodes |
+| `npa agent destroy` | Yes | Agent VM and its resources |
+| `npa storage bucket delete` | Yes | Contents and versions included |
+| `npa destroy --delete-project` | Yes | Ownership-gated, opt-in |
+
+`npa cleanup` never deletes cloud resources. It *reports* what teardown left
+behind and prints the ordered runbook, which makes it the right first command
+when you inherit a machine and do not know what is still running:
+
+```bash
+npa cleanup --json                 # report only
+npa cleanup --list-receipts        # durable audit trail, no secrets
+```
+
+## Auditing for orphans
+
+Residue accumulates when a teardown was interrupted or run out of order. Check
+each class explicitly — nothing sweeps them for you:
+
+```bash
+npa workbench workflow list --project <alias> --json    # non-terminal runs
+npa skypilot status --project <alias> --context <ctx>   # shared controller
+npa cluster list --project <alias>                      # clusters, incl. stale
+npa agent list                                          # agent VMs in config
+npa storage bucket list --project <alias>               # marks the configured one
+npa fleet status --spec <spec.yaml>                     # cross-project fleets
+```
+
+Cross-project fleets are the easiest thing to lose track of, because a fleet spec
+can create clusters in projects that never appear in your default alias. Audit
+fleets from the spec that created them.
+
+`npa cleanup` queries the SkyPilot managed-job queue as part of its report. Do
+not reach for `--skip-jobs` to make it quiet: skipping the queue with
+`--attest-no-active-jobs` is an explicit attestation that you verified terminal
+state some other way, not a shortcut.
+
+## Receipts: how to finish a teardown you can no longer address by alias
+
+Teardown receipts live under `~/.npa/teardown-receipts/`, contain no secrets, and
+survive removal of the project config. If you already ran
+`configure --forget-project` and later discover residue, the receipt is the
+recovery identity:
+
+```bash
+npa cleanup --list-receipts
+npa destroy --receipt <id> --all --delete-project --yes --json
+```
+
+Prune only aged terminal receipts, and only explicitly:
+
+```bash
+npa cleanup --prune-receipts --receipt-retention-days 90 --yes
+```
+
+## Choosing a cheap tier in the first place
+
+Most verification does not need a GPU, and the tiers are ordered by cost:
+
+1. **Dry run / plan.** `npa workbench workflow plan-spec`, `submit --plan-only`,
+   `golden-eval run <name>` (dry-run is the default), `provision-if-absent
+   --dry-run`. No cloud resources.
+2. **Zero-GPU hosted inference.** Token Factory (`skills/tools/token-factory`)
+   answers real captioning/generation/reasoning questions with no cluster at all.
+3. **Serverless single job.** `golden-eval run <name> --serverless` runs one
+   container on one GPU and returns PASS/FAIL, without standing up a cluster.
+4. **Cluster.** Only when the work genuinely needs a persistent multi-stage graph.
+
+Preemptible GPU nodes change the capacity pool but **not** hard instance, disk,
+or IP quotas, and a reclaim stops the node mid-run. They lower price, not
+requirements.
+
+## Gotchas
+
+- **A PENDING job is still billing the cluster it is stuck on.** `ImagePullBackOff`
+  and `Unschedulable` are retried forever and never self-terminate. Cancel them;
+  see `skills/atomic/debug-failed-run/SKILL.md`.
+- **`npa cluster down` going quiet for minutes is expected.** It previews the
+  PodDisruptionBudgets that hold up the node drain before it destroys anything.
+- **The controller is shared.** Never tear it down because *your* run finished;
+  it may be hosting someone else's managed jobs. That is why `cleanup-controller`
+  requires the exact project and saved context rather than an ambient
+  kube-context.
+- **Full cleanup exiting 2 is a real result, not a flake.** It means storage IAM
+  is present or unverified: cleanup was partial and something still exists.
+- **Never run a live GPU tier on a schedule.** Scheduled GPU runs are the classic
+  way to discover a five-figure bill; keep GPU rotations manually dispatched.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -380,6 +380,24 @@ skills:
         path: npa/src/npa/smoke/golden_evals.yaml
       - type: file_exists
         path: npa/tests/smoke/test_golden_eval_manifest.py
+  - name: gpu-cluster-provisioning
+    category: tools
+    when_to_use: "Create or repair a GPU Kubernetes cluster for npa: the managed-image vs GPU-Operator driver decision, why operator mode is unsafe on NVSwitch, the post-apply health gates (fabric, CUDA vectorAdd, stability window), accelerator-name discovery, and triage for nodes whose GPUs do not work."
+    path: skills/tools/gpu-cluster-provisioning/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["cluster", "up", "--help"]
+        contains: "gpu-driver-mode"
+      - type: cli_help
+        args: ["cluster", "node-group", "--help"]
+        contains: "add-cpu"
+      - type: cli_help
+        args: ["workbench", "workflow", "gpus", "--help"]
+        contains: "cluster"
+      - type: file_exists
+        path: docs/workbench/mk8s-gpu-driver-strategy.md
+      - type: file_exists
+        path: docs/workbench/image-gpu-compatibility-matrix.md
   - name: groot
     category: tools
     when_to_use: "GR00T model download, finetuning, evaluation, serving, inference, conversion, status, and routing."

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -122,6 +122,23 @@ skills:
       - type: workflow_yaml
         paths:
           - npa/workflows/workbench/npa-workflows/cosmos-fetch.yaml
+  - name: debug-failed-run
+    category: atomic
+    when_to_use: "Triage a workflow run that failed, hung, or produced no artifacts: status and pod-level reason, stage logs, S3 artifact evidence, image pullability, scheduling, and the resume-vs-cancel decision."
+    path: skills/atomic/debug-failed-run/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["workbench", "workflow", "status", "--help"]
+        contains: "watch"
+      - type: cli_help
+        args: ["workbench", "workflow", "logs", "--help"]
+        contains: "follow"
+      - type: cli_help
+        args: ["workbench", "workflow", "artifacts", "--help"]
+        contains: "stage"
+      - type: cli_help
+        args: ["workbench", "workflow", "load-artifact", "--help"]
+        contains: "run_id"
   - name: gpu-selection
     category: atomic
     when_to_use: "Choose or review GPU targets for training, rendering, inference, and workflow YAML resources."
@@ -133,6 +150,19 @@ skills:
       - type: cli_help
         args: ["workbench", "sonic", "train", "--help"]
         contains: "gpu"
+  - name: health-preflight
+    category: atomic
+    when_to_use: "Before any deploy, image build, or GPU submit: prove HF/NGC/S3/Token Factory credentials and gated-model access with `npa workbench health preflight` and `npa workbench health access` instead of failing mid-run."
+    path: skills/atomic/health-preflight/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["workbench", "health", "preflight", "--help"]
+        contains: "warn-only"
+      - type: cli_help
+        args: ["workbench", "health", "access", "--help"]
+        contains: "capability"
+      - type: file_exists
+        path: scripts/accept-model-access.sh
   - name: physical-ai-context
     category: atomic
     when_to_use: "Robotics, simulation, GPU routing, sim-to-real, or BDD100K domain context."
@@ -172,6 +202,20 @@ skills:
       - type: npa_workflow_yaml
         paths:
           - npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
+  - name: teardown-and-cost
+    category: atomic
+    when_to_use: "Stop spend safely and audit orphaned resources: the mandatory cancel-before-destroy ordering, which commands touch cloud versus local state, finding leaked clusters/agent VMs/controllers/buckets, and choosing the cheapest tier that proves the point."
+    path: skills/atomic/teardown-and-cost/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["cleanup", "--help"]
+        contains: "list-receipts"
+      - type: cli_help
+        args: ["destroy", "--help"]
+        contains: "delete-project"
+      - type: cli_help
+        args: ["workbench", "workflow", "cancel", "--help"]
+        contains: "repeat-safe"
   - name: super-prompt-patterns
     category: atomic
     when_to_use: "Draft, execute, or review Codex super-prompts for this repository."
@@ -196,6 +240,36 @@ skills:
         path: npa/tests/guardrails/test_third_party_eula_preflight_skill.py
       - type: file_exists
         path: npa/docker/workbench/common/isaac_bootstrap.sh
+  - name: artifact-viz-share
+    category: tools
+    when_to_use: "Turn run outputs into something a human can look at and hand it to someone else: `npa adapter convert` (sim demos to LeRobotDataset), `npa convert lerobot-to-rrd|lerobot-to-mp4`, and `npa rerun host|share|list-shares|revoke` time-boxed presigned links."
+    path: skills/tools/artifact-viz-share/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["adapter", "convert", "--help"]
+        contains: "fps"
+      - type: cli_help
+        args: ["convert", "lerobot-to-mp4", "--help"]
+        contains: "renderer"
+      - type: cli_help
+        args: ["convert", "lerobot-to-rrd", "--help"]
+        contains: "predictions-path"
+      - type: cli_help
+        args: ["rerun", "share", "--help"]
+        contains: "ttl-hours"
+  - name: burst
+    category: tools
+    when_to_use: "Run one gang-scheduled multi-node GPU job through SkyPilot without authoring a workflow: `npa burst submit` wires torchrun rendezvous across nodes, `submit-yaml` submits a single-task YAML with `${VAR}` substitution and Nebius registry login."
+    path: skills/tools/burst/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["burst", "submit", "--help"]
+        contains: "gpu-per-node"
+      - type: cli_help
+        args: ["burst", "logs", "--help"]
+        contains: "follow"
+      - type: file_exists
+        path: npa/src/npa/burst/examples/isaac-lab-cosmos-sdg-burst-smoke.yaml
   - name: cosmos
     category: tools
     when_to_use: "Cosmos world model serving, inference, serverless training smoke, backend selection, or rendering limits."
@@ -218,6 +292,20 @@ skills:
       - type: npa_workflow_yaml
         paths:
           - npa/workflows/workbench/npa-workflows/dataset-ingest-curate.yaml
+  - name: detection-training
+    category: tools
+    when_to_use: "Train and evaluate Faster R-CNN detectors from LanceDB materialized views (BDD100K failure-mode slices): direct versus deployed-service execution, the label map required for string categories, and checkpoint discovery at eval time."
+    path: skills/tools/detection-training/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["workbench", "detection-training", "train", "--help"]
+        contains: "label-map"
+      - type: cli_help
+        args: ["workbench", "detection-training", "deploy", "--help"]
+        contains: "gpu-type"
+      - type: npa_workflow_yaml
+        paths:
+          - npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml
   - name: foxglove
     category: tools
     when_to_use: "Embed, operate, or debug the Foxglove viewer in the NPA agent: the @foxglove/embed TypeScript SDK, MCAP recordings, the npa-foxglove-embed container, and /api/foxglove/* endpoints."
@@ -277,6 +365,21 @@ skills:
       - type: cli_help
         args: ["workbench", "genesis", "train-teacher", "--help"]
         contains: "serverless"
+  - name: golden-eval
+    category: tools
+    when_to_use: "Prove a workbench container image actually works: the per-container hello-world manifest, dry-run/local/serverless execution tiers, batch runs across every image, and the offline manifest validation that gates CI."
+    path: skills/tools/golden-eval/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["workbench", "golden-eval", "run", "--help"]
+        contains: "serverless"
+      - type: cli_help
+        args: ["workbench", "golden-eval", "run-all", "--help"]
+        contains: "include-blocked"
+      - type: file_exists
+        path: npa/src/npa/smoke/golden_evals.yaml
+      - type: file_exists
+        path: npa/tests/smoke/test_golden_eval_manifest.py
   - name: groot
     category: tools
     when_to_use: "GR00T model download, finetuning, evaluation, serving, inference, conversion, status, and routing."
@@ -441,6 +544,40 @@ skills:
       - type: cli_help
         args: ["workbench", "sonic", "serve", "--help"]
         contains: "model-repo"
+  - name: token-factory
+    category: tools
+    when_to_use: "Zero-GPU hosted inference through Nebius Token Factory: captioning, batch text generation, and Cosmos physical-AI reasoning, plus key setup, model availability, and the CPU-only npa.workflow toolRefs that need no cluster."
+    path: skills/tools/token-factory/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["workbench", "token-factory", "verify", "--help"]
+        contains: "Token Factory"
+      - type: cli_help
+        args: ["workbench", "token-factory", "caption", "--help"]
+        contains: "input-path"
+      - type: file_exists
+        path: docs/workbench/token-factory.md
+      - type: npa_workflow_yaml
+        paths:
+          - npa/workflows/workbench/npa-workflows/token-factory-caption.yaml
+          - npa/workflows/workbench/npa-workflows/token-factory-generate.yaml
+          - npa/workflows/workbench/npa-workflows/token-factory-cosmos-reason.yaml
+  - name: vlm-eval
+    category: tools
+    when_to_use: "Score rollouts with a vision-language model and turn the score into a pipeline gate: single rollout versus prefix-wide loop, rubric/threshold benchmark sweeps, backend selection (self-hosted, api, stub), and judging against a plan an earlier stage wrote."
+    path: skills/tools/vlm-eval/SKILL.md
+    smoke:
+      - type: cli_help
+        args: ["workbench", "vlm-eval", "run", "--help"]
+        contains: "success-threshold"
+      - type: cli_help
+        args: ["workbench", "vlm-eval", "loop", "--help"]
+        contains: "input-path"
+      - type: npa_workflow_yaml
+        paths:
+          - npa/workflows/workbench/npa-workflows/vlm-eval-single.yaml
+          - npa/workflows/workbench/npa-workflows/vlm-eval-loop.yaml
+          - npa/workflows/workbench/npa-workflows/vlm-eval-benchmark.yaml
   - name: workbench-tool
     category: tools
     when_to_use: "Add, change, deploy, or call any NPA workbench tool."
@@ -449,6 +586,20 @@ skills:
       - type: cli_help
         args: ["workbench", "--help"]
         contains: "Physical AI"
+  - name: first-run-setup
+    category: workflows
+    when_to_use: "Get from zero to a first verified result on a fresh machine or a new Nebius project: an ordered, gated path through install, configure, credential preflight, cheapest-proof workload, spec validation, provisioning, image pullability, and submit."
+    path: skills/workflows/first-run-setup/SKILL.md
+    smoke:
+      - type: configure_provision_dry_run
+      - type: cli_help
+        args: ["workbench", "workflow", "validate-spec", "--help"]
+        contains: "npa.workflow"
+      - type: cli_help
+        args: ["workbench", "health", "preflight", "--help"]
+        contains: "token_factory"
+      - type: file_exists
+        path: docs/quickstart.md
   - name: cosmos3-inference
     category: workflows
     when_to_use: "Run or modify Cosmos3 inference: the containerized npa-cosmos3 generate path (image/video) or the public text-to-image SkyPilot workflow."

--- a/skills/tools/artifact-viz-share/SKILL.md
+++ b/skills/tools/artifact-viz-share/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: artifact-viz-share
+description: Use to turn run outputs into something a human can look at and to hand it to someone else — `npa adapter convert` (sim demos to LeRobotDataset), `npa convert lerobot-to-rrd|lerobot-to-mp4`, and `npa rerun host|share|list-shares|revoke` for time-boxed presigned links.
+---
+
+# Artifact conversion, visualization, and sharing
+
+Three small command groups cover the last mile between a finished run and a
+human looking at it. They are standalone and local-first: none of them needs a
+cluster, and all of them accept `s3://` on both sides.
+
+Pick by what you have and what you need:
+
+| Have | Want | Command |
+|---|---|---|
+| Genesis/sim episode numpy arrays | A trainable dataset | `npa adapter convert` |
+| LeRobotDataset | Interactive timeline | `npa convert lerobot-to-rrd` |
+| LeRobotDataset | A video to paste in a review | `npa convert lerobot-to-mp4` |
+| `.rrd` recording | A link someone else can open | `npa rerun host` / `share` |
+
+## Sim output → LeRobotDataset
+
+```bash
+npa adapter convert \
+  --input-path ./data/demos/ \
+  --output-path ./data/lerobot_dataset/ \
+  --fps 20 --robot franka_panda \
+  --task "Pick and place cube to target"
+```
+
+Converts Genesis/sim demo numpy arrays to **LeRobotDataset v3**. This is the seam
+between simulation and policy training: `--fps` is the video encoding rate, and
+`--task` becomes the dataset's task description, so set it to what the episodes
+actually show rather than leaving the default. `-i`/`-o` are accepted aliases.
+
+## LeRobotDataset → Rerun recording
+
+```bash
+npa convert lerobot-to-rrd \
+  --input-path s3://<bucket>/datasets/<name>/ \
+  --output-path s3://<bucket>/reports/<name>.rrd \
+  --duration 30 \
+  --predictions-path s3://<bucket>/eval/groot-predictions.json
+```
+
+`.rrd` is the interactive format — scrub the timeline, inspect per-frame state.
+`--predictions-path` overlays a GR00T prediction artifact on the ground-truth
+trajectory, which is how you see *where* a policy diverges rather than only that
+it scored badly. `--duration` caps the recording; the default is the adapter cap.
+
+## LeRobotDataset → MP4
+
+```bash
+npa convert lerobot-to-mp4 \
+  --input-path ./data/lerobot_dataset/ \
+  --output-path ./rollout.mp4 \
+  --renderer matplotlib --layout single \
+  --resolution 1280x720 --fps 30 --duration 10 \
+  --title "<what this shows>"
+```
+
+Use MP4 when the audience will not install a viewer. `--renderer` is
+`matplotlib` (default) or `rerun`. `--layout` is `single`, `side-by-side`, or
+`overlay` — with `--predictions-path`, `side-by-side` and `overlay` are what make
+the comparison legible; `single` throws that away.
+
+Default duration is the source length capped at 10 seconds, so a long episode is
+silently truncated unless you set `--duration`.
+
+`npa viz lerobot` is deprecated and prints a deprecation notice; use
+`npa convert lerobot-to-mp4`.
+
+## Sharing a recording
+
+```bash
+npa rerun host <path.rrd> --ttl-hours 1
+npa rerun share <path.rrd> --label <name> --workspace <ws> --ttl-hours 168
+npa rerun list-shares --output json
+npa rerun revoke <sha256-or-label>
+```
+
+`host` is the quick look: upload or reference an `.rrd` and print an
+`app.rerun.io` URL, default TTL **1 hour**. `share` is the durable version:
+S3-backed under `rerun-shares/<workspace>/`, labelled, default TTL **168 hours**,
+which is also the maximum. Both accept a local path or an `s3://` URI.
+
+Project scoping is explicit and worth getting right: `--source-project` is the
+alias whose principal **reads** an `s3://` input, `--target-project` is the alias
+whose principal **writes** the upload, and `--target-bucket` overrides the
+destination (default: configured project storage). `--allow-host-creds` falls back
+to host credentials for the S3 operation — an explicit opt-in, not a default.
+
+Revoke by label or sha256 when the work is no longer for sharing. `list-shares`
+is the only way to find what you left behind; presigned links do not appear in
+any other inventory.
+
+## Related viewers
+
+`.rrd` is not the only option. For MCAP, ROS bags, and robotics logs there are
+two viewer tools: `skills/tools/foxglove/SKILL.md` (embedded in the agent UI,
+`npa workbench foxglove convert-run`) and `skills/tools/lichtblick/SKILL.md`
+(standalone web viewer served from S3). Use those when the artifact is a log
+rather than a dataset.
+
+## Gotchas
+
+- **A presigned link is a credential.** Anyone with the URL can read the
+  recording until it expires. Cap `--ttl-hours` to what the review needs, prefer
+  `host`'s 1-hour default for a quick look, and `revoke` when done.
+- **168 hours is the hard maximum.** There is no permanent share.
+- **Default MP4 duration is 10 seconds.** Long episodes are truncated without a
+  warning that says so.
+- **`--predictions-path` with `--layout single` hides the comparison** you
+  converted the file to see.
+- **Check what the recording actually contains before sharing it.** A viewer that
+  opens a stock demo rather than your run looks identical at a glance; confirm
+  the artifact came from your run id via `npa workbench workflow artifacts`.
+- **These commands do not clean up after themselves.** Uploaded shares live in the
+  bucket until revoked and count toward storage; include them in the audit in
+  `skills/atomic/teardown-and-cost/SKILL.md`.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/tools/burst/SKILL.md
+++ b/skills/tools/burst/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: burst
+description: Use to run one gang-scheduled multi-node GPU job through SkyPilot without authoring a workflow — `npa burst submit` wires torchrun rendezvous across nodes, `submit-yaml` submits a single-task YAML with `${VAR}` substitution and Nebius registry login.
+---
+
+# Burst (one coupled multi-node GPU job)
+
+Burst is the escape hatch for a **single** distributed task: gang-schedule N
+nodes, run one command under `torchrun`, get logs, exit. It is deliberately not a
+workflow surface — there is no plan, no stage graph, no decision artifact, and
+nothing for a `toolRef` to describe.
+
+**If you need a second stage, you need a workflow.** Author an
+`npa.workflow/v0.0.1` spec under `npa/workflows/workbench/npa-workflows/` instead
+(`skills/workflows/author-npa-workflow/SKILL.md`). `submit-yaml` rejects
+multi-task documents, and a guardrail pins the example set so a pipeline cannot
+quietly grow here.
+
+## Submit a distributed run directly
+
+```bash
+npa burst submit \
+  --image <registry>/<image>:<tag> \
+  --nodes 2 \
+  --gpu-per-node H100:8 \
+  --entrypoint "python train.py --config configs/run.yaml" \
+  --name <job-name> \
+  --json
+```
+
+All four of `--image`, `--nodes`, `--gpu-per-node`, `--entrypoint` are required.
+A plain image reference is rendered as `docker:<image>`. `--json` prints only the
+serialized job handle, which is what you want when scripting.
+
+**The entrypoint runs under `torchrun`, not directly.** Burst derives the
+rendezvous from SkyPilot's node environment and exports `MASTER_ADDR`,
+`MASTER_PORT`, `WORLD_SIZE`, and `RANK`, then execs `torchrun` with `--nnodes`,
+`--node-rank`, and `--master-addr` already set. Two consequences:
+
+- **`torchrun` must exist in the image.** Burst checks and fails with an explicit
+  message if it is missing.
+- **Do not set the distributed variables yourself** and do not wrap your command
+  in another `torchrun`. Pass the training command as if it were a single-process
+  entrypoint.
+
+`--gpu-per-node` is a SkyPilot accelerator spec such as `L40S:1` or `H100:8`, and
+it is per node: all GPUs of one task land on one node. Confirm the name the
+cluster actually advertises with `npa workbench workflow gpus --cluster <name>` —
+Kubernetes names accelerators after node labels, so the spec string is discovered
+rather than guessed.
+
+## Submit a single-task YAML
+
+```bash
+npa burst submit-yaml <task.yaml> \
+  --name <job-name> \
+  --var NPA_RUN_ID=<run-id> \
+  --var NPA_OUTPUT_URI=s3://<bucket>/<prefix>/<run-id>/ \
+  --json
+```
+
+`submit-yaml` loads one SkyPilot task document, substitutes `${VAR}` placeholders
+from repeated `--var`/`-v`, and **refuses to submit while any placeholder is
+unresolved** — an unsubstituted `${VAR}` is an error, never a literal sent to the
+cluster. `--name` defaults to the task name in the YAML.
+
+Unlike the npa.workflow renderer, `${VAR}` placeholders are the intended surface
+here. The committed example keeps them precisely so no concrete registry id,
+bucket name, or run id is ever baked in:
+`npa/src/npa/burst/examples/isaac-lab-cosmos-sdg-burst-smoke.yaml`.
+
+## Registry authentication
+
+Docker access on your dev VM does not authenticate freshly created SkyPilot
+worker VMs. `submit-yaml` injects a Nebius registry login for `cr.*.nebius.cloud`
+images by minting a short-lived IAM token when the submitter can mint one. If
+pulls fail with `401`/`403`, that mint is what failed — see the registry-token
+section of `skills/tools/nebius-infra/SKILL.md`. Kubernetes retries image pulls
+forever, so a bad pull presents as a job that never starts rather than one that
+fails.
+
+## Watch and collect
+
+```bash
+npa burst status <job-id-or-handle-json>
+npa burst logs <job-id-or-handle-json> --follow
+npa burst logs <job-id-or-handle-json> --tail 200
+```
+
+Both accept either a job ID or the serialized handle `--json` printed at submit.
+`--config <path>` points at a specific SkyPilot global config when you are not
+using the default runtime.
+
+## Gotchas
+
+- **`--nodes N` with `--gpu-per-node NAME:M` requests M GPUs on each of N nodes.**
+  It cannot spread one task's M GPUs across nodes. Asking for more GPUs per node
+  than a node has will not schedule, and this presents as a pending job rather
+  than a rejection.
+- **Gang scheduling means all-or-nothing.** The job waits for all N nodes; partial
+  capacity leaves it pending indefinitely, not running degraded.
+- **A pending burst job is still holding your intent, not your capacity.** Check
+  `status` before assuming the cluster is full, and cancel work you no longer
+  want — see `skills/atomic/teardown-and-cost/SKILL.md`.
+- **Burst has no durable S3 run ledger.** Unlike `workbench workflow`, there is no
+  `artifacts`/`list` surface and no resume. If you want durable per-stage state,
+  resume, and lineage, that is the workflow runtime, not burst.
+- **Do not add example YAMLs to `npa/src/npa/burst/examples/`.** The set is pinned
+  by `npa/tests/guardrails/test_burst_examples.py`; a new file must first answer
+  "why is this not a spec?".
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py \
+  npa/tests/guardrails/test_burst_examples.py -q
+```

--- a/skills/tools/detection-training/SKILL.md
+++ b/skills/tools/detection-training/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: detection-training
+description: Use to train and evaluate Faster R-CNN detectors from LanceDB materialized views (BDD100K failure-mode slices) — direct versus deployed-service execution, the mandatory label map for string categories, and checkpoint discovery at eval time.
+---
+
+# Detection training (LanceDB view → Faster R-CNN)
+
+This tool trains an object detector on a **slice** of a dataset rather than the
+whole thing. The input is a LanceDB materialized view, which is what makes the
+failure-mode workflow possible: curate a view of nighttime frames, or distant
+objects, or riders, then train and evaluate only on that slice.
+
+Upstream is `skills/tools/lancedb/SKILL.md` — create the view with
+`npa workbench lancedb create-mv` / `refresh-mv` before anything here. The end-to-end
+pipeline is `npa/workflows/workbench/npa-workflows/bdd100k-pipeline.yaml`, with a
+walkthrough in `docs/workbench/cookbooks/bdd100k-pipeline.md`.
+
+## Two execution modes
+
+Direct (the default) runs the work from your CLI invocation. Service mode calls a
+deployed Kubernetes endpoint:
+
+```bash
+npa workbench detection-training train --view <mv-name> --output-uri s3://<bucket>/runs/<id>/
+npa workbench detection-training train --view <mv-name> --service --endpoint <url>
+```
+
+Deploy the service only when you want a persistent endpoint several runs share:
+
+```bash
+npa workbench detection-training deploy \
+  --project <alias> --cluster-name <name> \
+  --input-path s3://<bucket>/lancedb/<db>/ \
+  --output-path s3://<bucket>/detection/ \
+  --gpu-type h100 --namespace default \
+  --dry-run                       # prints the manifest without applying
+npa workbench detection-training deploy --project <alias> --destroy
+```
+
+`--gpu-type` is `h100` or `l40s`. Auth defaults to `token` (the token comes from
+the variable named by `--token-env`, default `DETECTION_TRAINING_TOKEN`);
+`--insecure-no-auth` exists but should not be used. Private registries need
+`--image-pull-secret` (default `npa-nebius-registry`). Always `--dry-run` first
+and read the manifest.
+
+## Train
+
+```bash
+npa workbench detection-training train \
+  --view <materialized-view> \
+  --output-uri s3://<bucket>/detection/runs/<id>/ \
+  --num-classes 10 \
+  --label-map '{"person":0,"rider":1,"car":2}' \
+  --epochs 10 --batch-size 8 --learning-rate 0.005 \
+  --wait --poll-seconds 30 --timeout-seconds 21600 \
+  --output json
+```
+
+`--view` is the only required flag. `--data-path` (alias `--lance-uri` /
+`--input-path`) overrides which LanceDB the view is read from. `--override
+KEY=VALUE` sets request fields the flags do not expose. Weights and Biases
+logging is opt-in and defaults to `offline` mode.
+
+`--wait` polls `/status` until the run completes **and fails if it does not** —
+without it, the command returns as soon as the run is accepted, which is easy to
+misread as success. Default output format for `train` and `eval` is `json`.
+
+## The label map is not optional for BDD100K
+
+**`--label-map` is required whenever the dataset stores string categories, which
+BDD100K does.** Without it, category names reach `int()` and the run dies on:
+
+```
+invalid literal for int() with base 10: 'train'
+```
+
+`train` is a real BDD100K category — the vehicle. Reading that traceback as a
+bug in the training code, rather than a missing label map, costs more time than
+it should. Accepted formats are JSON (`{"person":0,...}`) or comma-separated
+pairs (`person=0,rider=1`). Keep `--num-classes` consistent with the map.
+
+## Evaluate
+
+```bash
+npa workbench detection-training eval \
+  --checkpoint-uri s3://<bucket>/detection/runs/<id>/ \
+  --eval-view <validation-mv> \
+  --output-uri s3://<bucket>/detection/eval/<id>/ \
+  --label-map '{"person":0,"rider":1,"car":2}' \
+  --discover-checkpoint \
+  --write-canonical-metrics
+```
+
+`--eval-view` and `--output-uri` are required. `--discover-checkpoint` changes
+what `--checkpoint-uri` means: it becomes the training **output prefix** to
+search, and the checkpoint is resolved from the last completed `/runs` entry with
+the trained epoch count substituted. Use it instead of hand-assembling a
+checkpoint filename from an epoch count you assumed.
+
+`--write-canonical-metrics` publishes the response under the output prefix so
+downstream stages and `npa workbench insights` can pick it up. Pass the **same**
+`--label-map` you trained with; a different map silently reindexes classes and
+produces plausible-looking but wrong per-class numbers.
+
+## In workflows
+
+toolRefs are per-slice pairs rather than one generic tool:
+`workbench.detection_training.train_nighttime` / `.eval_nighttime`,
+`.train_distant` / `.eval_distant`, `.train_rider` / `.eval_rider`. They appear
+together in `bdd100k-pipeline.yaml`, which builds the views, trains each slice,
+and evaluates each against its validation view.
+
+## Gotchas
+
+- **Train and eval must agree on the label map and class count.** Mismatches do
+  not error; they produce wrong metrics.
+- **Without `--wait`, "started" is not "succeeded".** Check `status` before
+  reporting a result.
+- **A view is a slice, so the metric is about that slice.** Nighttime mAP is not
+  overall mAP; label it accordingly when reporting.
+- **`--service` needs both a reachable `--endpoint` and the token variable set.**
+  A missing token presents as an auth failure from the endpoint, not as a CLI
+  validation error.
+- **Refresh the view after the underlying table changes.** `refresh-mv` is not
+  automatic, and training a stale view silently trains on old rows.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/tools/golden-eval/SKILL.md
+++ b/skills/tools/golden-eval/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: golden-eval
+description: Use to prove a workbench container image actually works — the per-container hello-world manifest, dry-run/local/serverless execution tiers, batch runs across every image, and the offline manifest validation that gates CI.
+---
+
+# Golden eval (does this container actually work?)
+
+A golden eval is the minimal tested rerun that proves one container image is
+functional. It answers a narrow, valuable question — *does this image run its own
+smoke on a real GPU?* — without standing up a cluster or a workflow. Reach for it
+after building or republishing an image, and when triaging whether a failure is
+the image or the pipeline around it.
+
+The manifest is `npa/src/npa/smoke/golden_evals.yaml`
+(format `npa_golden_evals_v1`); every container in `CONTAINER_IMAGE_NAMES` must
+have an entry, enforced by `npa/tests/smoke/test_golden_eval_manifest.py`.
+
+## Inspect before running
+
+```bash
+npa workbench golden-eval list                 # every container, kind, gpu, status
+npa workbench golden-eval list --output json
+npa workbench golden-eval show <container>     # full safety + Physical AI record
+```
+
+Read the `status` column before spending anything:
+
+- `ready` — runnable now.
+- `gpu-gated` — needs a real GPU; a local run without one proves nothing.
+- `blocked-on-upstream` — excluded from batch runs unless you pass
+  `--include-blocked`. A failure here is expected and is not your regression.
+- `needs-image-update` — the manifest and the published image disagree; rebuild
+  before drawing conclusions.
+
+`kind` tells you what is actually exercised: `container-smoke`, `server-smoke`,
+`entrypoint-smoke`, `workflow-smoke`, or `build-import`. A `build-import` passing
+means the package imports, not that the tool works. `gpu` is `required`,
+`optional`, or `none`.
+
+## Three execution tiers, cheapest first
+
+```bash
+npa workbench golden-eval run <container>                      # dry run (default)
+npa workbench golden-eval run <container> --execute            # local runtime
+npa workbench golden-eval run <container> --serverless         # one GPU, real image
+npa workbench golden-eval run <container> --serverless --gpu h200 --timeout 40m
+```
+
+**Dry run is the default and prints the command.** Use it to see exactly what
+would execute — often enough to answer a question without running anything.
+
+`--execute` runs locally and only works where the container runtime is present;
+for a `gpu-gated` entry on a machine with no GPU it tells you nothing.
+
+`--serverless` is the useful tier for verification: it submits the eval to a
+Nebius Serverless Job **in the real container image on a GPU** and waits for
+PASS/FAIL. No cluster, no node pool, no SkyPilot controller. This is the cheapest
+way to get a truthful answer about an image. `--gpu` overrides the type (for
+example `h200`, `h100`, `l40s`, `b300`) and `--timeout` defaults to `40m`.
+
+## Batch across every image
+
+```bash
+npa workbench golden-eval run-all --serverless --parallel 4 \
+  --json-out /tmp/golden-results.json
+npa workbench golden-eval run-all lerobot groot --serverless
+npa workbench golden-eval run-all --tools-only --serverless
+npa workbench golden-eval run-all --include-blocked --serverless
+```
+
+Positional arguments restrict the run to a subset; the default is every manifest
+entry. `--tools-only` skips foundation images. `--parallel` bounds concurrency
+and applies to `--serverless` and `--execute`. Always write `--json-out` for a
+batch — the console summary is not something you want to re-derive after a
+40-minute sweep.
+
+Like `run`, `run-all` defaults to dry-run. A batch with no `--execute` and no
+`--serverless` costs nothing and validates that every command is well-formed.
+
+## The offline gate
+
+```bash
+npa workbench golden-eval validate
+```
+
+Validates manifest completeness and consistency with no network and no GPU:
+every container has an entry, entries map to known images or foundation images,
+and each definition points at real Dockerfiles and entrypoints. This is the
+nightly CI gate and belongs in any change that adds, renames, or retags an image.
+
+## When to run which
+
+- **Added or changed an image** → `validate`, then `run <container> --serverless`.
+  Also update the catalogs; see `skills/atomic/audit-container-docs/SKILL.md`.
+- **A workflow stage fails and you suspect the image** → `run <container>
+  --serverless` isolates image from pipeline in one step.
+- **Before publishing a batch of images** → `run-all --serverless --json-out`.
+- **In a PR with no infra** → `validate` plus the pytest gate below.
+
+## Gotchas
+
+- **Dry run is the default everywhere.** A `run` that "passed" without
+  `--execute` or `--serverless` only printed a command. Check which tier you
+  actually used before reporting a result.
+- **A local `--execute` pass on a GPU-gated entry is not evidence.** Neither is a
+  `blocked-on-upstream` failure a regression.
+- **Serverless still needs registry access.** The eval pulls the real image, so a
+  `403` here is a pull-secret problem, not a broken smoke; see
+  `skills/atomic/debug-failed-run/SKILL.md`.
+- **Golden eval proves the container, not the pipeline.** It says nothing about
+  spec wiring, S3 paths, or multi-stage behavior — that is
+  `npa workbench workflow`.
+- **Do not weaken a manifest entry to make a sweep green.** The entry is the claim
+  about what the image can do.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/smoke/test_golden_eval_manifest.py \
+  npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/tools/gpu-cluster-provisioning/SKILL.md
+++ b/skills/tools/gpu-cluster-provisioning/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: gpu-cluster-provisioning
+description: Use when creating or repairing a GPU Kubernetes cluster for npa — the managed-image vs GPU-Operator driver decision, why operator mode is unsafe on NVSwitch, the post-apply health gates (fabric, CUDA vectorAdd, stability window), and triage for nodes that come up without working GPUs.
+---
+
+# GPU cluster provisioning and driver strategy
+
+Getting GPU nodes is the easy part. Getting nodes whose GPUs actually work — and
+knowing *before* you submit a job that they do — is what this skill covers. It
+complements `skills/atomic/gpu-selection/SKILL.md` (which GPU to ask for) and
+`skills/tools/nebius-infra/SKILL.md` (config, storage, teardown) with the driver
+and readiness decisions made at provisioning time.
+
+Source of record: `docs/workbench/mk8s-gpu-driver-strategy.md`.
+
+## The driver decision: default to managed, do not reach for operator
+
+One policy covers both direct `npa cluster` provisioning and `npa fleet`: **GPU
+node groups use a Nebius managed-driver image by default**, and CPU-only node
+groups get no GPU driver settings at all.
+
+| `--gpu-driver-mode` | Behavior | Use when |
+|---|---|---|
+| `auto` (default) | Managed-driver image whenever the recipe/provider supports it | Almost always |
+| `managed-image` | Explicitly require the managed-driver image | Pinning the operational contract |
+| `operator` | In-cluster NVIDIA GPU Operator driver path | Supported diagnostics or a recipe that requires it |
+
+```bash
+npa cluster up --gpu-driver-mode auto --managed-driver-preset cuda13.0
+```
+
+The default managed preset is `cuda13.0`. The same values exist on
+`npa provision-if-absent`, and in a fleet spec under `defaults` or a single
+cluster (`gpu_driver_mode`, `managed_driver_preset`).
+
+**Operator mode is unsafe on NVSwitch topologies.** Fabric Manager can start
+before Network Operator/MOFED exposes the host InfiniBand management devices,
+and the result is nodes that exist but cannot run CUDA. It presents as:
+
+- `NebiusGPUError=True`
+- Fabric status `In Progress` or `N/A`
+- CUDA `system not yet initialized`
+- Fabric Manager / NVLSM `umad_open_port()` or `IB_ERROR` failures
+
+NPA identifies an NVSwitch-risk topology from an explicit GPU cluster or a
+multi-GPU SXM/NVL preset and **rejects operator mode** unless you pass
+`--allow-unsafe-nvswitch-operator`. That flag is a diagnostics acknowledgement,
+not a workaround: if a deploy fails and the suggested fix is that flag, the fix
+is almost always `auto` instead.
+
+The policy is topology-independent — expected capacity is derived from the
+requested node count and GPU preset, not from a GPU SKU or an assumption of
+eight devices per node.
+
+## Provision with the health gates on
+
+```bash
+npa cluster up \
+  --project <alias> \
+  --gpu-nodes 2 --gpu-platform <platform> --gpu-preset <preset> \
+  --cpu-nodes 1 --cpu-platform <platform> --cpu-preset <preset> \
+  --gpu-driver-mode auto --managed-driver-preset cuda13.0 \
+  --gpu-health-stability-seconds 120 \
+  --validation-timeout 60 --timeout 120
+```
+
+Defaults are deliberately strict, and every one of them is on for a reason:
+
+- `--validate` (default) checks stable nodes, GPU capacity, fabric, driver
+  components, CUDA vectorAdd, and the default StorageClass.
+- `--gpu-cuda-smoke` (default) runs NVIDIA's CUDA vectorAdd **on every requested
+  GPU node**, which is the cheapest proof that drivers actually work.
+- `--gpu-health-stability-seconds` (default 120) requires nodes, boot IDs,
+  fabric, capacity, and components to stay healthy for that window. It exists
+  because GPU nodes routinely look healthy for a few seconds during labelling.
+- `--sky-smoke` (default) runs a SkyPilot Kubernetes GPU task and cleans it up.
+
+Do not reach for `--skip-validate` / `--skip-gpu-cuda-smoke` to make a deploy
+"succeed" faster. Skipping them moves the failure to your first real job, where
+it costs more and is harder to attribute. `-1` on `--gpu-nodes` / `--cpu-nodes`
+keeps the configured value rather than meaning zero.
+
+For reserved capacity, `--capacity-block-group-id` selects a private capacity
+block for strict GPU node-group reservation. `--preemptible` is often the only
+way to get several GPUs at once, but a reclaim stops nodes mid-run — keep CPU
+stages on the CPU pool, and note that preemptibility changes the capacity pool
+only, never the disk or IP quota requirements.
+
+## Node groups after the fact
+
+```bash
+npa cluster node-group list --project <alias>
+npa cluster node-group status --project <alias>
+npa cluster node-group add --project <alias> ...
+npa cluster node-group add-cpu --project <alias> ...
+npa cluster node-group remove --project <alias> ...
+```
+
+Add a CPU pool rather than running CPU stages on GPU nodes: it is cheaper and it
+keeps preemptible GPU reclaims from killing coordination work.
+
+## After provisioning: what the cluster calls its GPUs
+
+A healthy cluster is not yet a submittable one. SkyPilot addresses accelerators
+by the name the cluster advertises, which comes from node labels and **changes
+while the GPU operator is still labelling** (`nebius.com/gpu-name` first,
+`nvidia.com/gpu.product` after):
+
+```bash
+npa cluster status --project <alias>
+npa workbench workflow gpus --cluster <name> --json
+npa skypilot verify --cluster <name> --output-format json
+```
+
+Run `workflow gpus` once after provisioning and note the requestable quantity per
+node. A name mismatch fails as `FAILED_PRECHECKS` or "cluster does not contain
+any instances satisfying the request", which reads like a capacity shortage and
+is not one.
+
+## Triage: nodes exist but GPUs do not work
+
+1. **`NebiusGPUError=True`, fabric not ready, CUDA "system not yet initialized"**
+   → operator-mode/Fabric-Manager ordering on NVSwitch. Redeploy the GPU node
+   group with `--gpu-driver-mode auto`. Do not paper over it with the unsafe
+   acknowledgement flag.
+2. **Nodes Ready but zero schedulable `nvidia.com/gpu`** → drivers or device
+   plugin have not landed. Re-run validation rather than submitting; the
+   stability window exists precisely for this state.
+3. **Accelerator name not found by SkyPilot** → labelling is still in progress or
+   the spec uses a different spelling. Use `workflow gpus`.
+4. **CUDA vectorAdd fails on one node only** → that node is bad; remove and
+   re-add the node group rather than debugging the whole cluster.
+5. **Deploy succeeded but jobs stall in `ImagePullBackOff`** → not a GPU problem
+   at all. See `skills/atomic/debug-failed-run/SKILL.md`.
+
+An image can also be architecturally incapable of running on the GPU you
+provisioned — `sm_120` (RTX PRO 6000) and `sm_100`/`sm_103` (B200/B300) binaries
+are mutually incompatible across the CUDA major boundary. That is an image
+question, not a cluster question: see `docs/workbench/image-gpu-compatibility-matrix.md`
+and `skills/atomic/gpu-selection/SKILL.md`.
+
+## Gotchas
+
+- **`npa cluster` is not raw MK8s administration.** For edit, update, upgrade,
+  operation inspection, version listing, and the compatibility matrix, use
+  `nebius mk8s` directly.
+- **`npa cluster down` going silent for minutes is expected** — it previews the
+  PodDisruptionBudgets that hold up the node drain first.
+- **Stale `NEBIUS_IAM_TOKEN` breaks Terraform and the provider** even when the
+  `nebius` CLI works. `unset NEBIUS_IAM_TOKEN NPA_NEBIUS_IAM_TOKEN` first.
+- **SkyPilot task pods run in `default`; deployed workbench services run in
+  `workbench`.** A pull secret in the wrong namespace helps nothing.
+- **Provisioning is additive, teardown is not.** `provision-if-absent` never
+  replaces resources; `cluster down` destroys. See
+  `skills/atomic/teardown-and-cost/SKILL.md` for the ordering.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/tools/token-factory/SKILL.md
+++ b/skills/tools/token-factory/SKILL.md
@@ -92,10 +92,12 @@ npa workbench workflow submit <spec.yaml> --secret-env NEBIUS_TOKEN_FACTORY_KEY
 toolRefs: `workbench.token_factory.caption`, `.generate`, `.reason`, `.triage`
 (digest a run's textual artifacts into a triage report).
 
-Checked-in specs, listed by `npa workbench token-factory workflow`:
+`npa workbench token-factory workflow` prints exactly four:
+`token-factory-caption.yaml`, `token-factory-generate.yaml`,
+`token-factory-cosmos-reason.yaml`, and `vlm-eval-token-factory.yaml`. Several
+more are checked in but not listed by that command, so do not treat its output as
+the full inventory:
 
-- `token-factory-caption.yaml`, `token-factory-generate.yaml`,
-  `token-factory-cosmos-reason.yaml` — single-purpose.
 - `token-factory-parallel-fanout.yaml` — parallel batches.
 - `token-factory-gate-loop.yaml`, `tokenfactory-cosmos-gate.yaml` — a hosted
   model as a gate that decides whether the pipeline continues.

--- a/skills/tools/token-factory/SKILL.md
+++ b/skills/tools/token-factory/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: token-factory
+description: Use for zero-GPU hosted inference through Nebius Token Factory — captioning, batch text generation, and Cosmos physical-AI reasoning — including key setup, model selection, and the npa.workflow toolRefs that need no cluster.
+---
+
+# Token Factory (zero-GPU hosted inference)
+
+Nebius Token Factory is an OpenAI-compatible hosted-inference API for open text
+and vision models. It is the cheapest tier in the workbench that produces a real
+artifact: **no cluster, no GPU, no provisioning**. Reach for it before standing up
+anything, both for real work and to prove a toolchain end to end.
+
+Full reference: `docs/workbench/token-factory.md`. Key setup only:
+`docs/workbench/token-factory-key.md`.
+
+## The credential is not a Nebius IAM token
+
+This is the single most common failure. A Token Factory key is a separate
+credential minted in the separate Token Factory console
+(<https://tokenfactory.nebius.com/>). It is a long opaque token starting with
+`v1.`, read from `NEBIUS_TOKEN_FACTORY_KEY` or `~/.npa/credentials.yaml`. Your
+`nebius` CLI IAM token returns `403` here — having Nebius CLI access is not
+enough, and no amount of re-authenticating the CLI will help.
+
+Keys are shown once at creation. A project with no balance returns `402`/`403` on
+inference even with a valid key.
+
+```bash
+npa workbench token-factory status    # connection settings, no network call
+npa workbench token-factory verify    # live models call; non-zero on auth failure
+npa workbench token-factory models    # what this key can actually reach
+```
+
+Run `verify` before a batch job and `models` before pinning a model name — model
+availability is per-key, so a model in the docs may not be in your project.
+
+Defaults: base URL `https://api.tokenfactory.nebius.com/v1/`, overridable with
+`NEBIUS_TOKEN_FACTORY_BASE_URL`. Requests retry on 429 and 5xx.
+
+## Commands
+
+Every command takes local paths or `s3://` URIs for both input and output, and
+supports `--dry-run` (compute without writing the artifact) and
+`--output text|json`.
+
+**Caption images** — default model `Qwen/Qwen2.5-VL-72B-Instruct`:
+
+```bash
+npa workbench token-factory caption \
+  --input-path s3://<bucket>/frames/ \
+  --output-path s3://<bucket>/captions.json \
+  --max-images 50 --max-tokens 512 --temperature 0.2 \
+  --instruction "Describe the scene, objects, and any action."
+```
+
+**Batch text generation** over a JSONL/text prompt file — default model
+`meta-llama/Llama-3.3-70B-Instruct`:
+
+```bash
+npa workbench token-factory generate \
+  --input-path prompts.jsonl \
+  --output-path s3://<bucket>/generations.jsonl \
+  --max-prompts 0 --max-tokens 512 --temperature 0.7 \
+  --system-prompt "<applied to every request>"
+```
+
+`--max-prompts 0` means all of them. Set a small non-zero value first: this is
+the command that turns a typo into a large token bill.
+
+**Physical-AI reasoning over a scene** — default model
+`nvidia/Cosmos3-Super-Reasoner`. Point it at scene images and ask what a robot
+should do:
+
+```bash
+npa workbench token-factory reason \
+  --input-path s3://<bucket>/scene/ \
+  --output-path s3://<bucket>/plan.json \
+  --task "Describe this scene and give a step-by-step plan of action." \
+  --max-images 8 --max-tokens 1024 --temperature 0.2
+```
+
+## In workflows
+
+These run as CPU-only `npa.workflow` steps with no accelerator request. The
+renderer injects `NEBIUS_TOKEN_FACTORY_KEY` for `workbench.token_factory.*`
+steps, so pass it as a secret at submit time and never in the YAML:
+
+```bash
+npa workbench workflow submit <spec.yaml> --secret-env NEBIUS_TOKEN_FACTORY_KEY
+```
+
+toolRefs: `workbench.token_factory.caption`, `.generate`, `.reason`, `.triage`
+(digest a run's textual artifacts into a triage report).
+
+Checked-in specs, listed by `npa workbench token-factory workflow`:
+
+- `token-factory-caption.yaml`, `token-factory-generate.yaml`,
+  `token-factory-cosmos-reason.yaml` — single-purpose.
+- `token-factory-parallel-fanout.yaml` — parallel batches.
+- `token-factory-gate-loop.yaml`, `tokenfactory-cosmos-gate.yaml` — a hosted
+  model as a gate that decides whether the pipeline continues.
+- `tokenfactory-rollout-judge.yaml`, `tokenfactory-scene-to-rollout-judge.yaml` —
+  reason about a scene, then judge a rollout against that plan.
+- `tokenfactory-train-triage.yaml` — triage a training run's artifacts.
+
+All live under `npa/workflows/workbench/npa-workflows/`.
+
+## Choosing between Token Factory and VLM eval
+
+They overlap and are easy to confuse. `token-factory reason` **produces** an
+analysis or plan. `vlm-eval` **scores** a rollout against a task and emits a
+pass/fail gate with a threshold. When you want a judged number for a gate, use
+`skills/tools/vlm-eval/SKILL.md` — and note it can consume a Token Factory
+reasoning artifact directly through `--task-from`, so a judge scores against a
+plan an earlier stage wrote rather than a hardcoded string.
+
+## Gotchas
+
+- **Model availability is per-key.** Confirm with `models` before pinning a name
+  in a spec; a spec that names an unavailable model fails at run time, not at
+  validation.
+- **`--max-images` and `--max-prompts` are cost controls, not correctness knobs.**
+  Defaults are 50 images and unlimited prompts. Always bound the first run.
+- **`--dry-run` still calls the model.** It skips writing the artifact, so it is
+  not a free syntax check. For a free check, validate the spec instead.
+- **Hosted inference is not a rendering or simulation path.** It has no access to
+  your cluster, your PVCs, or a GPU; give it S3 or local inputs it can read.
+- **The key belongs in credentials, not in a spec or a shell history.** Persist it
+  with `npa configure --save-env-credentials` (atomic `0600` write, never
+  printed).
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/tools/vlm-eval/SKILL.md
+++ b/skills/tools/vlm-eval/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: vlm-eval
+description: Use to score rollouts with a vision-language model and turn the score into a pipeline gate — single rollout, prefix-wide loop, rubric/threshold benchmark sweeps, backend selection (self-hosted, api, stub), and judging against a plan an earlier stage wrote.
+---
+
+# VLM eval (scoring rollouts and gating pipelines)
+
+`vlm-eval` answers "did this rollout complete the task?" as a number, then turns
+that number into a gate. It is the judging half of the loop whose generating half
+is Cosmos/Genesis/Isaac rollouts and whose reasoning half is
+`skills/tools/token-factory/SKILL.md`.
+
+## Pick the right command
+
+```bash
+npa workbench vlm-eval run   --input-path <one-rollout>  --output-path <eval.json>
+npa workbench vlm-eval loop  --input-path <prefix>       --output-path <prefix>
+npa workbench vlm-eval benchmark --dataset <manifest> --output <report.json>
+npa workbench vlm-eval status
+npa workbench vlm-eval list
+npa workbench vlm-eval workflow
+```
+
+**`run` scores exactly one rollout.** It discovers frames recursively, so if you
+point it at a prefix holding many rollouts they blend into a single meaningless
+score. That is the mistake `loop` exists to prevent: `loop` treats each directory
+under the prefix as its own rollout, scores each, and writes per-rollout results
+plus an aggregate task-success report.
+
+**`benchmark` sweeps configuration, not data.** Use it to choose a threshold,
+rubric, or model against a labeled set before you trust any of them in a gate.
+
+## Backends
+
+`--backend` is `self-hosted` (default), `api`, or `stub`.
+
+- `self-hosted` — an OpenAI-compatible server you run, addressed with
+  `--endpoint-url`. This is the GPU-bearing path.
+- `api` — a hosted OpenAI-compatible endpoint; the key comes from the environment
+  variable named by `--api-key-env` (default `VLM_EVAL_API_KEY`). Point this at
+  Token Factory for a zero-GPU judge.
+- `stub` — deterministic, no model call. For wiring tests and CI only; a stub
+  score is never evidence about a policy.
+
+`--endpoint-url` accepts either a base URL or a full `/chat/completions` URL.
+Default model is `Qwen/Qwen2-VL-7B-Instruct`; `--timeout-s` defaults to 120.
+
+## Scoring controls that actually change the verdict
+
+```bash
+npa workbench vlm-eval run \
+  --input-path s3://<bucket>/runs/<id>/rollout/ \
+  --output-path s3://<bucket>/runs/<id>/eval.json \
+  --task "pick and place the cube" \
+  --backend api --model <model> --api-key-env NEBIUS_TOKEN_FACTORY_KEY \
+  --frame-selection keyframes --max-frames 4 \
+  --rubric-path ./rubric.txt \
+  --success-threshold 0.8
+```
+
+- `--frame-selection` is `final`, `keyframes` (default), or `sequence`. `final`
+  cannot distinguish "reached the goal" from "was already there"; `sequence`
+  costs the most tokens. `keyframes` is the default for a reason.
+- `--max-frames` (default 4) bounds both cost and how much of the episode the
+  judge can actually see. A four-frame view of a long episode judges a summary.
+- `--rubric` / `--rubric-path` carry the scoring instructions. The default rubric
+  reserves 1.0 for clear completion and 0.0 for clear failure, with intermediate
+  values for partial progress, and penalizes unsafe or ambiguous outcomes.
+- `--success-threshold` (default 0.8) is the gate. In `loop` it applies to the
+  **mean** score across rollouts, which is a coarser claim than per-rollout
+  success — do not report it as a per-rollout success rate.
+- `--score <float>` overrides the score and skips the VLM call entirely. It exists
+  for tests and dry validation. Never use it to produce a result you then report.
+
+## Judging against a plan instead of a fixed task
+
+`--task-from <reasoning-artifact>` reads the task from the artifact's `analysis`
+field rather than from `--task`. This is what makes the scene-to-judge pattern
+work: a Cosmos reasoner writes a plan for the scene, and the judge scores the
+rollout against *that* plan instead of a hardcoded string. The workflow toolRef
+is `workbench.vlm_eval.judge_against_plan`.
+
+## Choosing a threshold honestly
+
+```bash
+npa workbench vlm-eval benchmark \
+  --dataset <manifest.json> --output <report.json> \
+  --thresholds 0.5,0.8,0.9 \
+  --rubrics default,@./strict-rubric.txt \
+  --models <model-a>,<model-b> \
+  --backend api
+```
+
+`--rubrics` accepts names from the dataset, inline text, or `@file` paths.
+`--dataset` defaults to a packaged sample fixture, which is useful for proving
+the sweep runs but tells you nothing about your task. `--use-fixture-scores`
+honors recorded `fixture_score` values for non-stub backends; stub always uses
+them when present.
+
+## In workflows
+
+toolRefs: `workbench.vlm_eval.run`, `.loop`, `.judge_against_plan`, `.benchmark`.
+Specs under `npa/workflows/workbench/npa-workflows/`: `vlm-eval-single.yaml`,
+`vlm-eval-loop.yaml`, `vlm-eval-benchmark.yaml`, `vlm-eval-token-factory.yaml`
+(the zero-GPU judge), plus the rollout-judge combinations listed in
+`skills/tools/token-factory/SKILL.md`.
+
+Self-hosted VLM steps need a GPU image; set it with `--image` on
+`vlm-eval workflow` or the `NPA_VLM_IMAGE` environment variable. The `api` and
+`stub` backends need neither.
+
+## Gotchas
+
+- **Never move the threshold to make a run pass.** The threshold is the claim. If
+  a gate fails, the policy failed; report the measured score.
+- **`run` on a multi-rollout prefix silently produces one blended score.** Use
+  `loop`. This does not error.
+- **A stub score is not evidence.** Neither is `--score`. Both are wiring tests.
+- **The judge sees only the frames you send it.** A low score with
+  `--frame-selection final --max-frames 1` may be a sampling artifact rather than
+  a policy failure; re-score with keyframes before believing it.
+- **Benchmark the rubric before trusting it.** Rubric wording moves scores more
+  than most people expect, which is precisely what `benchmark` is for.
+- **A green gate does not mean a good policy.** It means the judge, at this
+  rubric and threshold, on these frames, said yes.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/workflows/first-run-setup/SKILL.md
+++ b/skills/workflows/first-run-setup/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: first-run-setup
+description: Use on a fresh machine or a new Nebius project to get from zero to a first verified result — an ordered, gated path through install, configure, credential preflight, cheapest-proof workload, then cluster provisioning, with an explicit stop condition at every step.
+---
+
+# First run: zero to a verified result
+
+The failure mode this skill exists to prevent is spending an hour provisioning a
+GPU cluster and discovering at stage three that a token was never accepted. Each
+step below has a **gate**: a command whose success is the precondition for the
+next step. Do not skip ahead because a later step looks more interesting.
+
+Escalate through the cheapest tier that can prove the thing you need. Most
+first-run questions are answered before any GPU is involved.
+
+## Step 1 — Install and prove the CLI runs
+
+```bash
+python3 -m venv npa/.venv
+npa/.venv/bin/pip install -e "npa[dev]"
+npa/.venv/bin/npa --version
+```
+
+**Gate:** `npa --version` and `npa --help` both succeed. They must work with no
+Nebius, Hugging Face, NGC, Kubernetes, or S3 credentials at all. If they do not,
+the problem is the install, not your cloud setup.
+
+Python 3.10+ is required. Terraform 1.x must be on `PATH` for anything managed
+(`npa cluster up`, `npa agent fresh-setup`); `pip install -e npa` does not install
+it. On Windows, work inside WSL2 — the cloud paths assume POSIX.
+
+Use `npa/.venv/bin/python` and `npa/.venv/bin/npa` explicitly for repo validation
+rather than a bare `python` or `npa` from `PATH`.
+
+## Step 2 — Configure Nebius
+
+```bash
+npa configure --show          # inspect the expected layout, writes nothing
+npa configure                 # interactive: creates/reuses the CLI profile
+```
+
+`configure` writes `~/.npa/config.yaml` (machine-managed, non-secret) and
+`~/.npa/credentials.yaml` (secrets, `0600`). It auto-provisions an S3 bucket and
+access key by default; `--no-provision` lets you supply existing object-storage
+credentials instead.
+
+For unattended setup, avoid the prompts entirely:
+
+```bash
+npa configure --no-interactive --save-env-credentials \
+  --tenant-id <id> --project-id <id> --region <region> --project-alias <alias>
+```
+
+**Gate:** `npa configure --show` reports the project stanza, bucket, and endpoint
+you intend to use. A silent exit or an empty storage section means configure did
+not write what you think it did — resolve it here, because every later command
+resolves credentials through this file.
+
+Do not hardcode project IDs, tenant IDs, registry IDs, or bucket names anywhere
+in the repo; they belong only in `~/.npa/`.
+
+## Step 3 — Prove credentials before spending anything
+
+```bash
+npa workbench health preflight --json
+npa workbench health access --capability <the-one-you-will-run> --json
+```
+
+**Gate:** both exit zero. `preflight` covers Hugging Face, NGC, S3, and Token
+Factory presence and authentication; `access` proves your token is actually
+entitled to the gated models a given capability pulls. Gated Hugging Face
+licenses can only be accepted interactively on the model page — `access` prints
+the exact URL, and nothing else will clear the gate. Full detail in
+`skills/atomic/health-preflight/SKILL.md`.
+
+## Step 4 — Get a real result with no GPU and no cluster
+
+Before provisioning, prove the toolchain end to end on the cheapest tier that
+produces a genuine artifact. Token Factory is hosted inference: no cluster, no
+GPU, real model output.
+
+```bash
+npa workbench token-factory verify
+npa workbench token-factory caption \
+  --input-path ./some-images/ --output-path ./captions.json --max-images 4
+```
+
+**Gate:** a real captions artifact exists. You have now proven credentials, S3 or
+local IO, and model access without provisioning anything. See
+`skills/tools/token-factory/SKILL.md`.
+
+If your goal genuinely needs a container on a GPU but not a cluster, the next
+cheapest tier is a single serverless job:
+
+```bash
+npa workbench golden-eval list
+npa workbench golden-eval run <tool>              # dry run: prints the command
+npa workbench golden-eval run <tool> --serverless # one GPU, PASS/FAIL
+```
+
+See `skills/tools/golden-eval/SKILL.md`.
+
+## Step 5 — Validate the workflow spec offline
+
+Still free, and it catches most authoring mistakes:
+
+```bash
+npa workbench workflow validate-spec <spec.yaml>
+npa workbench workflow plan-spec <spec.yaml>
+```
+
+**Gate:** the spec validates and the plan shows the stages you expect.
+
+## Step 6 — Provision only what the spec needs
+
+```bash
+unset NEBIUS_IAM_TOKEN NPA_NEBIUS_IAM_TOKEN   # stale ambient tokens break providers
+npa provision-if-absent --project <alias> --dry-run --output-format json
+npa provision-if-absent --project <alias>
+npa skypilot bootstrap
+npa skypilot verify --cluster <name> --output-format json
+```
+
+`provision-if-absent` is additive only — it never tears down or replaces
+resources — so the dry run is a genuine preview. `skypilot bootstrap` pins a
+Kubernetes client the controller can use; a newer client makes every `pod_config`
+fail validation and the controller retries forever, which presents as a hung
+submit rather than an error.
+
+**Gate:** `skypilot verify` passes against the exact context you will submit to.
+
+## Step 7 — Learn what this cluster calls its GPUs
+
+```bash
+npa workbench workflow gpus --cluster <name> --json
+```
+
+Kubernetes names accelerators after node labels, so the same card can be
+`RTXPRO6000` in a spec and something much longer on the cluster. Note the printed
+**requestable quantity per node**: SkyPilot places all GPUs of one task on a
+single node, so `NAME:2` never schedules on 1-GPU nodes regardless of node count.
+
+## Step 8 — Prove the images are pullable
+
+```bash
+npa workbench workflow preflight-images <spec.yaml> --project <alias> --json
+```
+
+**Gate:** every image reports `ok`. Nothing mirrors workbench images into the
+registry `npa configure` selected, so `not_found` means the image was never
+pushed to *your* registry. A `403` does not fail a job — Kubernetes retries pulls
+forever — so an unpullable image silently burns cluster time in
+`ImagePullBackOff`. `submit` runs this check before provisioning by default.
+
+## Step 9 — Submit
+
+```bash
+npa workbench workflow submit <spec.yaml> --project <alias> --plan-only
+npa workbench workflow submit <spec.yaml> --project <alias> \
+  --var bucket=<your-bucket> --secret-env NEBIUS_TOKEN_FACTORY_KEY
+```
+
+Reference specs default to `bucket: example-bucket`; override real values through
+`--var`. Pass secrets with `--secret-env`, never in the YAML. CPU tool steps and
+`run.shell` states have no heavy image and install npa from a source tarball, so
+persist that location once:
+
+```bash
+npa configure --src-s3-uri s3://<bucket>/<prefix>/npa
+```
+
+Then monitor and, on failure, triage with
+`skills/atomic/debug-failed-run/SKILL.md`.
+
+## Step 10 — Stop the spend
+
+A first run is not finished until the resources are gone or deliberately kept.
+Cancel runs before destroying anything that hosts them; see
+`skills/atomic/teardown-and-cost/SKILL.md` for the full ordering and the orphan
+audit.
+
+## Common cold-start stumbles
+
+- **`sim2real` and `sim-to-real` are different things.** `sim2real` is the staged
+  14-stage VLM-to-RL loop; `sim-to-real` is the older H100 pipeline. The spelling
+  is the disambiguator.
+- **A Token Factory key is not a Nebius IAM token.** It starts with `v1.` and
+  lives in `NEBIUS_TOKEN_FACTORY_KEY`.
+- **Isaac Lab needs an RT-core GPU** (L40S or RTX PRO 6000), not H100/H200. See
+  `skills/atomic/gpu-selection/SKILL.md`.
+- **Pass `-p <project> -n <name>` to any tool's `status`.** A bare `status` can
+  resolve a stale endpoint.
+- **`--offline` on health checks proves presence, not validity.** An expired token
+  passes offline and fails on first pull.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+```

--- a/skills/workflows/first-run-setup/SKILL.md
+++ b/skills/workflows/first-run-setup/SKILL.md
@@ -188,8 +188,11 @@ audit.
   lives in `NEBIUS_TOKEN_FACTORY_KEY`.
 - **Isaac Lab needs an RT-core GPU** (L40S or RTX PRO 6000), not H100/H200. See
   `skills/atomic/gpu-selection/SKILL.md`.
-- **Pass `-p <project> -n <name>` to any tool's `status`.** A bare `status` can
-  resolve a stale endpoint.
+- **Scope `status` explicitly where the tool supports it.** For deployed-service
+  tools that accept `-p <project>` / `-n <name>` (SONIC among them), a bare
+  `status` can resolve a stale endpoint. Flags differ per tool — `detection-training
+  status` wants `--run-id`, and `token-factory status` takes neither — so check
+  `--help` rather than assuming a common shape.
 - **`--offline` on health checks proves presence, not validity.** An expired token
   passes offline and fails on first pull.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Audited all 246 commits on `main` for recurring operational friction, and mapped the full `npa` CLI surface against `skills/index.yaml`. Both passes pointed at the same gaps: the deployment path (readiness, failure triage, teardown, cold start, GPU driver strategy) had no skills at all, and six advertised workbench command groups had none either.
- Adds **11 skills**, taking the manifest from 61 to 72. Every command, flag, default value, file path, and toolRef is verified against the installed CLI and the source — not written from memory. A fact-check pass found three wrong claims, which are fixed in the second commit.
- Each skill is registered in `skills/index.yaml` with smoke checks that `test_skills_index.py` actually executes, so a future CLI rename breaks the test rather than silently rotting the guidance.

### Deployment path (previously uncovered)

| Skill | Why it exists |
|---|---|
| `workflows/first-run-setup` | Zero to a first verified result, with a **gate** at each step, so a missing token surfaces before a cluster exists rather than at stage three |
| `atomic/health-preflight` | There is no `npa doctor`; `npa workbench health preflight`/`access` are the readiness gates, and gated HF licenses can only be cleared interactively |
| `atomic/debug-failed-run` | Triage from run id through status (pod-level reason for `PENDING`), stage logs, S3 evidence, image pullability, scheduling, to resume-vs-cancel |
| `atomic/teardown-and-cost` | Cancel-before-destroy ordering, which commands touch cloud vs local state, the orphan audit, and choosing the cheapest tier that proves the point |
| `tools/gpu-cluster-provisioning` | The managed-image vs GPU-Operator driver decision. Operator mode is unsafe on NVSwitch (Fabric Manager can start before MOFED exposes the IB management devices); this was not covered by `nebius-infra`, `fleet`, or `gpu-selection` |

### Workbench tools that had no skill

`tools/token-factory` (zero-GPU hosted inference — the cheapest tier producing a real artifact), `tools/vlm-eval` (scoring rollouts into a gate), `tools/golden-eval` (proving a container image works), `tools/burst` (one gang-scheduled multi-node job), `tools/detection-training` (LanceDB view → Faster R-CNN), `tools/artifact-viz-share` (dataset conversion, `.rrd`/MP4, time-boxed share links).

### Evidence behind the selection

Recurring failure classes in the history that these skills encode: 12+ commits on image publish/pull credentials, 8–10 on Blackwell/`sm120`/CUDA routing and mk8s driver defaults (`#298` made managed drivers the GPU-pool default), a repeated preflight-accretion loop (`FTUE-AUDIT.md` → `#197` → `#217` → `#302`), and live-forensics fix bundles (`#236`, `#258`) whose diagnosis steps existed nowhere in writing.

Deliberately not duplicated: the Blackwell two-target matrix stays in `gpu-selection`, teardown ownership-gating detail stays in `nebius-infra`, and Token Factory's full reference stays in `docs/workbench/token-factory.md`. The new skills cross-link to those instead of restating them.

## Verification

- [x] Ran the relevant unit, smoke, or workflow checks.
- [x] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`.
- [x] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

```
npa/.venv/bin/python -m pytest npa/tests/guardrails/ npa/tests/smoke/test_golden_eval_manifest.py -q
# 2067 passed, 1 skipped

npa/.venv/bin/python -m npa.guardrails.confidentiality --built-in-nebius-infra \
  --diff-range origin/main..HEAD
# confidentiality scan passed; hits=0
```

`test_skills_index.py` enforces set-equality between `skills/*/*/SKILL.md` and the manifest, frontmatter/name agreement, and execution of every smoke, so all 11 entries are proven wired. Smokes use `cli_help` against the real Typer app, `npa_workflow_yaml` validation of referenced specs, and `file_exists` for docs and manifests. No Python or CLI behavior changed, so `docs/cli/` has no drift.

## Exercised against live credentials

Ran the documented commands on the shared dev/operator VM, inside an isolated worktree + venv + tmux session so no other agent's checkout was disturbed:

- `npa workbench health preflight` returned 4 pass / 0 fail against real Hugging Face, NGC, S3, and Token Factory credentials, and `--checks s3` scoped correctly — the flag names and valid values in `health-preflight` are right.
- Token Factory authenticated and reported a live model list, confirming the premise of `token-factory` that this is a real zero-GPU tier rather than a documented aspiration.
- `npa workbench workflow gpus` and `validate-spec` behave as `debug-failed-run` describes.

That run also surfaced a gap in `health-preflight` worth fixing, now in the third commit: **a green `s3` row does not mean the submit can write.** The health check lists the configured project bucket, while `submit` puts a unique object into the bucket the *workflow* resolves — a different bucket whenever `NPA_S3_BUCKET` or `AWS_ENDPOINT_URL` is set. On this VM the two disagree, so preflight passed and the submit then refused with `writable S3 for this workflow (S3 write permission was denied.)`. An agent trusting the green row would have read that as a regression instead of an environment mismatch.

## Skill Maintenance

- [x] I updated the relevant root `skills/` entry and `skills/index.yaml`, or this PR does not change behavior that needs skill guidance.

`skills/index.yaml` gains 11 entries; `CLAUDE.md` and `AGENTS.md` gain matching index lines. Skills were added only under the root `skills/` tree — the `.claude/skills` and `.agents/skills` symlinks pick them up automatically, and the single-tree rule is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00dbc-8cd9-770f-899f-e287dfcebea5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00dbc-8cd9-770f-899f-e287dfcebea5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

