### PR TITLE
fix: harden workbench service boundaries

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -15,23 +15,6 @@ work lives).
 
 ### High
 
-#### [H] Agent VM S3 credentials are readable from its cloud-init user data
-
-- **Surfaced by**: third README-path walkthrough report on 2026-07-30.
-- **Status**: Active. The argv half is fixed (`npa.deploy.provisioner` passes
-  secret Terraform variables through a 0600 var-file instead of `-var`, so they
-  no longer appear in `ps`); the user-data half is not.
-- **Current issue**: `npa agent deploy` bakes the S3 access key and secret into
-  the VM's `cloud_init_user_data`, which anyone with read access to the project
-  can retrieve with `nebius compute instance get`. The IAM token was already
-  removed from the VM (the attached `npa-agent` service account self-mints one),
-  but the S3 keys still ride along in plaintext.
-- **Next step**: have the VM obtain S3 credentials at boot through its attached
-  service account (mint or read an access key with the token it already
-  self-mints) instead of receiving them in user data; until then, treat the keys
-  staged onto an agent VM as project-readable and rotate them when the VM is
-  destroyed.
-
 ### Medium
 
 #### [M] SkyPilot's runtime bootstrap stalled once in npa-cosmos-curate
@@ -86,6 +69,17 @@ work lives).
   document the API, and cover imports/behavior in tests.
 
 ## Resolved (recent)
+
+#### [H] Agent VM S3 credentials were readable from cloud-init user data
+
+- **Resolved**: 2026-08-27. Terraform/cloud-init no longer receives or renders
+  S3 access or secret keys for any workbench type. NPA verifies the created VM
+  and SSH channel, then stages scoped runtime credentials into owner-only files;
+  the attached service-account metadata identity remains the rotating
+  control-plane authentication path. Rendered-template tests cover every
+  workbench variant, and ingress is independently fail-closed.
+- **Migration**: redeploy affected VMs and rotate keys retained in historical
+  provider user-data. See `docs/security/workbench-service-boundaries.md`.
 
 #### [H] npa-cosmos2-transfer's inference venv was unusable as its own non-root user
 

--- a/docs/security/workbench-service-boundaries.md
+++ b/docs/security/workbench-service-boundaries.md
@@ -17,9 +17,9 @@ export INSIGHTS_TOKEN='<owner-provided-token>'
 `DATASET_AUTH_MODE=none` and `INSIGHTS_AUTH_MODE=none` remain explicit opt-ins
 for a deliberately local or isolated test service. They are never the default.
 
-Storage access also starts with no authorized roots. Configure one or more exact
-S3 bucket/prefix roots as a comma-separated list and local sandbox roots as a
-platform path-separated list:
+For deployed FastAPI requests, storage access also starts with no authorized
+roots. Configure one or more exact S3 bucket/prefix roots as a comma-separated
+list and local sandbox roots as a platform path-separated list:
 
 ```bash
 export DATASET_ALLOWED_S3_ROOTS='s3://<bucket>/<dataset-prefix>'
@@ -32,6 +32,13 @@ Every read, write, existence check, and prefix listing is checked in the storage
 layer. Foreign buckets/prefixes, unsupported schemes, traversal, and canonical
 local paths that escape through a symlink are rejected. A bucket root is allowed
 only when the operator explicitly configures `s3://<bucket>`.
+
+The allowlist variables are service-boundary configuration. Default embedded
+CLI commands, SDK calls with `service=False` / `mode="local"`, and workflow
+toolRef processes execute in the caller's existing filesystem and S3 security
+context and do not require these variables. They retain the pre-service path
+contract; deploying the FastAPI application is what activates the additional
+request-scoped containment boundary.
 
 Existing deployments must set their current roots before upgrade. Prefer the
 narrowest prefix each service needs; do not configure a whole bucket when one

--- a/docs/security/workbench-service-boundaries.md
+++ b/docs/security/workbench-service-boundaries.md
@@ -1,0 +1,103 @@
+# Workbench service storage and ingress boundaries
+
+Dataset, Insights, and Terraform-managed VM deployments fail closed unless an
+operator configures their authentication, storage, and ingress boundaries.
+This is an intentional security migration.
+
+## Dataset and Insights services
+
+The deployed FastAPI applications now default to token authentication. Set the
+service token and leave the mode at its secure default:
+
+```bash
+export DATASET_TOKEN='<owner-provided-token>'
+export INSIGHTS_TOKEN='<owner-provided-token>'
+```
+
+`DATASET_AUTH_MODE=none` and `INSIGHTS_AUTH_MODE=none` remain explicit opt-ins
+for a deliberately local or isolated test service. They are never the default.
+
+Storage access also starts with no authorized roots. Configure one or more exact
+S3 bucket/prefix roots as a comma-separated list and local sandbox roots as a
+platform path-separated list:
+
+```bash
+export DATASET_ALLOWED_S3_ROOTS='s3://<bucket>/<dataset-prefix>'
+export INSIGHTS_ALLOWED_S3_ROOTS='s3://<bucket>/<insights-prefix>'
+export DATASET_ALLOWED_LOCAL_ROOTS='/srv/npa/dataset-sandbox'
+export INSIGHTS_ALLOWED_LOCAL_ROOTS='/srv/npa/insights-sandbox'
+```
+
+Every read, write, existence check, and prefix listing is checked in the storage
+layer. Foreign buckets/prefixes, unsupported schemes, traversal, and canonical
+local paths that escape through a symlink are rejected. A bucket root is allowed
+only when the operator explicitly configures `s3://<bucket>`.
+
+Existing deployments must set their current roots before upgrade. Prefer the
+narrowest prefix each service needs; do not configure a whole bucket when one
+dataset or store prefix is sufficient.
+
+## Terraform VM ingress
+
+`ssh_cidr_block` no longer defaults to `0.0.0.0/0`. Application ingress is now a
+separate `application_cidr_block`; its rule covers `server_port` and
+`extra_ingress_ports`. Empty application ingress creates no public application
+rule. An ordinary NPA deploy that needs remote bootstrap must pass an
+operator-selected SSH CIDR, for example through its existing repeatable
+`--tf-var` option:
+
+```bash
+npa <deploy-command> \
+  --tf-var 'ssh_cidr_block=<operator-cidr>' \
+  --tf-var 'application_cidr_block=<operator-cidr>'
+```
+
+There is no repository-supplied live CIDR. Choose the narrow source authorized
+for the deployment. For an internal-only application, omit
+`application_cidr_block` and use the supported SSH/tunnel access path.
+
+World-open ingress requires a second, conspicuous acknowledgement in addition
+to the world-open CIDR:
+
+```text
+ssh_cidr_block=0.0.0.0/0
+allow_world_open_ssh=true
+
+application_cidr_block=0.0.0.0/0
+allow_world_open_application=true
+```
+
+The manual repair surfaces follow the same rule. They require `--source`; a
+`/0` source additionally requires `--allow-world-open`:
+
+```bash
+npa network ensure-ingress --vm <instance-id> --ports <port> \
+  --source '<operator-cidr>'
+npa workbench fiftyone ensure-ingress -n <alias> \
+  --source '<operator-cidr>'
+```
+
+Deploy-time ingress reconciliation uses only the explicit
+`application_cidr_block`; it never substitutes a world-open source. The simple
+agent setup path accepts repeatable `--tf-var` values and fails before VM
+creation when either its SSH bootstrap boundary or application boundary is
+missing.
+
+This is especially important for FiftyOne, which does not add application-level
+authentication. Upgrading an existing VM may change or remove its old shared
+SSH/application rule; review the Terraform plan and set the two boundaries
+independently before applying.
+
+## Storage credentials during VM bootstrap
+
+Terraform and cloud-init no longer receive S3 access or secret keys. NPA creates
+the VM with its attached service-account identity, verifies the exact resulting
+VM and SSH channel, then stages the already-scoped runtime storage environment
+through owner-only files. The metadata identity supplies rotating Nebius
+control-plane authentication; it is not treated as an S3 HMAC credential and no
+broader IAM role is created.
+
+If scoped storage credentials or exact VM identity cannot be resolved, runtime
+credential staging fails closed. Existing VMs whose old user-data contained S3
+keys must be redeployed and those old keys rotated; changing the template cannot
+erase provider-retained user-data from an existing instance.

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -9837,6 +9837,18 @@ def deploy_cmd(
             _fail(f"Invalid --tf-var value {item!r}; expected key=value")
         key, value = item.split("=", 1)
         merged_vars[key.strip()] = value.strip()
+    ssh_source = str(merged_vars.get("ssh_cidr_block", "")).strip()
+    application_source = str(merged_vars.get("application_cidr_block", "")).strip()
+    if not ssh_source:
+        _fail(
+            "Agent deploy requires an explicit ssh_cidr_block so the verified "
+            "post-create bootstrap can connect; pass it with --tf-var."
+        )
+    if not application_source:
+        _fail(
+            "Agent deploy requires an explicit application_cidr_block for its "
+            "public HTTPS health boundary; pass it with --tf-var."
+        )
     try:
         _ensure_terraform_state_bucket(
             project_id=env_project_id,
@@ -10113,7 +10125,16 @@ def deploy_cmd(
     if public_https:
         ingress_ports.append(DEFAULT_HTTPS_PORT)
     try:
-        ensure_ingress(vm_id=instance_id, ports=tuple(ingress_ports), tool="agent")
+        ensure_ingress(
+            vm_id=instance_id,
+            ports=tuple(ingress_ports),
+            source=application_source,
+            allow_world_open=str(
+                merged_vars.get("allow_world_open_application", "false")
+            ).lower()
+            == "true",
+            tool="agent",
+        )
         remove_npa_ingress_for_instance_ports(
             instance_id,
             ports=(backend_port,),
@@ -10330,6 +10351,11 @@ def setup_cmd(
         "--ssh-public-key-path",
         help="SSH public key for the VM.",
     ),
+    tf_var: list[str] = typer.Option(
+        [],
+        "--tf-var",
+        help="Additional Terraform var key=value; use for explicit SSH/application CIDRs.",
+    ),
     replace: bool = typer.Option(
         False,
         "--replace",
@@ -10421,6 +10447,7 @@ def setup_cmd(
         tenant_id=tenant_id,
         region=region,
         ssh_public_key_path=ssh_public_key_path,
+        tf_var=tf_var,
         replace=replace,
     )
 
@@ -10716,11 +10743,7 @@ def bootstrap_cmd(
         )
     instance_id = str(record.get("instance_id", "")).strip()
     if instance_id:
-        ingress_ports: list[int] = [agent_port, rerun_port]
-        if public_https:
-            ingress_ports.append(DEFAULT_HTTPS_PORT)
         try:
-            ensure_ingress(vm_id=instance_id, ports=tuple(ingress_ports), tool="agent")
             remove_npa_ingress_for_instance_ports(
                 instance_id,
                 ports=(backend_port,),

--- a/npa/src/npa/cli/cosmos/__init__.py
+++ b/npa/src/npa/cli/cosmos/__init__.py
@@ -26,8 +26,10 @@ from npa.cli.ingress import (
     ensure_alias_ingress,
     ensure_deploy_ingress,
     ingress_summary,
+    ingress_source_option,
     register_byovm_alias,
     resolve_deploy_instance_id,
+    world_open_ack_option,
 )
 from npa.cli.path_contract import PathContractError, validate_write_path
 from npa.clients.config import (
@@ -881,11 +883,8 @@ def ensure_ingress_cmd(
         "-n",
         help="Workbench alias to repair. Defaults to the active workbench alias.",
     ),
-    source: str = typer.Option(
-        "0.0.0.0/0",
-        "--source",
-        help="Source CIDR allowed to reach the Cosmos server.",
-    ),
+    source: str = ingress_source_option("Source CIDR allowed to reach the Cosmos server."),
+    allow_world_open: bool = world_open_ack_option(),
 ) -> None:
     """Ensure public ingress for the saved Cosmos BYOVM alias."""
     try:
@@ -895,6 +894,7 @@ def ensure_ingress_cmd(
             project_alias=_project_alias or None,
             name=name or _workbench_name or None,
             source=source,
+            allow_world_open=allow_world_open,
         )
     except (ConfigError, NetworkIngressError) as exc:
         _fail(str(exc))
@@ -910,6 +910,8 @@ def register_byovm_cmd(
         ..., "--instance-id", help="Nebius compute instance ID."
     ),
     port: int = typer.Option(8081, "--port", help="Cosmos HTTP service port."),
+    source: str = ingress_source_option("Source CIDR allowed to reach Cosmos."),
+    allow_world_open: bool = world_open_ack_option(),
 ) -> None:
     """Register an existing VM as a Cosmos BYOVM alias and ensure ingress."""
     try:
@@ -919,6 +921,8 @@ def register_byovm_cmd(
             instance_id=instance_id,
             port=port,
             project_alias=_project_alias or None,
+            source=source,
+            allow_world_open=allow_world_open,
             warn=console.print,
         )
     except (ConfigError, NetworkIngressError) as exc:
@@ -2852,6 +2856,8 @@ def deploy_cmd(
                     project_alias=proj_alias,
                     name=wb_name,
                 ),
+                source=str(merged_vars.get("application_cidr_block", "")),
+                allow_world_open=str(merged_vars.get("allow_world_open_application", "false")).lower() == "true",
                 warn=console.print,
             )
 

--- a/npa/src/npa/cli/fiftyone/__init__.py
+++ b/npa/src/npa/cli/fiftyone/__init__.py
@@ -26,8 +26,10 @@ from npa.cli.ingress import (
     ensure_alias_ingress,
     ensure_deploy_ingress,
     ingress_summary,
+    ingress_source_option,
     register_byovm_alias,
     resolve_deploy_instance_id,
+    world_open_ack_option,
 )
 from npa.cli.path_contract import (
     FIFTYONE_LOAD_DATASET_VM_LOCAL_ERROR,
@@ -1073,11 +1075,8 @@ def ensure_ingress_cmd(
         "-n",
         help="Workbench alias to repair. Defaults to the active workbench alias.",
     ),
-    source: str = typer.Option(
-        "0.0.0.0/0",
-        "--source",
-        help="Source CIDR allowed to reach the FiftyOne app.",
-    ),
+    source: str = ingress_source_option("Source CIDR allowed to reach the FiftyOne app."),
+    allow_world_open: bool = world_open_ack_option(),
 ) -> None:
     """Ensure public ingress for the saved FiftyOne BYOVM alias."""
     try:
@@ -1087,6 +1086,7 @@ def ensure_ingress_cmd(
             project_alias=_project_alias or None,
             name=name or _workbench_name or None,
             source=source,
+            allow_world_open=allow_world_open,
         )
     except (ConfigError, NetworkIngressError) as exc:
         _fail(str(exc))
@@ -1098,6 +1098,8 @@ def register_byovm_cmd(
     alias: str = typer.Option(..., "--alias", help="Workbench alias to create or update."),
     instance_id: str = typer.Option(..., "--instance-id", help="Nebius compute instance ID."),
     port: int = typer.Option(DEFAULT_APP_PORT, "--port", help="FiftyOne HTTP app port."),
+    source: str = ingress_source_option("Source CIDR allowed to reach FiftyOne."),
+    allow_world_open: bool = world_open_ack_option(),
 ) -> None:
     """Register an existing VM as a FiftyOne BYOVM alias and ensure ingress."""
     try:
@@ -1107,6 +1109,8 @@ def register_byovm_cmd(
             instance_id=instance_id,
             port=port,
             project_alias=_project_alias or None,
+            source=source,
+            allow_world_open=allow_world_open,
             warn=console.print,
         )
     except (ConfigError, NetworkIngressError) as exc:
@@ -3522,6 +3526,8 @@ def deploy_cmd(
                     project_alias=proj_alias,
                     name=wb_name,
                 ),
+                source=str(merged_vars.get("application_cidr_block", "")),
+                allow_world_open=str(merged_vars.get("allow_world_open_application", "false")).lower() == "true",
                 warn=console.print,
             )
 

--- a/npa/src/npa/cli/groot/__init__.py
+++ b/npa/src/npa/cli/groot/__init__.py
@@ -20,8 +20,10 @@ from npa.cli.ingress import (
     ensure_alias_ingress,
     ensure_deploy_ingress,
     ingress_summary,
+    ingress_source_option,
     register_byovm_alias,
     resolve_deploy_instance_id,
+    world_open_ack_option,
 )
 from npa.cli.path_contract import (
     PathContractError,
@@ -478,11 +480,8 @@ def ensure_ingress_cmd(
         "-n",
         help="Workbench alias to repair. Defaults to the active workbench alias.",
     ),
-    source: str = typer.Option(
-        "0.0.0.0/0",
-        "--source",
-        help="Source CIDR allowed to reach the GR00T server.",
-    ),
+    source: str = ingress_source_option("Source CIDR allowed to reach the GR00T server."),
+    allow_world_open: bool = world_open_ack_option(),
 ) -> None:
     """Ensure public ingress for the saved GR00T BYOVM alias."""
     try:
@@ -492,6 +491,7 @@ def ensure_ingress_cmd(
             project_alias=_project_alias or None,
             name=name or _workbench_name or None,
             source=source,
+            allow_world_open=allow_world_open,
         )
     except (ConfigError, NetworkIngressError) as exc:
         _fail(str(exc))
@@ -507,6 +507,8 @@ def register_byovm_cmd(
         ..., "--instance-id", help="Nebius compute instance ID."
     ),
     port: int = typer.Option(8082, "--port", help="GR00T HTTP service port."),
+    source: str = ingress_source_option("Source CIDR allowed to reach GR00T."),
+    allow_world_open: bool = world_open_ack_option(),
 ) -> None:
     """Register an existing VM as a GR00T BYOVM alias and ensure ingress."""
     try:
@@ -516,6 +518,8 @@ def register_byovm_cmd(
             instance_id=instance_id,
             port=port,
             project_alias=_project_alias or None,
+            source=source,
+            allow_world_open=allow_world_open,
             warn=console.print,
         )
     except (ConfigError, NetworkIngressError) as exc:
@@ -3157,6 +3161,8 @@ def deploy_cmd(
                     project_alias=proj_alias,
                     name=wb_name,
                 ),
+                source=str(merged_vars.get("application_cidr_block", "")),
+                allow_world_open=str(merged_vars.get("allow_world_open_application", "false")).lower() == "true",
                 warn=console.print,
             )
 

--- a/npa/src/npa/cli/ingress.py
+++ b/npa/src/npa/cli/ingress.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from ipaddress import ip_network
 from typing import Any
+
+import typer
 
 from npa.clients.config import (
     ConfigError,
@@ -15,6 +18,7 @@ from npa.clients.config import (
 from npa.clients.network import (
     EnsureIngressResult,
     InstanceNetworkContext,
+    NetworkIngressError,
     ensure_ingress,
     resolve_instance_network_context,
 )
@@ -42,6 +46,18 @@ class RegisterByovmResult:
     ingress: EnsureIngressResult | None
 
 
+def ingress_source_option(help_text: str):
+    return typer.Option(..., "--source", help=help_text)
+
+
+def world_open_ack_option():
+    return typer.Option(
+        False,
+        "--allow-world-open",
+        help="Acknowledge that a /0 source exposes the service to the world.",
+    )
+
+
 def resolve_alias_record(project_alias: str | None, name: str | None) -> AliasRecord:
     """Resolve a workbench alias to its raw config dictionary."""
     projects = list_projects()
@@ -52,7 +68,9 @@ def resolve_alias_record(project_alias: str | None, name: str | None) -> AliasRe
     if resolved_project not in projects:
         if project_alias:
             available = ", ".join(projects.keys())
-            raise ConfigError(f"Project '{project_alias}' not found. Available: {available}")
+            raise ConfigError(
+                f"Project '{project_alias}' not found. Available: {available}"
+            )
         resolved_project = next(iter(projects.keys()))
 
     project_config = projects[resolved_project]
@@ -70,7 +88,9 @@ def resolve_alias_record(project_alias: str | None, name: str | None) -> AliasRe
     alias_data = workbenches[resolved_name]
     if not isinstance(alias_data, dict):
         raise ConfigError(f"Workbench '{resolved_name}' is not a valid alias config")
-    return AliasRecord(project_alias=resolved_project, name=resolved_name, data=alias_data)
+    return AliasRecord(
+        project_alias=resolved_project, name=resolved_name, data=alias_data
+    )
 
 
 def register_byovm_alias(
@@ -80,7 +100,8 @@ def register_byovm_alias(
     instance_id: str,
     port: int,
     project_alias: str | None,
-    source: str = "0.0.0.0/0",
+    source: str = "",
+    allow_world_open: bool = False,
     warn,
 ) -> RegisterByovmResult:
     """Register a BYOVM workbench alias and best-effort ingress for its HTTP port."""
@@ -88,11 +109,17 @@ def register_byovm_alias(
     resolved_project = _registration_project_alias(project_alias)
     projects = list_projects()
     project_config = projects.get(resolved_project, {})
-    workbenches = project_config.get("workbenches", {}) if isinstance(project_config, dict) else {}
+    workbenches = (
+        project_config.get("workbenches", {})
+        if isinstance(project_config, dict)
+        else {}
+    )
     existing = workbenches.get(alias, {}) if isinstance(workbenches, dict) else {}
     existing_alias = existing if isinstance(existing, dict) else {}
     if existing_alias:
-        warn(f"Warning: alias '{alias}' already exists; overwriting BYOVM registration fields.")
+        warn(
+            f"Warning: alias '{alias}' already exists; overwriting BYOVM registration fields."
+        )
 
     alias_config = _byovm_alias_config(
         existing=existing_alias,
@@ -101,15 +128,17 @@ def register_byovm_alias(
         context=context,
         port=port,
     )
-    write_config({
-        "projects": {
-            resolved_project: {
-                "workbenches": {
-                    alias: alias_config,
+    write_config(
+        {
+            "projects": {
+                resolved_project: {
+                    "workbenches": {
+                        alias: alias_config,
+                    },
                 },
             },
-        },
-    })
+        }
+    )
     warn(f"Registered {tool} BYOVM alias '{alias}' in project '{resolved_project}'.")
     warn(f"  instance_id: {context.instance_id}")
     warn(f"  project_id: {context.project_id}")
@@ -120,6 +149,7 @@ def register_byovm_alias(
         alias=alias,
         instance_id=context.instance_id,
         source=source,
+        allow_world_open=allow_world_open,
         warn=warn,
     )
     return RegisterByovmResult(
@@ -139,7 +169,8 @@ def ensure_alias_ingress(
     port: int,
     project_alias: str | None,
     name: str | None,
-    source: str = "0.0.0.0/0",
+    source: str,
+    allow_world_open: bool = False,
 ) -> EnsureIngressResult:
     """Ensure ingress for a saved BYOVM alias that carries an instance ID."""
     alias = resolve_alias_record(project_alias, name)
@@ -149,10 +180,14 @@ def ensure_alias_ingress(
             f"alias '{alias.name}' has no instance_id; re-register with "
             f"'npa workbench {tool} register-byovm'"
         )
+    normalized_source = validate_ingress_source(
+        source, allow_world_open=allow_world_open
+    )
     return ensure_ingress(
         vm_id=instance_id,
         ports=(int(port),),
-        source=source,
+        source=normalized_source,
+        allow_world_open=allow_world_open,
         tool=tool,
     )
 
@@ -179,7 +214,8 @@ def ensure_deploy_ingress(
     port: int,
     alias: str,
     instance_id: str,
-    source: str = "0.0.0.0/0",
+    source: str = "",
+    allow_world_open: bool = False,
     warn,
 ) -> EnsureIngressResult | None:
     """Best-effort deploy-time ingress management.
@@ -187,14 +223,30 @@ def ensure_deploy_ingress(
     Deploy already completed by the time this runs, so ingress failures are
     reported as operator-actionable warnings instead of aborting the deploy.
     """
+    if not source.strip():
+        warn(
+            f"Public application ingress for port {port} was not requested; "
+            "no network rule was created."
+        )
+        return None
+    try:
+        normalized_source = validate_ingress_source(
+            source, allow_world_open=allow_world_open
+        )
+    except NetworkIngressError as exc:
+        warn(f"Warning: application ingress was not changed: {exc}")
+        return None
     if not instance_id:
-        warn(f"Debug: skipping network ingress for port {port}: instance_id unavailable.")
+        warn(
+            f"Debug: skipping network ingress for port {port}: instance_id unavailable."
+        )
         return None
     try:
         result = ensure_ingress(
             vm_id=instance_id,
             ports=(int(port),),
-            source=source,
+            source=normalized_source,
+            allow_world_open=allow_world_open,
             tool=tool,
         )
     except Exception as exc:
@@ -205,6 +257,26 @@ def ensure_deploy_ingress(
         return None
     warn(f"Network ingress confirmed for port {port}: {ingress_summary(result, port)}")
     return result
+
+
+def validate_ingress_source(source: str, *, allow_world_open: bool) -> str:
+    """Validate an operator-selected CIDR and require acknowledgement for /0."""
+
+    value = str(source or "").strip()
+    if not value:
+        raise NetworkIngressError("an explicit source CIDR is required")
+    try:
+        network = ip_network(value, strict=False)
+    except ValueError as exc:
+        raise NetworkIngressError(f"invalid source CIDR {value!r}") from exc
+    if network.version != 4:
+        raise NetworkIngressError("source CIDR must be IPv4")
+    normalized = str(network)
+    if network.prefixlen == 0 and not allow_world_open:
+        raise NetworkIngressError(
+            "world-open ingress requires the explicit --allow-world-open acknowledgement"
+        )
+    return normalized
 
 
 def ingress_summary(result: EnsureIngressResult, port: int) -> str:
@@ -229,8 +301,12 @@ def _byovm_alias_config(
     port: int,
 ) -> dict[str, Any]:
     host = _strip_cidr(context.public_ip)
-    existing_ssh = existing.get("ssh", {}) if isinstance(existing.get("ssh"), dict) else {}
-    existing_storage = existing.get("storage", {}) if isinstance(existing.get("storage"), dict) else {}
+    existing_ssh = (
+        existing.get("ssh", {}) if isinstance(existing.get("ssh"), dict) else {}
+    )
+    existing_storage = (
+        existing.get("storage", {}) if isinstance(existing.get("storage"), dict) else {}
+    )
 
     # Existing aliases are overwritten for the fields resolved from the VM so
     # re-registration repairs drift, while unrelated storage/custom fields remain.
@@ -251,7 +327,9 @@ def _byovm_alias_config(
             "key_path": str(existing_ssh.get("key_path", "") or "~/.ssh/id_ed25519"),
         },
         "storage": {
-            "checkpoint_bucket": str(existing_storage.get("checkpoint_bucket", "") or ""),
+            "checkpoint_bucket": str(
+                existing_storage.get("checkpoint_bucket", "") or ""
+            ),
             "endpoint_url": str(existing_storage.get("endpoint_url", "") or ""),
         },
     }

--- a/npa/src/npa/cli/network/__init__.py
+++ b/npa/src/npa/cli/network/__init__.py
@@ -147,9 +147,14 @@ def ensure_ingress(
         help="Comma-separated TCP port list, for example 5151,8081,8082.",
     ),
     source: str = typer.Option(
-        "0.0.0.0/0",
+        ...,
         "--source",
         help="Source CIDR allowed to reach the requested ports.",
+    ),
+    allow_world_open: bool = typer.Option(
+        False,
+        "--allow-world-open",
+        help="Acknowledge that a /0 source exposes the ports to the world.",
     ),
     tool: str = typer.Option(
         "manual",
@@ -169,12 +174,15 @@ def ensure_ingress(
         raise typer.BadParameter(str(exc), param_hint="--ports") from exc
 
     try:
+        from npa.cli.ingress import validate_ingress_source
+
         result = ensure_ingress_impl(
             vm_id=vm,
             ip=ip,
             project_id=project,
             ports=parsed_ports,
-            source=source,
+            source=validate_ingress_source(source, allow_world_open=allow_world_open),
+            allow_world_open=allow_world_open,
             tool=tool,
         )
     except NetworkIngressError as exc:

--- a/npa/src/npa/clients/network.py
+++ b/npa/src/npa/clients/network.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from ipaddress import ip_network
 import re
 from typing import Any
 from collections.abc import Callable, Sequence
@@ -173,6 +174,23 @@ class _SecurityGroupContext:
     rules: tuple[dict[str, Any], ...]
     covered_ports: frozenset[int]
     warnings: tuple[str, ...]
+
+
+def _validate_ingress_source(source: str, *, allow_world_open: bool) -> str:
+    value = str(source or "").strip()
+    if not value:
+        raise NetworkIngressError("an explicit source CIDR is required")
+    try:
+        network = ip_network(value, strict=False)
+    except ValueError as exc:
+        raise NetworkIngressError(f"invalid source CIDR {value!r}") from exc
+    if network.version != 4:
+        raise NetworkIngressError("source CIDR must be IPv4")
+    if network.prefixlen == 0 and not allow_world_open:
+        raise NetworkIngressError(
+            "world-open ingress requires explicit operator acknowledgement"
+        )
+    return str(network)
 
 
 def parse_ports(value: str) -> tuple[int, ...]:
@@ -358,7 +376,8 @@ def ensure_ingress(
     ip: str | None = None,
     project_id: str | None = None,
     ports: tuple[int, ...],
-    source: str = "0.0.0.0/0",
+    source: str = "",
+    allow_world_open: bool = False,
     tool: str = "manual",
     protocol: str = "TCP",
 ) -> EnsureIngressResult:
@@ -367,6 +386,7 @@ def ensure_ingress(
 
     forbid_destructive_provisioning("ensure_ingress")
     normalized_protocol = _normalize_protocol(protocol)
+    source = _validate_ingress_source(source, allow_world_open=allow_world_open)
     if bool(vm_id) == bool(ip and project_id):
         raise NetworkIngressError("pass exactly one of --vm or (--ip and --project)")
     if ip and not project_id:

--- a/npa/src/npa/deploy/terraform/cloud_init.yaml.tpl
+++ b/npa/src/npa/deploy/terraform/cloud_init.yaml.tpl
@@ -29,8 +29,6 @@ write_files:
       FIFTYONE_MODEL_ZOO_DIR=/opt/fiftyone/zoo/models
       FIFTYONE_DO_NOT_TRACK=true
       FIFTYONE_DATASET_NAME=
-      AWS_ACCESS_KEY_ID=${aws_access_key}
-      AWS_SECRET_ACCESS_KEY=${aws_secret_key}
       AWS_ENDPOINT_URL=${s3_endpoint}
       NEBIUS_S3_ENDPOINT=${s3_endpoint}
       NEBIUS_S3_BUCKET=${s3_bucket}
@@ -99,8 +97,6 @@ write_files:
     owner: ${ssh_user}:${ssh_user}
     permissions: "0600"
     content: |
-      AWS_ACCESS_KEY_ID=${aws_access_key}
-      AWS_SECRET_ACCESS_KEY=${aws_secret_key}
       NEBIUS_S3_ENDPOINT=${s3_endpoint}
       NEBIUS_S3_BUCKET=${s3_bucket}
       NEBIUS_REGION=${nebius_region}

--- a/npa/src/npa/deploy/terraform/main.tf
+++ b/npa/src/npa/deploy/terraform/main.tf
@@ -35,6 +35,7 @@ resource "nebius_vpc_v1_security_group" "workbench" {
 }
 
 resource "nebius_vpc_v1_security_rule" "allow_ssh" {
+  count     = trimspace(var.ssh_cidr_block) == "" ? 0 : 1
   parent_id = nebius_vpc_v1_security_group.workbench.id
   name      = "allow-ssh"
   protocol  = "TCP"
@@ -47,13 +48,14 @@ resource "nebius_vpc_v1_security_rule" "allow_ssh" {
 }
 
 resource "nebius_vpc_v1_security_rule" "allow_server" {
+  count     = trimspace(var.application_cidr_block) == "" ? 0 : 1
   parent_id = nebius_vpc_v1_security_group.workbench.id
   name      = "allow-server"
   protocol  = "TCP"
   access    = "ALLOW"
 
   ingress = {
-    source_cidrs      = [var.ssh_cidr_block]
+    source_cidrs      = [var.application_cidr_block]
     destination_ports = distinct(concat([var.server_port], jsondecode(var.extra_ingress_ports)))
   }
 }
@@ -148,8 +150,6 @@ resource "nebius_compute_v1_instance" "workbench" {
     fiftyone_version = var.fiftyone_version
     s3_bucket        = var.s3_bucket
     s3_endpoint      = var.s3_endpoint
-    aws_access_key   = var.nebius_api_key
-    aws_secret_key   = var.nebius_secret_key
     nebius_region    = var.nebius_region
   })
 
@@ -183,7 +183,7 @@ resource "null_resource" "wait_for_cloud_init" {
   # Skipped with wait_for_ssh = false, for a machine that cannot open outbound
   # tcp/22 to a fresh public IP (corporate VPN / split tunnel). The VM still
   # finishes cloud-init on its own; the deploy just stops verifying it over SSH.
-  count      = var.wait_for_ssh ? 1 : 0
+  count      = var.wait_for_ssh && trimspace(var.ssh_cidr_block) != "" ? 1 : 0
   depends_on = [nebius_compute_v1_instance.workbench]
 
   triggers = {

--- a/npa/src/npa/deploy/terraform/variables.tf
+++ b/npa/src/npa/deploy/terraform/variables.tf
@@ -127,9 +127,56 @@ variable "ssh_public_key_path" {
 }
 
 variable "ssh_cidr_block" {
-  description = "CIDR block allowed to SSH. Defaults to open access (0.0.0.0/0)."
+  description = "CIDR block allowed to SSH. Empty disables SSH ingress; set explicitly for remote bootstrap."
   type        = string
-  default     = "0.0.0.0/0"
+  default     = ""
+
+  validation {
+    condition = (
+      trimspace(var.ssh_cidr_block) == "" ||
+      can(cidrnetmask(var.ssh_cidr_block))
+    )
+    error_message = "ssh_cidr_block must be empty (no SSH ingress) or a valid IPv4 CIDR."
+  }
+
+  validation {
+    condition     = !endswith(trimspace(var.ssh_cidr_block), "/0") || var.allow_world_open_ssh
+    error_message = "World-open SSH (/0) requires allow_world_open_ssh=true."
+  }
+}
+
+variable "application_cidr_block" {
+  description = "CIDR block allowed to reach server_port and extra_ingress_ports. Empty disables public application ingress."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      trimspace(var.application_cidr_block) == "" ||
+      can(cidrnetmask(var.application_cidr_block))
+    )
+    error_message = "application_cidr_block must be empty (no application ingress) or a valid IPv4 CIDR."
+  }
+
+  validation {
+    condition = (
+      !endswith(trimspace(var.application_cidr_block), "/0") ||
+      var.allow_world_open_application
+    )
+    error_message = "World-open application ingress (/0) requires allow_world_open_application=true."
+  }
+}
+
+variable "allow_world_open_ssh" {
+  description = "Conspicuous operator acknowledgement required when SSH ingress is 0.0.0.0/0"
+  type        = bool
+  default     = false
+}
+
+variable "allow_world_open_application" {
+  description = "Conspicuous operator acknowledgement required when application ingress is 0.0.0.0/0; especially hazardous for unauthenticated apps such as FiftyOne"
+  type        = bool
+  default     = false
 }
 
 # ── LeRobot ────────────────────────────────────────────────────────────────
@@ -148,14 +195,14 @@ variable "lerobot_version" {
 # ── S3 credentials (from environment.sh) ──────────────────────────────────
 
 variable "nebius_api_key" {
-  description = "AWS-compatible access key for S3"
+  description = "Deprecated compatibility input for operator-side Terraform state access; never rendered into VM metadata or cloud-init"
   type        = string
   sensitive   = true
   default     = ""
 }
 
 variable "nebius_secret_key" {
-  description = "AWS-compatible secret key for S3"
+  description = "Deprecated compatibility input for operator-side Terraform state access; never rendered into VM metadata or cloud-init"
   type        = string
   sensitive   = true
   default     = ""

--- a/npa/src/npa/network/__init__.py
+++ b/npa/src/npa/network/__init__.py
@@ -14,7 +14,8 @@ def ensure_ingress(
     vm: str | None = None,
     ip: str | None = None,
     project: str | None = None,
-    source: str = "0.0.0.0/0",
+    source: str = "",
+    allow_world_open: bool = False,
     tool: str = "manual",
 ):
     """Ensure TCP ingress to a VM security group."""
@@ -22,12 +23,15 @@ def ensure_ingress(
         parsed_ports = list(parse_ports(ports))
     else:
         parsed_ports = [int(port) for port in ports]
+    from npa.cli.ingress import validate_ingress_source
+
     return _ensure_ingress(
         vm_id=vm,
         ip=ip,
         project_id=project,
         ports=parsed_ports,
-        source=source,
+        source=validate_ingress_source(source, allow_world_open=allow_world_open),
+        allow_world_open=allow_world_open,
         tool=tool,
     )
 

--- a/npa/src/npa/workbench/dataset/curation.py
+++ b/npa/src/npa/workbench/dataset/curation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from npa.workbench.storage_scope import StorageAuthorizationError
+
 from .ingestion import compute_manifest_sha256, manifest_uri
 from .integrations import query_lancedb
 from .schemas import (
@@ -55,6 +57,8 @@ def _filter_records(
 def _read_manifest(input_uri: str) -> dict[str, Any]:
     try:
         manifest = read_json_uri(input_uri)
+    except StorageAuthorizationError:
+        raise
     except FileNotFoundError as exc:
         raise DatasetCurateError(f"dataset manifest not found: {input_uri}") from exc
     except Exception as exc:

--- a/npa/src/npa/workbench/dataset/ingestion.py
+++ b/npa/src/npa/workbench/dataset/ingestion.py
@@ -6,6 +6,8 @@ import hashlib
 import json
 from typing import Any
 
+from npa.workbench.storage_scope import StorageAuthorizationError
+
 from .integrations import fiftyone_handoff, index_in_lancedb
 from .schemas import (
     COMPLETENESS_FIELDS,
@@ -42,6 +44,8 @@ def load_raw_records(input_uri: str) -> list[dict[str, Any]]:
     """Read raw sensor records from an input manifest URI."""
     try:
         payload = read_json_uri(input_uri)
+    except StorageAuthorizationError:
+        raise
     except FileNotFoundError as exc:
         raise DatasetIngestError(f"raw sensor data not found: {input_uri}") from exc
     except Exception as exc:

--- a/npa/src/npa/workbench/dataset/service.py
+++ b/npa/src/npa/workbench/dataset/service.py
@@ -6,9 +6,17 @@ import hmac
 import logging
 import os
 import platform
-from typing import Any
+from pathlib import Path
+from typing import Any, Sequence
 
 from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from npa.workbench.storage_scope import (
+    StorageAuthorizationError,
+    StorageScope,
+    use_storage_scope,
+)
 
 from .curation import DatasetCurateError, curate_dataset, query_dataset
 from .ingestion import DatasetIngestError, ingest_dataset
@@ -31,10 +39,26 @@ DATASETS: dict[str, dict[str, Any]] = {}
 LOGGER = logging.getLogger(__name__)
 
 
-def create_app(*, auth_mode: str | None = None, token: str | None = None) -> FastAPI:
+def create_app(
+    *,
+    auth_mode: str | None = None,
+    token: str | None = None,
+    allowed_s3_roots: Sequence[str] | None = None,
+    allowed_local_roots: Sequence[str | Path] | None = None,
+) -> FastAPI:
     """Create the dataset-of-record FastAPI application."""
-    resolved_auth_mode = auth_mode or os.environ.get("DATASET_AUTH_MODE", "none")
+    resolved_auth_mode = auth_mode or os.environ.get("DATASET_AUTH_MODE", "token")
+    if resolved_auth_mode not in {"token", "none"}:
+        raise ValueError("DATASET_AUTH_MODE must be 'token' or explicit 'none'")
     resolved_token = token if token is not None else os.environ.get("DATASET_TOKEN", "")
+    storage_scope = (
+        StorageScope.from_env("DATASET")
+        if allowed_s3_roots is None and allowed_local_roots is None
+        else StorageScope.from_config(
+            s3_roots=allowed_s3_roots or (),
+            local_roots=allowed_local_roots or (),
+        )
+    )
     app = FastAPI(title="NPA Dataset of Record")
     if resolved_auth_mode == "none":
         LOGGER.warning(
@@ -42,11 +66,20 @@ def create_app(*, auth_mode: str | None = None, token: str | None = None) -> Fas
             "without a token. Set DATASET_AUTH_MODE=token and DATASET_TOKEN."
         )
 
+    @app.middleware("http")
+    async def apply_storage_scope(request: Request, call_next):
+        with use_storage_scope(storage_scope):
+            return await call_next(request)
+
+    @app.exception_handler(StorageAuthorizationError)
+    async def storage_denied(_request: Request, exc: StorageAuthorizationError) -> JSONResponse:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+
     async def require_auth(request: Request, authorization: str = Header(default="")) -> None:
         if resolved_auth_mode == "none":
             return
         if not resolved_token:
-            raise HTTPException(status_code=500, detail="DATASET_TOKEN is not configured")
+            raise HTTPException(status_code=503, detail="DATASET_TOKEN is not configured")
         if not hmac.compare_digest(authorization, f"Bearer {resolved_token}"):
             raise HTTPException(status_code=401, detail="invalid token")
 

--- a/npa/src/npa/workbench/dataset/storage.py
+++ b/npa/src/npa/workbench/dataset/storage.py
@@ -17,7 +17,7 @@ def uri_join(base: str, *parts: str) -> str:
 
 
 def write_bytes_uri(uri: str, payload: bytes) -> None:
-    target = authorize_uri(uri, operation="write", env_prefix="DATASET")
+    target = authorize_uri(uri, operation="write")
     if target.kind == "s3":
         _s3_client().put_object(Bucket=target.bucket, Key=target.key, Body=payload)
         return
@@ -28,7 +28,7 @@ def write_bytes_uri(uri: str, payload: bytes) -> None:
 
 
 def read_bytes_uri(uri: str) -> bytes:
-    target = authorize_uri(uri, operation="read", env_prefix="DATASET")
+    target = authorize_uri(uri, operation="read")
     if target.kind == "s3":
         response = _s3_client().get_object(Bucket=target.bucket, Key=target.key)
         return response["Body"].read()

--- a/npa/src/npa/workbench/dataset/storage.py
+++ b/npa/src/npa/workbench/dataset/storage.py
@@ -4,16 +4,9 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
-
-@dataclass(frozen=True)
-class S3Uri:
-    bucket: str
-    key: str
+from npa.workbench.storage_scope import authorize_uri
 
 
 def uri_join(base: str, *parts: str) -> str:
@@ -23,33 +16,24 @@ def uri_join(base: str, *parts: str) -> str:
     return f"{prefix}/{suffix}" if suffix else prefix
 
 
-def parse_s3_uri(uri: str) -> S3Uri:
-    parsed = urlparse(uri)
-    if parsed.scheme != "s3" or not parsed.netloc:
-        raise ValueError(f"not an S3 URI: {uri}")
-    return S3Uri(bucket=parsed.netloc, key=parsed.path.lstrip("/"))
-
-
-def is_s3_uri(uri: str) -> bool:
-    return uri.startswith("s3://")
-
-
 def write_bytes_uri(uri: str, payload: bytes) -> None:
-    if is_s3_uri(uri):
-        target = parse_s3_uri(uri)
+    target = authorize_uri(uri, operation="write", env_prefix="DATASET")
+    if target.kind == "s3":
         _s3_client().put_object(Bucket=target.bucket, Key=target.key, Body=payload)
         return
-    path = _local_path(uri)
+    assert target.local_path is not None
+    path = target.local_path
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(payload)
 
 
 def read_bytes_uri(uri: str) -> bytes:
-    if is_s3_uri(uri):
-        target = parse_s3_uri(uri)
+    target = authorize_uri(uri, operation="read", env_prefix="DATASET")
+    if target.kind == "s3":
         response = _s3_client().get_object(Bucket=target.bucket, Key=target.key)
         return response["Body"].read()
-    return _local_path(uri).read_bytes()
+    assert target.local_path is not None
+    return target.local_path.read_bytes()
 
 
 def write_json_uri(uri: str, payload: dict[str, Any]) -> None:
@@ -59,12 +43,6 @@ def write_json_uri(uri: str, payload: dict[str, Any]) -> None:
 
 def read_json_uri(uri: str) -> dict[str, Any]:
     return json.loads(read_bytes_uri(uri).decode("utf-8"))
-
-
-def _local_path(uri: str) -> Path:
-    if uri.startswith("file://"):
-        return Path(urlparse(uri).path)
-    return Path(uri)
 
 
 def _s3_client():

--- a/npa/src/npa/workbench/dataset/validation.py
+++ b/npa/src/npa/workbench/dataset/validation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from npa.workbench.storage_scope import StorageAuthorizationError
+
 from .ingestion import compute_manifest_sha256
 from .schemas import (
     VALIDATION_REPORT_SCHEMA,
@@ -26,6 +28,8 @@ def validate_manifest(request: ValidateRequest) -> ValidateResponse:
     """Run schema + quality-metric checks and emit a validation report."""
     try:
         manifest = read_json_uri(request.input_uri)
+    except StorageAuthorizationError:
+        raise
     except FileNotFoundError as exc:
         raise DatasetValidationError(f"dataset manifest not found: {request.input_uri}") from exc
     except Exception as exc:

--- a/npa/src/npa/workbench/insights/service.py
+++ b/npa/src/npa/workbench/insights/service.py
@@ -6,9 +6,17 @@ import hmac
 import logging
 import os
 import platform
-from typing import Any
+from pathlib import Path
+from typing import Any, Sequence
 
 from fastapi import FastAPI, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+
+from npa.workbench.storage_scope import (
+    StorageAuthorizationError,
+    StorageScope,
+    use_storage_scope,
+)
 
 from .analytics import (
     InsightsQueryError,
@@ -40,10 +48,26 @@ STORES: dict[str, dict[str, Any]] = {}
 LOGGER = logging.getLogger(__name__)
 
 
-def create_app(*, auth_mode: str | None = None, token: str | None = None) -> FastAPI:
+def create_app(
+    *,
+    auth_mode: str | None = None,
+    token: str | None = None,
+    allowed_s3_roots: Sequence[str] | None = None,
+    allowed_local_roots: Sequence[str | Path] | None = None,
+) -> FastAPI:
     """Create the insights FastAPI application."""
-    resolved_auth_mode = auth_mode or os.environ.get("INSIGHTS_AUTH_MODE", "none")
+    resolved_auth_mode = auth_mode or os.environ.get("INSIGHTS_AUTH_MODE", "token")
+    if resolved_auth_mode not in {"token", "none"}:
+        raise ValueError("INSIGHTS_AUTH_MODE must be 'token' or explicit 'none'")
     resolved_token = token if token is not None else os.environ.get("INSIGHTS_TOKEN", "")
+    storage_scope = (
+        StorageScope.from_env("INSIGHTS")
+        if allowed_s3_roots is None and allowed_local_roots is None
+        else StorageScope.from_config(
+            s3_roots=allowed_s3_roots or (),
+            local_roots=allowed_local_roots or (),
+        )
+    )
     app = FastAPI(title="NPA Insights")
     if resolved_auth_mode == "none":
         LOGGER.warning(
@@ -51,11 +75,20 @@ def create_app(*, auth_mode: str | None = None, token: str | None = None) -> Fas
             "without a token. Set INSIGHTS_AUTH_MODE=token and INSIGHTS_TOKEN."
         )
 
+    @app.middleware("http")
+    async def apply_storage_scope(request: Request, call_next):
+        with use_storage_scope(storage_scope):
+            return await call_next(request)
+
+    @app.exception_handler(StorageAuthorizationError)
+    async def storage_denied(_request: Request, exc: StorageAuthorizationError) -> JSONResponse:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+
     async def require_auth(request: Request, authorization: str = Header(default="")) -> None:
         if resolved_auth_mode == "none":
             return
         if not resolved_token:
-            raise HTTPException(status_code=500, detail="INSIGHTS_TOKEN is not configured")
+            raise HTTPException(status_code=503, detail="INSIGHTS_TOKEN is not configured")
         if not hmac.compare_digest(authorization, f"Bearer {resolved_token}"):
             raise HTTPException(status_code=401, detail="invalid token")
 

--- a/npa/src/npa/workbench/insights/storage.py
+++ b/npa/src/npa/workbench/insights/storage.py
@@ -5,17 +5,10 @@ from __future__ import annotations
 import json
 import os
 import uuid
-from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
-
-@dataclass(frozen=True)
-class S3Uri:
-    bucket: str
-    key: str
+from npa.workbench.storage_scope import authorize_uri
 
 
 def uri_join(base: str, *parts: str) -> str:
@@ -25,44 +18,36 @@ def uri_join(base: str, *parts: str) -> str:
     return f"{prefix}/{suffix}" if suffix else prefix
 
 
-def parse_s3_uri(uri: str) -> S3Uri:
-    parsed = urlparse(uri)
-    if parsed.scheme != "s3" or not parsed.netloc:
-        raise ValueError(f"not an S3 URI: {uri}")
-    return S3Uri(bucket=parsed.netloc, key=parsed.path.lstrip("/"))
-
-
-def is_s3_uri(uri: str) -> bool:
-    return uri.startswith("s3://")
-
-
 def write_bytes_uri(uri: str, payload: bytes) -> None:
-    if is_s3_uri(uri):
-        target = parse_s3_uri(uri)
+    target = authorize_uri(uri, operation="write", env_prefix="INSIGHTS")
+    if target.kind == "s3":
         _s3_client().put_object(Bucket=target.bucket, Key=target.key, Body=payload)
         return
-    path = _local_path(uri)
+    assert target.local_path is not None
+    path = target.local_path
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(payload)
 
 
 def read_bytes_uri(uri: str) -> bytes:
-    if is_s3_uri(uri):
-        target = parse_s3_uri(uri)
+    target = authorize_uri(uri, operation="read", env_prefix="INSIGHTS")
+    if target.kind == "s3":
         response = _s3_client().get_object(Bucket=target.bucket, Key=target.key)
         return response["Body"].read()
-    return _local_path(uri).read_bytes()
+    assert target.local_path is not None
+    return target.local_path.read_bytes()
 
 
 def uri_exists(uri: str) -> bool:
-    if is_s3_uri(uri):
-        target = parse_s3_uri(uri)
+    target = authorize_uri(uri, operation="read", env_prefix="INSIGHTS")
+    if target.kind == "s3":
         try:
             _s3_client().head_object(Bucket=target.bucket, Key=target.key)
             return True
         except Exception:
             return False
-    return _local_path(uri).exists()
+    assert target.local_path is not None
+    return target.local_path.exists()
 
 
 def write_json_uri(uri: str, payload: dict[str, Any]) -> None:
@@ -103,8 +88,8 @@ def shard_prefix_for(uri: str) -> str:
 
 def list_jsonl_uris(prefix: str) -> list[str]:
     """List ``*.jsonl`` object URIs under a prefix (S3 or local), sorted."""
-    if is_s3_uri(prefix):
-        target = parse_s3_uri(prefix)
+    target = authorize_uri(prefix, operation="read", env_prefix="INSIGHTS")
+    if target.kind == "s3":
         client = _s3_client()
         paginator = client.get_paginator("list_objects_v2")
         found: list[str] = []
@@ -114,7 +99,8 @@ def list_jsonl_uris(prefix: str) -> list[str]:
                 if key.endswith(".jsonl"):
                     found.append(f"s3://{target.bucket}/{key}")
         return sorted(found)
-    base = _local_path(prefix)
+    assert target.local_path is not None
+    base = target.local_path
     if not base.exists():
         return []
     return sorted(str(path) for path in base.rglob("*.jsonl"))
@@ -167,8 +153,8 @@ def utc_stamp() -> str:
 
 def list_json_uris(prefix: str) -> list[str]:
     """List all ``*.json`` object URIs under a prefix (S3 or local)."""
-    if is_s3_uri(prefix):
-        target = parse_s3_uri(prefix)
+    target = authorize_uri(prefix, operation="read", env_prefix="INSIGHTS")
+    if target.kind == "s3":
         client = _s3_client()
         paginator = client.get_paginator("list_objects_v2")
         found: list[str] = []
@@ -178,18 +164,13 @@ def list_json_uris(prefix: str) -> list[str]:
                 if key.endswith(".json"):
                     found.append(f"s3://{target.bucket}/{key}")
         return sorted(found)
-    base = _local_path(prefix)
+    assert target.local_path is not None
+    base = target.local_path
     if base.is_file():
         return [str(base)] if base.suffix == ".json" else []
     if not base.exists():
         return []
     return sorted(str(path) for path in base.rglob("*.json"))
-
-
-def _local_path(uri: str) -> Path:
-    if uri.startswith("file://"):
-        return Path(urlparse(uri).path)
-    return Path(uri)
 
 
 def _s3_client():

--- a/npa/src/npa/workbench/insights/storage.py
+++ b/npa/src/npa/workbench/insights/storage.py
@@ -19,7 +19,7 @@ def uri_join(base: str, *parts: str) -> str:
 
 
 def write_bytes_uri(uri: str, payload: bytes) -> None:
-    target = authorize_uri(uri, operation="write", env_prefix="INSIGHTS")
+    target = authorize_uri(uri, operation="write")
     if target.kind == "s3":
         _s3_client().put_object(Bucket=target.bucket, Key=target.key, Body=payload)
         return
@@ -30,7 +30,7 @@ def write_bytes_uri(uri: str, payload: bytes) -> None:
 
 
 def read_bytes_uri(uri: str) -> bytes:
-    target = authorize_uri(uri, operation="read", env_prefix="INSIGHTS")
+    target = authorize_uri(uri, operation="read")
     if target.kind == "s3":
         response = _s3_client().get_object(Bucket=target.bucket, Key=target.key)
         return response["Body"].read()
@@ -39,7 +39,7 @@ def read_bytes_uri(uri: str) -> bytes:
 
 
 def uri_exists(uri: str) -> bool:
-    target = authorize_uri(uri, operation="read", env_prefix="INSIGHTS")
+    target = authorize_uri(uri, operation="read")
     if target.kind == "s3":
         try:
             _s3_client().head_object(Bucket=target.bucket, Key=target.key)
@@ -88,7 +88,7 @@ def shard_prefix_for(uri: str) -> str:
 
 def list_jsonl_uris(prefix: str) -> list[str]:
     """List ``*.jsonl`` object URIs under a prefix (S3 or local), sorted."""
-    target = authorize_uri(prefix, operation="read", env_prefix="INSIGHTS")
+    target = authorize_uri(prefix, operation="read")
     if target.kind == "s3":
         client = _s3_client()
         paginator = client.get_paginator("list_objects_v2")
@@ -153,7 +153,7 @@ def utc_stamp() -> str:
 
 def list_json_uris(prefix: str) -> list[str]:
     """List all ``*.json`` object URIs under a prefix (S3 or local)."""
-    target = authorize_uri(prefix, operation="read", env_prefix="INSIGHTS")
+    target = authorize_uri(prefix, operation="read")
     if target.kind == "s3":
         client = _s3_client()
         paginator = client.get_paginator("list_objects_v2")

--- a/npa/src/npa/workbench/insights/store.py
+++ b/npa/src/npa/workbench/insights/store.py
@@ -12,6 +12,8 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
+from npa.workbench.storage_scope import StorageAuthorizationError
+
 from .integrations import index_metrics_in_lancedb
 from .schemas import (
     ACCELERATORS_LABEL,
@@ -234,6 +236,8 @@ def record_metrics(request: RecordRequest) -> RecordResponse:
     if request.input_uri.strip():
         try:
             payload = read_json_uri(request.input_uri)
+        except StorageAuthorizationError:
+            raise
         except FileNotFoundError as exc:
             raise InsightsStoreError(f"record input not found: {request.input_uri}") from exc
         except Exception as exc:  # noqa: BLE001
@@ -284,6 +288,8 @@ def ingest_run(request: IngestRunRequest) -> IngestRunResponse:
         scanned += 1
         try:
             payload = read_json_uri(uri)
+        except StorageAuthorizationError:
+            raise
         except Exception:  # noqa: BLE001 - skip unreadable/non-object artifacts.
             continue
         if not isinstance(payload, dict):

--- a/npa/src/npa/workbench/storage_scope.py
+++ b/npa/src/npa/workbench/storage_scope.py
@@ -1,4 +1,4 @@
-"""Fail-closed URI authorization for workbench storage services."""
+"""Request-scoped URI authorization for workbench storage services."""
 
 from __future__ import annotations
 
@@ -63,30 +63,16 @@ class StorageScope:
         return cls.from_config(s3_roots=s3_values, local_roots=local_values)
 
     def authorize(self, uri: str, *, operation: str) -> AuthorizedUri:
-        value = str(uri or "").strip()
-        if not value:
-            raise StorageAuthorizationError(f"{operation} URI must not be empty")
-        parsed = urlparse(value)
-        if parsed.scheme == "s3":
-            return self._authorize_s3(value, parsed, operation=operation)
-        if parsed.scheme not in {"", "file"}:
-            raise StorageAuthorizationError(
-                f"{operation} URI scheme {parsed.scheme!r} is not allowed; use s3://, file://, or a local path"
-            )
-        return self._authorize_local(value, parsed, operation=operation)
+        target = _parse_uri(uri, operation=operation)
+        if target.kind == "s3":
+            return self._authorize_s3(target, operation=operation)
+        return self._authorize_local(target, operation=operation)
 
-    def _authorize_s3(self, value: str, parsed, *, operation: str) -> AuthorizedUri:
-        if (
-            not parsed.netloc
-            or parsed.username is not None
-            or parsed.password is not None
-            or parsed.port is not None
-            or parsed.query
-            or parsed.fragment
-        ):
-            raise StorageAuthorizationError(f"{operation} S3 URI is malformed")
-        bucket = parsed.hostname or ""
-        key = _canonical_s3_key(parsed.path)
+    def _authorize_s3(
+        self, target: AuthorizedUri, *, operation: str
+    ) -> AuthorizedUri:
+        bucket = target.bucket
+        key = target.key
         if not any(
             bucket == root.bucket
             and (
@@ -99,18 +85,13 @@ class StorageScope:
             raise StorageAuthorizationError(
                 f"{operation} S3 URI is outside the configured bucket/prefix roots"
             )
-        return AuthorizedUri(kind="s3", original=value, bucket=bucket, key=key)
+        return target
 
-    def _authorize_local(self, value: str, parsed, *, operation: str) -> AuthorizedUri:
-        if parsed.scheme == "file":
-            if parsed.netloc or parsed.query or parsed.fragment:
-                raise StorageAuthorizationError(
-                    f"{operation} file URI hosts, queries, and fragments are not allowed"
-                )
-            raw_path = unquote(parsed.path)
-        else:
-            raw_path = value
-        candidate = Path(raw_path).expanduser().resolve(strict=False)
+    def _authorize_local(
+        self, target: AuthorizedUri, *, operation: str
+    ) -> AuthorizedUri:
+        assert target.local_path is not None
+        candidate = target.local_path
         if not any(
             candidate == root or candidate.is_relative_to(root)
             for root in self.local_roots
@@ -118,7 +99,57 @@ class StorageScope:
             raise StorageAuthorizationError(
                 f"{operation} local path is outside the configured sandbox roots"
             )
-        return AuthorizedUri(kind="local", original=value, local_path=candidate)
+        return target
+
+
+def _parse_uri(uri: str, *, operation: str) -> AuthorizedUri:
+    """Parse a URI without applying service-only containment policy."""
+
+    value = str(uri or "").strip()
+    if not value:
+        raise StorageAuthorizationError(f"{operation} URI must not be empty")
+    parsed = urlparse(value)
+    if parsed.scheme == "s3":
+        return _parse_s3_uri(value, parsed, operation=operation)
+    if parsed.scheme not in {"", "file"}:
+        raise StorageAuthorizationError(
+            f"{operation} URI scheme {parsed.scheme!r} is not allowed; use s3://, file://, or a local path"
+        )
+    return _parse_local_uri(value, parsed, operation=operation)
+
+
+def _parse_s3_uri(value: str, parsed, *, operation: str) -> AuthorizedUri:
+    if (
+        not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise StorageAuthorizationError(f"{operation} S3 URI is malformed")
+    return AuthorizedUri(
+        kind="s3",
+        original=value,
+        bucket=parsed.hostname or "",
+        key=_canonical_s3_key(parsed.path),
+    )
+
+
+def _parse_local_uri(value: str, parsed, *, operation: str) -> AuthorizedUri:
+    if parsed.scheme == "file":
+        if parsed.netloc or parsed.query or parsed.fragment:
+            raise StorageAuthorizationError(
+                f"{operation} file URI hosts, queries, and fragments are not allowed"
+            )
+        raw_path = unquote(parsed.path)
+    else:
+        raw_path = value
+    return AuthorizedUri(
+        kind="local",
+        original=value,
+        local_path=Path(raw_path).expanduser().resolve(strict=False),
+    )
 
 
 _ACTIVE_SCOPE: ContextVar[StorageScope | None] = ContextVar(
@@ -136,8 +167,12 @@ def use_storage_scope(scope: StorageScope) -> Iterator[None]:
         _ACTIVE_SCOPE.reset(token)
 
 
-def authorize_uri(uri: str, *, operation: str, env_prefix: str) -> AuthorizedUri:
-    scope = _ACTIVE_SCOPE.get() or StorageScope.from_env(env_prefix)
+def authorize_uri(uri: str, *, operation: str) -> AuthorizedUri:
+    """Authorize inside an active service request; otherwise preserve embedded I/O."""
+
+    scope = _ACTIVE_SCOPE.get()
+    if scope is None:
+        return _parse_uri(uri, operation=operation)
     return scope.authorize(uri, operation=operation)
 
 

--- a/npa/src/npa/workbench/storage_scope.py
+++ b/npa/src/npa/workbench/storage_scope.py
@@ -1,0 +1,174 @@
+"""Fail-closed URI authorization for workbench storage services."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Sequence
+from urllib.parse import unquote, urlparse
+
+
+class StorageAuthorizationError(ValueError):
+    """Raised before a storage operation crosses its configured URI boundary."""
+
+
+@dataclass(frozen=True)
+class S3Root:
+    bucket: str
+    prefix: str
+
+
+@dataclass(frozen=True)
+class AuthorizedUri:
+    kind: str
+    original: str
+    local_path: Path | None = None
+    bucket: str = ""
+    key: str = ""
+
+
+@dataclass(frozen=True)
+class StorageScope:
+    """Canonical local sandboxes and S3 bucket/prefix roots allowed to a request."""
+
+    s3_roots: tuple[S3Root, ...] = ()
+    local_roots: tuple[Path, ...] = ()
+
+    @classmethod
+    def from_config(
+        cls,
+        *,
+        s3_roots: Sequence[str] = (),
+        local_roots: Sequence[str | Path] = (),
+    ) -> "StorageScope":
+        parsed_s3 = tuple(
+            _parse_s3_root(value) for value in s3_roots if str(value).strip()
+        )
+        parsed_local = tuple(
+            Path(value).expanduser().resolve(strict=False)
+            for value in local_roots
+            if str(value).strip()
+        )
+        return cls(s3_roots=parsed_s3, local_roots=parsed_local)
+
+    @classmethod
+    def from_env(cls, prefix: str) -> "StorageScope":
+        s3_values = _split_config(os.environ.get(f"{prefix}_ALLOWED_S3_ROOTS", ""), ",")
+        local_values = _split_config(
+            os.environ.get(f"{prefix}_ALLOWED_LOCAL_ROOTS", ""), os.pathsep
+        )
+        return cls.from_config(s3_roots=s3_values, local_roots=local_values)
+
+    def authorize(self, uri: str, *, operation: str) -> AuthorizedUri:
+        value = str(uri or "").strip()
+        if not value:
+            raise StorageAuthorizationError(f"{operation} URI must not be empty")
+        parsed = urlparse(value)
+        if parsed.scheme == "s3":
+            return self._authorize_s3(value, parsed, operation=operation)
+        if parsed.scheme not in {"", "file"}:
+            raise StorageAuthorizationError(
+                f"{operation} URI scheme {parsed.scheme!r} is not allowed; use s3://, file://, or a local path"
+            )
+        return self._authorize_local(value, parsed, operation=operation)
+
+    def _authorize_s3(self, value: str, parsed, *, operation: str) -> AuthorizedUri:
+        if (
+            not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.port is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise StorageAuthorizationError(f"{operation} S3 URI is malformed")
+        bucket = parsed.hostname or ""
+        key = _canonical_s3_key(parsed.path)
+        if not any(
+            bucket == root.bucket
+            and (
+                not root.prefix
+                or key == root.prefix
+                or key.startswith(root.prefix + "/")
+            )
+            for root in self.s3_roots
+        ):
+            raise StorageAuthorizationError(
+                f"{operation} S3 URI is outside the configured bucket/prefix roots"
+            )
+        return AuthorizedUri(kind="s3", original=value, bucket=bucket, key=key)
+
+    def _authorize_local(self, value: str, parsed, *, operation: str) -> AuthorizedUri:
+        if parsed.scheme == "file":
+            if parsed.netloc or parsed.query or parsed.fragment:
+                raise StorageAuthorizationError(
+                    f"{operation} file URI hosts, queries, and fragments are not allowed"
+                )
+            raw_path = unquote(parsed.path)
+        else:
+            raw_path = value
+        candidate = Path(raw_path).expanduser().resolve(strict=False)
+        if not any(
+            candidate == root or candidate.is_relative_to(root)
+            for root in self.local_roots
+        ):
+            raise StorageAuthorizationError(
+                f"{operation} local path is outside the configured sandbox roots"
+            )
+        return AuthorizedUri(kind="local", original=value, local_path=candidate)
+
+
+_ACTIVE_SCOPE: ContextVar[StorageScope | None] = ContextVar(
+    "npa_workbench_storage_scope", default=None
+)
+
+
+@contextmanager
+def use_storage_scope(scope: StorageScope) -> Iterator[None]:
+    """Apply one request/test scope without mutating process-global configuration."""
+    token = _ACTIVE_SCOPE.set(scope)
+    try:
+        yield
+    finally:
+        _ACTIVE_SCOPE.reset(token)
+
+
+def authorize_uri(uri: str, *, operation: str, env_prefix: str) -> AuthorizedUri:
+    scope = _ACTIVE_SCOPE.get() or StorageScope.from_env(env_prefix)
+    return scope.authorize(uri, operation=operation)
+
+
+def _parse_s3_root(value: str) -> S3Root:
+    parsed = urlparse(str(value).strip())
+    if (
+        parsed.scheme != "s3"
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise StorageAuthorizationError(
+            "allowed S3 roots must be canonical s3://bucket[/prefix] URIs"
+        )
+    return S3Root(bucket=parsed.hostname or "", prefix=_canonical_s3_key(parsed.path))
+
+
+def _canonical_s3_key(path: str) -> str:
+    decoded = unquote(path).lstrip("/")
+    if "\\" in decoded:
+        raise StorageAuthorizationError("S3 URI keys must not contain backslashes")
+    segments = decoded.split("/") if decoded else []
+    if any(segment in {"", ".", ".."} for segment in segments):
+        raise StorageAuthorizationError(
+            "S3 URI keys must be canonical and traversal-free"
+        )
+    return "/".join(segments)
+
+
+def _split_config(value: str, separator: str) -> tuple[str, ...]:
+    return tuple(item.strip() for item in value.split(separator) if item.strip())

--- a/npa/tests/agent_eval/test_agent_eval_scorecard.py
+++ b/npa/tests/agent_eval/test_agent_eval_scorecard.py
@@ -159,7 +159,9 @@ def test_no_task_crashes():
     assert not crashed, crashed
 
 
-def test_operate_eval_mocked_round_trip_is_grounded(tmp_path: Path):
+def test_operate_eval_mocked_round_trip_is_grounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     from npa.cli.agent_actions import summarize_observations
     from npa.workbench.insights.analytics import query_metrics
     from npa.workbench.insights.schemas import IngestRunRequest, QueryRequest
@@ -169,6 +171,7 @@ def test_operate_eval_mocked_round_trip_is_grounded(tmp_path: Path):
     fixture = tmp_path / "fixture"
     store = str(tmp_path / "store")
     empty_store = str(tmp_path / "empty-store")
+    monkeypatch.setenv("INSIGHTS_ALLOWED_LOCAL_ROOTS", str(tmp_path))
 
     def submit(observed_run_id: str) -> dict:
         fixture.mkdir()

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -1356,7 +1356,10 @@ def test_deploy_persists_terraform_state_before_apply(monkeypatch, tmp_path) -> 
         region="us-central1",
         ssh_user="ubuntu",
         ssh_public_key_path=str(tmp_path / "id_ed25519.pub"),
-        tf_var=[],
+        tf_var=[
+            "ssh_cidr_block=203.0.113.50/32",
+            "application_cidr_block=203.0.113.50/32",
+        ],
         agent_port=8088,
         backend_port=8787,
         rerun_port=9090,
@@ -2392,7 +2395,10 @@ def test_direct_run_load_cancels_background_discovery_and_uses_exact_artifacts()
     assert "singlePage: true," in source
     assert "background: true," in source
     assert "Render the authoritative workflow timeline before attempting" in source
-    assert "!context.deferPreferredViewer && !context.suppressPreferredAutoload && preferred" in source
+    assert (
+        "!context.deferPreferredViewer && !context.suppressPreferredAutoload && preferred"
+        in source
+    )
     assert "deferPreferredViewer: true" in source
     assert 'showToast("Run loaded; preferred viewer failed: "' in source
     assert '"#stageList .stage-physical-job"' in source
@@ -2401,11 +2407,13 @@ def test_direct_run_load_cancels_background_discovery_and_uses_exact_artifacts()
     )
 
 
-def test_artifact_inventory_autopaginates_before_global_preference_and_selection() -> None:
+def test_artifact_inventory_autopaginates_before_global_preference_and_selection() -> (
+    None
+):
     source = _agent_ui_bundle()
-    block = source.split(
-        "async function loadArtifactsForSelectedRun", 1
-    )[1].split("async function loadExactArtifactSource", 1)[0]
+    block = source.split("async function loadArtifactsForSelectedRun", 1)[1].split(
+        "async function loadExactArtifactSource", 1
+    )[0]
 
     assert "const seenCursors = new Set();" in block
     assert "while (nextCursor)" in block
@@ -2413,10 +2421,15 @@ def test_artifact_inventory_autopaginates_before_global_preference_and_selection
     assert "paginationEmptyPageCount" in block
     assert "paginationDuplicateCount" in block
     assert "Artifact inventory source changed during pagination" in block
-    assert "Artifact inventory is truncated but the server returned no continuation cursor" in block
+    assert (
+        "Artifact inventory is truncated but the server returned no continuation cursor"
+        in block
+    )
     assert 'continuation.set("project_id", selectedSource.project_id);' in block
     assert 'continuation.set("resource_bucket", selectedSource.bucket);' in block
-    assert 'continuation.set("resolved_prefix", selectedSource.resolved_prefix);' in block
+    assert (
+        'continuation.set("resolved_prefix", selectedSource.resolved_prefix);' in block
+    )
     assert 'continuation.set("source_selected", "1");' in block
     assert "const preferred = selectPreferredArtifact(artifacts);" in block
     assert block.index("while (nextCursor)") < block.index("setActiveRunId(runId)")
@@ -3979,7 +3992,10 @@ def test_deploy_seeds_cost_ordered_ladder_without_explicit_models(
         region="eu-north1",
         ssh_user="ubuntu",
         ssh_public_key_path=str(tmp_path / "id_ed25519.pub"),
-        tf_var=[],
+        tf_var=[
+            "ssh_cidr_block=203.0.113.50/32",
+            "application_cidr_block=203.0.113.50/32",
+        ],
         agent_port=8088,
         backend_port=8787,
         rerun_port=9090,
@@ -4591,7 +4607,17 @@ def test_agent_setup_picks_configured_project(monkeypatch, tmp_path) -> None:
     # Explicit --project resolves tenant/project/region from config (no typing).
     result = runner.invoke(
         app,
-        ["setup", "--project", "dev", "--ssh-public-key-path", str(key_file)],
+        [
+            "setup",
+            "--project",
+            "dev",
+            "--ssh-public-key-path",
+            str(key_file),
+            "--tf-var",
+            "ssh_cidr_block=203.0.113.50/32",
+            "--tf-var",
+            "application_cidr_block=203.0.113.50/32",
+        ],
     )
 
     assert result.exit_code == 0, result.output
@@ -4665,7 +4691,17 @@ def test_agent_setup_passes_concrete_defaults_to_deploy(monkeypatch, tmp_path) -
 
     result = runner.invoke(
         app,
-        ["setup", "--project", "dev", "--ssh-public-key-path", str(key_file)],
+        [
+            "setup",
+            "--project",
+            "dev",
+            "--ssh-public-key-path",
+            str(key_file),
+            "--tf-var",
+            "ssh_cidr_block=203.0.113.50/32",
+            "--tf-var",
+            "application_cidr_block=203.0.113.50/32",
+        ],
     )
     assert result.exit_code == 0, result.output
 
@@ -4680,7 +4716,10 @@ def test_agent_setup_passes_concrete_defaults_to_deploy(monkeypatch, tmp_path) -
     assert captured["agent_port"] == DEFAULT_AGENT_PORT
     assert captured["backend_port"] == DEFAULT_BACKEND_PORT
     assert captured["rerun_port"] == DEFAULT_RERUN_PORT
-    assert captured["tf_var"] == []
+    assert captured["tf_var"] == [
+        "ssh_cidr_block=203.0.113.50/32",
+        "application_cidr_block=203.0.113.50/32",
+    ]
     assert captured["llm_models"] == []
     assert captured["no_public_https"] is False
 
@@ -4688,7 +4727,9 @@ def test_agent_setup_passes_concrete_defaults_to_deploy(monkeypatch, tmp_path) -
 def test_agent_fresh_setup_forwards_agent_only(monkeypatch) -> None:
     captured: dict = {}
     monkeypatch.setattr("npa.cli.agent._agent_record", lambda *args, **kwargs: {})
-    monkeypatch.setattr("npa.cli.agent._store_project_environment", lambda **kwargs: None)
+    monkeypatch.setattr(
+        "npa.cli.agent._store_project_environment", lambda **kwargs: None
+    )
     monkeypatch.setattr(
         "npa.cli.agent.deploy_cmd", lambda **kwargs: captured.update(kwargs)
     )
@@ -4796,7 +4837,17 @@ def test_agent_setup_renders_string_terraform_vars(monkeypatch, tmp_path) -> Non
 
     result = runner.invoke(
         app,
-        ["setup", "--project", "dev", "--ssh-public-key-path", str(key_file)],
+        [
+            "setup",
+            "--project",
+            "dev",
+            "--ssh-public-key-path",
+            str(key_file),
+            "--tf-var",
+            "ssh_cidr_block=203.0.113.50/32",
+            "--tf-var",
+            "application_cidr_block=203.0.113.50/32",
+        ],
     )
     assert result.exit_code == 0, result.output
 
@@ -4831,7 +4882,17 @@ def test_agent_deploy_keeps_s3_sentinels_out_of_terraform_and_agent_record(
 
     result = runner.invoke(
         app,
-        ["setup", "--project", "dev", "--ssh-public-key-path", str(key_file)],
+        [
+            "setup",
+            "--project",
+            "dev",
+            "--ssh-public-key-path",
+            str(key_file),
+            "--tf-var",
+            "ssh_cidr_block=203.0.113.50/32",
+            "--tf-var",
+            "application_cidr_block=203.0.113.50/32",
+        ],
     )
 
     assert result.exit_code == 0, result.output
@@ -4853,12 +4914,10 @@ def test_agent_deploy_keeps_s3_sentinels_out_of_terraform_and_agent_record(
         / "terraform"
         / "cloud_init.yaml.tpl"
     ).read_text(encoding="utf-8")
-    protected_write_files = template.split('%{ if workbench_type != "agent" ~}', 1)[
-        1
-    ].split("%{ endif ~}", 1)[0]
-    assert "write_files:" in protected_write_files
-    assert "${aws_access_key}" in protected_write_files
-    assert "${aws_secret_key}" in protected_write_files
+    assert "${aws_access_key}" not in template
+    assert "${aws_secret_key}" not in template
+    assert "AWS_ACCESS_KEY_ID=" not in template
+    assert "AWS_SECRET_ACCESS_KEY=" not in template
 
 
 def test_agent_setup_keeps_public_https_enabled(monkeypatch, tmp_path) -> None:
@@ -4873,7 +4932,17 @@ def test_agent_setup_keeps_public_https_enabled(monkeypatch, tmp_path) -> None:
 
     result = runner.invoke(
         app,
-        ["setup", "--project", "dev", "--ssh-public-key-path", str(key_file)],
+        [
+            "setup",
+            "--project",
+            "dev",
+            "--ssh-public-key-path",
+            str(key_file),
+            "--tf-var",
+            "ssh_cidr_block=203.0.113.50/32",
+            "--tf-var",
+            "application_cidr_block=203.0.113.50/32",
+        ],
     )
     assert result.exit_code == 0, result.output
     assert calls["bootstrap"]["public_https"] is True
@@ -5012,7 +5081,10 @@ def test_agent_whole_path_blocker_precedes_storage_and_terraform(
             region="us-central1",
             ssh_user="ubuntu",
             ssh_public_key_path=str(tmp_path / "id_ed25519.pub"),
-            tf_var=[],
+            tf_var=[
+                "ssh_cidr_block=203.0.113.50/32",
+                "application_cidr_block=203.0.113.50/32",
+            ],
             agent_port=8088,
             backend_port=8787,
             rerun_port=9090,
@@ -5075,7 +5147,10 @@ def test_agent_only_deploy_omits_paidf_capacity_reservation(
             region="us-central1",
             ssh_user="ubuntu",
             ssh_public_key_path=str(tmp_path / "id_ed25519.pub"),
-            tf_var=[],
+            tf_var=[
+                "ssh_cidr_block=203.0.113.50/32",
+                "application_cidr_block=203.0.113.50/32",
+            ],
             agent_only=True,
             agent_port=8088,
             backend_port=8787,

--- a/npa/tests/cli/test_dataset_cli.py
+++ b/npa/tests/cli/test_dataset_cli.py
@@ -6,10 +6,16 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
+import pytest
 
 from npa.cli.main import app
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _allow_test_storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATASET_ALLOWED_LOCAL_ROOTS", str(tmp_path))
 
 
 def _raw(tmp_path: Path) -> str:

--- a/npa/tests/cli/test_dataset_cli.py
+++ b/npa/tests/cli/test_dataset_cli.py
@@ -6,16 +6,10 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
-import pytest
 
 from npa.cli.main import app
 
 runner = CliRunner()
-
-
-@pytest.fixture(autouse=True)
-def _allow_test_storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("DATASET_ALLOWED_LOCAL_ROOTS", str(tmp_path))
 
 
 def _raw(tmp_path: Path) -> str:
@@ -96,7 +90,9 @@ def test_dataset_service_mode_parity(monkeypatch: Any, tmp_path: Path) -> None:
     import npa.cli.workbench.dataset as cli_module
     from npa.workbench.dataset.service import create_app
 
-    client = TestClient(create_app(auth_mode="none"))
+    client = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    )
 
     def fake_request(method: str, endpoint: str, path: str, **kwargs: Any) -> dict[str, Any]:
         response = client.request(method, path, json=kwargs.get("payload"), params=kwargs.get("params"))
@@ -126,3 +122,41 @@ def test_dataset_service_mode_parity(monkeypatch: Any, tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)["record_count"] == 2
+
+
+def test_dataset_service_storage_denial_is_a_command_error(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    import npa.cli.workbench.dataset as cli_module
+    from npa.workbench.dataset.service import create_app
+
+    client = TestClient(create_app(auth_mode="none"))
+
+    def fake_request(method: str, url: str, **kwargs: Any):
+        return client.request(
+            method,
+            url.removeprefix("http://dataset.example"),
+            json=kwargs.get("json"),
+            params=kwargs.get("params"),
+        )
+
+    monkeypatch.setattr(cli_module.httpx, "request", fake_request)
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "dataset",
+            "ingest",
+            "--service",
+            "--endpoint",
+            "http://dataset.example",
+            "--input-path",
+            _raw(tmp_path),
+            "--output-path",
+            str(tmp_path / "store"),
+            "--dataset-id",
+            "scoped",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Dataset request failed (403)" in result.output

--- a/npa/tests/cli/test_deploy_ingress_cli.py
+++ b/npa/tests/cli/test_deploy_ingress_cli.py
@@ -13,7 +13,10 @@ from npa.clients.network import EnsureIngressResult, NetworkIngressError
 
 
 runner = CliRunner()
-TERRAFORM_PLAN_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "terraform_plans"
+NARROW_SOURCE = "192.0.2.0/24"
+TERRAFORM_PLAN_FIXTURES = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "terraform_plans"
+)
 
 
 @dataclass(frozen=True)
@@ -52,13 +55,15 @@ def _ingress_result(case: DeployIngressCase) -> EnsureIngressResult:
         project_id="project-test",
         public_ip="203.0.113.10/32",
         ports=(case.port,),
-        source="0.0.0.0/0",
+        source=NARROW_SOURCE,
         tool=case.tool,
         security_groups=(),
     )
 
 
-def _patch_successful_deploy(mocker, case: DeployIngressCase, *, instance_id: str | None) -> None:
+def _patch_successful_deploy(
+    mocker, case: DeployIngressCase, *, instance_id: str | None
+) -> None:
     if case.tool == "groot":
         mocker.patch.dict("os.environ", {"ACCEPT_EULA": "Y"})
     module = case.module
@@ -91,14 +96,19 @@ def _patch_successful_deploy(mocker, case: DeployIngressCase, *, instance_id: st
     mocker.patch("npa.cli.ingress.list_projects", return_value={})
 
     if case.tool == "cosmos":
-        mocker.patch(f"{module}.resolve_credentials", return_value=SimpleNamespace(hf_token="", tokens={}))
+        mocker.patch(
+            f"{module}.resolve_credentials",
+            return_value=SimpleNamespace(hf_token="", tokens={}),
+        )
         mocker.patch(
             f"{module}.validate_hf_access",
             return_value=SimpleNamespace(ok=True, error=""),
         )
         mocker.patch(f"{module}.health_check_auto", return_value=(True, ""))
     elif case.tool == "groot":
-        mocker.patch(f"{module}.resolve_credentials", return_value=CredentialsConfig(tokens={}))
+        mocker.patch(
+            f"{module}.resolve_credentials", return_value=CredentialsConfig(tokens={})
+        )
         mocker.patch(
             f"{module}.validate_hf_access",
             return_value=SimpleNamespace(ok=True, error=""),
@@ -106,7 +116,9 @@ def _patch_successful_deploy(mocker, case: DeployIngressCase, *, instance_id: st
         mocker.patch(f"{module}.health_check_auto", return_value=(True, ""))
         mocker.patch(f"{module}.write_remote_docker_env_file")
     else:
-        mocker.patch(f"{module}.resolve_credentials", return_value=SimpleNamespace(tokens={}))
+        mocker.patch(
+            f"{module}.resolve_credentials", return_value=SimpleNamespace(tokens={})
+        )
         mocker.patch(f"{module}._run_fiftyone_command", return_value=(0, "", ""))
         mocker.patch(f"{module}._app_health_check", return_value=True)
 
@@ -129,15 +141,19 @@ def _deploy_args(case: DeployIngressCase, tmp_path: Path) -> list[str]:
         "--tf-dir",
         str(tmp_path),
         "--no-verify-env",
+        "--tf-var",
+        f"application_cidr_block={NARROW_SOURCE}",
         *case.command_port_args,
     ]
     if case.tool == "cosmos":
-        args.extend([
-            "--gpu-type",
-            "gpu-h100-sxm",
-            "--gpu-preset",
-            "1gpu-16vcpu-200gb",
-        ])
+        args.extend(
+            [
+                "--gpu-type",
+                "gpu-h100-sxm",
+                "--gpu-preset",
+                "1gpu-16vcpu-200gb",
+            ]
+        )
     return args
 
 
@@ -148,7 +164,9 @@ def test_deploy_success_ensures_ingress_for_tool_port(
     case: DeployIngressCase,
 ) -> None:
     _patch_successful_deploy(mocker, case, instance_id="computeinstance-test")
-    ensure = mocker.patch("npa.cli.ingress.ensure_ingress", return_value=_ingress_result(case))
+    ensure = mocker.patch(
+        "npa.cli.ingress.ensure_ingress", return_value=_ingress_result(case)
+    )
 
     result = runner.invoke(app, _deploy_args(case, tmp_path))
 
@@ -158,9 +176,27 @@ def test_deploy_success_ensures_ingress_for_tool_port(
     ensure.assert_called_once_with(
         vm_id="computeinstance-test",
         ports=(case.port,),
-        source="0.0.0.0/0",
+        source=NARROW_SOURCE,
+        allow_world_open=False,
         tool=case.tool,
     )
+
+
+@pytest.mark.parametrize("case", TOOL_CASES, ids=lambda case: case.tool)
+def test_deploy_without_application_cidr_does_not_create_ingress(
+    tmp_path: Path, mocker, case: DeployIngressCase
+) -> None:
+    _patch_successful_deploy(mocker, case, instance_id="computeinstance-test")
+    ensure = mocker.patch("npa.cli.ingress.ensure_ingress")
+    args = _deploy_args(case, tmp_path)
+    option = f"application_cidr_block={NARROW_SOURCE}"
+    args.remove(option)
+    args.remove("--tf-var")
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 0
+    ensure.assert_not_called()
 
 
 @pytest.mark.parametrize("case", TOOL_CASES, ids=lambda case: case.tool)
@@ -179,7 +215,10 @@ def test_deploy_ingress_failure_warns_and_still_succeeds(
 
     assert result.exit_code == 0
     assert "Deploy complete" in result.output
-    assert f"Warning: could not ensure network ingress for port {case.port}: permission denied." in result.output
+    assert (
+        f"Warning: could not ensure network ingress for port {case.port}: permission denied."
+        in result.output
+    )
     assert f"npa workbench {case.tool} ensure-ingress -n demo" in result.output
 
 
@@ -196,5 +235,8 @@ def test_deploy_skips_ingress_when_instance_id_unavailable(
 
     assert result.exit_code == 0
     assert "Deploy complete" in result.output
-    assert f"Debug: skipping network ingress for port {case.port}: instance_id unavailable." in result.output
+    assert (
+        f"Debug: skipping network ingress for port {case.port}: instance_id unavailable."
+        in result.output
+    )
     ensure.assert_not_called()

--- a/npa/tests/cli/test_insights_cli.py
+++ b/npa/tests/cli/test_insights_cli.py
@@ -6,16 +6,10 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
-import pytest
 
 from npa.cli.main import app
 
 runner = CliRunner()
-
-
-@pytest.fixture(autouse=True)
-def _allow_test_storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("INSIGHTS_ALLOWED_LOCAL_ROOTS", str(tmp_path))
 
 
 def _record(tmp_path: Path, store: str, run_id: str, metric: str, value: float) -> None:
@@ -132,7 +126,9 @@ def test_insights_service_mode_parity(monkeypatch: Any, tmp_path: Path) -> None:
     import npa.cli.workbench.insights as cli_module
     from npa.workbench.insights.service import create_app
 
-    client = TestClient(create_app(auth_mode="none"))
+    client = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    )
 
     def fake_request(method: str, endpoint: str, path: str, **kwargs: Any) -> dict[str, Any]:
         response = client.request(method, path, json=kwargs.get("payload"), params=kwargs.get("params"))
@@ -164,3 +160,43 @@ def test_insights_service_mode_parity(monkeypatch: Any, tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)["recorded_count"] == 1
+
+
+def test_insights_service_storage_denial_is_a_command_error(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    import npa.cli.workbench.insights as cli_module
+    from npa.workbench.insights.service import create_app
+
+    client = TestClient(create_app(auth_mode="none"))
+
+    def fake_request(method: str, url: str, **kwargs: Any):
+        return client.request(
+            method,
+            url.removeprefix("http://insights.example"),
+            json=kwargs.get("json"),
+            params=kwargs.get("params"),
+        )
+
+    monkeypatch.setattr(cli_module.httpx, "request", fake_request)
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "insights",
+            "record",
+            "--service",
+            "--endpoint",
+            "http://insights.example",
+            "--output-path",
+            str(tmp_path / "store"),
+            "--run-id",
+            "scoped",
+            "--metric",
+            "accuracy",
+            "--value",
+            "0.9",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Insights request failed (403)" in result.output

--- a/npa/tests/cli/test_insights_cli.py
+++ b/npa/tests/cli/test_insights_cli.py
@@ -6,10 +6,16 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
+import pytest
 
 from npa.cli.main import app
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _allow_test_storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INSIGHTS_ALLOWED_LOCAL_ROOTS", str(tmp_path))
 
 
 def _record(tmp_path: Path, store: str, run_id: str, metric: str, value: float) -> None:

--- a/npa/tests/cli/test_network_cli.py
+++ b/npa/tests/cli/test_network_cli.py
@@ -11,6 +11,7 @@ from npa.clients.nebius import NebiusError
 
 
 runner = CliRunner()
+NARROW_SOURCE = "192.0.2.0/24"
 
 
 def _instance(
@@ -57,7 +58,7 @@ def _ingress_rule(
     rule_id: str = "rule-existing",
     name: str = "allow-existing",
     ports: list[int],
-    source: str = "0.0.0.0/0",
+    source: str = NARROW_SOURCE,
     protocol: str = "TCP",
     access: str = "ALLOW",
 ) -> dict[str, Any]:
@@ -129,6 +130,8 @@ def test_network_ensure_ingress_success_with_vm(mocker) -> None:
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -152,6 +155,8 @@ def test_network_ensure_ingress_success_with_ip_project(mocker) -> None:
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--ip",
             "203.0.113.10",
             "--project",
@@ -183,6 +188,8 @@ def test_network_ensure_ingress_matching_spec_is_noop(mocker) -> None:
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -206,6 +213,8 @@ def test_network_empty_destination_ports_authoritatively_covers_all_ports(
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -234,6 +243,8 @@ def test_network_ensure_ingress_same_name_different_spec_warns(mocker) -> None:
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -263,6 +274,8 @@ def test_network_ensure_ingress_partial_coverage_creates_missing_ports(mocker) -
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -332,6 +345,8 @@ def test_network_ensure_ingress_permission_failure_is_clean(mocker) -> None:
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -349,7 +364,16 @@ def test_network_ensure_ingress_missing_instance_is_clean(mocker) -> None:
 
     result = runner.invoke(
         app,
-        ["network", "ensure-ingress", "--vm", "missing-vm", "--ports", "8081"],
+        [
+            "network",
+            "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
+            "--vm",
+            "missing-vm",
+            "--ports",
+            "8081",
+        ],
     )
 
     assert result.exit_code == 1
@@ -365,6 +389,8 @@ def test_network_ensure_ingress_missing_security_group_is_clean(mocker) -> None:
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -386,6 +412,8 @@ def test_network_ensure_ingress_multiple_ports_collapsed_into_single_rule(
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -428,6 +456,8 @@ def test_network_ensure_ingress_multi_sg_coverage_in_second_group_is_noop(
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -454,6 +484,8 @@ def test_network_ensure_ingress_multi_sg_missing_ports_create_on_first_group_onl
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ports",
@@ -473,6 +505,8 @@ def test_network_ensure_ingress_rejects_vm_and_ip_combination() -> None:
         [
             "network",
             "ensure-ingress",
+            "--source",
+            NARROW_SOURCE,
             "--vm",
             "computeinstance-test",
             "--ip",
@@ -489,10 +523,50 @@ def test_network_ensure_ingress_rejects_vm_and_ip_combination() -> None:
 
 
 def test_network_ensure_ingress_rejects_missing_target() -> None:
-    result = runner.invoke(app, ["network", "ensure-ingress", "--ports", "8081"])
+    result = runner.invoke(
+        app, ["network", "ensure-ingress", "--source", NARROW_SOURCE, "--ports", "8081"]
+    )
 
     assert result.exit_code != 0
     assert "pass exactly one of --vm or (--ip and --project)" in result.output
+
+
+def test_network_world_open_ingress_requires_explicit_acknowledgement(mocker) -> None:
+    calls = _mock_nebius(mocker)
+
+    denied = runner.invoke(
+        app,
+        [
+            "network",
+            "ensure-ingress",
+            "--source",
+            "0.0.0.0/0",
+            "--vm",
+            "computeinstance-test",
+            "--ports",
+            "8081",
+        ],
+    )
+    assert denied.exit_code == 1
+    assert "acknowledgement" in denied.output
+    assert _create_calls(calls) == []
+
+    allowed = runner.invoke(
+        app,
+        [
+            "network",
+            "ensure-ingress",
+            "--source",
+            "0.0.0.0/0",
+            "--allow-world-open",
+            "--vm",
+            "computeinstance-test",
+            "--ports",
+            "8081",
+        ],
+    )
+    assert allowed.exit_code == 0
+    assert len(_create_calls(calls)) == 1
 
 
 def test_remove_npa_ingress_rules_deletes_allow_npa_rules(mocker) -> None:

--- a/npa/tests/cli/test_register_byovm_cli.py
+++ b/npa/tests/cli/test_register_byovm_cli.py
@@ -6,10 +6,15 @@ import pytest
 from typer.testing import CliRunner
 
 from npa.cli.main import app
-from npa.clients.network import EnsureIngressResult, InstanceNetworkContext, NetworkIngressError
+from npa.clients.network import (
+    EnsureIngressResult,
+    InstanceNetworkContext,
+    NetworkIngressError,
+)
 
 
 runner = CliRunner()
+NARROW_SOURCE = "192.0.2.0/24"
 
 
 @dataclass(frozen=True)
@@ -40,14 +45,16 @@ def _result(case: RegisterCase) -> EnsureIngressResult:
         project_id="project-test",
         public_ip="203.0.113.10/32",
         ports=(case.port,),
-        source="0.0.0.0/0",
+        source=NARROW_SOURCE,
         tool=case.tool,
         security_groups=(),
     )
 
 
 def _patch_register_context(mocker, *, workbenches: dict | None = None):
-    mocker.patch("npa.cli.ingress.resolve_instance_network_context", return_value=_context())
+    mocker.patch(
+        "npa.cli.ingress.resolve_instance_network_context", return_value=_context()
+    )
     mocker.patch(
         "npa.cli.ingress.list_projects",
         return_value={"proj": {"workbenches": workbenches or {}}},
@@ -57,7 +64,9 @@ def _patch_register_context(mocker, *, workbenches: dict | None = None):
 
 
 @pytest.mark.parametrize("case", TOOL_CASES, ids=lambda case: case.tool)
-def test_register_byovm_writes_alias_and_ensures_ingress(mocker, case: RegisterCase) -> None:
+def test_register_byovm_writes_alias_and_ensures_ingress(
+    mocker, case: RegisterCase
+) -> None:
     write_config = _patch_register_context(mocker)
     ensure = mocker.patch("npa.cli.ingress.ensure_ingress", return_value=_result(case))
 
@@ -71,19 +80,26 @@ def test_register_byovm_writes_alias_and_ensures_ingress(mocker, case: RegisterC
             "demo",
             "--instance-id",
             "computeinstance-test",
+            "--source",
+            NARROW_SOURCE,
         ],
     )
 
     assert result.exit_code == 0
-    assert f"Registered {case.tool} BYOVM alias 'demo' in project 'proj'." in result.output
+    assert (
+        f"Registered {case.tool} BYOVM alias 'demo' in project 'proj'." in result.output
+    )
     assert f"Network ingress confirmed for port {case.port}" in result.output
     ensure.assert_called_once_with(
         vm_id="computeinstance-test",
         ports=(case.port,),
-        source="0.0.0.0/0",
+        source=NARROW_SOURCE,
+        allow_world_open=False,
         tool=case.tool,
     )
-    alias_config = write_config.call_args.args[0]["projects"]["proj"]["workbenches"]["demo"]
+    alias_config = write_config.call_args.args[0]["projects"]["proj"]["workbenches"][
+        "demo"
+    ]
     assert alias_config["alias"] == "demo"
     assert alias_config["endpoint"] == f"http://203.0.113.10:{case.port}"
     assert alias_config["runtime"] == "byovm"
@@ -115,6 +131,8 @@ def test_register_byovm_instance_get_failure_does_not_write_alias(mocker) -> Non
             "demo",
             "--instance-id",
             "computeinstance-missing",
+            "--source",
+            NARROW_SOURCE,
         ],
     )
 
@@ -124,7 +142,9 @@ def test_register_byovm_instance_get_failure_does_not_write_alias(mocker) -> Non
     ensure.assert_not_called()
 
 
-def test_register_byovm_existing_alias_overwrites_registration_fields_with_warning(mocker) -> None:
+def test_register_byovm_existing_alias_overwrites_registration_fields_with_warning(
+    mocker,
+) -> None:
     existing = {
         "endpoint": "http://old.example:9999",
         "runtime": "vm",
@@ -139,7 +159,10 @@ def test_register_byovm_existing_alias_overwrites_registration_fields_with_warni
         },
     }
     write_config = _patch_register_context(mocker, workbenches={"demo": existing})
-    mocker.patch("npa.cli.ingress.ensure_ingress", return_value=_result(RegisterCase("groot", 8082)))
+    mocker.patch(
+        "npa.cli.ingress.ensure_ingress",
+        return_value=_result(RegisterCase("groot", 8082)),
+    )
 
     result = runner.invoke(
         app,
@@ -151,12 +174,19 @@ def test_register_byovm_existing_alias_overwrites_registration_fields_with_warni
             "demo",
             "--instance-id",
             "computeinstance-test",
+            "--source",
+            NARROW_SOURCE,
         ],
     )
 
     assert result.exit_code == 0
-    assert "Warning: alias 'demo' already exists; overwriting BYOVM registration fields." in result.output
-    alias_config = write_config.call_args.args[0]["projects"]["proj"]["workbenches"]["demo"]
+    assert (
+        "Warning: alias 'demo' already exists; overwriting BYOVM registration fields."
+        in result.output
+    )
+    alias_config = write_config.call_args.args[0]["projects"]["proj"]["workbenches"][
+        "demo"
+    ]
     assert alias_config["endpoint"] == "http://203.0.113.10:8082"
     assert alias_config["runtime"] == "byovm"
     assert alias_config["project_id"] == "project-test"

--- a/npa/tests/cli/test_teardown_inventory.py
+++ b/npa/tests/cli/test_teardown_inventory.py
@@ -736,4 +736,7 @@ def test_wait_for_ssh_gates_the_terraform_wait_resource() -> None:
 
     assert 'variable "wait_for_ssh"' in variables_tf
     body = main_tf[main_tf.index('resource "null_resource" "wait_for_cloud_init"') :]
-    assert "count      = var.wait_for_ssh ? 1 : 0" in body[: body.index("provisioner")]
+    assert (
+        'count      = var.wait_for_ssh && trimspace(var.ssh_cidr_block) != "" ? 1 : 0'
+        in body[: body.index("provisioner")]
+    )

--- a/npa/tests/cli/test_tool_ingress_cli.py
+++ b/npa/tests/cli/test_tool_ingress_cli.py
@@ -8,6 +8,7 @@ from npa.clients.network import EnsureIngressResult
 
 
 runner = CliRunner()
+NARROW_SOURCE = "192.0.2.0/24"
 
 
 TOOL_CASES = [
@@ -23,7 +24,7 @@ def _result(tool: str, port: int) -> EnsureIngressResult:
         project_id="project-test",
         public_ip="203.0.113.10/32",
         ports=(port,),
-        source="0.0.0.0/0",
+        source=NARROW_SOURCE,
         tool=tool,
         security_groups=(),
     )
@@ -39,28 +40,41 @@ def _patch_projects(mocker, workbenches: dict):
 
 
 @pytest.mark.parametrize(("tool", "port"), TOOL_CASES)
-def test_tool_ensure_ingress_calls_primitive_with_instance_and_port(mocker, tool: str, port: int) -> None:
+def test_tool_ensure_ingress_calls_primitive_with_instance_and_port(
+    mocker, tool: str, port: int
+) -> None:
     _patch_projects(mocker, {"demo": {"instance_id": "computeinstance-test"}})
-    ensure = mocker.patch("npa.cli.ingress.ensure_ingress", return_value=_result(tool, port))
+    ensure = mocker.patch(
+        "npa.cli.ingress.ensure_ingress", return_value=_result(tool, port)
+    )
 
-    result = runner.invoke(app, ["workbench", tool, "ensure-ingress", "-n", "demo"])
+    result = runner.invoke(
+        app,
+        ["workbench", tool, "ensure-ingress", "-n", "demo", "--source", NARROW_SOURCE],
+    )
 
     assert result.exit_code == 0
     assert f"ingress already covered for port {port}" in result.output
     ensure.assert_called_once_with(
         vm_id="computeinstance-test",
         ports=(port,),
-        source="0.0.0.0/0",
+        source=NARROW_SOURCE,
+        allow_world_open=False,
         tool=tool,
     )
 
 
 @pytest.mark.parametrize(("tool", "port"), TOOL_CASES)
-def test_tool_ensure_ingress_missing_alias_is_clean(mocker, tool: str, port: int) -> None:
+def test_tool_ensure_ingress_missing_alias_is_clean(
+    mocker, tool: str, port: int
+) -> None:
     _patch_projects(mocker, {"other": {"instance_id": "computeinstance-test"}})
     ensure = mocker.patch("npa.cli.ingress.ensure_ingress")
 
-    result = runner.invoke(app, ["workbench", tool, "ensure-ingress", "-n", "demo"])
+    result = runner.invoke(
+        app,
+        ["workbench", tool, "ensure-ingress", "-n", "demo", "--source", NARROW_SOURCE],
+    )
 
     assert result.exit_code == 1
     assert "Workbench 'demo' not found" in result.output
@@ -68,11 +82,16 @@ def test_tool_ensure_ingress_missing_alias_is_clean(mocker, tool: str, port: int
 
 
 @pytest.mark.parametrize(("tool", "port"), TOOL_CASES)
-def test_tool_ensure_ingress_missing_instance_id_has_remediation(mocker, tool: str, port: int) -> None:
+def test_tool_ensure_ingress_missing_instance_id_has_remediation(
+    mocker, tool: str, port: int
+) -> None:
     _patch_projects(mocker, {"demo": {"endpoint": "http://203.0.113.10"}})
     ensure = mocker.patch("npa.cli.ingress.ensure_ingress")
 
-    result = runner.invoke(app, ["workbench", tool, "ensure-ingress", "-n", "demo"])
+    result = runner.invoke(
+        app,
+        ["workbench", tool, "ensure-ingress", "-n", "demo", "--source", NARROW_SOURCE],
+    )
 
     assert result.exit_code == 1
     normalized = " ".join(result.output.split())
@@ -80,4 +99,21 @@ def test_tool_ensure_ingress_missing_instance_id_has_remediation(mocker, tool: s
         f"alias 'demo' has no instance_id; re-register with "
         f"'npa workbench {tool} register-byovm'"
     ) in normalized
+    ensure.assert_not_called()
+
+
+@pytest.mark.parametrize(("tool", "port"), TOOL_CASES)
+def test_tool_world_open_ingress_requires_acknowledgement(
+    mocker, tool: str, port: int
+) -> None:
+    _patch_projects(mocker, {"demo": {"instance_id": "computeinstance-test"}})
+    ensure = mocker.patch("npa.cli.ingress.ensure_ingress")
+
+    result = runner.invoke(
+        app,
+        ["workbench", tool, "ensure-ingress", "-n", "demo", "--source", "0.0.0.0/0"],
+    )
+
+    assert result.exit_code == 1
+    assert "--allow-world-open" in result.output
     ensure.assert_not_called()

--- a/npa/tests/test_deploy.py
+++ b/npa/tests/test_deploy.py
@@ -266,6 +266,79 @@ output "rendered" {{
     ]
 
 
+@pytest.mark.parametrize(
+    "workbench_type",
+    ["fiftyone", "lerobot", "lerobot-container", "cosmos", "genesis", "groot", "agent"],
+)
+def test_every_cloud_init_variant_omits_storage_secrets(
+    tmp_path: Path, workbench_type: str
+) -> None:
+    terraform = shutil.which("terraform")
+    if terraform is None:
+        pytest.skip("terraform is required to parse the deployment template")
+    template = PACKAGE_ROOT / "src/npa/deploy/terraform/cloud_init.yaml.tpl"
+    config = tmp_path / "main.tf"
+    config.write_text(
+        f'''locals {{
+  rendered = templatefile({json.dumps(str(template))}, {{
+    ssh_user = "ubuntu"
+    ssh_public_key = "ssh-ed25519 AAAA fixture"
+    workbench_type = {json.dumps(workbench_type)}
+    server_port = 8088
+    lerobot_version = "0.6.0"
+    fiftyone_version = "1.8.0"
+    s3_bucket = "fixture-bucket"
+    s3_endpoint = "https://storage.invalid"
+    nebius_region = "us-central1"
+    aws_access_key = "NPA_STORAGE_ACCESS_SENTINEL"
+    aws_secret_key = "NPA_STORAGE_SECRET_SENTINEL"
+  }})
+}}
+output "rendered" {{ value = local.rendered }}
+''',
+        encoding="utf-8",
+    )
+
+    rendered = subprocess.run(
+        [terraform, "apply", "-auto-approve", "-no-color"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert rendered.returncode == 0, rendered.stderr
+    assert "NPA_STORAGE_ACCESS_SENTINEL" not in rendered.stdout
+    assert "NPA_STORAGE_SECRET_SENTINEL" not in rendered.stdout
+    assert "AWS_ACCESS_KEY_ID=" not in rendered.stdout
+    assert "AWS_SECRET_ACCESS_KEY=" not in rendered.stdout
+
+
+def test_terraform_splits_and_fails_closed_ingress() -> None:
+    main_tf = (PACKAGE_ROOT / "src/npa/deploy/terraform/main.tf").read_text()
+    variables_tf = (PACKAGE_ROOT / "src/npa/deploy/terraform/variables.tf").read_text()
+
+    ssh_rule = main_tf.split('resource "nebius_vpc_v1_security_rule" "allow_ssh"', 1)[1].split(
+        'resource "nebius_vpc_v1_security_rule" "allow_server"', 1
+    )[0]
+    app_rule = main_tf.split('resource "nebius_vpc_v1_security_rule" "allow_server"', 1)[1].split(
+        'resource "nebius_vpc_v1_security_rule" "allow_egress"', 1
+    )[0]
+    template_args = main_tf.split("cloud_init_user_data = templatefile", 1)[1].split(")", 1)[0]
+
+    assert 'default     = ""' in variables_tf.split('variable "ssh_cidr_block"', 1)[1].split("}", 1)[0]
+    assert 'default     = ""' in variables_tf.split('variable "application_cidr_block"', 1)[1].split("}", 1)[0]
+    assert "var.allow_world_open_ssh" in variables_tf
+    assert "var.allow_world_open_application" in variables_tf
+    assert 'count     = trimspace(var.ssh_cidr_block) == "" ? 0 : 1' in ssh_rule
+    assert "source_cidrs      = [var.ssh_cidr_block]" in ssh_rule
+    assert 'count     = trimspace(var.application_cidr_block) == "" ? 0 : 1' in app_rule
+    assert "source_cidrs      = [var.application_cidr_block]" in app_rule
+    assert "var.ssh_cidr_block" not in app_rule
+    assert "nebius_api_key" not in template_args
+    assert "nebius_secret_key" not in template_args
+
+
 def test_terraform_outputs_use_compute_and_cpu_names_with_legacy_aliases() -> None:
     outputs = (PACKAGE_ROOT / "src/npa/deploy/terraform/outputs.tf").read_text()
 

--- a/npa/tests/test_sdk_surface.py
+++ b/npa/tests/test_sdk_surface.py
@@ -212,6 +212,12 @@ def test_network_ensure_ingress_parses_cli_style_ports(mocker) -> None:
 
     mock_ensure = mocker.patch("npa.network._ensure_ingress", return_value="ok")
 
-    assert network.ensure_ingress(vm="vm-id", ports="5151,8080") == "ok"
+    assert (
+        network.ensure_ingress(
+            vm="vm-id", ports="5151,8080", source="203.0.113.50/32"
+        )
+        == "ok"
+    )
     mock_ensure.assert_called_once()
     assert mock_ensure.call_args.kwargs["ports"] == [5151, 8080]
+    assert mock_ensure.call_args.kwargs["source"] == "203.0.113.50/32"

--- a/npa/tests/workbench/test_dataset.py
+++ b/npa/tests/workbench/test_dataset.py
@@ -20,17 +20,8 @@ from npa.workbench.dataset.schemas import (
     ValidateRequest,
 )
 from npa.workbench.dataset.validation import DatasetValidationError, validate_manifest
-from npa.workbench.storage_scope import StorageScope, use_storage_scope
 
 runner = CliRunner()
-
-
-@pytest.fixture(autouse=True)
-def _explicit_local_storage_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Dataset tests intentionally operate only inside their per-test sandbox."""
-    monkeypatch.setenv("DATASET_ALLOWED_LOCAL_ROOTS", str(tmp_path))
-    with use_storage_scope(StorageScope.from_config(local_roots=[tmp_path])):
-        yield
 
 
 def _raw(tmp_path: Path, records: list[dict[str, Any]] | None = None) -> str:
@@ -196,7 +187,9 @@ def test_query_lancedb_backend_when_endpoint_set(tmp_path: Path, monkeypatch: py
 def test_ingest_endpoint_success_and_status_list(tmp_path: Path) -> None:
     from npa.workbench.dataset.service import create_app
 
-    client = TestClient(create_app(auth_mode="none"))
+    client = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    )
     response = client.post(
         "/ingest",
         json={"input_uri": _raw(tmp_path), "output_uri": str(tmp_path / "ds"), "dataset_id": "fleet", "version": "v1"},
@@ -214,7 +207,9 @@ def test_ingest_endpoint_success_and_status_list(tmp_path: Path) -> None:
 def test_ingest_endpoint_failure_returns_400(tmp_path: Path) -> None:
     from npa.workbench.dataset.service import create_app
 
-    client = TestClient(create_app(auth_mode="none"))
+    client = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    )
     empty = tmp_path / "empty.json"
     empty.write_text(json.dumps({"records": []}))
     response = client.post(
@@ -227,7 +222,9 @@ def test_ingest_endpoint_failure_returns_400(tmp_path: Path) -> None:
 def test_validate_and_curate_and_query_endpoints(tmp_path: Path) -> None:
     from npa.workbench.dataset.service import create_app
 
-    client = TestClient(create_app(auth_mode="none"))
+    client = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    )
     ingested = client.post(
         "/ingest",
         json={"input_uri": _raw(tmp_path), "output_uri": str(tmp_path / "ds"), "dataset_id": "fleet"},
@@ -247,6 +244,31 @@ def test_validate_and_curate_and_query_endpoints(tmp_path: Path) -> None:
 
     bad = client.post("/curate", json={"input_uri": manifest_uri, "output_uri": str(tmp_path / "cur2"), "event": "nope"})
     assert bad.status_code == 400
+
+
+def test_service_storage_scope_fails_closed_and_enforces_configured_root(
+    tmp_path: Path,
+) -> None:
+    from npa.workbench.dataset.service import create_app
+
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    raw = _raw(allowed)
+    payload = {
+        "input_uri": raw,
+        "output_uri": str(allowed / "dataset"),
+        "dataset_id": "scoped",
+    }
+
+    unconfigured = TestClient(create_app(auth_mode="none"))
+    assert unconfigured.post("/ingest", json=payload).status_code == 403
+
+    configured = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[allowed])
+    )
+    assert configured.post("/ingest", json=payload).status_code == 200
+    payload["output_uri"] = str(tmp_path / "outside")
+    assert configured.post("/ingest", json=payload).status_code == 403
 
 
 def test_health_system_info_and_token_auth() -> None:
@@ -295,6 +317,22 @@ def test_cli_ingest_validate_curate_query(tmp_path: Path) -> None:
         ["query", "--input-path", manifest_uri, "--event", "cut_in", "--output", "json"],
     )
     assert json.loads(query.output)["count"] == 2
+
+
+def test_embedded_sdk_does_not_require_service_allowlists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from npa.sdk.workbench.dataset import ingest
+
+    monkeypatch.delenv("DATASET_ALLOWED_LOCAL_ROOTS", raising=False)
+    monkeypatch.delenv("DATASET_ALLOWED_S3_ROOTS", raising=False)
+    result = ingest(
+        input_uri=_raw(tmp_path),
+        output_uri=str(tmp_path / "sdk-dataset"),
+        dataset_id="embedded",
+    )
+    assert result.record_count == 3
+    assert Path(result.manifest_uri).exists()
 
 
 def test_cli_and_sdk_do_not_import_heavy_ml_dependencies_at_module_level() -> None:

--- a/npa/tests/workbench/test_dataset.py
+++ b/npa/tests/workbench/test_dataset.py
@@ -20,8 +20,17 @@ from npa.workbench.dataset.schemas import (
     ValidateRequest,
 )
 from npa.workbench.dataset.validation import DatasetValidationError, validate_manifest
+from npa.workbench.storage_scope import StorageScope, use_storage_scope
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _explicit_local_storage_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Dataset tests intentionally operate only inside their per-test sandbox."""
+    monkeypatch.setenv("DATASET_ALLOWED_LOCAL_ROOTS", str(tmp_path))
+    with use_storage_scope(StorageScope.from_config(local_roots=[tmp_path])):
+        yield
 
 
 def _raw(tmp_path: Path, records: list[dict[str, Any]] | None = None) -> str:
@@ -250,6 +259,20 @@ def test_health_system_info_and_token_auth() -> None:
     secure = TestClient(create_app(auth_mode="token", token="s3cr3t"))
     assert secure.get("/health").status_code == 401
     assert secure.get("/health", headers={"Authorization": "Bearer s3cr3t"}).status_code == 200
+
+
+def test_deployed_default_is_not_unauthenticated(monkeypatch: pytest.MonkeyPatch) -> None:
+    from npa.workbench.dataset.service import create_app
+
+    monkeypatch.delenv("DATASET_AUTH_MODE", raising=False)
+    monkeypatch.delenv("DATASET_TOKEN", raising=False)
+    assert TestClient(create_app()).get("/health").status_code == 503
+
+
+def test_explicit_auth_none_remains_an_opt_in() -> None:
+    from npa.workbench.dataset.service import create_app
+
+    assert TestClient(create_app(auth_mode="none")).get("/health").status_code == 200
 
 
 def test_cli_ingest_validate_curate_query(tmp_path: Path) -> None:

--- a/npa/tests/workbench/test_insights.py
+++ b/npa/tests/workbench/test_insights.py
@@ -33,15 +33,6 @@ from npa.workbench.insights.store import (
     read_records,
     record_metrics,
 )
-from npa.workbench.storage_scope import StorageScope, use_storage_scope
-
-
-@pytest.fixture(autouse=True)
-def _explicit_local_storage_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Insights tests intentionally operate only inside their per-test sandbox."""
-    monkeypatch.setenv("INSIGHTS_ALLOWED_LOCAL_ROOTS", str(tmp_path))
-    with use_storage_scope(StorageScope.from_config(local_roots=[tmp_path])):
-        yield
 
 
 def _metric(run_id: str, name: str, value: float, **kw: Any) -> dict[str, Any]:
@@ -682,7 +673,9 @@ def test_cost_basis_survives_ingest_query_compare_dashboard_sdk_service_cli(
     assert query_metrics(QueryRequest(input_uri=store, cost_basis="billed")).count == 1
     assert sdk_query(input_uri=store, cost_basis="estimated").count == 1
 
-    client = TestClient(create_app(auth_mode="none"))
+    client = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    )
     response = client.get(
         "/query", params={"input_uri": store, "cost_basis": "billed"}
     )
@@ -756,7 +749,9 @@ def test_new_signal_facets_thread_through_service_sdk_and_cli(tmp_path: Path) ->
     )
     assert sdk_result.count == 2
 
-    service_result = TestClient(create_app(auth_mode="none")).get(
+    service_result = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    ).get(
         "/query",
         params={
             "input_uri": store,
@@ -926,7 +921,9 @@ def test_dashboard_groups_and_writes_html(tmp_path: Path) -> None:
 def test_service_record_query_lineage_compare_dashboard(tmp_path: Path) -> None:
     from npa.workbench.insights.service import create_app
 
-    client = TestClient(create_app(auth_mode="none"))
+    client = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    )
     store = str(tmp_path / "store")
     record = client.post(
         "/record",
@@ -968,7 +965,9 @@ def test_service_record_query_lineage_compare_dashboard(tmp_path: Path) -> None:
 def test_service_ingest_run_endpoint_and_failure(tmp_path: Path) -> None:
     from npa.workbench.insights.service import create_app
 
-    client = TestClient(create_app(auth_mode="none"))
+    client = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    )
     _write_run_prefix(tmp_path / "run")
     ok = client.post(
         "/ingest-run",
@@ -985,11 +984,36 @@ def test_service_ingest_run_endpoint_and_failure(tmp_path: Path) -> None:
 def test_service_compare_failure_returns_400(tmp_path: Path) -> None:
     from npa.workbench.insights.service import create_app
 
-    client = TestClient(create_app(auth_mode="none"))
+    client = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[tmp_path])
+    )
     store = str(tmp_path / "store")
     _seed_two_runs(store)
     bad = client.get("/compare", params={"input_uri": store, "base_run": "r1", "candidate_run": "nope"})
     assert bad.status_code == 400
+
+
+def test_service_storage_scope_fails_closed_and_enforces_configured_root(
+    tmp_path: Path,
+) -> None:
+    from npa.workbench.insights.service import create_app
+
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    payload = {
+        "output_uri": str(allowed / "store"),
+        "records": [_metric("scoped", "accuracy", 0.9)],
+    }
+
+    unconfigured = TestClient(create_app(auth_mode="none"))
+    assert unconfigured.post("/record", json=payload).status_code == 403
+
+    configured = TestClient(
+        create_app(auth_mode="none", allowed_local_roots=[allowed])
+    )
+    assert configured.post("/record", json=payload).status_code == 200
+    payload["output_uri"] = str(tmp_path / "outside")
+    assert configured.post("/record", json=payload).status_code == 403
 
 
 def test_service_health_system_info_and_token_auth() -> None:
@@ -1024,6 +1048,21 @@ def test_sdk_workbench_namespace_exports_insights() -> None:
     assert workbench.insights.__name__ == "npa.sdk.workbench.insights"
     for attr in ("record", "ingest_run", "query", "lineage", "compare", "dashboard"):
         assert hasattr(workbench.insights, attr)
+
+
+def test_embedded_sdk_does_not_require_service_allowlists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from npa.sdk.workbench.insights import record
+
+    monkeypatch.delenv("INSIGHTS_ALLOWED_LOCAL_ROOTS", raising=False)
+    monkeypatch.delenv("INSIGHTS_ALLOWED_S3_ROOTS", raising=False)
+    result = record(
+        output_uri=str(tmp_path / "sdk-store"),
+        records=[_metric("embedded", "accuracy", 0.9)],
+    )
+    assert result.recorded_count == 1
+    assert Path(result.store_uri).exists()
 
 
 def test_cli_and_sdk_do_not_import_heavy_ml_dependencies_at_module_level() -> None:

--- a/npa/tests/workbench/test_insights.py
+++ b/npa/tests/workbench/test_insights.py
@@ -33,6 +33,15 @@ from npa.workbench.insights.store import (
     read_records,
     record_metrics,
 )
+from npa.workbench.storage_scope import StorageScope, use_storage_scope
+
+
+@pytest.fixture(autouse=True)
+def _explicit_local_storage_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Insights tests intentionally operate only inside their per-test sandbox."""
+    monkeypatch.setenv("INSIGHTS_ALLOWED_LOCAL_ROOTS", str(tmp_path))
+    with use_storage_scope(StorageScope.from_config(local_roots=[tmp_path])):
+        yield
 
 
 def _metric(run_id: str, name: str, value: float, **kw: Any) -> dict[str, Any]:
@@ -993,6 +1002,20 @@ def test_service_health_system_info_and_token_auth() -> None:
     secure = TestClient(create_app(auth_mode="token", token="s3cr3t"))
     assert secure.get("/health").status_code == 401
     assert secure.get("/health", headers={"Authorization": "Bearer s3cr3t"}).status_code == 200
+
+
+def test_deployed_default_is_not_unauthenticated(monkeypatch: pytest.MonkeyPatch) -> None:
+    from npa.workbench.insights.service import create_app
+
+    monkeypatch.delenv("INSIGHTS_AUTH_MODE", raising=False)
+    monkeypatch.delenv("INSIGHTS_TOKEN", raising=False)
+    assert TestClient(create_app()).get("/health").status_code == 503
+
+
+def test_explicit_auth_none_remains_an_opt_in() -> None:
+    from npa.workbench.insights.service import create_app
+
+    assert TestClient(create_app(auth_mode="none")).get("/health").status_code == 200
 
 
 def test_sdk_workbench_namespace_exports_insights() -> None:

--- a/npa/tests/workbench/test_storage_scope.py
+++ b/npa/tests/workbench/test_storage_scope.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from npa.workbench.storage_scope import (
+    StorageAuthorizationError,
+    StorageScope,
+    use_storage_scope,
+)
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+def test_local_scope_accepts_absolute_and_file_uris(
+    tmp_path: Path, operation: str
+) -> None:
+    scope = StorageScope.from_config(local_roots=[tmp_path])
+    target = tmp_path / "nested" / "artifact.json"
+
+    assert scope.authorize(str(target), operation=operation).local_path == target
+    assert scope.authorize(target.as_uri(), operation=operation).local_path == target
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+@pytest.mark.parametrize(
+    "uri", ["https://example.invalid/a", "ftp://example.invalid/a"]
+)
+def test_scope_rejects_unknown_schemes(uri: str, operation: str) -> None:
+    with pytest.raises(StorageAuthorizationError, match="scheme"):
+        StorageScope().authorize(uri, operation=operation)
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "file://remote.invalid/sandbox/artifact.json",
+        "file:///sandbox/artifact.json?version=1",
+        "file:///sandbox/artifact.json#fragment",
+    ],
+)
+def test_scope_rejects_noncanonical_file_uris(uri: str, operation: str) -> None:
+    with pytest.raises(StorageAuthorizationError, match="file URI"):
+        StorageScope.from_config(local_roots=["/sandbox"]).authorize(
+            uri, operation=operation
+        )
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+def test_local_scope_rejects_absolute_and_traversal_escape(
+    tmp_path: Path, operation: str
+) -> None:
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    scope = StorageScope.from_config(local_roots=[sandbox])
+
+    for candidate in (tmp_path / "outside.json", sandbox / ".." / "outside.json"):
+        with pytest.raises(StorageAuthorizationError, match="outside"):
+            scope.authorize(str(candidate), operation=operation)
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+def test_local_scope_rejects_symlink_escape(tmp_path: Path, operation: str) -> None:
+    sandbox = tmp_path / "sandbox"
+    outside = tmp_path / "outside"
+    sandbox.mkdir()
+    outside.mkdir()
+    (sandbox / "escape").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(StorageAuthorizationError, match="outside"):
+        StorageScope.from_config(local_roots=[sandbox]).authorize(
+            str(sandbox / "escape" / "artifact.json"), operation=operation
+        )
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+def test_s3_scope_enforces_bucket_and_prefix(operation: str) -> None:
+    scope = StorageScope.from_config(s3_roots=["s3://allowed-bucket/team/run"])
+
+    allowed = scope.authorize(
+        "s3://allowed-bucket/team/run/artifact.json", operation=operation
+    )
+    assert (allowed.bucket, allowed.key) == (
+        "allowed-bucket",
+        "team/run/artifact.json",
+    )
+    for candidate in (
+        "s3://foreign-bucket/team/run/artifact.json",
+        "s3://allowed-bucket/team/runner/artifact.json",
+        "s3://allowed-bucket/team/run/../secret.json",
+        "s3://allowed-bucket/team/run/%2e%2e/secret.json",
+    ):
+        with pytest.raises(StorageAuthorizationError):
+            scope.authorize(candidate, operation=operation)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["npa.workbench.dataset.storage", "npa.workbench.insights.storage"],
+)
+def test_storage_helpers_enforce_s3_read_write_parity(
+    module_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib
+    from unittest.mock import Mock
+
+    module = importlib.import_module(module_name)
+    client = Mock()
+    body = Mock()
+    body.read.return_value = b"payload"
+    client.get_object.return_value = {"Body": body}
+    monkeypatch.setattr(module, "_s3_client", lambda: client)
+    scope = StorageScope.from_config(s3_roots=["s3://allowed-bucket/team/run"])
+
+    with use_storage_scope(scope):
+        module.write_bytes_uri("s3://allowed-bucket/team/run/output.bin", b"payload")
+        assert (
+            module.read_bytes_uri("s3://allowed-bucket/team/run/output.bin")
+            == b"payload"
+        )
+        with pytest.raises(StorageAuthorizationError):
+            module.write_bytes_uri(
+                "s3://foreign-bucket/team/run/output.bin", b"payload"
+            )
+        with pytest.raises(StorageAuthorizationError):
+            module.read_bytes_uri("s3://foreign-bucket/team/run/output.bin")
+
+    client.put_object.assert_called_once()
+    client.get_object.assert_called_once()

--- a/npa/tests/workbench/test_storage_scope.py
+++ b/npa/tests/workbench/test_storage_scope.py
@@ -128,3 +128,39 @@ def test_storage_helpers_enforce_s3_read_write_parity(
 
     client.put_object.assert_called_once()
     client.get_object.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("module_name", "env_prefix"),
+    [
+        ("npa.workbench.dataset.storage", "DATASET"),
+        ("npa.workbench.insights.storage", "INSIGHTS"),
+    ],
+)
+def test_embedded_storage_does_not_require_service_allowlists(
+    module_name: str,
+    env_prefix: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+    from unittest.mock import Mock
+
+    monkeypatch.delenv(f"{env_prefix}_ALLOWED_LOCAL_ROOTS", raising=False)
+    monkeypatch.delenv(f"{env_prefix}_ALLOWED_S3_ROOTS", raising=False)
+    module = importlib.import_module(module_name)
+
+    local_uri = str(tmp_path / "embedded.bin")
+    module.write_bytes_uri(local_uri, b"local")
+    assert module.read_bytes_uri(local_uri) == b"local"
+
+    client = Mock()
+    body = Mock()
+    body.read.return_value = b"s3"
+    client.get_object.return_value = {"Body": body}
+    monkeypatch.setattr(module, "_s3_client", lambda: client)
+    s3_uri = "s3://example-bucket/valid-prefix/embedded.bin"
+    module.write_bytes_uri(s3_uri, b"s3")
+    assert module.read_bytes_uri(s3_uri) == b"s3"
+    client.put_object.assert_called_once()
+    client.get_object.assert_called_once()

--- a/skills/tools/dataset/SKILL.md
+++ b/skills/tools/dataset/SKILL.md
@@ -87,3 +87,8 @@ toolRefs: `workbench.dataset.ingest`, `workbench.dataset.validate`,
 - Curated child versions are content-addressed (`<parent>.curated-<hash>`); a
   workflow that queries a curated version wires the concrete manifest URI at
   runtime.
+- The service defaults to token authentication and an empty storage scope. Set
+  `DATASET_TOKEN`, plus the narrow `DATASET_ALLOWED_S3_ROOTS` and/or
+  `DATASET_ALLOWED_LOCAL_ROOTS` boundary. `DATASET_AUTH_MODE=none` is an
+  explicit local/test opt-in only; see
+  `docs/security/workbench-service-boundaries.md`.

--- a/skills/tools/dataset/SKILL.md
+++ b/skills/tools/dataset/SKILL.md
@@ -87,8 +87,9 @@ toolRefs: `workbench.dataset.ingest`, `workbench.dataset.validate`,
 - Curated child versions are content-addressed (`<parent>.curated-<hash>`); a
   workflow that queries a curated version wires the concrete manifest URI at
   runtime.
-- The service defaults to token authentication and an empty storage scope. Set
-  `DATASET_TOKEN`, plus the narrow `DATASET_ALLOWED_S3_ROOTS` and/or
-  `DATASET_ALLOWED_LOCAL_ROOTS` boundary. `DATASET_AUTH_MODE=none` is an
-  explicit local/test opt-in only; see
-  `docs/security/workbench-service-boundaries.md`.
+- The service defaults to token authentication and an empty request storage
+  scope. Set `DATASET_TOKEN`, plus the narrow `DATASET_ALLOWED_S3_ROOTS` and/or
+  `DATASET_ALLOWED_LOCAL_ROOTS` boundary. These allowlists apply to deployed
+  FastAPI requests, not default embedded CLI, SDK, or workflow toolRef
+  execution. `DATASET_AUTH_MODE=none` is an explicit local/test service opt-in
+  only; see `docs/security/workbench-service-boundaries.md`.

--- a/skills/tools/insights/SKILL.md
+++ b/skills/tools/insights/SKILL.md
@@ -143,8 +143,9 @@ toolRefs: `workbench.insights.record`, `workbench.insights.ingest_run`,
   a step whose `resources_profile.accelerators` parses to >= 1, and manifests with
   status `planned` are skipped. CPU-only and never-executed runs therefore report
   no GPU count at all rather than a fabricated zero.
-- The service defaults to token authentication and an empty storage scope. Set
-  `INSIGHTS_TOKEN`, plus the narrow `INSIGHTS_ALLOWED_S3_ROOTS` and/or
-  `INSIGHTS_ALLOWED_LOCAL_ROOTS` boundary. `INSIGHTS_AUTH_MODE=none` is an
-  explicit local/test opt-in only; see
-  `docs/security/workbench-service-boundaries.md`.
+- The service defaults to token authentication and an empty request storage
+  scope. Set `INSIGHTS_TOKEN`, plus the narrow `INSIGHTS_ALLOWED_S3_ROOTS` and/or
+  `INSIGHTS_ALLOWED_LOCAL_ROOTS` boundary. These allowlists apply to deployed
+  FastAPI requests, not default embedded CLI, SDK, or workflow toolRef
+  execution. `INSIGHTS_AUTH_MODE=none` is an explicit local/test service opt-in
+  only; see `docs/security/workbench-service-boundaries.md`.

--- a/skills/tools/insights/SKILL.md
+++ b/skills/tools/insights/SKILL.md
@@ -143,3 +143,8 @@ toolRefs: `workbench.insights.record`, `workbench.insights.ingest_run`,
   a step whose `resources_profile.accelerators` parses to >= 1, and manifests with
   status `planned` are skipped. CPU-only and never-executed runs therefore report
   no GPU count at all rather than a fabricated zero.
+- The service defaults to token authentication and an empty storage scope. Set
+  `INSIGHTS_TOKEN`, plus the narrow `INSIGHTS_ALLOWED_S3_ROOTS` and/or
+  `INSIGHTS_ALLOWED_LOCAL_ROOTS` boundary. `INSIGHTS_AUTH_MODE=none` is an
+  explicit local/test opt-in only; see
+  `docs/security/workbench-service-boundaries.md`.

--- a/skills/tools/npa-agent/SKILL.md
+++ b/skills/tools/npa-agent/SKILL.md
@@ -20,7 +20,10 @@ Sim Assets + Cameras panels, embedded Rerun viewer, and Sim2Real submit hooks.
 ## Bootstrap And Verify
 
 ```bash
-npa/.venv/bin/npa agent fresh-setup --project rtxpro --name agent --project-id <project-id> --tenant-id <tenant-id> --region us-central1
+npa/.venv/bin/npa agent fresh-setup --project <alias> --name agent \
+  --project-id <project-id> --tenant-id <tenant-id> --region <region> \
+  --tf-var ssh_cidr_block=<operator-cidr> \
+  --tf-var application_cidr_block=<operator-cidr>
 npa/.venv/bin/npa agent bootstrap --project rtxpro --name agent
 # Existing agents missing credentials: refresh long-lived npa-agent SA + restage VM env
 npa/.venv/bin/npa agent bootstrap --project rtxpro --name agent --refresh-credentials
@@ -48,6 +51,14 @@ keys, product tokens, or basic-auth password. After the exact VM identity and SS
 channel are verified, bootstrap stages runtime credentials with owner-only SFTP
 uploads and atomic installs. A client failure resumes staging on that VM; it does
 not recreate the instance or copy secrets into Terraform state/user-data.
+
+SSH and application ingress are separate and empty by default. Agent deploy and
+fresh-setup require explicit `ssh_cidr_block` and `application_cidr_block`
+Terraform values because verified bootstrap and public HTTPS health checks use
+those paths. Any `/0` additionally requires the matching
+`allow_world_open_ssh=true` or `allow_world_open_application=true`
+acknowledgement. Post-deploy reconciliation reuses the application CIDR and
+never creates a world-open fallback rule.
 
 All `npa agent …` and `nebius` IAM commands run on the **operator/dev VM**.
 The **agent VM** only receives staged `/opt/npa-agent/*.env` files.


### PR DESCRIPTION
## Rationale

Closes three security-boundary gaps identified by the independent audit:

- Dataset and Insights services now default to bearer authentication and authorize every local/S3 read and write against explicit sandbox or bucket-prefix roots.
- Agent and workbench ingress now fail closed, separate SSH and application sources, and require conspicuous acknowledgement for IPv4 `/0` rules.
- Agent cloud-init no longer receives or persists static S3 credentials; credentials are staged only after the verified SSH boundary is available.

## Impact

Operators must configure service storage scopes and tokens, supply explicit ingress CIDRs, and acknowledge world-open rules. Legacy behavior remains available only through explicit insecure-development choices. The migration is documented in `docs/security/workbench-service-boundaries.md`.

## Validation

- Full non-e2e suite: `12,175 passed, 37 skipped, 12 deselected, 1 xpassed`
- Complete guardrails: `2,293 passed`
- Focused final compatibility checks: `17 passed`
- Ruff: `npa/src` and `npa/tests` clean
- Generated CLI docs: up to date
- Terraform format and isolated validation: clean
- Built-in confidentiality scan: 0 hits
- Gitleaks over `origin/main..HEAD`: no leaks
- Independent DeepSeek audit completed over the sanitized aggregate diff with a no-tools synthesis call. No findings were accepted after cross-file verification: the reported concerns either overlooked implementation/tests present in other chunks, described intentional fail-closed no-ops as exposure, conflicted with Terraform/provider validation and boolean syntax, or requested non-semantic test/tool changes. The recommended edge cases are already covered by the storage, ingress, Terraform, and CLI tests in this diff.

## Limitations

- No live cloud deployment was performed: the task supplied neither operator-selected CIDRs nor authority to create/destroy a deployment. The committed deploy path is covered by Terraform validation, complete guardrails, CLI/deploy tests, and the full non-e2e suite.
- Operator-provided confidentiality denylist CI remains the authoritative supplemental scan; the local built-in scan is the documented reproducible substitute.
