### PR TITLE
fix(cosmos3): default expandable_segments for the generation subprocess

### DIFF
--- a/npa/src/npa/workbench/cosmos/generate.py
+++ b/npa/src/npa/workbench/cosmos/generate.py
@@ -532,6 +532,12 @@ def run_cosmos3_generate(
         env.setdefault("HUGGING_FACE_HUB_TOKEN", token)
     env.setdefault("HF_HOME", str(Path(output_root).parent / "hf_home"))
     env.setdefault("TOKENIZERS_PARALLELISM", "false")
+    # Wan VAE decode allocates multi-GiB chunks; on 48GB-class GPUs (L40S) the
+    # default caching allocator fragments and OOMs with head-room still free.
+    # Same default the Alpamayo2-Super runtime ships; operators can override.
+    # Both spellings: torch renamed PYTORCH_CUDA_ALLOC_CONF to PYTORCH_ALLOC_CONF.
+    env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    env.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
 
     run = runner or subprocess.run
     completed = run(list(plan["argv"]), cwd=str(plan["repo"]), env=env, check=False)

--- a/npa/tests/workbench/test_cosmos3_generate.py
+++ b/npa/tests/workbench/test_cosmos3_generate.py
@@ -183,7 +183,10 @@ def test_run_generate_without_guardrails_needs_no_token_for_staged_weights(
     env.pop("HF_TOKEN")
     output_dir = tmp_path / "out"
 
+    captured_env: dict = {}
+
     def fake_runner(argv, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
         sample = output_dir / "npa-generate"
         sample.mkdir(parents=True)
         (sample / "vision.jpg").write_bytes(b"y" * 2048)
@@ -201,6 +204,10 @@ def test_run_generate_without_guardrails_needs_no_token_for_staged_weights(
     assert result["status"] == "executed"
     assert result["hf_auth"] == "skipped"
     assert result["guardrails"] is False
+    # Fragmentation-resilient allocator default (48GB-class GPUs OOM in the Wan
+    # VAE decode without it); operators can still override either spelling.
+    assert captured_env["PYTORCH_CUDA_ALLOC_CONF"] == "expandable_segments:True"
+    assert captured_env["PYTORCH_ALLOC_CONF"] == "expandable_segments:True"
 
 
 def test_staged_checkpoint_tilde_is_expanded(tmp_path: Path) -> None:


### PR DESCRIPTION
The Wan VAE decode allocates multi-GiB chunks; on 48GB-class GPUs (L40S) the default caching allocator fragments and OOMs with headroom still free. Observed live: a video2video run failed allocating 1.33 GiB with 45 MiB free while 2.88 GiB sat reserved-but-unallocated; with expandable_segments the same decode reached 1.29 GiB free before hitting the card's genuine capacity ceiling.

Set both spellings via env.setdefault (torch renamed PYTORCH_CUDA_ALLOC_CONF to PYTORCH_ALLOC_CONF), matching the default the Alpamayo2-Super runtime already ships; operators can still override. Locked in by an assertion in the existing runner-capture test.

## Summary

-

## Verification

- [ ] Ran the relevant unit, smoke, or workflow checks.
- [ ] For workflow/tool changes: ran or updated the matching skill smoke in `npa/tests/guardrails/test_skills_index.py`.
- [ ] Checked public-repo hygiene: no customer names, VM IPs, private endpoints, project IDs, tenant IDs, registry IDs, bucket names, or secrets.

## Skill Maintenance

- [ ] I updated the relevant root `skills/` entry and `skills/index.yaml`, or this PR does not change behavior that needs skill guidance.
