### PR TITLE
Support noninteractive object-storage shape selection

### DIFF
--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -25,6 +25,8 @@ Options
 --project-id  <str>  Known Nebius project ID for prompt-free configure (requires the other known-project flags).
 --region  <str>  Known Nebius project region for prompt-free configure.
 --project-alias  <str>  Local NPA alias to write for the known project (prompt-free configure).
+--bucket-storage-class  <str>  Storage class for a newly created known-project bucket: standard, enhanced, or intelligent.
+--bucket-size-gb  <str>  GiB cap for a newly created known-project bucket; 0 means unlimited.
 --help  Show this message and exit.
 ```
 
@@ -43,6 +45,8 @@ Options
 | `--project-id` | <str>  Known Nebius project ID for prompt-free configure (requires the other known-project flags). |
 | `--region` | <str>  Known Nebius project region for prompt-free configure. |
 | `--project-alias` | <str>  Local NPA alias to write for the known project (prompt-free configure). |
+| `--bucket-storage-class` | <str>  Storage class for a newly created known-project bucket: standard, enhanced, or intelligent. |
+| `--bucket-size-gb` | <str>  GiB cap for a newly created known-project bucket; 0 means unlimited. |
 | `--help` | Show this message and exit. |
 
 ## Subcommands

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -22,6 +22,8 @@ Options
 --project-id  <str>  Known Nebius project ID for prompt-free configure.
 --region  <str>  Known Nebius project region for prompt-free configure.
 --project-alias  <str>  Local NPA alias for prompt-free configure.
+--bucket-storage-class  <str>  Storage class for a newly created known-project bucket: standard, enhanced, or intelligent.
+--bucket-size-gb  <str>  GiB cap for a newly created known-project bucket; 0 means unlimited.
 --help  Show this message and exit.
 ```
 
@@ -39,6 +41,8 @@ Options
 | `--project-id` | <str>  Known Nebius project ID for prompt-free configure. |
 | `--region` | <str>  Known Nebius project region for prompt-free configure. |
 | `--project-alias` | <str>  Local NPA alias for prompt-free configure. |
+| `--bucket-storage-class` | <str>  Storage class for a newly created known-project bucket: standard, enhanced, or intelligent. |
+| `--bucket-size-gb` | <str>  GiB cap for a newly created known-project bucket; 0 means unlimited. |
 | `--help` | Show this message and exit. |
 
 ## Subcommands

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -311,6 +311,19 @@ npa configure --no-interactive \
   --region "$NEBIUS_REGION" --project-alias "$PROJECT_ALIAS"
 ```
 
+For a newly created bucket, automation may also select its create-only storage
+class and size cap without putting credentials on the command line:
+
+```bash
+npa configure --no-interactive \
+  --tenant-id "$YOUR_TENANT_ID" --project-id "$YOUR_PROJECT_ID" \
+  --region "$NEBIUS_REGION" --project-alias "$PROJECT_ALIAS" \
+  --bucket-storage-class enhanced --bucket-size-gb 100
+```
+
+If the deterministic bucket already exists, these options verify its class and
+cap exactly and fail closed on a mismatch; they never alter an existing bucket.
+
 These are non-secret identifiers; do not pass IAM, S3, Token Factory, HF, or NGC
 secrets on the command line. The command reuses existing storage only after the
 same write/read capability probe deployment uses. If none is configured, it

--- a/npa/src/npa/cli/main.py
+++ b/npa/src/npa/cli/main.py
@@ -729,6 +729,8 @@ def _provision_object_storage(
     region: str,
     existing_bucket: str = "",
     interactive: bool = True,
+    bucket_storage_class: str = "",
+    bucket_max_size_bytes: int | None = None,
 ) -> dict[str, str] | None:
     """Auto-create the S3 bucket + access key for the project."""
     if not (project_id and tenant_id):
@@ -771,18 +773,61 @@ def _provision_object_storage(
         )
         return None
 
-    bucket_max_size_bytes = 0
-    bucket_storage_class = DEFAULT_BUCKET_STORAGE_CLASS
+    requested_storage_class = str(bucket_storage_class or "").strip()
+    requested_max_size_bytes = bucket_max_size_bytes
+    create_max_size_bytes = 0
+    create_storage_class = DEFAULT_BUCKET_STORAGE_CLASS
     if exists is True:
+        if requested_storage_class or requested_max_size_bytes is not None:
+            item = nebius_client.get_bucket_by_name(project_id, bucket_name)
+            spec = (item or {}).get("spec", {})
+            actual_storage_class = nebius_client.normalize_bucket_storage_class(
+                str(spec.get("default_storage_class", ""))
+            )
+            actual_max_size_bytes = int(spec.get("max_size_bytes", 0) or 0)
+            expected_storage_class = (
+                nebius_client.normalize_bucket_storage_class(requested_storage_class)
+                if requested_storage_class
+                else actual_storage_class
+            )
+            expected_max_size_bytes = (
+                int(requested_max_size_bytes)
+                if requested_max_size_bytes is not None
+                else actual_max_size_bytes
+            )
+            if (
+                actual_storage_class != expected_storage_class
+                or actual_max_size_bytes != expected_max_size_bytes
+            ):
+                typer.echo(
+                    "Existing object-storage bucket does not match the requested "
+                    "create-only storage class and size; refusing to reuse it."
+                )
+                return None
         typer.echo(f"Reusing existing object-storage bucket '{bucket_name}'.")
     elif exists is False:
         typer.echo(
             f"No existing bucket named '{bucket_name}' found; npa will create it."
         )
-        bucket_storage_class, bucket_max_size_bytes = _prompt_new_bucket_settings(
-            ask,
-            bucket_name=bucket_name,
-        )
+        if interactive:
+            create_storage_class, create_max_size_bytes = _prompt_new_bucket_settings(
+                ask,
+                bucket_name=bucket_name,
+            )
+        else:
+            create_storage_class = nebius_client.normalize_bucket_storage_class(
+                requested_storage_class
+            )
+            create_max_size_bytes = int(requested_max_size_bytes or 0)
+            typer.echo(
+                f"  Will create '{bucket_name}' with {create_storage_class} storage "
+                f"and "
+                + (
+                    f"a {create_max_size_bytes} byte cap."
+                    if create_max_size_bytes
+                    else "no size limit."
+                )
+            )
     # exists is None: existence unknown, so skip the create-only prompts and let
     # provisioning get-or-create with defaults rather than risk creating a
     # duplicate of a bucket that may already exist.
@@ -796,8 +841,8 @@ def _provision_object_storage(
             tenant_id=tenant_id,
             region=region,
             bucket_name=bucket_name,
-            bucket_max_size_bytes=bucket_max_size_bytes,
-            bucket_storage_class=bucket_storage_class,
+            bucket_max_size_bytes=create_max_size_bytes,
+            bucket_storage_class=create_storage_class,
             on_status=lambda msg: typer.echo(f"  - {msg}"),
         )
     except nebius_client.NebiusError as exc:
@@ -819,6 +864,8 @@ def _provision_object_storage(
                 region=region,
                 existing_bucket=alternate,
                 interactive=interactive,
+                bucket_storage_class=requested_storage_class,
+                bucket_max_size_bytes=requested_max_size_bytes,
             )
         if nebius_client.is_permission_denied(str(exc)):
             typer.echo(
@@ -2206,6 +2253,8 @@ def _run_known_project_configure(
     region: str,
     project_alias: str,
     provision: bool,
+    bucket_storage_class: str = "",
+    bucket_size_gb: str = "",
 ) -> None:
     """Configure a known project without profile creation, discovery, or prompts."""
 
@@ -2233,6 +2282,50 @@ def _run_known_project_configure(
             "--project-alias must start with a letter or digit and contain only "
             "letters, digits, '.', '_', or '-' (maximum 64 characters)"
         )
+    requested_storage_class = str(bucket_storage_class or "").strip()
+    requested_size_gb = str(bucket_size_gb or "").strip()
+    if (requested_storage_class or requested_size_gb) and not provision:
+        raise typer.BadParameter(
+            "--bucket-storage-class and --bucket-size-gb require --provision"
+        )
+    if requested_storage_class:
+        normalized_label = (
+            requested_storage_class.lower().replace("-", "_").replace(" ", "_")
+        )
+        if normalized_label not in {
+            "standard",
+            "std",
+            "storage_class_unspecified",
+            "enhanced",
+            "enhanced_throughput",
+            "enhancedthroughput",
+            "intelligent",
+        }:
+            raise typer.BadParameter(
+                "--bucket-storage-class must be standard, enhanced, or intelligent"
+            )
+        requested_storage_class = nebius_client.normalize_bucket_storage_class(
+            requested_storage_class
+        )
+    requested_max_size_bytes: int | None = None
+    if requested_size_gb:
+        from decimal import Decimal, InvalidOperation
+
+        try:
+            parsed_size = Decimal(requested_size_gb)
+        except InvalidOperation as exc:
+            raise typer.BadParameter(
+                "--bucket-size-gb must be a finite non-negative number"
+            ) from exc
+        if not parsed_size.is_finite() or parsed_size < 0:
+            raise typer.BadParameter(
+                "--bucket-size-gb must be a finite non-negative number"
+            )
+        requested_max_size_bytes = _gb_to_bytes(requested_size_gb)
+        if parsed_size > 0 and requested_max_size_bytes == 0:
+            raise typer.BadParameter(
+                "--bucket-size-gb must resolve to at least one byte, or be 0 for unlimited"
+            )
 
     # This path consumes existing local profile/credential material only. It
     # never invokes profile creation or tenant/project discovery, so a valid
@@ -2261,7 +2354,11 @@ def _run_known_project_configure(
     existing_relationship_verified = _storage_relationship_verified(
         existing, values["--project-id"]
     )
-    if existing_complete and existing_relationship_verified:
+    if (
+        existing_complete
+        and existing_relationship_verified
+        and not (requested_storage_class or requested_size_gb)
+    ):
         from npa.clients.storage_validation import probe_storage_write
 
         probe = probe_storage_write(
@@ -2315,6 +2412,8 @@ def _run_known_project_configure(
                 else ""
             ),
             interactive=False,
+            bucket_storage_class=requested_storage_class,
+            bucket_max_size_bytes=requested_max_size_bytes,
         )
         if provisioned is None or provisioned.get("_validated") != "true":
             raise typer.BadParameter(
@@ -2404,6 +2503,8 @@ def _configure_impl(
     project_id: str = "",
     region: str = "",
     project_alias: str = "",
+    bucket_storage_class: str = "",
+    bucket_size_gb: str = "",
 ) -> None:
     if src_s3_uri.strip():
         _store_src_s3_uri(src_s3_uri.strip())
@@ -2466,7 +2567,14 @@ def _configure_impl(
         typer.echo("")
         typer.echo(_SETUP_GUIDANCE)
         return
-    known_project_values = (tenant_id, project_id, region, project_alias)
+    known_project_values = (
+        tenant_id,
+        project_id,
+        region,
+        project_alias,
+        bucket_storage_class,
+        bucket_size_gb,
+    )
     if any(str(value or "").strip() for value in known_project_values):
         if interactive is True:
             raise typer.BadParameter(
@@ -2479,6 +2587,8 @@ def _configure_impl(
             region=region,
             project_alias=project_alias,
             provision=provision,
+            bucket_storage_class=bucket_storage_class,
+            bucket_size_gb=bucket_size_gb,
         )
         return
     preset_tokens: set[str] = set()
@@ -2721,6 +2831,16 @@ def configure(
         "--project-alias",
         help="Local NPA alias to write for the known project (prompt-free configure).",
     ),
+    bucket_storage_class: str = typer.Option(
+        "",
+        "--bucket-storage-class",
+        help="Storage class for a newly created known-project bucket: standard, enhanced, or intelligent.",
+    ),
+    bucket_size_gb: str = typer.Option(
+        "",
+        "--bucket-size-gb",
+        help="GiB cap for a newly created known-project bucket; 0 means unlimited.",
+    ),
 ) -> None:
     """Interactively write ~/.npa credentials and config, or show guidance."""
     _configure_impl(
@@ -2735,6 +2855,8 @@ def configure(
         project_id=project_id,
         region=region,
         project_alias=project_alias,
+        bucket_storage_class=bucket_storage_class,
+        bucket_size_gb=bucket_size_gb,
     )
 
 
@@ -2800,6 +2922,16 @@ def init(
     project_alias: str = typer.Option(
         "", "--project-alias", help="Local NPA alias for prompt-free configure."
     ),
+    bucket_storage_class: str = typer.Option(
+        "",
+        "--bucket-storage-class",
+        help="Storage class for a newly created known-project bucket: standard, enhanced, or intelligent.",
+    ),
+    bucket_size_gb: str = typer.Option(
+        "",
+        "--bucket-size-gb",
+        help="GiB cap for a newly created known-project bucket; 0 means unlimited.",
+    ),
 ) -> None:
     """Interactively write ~/.npa credentials and config, or show guidance."""
     _configure_impl(
@@ -2813,6 +2945,8 @@ def init(
         project_id=project_id,
         region=region,
         project_alias=project_alias,
+        bucket_storage_class=bucket_storage_class,
+        bucket_size_gb=bucket_size_gb,
     )
 
 

--- a/npa/tests/cli/test_onboarding_smoke.py
+++ b/npa/tests/cli/test_onboarding_smoke.py
@@ -158,6 +158,79 @@ def test_known_project_configure_requires_complete_identity_flags() -> None:
     assert "--project-alias" in result.output
 
 
+def test_known_project_configure_forwards_new_bucket_class_and_size(
+    monkeypatch, tmp_path
+) -> None:
+    from npa.clients import config as config_module
+    from npa.clients import credentials as credentials_module
+
+    monkeypatch.setattr(config_module, "CONFIG_PATH", tmp_path / "config.yaml")
+    monkeypatch.setattr(
+        credentials_module, "CREDENTIALS_PATH", tmp_path / "credentials.yaml"
+    )
+    monkeypatch.setattr("npa.clients.nebius.get_iam_token", lambda: "iam-token")
+    monkeypatch.setattr("npa.clients.nebius.set_profile_project", lambda *a, **k: True)
+    captured: dict[str, object] = {}
+
+    def fake_provision(*_args, **kwargs):
+        captured.update(kwargs)
+        return {
+            "aws_access_key_id": "access",
+            "aws_secret_access_key": "secret",
+            "endpoint_url": "https://storage.invalid",
+            "bucket": "s3://derived-bucket/",
+            "_validated": "true",
+        }
+
+    monkeypatch.setattr("npa.cli.main._provision_object_storage", fake_provision)
+    result = runner.invoke(
+        app,
+        [
+            "configure",
+            "--no-interactive",
+            "--tenant-id",
+            "tenant-known",
+            "--project-id",
+            "project-known",
+            "--region",
+            "us-central1",
+            "--project-alias",
+            "fleet-a",
+            "--bucket-storage-class",
+            "enhanced",
+            "--bucket-size-gb",
+            "100",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["interactive"] is False
+    assert captured["bucket_storage_class"] == "enhanced_throughput"
+    assert captured["bucket_max_size_bytes"] == 100 * 1024**3
+
+
+def test_known_project_bucket_options_reject_invalid_values() -> None:
+    common = [
+        "configure",
+        "--no-interactive",
+        "--tenant-id",
+        "tenant-known",
+        "--project-id",
+        "project-known",
+        "--region",
+        "us-central1",
+        "--project-alias",
+        "fleet-a",
+    ]
+    result = runner.invoke(app, [*common, "--bucket-storage-class", "mystery"])
+    assert result.exit_code != 0
+    assert "must be standard, enhanced, or intelligent" in result.output
+
+    result = runner.invoke(app, [*common, "--bucket-size-gb", "not-a-number"])
+    assert result.exit_code != 0
+    assert "must be a finite non-negative number" in result.output
+
+
 def test_noninteractive_storage_selection_never_prints_prompt_language(
     monkeypatch, capsys
 ) -> None:
@@ -199,6 +272,90 @@ def test_noninteractive_storage_selection_never_prints_prompt_language(
     assert "Object storage (non-interactive): selected 'derived-bucket'" in output
     assert "enter a bucket name" not in output.lower()
     assert "press Enter" not in output
+
+
+def test_noninteractive_storage_creation_forwards_requested_shape(
+    monkeypatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from npa.cli.main import _provision_object_storage
+    from npa.clients.storage_validation import StorageProbeResult
+
+    fake_nebius = SimpleNamespace(
+        bucket_name_for=lambda _tenant, _project: "derived-bucket",
+        bucket_exists=lambda _project, _bucket: False,
+        normalize_bucket_storage_class=lambda value: (
+            "enhanced_throughput" if value == "enhanced_throughput" else "standard"
+        ),
+        NebiusError=RuntimeError,
+        is_permission_denied=lambda _message: False,
+    )
+    captured: dict[str, object] = {}
+
+    def fake_provision(**kwargs):
+        captured.update(kwargs)
+        return (
+            {
+                "nebius_api_key": "access",
+                "nebius_secret_key": "secret",
+                "s3_bucket": "derived-bucket",
+                "s3_endpoint": "https://storage.invalid",
+            },
+            StorageProbeResult(True, "ok", "verified"),
+        )
+
+    monkeypatch.setattr("npa.clients.storage_setup.provision_storage", fake_provision)
+    result = _provision_object_storage(
+        fake_nebius,
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("prompted")),
+        project_id="project",
+        tenant_id="tenant",
+        region="us-central1",
+        interactive=False,
+        bucket_storage_class="enhanced_throughput",
+        bucket_max_size_bytes=100 * 1024**3,
+    )
+
+    assert result is not None
+    assert captured["bucket_storage_class"] == "enhanced_throughput"
+    assert captured["bucket_max_size_bytes"] == 100 * 1024**3
+
+
+def test_noninteractive_storage_reuse_rejects_shape_mismatch(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from npa.cli.main import _provision_object_storage
+
+    fake_nebius = SimpleNamespace(
+        bucket_name_for=lambda _tenant, _project: "derived-bucket",
+        bucket_exists=lambda _project, _bucket: True,
+        get_bucket_by_name=lambda _project, _bucket: {
+            "spec": {"default_storage_class": "standard", "max_size_bytes": "1"}
+        },
+        normalize_bucket_storage_class=lambda value: str(value).lower(),
+        NebiusError=RuntimeError,
+        is_permission_denied=lambda _message: False,
+    )
+
+    def must_not_provision(**_kwargs):
+        raise AssertionError("mismatched existing bucket must not be provisioned")
+
+    monkeypatch.setattr(
+        "npa.clients.storage_setup.provision_storage", must_not_provision
+    )
+    result = _provision_object_storage(
+        fake_nebius,
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("prompted")),
+        project_id="project",
+        tenant_id="tenant",
+        region="us-central1",
+        interactive=False,
+        bucket_storage_class="enhanced_throughput",
+        bucket_max_size_bytes=100 * 1024**3,
+    )
+
+    assert result is None
 
 
 def test_npa_version_emits_no_syntax_warning(tmp_path) -> None:


### PR DESCRIPTION
## What changed

- Added prompt-free `configure` and `init` options for selecting the storage class and GiB cap of a newly created known-project object-storage bucket.
- Added fail-closed verification when automation requests a bucket shape but the deterministic bucket already exists with a different class or cap.
- Added focused CLI/provisioning regression tests and regenerated the command reference documentation.

## Why

Fleet automation needed to configure project-scoped enhanced object storage with an explicit size cap. The known-project non-interactive path previously created only the default standard, unlimited bucket shape, while custom shape selection was available only through prompts.

## Developer and user impact

Automation can now request an enhanced, capped bucket without interactive input. Existing buckets are never resized or reclassified: an exact match is reused, while a mismatch produces an actionable error.

## Validation

- Ruff over source and tests
- Focused onboarding and main CLI tests: 113 passed
- Smoke tests: 113 passed
- Guardrails: 2,274 passed
- Full serial suite: 11,900 passed, 36 skipped, 12 deselected, 1 xpassed
- Generated documentation consistency check
- Staged and commit-range Nebius confidentiality scans: zero findings
- Staged and commit-range gitleaks scans: zero findings
- Live, task-owned verification: three managed clusters healthy; each has two small CPU workers and two single-GPU reserved-capacity RTX workers under strict placement, plus one ready 100 GiB shared filesystem and one active enhanced 100 GiB object-storage bucket. All six CUDA smoke tests and all three object-storage write/delete probes passed.

## Limitations

The new bucket shape options are create-only. They intentionally do not mutate an existing bucket, and require the provisioning path.
