### PR TITLE
Simplify Sim2Real prerequisites and document source SHA

### DIFF
--- a/docs/architecture/sim2real-compositional-workflow.md
+++ b/docs/architecture/sim2real-compositional-workflow.md
@@ -39,13 +39,12 @@ same workflow/S3 state instead of reconstructing private controller memory.
 ## Execution ownership
 
 SkyPilot/Kubernetes owns each state Job. Isaac rollout, PPO, and evaluation run
-their existing fail-closed payload in the already admitted workflow task; they
-do not create hidden sibling Jobs. Kubernetes scheduling, retries, queueing,
-credentials, and image pull behavior therefore remain visible to the standard
-runtime. Each GPU resource profile attaches the configurable Kueue LocalQueue
-label and Kubernetes priority class to the SkyPilot Pod, so parallel waves use
-observable admission instead of delete/recreate contention. The workflow task
-image must equal the payload's immutable digest.
+their existing fail-closed payload in the workflow task; they do not create
+hidden sibling Jobs. Kubernetes scheduling, retries, credentials, and image pull
+behavior therefore remain visible to the standard runtime. SkyPilot submits each
+bounded parallel wave directly to Kubernetes; `gpu_concurrency` keeps each wave
+within the cluster's schedulable GPU capacity. The workflow task image must equal
+the payload's immutable digest.
 
 Isaac terms remain runtime state rather than image metadata. NPA applies its
 single `ACCEPT_EULA=Y` non-interactive default only to resolved Isaac routes;

--- a/docs/workbench/getting-started.md
+++ b/docs/workbench/getting-started.md
@@ -219,8 +219,8 @@ projects are configured.
 
 ## First Sim-To-Real Run
 
-The production loop has gated models, Isaac runtime terms/cache, private images,
-Kueue objects, and a dedicated CPU scheduling requirement. Follow the
+The production loop has gated models, Isaac runtime terms/cache, immutable images,
+bounded GPU concurrency, and a dedicated CPU scheduling requirement. Follow the
 [compositional Sim2Real operator runbook](guides/sim2real-workflow.md) in order;
 it is the authoritative copy-paste path from access checks through durable
 submit and resume. Do not adapt the older environment-variable examples: the

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -107,44 +107,12 @@ controller alone, but not for the canonical Sim2Real CPU states.
 If the preflight reports no fitting CPU node, remove `NoSchedule`/`NoExecute`
 taints that the tasks do not tolerate or add/resize this pool.
 
-## 4. Create Kueue admission objects and warm Isaac once
+## 4. Warm Isaac once
 
-The canonical defaults name the `sim2real-gpu` LocalQueue and
-`sim2real-production` PriorityClass. Create the queue objects with quotas that
-cover the cluster's actual concurrent GPU, CPU, and memory requests; the helper
-generates the exact repository-owned schemas:
-
-```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version 0.17.3 --namespace kueue-system --create-namespace --wait
-
-export NPA_GPU_PRODUCT='<exact nvidia.com/gpu.product label from kubectl get nodes>'
-export NPA_GPU_QUOTA='<concurrent GPU count>'
-export NPA_CPU_QUOTA='<aggregate CPU quota, for example 64>'
-export NPA_MEMORY_QUOTA='<aggregate memory quota, for example 512Gi>'
-
-npa/.venv/bin/python - <<'PY' | kubectl apply -f -
-import os
-import yaml
-from npa.workflows.sim2real.job_scheduling import kueue_queue_manifests
-
-docs = kueue_queue_manifests(
-    namespace="default",
-    gpu_product=os.environ["NPA_GPU_PRODUCT"],
-    gpu_quota=int(os.environ["NPA_GPU_QUOTA"]),
-    cpu_quota=os.environ["NPA_CPU_QUOTA"],
-    memory_quota=os.environ["NPA_MEMORY_QUOTA"],
-)
-print(yaml.safe_dump_all(docs, sort_keys=False))
-PY
-
-kubectl get localqueue.kueue.x-k8s.io sim2real-gpu -n default
-kubectl get priorityclass sim2real-production
-```
-
-The Helm chart version is `0.17.3`, matching the code pin; it has no leading
-`v`. Expected: both `get` commands return their named object. A queue with
-insufficient CPU or memory quota can leave a GPU Job suspended even when a GPU
-is free.
+The canonical workflow relies on SkyPilot and the Kubernetes scheduler directly;
+it does not require Kueue, a LocalQueue, or a custom PriorityClass. Bound
+parallelism with `gpu_concurrency` so a wave never requests more GPUs than the
+cluster can schedule.
 
 Choose the digest-pinned Isaac image now, then warm a shared RWX cache. The
 template is the authoritative PVC/security/bootstrap contract:
@@ -342,9 +310,8 @@ npa/.venv/bin/npa workbench workflow submit "${SPEC}" \
 
 Before any launch, submit now fails with one consolidated prerequisite report if
 the required secret propagation, three gated model probes, CPU node, cache PVC,
-Kueue queue, PriorityClass, S3 write probe, immutable images, or image pulls are
-not ready. `--skip-preflight` is an expert escape hatch and is not part of this
-runbook.
+S3 write probe, immutable images, or image pulls are not ready. `--skip-preflight`
+is an expert escape hatch and is not part of this runbook.
 
 For a reduced plumbing proof, add `--var outer_iterations=1 --var
 inner_iterations=1` and deliberately chosen smaller scenario/PPO values. Do not

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -115,6 +115,8 @@ cover the cluster's actual concurrent GPU, CPU, and memory requests; the helper
 generates the exact repository-owned schemas:
 
 ```bash
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version 0.17.3 --namespace kueue-system --create-namespace --wait
+
 export NPA_GPU_PRODUCT='<exact nvidia.com/gpu.product label from kubectl get nodes>'
 export NPA_GPU_QUOTA='<concurrent GPU count>'
 export NPA_CPU_QUOTA='<aggregate CPU quota, for example 64>'
@@ -139,9 +141,10 @@ kubectl get localqueue.kueue.x-k8s.io sim2real-gpu -n default
 kubectl get priorityclass sim2real-production
 ```
 
-Expected: both `get` commands return their named object. Missing Kueue CRDs mean
-Kueue must be installed first; a queue with insufficient CPU or memory quota can
-leave a GPU Job suspended even when a GPU is free.
+The Helm chart version is `0.17.3`, matching the code pin; it has no leading
+`v`. Expected: both `get` commands return their named object. A queue with
+insufficient CPU or memory quota can leave a GPU Job suspended even when a GPU
+is free.
 
 Choose the digest-pinned Isaac image now, then warm a shared RWX cache. The
 template is the authoritative PVC/security/bootstrap contract:
@@ -190,18 +193,25 @@ export TRANSFER_IMAGE='<registry>/npa-cosmos2-transfer@sha256:<64-hex>'
 export ENVGEN_IMAGE='<registry>/npa-envgen@sha256:<64-hex>'
 export ISAAC_IMAGE="${NPA_ISAAC_IMAGE}"
 export VIEWER_IMAGE='<registry>/npa-rerun-viewer@sha256:<64-hex>'
+export SOURCE_SHA='<40-hex-source-sha>'
 export SPEC=npa/workflows/workbench/npa-workflows/sim2real.yaml
 
 npa/.venv/bin/npa workbench workflow preflight-images "${SPEC}" \
   --project "${NPA_PROJECT}" \
   --infra "k8s/${NPA_CLUSTER}" \
   --assume-decision promote_checkpoint \
+  --var source_sha="${SOURCE_SHA}" \
   --var controller_image="${CONTROLLER_IMAGE}" \
   --var transfer_image="${TRANSFER_IMAGE}" \
   --var envgen_image="${ENVGEN_IMAGE}" \
   --var isaac_image="${ISAAC_IMAGE}" \
   --var viewer_image="${VIEWER_IMAGE}"
 ```
+
+`SOURCE_SHA` must be exactly 40 hexadecimal characters and must match the baked
+`NPA_IMAGE_SOURCE_SHA` in every selected Sim2Real image. Supply the SHA attested
+by the coherent image set you selected; do not assume the current repository
+checkout matches those image bytes.
 
 Expected: every image is pullable and bootstrap-compatible. `not_found` means
 build/push the printed image; `forbidden` means fix the exact-host registry
@@ -247,13 +257,14 @@ npa/.venv/bin/npa workbench workflow validate-spec "${SPEC}" \
   --preset public-franka-lift --json
 npa/.venv/bin/npa workbench workflow plan-spec "${SPEC}" \
   --preset public-franka-lift --run-id "${RUN_ID}" \
-  --var bucket="${NPA_BUCKET}" --waves \
+  --var bucket="${NPA_BUCKET}" --var source_sha="${SOURCE_SHA}" --waves \
   --assume-decision promote_checkpoint
 
 npa/.venv/bin/npa workbench workflow submit "${SPEC}" \
   --preset public-franka-lift --project "${NPA_PROJECT}" \
   --infra "k8s/${NPA_CLUSTER}" --runtime --run-id "${RUN_ID}" \
   --var bucket="${NPA_BUCKET}" \
+  --var source_sha="${SOURCE_SHA}" \
   --var controller_image="${CONTROLLER_IMAGE}" \
   --var transfer_image="${TRANSFER_IMAGE}" \
   --var envgen_image="${ENVGEN_IMAGE}" \
@@ -294,6 +305,7 @@ npa/.venv/bin/npa workbench workflow validate-spec "${SPEC}" --json
 npa/.venv/bin/npa workbench workflow plan-spec "${SPEC}" \
   --run-id "${RUN_ID}" --waves --assume-decision promote_checkpoint \
   --var bucket="${NPA_BUCKET}" \
+  --var source_sha="${SOURCE_SHA}" \
   --var controller_image="${CONTROLLER_IMAGE}" \
   --var transfer_image="${TRANSFER_IMAGE}" \
   --var envgen_image="${ENVGEN_IMAGE}" \
@@ -313,6 +325,7 @@ npa/.venv/bin/npa workbench workflow submit "${SPEC}" \
   --runtime --resume --max-wait-seconds 0 \
   --run-id "${RUN_ID}" \
   --var bucket="${NPA_BUCKET}" \
+  --var source_sha="${SOURCE_SHA}" \
   --var trigger_uri="s3://${NPA_BUCKET}/sim2real-triggers/${RUN_ID}/" \
   --var seed_manifest_uri="s3://${NPA_BUCKET}/sim2real-triggers/${RUN_ID}/dataset-manifest.json" \
   --var controller_image="${CONTROLLER_IMAGE}" \
@@ -347,7 +360,20 @@ npa/.venv/bin/npa workbench workflow status "${RUN_ID}" --project "${NPA_PROJECT
 npa/.venv/bin/npa workbench workflow submit "${SPEC}" \
   --project "${NPA_PROJECT}" --infra "k8s/${NPA_CLUSTER}" \
   --runtime --resume-run "${RUN_ID}" --max-wait-seconds 0 \
-  <the same --var and --secret-env arguments>
+  --var bucket="${NPA_BUCKET}" \
+  --var source_sha="${SOURCE_SHA}" \
+  --var trigger_uri="s3://${NPA_BUCKET}/sim2real-triggers/${RUN_ID}/" \
+  --var seed_manifest_uri="s3://${NPA_BUCKET}/sim2real-triggers/${RUN_ID}/dataset-manifest.json" \
+  --var controller_image="${CONTROLLER_IMAGE}" \
+  --var transfer_image="${TRANSFER_IMAGE}" \
+  --var envgen_image="${ENVGEN_IMAGE}" \
+  --var isaac_image="${ISAAC_IMAGE}" \
+  --var viewer_image="${VIEWER_IMAGE}" \
+  --var isaac_cache_pvc=npa-isaac-cache \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY \
+  --secret-env HF_TOKEN \
+  --secret-env NEBIUS_TOKEN_FACTORY_KEY
 ```
 
 Completion must include `reports/sim2real-report.json`, non-empty

--- a/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
+++ b/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
@@ -202,27 +202,4 @@ def kubernetes_prerequisites(
                 )
             )
 
-    queue = str(config.get("gpu_queue") or "").strip()
-    if queue:
-        result = runner(["get", "localqueue.kueue.x-k8s.io", queue, "-n", namespace, "-o", "json"])
-        if getattr(result, "returncode", 1) != 0:
-            issues.append(
-                (
-                    f"Kueue LocalQueue {queue!r} is not readable in namespace {namespace!r}",
-                    "install/configure Kueue and apply the Sim2Real ResourceFlavor, "
-                    "ClusterQueue, and LocalQueue before submission",
-                )
-            )
-
-    priority = str(config.get("gpu_priority_class") or "").strip()
-    if priority:
-        result = runner(["get", "priorityclass.scheduling.k8s.io", priority, "-o", "json"])
-        if getattr(result, "returncode", 1) != 0:
-            issues.append(
-                (
-                    f"PriorityClass {priority!r} is not readable",
-                    "create the Sim2Real PriorityClass before submission (the canonical "
-                    "default is sim2real-production)",
-                )
-            )
     return issues

--- a/npa/src/npa/workflows/sim2real_health.py
+++ b/npa/src/npa/workflows/sim2real_health.py
@@ -189,8 +189,6 @@ def coherence_failures(repo_root: Path) -> list[str]:
         "isaac_image",
         "viewer_image",
         "isaac_cache_pvc",
-        "gpu_queue",
-        "gpu_priority_class",
     }
     missing_config = sorted(required_config - set(config))
     if missing_config:
@@ -541,33 +539,6 @@ def check_cluster(config: Sim2RealLoopConfig, *, probes: DoctorProbes) -> CheckR
                 "and adopts exact-identity Jobs through the Kubernetes API."
             ),
             details=(_short(controller_patch.stderr or controller_patch.stdout),),
-        )
-
-    kueue_observe = runner(
-        [
-            "auth",
-            "can-i",
-            "list",
-            "workloads.kueue.x-k8s.io",
-            f"--as={service_account_user}",
-            "-n",
-            namespace,
-        ]
-    )
-    if kueue_observe.returncode != 0 or kueue_observe.stdout.strip().lower() != "yes":
-        return CheckResult(
-            name="cluster",
-            status=FAIL,
-            summary=(
-                f"Service account {service_account!r} cannot list Kueue Workloads "
-                f"in namespace {namespace!r}."
-            ),
-            remedy=(
-                "Grant the Sim2Real controller Role the 'list' verb on "
-                "kueue.x-k8s.io/workloads. Durable reconciliation must observe "
-                "the generated Workload admission, flavor, and terminal state."
-            ),
-            details=(_short(kueue_observe.stderr or kueue_observe.stdout),),
         )
 
     cache_pvc = config.k8s_isaac_cache_pvc.strip()

--- a/npa/tests/cli/test_workflow_submit_preflight.py
+++ b/npa/tests/cli/test_workflow_submit_preflight.py
@@ -439,6 +439,8 @@ def test_sim2real_submit_propagates_explicit_kubernetes_target(
             "k8s/sim2real-review",
             "--var",
             "bucket=real-bucket",
+            "--var",
+            "isaac_cache_pvc=npa-isaac-cache",
         ],
     )
 
@@ -451,10 +453,7 @@ def test_sim2real_submit_propagates_explicit_kubernetes_target(
     namespaced_calls = [
         call[0]
         for call in calls
-        if call[0][:2] in (
-            ["get", "pvc"],
-            ["get", "localqueue.kueue.x-k8s.io"],
-        )
+        if call[0][:2] == ["get", "pvc"]
     ]
     assert namespaced_calls
     assert all(

--- a/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
+++ b/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
@@ -22,8 +22,6 @@ def _config(**overrides):
         "viewer_image": digest,
         "isaac_cache_pvc": "npa-isaac-cache",
         "cosmos3_model": "nvidia/Cosmos3-Super-Reasoner",
-        "gpu_queue": "sim2real-gpu",
-        "gpu_priority_class": "sim2real-production",
     }
     config.update(overrides)
     return config
@@ -146,7 +144,7 @@ def test_cpu_node_parser_requires_the_real_schedulable_profile():
     )
 
 
-def test_kubernetes_preflight_parses_nodes_pvc_queue_and_priority_class():
+def test_kubernetes_preflight_parses_nodes_and_pvc():
     calls = []
 
     def run(args):
@@ -170,8 +168,6 @@ def test_kubernetes_preflight_parses_nodes_pvc_queue_and_priority_class():
     assert [call[:2] for call in calls] == [
         ["get", "nodes"],
         ["get", "pvc"],
-        ["get", "localqueue.kueue.x-k8s.io"],
-        ["get", "priorityclass.scheduling.k8s.io"],
     ]
 
 
@@ -185,5 +181,3 @@ def test_kubernetes_preflight_reports_every_missing_cluster_object_together():
     rendered = "\n".join(item for item, _ in issues)
     assert "no Ready" in rendered
     assert "Isaac cache PVC" in rendered
-    assert "LocalQueue" in rendered
-    assert "PriorityClass" in rendered

--- a/npa/tests/workflows/test_sim2real_compositional_workflow.py
+++ b/npa/tests/workflows/test_sim2real_compositional_workflow.py
@@ -871,10 +871,10 @@ def test_exact_source_and_per_state_immutable_images_reach_rendered_tasks() -> N
     assert gpu_tasks
     for task in gpu_tasks:
         pod_config = task["config"]["kubernetes"]["pod_config"]
-        assert pod_config["metadata"]["labels"] == {
-            "kueue.x-k8s.io/queue-name": "sim2real-gpu"
-        }
-        assert pod_config["spec"]["priorityClassName"] == "sim2real-production"
+        assert "kueue.x-k8s.io/queue-name" not in pod_config.get(
+            "metadata", {}
+        ).get("labels", {})
+        assert "priorityClassName" not in pod_config["spec"]
 
     transfer_pod = spec.resources["transfer-gpu"]["kubernetes"]["pod_config"][
         "spec"

--- a/npa/tests/workflows/test_sim2real_health.py
+++ b/npa/tests/workflows/test_sim2real_health.py
@@ -292,32 +292,6 @@ def test_cluster_fails_when_controller_service_account_cannot_patch_jobs() -> No
     assert any("--as=system:serviceaccount:default:agent-sa" in call for call in calls)
 
 
-def test_cluster_fails_when_controller_cannot_observe_kueue_workloads() -> None:
-    calls: list[list[str]] = []
-
-    def runner(args):
-        calls.append(args)
-        if args[:2] == ["config", "current-context"]:
-            return KubeResult(0, "prod-cluster")
-        if args[:4] == ["auth", "can-i", "create", "pods"]:
-            return KubeResult(0, "yes")
-        if args[:4] == ["auth", "can-i", "patch", "jobs.batch"]:
-            return KubeResult(0, "yes")
-        if args[:4] == [
-            "auth",
-            "can-i",
-            "list",
-            "workloads.kueue.x-k8s.io",
-        ]:
-            return KubeResult(0, "no")
-        return KubeResult(1, "", "unexpected")
-
-    result = check_cluster(_config(), probes=DoctorProbes(kube_runner=runner))
-    assert result.status == health.FAIL
-    assert "cannot list Kueue Workloads" in result.summary
-    assert any("--as=system:serviceaccount:default:agent-sa" in call for call in calls)
-
-
 @pytest.mark.parametrize(
     ("pvc_payload", "expected"),
     [

--- a/npa/workflows/workbench/npa-workflows/sim2real.yaml
+++ b/npa/workflows/workbench/npa-workflows/sim2real.yaml
@@ -83,8 +83,6 @@ config:
   viewer_image: ""
   isaac_cache_pvc: ""
   # Isaac EULA acceptance is injected by the renderer (default on, explicit CLI opt-out).
-  gpu_queue: sim2real-gpu
-  gpu_priority_class: sim2real-production
 
 resources:
   cpu:
@@ -100,11 +98,7 @@ resources:
     image: "{{config.transfer_image}}"
     kubernetes:
       pod_config:
-        metadata:
-          labels:
-            kueue.x-k8s.io/queue-name: "{{config.gpu_queue}}"
         spec:
-          priorityClassName: "{{config.gpu_priority_class}}"
           # The immutable Cosmos Transfer image keeps its model cache under /opt,
           # but SkyPilot bootstraps uv as its non-root runtime user before the task
           # starts. Keep only bootstrap caches in writable ephemeral storage; model
@@ -122,13 +116,6 @@ resources:
     cpus: 8
     memory: 32Gi
     image: "{{config.envgen_image}}"
-    kubernetes:
-      pod_config:
-        metadata:
-          labels:
-            kueue.x-k8s.io/queue-name: "{{config.gpu_queue}}"
-        spec:
-          priorityClassName: "{{config.gpu_priority_class}}"
   stage8-cpu:
     cloud: kubernetes
     cpus: 8
@@ -143,11 +130,7 @@ resources:
     kubernetes:
       provision_timeout: 2400
       pod_config:
-        metadata:
-          labels:
-            kueue.x-k8s.io/queue-name: "{{config.gpu_queue}}"
         spec:
-          priorityClassName: "{{config.gpu_priority_class}}"
           containers:
             - name: ray-node
               env:

--- a/npa/workflows/workbench/sim2real/README.md
+++ b/npa/workflows/workbench/sim2real/README.md
@@ -48,6 +48,6 @@ window for archived callers and artifacts. They are lazy, are not called by the
 canonical workflow, and cannot materialize or submit its retired controller.
 
 The submit path fails before launch when storage, secret propagation, gated
-model access, the dedicated CPU capacity, Kueue/PriorityClass, Isaac cache PVC,
+model access, the dedicated CPU capacity, Isaac cache PVC,
 immutable images, or real image pulls are not ready. The linked runbook gives
 copy-paste setup, expected results, and remediation without duplicating it here.

--- a/skills/workflows/sim2real-operate/SKILL.md
+++ b/skills/workflows/sim2real-operate/SKILL.md
@@ -16,8 +16,8 @@ with an actionable migration to this canonical spec.
 
 ## Preflight
 
-1. Validate tenant/project/region, bucket, registry, Kubernetes context, Kueue
-   admission, Ready RT-core nodes, and the read-only Isaac cache PVC.
+1. Validate tenant/project/region, bucket, registry, Kubernetes context, Ready
+   RT-core nodes, bounded GPU concurrency, and the read-only Isaac cache PVC.
 2. Require registry-qualified immutable digests for controller, Transfer,
    EnvGen, Reason, Isaac, and viewer images. Confirm each image attests the exact
    source SHA; never use source overlays or best-effort bootstrap.


### PR DESCRIPTION
## What changed

- Document the required baked image source SHA and pass `source_sha` in Sim2Real plan/submit examples.
- Remove Kueue queue configuration, queue labels, custom priority classes, and Kueue-specific preflight/RBAC requirements from the canonical Sim2Real workflow.
- Keep GPU work directly scheduled through SkyPilot/Kubernetes and bound concurrency with the existing `gpu_concurrency` setting.
- Update tests, architecture docs, operator docs, and the Sim2Real operating skill.

## Why

Kueue added an installation and RBAC prerequisite without providing useful scheduling value for this single workflow. The source-SHA examples also need to match the workflow’s fail-closed baked-image contract.

Repository-wide workflow audit: no other current workflow YAML uses or requires Kueue. Kueue-aware helpers remain only in legacy Sim2Real compatibility code for archived callers.

## Impact

Operators no longer need to install Kueue, create a LocalQueue, or create a custom PriorityClass before submitting the canonical Sim2Real workflow. Native Kubernetes placement and SkyPilot orchestration remain unchanged.

## Validation

- Sim2Real focused tests: 79 passed
- submit-preflight tests: 55 passed
- workflow test suite: 907 passed
- guardrail suite: 2,334 passed
- full non-E2E suite: 12,601 passed, 48 skipped, 1 xpassed; the one related failure was corrected and passed in the focused rerun. Two unrelated host-tool failures remain because the VM `rerun` launcher cannot import `rerun_cli`.
- Ruff, `git diff --check`, docs build/check, skill validation, workflow spec validation, plan rendering, confidentiality scan, and gitleaks passed

## Limitations

- No live GPU workload was resubmitted for this docs/preflight/scheduling-prerequisite simplification.
- Legacy compatibility helpers still understand Kueue state; they are not used by the canonical workflow spec.
