### PR TITLE
fix(configure): verify HF and NGC access

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -239,10 +239,13 @@ On a re-run every prompt is pre-filled with the value already saved in
 flow keeps your current setup unchanged, and typing a new value updates just
 that field. When object storage is already configured it defaults to keeping the
 existing bucket and S3 key (so a re-run does not mint a new access key); decline
-that prompt to re-provision. It then
-writes `~/.npa/credentials.yaml` and `~/.npa/config.yaml`, and prints a one-line
-`[NOTE]` summarizing which gated workbench models your HF and NGC tokens can (or
-cannot) access — see [§4e](#4e-accept-and-verify-gated-model-access):
+that prompt to re-provision. It then writes `~/.npa/credentials.yaml` and
+`~/.npa/config.yaml`, performs bounded live checks through the same Hugging Face
+model/dataset and NGC repository-entitlement paths as
+`npa workbench health access`, and prints a one-line `[NOTE]` summary. The note
+is advisory so a transient upstream outage does not undo otherwise valid local
+setup; use the health command as the access gate — see
+[§4e](#4e-accept-and-verify-gated-model-access):
 
 ```bash
 npa configure
@@ -449,10 +452,13 @@ A convenience wrapper is also available:
 HF_TOKEN=hf_xxx NGC_API_KEY=nvapi-xxx scripts/accept-model-access.sh
 ```
 
-The report is PASS/WARN/FAIL per model; it exits non-zero if a required gated
-model is still inaccessible, so it fits a CI or cold-start preflight. For the
-broader credential preflight (HF/NGC/S3/Token Factory presence and
-reachability), use `npa workbench health preflight`.
+The report is PASS/WARN/FAIL per model or repository; it exits non-zero if a
+required gated Hugging Face asset or NGC pull is definitively rejected, so it
+fits a CI or cold-start preflight. `npa configure` uses these same live access
+probes for its bounded advisory summary, but does not turn an optional missing
+credential or transient network failure into a setup failure. For the broader
+credential preflight (presence/format plus basic HF, S3, and Token Factory
+connectivity), use `npa workbench health preflight`.
 
 ## 5. First platform checks
 

--- a/docs/workbench/huggingface-token.md
+++ b/docs/workbench/huggingface-token.md
@@ -82,7 +82,9 @@ npa workbench health preflight --offline
 
 `health access` reports `HF access ok: <repo>` for each model your token can
 reach and, for anything still gated, the exact **Agree and access repository**
-URL to open.
+URL to open. Interactive `npa configure` runs the same repository-aware probe
+(including the dataset API for gated datasets) and prints a bounded advisory
+summary; use `health access` when you need an enforcing PASS/FAIL gate.
 
 ## Troubleshooting
 

--- a/docs/workbench/ngc-api-key.md
+++ b/docs/workbench/ngc-api-key.md
@@ -57,14 +57,17 @@ export NGC_API_KEY=nvapi-XXXXXXXXXXXXXXXXXXXX
 ## 3. Verify
 
 ```bash
-npa workbench health access          # checks NGC key presence/format + HF access
+npa workbench health access          # checks NGC repository entitlement + HF access
 # or presence-only, no network:
 npa workbench health preflight --offline
 ```
 
-A well-formed key (starting with `nvapi-`) reports as configured. A real image
-pull is the authoritative entitlement check; credentials alone do not grant
-rights or make restricted image bytes redistributable.
+A well-formed key (starting with `nvapi-`) is not treated as proof by itself.
+`health access` performs the registry token exchange and tag-listing request for
+the selected NGC repository without downloading image layers. Interactive
+`npa configure` uses the same probe for its bounded advisory summary. A
+successful pull preflight proves access at that moment; it does not grant rights
+or make restricted image bytes redistributable.
 
 ## Troubleshooting
 

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -1823,42 +1823,54 @@ def _run_interactive_configure(
     # the resumable prerequisite succeeds.
 
 
-def _probe_hf_repos_parallel(
+def _probe_hf_assets_parallel(
     validator: Callable[..., Any],
     token: str,
-    repos: Iterable[str],
+    assets: Iterable[Any],
     *,
     per_probe_timeout: float = 2.0,
     total_budget: float = 5.0,
-) -> dict[str, Any]:
-    """Probe HF access for *repos* concurrently within a wall-clock budget.
+) -> dict[tuple[str, str], Any]:
+    """Probe HF access for *assets* concurrently within a wall-clock budget.
 
-    Returns ``{repo: result}``. Repos that do not finish inside ``total_budget``
-    (or whose probe raises) are omitted, so the caller treats them as unverified
-    rather than stalling the primary onboarding command.
+    Cache keys include ``repo_type`` so datasets are never accidentally checked
+    through the model API. Assets that do not finish inside ``total_budget`` (or
+    whose probe raises) are omitted, so the caller treats them as unverified
+    rather than stalling the primary onboarding command. Exception messages are
+    deliberately not logged because an injected client may echo its credential.
     """
 
     from concurrent.futures import ThreadPoolExecutor
     from concurrent.futures import TimeoutError as FuturesTimeout
     from concurrent.futures import as_completed
 
-    repo_list = list(repos)
-    results: dict[str, Any] = {}
-    if not repo_list:
+    asset_list = list(assets)
+    results: dict[tuple[str, str], Any] = {}
+    if not asset_list:
         return results
-    pool = ThreadPoolExecutor(max_workers=min(8, len(repo_list)))
+    pool = ThreadPoolExecutor(max_workers=min(8, len(asset_list)))
     try:
         futures = {
-            pool.submit(validator, token, repo, timeout=per_probe_timeout): repo
-            for repo in repo_list
+            pool.submit(
+                validator,
+                token,
+                asset.repo,
+                asset.repo_type,
+                timeout=per_probe_timeout,
+            ): (asset.repo, asset.repo_type)
+            for asset in asset_list
         }
         try:
             for fut in as_completed(futures, timeout=total_budget):
-                repo = futures[fut]
+                cache_key = futures[fut]
                 try:
-                    results[repo] = fut.result()
-                except Exception:  # noqa: BLE001 - a failed probe -> unverified
-                    logger.debug("HF access probe failed for %s", repo, exc_info=True)
+                    results[cache_key] = fut.result()
+                except Exception as exc:  # noqa: BLE001 - failed probe -> unverified
+                    logger.debug(
+                        "HF access probe failed for %s (%s)",
+                        cache_key[0],
+                        type(exc).__name__,
+                    )
         except FuturesTimeout:
             # Budget exceeded: keep whatever finished; the rest stay unverified.
             logger.debug("HF access probe budget of %.1fs exceeded", total_budget)
@@ -1870,11 +1882,12 @@ def _probe_hf_repos_parallel(
 def _model_access_note(hf_token: str, ngc_key: str) -> str:
     """Return a one-line ``[NOTE]`` on which gated workbench models the tokens can access.
 
-    Runs a live Hugging Face access check for each license-gated model the
-    workbench uses and a presence/format check for the NGC key, then summarizes
-    the models without access on a single line. HF probes run in parallel under a
-    total wall-clock budget, and any failure is swallowed, so a preflight note
-    can never stall or break `npa configure`.
+    Runs the same repository-aware checks as ``npa workbench health access``:
+    each license-gated Hugging Face model or dataset is probed through the right
+    API, and NGC performs a real token-exchange/tag-listing entitlement probe.
+    Configure keeps these advisory: HF probes run in parallel under a wall-clock
+    budget, NGC uses the same short per-probe timeout, and failures never break
+    setup. The health command remains the authoritative enforcement gate.
     """
 
     try:
@@ -1883,24 +1896,29 @@ def _model_access_note(hf_token: str, ngc_key: str) -> str:
         from npa.workbench.model_access import (
             access_note,
             check_workbench_access,
-            gated_hf_repos,
+            gated_hf_assets,
         )
+        from npa.workbench.nurec.nurec import check_ngc_image_access
 
-        cache: dict[str, Any] = {}
+        cache: dict[tuple[str, str], Any] = {}
         if hf_token:
-            cache = _probe_hf_repos_parallel(
-                huggingface.validate_hf_access, hf_token, gated_hf_repos()
+            cache = _probe_hf_assets_parallel(
+                huggingface.validate_hf_access, hf_token, gated_hf_assets()
             )
 
         def _validator(token: str, repo: str, repo_type: str = "model"):
-            return cache.get(repo) or HFAccessResult(
+            return cache.get((repo, repo_type)) or HFAccessResult(
                 repo=repo, ok=False, error="not verified (timed out)"
             )
+
+        def _ngc_validator(api_key: str) -> str:
+            return check_ngc_image_access(api_key, timeout=2.0)
 
         results = check_workbench_access(
             hf_token=hf_token,
             ngc_key=ngc_key,
             hf_validator=_validator if hf_token else None,
+            ngc_validator=_ngc_validator,
             gated_only=True,
         )
         return access_note(results)

--- a/npa/src/npa/workbench/model_access.py
+++ b/npa/src/npa/workbench/model_access.py
@@ -9,10 +9,10 @@ account authorization upstream. NPA checks repository access with the supplied
 token and does not invent another acceptance flag. NGC access likewise requires
 both a key and a successful repository entitlement probe.
 
-Every check is a pure function that takes the resolved tokens plus an injectable
-Hugging Face validator; the CLI wires the real probe, tests inject fakes.
-Nothing here imports GPU-heavy packages or touches infrastructure at import
-time.
+Every check is a pure function that takes the resolved tokens plus injectable
+Hugging Face and NGC validators; the CLI wires the real probes, tests inject
+fakes. Nothing here imports GPU-heavy packages or touches infrastructure at
+import time.
 """
 
 from __future__ import annotations
@@ -135,8 +135,16 @@ def assets_for(capabilities: Iterable[str] | None) -> tuple[GatedAsset, ...]:
 
 def gated_hf_repos(capabilities: Iterable[str] | None = None) -> tuple[str, ...]:
     """Return the license-gated Hugging Face repos for *capabilities*."""
+    return tuple(asset.repo for asset in gated_hf_assets(capabilities))
+
+
+def gated_hf_assets(
+    capabilities: Iterable[str] | None = None,
+) -> tuple[GatedAsset, ...]:
+    """Return gated HF assets with the repository type needed by live probes."""
+
     return tuple(
-        asset.repo
+        asset
         for asset in assets_for(capabilities)
         if asset.provider == HF and asset.gated
     )
@@ -153,6 +161,13 @@ def _ngc_needed(capabilities: Iterable[str] | None) -> bool:
 
 def _cap_suffix(asset: GatedAsset) -> str:
     return f" [{', '.join(asset.capabilities)}]"
+
+
+def _redact_secret(text: Any, secret: str) -> str:
+    """Keep validator diagnostics useful without ever returning a credential."""
+
+    rendered = str(text or "")
+    return rendered.replace(secret, "<redacted>") if secret else rendered
 
 
 def check_hf_asset(
@@ -192,7 +207,16 @@ def check_hf_asset(
             status=PASS,
             summary=f"HF token present; {asset.repo} access not verified (offline).{caps}",
         )
-    result = hf_validator(token, asset.repo, asset.repo_type)
+    try:
+        result = hf_validator(token, asset.repo, asset.repo_type)
+    except Exception as exc:  # noqa: BLE001 - a probe exception is transient
+        return CheckResult(
+            name=name,
+            status=WARN,
+            summary=f"Could not verify HF access to {asset.repo} (transient).{caps}",
+            remedy="Retry when the network is available.",
+            details=(f"probe failed ({type(exc).__name__})",),
+        )
     if getattr(result, "ok", False):
         return CheckResult(
             name=name,
@@ -203,7 +227,10 @@ def check_hf_asset(
             ),
         )
     status_code = getattr(result, "status_code", None)
-    error = getattr(result, "error", "") or "unknown error"
+    error = _redact_secret(
+        getattr(result, "error", "") or "unknown error",
+        token,
+    )
     if status_code in {401, 403}:
         if asset.gated:
             return CheckResult(
@@ -281,20 +308,49 @@ def check_ngc_key(
                 "was not probed in offline mode."
             ),
         )
-    outcome = str(ngc_validator(key) or "unreachable")
+    try:
+        outcome = _redact_secret(ngc_validator(key) or "unreachable", key)
+    except Exception as exc:  # noqa: BLE001 - a probe exception is transient
+        return CheckResult(
+            name="ngc",
+            status=WARN,
+            summary="Could not verify NGC repository access (transient).",
+            remedy="Retry `npa workbench health access` when the network is available.",
+            details=(f"probe failed ({type(exc).__name__})",),
+        )
     if outcome == "reachable":
         return CheckResult(
             name="ngc",
             status=PASS,
             summary="NGC_API_KEY can pull the selected NuRec NRE repository.",
         )
+    credential_rejected = outcome in {
+        "auth-no-token",
+        "auth-401",
+        "auth-403",
+    }
+    entitlement_rejected = outcome in {
+        "entitlement-required",
+        "tags-401",
+        "tags-403",
+    }
+    rejected = credential_rejected or entitlement_rejected
+    if credential_rejected:
+        summary = f"NGC credential rejected during repository auth: {outcome}."
+    elif entitlement_rejected:
+        summary = f"NGC repository entitlement denied: {outcome}."
+    else:
+        summary = f"NGC repository pull preflight failed: {outcome}."
     return CheckResult(
         name="ngc",
-        status=FAIL if outcome == "entitlement-required" else WARN,
-        summary=f"NGC repository pull preflight failed: {outcome}.",
+        status=FAIL if rejected else WARN,
+        summary=summary,
         remedy=(
-            "Verify NGC_API_KEY and repository entitlement. The credential alone "
-            "does not grant pull access."
+            "Regenerate NGC_API_KEY with NGC Catalog access if needed, verify the "
+            "repository entitlement, then re-run `npa workbench health access`."
+            if rejected
+            else "Retry when the NGC registry is reachable; credential presence "
+            "alone does not prove pull access."
         ),
     )
 
@@ -338,9 +394,9 @@ def access_note(results: list[CheckResult]) -> str:
     """Return a one-line ``[NOTE]`` naming the models HF/NGC cannot access.
 
     HF entries with a definitive rejection (401/403) are listed as "no access";
-    entries that could not be reached are counted as "unverified". NGC access is
-    a key presence/format check (there is no offline NGC probe), so a missing or
-    malformed key lists the NVIDIA models its absence blocks.
+    entries that could not be reached are counted as "unverified". NGC separates
+    missing/malformed keys, transient probe failures, credential rejection, and
+    repository-entitlement denial.
     """
 
     hf_no = [r.name for r in results if r.name != "ngc" and r.status == FAIL]
@@ -353,6 +409,11 @@ def access_note(results: list[CheckResult]) -> str:
         and ("not set" in ngc.summary or "does not look" in ngc.summary)
     )
     ngc_unverified = bool(ngc is not None and ngc.status == WARN and not ngc_missing)
+    ngc_credential_rejected = bool(
+        ngc is not None
+        and ngc.status == FAIL
+        and "credential rejected" in ngc.summary
+    )
 
     if not hf_no and ngc_ok and not hf_unverified:
         return "[NOTE] HF and NGC tokens can access all checked workbench models."
@@ -373,6 +434,10 @@ def access_note(results: list[CheckResult]) -> str:
             "NGC repository entitlement unverified for: "
             + ", ".join(NGC_CAPABILITIES)
         )
+    elif ngc_credential_rejected:
+        parts.append(
+            "NGC credential rejected for: " + ", ".join(NGC_CAPABILITIES)
+        )
     elif not ngc_ok:
         parts.append(
             "NGC repository entitlement denied for: "
@@ -384,6 +449,7 @@ def access_note(results: list[CheckResult]) -> str:
     note = "[NOTE] " + "; ".join(parts) + "."
     if hf_no:
         note += " Accept gated licenses at https://huggingface.co/<model>."
+    note += " Re-run `npa workbench health access` for full remediation."
     return note
 
 
@@ -400,6 +466,7 @@ __all__ = [
     "check_hf_asset",
     "check_ngc_key",
     "check_workbench_access",
+    "gated_hf_assets",
     "gated_hf_repos",
     "has_failure",
     "hf_model_url",

--- a/npa/tests/cli/test_main.py
+++ b/npa/tests/cli/test_main.py
@@ -17,21 +17,25 @@ runner = CliRunner()
 
 
 @pytest.fixture(autouse=True)
-def _stub_hf_model_access(monkeypatch):
-    """Keep `npa configure`'s model-access NOTE off the real Hugging Face API.
+def _stub_model_access(monkeypatch):
+    """Keep `npa configure`'s model-access NOTE off real HF and NGC APIs.
 
-    `configure` runs a live HF access check for the gated workbench models after
-    collecting tokens. Default every probe to "accessible" so unrelated tests
-    stay hermetic; individual tests override this to exercise the NOTE.
+    `configure` runs live access checks after collecting tokens. Default every
+    probe to "accessible" so unrelated tests stay hermetic; individual tests
+    override these fakes to exercise the NOTE.
     """
 
     from npa.clients import huggingface
     from npa.clients.huggingface import HFAccessResult
 
-    def _ok(token, repo, *, timeout=10.0):
+    def _ok(token, repo, repo_type="model", *, timeout=10.0):
         return HFAccessResult(repo=repo, ok=True, status_code=200)
 
     monkeypatch.setattr(huggingface, "validate_hf_access", _ok)
+    monkeypatch.setattr(
+        "npa.workbench.nurec.nurec.check_ngc_image_access",
+        lambda key, *, timeout=30.0: "reachable",
+    )
 
     from npa.clients import storage_setup, storage_validation
     from npa.clients.storage_validation import StorageProbeResult
@@ -1364,14 +1368,33 @@ def _note_line(output: str) -> str:
 
 
 def test_configure_prints_model_access_note_all_ok(monkeypatch, tmp_path) -> None:
-    # Autouse fixture makes every HF probe succeed. Configure does not pull an
-    # NGC image, so a well-formed key cannot prove repository entitlement here.
+    # The autouse fixture makes both canonical live access probes succeed.
     result = _run_reuse_bucket_configure(
         monkeypatch, tmp_path, hf_token="hf_good", ngc_key="nvapi-good"
     )
     assert result.exit_code == 0, result.output
     note = _note_line(result.output)
-    assert note == "[NOTE] NGC repository entitlement unverified for: nurec."
+    assert note == "[NOTE] HF and NGC tokens can access all checked workbench models."
+
+
+def test_configure_hf_probe_preserves_gated_dataset_type(monkeypatch, tmp_path) -> None:
+    from npa.clients import huggingface
+    from npa.clients.huggingface import HFAccessResult
+
+    observed: dict[str, str] = {}
+
+    def _record(token, repo, repo_type="model", *, timeout=10.0):
+        observed[repo] = repo_type
+        return HFAccessResult(repo=repo, ok=True, status_code=200)
+
+    monkeypatch.setattr(huggingface, "validate_hf_access", _record)
+
+    result = _run_reuse_bucket_configure(
+        monkeypatch, tmp_path, hf_token="hf_synthetic", ngc_key="nvapi-synthetic"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed["nvidia/PhysicalAI-Autonomous-Vehicles"] == "dataset"
 
 
 def test_configure_note_lists_inaccessible_hf_models(monkeypatch, tmp_path) -> None:
@@ -1380,7 +1403,7 @@ def test_configure_note_lists_inaccessible_hf_models(monkeypatch, tmp_path) -> N
 
     denied = "nvidia/Cosmos-Reason2-2B"
 
-    def _deny_one(token, repo, *, timeout=10.0):
+    def _deny_one(token, repo, repo_type="model", *, timeout=10.0):
         if repo == denied:
             return HFAccessResult(
                 repo=repo, ok=False, status_code=403, error="no access"
@@ -1399,6 +1422,26 @@ def test_configure_note_lists_inaccessible_hf_models(monkeypatch, tmp_path) -> N
     assert "huggingface.co" in note
 
 
+def test_configure_note_reports_ngc_entitlement_rejection(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(
+        "npa.workbench.nurec.nurec.check_ngc_image_access",
+        lambda key, *, timeout=30.0: "entitlement-required",
+    )
+    secret = "nvapi-synthetic-rejected"
+
+    result = _run_reuse_bucket_configure(
+        monkeypatch, tmp_path, hf_token="hf_synthetic", ngc_key=secret
+    )
+
+    assert result.exit_code == 0, result.output
+    note = _note_line(result.output)
+    assert "NGC repository entitlement denied for: nurec" in note
+    assert "npa workbench health access" in note
+    assert secret not in note
+
+
 def test_configure_note_lists_ngc_blocked_when_key_missing(
     monkeypatch, tmp_path
 ) -> None:
@@ -1413,16 +1456,35 @@ def test_configure_note_lists_ngc_blocked_when_key_missing(
     assert "groot" not in note and "cosmos" not in note
 
 
-def test_configure_note_never_breaks_on_probe_error(monkeypatch, tmp_path) -> None:
+def test_configure_note_keeps_optional_hf_and_ngc_credentials_non_blocking(
+    monkeypatch, tmp_path
+) -> None:
+    result = _run_reuse_bucket_configure(
+        monkeypatch, tmp_path, hf_token="", ngc_key=""
+    )
+
+    assert result.exit_code == 0, result.output
+    note = _note_line(result.output)
+    assert "NGC not configured" in note
+    assert "model(s) unverified" in note
+    assert "npa workbench health access" in note
+
+
+def test_configure_note_never_breaks_on_probe_error(
+    monkeypatch, tmp_path, caplog
+) -> None:
     from npa.clients import huggingface
 
-    def _boom(token, repo, *, timeout=10.0):
-        raise RuntimeError("network exploded")
+    secret = "hf_synthetic_not_for_logs"
+
+    def _boom(token, repo, repo_type="model", *, timeout=10.0):
+        raise RuntimeError(f"network exploded for {token}")
 
     monkeypatch.setattr(huggingface, "validate_hf_access", _boom)
+    caplog.set_level("DEBUG", logger="npa.cli.main")
 
     result = _run_reuse_bucket_configure(
-        monkeypatch, tmp_path, hf_token="hf_good", ngc_key="nvapi-good"
+        monkeypatch, tmp_path, hf_token=secret, ngc_key="nvapi-good"
     )
     # A probe blowing up must not break configure; each affected model is simply
     # reported as unverified on the single NOTE line.
@@ -1430,6 +1492,8 @@ def test_configure_note_never_breaks_on_probe_error(monkeypatch, tmp_path) -> No
     note = _note_line(result.output)
     assert note.startswith("[NOTE]")
     assert "unverified" in note
+    assert secret not in note
+    assert secret not in caplog.text
 
 
 def _prepopulate_config(monkeypatch, tmp_path):

--- a/npa/tests/cli/test_workbench_health_cli.py
+++ b/npa/tests/cli/test_workbench_health_cli.py
@@ -370,6 +370,60 @@ def test_access_pass_when_validator_ok(monkeypatch) -> None:
     assert "ngc" in {c["name"] for c in payload["checks"]}
 
 
+def test_access_fails_on_ngc_auth_rejection(monkeypatch) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(
+        health_module, "load_credentials", lambda *a, **k: _AccessCreds()
+    )
+    monkeypatch.setattr(
+        health_module,
+        "validate_hf_access",
+        lambda token, repo, repo_type: _HFOK(ok=True),
+    )
+    monkeypatch.setattr(
+        "npa.workbench.nurec.nurec.check_ngc_image_access",
+        lambda key: "auth-401",
+    )
+
+    result = runner.invoke(
+        app,
+        ["workbench", "health", "access", "--capability", "nurec"],
+    )
+
+    assert result.exit_code == 1
+    assert "FAIL" in result.output
+    assert "NGC Catalog access" in result.output
+
+
+def test_access_warns_on_transient_ngc_failure_without_rejecting_key(
+    monkeypatch,
+) -> None:
+    from npa.cli.workbench import health as health_module
+
+    monkeypatch.setattr(
+        health_module, "load_credentials", lambda *a, **k: _AccessCreds()
+    )
+    monkeypatch.setattr(
+        health_module,
+        "validate_hf_access",
+        lambda token, repo, repo_type: _HFOK(ok=True),
+    )
+    monkeypatch.setattr(
+        "npa.workbench.nurec.nurec.check_ngc_image_access",
+        lambda key: "unreachable",
+    )
+
+    result = runner.invoke(
+        app,
+        ["workbench", "health", "access", "--capability", "nurec"],
+    )
+
+    assert result.exit_code == 0
+    assert "WARN" in result.output
+    assert "credential presence alone does not prove pull access" in result.output
+
+
 def test_access_rejects_unknown_capability(monkeypatch) -> None:
     from npa.cli.workbench import health as health_module
 

--- a/npa/tests/workbench/test_model_access.py
+++ b/npa/tests/workbench/test_model_access.py
@@ -13,6 +13,7 @@ from npa.workbench.model_access import (
     check_hf_asset,
     check_ngc_key,
     check_workbench_access,
+    gated_hf_assets,
     gated_hf_repos,
     has_failure,
     hf_model_url,
@@ -134,6 +135,33 @@ def test_hf_transient_error_warns() -> None:
     assert result.status == WARN
 
 
+def test_hf_validator_diagnostic_redacts_token() -> None:
+    token = "hf_synthetic_secret"
+    result = check_hf_asset(
+        _gated_asset(),
+        token,
+        hf_validator=lambda t, r, k: _HFResult(
+            ok=False, status_code=403, error=f"upstream echoed {t}"
+        ),
+    )
+
+    assert token not in " ".join((*result.details, result.summary, result.remedy))
+    assert "<redacted>" in result.details[0]
+
+
+def test_hf_validator_exception_is_sanitized() -> None:
+    token = "hf_synthetic_exception_secret"
+
+    def _raise(t, r, k):
+        raise RuntimeError(f"upstream echoed {t}")
+
+    result = check_hf_asset(_gated_asset(), token, hf_validator=_raise)
+
+    assert result.status == WARN
+    assert token not in " ".join((*result.details, result.summary, result.remedy))
+    assert result.details == ("probe failed (RuntimeError)",)
+
+
 def test_ngc_warns_when_needed_and_missing() -> None:
     assert check_ngc_key("", needed=True).status == WARN
 
@@ -171,6 +199,59 @@ def test_ngc_credential_does_not_masquerade_as_entitlement() -> None:
     )
     assert result.status == FAIL
     assert "entitlement" in result.summary
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    ["auth-no-token", "auth-401", "auth-403"],
+)
+def test_ngc_definitive_auth_rejection_fails(outcome: str) -> None:
+    result = check_ngc_key(
+        "nvapi-synthetic",
+        needed=True,
+        ngc_validator=lambda key: outcome,
+    )
+
+    assert result.status == FAIL
+    assert "credential rejected" in result.summary
+    assert "health access" in result.remedy
+
+
+@pytest.mark.parametrize("outcome", ["entitlement-required", "tags-401", "tags-403"])
+def test_ngc_definitive_entitlement_rejection_fails(outcome: str) -> None:
+    result = check_ngc_key(
+        "nvapi-synthetic",
+        needed=True,
+        ngc_validator=lambda key: outcome,
+    )
+
+    assert result.status == FAIL
+    assert "entitlement denied" in result.summary
+    assert "health access" in result.remedy
+
+
+def test_ngc_transport_failure_warns() -> None:
+    result = check_ngc_key(
+        "nvapi-synthetic",
+        needed=True,
+        ngc_validator=lambda key: "unreachable",
+    )
+
+    assert result.status == WARN
+    assert "reachable" in result.remedy
+
+
+def test_ngc_validator_exception_is_sanitized() -> None:
+    secret = "nvapi-synthetic-exception-secret"
+
+    def _raise(key: str) -> str:
+        raise RuntimeError(f"upstream echoed {key}")
+
+    result = check_ngc_key(secret, needed=True, ngc_validator=_raise)
+
+    assert result.status == WARN
+    assert secret not in " ".join((*result.details, result.summary, result.remedy))
+    assert result.details == ("probe failed (RuntimeError)",)
 
 
 def test_ngc_warns_on_bad_prefix() -> None:
@@ -221,6 +302,13 @@ def test_gated_hf_repos_returns_only_gated_hf() -> None:
     assert "nvidia/GR00T-N1.7-3B" not in groot
     assert "nvidia/Cosmos-Reason2-2B" in groot
     assert all("groot" in a.capabilities for a in WORKBENCH_ASSETS if a.repo in groot)
+
+
+def test_gated_hf_assets_preserve_repository_types() -> None:
+    assets = {asset.repo: asset for asset in gated_hf_assets()}
+
+    assert assets["nvidia/PhysicalAI-Autonomous-Vehicles"].repo_type == "dataset"
+    assert assets["nvidia/Cosmos-Reason2-2B"].repo_type == "model"
 
 
 def test_check_workbench_access_gated_only_skips_public() -> None:
@@ -278,6 +366,20 @@ def test_access_note_ngc_missing_names_capabilities() -> None:
     assert "nurec" in note
     # NGC line must not conflate HF repo IDs with NGC container access.
     assert "nvidia/" not in note
+
+
+def test_access_note_distinguishes_ngc_credential_rejection() -> None:
+    results = check_workbench_access(
+        hf_token="hf_synthetic",
+        ngc_key="nvapi-synthetic",
+        hf_validator=lambda t, r, k: _HFResult(ok=True),
+        ngc_validator=lambda key: "auth-401",
+        gated_only=True,
+    )
+
+    note = access_note(results)
+    assert "NGC credential rejected for: nurec" in note
+    assert "entitlement denied" not in note
 
 
 def test_access_note_counts_unverified() -> None:


### PR DESCRIPTION
## What changed

- make `npa configure` reuse the canonical Hugging Face model/dataset and NGC repository-access probes used by `npa workbench health access`
- preserve Hugging Face repository types so gated datasets are checked through the dataset API
- distinguish definitive NGC credential rejection, repository-entitlement denial, and transient registry failures
- keep configure's interactive and non-interactive setup advisory and non-blocking while directing users to the enforcing health command
- redact credentials from validator diagnostics and sanitize probe exceptions
- document the revised configure/access contract and add focused synthetic tests for success, rejection, transient failure, and optional/missing credentials

## Why

`npa configure` previously treated a well-formed NGC key as unverified without exercising the canonical repository entitlement check, and its Hugging Face probe discarded repository type information. This could misclassify gated dataset access and provided less useful NGC guidance than the health command.

## User and developer impact

Users now get a bounded live access summary after configuration that matches the canonical health behavior. A transient upstream outage still does not invalidate otherwise successful setup; `npa workbench health access` remains the deterministic enforcing gate. Developers have one shared credential-access classification path with test coverage for redaction and failure modes.

## Validation

- `npa/.venv/bin/python -m pytest npa/tests/cli/test_main.py npa/tests/cli/test_workbench_health_cli.py npa/tests/workbench/test_model_access.py npa/tests/workflows/test_credential_preflight.py -q` — 185 passed
- `npa/.venv/bin/python -m ruff check npa/src npa/tests` — passed
- `make test-smoke PYTHON="$(pwd)/npa/.venv/bin/python"` — 110 passed
- `npa/.venv/bin/python -m pytest npa/tests/guardrails -q` — passed
- `make test PYTHON="$(pwd)/npa/.venv/bin/python"` — 11,791 passed, 37 skipped, 12 deselected, 1 xpassed
- `bash scripts/build_docs.sh --check` — passed
- diff-scoped confidentiality guardrail — passed, 0 hits
- Gitleaks over `origin/main..HEAD` — passed, no leaks

## Limitations

- External access scenarios are covered with synthetic placeholders and mocked responses; no live customer credentials, model downloads, image layers, or infrastructure were used.
- Configure intentionally treats access checks as advisory. Use `npa workbench health access` when a failing exit status is required.
