### PR TITLE
Fix Sim2Real stages on Isaac Lab 3.0 / rsl-rl 5.0 and operator-host issues found in a live run

### DIFF
--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -205,6 +205,7 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true
           vuln-type: os
+          timeout: 2562047h47m16s
           format: table
 
       - name: Trivy image scan (SARIF)
@@ -215,6 +216,7 @@ jobs:
           severity: CRITICAL
           ignore-unfixed: true
           vuln-type: os
+          timeout: 2562047h47m16s
           limit-severities-for-sarif: true
           format: sarif
           output: trivy-${{ matrix.name }}.sarif

--- a/npa/docker/workbench/sim2real-control/Dockerfile
+++ b/npa/docker/workbench/sim2real-control/Dockerfile
@@ -7,7 +7,8 @@ ARG DEBIAN_SNAPSHOT=20260801T000000Z
 
 LABEL npa.tool="sim2real-control" \
       npa.version="${SIM2REAL_CONTROL_VERSION}" \
-      org.opencontainers.image.revision="${NPA_SOURCE_SHA}"
+      org.opencontainers.image.revision="${NPA_SOURCE_SHA}" \
+      org.nebius.npa.skypilot-bootstrap-contract="skypilot-0.12.2-v1"
 
 ENV NPA_IMAGE_SOURCE_SHA=${NPA_SOURCE_SHA} \
     NPA_SKIP_EAGER_IMPORTS=1 \

--- a/npa/src/npa/clients/json_output.py
+++ b/npa/src/npa/clients/json_output.py
@@ -3,11 +3,23 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
+
+# ANSI CSI/OSC control sequences (colors, cursor movement, erase-line) emitted
+# by rich status spinners; their introducer is ESC+"[", which must not be
+# mistaken for the start of a JSON array.
+_ANSI_SEQUENCE_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?")
 
 
 def parse_single_json_document(output: str) -> Any | None:
-    """Return one trailing JSON document, rejecting ambiguity and trailing text."""
+    """Return one trailing JSON document, rejecting ambiguity and trailing text.
+
+    Trailing output that cannot begin another JSON value (for example SkyPilot's
+    rich status spinner occasionally flushing one final ``⠏ Checking managed
+    jobs`` frame with ANSI control sequences after the JSON array) is not
+    ambiguity and is ignored; any trailing ``[`` or ``{`` still rejects.
+    """
 
     text = str(output or "")
     decoder = json.JSONDecoder()
@@ -18,7 +30,10 @@ def parse_single_json_document(output: str) -> Any | None:
             payload, end = decoder.raw_decode(text, index)
         except json.JSONDecodeError:
             continue
-        if text[end:].strip() or _contains_json_value(text[:index], decoder):
+        trailing = _ANSI_SEQUENCE_RE.sub("", text[end:])
+        if any(ch in "[{" for ch in trailing) or _contains_json_value(
+            text[:index], decoder
+        ):
             continue
         return payload
     return None

--- a/npa/src/npa/orchestration/skypilot/workflow.py
+++ b/npa/src/npa/orchestration/skypilot/workflow.py
@@ -247,6 +247,13 @@ def _probe_local_api_daemon_cwd(
     # would put them in different parent directories and miss the real daemon.
     sky_bin_dir = Path(sky_executable).expanduser().absolute().parent
     records: dict[int, tuple[int, tuple[str, ...], Path]] = {}
+    if sys.platform == "darwin" and proc_root == Path("/proc"):
+        # macOS has no procfs, so the deleted-cwd poisoning this probe detects
+        # cannot be inspected here. Treat the daemon as healthy rather than
+        # failing closed on every macOS operator host; the Linux-specific
+        # cwd_deleted recovery below remains unchanged, as do hermetic
+        # non-/proc test fixtures on every platform.
+        return ApiDaemonCwdProbe(True, "procfs_unavailable_darwin")
     try:
         candidates = tuple(proc_root.iterdir())
     except OSError as exc:

--- a/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_eval.py
@@ -514,6 +514,8 @@ try:
         from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper  # older layout
     from rsl_rl.runners import OnPolicyRunner
     env_cfg = parse_env_cfg(TASK, device="cuda:0", num_envs=N)
+    from npa.workflows.sim2real.isaac_assets_compat import remap_moved_franka_usd
+    print("EVAL_ROBOT_USD_EFFECTIVE", remap_moved_franka_usd(env_cfg), flush=True)
     # CUSTOM asset: override the manipuland USD so eval scores the policy on the
     # same custom object it trained on (physically simulated, not the stock cube).
     OBJECT_USD = os.environ.get("EVAL_OBJECT_USD", "").strip()
@@ -582,6 +584,8 @@ try:
             print("cfg loader", loader, "failed:", repr(e), flush=True)
     if agent_cfg is None:
         raise RuntimeError("could not load rsl_rl_cfg_entry_point for task")
+    from npa.workflows.sim2real.isaac_assets_compat import migrate_rsl_rl_agent_cfg
+    agent_cfg = migrate_rsl_rl_agent_cfg(agent_cfg)
     acfg = agent_cfg.to_dict() if hasattr(agent_cfg, "to_dict") else dict(agent_cfg)
     print("AGENT_CFG_KEYS", sorted(acfg.keys()), flush=True)
     # The ACTUAL env count is the single source of truth for per-env sizing.

--- a/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_policy_rollout.py
@@ -369,6 +369,8 @@ try:
         from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper
     from rsl_rl.runners import OnPolicyRunner
     env_cfg = parse_env_cfg(TASK, device=SIM_DEVICE, num_envs=N)
+    from npa.workflows.sim2real.isaac_assets_compat import remap_moved_franka_usd
+    print("ROLLOUT_ROBOT_USD_EFFECTIVE", remap_moved_franka_usd(env_cfg), flush=True)
     if SIM_DEVICE == "cpu":
         if N != 1:
             raise RuntimeError("CPU physics camera fallback requires ROLLOUT_COUNT=1")
@@ -440,6 +442,8 @@ try:
             print("cfg loader", loader, "failed:", repr(e), flush=True)
     if agent_cfg is None:
         raise RuntimeError("could not load rsl_rl_cfg_entry_point for task")
+    from npa.workflows.sim2real.isaac_assets_compat import migrate_rsl_rl_agent_cfg
+    agent_cfg = migrate_rsl_rl_agent_cfg(agent_cfg)
     acfg = agent_cfg.to_dict() if hasattr(agent_cfg, "to_dict") else dict(agent_cfg)
     runner = OnPolicyRunner(env, acfg, log_dir=None, device=SIM_DEVICE)
     trained = False

--- a/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
+++ b/npa/src/npa/workflows/sim2real/byo_isaac_trainer.py
@@ -359,6 +359,8 @@ _PPO_METRIC_RE = re.compile(r"^\s*([^:]+):\s*(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\
 _PPO_FIELDS = {
     "Mean action noise std": "action_noise_std",
     "Mean value_function loss": "value_loss",
+    # rsl-rl >= 5.0 renamed the console field and dropped the timesteps line.
+    "Mean value loss": "value_loss",
     "Mean surrogate loss": "surrogate_loss",
     "Mean entropy loss": "entropy",
     "Mean reward": "episode_return",
@@ -424,7 +426,9 @@ def parse_ppo_training_log(text: str) -> dict[str, Any]:
 
     if not iterations:
         raise ValueError("RSL-RL log contains no Learning iteration records")
-    required = {"episode_return", "value_loss", "surrogate_loss", "total_timesteps"}
+    # rsl-rl >= 5.0 no longer prints "Total timesteps" in the iteration table;
+    # treat it as optional evidence rather than a completeness requirement.
+    required = {"episode_return", "value_loss", "surrogate_loss"}
     complete = [item for item in iterations if required.issubset(item)]
     if not complete:
         raise ValueError("RSL-RL log contains no complete PPO telemetry iteration")

--- a/npa/src/npa/workflows/sim2real/isaac_assets_compat.py
+++ b/npa/src/npa/workflows/sim2real/isaac_assets_compat.py
@@ -1,0 +1,52 @@
+"""Compatibility remaps for upstream Omniverse asset-tree moves.
+
+Isaac Lab 3.0.0b2.post1 pins the stock Franka Panda robot at
+``{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd``. In the
+Isaac 6.0 content tree NVIDIA later moved that asset (and its Props/Materials)
+under ``FrankaEmika/Legacy/``, so the pinned URL now returns 404 and every
+stock-Franka stage fails closed with ``USD file not found``. Remap the exact
+stale path to its relocated, byte-identical Legacy location; any other robot
+spec (BYO robots, explicit robot_spec_uri overrides) is left untouched.
+"""
+
+from __future__ import annotations
+
+_STALE_SUFFIX = "/Robots/FrankaEmika/panda_instanceable.usd"
+_LEGACY_SUFFIX = "/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
+
+
+def remap_moved_franka_usd(env_cfg) -> str:
+    """Point a stale stock-Franka spawn at the relocated Legacy USD.
+
+    Returns the effective robot USD path (possibly unchanged) for logging.
+    """
+
+    robot = getattr(getattr(env_cfg, "scene", None), "robot", None)
+    spawn = getattr(robot, "spawn", None)
+    usd_path = str(getattr(spawn, "usd_path", "") or "")
+    if spawn is not None and usd_path.endswith(_STALE_SUFFIX) and "/Legacy/" not in usd_path:
+        spawn.usd_path = usd_path[: -len(_STALE_SUFFIX)] + _LEGACY_SUFFIX
+        return spawn.usd_path
+    return usd_path
+
+
+def migrate_rsl_rl_agent_cfg(agent_cfg):
+    """Apply Isaac Lab's own rsl-rl cross-version migration to a registry cfg.
+
+    Isaac Lab 3.0 cfg dataclasses still carry legacy fields (e.g. the model
+    ``stochastic`` flag) that rsl-rl >= 5.0.0 no longer accepts; upstream's
+    train scripts run ``handle_deprecated_rsl_rl_cfg`` before constructing
+    ``OnPolicyRunner`` and so must every direct runner construction here.
+    Absence of the utility (older Isaac Lab) means no migration is needed.
+    """
+
+    try:
+        import importlib.metadata as _md
+
+        from isaaclab_rl.rsl_rl.utils import handle_deprecated_rsl_rl_cfg
+
+        migrated = handle_deprecated_rsl_rl_cfg(agent_cfg, _md.version("rsl-rl-lib"))
+        return migrated if migrated is not None else agent_cfg
+    except Exception as exc:  # noqa: BLE001 - fail open: older stacks need none
+        print("RSL_RL_CFG_MIGRATION_SKIPPED", repr(exc), flush=True)
+        return agent_cfg

--- a/npa/src/npa/workflows/sim2real/isaac_byo_robot_task.py
+++ b/npa/src/npa/workflows/sim2real/isaac_byo_robot_task.py
@@ -1284,6 +1284,48 @@ def configure_convergence_action_noise(
     target = float(target_std)
     if not math.isfinite(target) or not 0.0 < target <= 1.0:
         raise ValueError("target_std must be finite and between zero and one")
+    # rsl-rl >= 5.0: the actor MLPModel keeps its noise in a Distribution module
+    # (std_type + std_param/log_std_param). Map that shape onto the legacy
+    # attribute names so one code path performs the exact same update.
+    distribution = getattr(policy, "distribution", None)
+    if distribution is not None and hasattr(distribution, "std_type"):
+        if "Heteroscedastic" in type(distribution).__name__:
+            raise RuntimeError(
+                "resume convergence does not support state-dependent action noise"
+            )
+        std_type = str(getattr(distribution, "std_type", ""))
+        if std_type == "scalar":
+            parameter_name = "std_param"
+        elif std_type == "log":
+            parameter_name = "log_std_param"
+        else:
+            raise RuntimeError(f"unsupported RSL-RL std_type: {std_type!r}")
+        noise_std_type = std_type
+        stored_value = math.log(target) if std_type == "log" else target
+        parameter = getattr(distribution, parameter_name, None)
+        if parameter is None or not hasattr(parameter, "detach"):
+            raise RuntimeError(
+                f"RSL-RL distribution lacks mutable {parameter_name} parameter"
+            )
+        detached = parameter.detach()
+        detached.fill_(stored_value)
+        parameter.requires_grad_(not freeze)
+        raw_values = detached.reshape(-1).tolist()
+        actual_values = [
+            math.exp(float(value)) if std_type == "log" else float(value)
+            for value in (raw_values if isinstance(raw_values, list) else [raw_values])
+        ]
+        if not actual_values or any(
+            not math.isclose(value, target, rel_tol=1.0e-6, abs_tol=1.0e-7)
+            for value in actual_values
+        ):
+            raise RuntimeError("RSL-RL action-noise convergence update did not persist")
+        return {
+            "noise_std_type": noise_std_type,
+            "target_std": target,
+            "parameter_count": len(actual_values),
+            "frozen": bool(freeze),
+        }
     if bool(getattr(policy, "state_dependent_std", False)):
         raise RuntimeError(
             "resume convergence does not support state-dependent action noise"
@@ -1385,6 +1427,8 @@ try:
         from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper  # older layout
     from rsl_rl.runners import OnPolicyRunner
     env_cfg = parse_env_cfg(task, device="cuda:0", num_envs=NUM_ENVS)
+    from npa.workflows.sim2real.isaac_assets_compat import remap_moved_franka_usd
+    print("TASK_ROBOT_USD_EFFECTIVE", remap_moved_franka_usd(env_cfg), flush=True)
     # The scenario wrapper is the canonical stock-Franka path. Apply the exact
     # reward, object, and optimizer contract here so those settings cannot be
     # lost as provenance-only Hydra arguments on the bypassed train.py branch.
@@ -1420,6 +1464,8 @@ try:
     torch.manual_seed(SEED)
     print("ROBOT_SEED_APPLIED", SEED, flush=True)
     agent_cfg = load_cfg_from_registry(task, "rsl_rl_cfg_entry_point")
+    from npa.workflows.sim2real.isaac_assets_compat import migrate_rsl_rl_agent_cfg
+    agent_cfg = migrate_rsl_rl_agent_cfg(agent_cfg)
     acfg = agent_cfg.to_dict() if hasattr(agent_cfg, "to_dict") else dict(agent_cfg)
     acfg["max_iterations"] = ITERS
     acfg["num_steps_per_env"] = STEPS_PER_ENV
@@ -1533,8 +1579,16 @@ try:
             raise RuntimeError("RSL-RL algorithm cannot apply the entropy curriculum")
         runner.alg.entropy_coef = float(ENT_FINAL)
         if CONVERGENCE_STD:
+            # rsl-rl >= 5.0 renamed alg.policy; the actor model carries the noise.
+            _policy_model = (
+                getattr(runner.alg, "policy", None)
+                or getattr(runner.alg, "actor_critic", None)
+                or getattr(runner.alg, "actor", None)
+            )
+            if _policy_model is None:
+                raise RuntimeError("RSL-RL algorithm exposes no policy/actor model")
             noise_audit = robotmod.configure_convergence_action_noise(
-                runner.alg.policy,
+                _policy_model,
                 target_std=float(CONVERGENCE_STD),
                 freeze=True,
             )

--- a/npa/src/npa/workflows/sim2real/isaac_physics_task.py
+++ b/npa/src/npa/workflows/sim2real/isaac_physics_task.py
@@ -183,11 +183,15 @@ try:
         from omni.isaac.lab_rl.rsl_rl import RslRlVecEnvWrapper  # older layout
     from rsl_rl.runners import OnPolicyRunner
     env_cfg = parse_env_cfg(task, device="cuda:0", num_envs=NUM_ENVS)
+    from npa.workflows.sim2real.isaac_assets_compat import remap_moved_franka_usd
+    print("PHYS_ROBOT_USD_EFFECTIVE", remap_moved_franka_usd(env_cfg), flush=True)
     # Zero is a real reproducibility seed, not an unset sentinel.
     env_cfg.seed = SEED
     torch.manual_seed(SEED)
     print("PHYS_SEED_APPLIED", SEED, flush=True)
     agent_cfg = load_cfg_from_registry(task, "rsl_rl_cfg_entry_point")
+    from npa.workflows.sim2real.isaac_assets_compat import migrate_rsl_rl_agent_cfg
+    agent_cfg = migrate_rsl_rl_agent_cfg(agent_cfg)
     acfg = agent_cfg.to_dict() if hasattr(agent_cfg, "to_dict") else dict(agent_cfg)
     acfg["max_iterations"] = ITERS
     acfg["num_steps_per_env"] = STEPS_PER_ENV

--- a/npa/src/npa/workflows/sim2real/isaac_scenario_task.py
+++ b/npa/src/npa/workflows/sim2real/isaac_scenario_task.py
@@ -361,27 +361,70 @@ def apply_scenario_reset(env: Any, env_ids: Any, asset_cfg: Any) -> None:
 
     ids_cpu = ids.cpu()
     # Exact per-env material values.  This mirrors Isaac Lab's own material event
-    # setter but supplies the curated values instead of resampling buckets.
-    materials = asset.root_physx_view.get_material_properties()
-    friction = torch.tensor(
-        [float(row["physics"]["friction"]) for row in selected],
-        dtype=materials.dtype,
-        device=materials.device,
-    )
-    materials[ids_cpu, :, 0] = friction[:, None]
-    materials[ids_cpu, :, 1] = friction[:, None]
-    materials[ids_cpu, :, 2] = 0.0
-    asset.root_physx_view.set_material_properties(materials, ids_cpu)
+    # setter (envs/mdp/events.py) but supplies the curated values instead of
+    # resampling buckets. Isaac Lab 3.0's views hand out warp arrays and expect
+    # warp round-trips through `root_view`; older releases returned torch
+    # tensors from `root_physx_view`. Support both without changing values.
+    root_view = getattr(asset, "root_view", None) or asset.root_physx_view
+    materials_raw = root_view.get_material_properties()
+    friction_values = [float(row["physics"]["friction"]) for row in selected]
+    if isinstance(materials_raw, torch.Tensor):
+        materials = materials_raw
+        friction = torch.tensor(
+            friction_values, dtype=materials.dtype, device=materials.device
+        )
+        materials[ids_cpu, :, 0] = friction[:, None]
+        materials[ids_cpu, :, 1] = friction[:, None]
+        materials[ids_cpu, :, 2] = 0.0
+        root_view.set_material_properties(materials, ids_cpu)
+    else:
+        import warp as wp
 
-    masses = asset.root_physx_view.get_masses()
-    default_mass = asset.data.default_mass.cpu()
-    mass_scale = torch.tensor(
-        [float(row["physics"]["mass_scale"]) for row in selected],
-        dtype=masses.dtype,
-        device=masses.device,
-    )
-    masses[ids_cpu] = default_mass[ids_cpu].to(masses.device) * mass_scale[:, None]
-    asset.root_physx_view.set_masses(masses, ids_cpu)
+        materials = wp.to_torch(materials_raw)
+        ids_mat = ids.to(device=materials.device, dtype=torch.int32).contiguous()
+        friction = torch.tensor(
+            friction_values, dtype=materials.dtype, device=materials.device
+        )
+        materials[ids_mat.long(), :, 0] = friction[:, None]
+        materials[ids_mat.long(), :, 1] = friction[:, None]
+        materials[ids_mat.long(), :, 2] = 0.0
+        root_view.set_material_properties(
+            wp.from_torch(materials, dtype=wp.float32),
+            wp.from_torch(ids_mat, dtype=wp.int32),
+        )
+
+    # Exact per-env mass scaling. Isaac Lab 3.0 exposes the backend-safe
+    # partial setter `set_masses_index` (its own mass-randomization event uses
+    # it); the raw physx-view set_masses path remains only for older releases.
+    mass_scale_values = [float(row["physics"]["mass_scale"]) for row in selected]
+    set_masses_index = getattr(asset, "set_masses_index", None)
+    if callable(set_masses_index):
+        body_mass = asset.data.body_mass
+        body_mass = body_mass if isinstance(body_mass, torch.Tensor) else body_mass.torch
+        default_mass = asset.data.default_mass
+        default_mass = (
+            default_mass
+            if isinstance(default_mass, torch.Tensor)
+            else default_mass.torch
+        )
+        num_bodies = body_mass.shape[1] if body_mass.dim() > 1 else 1
+        device = body_mass.device
+        env_ids32 = ids.to(device=device, dtype=torch.int32).contiguous()
+        body_ids32 = torch.arange(num_bodies, dtype=torch.int32, device=device)
+        mass_scale = torch.tensor(
+            mass_scale_values, dtype=body_mass.dtype, device=device
+        )
+        partial = default_mass[ids.to(device).long()].reshape(len(selected), num_bodies)
+        partial = partial * mass_scale[:, None]
+        set_masses_index(masses=partial, body_ids=body_ids32, env_ids=env_ids32)
+    else:
+        masses = asset.root_physx_view.get_masses()
+        default_mass = asset.data.default_mass.cpu()
+        mass_scale = torch.tensor(
+            mass_scale_values, dtype=masses.dtype, device=masses.device
+        )
+        masses[ids_cpu] = default_mass[ids_cpu].to(masses.device) * mass_scale[:, None]
+        asset.root_physx_view.set_masses(masses, ids_cpu)
 
     if not getattr(env, "npa_scenario_first_reset_logged", False):
         print(
@@ -684,10 +727,27 @@ def _placement_state(
     command = env.command_manager.get_command(command_name)
     from isaaclab.utils.math import combine_frame_transforms
 
+    def _as_torch(value):
+        # Isaac Lab 3.0 asset buffers are lazy ProxyArrays; TorchScript
+        # functions such as combine_frame_transforms reject them. `.torch` is
+        # the documented zero-copy tensor view (a property in Isaac Lab 3.0);
+        # older releases already return torch tensors.
+        if isinstance(value, torch.Tensor):
+            return value
+        torch_view = getattr(value, "torch", None)
+        if isinstance(torch_view, torch.Tensor):
+            return torch_view
+        if callable(torch_view):
+            converted = torch_view()
+            if isinstance(converted, torch.Tensor):
+                return converted
+        # Last resort: ProxyArray.__getitem__ indexes the torch view.
+        return value[:]
+
     goal, _ = combine_frame_transforms(
-        robot.data.root_pos_w,
-        robot.data.root_quat_w,
-        command[:, :3],
+        _as_torch(robot.data.root_pos_w),
+        _as_torch(robot.data.root_quat_w),
+        _as_torch(command)[:, :3],
     )
     distance = torch.linalg.norm(position - goal, dim=1)
     speed = torch.linalg.norm(obj.data.root_lin_vel_w[:, :3], dim=1)

--- a/npa/tests/clients/test_json_output.py
+++ b/npa/tests/clients/test_json_output.py
@@ -1,0 +1,33 @@
+"""Strict single-document JSON parsing for CLI output with presentation noise."""
+
+from __future__ import annotations
+
+from npa.clients.json_output import parse_single_json_document
+
+
+def test_parses_document_with_diagnostic_preamble() -> None:
+    assert parse_single_json_document('note\n[{"a": 1}]') == [{"a": 1}]
+
+
+def test_tolerates_trailing_ansi_spinner_frame() -> None:
+    # SkyPilot's rich status spinner can flush one final frame to stdout after
+    # the JSON payload; ANSI erase/cursor sequences contain ESC+"[" which must
+    # not be mistaken for a second JSON document.
+    output = (
+        '[{"job_id": 5, "status": "RUNNING"}]\n'
+        "\x1b[2K\x1b[32m⠏\x1b[0m \x1b[36mChecking managed jobs\x1b[0m\n"
+        "\x1b[?25h\x1b[1A\x1b[2K"
+    )
+    assert parse_single_json_document(output) == [{"job_id": 5, "status": "RUNNING"}]
+
+
+def test_rejects_second_document_after_payload() -> None:
+    assert parse_single_json_document('{"a": 1}\n{"b": 2}') is None
+
+
+def test_rejects_ambiguous_preamble_value() -> None:
+    assert parse_single_json_document('junk [1, 2] trailing {') is None
+
+
+def test_rejects_trailing_json_start_outside_ansi() -> None:
+    assert parse_single_json_document('[{"a": 1}]\n[') is None

--- a/npa/tests/guardrails/test_public_release_workflows.py
+++ b/npa/tests/guardrails/test_public_release_workflows.py
@@ -158,6 +158,19 @@ def test_large_image_scan_reclaims_build_cache_and_reuses_large_volume() -> None
     assert "docker image prune" not in text[scan:push]
 
 
+def test_base_image_scans_do_not_inherit_trivys_five_minute_timeout() -> None:
+    spec = _spec(SECURITY_SCAN)
+    steps = spec["jobs"]["base-image-cve-scan"]["steps"]
+    scans = [
+        step
+        for step in steps
+        if step.get("uses") == "aquasecurity/trivy-action@v0.36.0"
+    ]
+
+    assert len(scans) == 2
+    assert all(step["with"]["timeout"] == "2562047h47m16s" for step in scans)
+
+
 def test_post_push_and_promotion_gates_are_digest_bound() -> None:
     text = PUBLISH.read_text(encoding="utf-8")
     for required in (

--- a/npa/tests/orchestration/skypilot/test_workflow.py
+++ b/npa/tests/orchestration/skypilot/test_workflow.py
@@ -320,6 +320,34 @@ def test_local_api_daemon_probe_accepts_durable_process_tree(tmp_path) -> None:
     assert result.process_count == 2
 
 
+def test_local_api_daemon_probe_is_healthy_without_procfs_on_darwin(
+    tmp_path, monkeypatch
+) -> None:
+    # macOS has no /proc, so the deleted-cwd poisoning this probe detects is
+    # un-inspectable there; submit must not fail closed on every macOS host.
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    sky = bin_dir / "sky"
+    sky.touch()
+    monkeypatch.setattr(workflow_module.sys, "platform", "darwin")
+
+    result = workflow_module._probe_local_api_daemon_cwd(
+        str(sky), proc_root=Path("/proc"), uid=1234
+    )
+
+    assert result.healthy is True
+    assert result.outcome == "procfs_unavailable_darwin"
+
+    # A hermetic non-/proc fixture keeps the conservative legacy behavior even
+    # on darwin: absence there is still reported as procfs_unavailable.
+    missing = tmp_path / "missing-proc"
+    hermetic = workflow_module._probe_local_api_daemon_cwd(
+        str(sky), proc_root=missing, uid=1234
+    )
+    assert hermetic.healthy is False
+    assert hermetic.outcome == "procfs_unavailable"
+
+
 def test_local_api_daemon_probe_ignores_other_mount_namespaces(tmp_path) -> None:
     proc_root = tmp_path / "proc"
     bin_dir = tmp_path / "venv" / "bin"

--- a/npa/tests/workflows/test_byo_isaac_trainer.py
+++ b/npa/tests/workflows/test_byo_isaac_trainer.py
@@ -108,6 +108,50 @@ def test_resume_convergence_noise_supports_log_std_and_fails_closed() -> None:
         configure_convergence_action_noise(LogPolicy(), target_std=float("nan"))
 
 
+def test_resume_convergence_noise_supports_rsl_rl_5_distribution() -> None:
+    # rsl-rl >= 5.0: the actor MLPModel carries a Distribution module with
+    # std_type plus std_param/log_std_param instead of policy-level attributes.
+    class GaussianDistribution:
+        std_type = "scalar"
+        std_param = _FakeNoiseParameter([0.41] * 8)
+
+    class Actor:
+        distribution = GaussianDistribution()
+
+    audit = configure_convergence_action_noise(Actor(), target_std=0.05)
+    assert audit == {
+        "noise_std_type": "scalar",
+        "target_std": 0.05,
+        "parameter_count": 8,
+        "frozen": True,
+    }
+    assert GaussianDistribution.std_param.values == pytest.approx([0.05] * 8)
+    assert GaussianDistribution.std_param.requires_grad is False
+
+    class LogGaussianDistribution:
+        std_type = "log"
+        log_std_param = _FakeNoiseParameter([0.0, 0.0, 0.0])
+
+    class LogActor:
+        distribution = LogGaussianDistribution()
+
+    log_audit = configure_convergence_action_noise(LogActor(), target_std=0.1)
+    assert log_audit["parameter_count"] == 3
+    assert LogGaussianDistribution.log_std_param.values == pytest.approx(
+        [-2.302585093] * 3
+    )
+
+    class HeteroscedasticGaussianDistribution:
+        std_type = "scalar"
+        std_param = _FakeNoiseParameter([0.41])
+
+    class StateDependentActor:
+        distribution = HeteroscedasticGaussianDistribution()
+
+    with pytest.raises(RuntimeError, match="state-dependent"):
+        configure_convergence_action_noise(StateDependentActor(), target_std=0.05)
+
+
 def test_read_signal_stats(tmp_path):
     stats = byo.read_signal_stats(str(_write_signal(tmp_path)))
     assert stats["step_count"] == 3

--- a/npa/tests/workflows/test_isaac_assets_compat.py
+++ b/npa/tests/workflows/test_isaac_assets_compat.py
@@ -1,0 +1,57 @@
+"""Isaac Lab 3.0 compatibility remaps for upstream asset-tree moves."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from npa.workflows.sim2real.isaac_assets_compat import (
+    migrate_rsl_rl_agent_cfg,
+    remap_moved_franka_usd,
+)
+
+_STALE = (
+    "https://omniverse-content-production.s3-us-west-2.amazonaws.com/"
+    "Assets/Isaac/6.0/Isaac/IsaacLab/Robots/FrankaEmika/panda_instanceable.usd"
+)
+_LEGACY = (
+    "https://omniverse-content-production.s3-us-west-2.amazonaws.com/"
+    "Assets/Isaac/6.0/Isaac/IsaacLab/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
+)
+
+
+def _env_cfg(usd_path: str):
+    spawn = SimpleNamespace(usd_path=usd_path)
+    robot = SimpleNamespace(spawn=spawn)
+    scene = SimpleNamespace(robot=robot)
+    return SimpleNamespace(scene=scene)
+
+
+def test_remaps_stale_stock_franka_usd_to_legacy_location() -> None:
+    cfg = _env_cfg(_STALE)
+    assert remap_moved_franka_usd(cfg) == _LEGACY
+    assert cfg.scene.robot.spawn.usd_path == _LEGACY
+
+
+def test_remap_is_idempotent_on_legacy_path() -> None:
+    cfg = _env_cfg(_LEGACY)
+    assert remap_moved_franka_usd(cfg) == _LEGACY
+    assert cfg.scene.robot.spawn.usd_path == _LEGACY
+
+
+def test_remap_leaves_byo_robot_specs_untouched() -> None:
+    byo = "s3://customer-bucket/robots/custom_arm.usd"
+    cfg = _env_cfg(byo)
+    assert remap_moved_franka_usd(cfg) == byo
+    assert cfg.scene.robot.spawn.usd_path == byo
+
+
+def test_remap_handles_missing_robot_gracefully() -> None:
+    cfg = SimpleNamespace(scene=SimpleNamespace())
+    assert remap_moved_franka_usd(cfg) == ""
+
+
+def test_cfg_migration_fails_open_without_isaaclab_rl() -> None:
+    # Environments without isaaclab_rl (or with a pre-migration Isaac Lab) need
+    # no migration; the cfg must pass through unchanged.
+    sentinel = SimpleNamespace(policy="unchanged")
+    assert migrate_rsl_rl_agent_cfg(sentinel) is sentinel

--- a/npa/tests/workflows/test_sim2real_efficacy_contract.py
+++ b/npa/tests/workflows/test_sim2real_efficacy_contract.py
@@ -928,3 +928,24 @@ Total timesteps: 24576
     assert telemetry["final_iteration"]["stable_placement_departure_reward"] == -0.5
     with pytest.raises(ValueError, match="no Learning iteration"):
         parse_ppo_training_log("no telemetry")
+
+
+def test_parse_ppo_telemetry_accepts_rsl_rl_5_console_format() -> None:
+    # rsl-rl >= 5.0 renamed "Mean value_function loss" to "Mean value loss" and
+    # no longer prints a "Total timesteps" line in the iteration table.
+    log = """
+Learning iteration 199/199
+Mean value loss: 1.4190
+Mean surrogate loss: -0.0027
+Mean entropy loss: 11.9853
+Mean reward: 19.96
+Mean episode length: 248.12
+Episode_Reward/lifting_object: 0.4100
+Metrics/object_pose/position_error: 0.3215
+"""
+    telemetry = parse_ppo_training_log(log)
+    assert telemetry["configured_iterations"] == 199
+    assert telemetry["final_iteration"]["value_loss"] == 1.419
+    assert telemetry["final_iteration"]["surrogate_loss"] == -0.0027
+    assert telemetry["final_iteration"]["episode_return"] == 19.96
+    assert "total_timesteps" not in telemetry["final_iteration"]

--- a/npa/workflows/workbench/npa-workflows/sim2real.yaml
+++ b/npa/workflows/workbench/npa-workflows/sim2real.yaml
@@ -47,6 +47,13 @@ config:
   # EnvGen is rank-aware and scales horizontally; use half of a 16-GPU pool so
   # adjacent GPU stages retain scheduling headroom.
   shard_count: "8"
+  # Concurrent Stage 4 tasks per JobGroup. Must not exceed the cluster's
+  # concurrent-GPU capacity: a group larger than the schedulable GPU count
+  # deadlocks, because the admitted shards' pods are only reaped when the whole
+  # group starts, while the remaining shards wait on the GPUs those pods hold.
+  # Set to min(shard_count, concurrent GPUs), e.g. --var gpu_concurrency=2 on a
+  # 2-GPU cluster (renders ceil(8/2)=4 sequential batches).
+  gpu_concurrency: "8"
   envgen_seed: "42"
   rollout_count: "64"
   steps_per_rollout: "32"
@@ -225,7 +232,7 @@ states:
     # v0.0.1 groups are explicit. This generic assertion makes shard_count=8 an
     # honest validate/plan/submit contract instead of silently under-fanning out.
     parallelCount: "{{config.shard_count}}"
-    maxConcurrency: 8
+    maxConcurrency: "{{config.gpu_concurrency}}"
     next: stage-05-split
 
   stage-04-shard-0:


### PR DESCRIPTION
## Summary

This PR fixes every defect we hit while driving the canonical `sim2real.yaml` to a **terminal `succeeded` state** on a Living Lab test project (2× RTX PRO 6000 mk8s cluster, 200 GB boot disks), operating the workflow exactly as `docs/workbench/guides/sim2real-workflow.md` prescribes. Each fix was validated by resuming the same durable run (`--resume-run`) through the previously failing stage — the run completed all 14 stages, produced the full evidence set (`sim2real-report.json`, non-empty `.rrd`/`.mcap`, 14 ComponentRecords), and ended with an honest fail-closed quality rejection (gold strict success 0/64 vs threshold 0.50 on the reduced plumbing-proof profile), which is the designed outcome for a 200-update PPO pass.

The changes fall into three groups.

## 1. Isaac Lab 3.0.0b2.post1 / rsl-rl-lib 5.0.1 compatibility (stages 7/9/10)

The pinned Isaac stack has five API/format changes that each fail-close an Isaac stage. None of these can have passed a live run on the current pin, which suggests the last live validation predates the Isaac Lab 3 bump.

**New `npa/src/npa/workflows/sim2real/isaac_assets_compat.py`** with two helpers, wired into the four direct env/runner constructions (`byo_isaac_policy_rollout`, `byo_isaac_eval`, `isaac_physics_task`, `isaac_byo_robot_task`):

- `remap_moved_franka_usd`: NVIDIA moved `Assets/Isaac/6.0/Isaac/IsaacLab/Robots/FrankaEmika/panda_instanceable.usd` (and its Props/Materials) under `FrankaEmika/Legacy/` in the Omniverse content tree. Isaac Lab 3.0.0b2.post1's `FRANKA_PANDA_CFG` still points at the old path, which now returns 404, so every stock-Franka stage died with `FileNotFoundError: USD file not found`. The helper remaps exactly that stale suffix; BYO robot specs are untouched. (Longer term, robot assets deserve the same content-addressed runtime-fetch treatment as model weights rather than live CDN URLs inside a pinned library.)
- `migrate_rsl_rl_agent_cfg`: registry agent cfgs (`rsl_rl_cfg_entry_point`) still carry the legacy model `stochastic` field, which rsl-rl 5's `MLPModel` rejects (`unexpected keyword argument 'stochastic'`). Upstream's own train scripts run `isaaclab_rl.rsl_rl.utils.handle_deprecated_rsl_rl_cfg` before constructing `OnPolicyRunner`; our direct constructions now do the same (fail-open when `isaaclab_rl` is absent, i.e. pre-migration stacks).

**`isaac_scenario_task.py` — scenario reset on warp-backed physx views:**

- Isaac Lab 3.0's views hand out **warp arrays**; the previous code passed `materials.dtype` (a warp type) into `torch.tensor(...)` → `TypeError: argument 'dtype' must be torch.dtype, not type`. Material writes now mirror upstream `envs/mdp/events.py` exactly: `wp.to_torch` on read, `wp.from_torch(..., dtype=wp.float32/int32)` on write, with the torch path preserved for older releases.
- Mass scaling goes through the backend-safe partial setter `set_masses_index` (what upstream's mass randomization uses) instead of raw `root_physx_view.set_masses`, which corrupted device memory on this stack (`CUDA error 700: illegal memory access` in subsequent warp kernels/camera copies).
- Lazy `ProxyArray` buffers (`robot.data.root_pos_w` etc., whose `.torch` is a *property*) are converted to tensors before TorchScript `combine_frame_transforms`, which rejects `ProxyArray` (`Expected a value of type 'Tensor' for argument 't01'`).

**`byo_isaac_trainer.py` — telemetry parser:** rsl-rl 5 renamed the console field to `Mean value loss` (was `Mean value_function loss`) and no longer prints `Total timesteps` in the iteration table. `parse_ppo_training_log` raised `RSL-RL log contains no complete PPO telemetry iteration` **after a fully successful 200-iteration training run** (checkpoint already uploaded). The parser now accepts both formats and treats timesteps as optional evidence.

**`isaac_byo_robot_task.py` — resume convergence noise:** rsl-rl 5's `PPO` has no `.policy` attribute (`AttributeError` at the entropy-curriculum phase), and the action noise lives on `actor.distribution` (`std_type` + `std_param`/`log_std_param`) instead of policy-level `noise_std_type` + `std`/`log_std`. `configure_convergence_action_noise` handles both representations with the same exact-update-and-verify semantics (state-dependent/heteroscedastic still refused), and the caller resolves `policy → actor_critic → actor`.

## 2. Operator-host and orchestration fixes

- **`clients/json_output.py`:** `sky jobs queue --all --output json` intermittently flushes one final rich-spinner frame (`⠏ Checking managed jobs` + ANSI erase/cursor sequences) to stdout *after* the JSON array. The strict single-document parser treated it as trailing text, and the durable driver aborted mid-run with `managed-job launch indeterminate … malformed, ambiguous, or schema-invalid JSON`, then refused to reconcile. The parser now strips ANSI CSI/OSC sequences from the trailing segment and rejects only content that could start another JSON value — genuine two-document ambiguity is still refused (covered by tests, including the exact captured failing output shape).
- **`orchestration/skypilot/workflow.py`:** macOS has no procfs, so `_probe_local_api_daemon_cwd` failed **every** `workflow submit` from a macOS operator host (`SkyPilot API daemon preflight failed: … procfs_unavailable: [Errno 2] No such file or directory: '/proc'`) with no escape hatch. On darwin with the real `/proc` root the probe now returns healthy with an explicit `procfs_unavailable_darwin` outcome (the deleted-cwd poisoning it detects is un-inspectable there). Linux behavior and hermetic non-`/proc` test fixtures are unchanged.

## 3. Spec and image contract

- **`sim2real.yaml`:** Stage 4's `maxConcurrency` was hardcoded to 8. A JobGroup larger than the cluster's schedulable GPU count **deadlocks**: the two admitted shards ran their payloads to completion, but their pods are only reaped when the whole group starts, while the remaining six shards waited on the GPUs those pods still held (observed live for 2 h on a 2-GPU cluster; the controller provision-timeout-looped the pending shards). Concurrency is now the operator input `config.gpu_concurrency` (default `"8"` — rendering is byte-identical to today, verified with `plan-spec --waves`); `--var gpu_concurrency=2` renders 4 sequential batches of 2 and the wave completes.
- **`sim2real-control/Dockerfile`:** declares `org.nebius.npa.skypilot-bootstrap-contract="skypilot-0.12.2-v1"` — the image already bakes the full bootstrap closure (sudo/sshd/rsync, per its own comment) but was the only workflow image without the label, so `preflight-images` rejected even freshly built controller images as `missing bootstrap-contract attestation`.

## Tests

New units: Franka USD remap (stale → Legacy, idempotence, BYO passthrough), cfg-migration fail-open, rsl-rl 5 telemetry format, rsl-rl 5 distribution noise shape (scalar/log/heteroscedastic-refusal), ANSI-tolerant queue JSON parsing (incl. ambiguity guards), darwin probe (plus the conservative hermetic-fixture case). Locally green: `npa/tests/workflows` (trainer, rollout, efficacy contract), `npa/tests/orchestration/skypilot/test_workflow.py`, `npa/tests/clients/test_json_output.py`, `npa/tests/smoke/test_npa_workflow_smoke.py`, `npa/tests/smoke/test_all_workflow_yamls.py`, `npa/tests/guardrails/` (skills index, shown-workflow catalog, confidentiality scan).

## Not included (known issues, reported separately)

Publishing gaps that block running this workflow from the public GHCR mirror (`npa-sim2real-control` unpublished; published `npa-cosmos2-transfer`/`npa-envgen`/`npa-rerun-viewer` tags lack `NPA_IMAGE_SOURCE_SHA` and the bootstrap label, so no single `--var source_sha` can satisfy the runtime attestation), the runbook's missing mandatory `--var source_sha`, the absent Kueue install step (code pins 0.17.3), and compute-only GPU-node drivers (no Vulkan userspace anywhere on the host) that prevent Omniverse RTX rendering without a version-matched `libnvidia-gl` layer in the Isaac image — these need publishing/infra/doc decisions rather than code in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
