### PR TITLE
Audit and reconcile GHCR public release inventory

### DIFF
--- a/docs/workbench/container-image-catalog.md
+++ b/docs/workbench/container-image-catalog.md
@@ -17,10 +17,9 @@ docker pull ghcr.io/nebius/nebius-physical-ai/npa-retargeting:0.1.1
 existing saved `container_registry` overrides remain compatible.
 
 The accepted-release manifest was verified against the public GHCR tag and OCI
-manifest APIs on 2026-08-26. All 29 recorded release digests resolved
-anonymously; the active publication plan also records LeIsaac as pending rather
-than treating it as an accepted release claim. **Built** is the UTC build date
-of the newest listed variant; reproducible images that
+manifest APIs on 2026-08-29. All 31 recorded release digests resolved
+anonymously. **Built** is the UTC build date of the newest listed variant;
+reproducible images that
 intentionally zero their OCI `created` field use the timestamp in the immutable
 tag and `npa.build_ts` label.
 
@@ -29,6 +28,18 @@ tags can be moved, so resolve and retain the manifest digest as well when strict
 reproducibility is required.
 
 Rows are ordered by **Built** date, then by friendly name.
+
+## 2026-08-29 main publication audit
+
+The main-branch publishing plan, packaging contract, accepted-release manifest,
+and catalog were compared with GHCR without credentials. All 31 exact plan tags
+resolved anonymously, so no image build or registry write was required. The
+accepted-release manifest's stale LeIsaac pending marker was replaced with its
+already-published exact digest. That digest matched the earlier publication
+record, ran as the non-root `ubuntu` user, and passed the full layer/history
+payload scanner across 98,792 filesystem entries with zero restricted-payload
+findings. Public contract entries outside the tool publishing plan remain
+intentionally excluded rather than being treated as missing releases.
 
 ## 2026-08-19 main publication audit
 

--- a/npa/src/npa/deploy/public_release_manifest.json
+++ b/npa/src/npa/deploy/public_release_manifest.json
@@ -18,6 +18,7 @@
     "groot": {"tag": "0.1.0", "published_digest": "sha256:47fd6b727f249fbdb0ec237dc748c8bdc7cbf38474dc12c1cffe82f17fdde37b"},
     "isaac-lab": {"tag": "2.3.2.post1", "published_digest": "sha256:c2e142c5312c903fd2a165028ca17e34335813d034ce036b936c6dc3a886bea8"},
     "lancedb": {"tag": "cuda13-b300-0.30.3-sm80-sm90-sm100-sm103-sm120-20260803T031514Z", "published_digest": "sha256:a303b53d0769e612101d468ba957656997838f4b8e6a03430f2b5a2c89e3f8b5"},
+    "leisaac": {"tag": "0.4.0-20260817T231825Z", "published_digest": "sha256:82069eb74a18a88f77ad3149b6c5ed220c4eed33b1d550c26d361947805e8280"},
     "lerobot": {"tag": "cuda13-b300-0.5.1-sm80-sm90-sm100-sm103-sm120-20260803T034152Z", "published_digest": "sha256:14a2e0dfe61fb2c46c6e4b8d75f1a06f2f68f9cfa4a6428a175411afaf93749e"},
     "lerobot-policy": {"tag": "0.1.1", "published_digest": "sha256:fe787495c11747995539b93f6192a1fee3e14b0f1683ea188a95109d762e6adb"},
     "lerobot-vlm-rl": {"tag": "cuda13-b300-0.1.1-sm80-sm90-sm100-sm103-sm120-20260803T034152Z", "published_digest": "sha256:7bd5b21d487f3ab6614197b8a8af81fe3ed001247b4501740615540cb55998e5"},
@@ -33,7 +34,5 @@
     "alpamayo2-super": {"tag": "0.1.0-cu128", "published_digest": "sha256:2164450f8baf57d8798f64063ea27bf11611f5b695c467de0c2e319e3134ebd5"},
     "content-agents": {"tag": "0.5.2-npa2", "published_digest": "sha256:c64aaf6201bdaa013f9d16e8497290cf166907932f036297d7abaa430cbad7db"}
   },
-  "publication_pending": {
-    "leisaac": "The supported tag is not yet anonymously pullable; it is not an accepted public release claim."
-  }
+  "publication_pending": {}
 }

--- a/npa/tests/deploy/test_public_publish.py
+++ b/npa/tests/deploy/test_public_publish.py
@@ -363,7 +363,20 @@ def test_publish_plan_still_refuses_a_restricted_image(monkeypatch) -> None:
     refusal and the whole plan raised. A defence-in-depth check holding a stale copy of the
     thing it defends is worse than no check.
     """
+    manifest = images.public_release_manifest()
     monkeypatch.setattr(images, "RESTRICTED_PUBLICATION_TOOLS", frozenset({"genesis"}))
+    monkeypatch.setattr(
+        images,
+        "public_release_manifest",
+        lambda: {
+            **manifest,
+            "releases": {
+                tool: entry
+                for tool, entry in manifest["releases"].items()
+                if tool != "genesis"
+            },
+        },
+    )
     plan = build_publish_plan(target_registry="ghcr.io/example/workbench")
     names = {item.source_ref.rsplit("/", 1)[-1].split(":", 1)[0] for item in plan}
     assert "npa-genesis" not in names
@@ -832,11 +845,11 @@ def test_accepted_release_plan_partitions_published_and_pending_tools() -> None:
         target_registry="ghcr.io/nebius/nebius-physical-ai"
     )
 
-    assert len(plan) == 30
+    assert len(plan) == 31
     assert set(manifest["releases"]) | set(manifest["publication_pending"]) == set(
         publicly_publishable_tools()
     )
-    assert set(manifest["publication_pending"]) == {"leisaac"}
+    assert not manifest["publication_pending"]
     for item in plan:
         recorded = manifest["releases"][item.tool]["published_digest"]
         assert item.source_ref.endswith(f"@{recorded}")


### PR DESCRIPTION
## What changed

- audited the repository public-release plan, packaging contract, accepted-release manifest, and public image catalog against anonymous GHCR evidence;
- confirmed all 31 planned release tags resolve anonymously, so there were no genuinely missing publishable images to build or publish;
- moved LeIsaac from the stale publication-pending record into the accepted-release manifest at its existing exact public digest;
- updated the catalog audit date/count/evidence and reconciled deployment tests with the complete published partition.

## Why

The LeIsaac release was already public and documented, but `public_release_manifest.json` still described it as unavailable. That made repository metadata disagree with both the catalog and live anonymous registry state.

## User/developer impact

Anonymous accepted-release verification now covers every publisher-selected tool, including LeIsaac. Maintainers and health checks no longer report a false pending release, and the release-partition tests enforce the 31-image inventory.

## Validation

- anonymous plan audit: 31/31 resolved;
- accepted-release verification: 31/31 exact digests matched;
- LeIsaac exact-digest payload scan: 98,792 filesystem entries, zero restricted-payload findings; non-root `ubuntu` runtime and expected service entrypoint confirmed;
- focused catalog/publication/packaging tests: 291 passed;
- Docker/deploy/security/skills tests: 874 passed;
- full final non-E2E suite on rebased `main`: 12,343 passed, 37 skipped, 12 deselected, 1 xpassed;
- onboarding smoke: 113 passed;
- Ruff, docs drift, tag consistency, confidentiality scan, and gitleaks: passed.

## Limitations

No image was built or pushed because the anonymous audit found no missing tag in the public plan. No new GPU capability run was required because the reconciled LeIsaac tag is byte-identical to the previously documented, full-layer-scanned release; this change records current registry state rather than introducing new image bytes or capability claims.