### PR TITLE
docs: fix Nebius CLI setup for LeRobot deploy

### DIFF
--- a/research/lerobot-deploy/README.md
+++ b/research/lerobot-deploy/README.md
@@ -15,11 +15,21 @@ repo owns only infrastructure and orchestration.
 
 ## Prerequisites
 
+The [official Nebius CLI installer](https://docs.nebius.com/cli/install) supports
+Ubuntu and macOS. Install and verify the CLI:
+
 ```bash
-brew install nebius/tap/nebius   # Nebius CLI
-brew install jq                  # JSON parser
-brew install terraform           # Infrastructure
-nebius config init               # Authenticate
+curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | bash
+exec -l "$SHELL"
+nebius version
+```
+
+Install [jq](https://jqlang.org/download/) and
+[Terraform 1.x](https://developer.hashicorp.com/terraform/install) for your
+operating system, then authenticate and create an SSH key if needed:
+
+```bash
+nebius profile create            # Authenticate
 ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519  # SSH key (if needed)
 ```
 


### PR DESCRIPTION
## What changed
- Replaced the unavailable Homebrew tap command with the official Nebius CLI installer for Ubuntu and macOS.
- Added the documented shell reload and CLI version verification steps.
- Replaced the obsolete nebius config init authentication instruction with nebius profile create.
- Linked platform-specific jq and Terraform installation guidance.

## Why
The public Homebrew tap/formula referenced by this README is unavailable, so new users cannot complete the documented prerequisites. The replacement matches the current official Nebius CLI installation and interactive profile setup documentation.

## User and developer impact
Users on Ubuntu and macOS get a working public installation path and the current authentication command. This is documentation-only and does not change runtime behavior.

## Validation
- git diff --check
- Ruff: npa/src and npa/tests passed
- Pytest collection: 11,946 tests collected; 2 skipped
- Guardrails: 2,277 passed
- Diff confidentiality scan: 0 hits
- Gitleaks: no leaks found
- Official Nebius, jq, and Terraform installation pages reviewed

## Limitations
Documentation-only validation; the installer was not executed and no cloud resources were provisioned.