### PR TITLE
fix: make the agent-guided Workbench first run reliable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ You bring a robot, a dataset, or a pipeline idea. `npa` brings the containers,
 the orchestration, and the preflight checks that catch a missing token before it
 stalls your run.
 
+Workbench is meant to be operated by **your own coding agent**. Connect the
+agent to this checkout with terminal access, attach your cloud and model
+credentials through its private environment or secret manager, and ask it to
+configure, validate, provision, submit, and inspect workflows with you. The
+prompts below are a starting point; you do not need to learn every `npa` command
+before running something real.
+
 |                       |                                                                                                              |
 | --------------------- | ------------------------------------------------------------------------------------------------------------ |
 | **What you can do**   | Curate datasets · train and evaluate policies · render synthetic data · run sim-to-real loops · serve models  |
@@ -97,6 +104,52 @@ each setup guide inline: [Hugging Face](docs/workbench/huggingface-token.md) ·
 [NVIDIA NGC](docs/workbench/ngc-api-key.md) ·
 [Nebius Token Factory](docs/workbench/token-factory-key.md).
 
+If an agent is operating the checkout, attach these values to its **private
+environment** instead of pasting token values into chat:
+
+```bash
+NEBIUS_TENANT_ID=<your-tenant-id>
+NEBIUS_PROJECT_ID=<your-project-id>
+NEBIUS_REGION=<your-project-region>
+HF_TOKEN=<your-hugging-face-read-token>
+NGC_API_KEY=<your-ngc-api-key>
+NEBIUS_TOKEN_FACTORY_KEY=<your-token-factory-key>
+```
+
+The Hugging Face account behind `HF_TOKEN` must already have access to the
+models used by the workflow. A fine-grained token must include those repos.
+Gated terms can only be accepted by you on Hugging Face; the access check below
+prints every exact page still requiring action. NGC is part of the general
+Workbench setup even though the PAIDF + Cosmos 3 path below currently obtains
+its model weights from Hugging Face. Token Factory is required by that path for
+captioning and evaluation.
+
+Then give your agent this prompt:
+
+```text
+Set up Nebius Physical AI Workbench in this checkout. Read AGENTS.md and
+skills/index.yaml first and follow the relevant first-run, credential-preflight,
+and GPU guidance.
+
+Use NEBIUS_TENANT_ID, NEBIUS_PROJECT_ID, NEBIUS_REGION, HF_TOKEN, NGC_API_KEY,
+and NEBIUS_TOKEN_FACTORY_KEY from the private process environment. Never print
+secret values, put them in command arguments, or write them into the repository.
+Use NPA_PROJECT_ALIAS if it is set; otherwise use "workbench" as the local alias.
+
+Install or verify npa, verify the active Nebius CLI identity, and configure the
+known tenant, project, and region non-interactively. Persist supported environment
+credentials with npa configure --save-env-credentials and provision or reuse
+writable project object storage. Then run npa configure --show,
+npa workbench health preflight --json, and
+npa workbench health access --capability paidf,cosmos3 --json.
+
+Do not bypass a failed gate or provision GPU resources yet. If Hugging Face
+access is missing, give me the exact model-page links, wait for me to accept the
+terms, and rerun the check. Finish only when project storage, credentials, and
+the PAIDF/Cosmos 3 model access checks pass, then guide me straight into my first
+workflow.
+```
+
 > Creating projects from the CLI, SSO/federation profiles, non-interactive
 > automation, and the full credential model live in
 > **[docs/quickstart.md](docs/quickstart.md)**.
@@ -118,6 +171,41 @@ Once it comes back green, launch something real on Nebius GPUs. The flagship is
 any robot guide below will take you from a public dataset to a trained and
 evaluated policy.
 
+**Do not stop at setup.** Keep the same agent in the loop and have it guide the
+first workflow from input selection through the final artifact. For the
+Physical AI Data Factory with real source-video-conditioned Cosmos 3, attach a
+local H.264 MP4 or set `PAIDF_INPUT_URI` to one private `s3://` MP4, then paste:
+
+```text
+Run my first Workbench workflow with me: the PAIDF Cosmos 3 video-conditioning
+workflow at npa/workflows/workbench/npa-workflows/paidf-cosmos3.yaml. Follow
+docs/workbench/guides/paidf-cosmos3.md and the repository skills. Use the
+configured Nebius project, region, writable bucket, and credentials. Use the
+attached local H.264 MP4, or PAIDF_INPUT_URI if it is set; if neither is
+available, ask me only for the input video before continuing. Keep all input and
+artifact locations private.
+
+Re-run the credential and model-access gates for paidf,cosmos3. Validate and
+plan the spec with the real bucket and input, starting with one variant and one
+supported GPU. Bootstrap and verify SkyPilot, discover the accelerator name the
+target cluster advertises, and provision the required CPU/GPU resources if they
+are absent. Show me the validated plan and explain the resources it will create,
+then stage the input, preflight the selected images, and submit with --runtime.
+Forward only secret names through --secret-env: HF_TOKEN,
+NEBIUS_TOKEN_FACTORY_KEY, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY; never put
+secret values in YAML or command arguments.
+
+Stay with the run until it reaches a terminal state. If it fails, diagnose the
+recorded stage and resume safely rather than starting an unrelated run. If it
+succeeds, show me the generated and curated artifacts and load the final Rerun
+recording when an agent viewer is available.
+```
+
+The workflow uses the independent
+[`paidf-cosmos3.yaml`](docs/workbench/guides/paidf-cosmos3.md) composition; the
+original Physical AI Data Factory workflow continues to use Cosmos Transfer
+2.5.
+
 ---
 
 ## Pick your first win
@@ -132,6 +220,7 @@ Short, copy-paste walkthroughs. Pick whichever sounds fun — they are independe
 | Make a Unitree G1 walk                           | [G1 + SONIC](docs/workbench/guides/g1-humanoid-walk-sonic.md)                             | GPU cluster                |
 | Train a quadruped to run                         | [Quadruped + Isaac Lab](docs/workbench/guides/quadruped-isaac-lab.md)                     | RT-core GPU                |
 | Run the flagship GPU workload                    | [NVIDIA Cosmos](docs/quickstart.md#7-flagship-gpu-workload-nvidia-cosmos)                 | GPU cluster                |
+| Augment robot video with PAIDF + Cosmos 3        | [PAIDF with Cosmos 3](docs/workbench/guides/paidf-cosmos3.md)                             | GPU cluster + S3           |
 | Run a real data pipeline, not a robot            | [Physical AI Data Factory](docs/workbench/guides/physical-ai-data-factory-deploy.md)      | GPU cluster + S3           |
 | Rebuild a real scene in 3D                       | [Neural reconstruction](docs/workbench/guides/neural-reconstruction.md)                   | RT-core GPU                |
 | Get a browser workbench with a Rerun viewer      | [Deploy the `npa` agent](docs/agent.md)                                                  | Terraform + S3 (~20 min)   |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ and GPU guidance.
 Use NEBIUS_TENANT_ID, NEBIUS_PROJECT_ID, NEBIUS_REGION, HF_TOKEN, NGC_API_KEY,
 and NEBIUS_TOKEN_FACTORY_KEY from the private process environment. Never print
 secret values, put them in command arguments, or write them into the repository.
+Never run `env`, `printenv`, `set`, `export -p`, or another command that dumps
+the process environment; inspect only allowlisted names and report present or
+missing. Do not read credential files except through npa's credential APIs.
 Use NPA_PROJECT_ALIAS if it is set; otherwise use "workbench" as the local alias.
 
 Install or verify npa and its reported host prerequisites, including Terraform
@@ -193,6 +196,10 @@ configured Nebius project, region, writable bucket, and credentials. Use the
 attached local H.264 MP4, or PAIDF_INPUT_URI if it is set; if neither is
 available, ask me only for the input video before continuing. Keep all input and
 artifact locations private.
+
+Never run `env`, `printenv`, `set`, `export -p`, or another command that dumps
+the process environment. Inspect only allowlisted variable names and report
+present or missing; do not print secret values or read credential files directly.
 
 Re-run the credential and model-access gates for paidf,cosmos3. Validate and
 plan the spec with the real bucket and input, starting with one variant and one

--- a/README.md
+++ b/README.md
@@ -218,7 +218,11 @@ secret values in YAML or command arguments.
 Stay with the run until it reaches a terminal state. If it fails, diagnose the
 recorded stage and resume safely rather than starting an unrelated run. If it
 succeeds, show me the generated and curated artifacts and load the final Rerun
-recording when an agent viewer is available.
+recording when an agent viewer is available. A terminal quality rejection after
+the workflow's bounded refinement loop is a valid fail-closed result: do not
+lower the threshold or force promotion. Show me the generated video, evaluator
+report, quality disposition, and Rerun evidence, and explain that labeling and
+curation were intentionally skipped.
 ```
 
 The workflow uses the independent

--- a/README.md
+++ b/README.md
@@ -142,11 +142,13 @@ and NEBIUS_TOKEN_FACTORY_KEY from the private process environment. Never print
 secret values, put them in command arguments, or write them into the repository.
 Use NPA_PROJECT_ALIAS if it is set; otherwise use "workbench" as the local alias.
 
-Install or verify npa, verify the active Nebius CLI identity, and configure the
-known tenant, project, and region non-interactively. Persist supported environment
-credentials with npa configure --save-env-credentials and provision or reuse
-writable project object storage. Confirm the active identity can create the
-tenant IAM objects that secure that storage. Then run npa configure --show,
+Install or verify npa and its reported host prerequisites, including Terraform
+and, for SkyPilot Kubernetes on Debian/Ubuntu, socat. Verify the active Nebius
+CLI identity and configure the known tenant, project, and region
+non-interactively. Persist supported environment credentials with npa configure
+--save-env-credentials and provision or reuse writable project object storage.
+Confirm the active identity can create the tenant IAM objects that secure that
+storage. Then run npa configure --show,
 npa workbench health preflight --json, and
 npa workbench health access --capability paidf,cosmos3 --json.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ Workbench setup even though the PAIDF + Cosmos 3 path below currently obtains
 its model weights from Hugging Face. Token Factory is required by that path for
 captioning and evaluation.
 
+The active Nebius CLI identity must also be allowed to administer tenant IAM
+during first-time storage setup. `npa configure` creates a project service
+account and access key plus a tenant IAM group and bucket-scoped permit; project
+admin alone is not sufficient. Remove any temporary broad role after setup and
+teardown are complete.
+
 Then give your agent this prompt:
 
 ```text
@@ -139,7 +145,8 @@ Use NPA_PROJECT_ALIAS if it is set; otherwise use "workbench" as the local alias
 Install or verify npa, verify the active Nebius CLI identity, and configure the
 known tenant, project, and region non-interactively. Persist supported environment
 credentials with npa configure --save-env-credentials and provision or reuse
-writable project object storage. Then run npa configure --show,
+writable project object storage. Confirm the active identity can create the
+tenant IAM objects that secure that storage. Then run npa configure --show,
 npa workbench health preflight --json, and
 npa workbench health access --capability paidf,cosmos3 --json.
 
@@ -187,10 +194,14 @@ artifact locations private.
 
 Re-run the credential and model-access gates for paidf,cosmos3. Validate and
 plan the spec with the real bucket and input, starting with one variant and one
-supported GPU. Bootstrap and verify SkyPilot, discover the accelerator name the
-target cluster advertises, and provision the required CPU/GPU resources if they
-are absent. Show me the validated plan and explain the resources it will create,
-then stage the input, preflight the selected images, and submit with --runtime.
+supported GPU. Honor configured TF_VAR_* topology and reserved-capacity settings.
+Bootstrap and verify SkyPilot, discover the accelerator name the target cluster
+advertises, and provision the required CPU/GPU resources if they are absent.
+Show me the validated plan and explain the resources it will create, then stage
+the input and preflight the selected images. If a selected image fails the
+SkyPilot bootstrap contract, build the repository's current compliant image,
+push it to an authorized private project registry at an immutable digest, and
+repeat preflight. Then submit with --runtime.
 Forward only secret names through --secret-env: HF_TOKEN,
 NEBIUS_TOKEN_FACTORY_KEY, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY; never put
 secret values in YAML or command arguments.

--- a/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
+++ b/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
@@ -938,7 +938,13 @@ def render_task_run_script(command: Sequence[str], *, preamble: str = "") -> str
         # succeeds), the overlay lands in the vendor interpreter, and the stage runs the stale
         # CLI. Live job 284: `No such command 'cosmos2'. Did you mean 'cosmos'?` — from an npa
         # predating the subcommand, while the recorded interpreter had the current one.
-        '  printf \'#!/bin/sh\\nexec "%s" -m npa "$@"\\n\' '
+        # The distribution intentionally has no top-level ``npa.__main__``.
+        # Invoke the same import-light module used by the installed console
+        # script so the shim stays bound to the recorded interpreter without
+        # relying on a scripts directory that may be outside PATH.  A live
+        # PAIDF/Cosmos 3 run reached the stage and failed immediately at
+        # ``python -m npa`` before this was corrected.
+        '  printf \'#!/bin/sh\\nexec "%s" -m npa.cli.entry "$@"\\n\' '
         '"$npa_python" > /tmp/npa-shim/npa\n'
         "  chmod +x /tmp/npa-shim/npa\n"
         '  export PATH="/tmp/npa-shim:$PATH"\n'

--- a/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
+++ b/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
@@ -939,12 +939,14 @@ def render_task_run_script(command: Sequence[str], *, preamble: str = "") -> str
         # CLI. Live job 284: `No such command 'cosmos2'. Did you mean 'cosmos'?` — from an npa
         # predating the subcommand, while the recorded interpreter had the current one.
         # The distribution intentionally has no top-level ``npa.__main__``.
-        # Invoke the same import-light module used by the installed console
-        # script so the shim stays bound to the recorded interpreter without
-        # relying on a scripts directory that may be outside PATH.  A live
-        # PAIDF/Cosmos 3 run reached the stage and failed immediately at
-        # ``python -m npa`` before this was corrected.
-        '  printf \'#!/bin/sh\\nexec "%s" -m npa.cli.entry "$@"\\n\' '
+        # Import and CALL the same lightweight entry function used by the
+        # installed console script so the shim stays bound to the recorded
+        # interpreter without relying on a scripts directory that may be
+        # outside PATH.  Calling it explicitly also supports older baked NPA
+        # images whose entry module defines ``main`` but has no ``__main__``
+        # guard: ``python -m npa.cli.entry`` silently exited 0 in a live Cosmos
+        # Evaluator stage and therefore produced no declared report.
+        '  printf \'#!/bin/sh\\nexec "%s" -c "from npa.cli.entry import main; main()" "$@"\\n\' '
         '"$npa_python" > /tmp/npa-shim/npa\n'
         "  chmod +x /tmp/npa-shim/npa\n"
         '  export PATH="/tmp/npa-shim:$PATH"\n'

--- a/npa/src/npa/provisioning.py
+++ b/npa/src/npa/provisioning.py
@@ -656,7 +656,10 @@ def provision_if_absent(
     needs_gpu_setup = bool(requested_accelerator or sky_smoke)
     if needs_gpu_setup and k8s_ready and not skip_k8s and not dry_run:
         from npa.controller_ownership import ensure_controller_owner
-        from npa.cli.cluster.terraform_lifecycle import _run_skypilot_smoke
+        from npa.cli.cluster.terraform_lifecycle import (
+            _check_skypilot_kubernetes,
+            _run_skypilot_smoke,
+        )
         from npa.orchestration.skypilot.k8s_gpu_catalog import (
             wait_for_kubernetes_accelerators,
         )
@@ -666,6 +669,13 @@ def provision_if_absent(
             actions.append(
                 f"controller:bound {owner.project_alias}/{owner.context}/{owner.cluster_id}"
             )
+
+            _check_skypilot_kubernetes(
+                Path(kubeconfig_path),
+                context,
+                sky_bin=sky_bin,
+            )
+            actions.append("skypilot:kubernetes-enabled")
 
             def report_gpu_status(message: str) -> None:
                 actions.append(f"gpu:{message}")
@@ -692,6 +702,7 @@ def provision_if_absent(
                     cluster_name,
                     requested_accelerator,
                     sky_bin=sky_bin,
+                    credentials_checked=True,
                 )
                 actions.append("sky-smoke:passed")
         except Exception as exc:  # noqa: BLE001 - return a resumable partial result

--- a/npa/src/npa/provisioning.py
+++ b/npa/src/npa/provisioning.py
@@ -532,6 +532,7 @@ def provision_if_absent(
                     count=desired_cpu_count,
                     platform=cpu_platform,
                     preset=cpu_preset,
+                    disk_size_gib=topology.cpu_disk_gib,
                 )
                 if desired_cpu_count
                 else None
@@ -541,7 +542,9 @@ def provision_if_absent(
                     count=desired_gpu_count,
                     platform=gpu_platform,
                     preset=gpu_preset,
-                    disk_size_gib=128 if mig_enabled else 0,
+                    disk_size_gib=(
+                        128 if mig_enabled else topology.gpu_disk_gib
+                    ),
                     capacity_block_group=capacity_block_group,
                     preemptible=bool(preemptible),
                 )
@@ -769,6 +772,8 @@ def _build_provision_plan(
     )
 
     cluster_exists = skip_k8s or _has_cached_kubeconfig(context, kubeconfig)
+    cpu_disk_gib = _terraform_disk_size_gib("TF_VAR_cpu_disk_size", 128)
+    gpu_disk_gib = _terraform_disk_size_gib("TF_VAR_gpu_disk_size", 1023)
     requested = resolve_topology(
         cluster_name=cluster_name,
         accelerator=accelerator,
@@ -780,6 +785,8 @@ def _build_provision_plan(
         gpu_platform=gpu_platform,
         gpu_preset=gpu_preset,
         preemptible=preemptible,
+        cpu_disk_gib=cpu_disk_gib,
+        gpu_disk_gib=gpu_disk_gib,
     )
     checks = []
     if skip_k8s:
@@ -825,6 +832,8 @@ def _build_provision_plan(
         gpu_platform=requested.gpu_platform,
         gpu_preset=requested.gpu_preset,
         preemptible=requested.gpu_preemptible,
+        cpu_disk_gib=requested.cpu_disk_gib,
+        gpu_disk_gib=requested.gpu_disk_gib,
     )
     return build_whole_path_plan(
         project_alias=alias,
@@ -835,6 +844,27 @@ def _build_provision_plan(
         checks=checks,
         mutation=not dry_run,
     )
+
+
+def _terraform_disk_size_gib(name: str, default: int) -> int:
+    """Resolve the Terraform worker-disk override used by ``cluster up``.
+
+    ``provision-if-absent`` delegates the real apply to ``cluster up``, which
+    already honors ``TF_VAR_cpu_disk_size`` and ``TF_VAR_gpu_disk_size``. The
+    immutable outer preflight must account for those same values or it can
+    reject an otherwise valid topology before Terraform sees it.
+    """
+
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a positive integer GiB value") from exc
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer GiB value")
+    return value
 
 
 def resolve_provision_plan(

--- a/npa/src/npa/workflows/data_factory_stages.py
+++ b/npa/src/npa/workflows/data_factory_stages.py
@@ -1398,9 +1398,11 @@ def _persist_quality_disposition(
         reasons.append("one or more required checks did not pass")
 
     accepted = not reasons
+    decision = "promote_checkpoint" if accepted else "loop_back"
     payload = {
         "schema": "npa.data_factory.quality_disposition.v1",
         "quality_status": "accepted" if accepted else "rejected",
+        "decision": decision,
         "evaluator_status": evaluator_status,
         "score": score,
         "threshold": numeric_threshold,
@@ -1429,11 +1431,8 @@ def write_quality_disposition(
     from npa.orchestration.npa_workflow.decisions import write_decision
 
     payload = _persist_quality_disposition(scores_uri, disposition_uri, threshold)
-    decision = (
-        "promote_checkpoint" if payload["quality_status"] == "accepted" else "loop_back"
-    )
+    decision = str(payload["decision"])
     write_decision(decision_uri, decision)
-    payload["decision"] = decision
     print(
         json.dumps(
             {

--- a/npa/tests/orchestration/npa_workflow/test_tool_pip_requirements.py
+++ b/npa/tests/orchestration/npa_workflow/test_tool_pip_requirements.py
@@ -338,9 +338,15 @@ def test_the_npa_console_script_is_shimmed_to_the_recorded_interpreter(
     # so the recorded source goes in front of it.
     assert 'export PYTHONPATH="$npa_src_path:$PYTHONPATH"' in run_script
     assert "${" not in run_script, "the placeholder guard rejects braced expansions"
-    # npa has no top-level __main__; the generated shim must invoke the same
-    # supported entry module as the installed console script.
-    assert 'exec "%s" -m npa.cli.entry "$@"' in run_script
+    # npa has no top-level __main__; the generated shim must call the same
+    # supported entry function as the installed console script.  An explicit
+    # call also works with older images whose entry module lacks a __main__
+    # guard and would otherwise silently no-op under ``python -m``.
+    assert (
+        'exec "%s" -c "from npa.cli.entry import main; main()" "$@"'
+        in run_script
+    )
+    assert 'exec "%s" -m npa.cli.entry "$@"' not in run_script
     assert 'exec "%s" -m npa "$@"' not in run_script
     # Both shims come from the same recorded interpreter.
     assert run_script.count('"$npa_python"') >= 2

--- a/npa/tests/orchestration/npa_workflow/test_tool_pip_requirements.py
+++ b/npa/tests/orchestration/npa_workflow/test_tool_pip_requirements.py
@@ -338,7 +338,10 @@ def test_the_npa_console_script_is_shimmed_to_the_recorded_interpreter(
     # so the recorded source goes in front of it.
     assert 'export PYTHONPATH="$npa_src_path:$PYTHONPATH"' in run_script
     assert "${" not in run_script, "the placeholder guard rejects braced expansions"
-    assert 'exec "%s" -m npa "$@"' in run_script
+    # npa has no top-level __main__; the generated shim must invoke the same
+    # supported entry module as the installed console script.
+    assert 'exec "%s" -m npa.cli.entry "$@"' in run_script
+    assert 'exec "%s" -m npa "$@"' not in run_script
     # Both shims come from the same recorded interpreter.
     assert run_script.count('"$npa_python"') >= 2
 

--- a/npa/tests/test_provisioning.py
+++ b/npa/tests/test_provisioning.py
@@ -167,6 +167,26 @@ def test_provision_if_absent_dry_run_reports_actions(
     assert result.storage_bucket == "s3://bucket/checkpoints/"
 
 
+def test_provision_if_absent_preflight_uses_terraform_disk_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_runtime(tmp_path, monkeypatch)
+    monkeypatch.setenv("TF_VAR_cpu_disk_size", "96")
+    monkeypatch.setenv("TF_VAR_gpu_disk_size", "600")
+
+    result = provisioning.provision_if_absent(
+        project="proj",
+        kubeconfig=tmp_path / "missing-kubeconfig",
+        dry_run=True,
+        skip_s3=True,
+    )
+
+    topology = result.preflight["topology"]
+    assert topology["cpu_disk_gib"] == 96
+    assert topology["gpu_disk_gib"] == 600
+    assert topology["required_network_ssd_gib"] == "696"
+
+
 def test_provision_dry_run_from_installed_package_ignores_cached_cluster(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/npa/tests/test_provisioning.py
+++ b/npa/tests/test_provisioning.py
@@ -83,6 +83,12 @@ def _successful_storage_probe(monkeypatch):
             "default_storage_class": "compute-csi-default-sc",
         },
     )
+    # SkyPilot context enablement has its own CLI tests. Provisioning tests
+    # assert orchestration and must never invoke a real SkyPilot process.
+    monkeypatch.setattr(
+        "npa.cli.cluster.terraform_lifecycle._check_skypilot_kubernetes",
+        lambda *_args, **_kwargs: ("sky", {}, "config"),
+    )
     # provision_if_absent resolves kubectl before calling the validator stubbed
     # above, so without this the cached-cluster tests pass only on a machine that
     # happens to have kubectl installed. Nothing here ever executes the binary.
@@ -350,6 +356,10 @@ def test_reused_cluster_runs_requested_skypilot_smoke(
     kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
     seen: list[tuple[object, ...]] = []
     monkeypatch.setattr(
+        "npa.cli.cluster.terraform_lifecycle._check_skypilot_kubernetes",
+        lambda *args, **kwargs: seen.append(("check", *args, kwargs)),
+    )
+    monkeypatch.setattr(
         "npa.cli.cluster.terraform_lifecycle._run_skypilot_smoke",
         lambda *args, **kwargs: seen.append(("smoke", *args, kwargs)),
     )
@@ -369,19 +379,25 @@ def test_reused_cluster_runs_requested_skypilot_smoke(
 
     assert result.status == "ok"
     assert "sky-smoke:passed" in result.actions
-    assert [item[0] for item in seen] == ["readiness", "smoke"]
-    readiness = seen[0]
+    assert [item[0] for item in seen] == ["check", "readiness", "smoke"]
+    assert seen[0] == (
+        "check",
+        kubeconfig,
+        "npa-cluster",
+        {"sky_bin": "/opt/npa/sky"},
+    )
+    readiness = seen[1]
     assert readiness[1] == ["RTXPRO6000:1"]
     assert readiness[-1]["kubeconfig"] == kubeconfig
     assert readiness[-1]["sky_bin"] == "/opt/npa/sky"
     assert readiness[-1]["label_known_gpus"] is True
-    assert seen[1] == (
+    assert seen[2] == (
         "smoke",
         kubeconfig,
         "npa-cluster",
         "npa-cluster",
         "RTXPRO6000:1",
-        {"sky_bin": "/opt/npa/sky"},
+        {"sky_bin": "/opt/npa/sky", "credentials_checked": True},
     )
 
 
@@ -396,6 +412,10 @@ def test_fresh_cluster_uses_the_same_readiness_then_smoke_boundary(
         seen.append(("up", kwargs))
 
     monkeypatch.setattr("npa.cli.cluster.terraform_lifecycle.up_cmd", up)
+    monkeypatch.setattr(
+        "npa.cli.cluster.terraform_lifecycle._check_skypilot_kubernetes",
+        lambda *_args, **kwargs: seen.append(("check", kwargs)),
+    )
     monkeypatch.setattr(
         "npa.orchestration.skypilot.k8s_gpu_catalog.wait_for_kubernetes_accelerators",
         lambda *_args, **kwargs: seen.append(("readiness", kwargs)) or {},
@@ -415,13 +435,15 @@ def test_fresh_cluster_uses_the_same_readiness_then_smoke_boundary(
     )
 
     assert result.status == "ok"
-    assert [item[0] for item in seen] == ["up", "readiness", "smoke"]
+    assert [item[0] for item in seen] == ["up", "check", "readiness", "smoke"]
     up_kwargs = seen[0][1]
     assert up_kwargs["sky_smoke"] is False
     assert up_kwargs["sky_bin"] == "/opt/npa/sky"
-    assert seen[1][1]["label_known_gpus"] is True
     assert seen[1][1]["sky_bin"] == "/opt/npa/sky"
+    assert seen[2][1]["label_known_gpus"] is True
     assert seen[2][1]["sky_bin"] == "/opt/npa/sky"
+    assert seen[3][1]["sky_bin"] == "/opt/npa/sky"
+    assert seen[3][1]["credentials_checked"] is True
 
 
 def test_cached_smoke_without_accelerator_keeps_auto_detection(

--- a/npa/tests/workflows/test_data_factory_stages.py
+++ b/npa/tests/workflows/test_data_factory_stages.py
@@ -1283,7 +1283,9 @@ def test_write_quality_disposition_routes_without_raising(
 
     assert result["quality_status"] == expected_status
     assert result["decision"] == expected_decision
-    assert json.loads(disposition.read_text())["quality_status"] == expected_status
+    persisted = json.loads(disposition.read_text())
+    assert persisted["quality_status"] == expected_status
+    assert persisted["decision"] == expected_decision
     assert decisions == [("s3://example/grade/decision.json", expected_decision)]
 
 
@@ -1406,7 +1408,9 @@ def test_dynamic_quality_disposition_persists_strict_route(
     assert result["quality_status"] == expected_status
     assert result["decision"] == expected_decision
     assert decisions == [("s3://example-bucket/run/decision.json", expected_decision)]
-    assert json.loads(disposition.read_text())["quality_status"] == expected_status
+    persisted = json.loads(disposition.read_text())
+    assert persisted["quality_status"] == expected_status
+    assert persisted["decision"] == expected_decision
 
 
 @pytest.mark.parametrize("contents", [None, "not-json", "[]"])


### PR DESCRIPTION
## Summary

- position Workbench as the surface operators connect their own coding agent to
- add copyable, secret-safe prompts for Nebius tenant/project/region setup, Hugging Face and NGC access, and an agent-guided first PAIDF workflow using Cosmos 3
- reinforce immediately after setup step 3 that the first workflow should be run under agent guidance
- make the cold-start path reliable by honoring provisioning disk overrides, checking Kubernetes readiness before GPU scheduling, and supporting older baked NPA CLI import/call surfaces
- persist the PAIDF quality decision in the durable disposition artifact before upload so bounded refinement resumes deterministically

## Fresh-machine proof

Validated from a newly deployed operator VM in `us-central1`, using a newly created disposable project and real gated-model credentials:

- setup completed from only the documented prompt, including credential/model access gates and writable object storage
- a fresh managed cluster provisioned one reserved RTX PRO 6000 GPU node; the existing B200 reservation was not used or modified
- the agent launched real Cosmos 3 video-to-video generation twice through the PAIDF bounded-refinement loop
- the refined run produced an 8-frame, 19.8 MB video plus a 20.0 MB Rerun evidence artifact and 32 durable objects
- the final score was `0.716296` against the unchanged `0.75` threshold and failed the hard checks, so the workflow correctly terminated as a quality rejection
- no rejected output entered label augmentation or curation; the generated video, evaluator report, disposition, repair audit, and Rerun evidence were preserved
- all disposable workflows, controllers, images, registry, cluster, VM, buckets, IAM, networks, and three setup projects were removed; the pre-existing RTX PRO 6000 and B200 capacity-block allocations were verified unchanged

## Validation

- `npa/.venv/bin/python -m pytest npa/tests --ignore=npa/tests/e2e -q` (11,789 passed, 50 skipped, 1 xpassed)
- targeted compatibility tests (159 passed)
- targeted PAIDF quality/disposition tests (111 passed)
- documentation guard tests (26 passed)
- guardrail suite (2,270 passed)
- `npa/.venv/bin/python -m ruff check npa/src npa/tests`
- `git diff --check`
- diff-scoped Nebius confidentiality scan (0 hits)
- gitleaks over `origin/main..HEAD` (no leaks)
