### PR TITLE
Harden Isaac motion capture for Foxglove qualification

### DIFF
--- a/docs/workbench/foxglove-export.md
+++ b/docs/workbench/foxglove-export.md
@@ -125,6 +125,37 @@ and build a web-only link for an already indexed recording with:
 npa workbench foxglove open --recording-id <recording-id>
 ```
 
+## Real Isaac motion qualification
+
+A production robot-motion qualification must start from the canonical Sim2Real
+Isaac policy-rollout component, not from copied images or a synthetic MCAP. Run
+the component on a strictly reserved RT-capable GPU with a digest-pinned Isaac
+image, a pre-warmed read-only `NPA_SIM2REAL_ISAAC_CACHE_PVC`, and scenarios bound
+to `NPA_SIM2REAL_TASK_CONTRACT_DIGEST`. Keep `ACCEPT_EULA=Y`; leave privacy and
+telemetry consent unset. The selected rollout's `action_rollout.v1` manifest and
+camera frames are then the inputs to `npa workbench foxglove export-run`.
+
+For parity with the multi-camera motion reference, capture 32 decision samples
+over a 32-step horizon at stride 1. This yields 32 source action/ground-truth
+records and 33 source frames for each of the primary, side, and overhead views.
+The converter maps those physical views to `/camera`, `/camera/side`, and
+`/camera/workspace` and emits the `npa.foxglove.robot-motion.v3` contract. Report
+policy state honestly: a first-pass rollout without a checkpoint is a real Isaac
+execution, but it is not a trained-policy efficacy claim.
+
+The default physics device remains `cuda:0`. If a supported RT GPU renders
+cameras correctly but its PhysX GPU pipeline cannot initialize, set
+`NPA_SIM2REAL_ISAAC_DEVICE=cpu` for an explicit CPU-physics fallback. The Job
+still requests and attests its GPU, and the RTX camera renderer still uses that
+device; `simulation_device` in the source manifest records the fallback so it
+cannot be mistaken for GPU physics.
+
+Before handing off the run, inspect the canonical MCAP and require the expected
+per-topic counts, action-derived robot channels, valid MCAP magic, and a matching
+SHA-256 provenance sidecar. The live Cypress tier below then verifies the same
+S3-discovered recording through the deployed agent's SDK, transport, CORS, range,
+and download contracts.
+
 ## Cypress regression tiers
 
 The mocked tier serves the production Agent UI, the real pinned

--- a/docs/workbench/foxglove-export.md
+++ b/docs/workbench/foxglove-export.md
@@ -148,7 +148,9 @@ cameras correctly but its PhysX GPU pipeline cannot initialize, set
 `NPA_SIM2REAL_ISAAC_DEVICE=cpu` for an explicit CPU-physics fallback. The Job
 still requests and attests its GPU, and the RTX camera renderer still uses that
 device; `simulation_device` in the source manifest records the fallback so it
-cannot be mistaken for GPU physics.
+cannot be mistaken for GPU physics. This compatibility mode requires one
+rollout environment and uses ordinary Camera sensors with Fabric disabled;
+multi-environment tiled capture remains CUDA-only.
 
 Before handing off the run, inspect the canonical MCAP and require the expected
 per-topic counts, action-derived robot channels, valid MCAP magic, and a matching

--- a/npa/src/npa/cli/agent_access.py
+++ b/npa/src/npa/cli/agent_access.py
@@ -391,10 +391,15 @@ def discover_agent_access(
     resources_by_project: dict[str, list[StorageResourceAccess]] = {
         project_id: [] for project_id in ordered_project_ids
     }
-    for project_id, resource, error in probe_results:
+    for project_id, resource, _error in probe_results:
         resources_by_project[project_id].append(resource)
-        if error is not None:
-            errors.append(error)
+        # A bucket-level S3 denial is an effective capability result for that
+        # resource, not a failure of tenant/project discovery.  Keep it on the
+        # resource's list/read capabilities so selecting that bucket remains
+        # visibly blocked, but do not promote every inaccessible sibling into
+        # the report-wide error banner.  Structural inventory failures above
+        # still remain global because they prevent the affected scope from
+        # being enumerated at all.
 
     projects: list[ProjectAccess] = []
     for inventory in inventories:

--- a/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
@@ -324,6 +324,17 @@ try:
             "NPA_ISAAC_KIT_ARGS", "--portable-root /tmp/npa-isaac-kit"
         ),
     ).app
+    # Isaac Sim 5.1 may leave the RTX data-window settings unset under a
+    # portable root. Replicator treats those ``None`` values as overscan and
+    # then subtracts them while reading RGB. Initialize the standard full-frame
+    # window so Replicator preserves exact WxH output without fake overscan.
+    import carb
+    rtx_settings = carb.settings.get_settings()
+    rtx_settings.set_float("/rtx/dataWindowNDC/0", 0.0)
+    rtx_settings.set_float("/rtx/dataWindowNDC/1", 0.0)
+    rtx_settings.set_float("/rtx/dataWindowNDC/2", 1.0)
+    rtx_settings.set_float("/rtx/dataWindowNDC/3", 1.0)
+    rtx_settings.set_bool("/rtx/dataWindow/fitOutputToDataWindow", False)
     import gymnasium as gym, torch
     import isaaclab_tasks  # noqa: F401
     _scenarios = None
@@ -384,6 +395,19 @@ try:
         )
     print("ROLLOUT_CAMERA_VIEWS", [view["name"] for view in CAMERA_VIEWS], flush=True)
     env = gym.make(TASK, cfg=env_cfg)
+    capture_annotators = {}
+    if SIM_DEVICE == "cpu":
+        # Physics remains on CPU for the compatibility route, but rendering is
+        # backed by the reserved RTX device. A CUDA annotator avoids Isaac
+        # Replicator's empty CPU render buffers while leaving simulation state
+        # and policy inference on the explicitly selected device.
+        import omni.replicator.core as rep
+        for view in CAMERA_VIEWS:
+            view_name = view["name"]
+            sensor = env.unwrapped.scene[_camera_key(view_name)]
+            annotator = rep.AnnotatorRegistry.get_annotator("rgb", device="cuda:0")
+            annotator.attach(sensor.render_product_paths)
+            capture_annotators[view_name] = annotator
     if OBJECT_USD:
         got_object_usd = getattr(env.unwrapped.scene["object"].cfg.spawn, "usd_path", None)
         if got_object_usd != OBJECT_USD:
@@ -451,7 +475,10 @@ try:
         import binascii, struct, zlib
         pixels = np.asarray(rgb, dtype=np.uint8)
         if pixels.ndim != 3 or pixels.shape[2] < 3:
-            raise RuntimeError("camera rgb output must be HxWxC")
+            raise RuntimeError(
+                "camera rgb output must be HxWxC with at least three channels; "
+                "got shape=%r dtype=%s" % (pixels.shape, pixels.dtype)
+            )
         pixels = np.ascontiguousarray(pixels[:, :, :3])
         height, width = pixels.shape[:2]
         raw = b"".join(b"\x00" + row.tobytes() for row in pixels)
@@ -497,8 +524,34 @@ try:
         for view in CAMERA_VIEWS:
             view_name = view["name"]
             try:
-                rgb = env.unwrapped.scene[_camera_key(view_name)].data.output["rgb"]
-                arr = rgb.detach().cpu().numpy()
+                sensor = env.unwrapped.scene[_camera_key(view_name)]
+                if SIM_DEVICE == "cpu":
+                    output = capture_annotators[view_name].get_data()
+                    raw = output["data"] if isinstance(output, dict) else output
+                    if hasattr(raw, "detach"):
+                        arr = raw.detach().cpu().numpy()
+                    elif isinstance(raw, np.ndarray):
+                        arr = raw
+                    else:
+                        import warp as wp
+                        arr = wp.to_torch(raw).cpu().numpy()
+                    pixels = CAPTURE_HEIGHT * CAPTURE_WIDTH
+                    if arr.size == pixels and arr.dtype.itemsize >= 4:
+                        # Replicator may expose packed RGBA pixels as uint32.
+                        arr = arr.view(np.uint8)
+                    if arr.size % pixels:
+                        raise RuntimeError("camera rgb buffer size is not image-shaped")
+                    arr = arr.reshape(1, CAPTURE_HEIGHT, CAPTURE_WIDTH, arr.size // pixels)
+                else:
+                    rgb = sensor.data.output["rgb"]
+                    arr = rgb.detach().cpu().numpy()
+                # A single non-tiled Camera returns HxWxC, while TiledCamera
+                # returns NxHxWxC. Normalize both sensor contracts before the
+                # per-environment writer loop.
+                if arr.ndim == 3:
+                    arr = arr[None, ...]
+                if arr.ndim != 4:
+                    raise RuntimeError("camera rgb output must be HxWxC or NxHxWxC")
                 for i in range(min(N, arr.shape[0])):
                     d = os.path.join(FRAMES_DIR, rollout_ids[i]); os.makedirs(d, exist_ok=True)
                     index = len(frame_names[i][view_name])
@@ -530,10 +583,13 @@ try:
             print("STEP0 act_shape", tuple(getattr(actions, "shape", ())), flush=True)
         if hasattr(actions, "ndim") and actions.ndim == 1:
             actions = actions.reshape(N, -1)
-        if _step in SAMPLE_INDEX:
-            capture(_step)
         a_np = actions.detach().cpu().numpy()
         obs, _, dones, extras = env.step(actions)
+        # TiledCamera annotators need the first rendered simulation step before
+        # their initial read. Capture the post-action state, which also aligns
+        # each image with the simulator ground truth recorded below.
+        if _step in SAMPLE_INDEX:
+            capture(_step)
         done_np = dones.detach().cpu().numpy().astype(bool)
         obj = uenv.scene["object"].data.root_pos_w[:, :3]
         cmd = uenv.command_manager.get_command("object_pose")

--- a/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
@@ -268,6 +268,11 @@ CAPTURE_HEIGHT = int(os.environ.get("ROLLOUT_CAPTURE_HEIGHT", "480"))
 CAPTURE_STRIDE = max(1, int(os.environ.get("ROLLOUT_CAPTURE_STRIDE", "1")))
 PNG_COMPRESS_LEVEL = int(os.environ.get("ROLLOUT_PNG_COMPRESS_LEVEL", "3"))
 CAPTURE_FPS = float(os.environ.get("ROLLOUT_CAPTURE_FPS", "10"))
+SIM_DEVICE = os.environ.get("ROLLOUT_SIM_DEVICE", "cuda:0").strip() or "cuda:0"
+if SIM_DEVICE != "cpu" and not (
+    SIM_DEVICE.startswith("cuda:") and SIM_DEVICE.removeprefix("cuda:").isdigit()
+):
+    raise RuntimeError("ROLLOUT_SIM_DEVICE must be cpu or cuda:<index>")
 CKPT_URI = os.environ.get("ROLLOUT_CKPT_URI", "").strip()
 trained = False
 def checkpoint_provenance():
@@ -285,6 +290,7 @@ def upload_and_exit(rollouts, note, applied=None):
             "applied_scenarios": applied or {},
             "policy_checkpoint": checkpoint,
             "camera_metadata": CAMERA_VIEWS,
+            "simulation_device": SIM_DEVICE,
             "capture": {"width": CAPTURE_WIDTH, "height": CAPTURE_HEIGHT,
                         "rollout_stride": CAPTURE_STRIDE,
                         "decision_points": STEPS, "horizon_steps": HORIZON_STEPS,
@@ -338,7 +344,8 @@ try:
     except Exception:
         from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper
     from rsl_rl.runners import OnPolicyRunner
-    env_cfg = parse_env_cfg(TASK, device="cuda:0", num_envs=N)
+    env_cfg = parse_env_cfg(TASK, device=SIM_DEVICE, num_envs=N)
+    print("ROLLOUT_SIM_DEVICE", SIM_DEVICE, flush=True)
     OBJECT_USD = os.environ.get("ROLLOUT_OBJECT_USD", "").strip()
     if OBJECT_USD:
         try:
@@ -716,6 +723,7 @@ def build_isaac_rollout_job_manifest(
         f'ROLLOUT_CAPTURE_STRIDE="{capture["rollout_stride"]}" '
         f'ROLLOUT_PNG_COMPRESS_LEVEL="{capture["png_compress_level"]}" '
         f'ROLLOUT_CAPTURE_FPS="{capture["fps"]}" '
+        f"ROLLOUT_SIM_DEVICE={_shlex.quote(_env('NPA_SIM2REAL_ISAAC_DEVICE', 'cuda:0'))} "
         f"ROLLOUT_CKPT_URI={_shlex.quote(checkpoint_uri)} "
         f'ROLLOUT_CKPT_LOCAL="{ckpt_local}" '
         f"ROLLOUT_OUT_S3={_shlex.quote(out_s3_prefix)} "

--- a/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
@@ -399,7 +399,7 @@ try:
     if agent_cfg is None:
         raise RuntimeError("could not load rsl_rl_cfg_entry_point for task")
     acfg = agent_cfg.to_dict() if hasattr(agent_cfg, "to_dict") else dict(agent_cfg)
-    runner = OnPolicyRunner(env, acfg, log_dir=None, device="cuda:0")
+    runner = OnPolicyRunner(env, acfg, log_dir=None, device=SIM_DEVICE)
     trained = False
     if CKPT and os.path.isfile(CKPT):
         try:
@@ -409,7 +409,7 @@ try:
             raise RuntimeError("trained checkpoint failed to load: %r" % (e,)) from e
     else:
         print("ROLLOUT_UNTRAINED_POLICY (no checkpoint yet)", flush=True)
-    policy = runner.get_inference_policy(device="cuda:0")
+    policy = runner.get_inference_policy(device=SIM_DEVICE)
     realN = int(getattr(env.unwrapped, "num_envs", N) or N)
     try:
         reset_out = env.reset()

--- a/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
@@ -72,6 +72,7 @@ def build_rollout_manifest(
     checkpoint_sha256: str = "",
     checkpoint_size_bytes: int = 0,
     scenario: dict[str, Any] | None = None,
+    simulation_device: str = "cuda:0",
 ) -> dict[str, Any]:
     """Build an ``npa.sim2real.action_rollout.v1`` manifest for one rollout.
 
@@ -98,6 +99,7 @@ def build_rollout_manifest(
         # Provenance: distinguishes a real policy rollout from the synthetic stub.
         "source": "byo_isaac_policy_rollout",
         "sim_backend": "isaac",
+        "simulation_device": simulation_device,
         "policy_checkpoint": checkpoint_uri,
         "policy_checkpoint_sha256": checkpoint_sha256,
         "policy_checkpoint_size_bytes": int(checkpoint_size_bytes),
@@ -338,13 +340,17 @@ try:
         print("ROLLOUT_SCENARIO_TASK", TASK, flush=True)
     from isaaclab_tasks.utils import parse_env_cfg
     import isaaclab.sim as sim_utils
-    from isaaclab.sensors import TiledCameraCfg
+    from isaaclab.sensors import CameraCfg, TiledCameraCfg
     try:
         from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
     except Exception:
         from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper
     from rsl_rl.runners import OnPolicyRunner
     env_cfg = parse_env_cfg(TASK, device=SIM_DEVICE, num_envs=N)
+    if SIM_DEVICE == "cpu":
+        if N != 1:
+            raise RuntimeError("CPU physics camera fallback requires ROLLOUT_COUNT=1")
+        env_cfg.sim.use_fabric = False
     print("ROLLOUT_SIM_DEVICE", SIM_DEVICE, flush=True)
     OBJECT_USD = os.environ.get("ROLLOUT_OBJECT_USD", "").strip()
     if OBJECT_USD:
@@ -355,13 +361,14 @@ try:
             raise RuntimeError("could not apply task-contract object USD: %r" % (e,)) from e
     def _camera_key(name):
         return "rollout_cam" if name == "primary" else "rollout_cam_" + name
+    CameraType = CameraCfg if SIM_DEVICE == "cpu" else TiledCameraCfg
     for view in CAMERA_VIEWS:
         setattr(
             env_cfg.scene,
             _camera_key(view["name"]),
-            TiledCameraCfg(
+            CameraType(
                 prim_path="{ENV_REGEX_NS}/rollout_cam_" + view["name"],
-                offset=TiledCameraCfg.OffsetCfg(
+                offset=CameraType.OffsetCfg(
                     pos=tuple(view["position"]),
                     rot=tuple(view["rotation"]),
                     convention="world",
@@ -883,6 +890,31 @@ def materialize_rollout_dirs(
         }
         if not view_frames:
             view_frames = {"primary": [str(name) for name in roll.get("frames", [])]}
+        expected_views = {
+            str(item.get("name") or "") for item in camera_meta if item.get("name")
+        }
+        horizon_steps = int(capture.get("horizon_steps") or 0)
+        capture_stride = max(1, int(capture.get("rollout_stride") or 1))
+        expected_frame_count = (
+            len(range(0, horizon_steps, capture_stride)) + 1
+            if horizon_steps > 0
+            else 0
+        )
+        missing_views = sorted(
+            name for name in expected_views if not view_frames.get(name)
+        )
+        wrong_counts = {
+            name: len(view_frames.get(name) or [])
+            for name in expected_views
+            if expected_frame_count
+            and len(view_frames.get(name) or []) != expected_frame_count
+        }
+        if missing_views or wrong_counts:
+            raise RuntimeError(
+                "real Isaac rollout camera coverage mismatch: "
+                f"missing={missing_views} counts={wrong_counts} "
+                f"expected_per_view={expected_frame_count}"
+            )
         all_frames = list(
             dict.fromkeys(frame for frames in view_frames.values() for frame in frames)
         )
@@ -907,6 +939,7 @@ def materialize_rollout_dirs(
             checkpoint_sha256=str(checkpoint.get("sha256") or ""),
             checkpoint_size_bytes=int(checkpoint.get("size_bytes") or 0),
             scenario=dict(roll.get("scenario") or {}),
+            simulation_device=str(meta.get("simulation_device") or "cuda:0"),
         )
         (rdir / "manifest.json").write_text(
             json.dumps(manifest, indent=2), encoding="utf-8"

--- a/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
@@ -445,11 +445,29 @@ try:
         "ROLLOUT realN", realN, "DECISION_POINTS", STEPS,
         "HORIZON_STEPS", HORIZON_STEPS, flush=True,
     )
-    try:
-        from PIL import Image as _PILImage
-        _have_pil = True
-    except Exception:
-        _have_pil = False
+    def _write_rgb_png(path, rgb):
+        # Isaac runtime images do not guarantee Pillow.  Keep capture independent
+        # of optional packages so a valid sensor stream cannot be silently lost.
+        import binascii, struct, zlib
+        pixels = np.asarray(rgb, dtype=np.uint8)
+        if pixels.ndim != 3 or pixels.shape[2] < 3:
+            raise RuntimeError("camera rgb output must be HxWxC")
+        pixels = np.ascontiguousarray(pixels[:, :, :3])
+        height, width = pixels.shape[:2]
+        raw = b"".join(b"\x00" + row.tobytes() for row in pixels)
+        def chunk(kind, payload):
+            body = kind + payload
+            return struct.pack(">I", len(payload)) + body + struct.pack(
+                ">I", binascii.crc32(body) & 0xFFFFFFFF
+            )
+        encoded = (
+            b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(raw, PNG_COMPRESS_LEVEL))
+            + chunk(b"IEND", b"")
+        )
+        with open(path, "wb") as handle:
+            handle.write(encoded)
     rollout_ids = [f"rollout-{i:04d}" for i in range(N)]
     frame_names = {
         i: {view["name"]: [] for view in CAMERA_VIEWS}
@@ -474,8 +492,6 @@ try:
     stable_grasp_steps = np.zeros(N, dtype=np.int64)
     stable_place_steps = np.zeros(N, dtype=np.int64)
     def capture(step):
-        if not _have_pil:
-            return
         if step % CAPTURE_STRIDE != 0 and step != HORIZON_STEPS:
             return
         for view in CAMERA_VIEWS:
@@ -491,9 +507,7 @@ try:
                         if view_name == "primary"
                         else "camera-%s-%03d.png" % (view_name, index)
                     )
-                    _PILImage.fromarray(arr[i, :, :, :3].astype(np.uint8)).save(
-                        os.path.join(d, name), compress_level=PNG_COMPRESS_LEVEL
-                    )
+                    _write_rgb_png(os.path.join(d, name), arr[i])
                     frame_names[i][view_name].append(name)
                     frame_metadata[i][view_name].append({
                         "path": name,

--- a/npa/tests/browser/cypress/e2e/agent_mocked.cy.js
+++ b/npa/tests/browser/cypress/e2e/agent_mocked.cy.js
@@ -633,6 +633,9 @@ describe("NPA agent UI with mocked APIs", () => {
   });
 
   it("disables denied and unavailable access actions with visible reasons", () => {
+    // Expected sibling-bucket capability gaps stay on the selected resource;
+    // they must not appear as repeated report-wide fatal-looking errors.
+    cy.get("#agentAccessErrors").should("have.text", "");
     for (const bucket of ["denied-artifacts", "unavailable-artifacts"]) {
       cy.get("#agentAccessBucketSelect").select(bucket);
       cy.get(`#agentAccessProjects [data-resource-bucket="${bucket}"]`).each(($button) => {

--- a/npa/tests/cli/test_agent_access.py
+++ b/npa/tests/cli/test_agent_access.py
@@ -124,6 +124,40 @@ def test_partial_access_keeps_accessible_project_and_reports_denied_project() ->
     assert any(error["code"] == "permission_denied" for error in payload["errors"])
 
 
+def test_bucket_probe_denials_are_resource_scoped_and_fail_closed() -> None:
+    def probe(bucket_name: str) -> BucketProbe:
+        if bucket_name == "bucket-b":
+            raise AccessProbeError("denied", "probe selected object storage bucket")
+        return _available_probe(bucket_name)
+
+    report = _discover(probe_bucket=probe)
+    payload = report.to_dict()
+    resources = {
+        resource["name"]: resource
+        for project in payload["projects"]
+        for resource in project["resources"]
+    }
+
+    assert payload["status"] == "partial"
+    assert payload["errors"] == []
+    assert (
+        resources["bucket-b"]["capabilities"]["artifact_discovery"]["status"]
+        == "denied"
+    )
+    assert resources["bucket-b"]["capabilities"]["artifact_read"]["status"] == "denied"
+    assert (
+        "Permission denied"
+        in resources["bucket-b"]["capabilities"]["artifact_read"]["reason"]
+    )
+    assert accessible_artifact_buckets(report) == ["bucket-a"]
+    with pytest.raises(ValueError, match="outside effective agent access"):
+        scoped_artifact_buckets(
+            report,
+            project_id="project-b",
+            resource_bucket="bucket-b",
+        )
+
+
 def test_denied_access_has_no_searchable_storage() -> None:
     def denied(_value: str):
         raise AccessProbeError("denied", "access resource")

--- a/npa/tests/workflows/test_byo_isaac_policy_rollout.py
+++ b/npa/tests/workflows/test_byo_isaac_policy_rollout.py
@@ -157,6 +157,7 @@ def test_build_isaac_rollout_job_manifest_shape():
     assert "ROLLOUT_CAMERA_VIEWS_JSON=" in script
     assert 'ROLLOUT_CAPTURE_WIDTH="640"' in script
     assert 'ROLLOUT_CAPTURE_HEIGHT="480"' in script
+    assert "ROLLOUT_SIM_DEVICE=cuda:0" in script
     assert '"name":"side"' in script
     assert '"name":"overhead"' in script
     assert "/opt/npa/isaac-runtime/isaac_rollout.py" in script
@@ -166,6 +167,36 @@ def test_build_isaac_rollout_job_manifest_shape():
     assert m["spec"]["backoffLimit"] == 1
     assert "--portable-root /tmp/npa-isaac-kit" in pr.ISAAC_ROLLOUT_SCRIPT
     assert "kit_args=os.environ.get(" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert "device=SIM_DEVICE" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert '"simulation_device": SIM_DEVICE' in pr.ISAAC_ROLLOUT_SCRIPT
+
+
+def test_rollout_job_can_select_cpu_physics_without_releasing_gpu(
+    monkeypatch,
+):
+    monkeypatch.setenv("NPA_SIM2REAL_ISAAC_DEVICE", "cpu")
+    manifest = pr.build_isaac_rollout_job_manifest(
+        job_name="s2r-byo-isaac-roll-run1-cpu",
+        run_id="run1",
+        image="reg/npa-isaac-lab:2.3.2.post1",
+        task="Isaac-Lift-Cube-Franka-v0",
+        rollout_count=1,
+        steps_per_rollout=1,
+        checkpoint_uri="",
+        out_s3_prefix="s3://b/sim2real-b/run1/byo-rollouts/cpu",
+        s3_endpoint="",
+        namespace="default",
+        service_account="agent-sa",
+        gpu_product="NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition",
+    )
+
+    script = _manifest_script(manifest)
+    assert "ROLLOUT_SIM_DEVICE=cpu" in script
+    resources = manifest["spec"]["template"]["spec"]["containers"][0][
+        "resources"
+    ]
+    assert resources["requests"]["nvidia.com/gpu"] == "1"
+    assert resources["limits"]["nvidia.com/gpu"] == "1"
 
 
 def test_untrained_job_manifest_skips_download():

--- a/npa/tests/workflows/test_byo_isaac_policy_rollout.py
+++ b/npa/tests/workflows/test_byo_isaac_policy_rollout.py
@@ -49,6 +49,7 @@ def test_build_rollout_manifest_keeps_primary_compatibility_and_named_views():
         checkpoint_uri="s3://bucket/model_latest.pt",
         checkpoint_sha256="b" * 64,
         checkpoint_size_bytes=12345,
+        simulation_device="cpu",
         is_trained=True,
         capture={"width": 640, "height": 480, "fps": 10.0},
         camera_metadata_items=[
@@ -80,6 +81,7 @@ def test_build_rollout_manifest_keeps_primary_compatibility_and_named_views():
     )
     assert manifest["policy_checkpoint_sha256"] == "b" * 64
     assert manifest["policy_checkpoint_size_bytes"] == 12345
+    assert manifest["simulation_device"] == "cpu"
 
 
 def test_latest_checkpoint_uri_empty_inputs():
@@ -173,6 +175,13 @@ def test_build_isaac_rollout_job_manifest_shape():
     )
     assert "get_inference_policy(device=SIM_DEVICE)" in pr.ISAAC_ROLLOUT_SCRIPT
     assert 'device="cuda:0"' not in pr.ISAAC_ROLLOUT_SCRIPT
+    assert 'CameraType = CameraCfg if SIM_DEVICE == "cpu" else TiledCameraCfg' in (
+        pr.ISAAC_ROLLOUT_SCRIPT
+    )
+    assert "env_cfg.sim.use_fabric = False" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert "CPU physics camera fallback requires ROLLOUT_COUNT=1" in (
+        pr.ISAAC_ROLLOUT_SCRIPT
+    )
     assert '"simulation_device": SIM_DEVICE' in pr.ISAAC_ROLLOUT_SCRIPT
 
 

--- a/npa/tests/workflows/test_byo_isaac_policy_rollout.py
+++ b/npa/tests/workflows/test_byo_isaac_policy_rollout.py
@@ -182,6 +182,11 @@ def test_build_isaac_rollout_job_manifest_shape():
     assert "CPU physics camera fallback requires ROLLOUT_COUNT=1" in (
         pr.ISAAC_ROLLOUT_SCRIPT
     )
+    assert "def _write_rgb_png(path, rgb):" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert "from PIL import" not in pr.ISAAC_ROLLOUT_SCRIPT
+    assert "_write_rgb_png(os.path.join(d, name), arr[i])" in (
+        pr.ISAAC_ROLLOUT_SCRIPT
+    )
     assert '"simulation_device": SIM_DEVICE' in pr.ISAAC_ROLLOUT_SCRIPT
 
 

--- a/npa/tests/workflows/test_byo_isaac_policy_rollout.py
+++ b/npa/tests/workflows/test_byo_isaac_policy_rollout.py
@@ -174,7 +174,9 @@ def test_build_isaac_rollout_job_manifest_shape():
         pr.ISAAC_ROLLOUT_SCRIPT
     )
     assert "get_inference_policy(device=SIM_DEVICE)" in pr.ISAAC_ROLLOUT_SCRIPT
-    assert 'device="cuda:0"' not in pr.ISAAC_ROLLOUT_SCRIPT
+    assert 'OnPolicyRunner(env, acfg, log_dir=None, device="cuda:0")' not in (
+        pr.ISAAC_ROLLOUT_SCRIPT
+    )
     assert 'CameraType = CameraCfg if SIM_DEVICE == "cpu" else TiledCameraCfg' in (
         pr.ISAAC_ROLLOUT_SCRIPT
     )
@@ -184,6 +186,18 @@ def test_build_isaac_rollout_job_manifest_shape():
     )
     assert "def _write_rgb_png(path, rgb):" in pr.ISAAC_ROLLOUT_SCRIPT
     assert "from PIL import" not in pr.ISAAC_ROLLOUT_SCRIPT
+    assert '"/rtx/dataWindowNDC/2", 1.0' in pr.ISAAC_ROLLOUT_SCRIPT
+    assert '"/rtx/dataWindow/fitOutputToDataWindow", False' in (
+        pr.ISAAC_ROLLOUT_SCRIPT
+    )
+    assert "if arr.ndim == 3:" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert "arr = arr[None, ...]" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert 'get_annotator("rgb", device="cuda:0")' in pr.ISAAC_ROLLOUT_SCRIPT
+    assert "annotator.attach(sensor.render_product_paths)" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert "arr = arr.view(np.uint8)" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert pr.ISAAC_ROLLOUT_SCRIPT.index("obs, _, dones, extras = env.step(actions)") < (
+        pr.ISAAC_ROLLOUT_SCRIPT.index("capture(_step)")
+    )
     assert "_write_rgb_png(os.path.join(d, name), arr[i])" in (
         pr.ISAAC_ROLLOUT_SCRIPT
     )

--- a/npa/tests/workflows/test_byo_isaac_policy_rollout.py
+++ b/npa/tests/workflows/test_byo_isaac_policy_rollout.py
@@ -168,6 +168,11 @@ def test_build_isaac_rollout_job_manifest_shape():
     assert "--portable-root /tmp/npa-isaac-kit" in pr.ISAAC_ROLLOUT_SCRIPT
     assert "kit_args=os.environ.get(" in pr.ISAAC_ROLLOUT_SCRIPT
     assert "device=SIM_DEVICE" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert "OnPolicyRunner(env, acfg, log_dir=None, device=SIM_DEVICE)" in (
+        pr.ISAAC_ROLLOUT_SCRIPT
+    )
+    assert "get_inference_policy(device=SIM_DEVICE)" in pr.ISAAC_ROLLOUT_SCRIPT
+    assert 'device="cuda:0"' not in pr.ISAAC_ROLLOUT_SCRIPT
     assert '"simulation_device": SIM_DEVICE' in pr.ISAAC_ROLLOUT_SCRIPT
 
 


### PR DESCRIPTION
## Summary

- harden real Isaac policy-rollout capture so canonical Foxglove exports contain complete, synchronized multi-camera evidence
- keep physics and policy execution on the explicitly selected device while retaining the reserved RTX rendering requirement
- classify inaccessible sibling object-storage buckets as resource-scoped capability state instead of repeated global fatal-looking errors
- preserve narrow, fail-closed authorization for exact source-qualified artifact inventory and Foxglove playback

## Root cause

Live validation found two independent issues. First, the Isaac capture lifecycle could read camera buffers before the first rendered step, inherit unset RTX data-window defaults, depend on an optional PNG library, or accept incomplete view coverage. That could leave a discoverable run without a trustworthy canonical motion recording. Second, tenant inventory correctly discovered buckets that the configured S3 credential could not read, but each expected bucket denial was duplicated into the report-wide error list even though the resource already carried denied list/read capabilities.

The access banner was therefore misleading, but it was not the playback root cause. Playback depends on complete source camera evidence and on retaining the exact server-issued project/bucket/prefix/run tuple through inventory, canonical export, publication, and SDK `setDataSource`.

## Fix and impact

The rollout now initializes the RTX data window, captures only after a rendered simulation step, writes PNG directly without an optional dependency, normalizes camera buffer shapes, records the selected simulation device, and fails closed when any required view or frame count is incomplete. A single-environment CPU-physics compatibility route remains explicit and still requires the RTX GPU for rendering.

Bucket probe denials remain visible on the affected bucket's discovery/read capabilities and keep its actions disabled. They are no longer promoted to the global access error banner. Tenant/project inventory failures remain global. Exact selected-source authorization still verifies project visibility, bucket ownership, current list/read scope, run reference, prefix, object identity, and canonical SHA-256 without depending on unrelated tenant-wide bucket probes.

## Validation

- Ruff clean; onboarding smoke: 104 passed; guardrails: 2,228 passed
- focused access, artifact, Foxglove backend/UI/CLI/MCAP/image, Isaac-rollout, and agent smoke tests: 310 passed, 1 skipped
- rendered-agent access/Foxglove tests: 149 passed, 1 skipped
- mocked Cypress: 111 passed across Agent UI, LeIsaac, and Foxglove suites
- full serial PR gate: 11,625 passed, 38 skipped, 12 intentionally deselected, 1 expected xpass
- docs drift, aggregate diff check, diff-scoped confidentiality scan, and gitleaks passed
- in-place agent bootstrap succeeded; built-in verification passed 324 local checks and 27 live checks with 2 intentional live skips
- live Cypress passed the Foxglove scenario in a clean browser; the two unrelated LeIsaac scenarios were intentionally pending
- live exact-run validation proved source-qualified discovery and inventory, canonical MCAP integrity and matching published SHA-256, 300 messages with 33 synchronized frames on each of three camera topics, HTTPS download, CORS preflight, byte ranges, and exact SDK data-source/layout binding in a clean browser
- post-deploy access validation retained inaccessible sibling resources at capability scope with zero global access errors

## Limitations

The qualification rollout uses a deterministic untrained policy, so it validates simulator execution, capture, provenance, storage, transport, and viewer behavior rather than trained-policy efficacy. The official hosted viewer can still require interactive sign-in and an eligible organization plan. CPU physics compatibility is limited to one rollout environment and still requires an RTX GPU for camera rendering.
