### PR TITLE
Add agent run data collection skill

### DIFF
--- a/skills/atomic/agent-run-data-collection/SKILL.md
+++ b/skills/atomic/agent-run-data-collection/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: agent-run-data-collection
+description: Use when collecting NPA agent work for fine-tuning or evaluation so every goal-level episode emits a sanitized, outcome-linked trajectory to an append-only S3 dataset in an operator-specified Nebius tenant and bucket.
+---
+
+# Agent Run Data Collection
+
+Collect complete, replayable agent trajectories without making telemetry a new
+source of fabricated success or lost operator work.
+
+## Required runtime configuration
+
+Resolve these from owner-only runtime configuration; never commit their values:
+
+- `NPA_AGENT_DATASET_TENANT_ID`: exact tenant that owns the destination.
+- `NPA_AGENT_DATASET_URI`: exact `s3://<bucket>/<prefix>` dataset root.
+- Existing NPA S3 endpoint and credentials for that bucket. Do not copy secrets
+  into a trajectory, command line, workflow spec, log, or skill file.
+
+Before enabling collection, verify the active agent deployment reports the same
+tenant and that the destination bucket is a writable resource in that tenant.
+Tenant-wide discovery alone does not authorize cross-project writes. Do not
+create a bucket, grant IAM, or change tenant/project configuration unless the
+operator separately requests it.
+
+## Collection hierarchy and episode boundary
+
+Use three levels:
+
+- **Session:** the whole conversation or operator work period.
+- **Episode:** one accepted goal pursued until objective success, failure,
+  refusal, cancellation, or an explicit handoff. Follow-up messages that refine
+  the same unfinished goal stay in the episode; a materially new goal starts a
+  new episode.
+- **Event:** each prompt, plan, model decision, tool call, observation,
+  confirmation, retry, correction, or final response inside an episode.
+
+The episode is the dataset row. Assign its id when the goal is accepted and
+finalize exactly one `npa.agent.trajectory.v1` record at the terminal boundary.
+Link it to its parent session and include all nested events; do not create a
+separate dataset row for every chat turn or tool call.
+
+## Preamble integration
+
+Link the skill explicitly from the agent preamble. Use this canonical line:
+
+> For every goal-level episode, load and follow `$agent-run-data-collection` at `skills/atomic/agent-run-data-collection/SKILL.md`; record the episode from goal acceptance through success, failure, refusal, cancellation, or handoff as one sanitized trajectory containing all nested events, linked to its parent session and stored using `NPA_AGENT_DATASET_TENANT_ID` and `NPA_AGENT_DATASET_URI`.
+
+The preamble selects the skill; the runtime emitter still must be implemented
+and configured. Do not claim collection is active merely because this sentence
+is present.
+
+## Write contract
+
+Write a new immutable object for every episode:
+
+```text
+<dataset-root>/episodes/<yyyy>/<mm>/<dd>/<episode-id>-<content-sha256>.json
+```
+
+Never append by rewriting one shared JSONL object: concurrent S3 writers lose
+rows. Retrying the same finalized payload must resolve to the same object key;
+different payloads for one episode id remain visible and must be treated as a data
+quality conflict rather than overwritten.
+
+If the S3 write fails, persist the same finalized record to an owner-only local
+outbox and mark collection `pending`. Never report the record as collected until
+a read-after-write check confirms the object hash. Do not fail or repeat an
+otherwise completed GPU or destructive operation merely because telemetry
+failed. Retry pending records at the start of the next episode or through an
+explicit flush.
+
+## Record contents
+
+Read [references/trajectory-schema.md](references/trajectory-schema.md) before
+implementing or changing the emitter. Preserve:
+
+- sanitized request and relevant initial state;
+- ordered plans, tool calls, arguments, observations, retries, and confirmations;
+- objective outcome evidence, produced artifact URIs, and operator corrections;
+- grounded/model routing, model name, token usage, latency, and agent/tool versions;
+- tenant scope, dataset URI role, timestamps, redaction status, and collection status.
+
+Use live workflow status, exit codes, validation reports, tests, and artifact
+existence as outcome evidence. The agent's own final sentence is not proof of
+success. Store operator corrections as explicit preference pairs when both the
+rejected and corrected actions are available.
+
+## Privacy and integrity
+
+Redact before serialization and again before upload. Remove credentials,
+authorization headers, environment dumps, private keys, signed URLs, raw image
+data, and secret-shaped values. Replace concrete infrastructure identifiers in
+free text with typed references; retain the configured tenant id only in the
+access-controlled scope field needed to prove routing. Keep raw and curated
+datasets separate, and never train on evaluation or held-out runs.
+
+At completion, surface only `collected`, `pending`, or `disabled` plus the episode
+id. Do not print the tenant id, bucket name, credentials, or full destination
+URI in ordinary handoffs.
+
+## Verification
+
+For emitter changes, test at least:
+
+1. success, tool failure, refusal, cancellation, and grounded zero-token runs;
+2. redaction before either S3 or outbox writes;
+3. deterministic keys and idempotent retries;
+4. concurrent runs producing distinct immutable objects;
+5. tenant/bucket mismatch failing before collection is enabled;
+6. S3 failure entering the outbox and later flushing with read-after-write proof.
+
+Use `npa/.venv/bin/python` for repository validation. Load
+`skills/atomic/testing-conventions/SKILL.md` when implementing the emitter and
+`skills/atomic/protect-nebius-infra-details/SKILL.md` before publishing evidence.

--- a/skills/atomic/agent-run-data-collection/references/trajectory-schema.md
+++ b/skills/atomic/agent-run-data-collection/references/trajectory-schema.md
@@ -1,0 +1,80 @@
+# `npa.agent.trajectory.v1`
+
+Emit one JSON object per terminal goal-level episode. A session contains one or
+more episodes, and an episode contains ordered events. This is a semantic
+contract; an implementation may use stricter typed models.
+
+## Required shape
+
+```json
+{
+  "schema_version": "npa.agent.trajectory.v1",
+  "episode_id": "stable-episode-id",
+  "session_id": "parent-session-id",
+  "scope": {
+    "tenant_id": "runtime-resolved",
+    "dataset_role": "agent-finetuning-raw"
+  },
+  "timing": {
+    "started_at": "RFC3339",
+    "ended_at": "RFC3339",
+    "latency_ms": 0
+  },
+  "request": {
+    "content": "sanitized user request",
+    "intent": "resolved intent"
+  },
+  "initial_state": {},
+  "trajectory": [
+    {
+      "sequence": 0,
+      "phase": "plan|tool|observation|confirm|final",
+      "tool": "",
+      "arguments": {},
+      "observation": {},
+      "status": "ok|error|rejected|cancelled"
+    }
+  ],
+  "outcome": {
+    "status": "succeeded|failed|refused|cancelled",
+    "verified": false,
+    "verified_by": [],
+    "artifact_uris": [],
+    "operator_interventions": [],
+    "preference_pairs": []
+  },
+  "routing": {
+    "grounded": false,
+    "tier": "",
+    "model": "",
+    "input_tokens": 0,
+    "output_tokens": 0
+  },
+  "versions": {
+    "agent": "",
+    "tools": {}
+  },
+  "redaction": {
+    "applied": true,
+    "fields_removed": []
+  },
+  "collection": {
+    "status": "collected|pending|disabled",
+    "content_sha256": ""
+  }
+}
+```
+
+## Invariants
+
+- `episode_id` is assigned when the goal is accepted, before its first plan or tool call.
+- `session_id` is stable across episodes in the same conversation or operator work period.
+- `trajectory.sequence` is strictly increasing and preserves retries.
+- `outcome.verified=true` requires at least one objective `verified_by` entry.
+- A grounded reply records zero model tokens; missing usage is not fabricated as zero.
+- Store large artifacts by sanitized URI and digest, never inline their bytes.
+- `content_sha256` is computed over canonical JSON with that field empty.
+- Collection metadata must not claim `collected` until S3 read-after-write verifies
+  the uploaded bytes.
+- A curated training example references its raw source episode and dataset version;
+  it does not replace or mutate this raw record.

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -41,6 +41,13 @@ skills:
       - type: cli_help
         args: ["agent", "deploy", "--help"]
         contains: "llm-model"
+  - name: agent-run-data-collection
+    category: atomic
+    when_to_use: "Collect NPA agent work for fine-tuning or evaluation so every goal-level episode emits a sanitized, outcome-linked trajectory to an append-only S3 dataset in an operator-specified tenant and bucket."
+    path: skills/atomic/agent-run-data-collection/SKILL.md
+    smoke:
+      - type: file_exists
+        path: skills/atomic/agent-run-data-collection/references/trajectory-schema.md
   - name: architecture
     category: atomic
     when_to_use: "Platform architecture, tool-layer scope, orchestrator decisions, partner model, and validation state."


### PR DESCRIPTION
## Summary

- add the agent-run-data-collection skill for fine-tuning and evaluation data capture
- define session, goal-level episode, and nested event boundaries
- specify immutable S3 objects, deterministic hashes, redaction, objective outcome evidence, and a durable local outbox
- register the skill in the repository index and provide a canonical agent preamble link

This PR adds the collection contract and schema; it does not wire a runtime emitter into the agent backend.

## Validation

- skill validator: passed
- ruff: passed
- skill guardrails: 103 passed
- onboarding smoke: 109 passed
- full guardrails: 2,280 passed
- confidentiality scan: 0 findings
- gitleaks: 0 findings
- full unit gate: 11,895 passed, 37 skipped, 12 deselected, 1 xpassed, 6 environment failures

The full-gate failures are unrelated to this Markdown/YAML-only change: four tmux smoke tests timed out against the shared default tmux server, which has unrelated stuck clients, and two LeIsaac media tests report the shared venv is missing imageio_ffmpeg. The directly applicable gates all pass.