### PR TITLE
Fix Rerun browser sharing CORS setup

### DIFF
--- a/docs/architecture/cli-namespaces.md
+++ b/docs/architecture/cli-namespaces.md
@@ -77,7 +77,9 @@ A command belongs at top level when it:
 `npa rerun host`, `share`, `list-shares`, and `revoke` are stateless actions for
 ad-hoc recording sharing via `app.rerun.io` and presigned URLs. They are at top
 level because there is no Nebius service to manage: the viewer runs in the
-user's browser, and the recording sits in S3.
+user's browser, and the recording sits in S3. The separate
+`npa storage bucket cors` command is a bucket-admin control-plane operation; it
+does not expand the object-only credential boundary of the stateless commands.
 
 A future Tier 2 capability, such as a managed Rerun service on a Nebius VM,
 would correctly live under `npa workbench rerun deploy/status/serve/...`.
@@ -147,7 +149,7 @@ Public top-level SDK namespaces are:
 
 - `npa.convert` - `lerobot_to_mp4`, `lerobot_to_rrd`
 - `npa.demo` - `stage`, `verify`
-- `npa.rerun` - `host`, `share`, `list_shares`, `revoke`
+- `npa.rerun` - `configure_browser_cors`, `host`, `share`, `list_shares`, `revoke`
 - `npa.network` - `ensure_ingress`
 - `npa.workflow` - `run`, `status`, `logs`, `teardown`, `distill`
 - `npa.workbench` - `cosmos`, `fiftyone`, `genesis`, `groot`, `isaac_lab`,

--- a/docs/cli/bucket.md
+++ b/docs/cli/bucket.md
@@ -11,6 +11,7 @@ Options
 --help  Show this message and exit.
 Commands
 list  List the object-storage buckets in a project, marking the configured one.
+cors  Check or configure the app.rerun.io browser CORS contract.
 delete  Delete an object-storage bucket npa provisioned, contents and versions included.
 ```
 
@@ -25,6 +26,7 @@ delete  Delete an object-storage bucket npa provisioned, contents and versions i
 | Command | Description |
 | --- | --- |
 | `list` | List the object-storage buckets in a project, marking the configured one. |
+| `cors` | Check or configure the app.rerun.io browser CORS contract. |
 | `delete` | Delete an object-storage bucket npa provisioned, contents and versions included. |
 
 ## Examples

--- a/docs/cli/storage.md
+++ b/docs/cli/storage.md
@@ -5,7 +5,7 @@
 ```text
 Usage: npa storage [OPTIONS] COMMAND [ARGS]...
 
-Inspect and tear down npa-managed object storage.
+Inspect, configure, and tear down npa-managed object storage.
 
 Options
 --help  Show this message and exit.

--- a/docs/workbench/README.md
+++ b/docs/workbench/README.md
@@ -12,6 +12,7 @@ workflows, and operational runbooks.
 | [container-packaging.md](container-packaging.md) | Container packaging tiers, security baseline, and feature exposure contract |
 | [isaac-lab-3.md](isaac-lab-3.md) | Isaac Lab 3 beta pin, payload-clean runtime bootstrap, hardened RL sweep, and generation 2 comparison method |
 | [model-weight-cache.md](model-weight-cache.md) | Durable cache for model weights and reviewed SDKs the public images do not bake, so a second run is a cache hit |
+| [rerun-sharing.md](rerun-sharing.md) | Time-boxed Rerun browser shares, one-time least-privilege bucket CORS setup, and native local fallback |
 | [cosmos3-b200-checkpoint-evaluation-20260814.md](cosmos3-b200-checkpoint-evaluation-20260814.md) | Reserved-B200, 72-image Cosmos3 checkpoint evaluation and three-seed investment decision |
 | [cosmos3-ray-serve.md](cosmos3-ray-serve.md) | Persistent Cosmos3-Nano serving through native Ray Serve batching with durable S3 outputs |
 | [leisaac-teleoperation.md](leisaac-teleoperation.md) | Capability-gated LeIsaac agent tab, RT-core launch, keyboard teleoperation, and cleanup |

--- a/docs/workbench/rerun-sharing.md
+++ b/docs/workbench/rerun-sharing.md
@@ -1,0 +1,75 @@
+# Share Rerun recordings safely
+
+`npa rerun host` and `npa rerun share` create time-boxed `app.rerun.io` links
+for `.rrd` recordings in object storage. Browser loading requires a one-time
+bucket CORS rule because the viewer fetches the recording from a different
+origin and uses the `Range` request header.
+
+## Configure the bucket once
+
+First inspect the additive plan, then apply it with a Nebius profile that can
+administer the bucket:
+
+```bash
+npa storage bucket cors --project <alias>
+npa storage bucket cors --project <alias> --apply
+```
+
+Use `--name <bucket>` when sharing from a bucket other than the project's
+configured storage. The command preserves unrelated CORS rules. The NPA-owned
+rule grants only:
+
+- origin: `https://app.rerun.io`
+- method: `GET`
+- request header: `Range`
+- exposed response headers: `Accept-Ranges`, `Content-Length`, `Content-Range`
+
+This is a bucket control-plane operation. The scoped S3 key created by
+`npa configure` can read and write objects but deliberately cannot update bucket
+CORS. Do not broaden that workload key to fix browser sharing.
+
+The Python SDK exposes the same plan/apply operation:
+
+```python
+from npa import rerun
+
+plan = rerun.configure_browser_cors(target_project="<alias>")
+if plan.changed:
+    rerun.configure_browser_cors(target_project="<alias>", apply=True)
+```
+
+## Create and verify a share
+
+```bash
+npa rerun host recording.rrd --target-project <alias> --ttl-hours 1
+npa rerun share recording.rrd \
+  --target-project <alias> \
+  --workspace <workspace> \
+  --label <label> \
+  --ttl-hours 24
+```
+
+Both commands send the same unauthenticated CORS preflight the browser sends
+against the final presigned URL. They return the viewer URL only after that
+preflight allows the Rerun origin, `GET`, and `Range`. On failure, the error
+prints the bucket-admin setup command without printing the signed URL.
+
+The URL is itself a temporary credential. Give it the shortest useful lifetime
+and revoke durable shares when the review ends:
+
+```bash
+npa rerun list-shares --target-project <alias> --output json
+npa rerun revoke <sha256-or-label> --target-project <alias>
+```
+
+## Native local fallback
+
+When a bucket administrator cannot update CORS, download the recording and open
+it in the native viewer:
+
+```bash
+rerun <recording.rrd>
+```
+
+This fallback does not require a browser origin, a presigned URL, or bucket
+CORS.

--- a/npa/src/npa/cli/rerun/__init__.py
+++ b/npa/src/npa/cli/rerun/__init__.py
@@ -10,6 +10,8 @@ import json
 import logging
 from pathlib import Path
 from urllib.parse import quote, urlparse
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 
 import boto3
 from botocore.config import Config as BotoConfig
@@ -35,6 +37,7 @@ logger = logging.getLogger(__name__)
 RERUN_VERSION = "0.31.4"
 MAX_TTL_HOURS = 168
 UTC = timezone.utc
+RERUN_BROWSER_ORIGIN = "https://app.rerun.io"
 
 
 class RerunHostError(ValueError):
@@ -54,6 +57,7 @@ class RerunHostResult:
     ttl_expires_at: str
     sha256: str
     rerun_version: str
+    browser_cors_verified: bool
 
 
 @dataclass(frozen=True)
@@ -113,6 +117,12 @@ def host_recording(
         bucket, key, data, sha = _prepare_local_recording(recording_path, target_bucket)
 
     uri = f"s3://{bucket}/{key}"
+    presigned = _presign(scoped_s3, bucket, key, ttl_hours)
+    _verify_browser_cors(
+        presigned,
+        bucket=bucket,
+        project=source_project if _is_s3_uri(recording_path) else target_project,
+    )
     _ensure_uploaded(
         scoped_s3,
         fallback_s3,
@@ -122,7 +132,6 @@ def host_recording(
         sha,
         allow_host_creds=allow_host_creds,
     )
-    presigned = _presign(scoped_s3, bucket, key, ttl_hours)
     expires_at = ((now or datetime.now(UTC)) + timedelta(hours=ttl_hours)).replace(
         microsecond=0
     )
@@ -134,6 +143,7 @@ def host_recording(
         ttl_expires_at=expires_at.isoformat().replace("+00:00", "Z"),
         sha256=sha,
         rerun_version=RERUN_VERSION,
+        browser_cors_verified=True,
     )
 
 
@@ -194,6 +204,8 @@ def share_recording(
     if label:
         metadata["rerun-label"] = label
 
+    presigned = _presign(target_scoped_s3, bucket, key, ttl_hours)
+    _verify_browser_cors(presigned, bucket=bucket, project=target_project)
     _ensure_uploaded(
         target_scoped_s3,
         target_fallback_s3,
@@ -204,7 +216,6 @@ def share_recording(
         allow_host_creds=allow_host_creds,
         metadata=metadata,
     )
-    presigned = _presign(target_scoped_s3, bucket, key, ttl_hours)
     expires_at = ((now or datetime.now(UTC)) + timedelta(hours=ttl_hours)).replace(
         microsecond=0
     )
@@ -215,6 +226,7 @@ def share_recording(
         ttl_expires_at=expires_at.isoformat().replace("+00:00", "Z"),
         sha256=sha,
         rerun_version=RERUN_VERSION,
+        browser_cors_verified=True,
     )
 
 
@@ -727,6 +739,91 @@ def _presign(s3, bucket: str, key: str, ttl_hours: int) -> str:
         )
     except (ClientError, NoCredentialsError) as exc:
         raise RerunHostError(f"Failed to presign s3://{bucket}/{key}: {exc}") from exc
+
+
+def _verify_browser_cors(
+    presigned_url: str,
+    *,
+    bucket: str,
+    project: str | None,
+) -> None:
+    """Exercise the same unauthenticated preflight the Rerun browser performs.
+
+    Bucket-level CORS reads require privileges the scoped object key intentionally
+    lacks. Probing the presigned URL is both privilege-neutral and closer to the
+    browser behavior we need to guarantee.
+    """
+
+    request = Request(
+        presigned_url,
+        method="OPTIONS",
+        headers={
+            "Origin": RERUN_BROWSER_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Range",
+        },
+    )
+    status = 0
+    try:
+        with urlopen(request) as response:  # noqa: S310 - exact presigned HTTPS URL
+            status = int(getattr(response, "status", 0) or response.getcode() or 0)
+            allow_origin = str(response.headers.get("Access-Control-Allow-Origin", ""))
+            allow_methods = {
+                item.strip().upper()
+                for item in str(
+                    response.headers.get("Access-Control-Allow-Methods", "")
+                ).split(",")
+                if item.strip()
+            }
+            allow_headers = {
+                item.strip().lower()
+                for item in str(
+                    response.headers.get("Access-Control-Allow-Headers", "")
+                ).split(",")
+                if item.strip()
+            }
+            expose_headers = {
+                item.strip().lower()
+                for item in str(
+                    response.headers.get("Access-Control-Expose-Headers", "")
+                ).split(",")
+                if item.strip()
+            }
+    except HTTPError as exc:
+        status = int(exc.code or 0)
+        allow_origin = ""
+        allow_methods = set()
+        allow_headers = set()
+        expose_headers = set()
+    except OSError as exc:
+        raise RerunHostError(
+            _browser_cors_remedy(bucket, project, "request failed")
+        ) from exc
+
+    required_exposed = {"accept-ranges", "content-length", "content-range"}
+    if not (
+        200 <= status < 300
+        and allow_origin in {RERUN_BROWSER_ORIGIN, "*"}
+        and "GET" in allow_methods
+        and ("range" in allow_headers or "*" in allow_headers)
+        and (required_exposed <= expose_headers or "*" in expose_headers)
+    ):
+        raise RerunHostError(
+            _browser_cors_remedy(bucket, project, f"preflight returned HTTP {status}")
+        )
+
+
+def _browser_cors_remedy(bucket: str, project: str | None, detail: str) -> str:
+    command = "npa storage bucket cors --apply"
+    if project:
+        command += f" --project {project}"
+    command += f" --name {bucket}"
+    return (
+        f"Rerun browser CORS validation failed ({detail}). A bucket administrator "
+        f"must run `{command}`; the scoped S3 object key created by `npa configure` "
+        "cannot change bucket CORS. Then retry this command. For a local fallback, "
+        "download the recording and run `rerun <recording.rrd>`."
+    )
 
 
 def _share_url(presigned_url: str) -> str:

--- a/npa/src/npa/cli/storage.py
+++ b/npa/src/npa/cli/storage.py
@@ -173,8 +173,8 @@ def configure_bucket_cors_cmd(
         "--apply",
         help="Apply the planned CORS update using Nebius bucket-admin credentials.",
     ),
-    output_json: bool = typer.Option(
-        False, "--json", help="Emit one machine-readable result."
+    output_format: str = typer.Option(
+        "text", "--output", help="Output format: text or json."
     ),
 ) -> None:
     """Check or configure the app.rerun.io browser CORS contract.
@@ -190,6 +190,8 @@ def configure_bucket_cors_cmd(
     from npa.clients.nebius import RERUN_BROWSER_CORS_RULE_ID, RERUN_BROWSER_ORIGIN
     from npa.rerun import configure_browser_cors
 
+    if output_format not in {"text", "json"}:
+        raise typer.BadParameter("--output must be text or json")
     try:
         plan = configure_browser_cors(
             target_bucket=name.strip(),
@@ -214,8 +216,8 @@ def configure_bucket_cors_cmd(
         "allowed_origin": RERUN_BROWSER_ORIGIN,
         "preserved_rule_count": plan.preserved_rule_count,
     }
-    if output_json:
-        typer.echo(json.dumps(payload, sort_keys=True))
+    if output_format == "json":
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
         return
     if status == "update_required":
         command = "npa storage bucket cors --apply"

--- a/npa/src/npa/cli/storage.py
+++ b/npa/src/npa/cli/storage.py
@@ -19,7 +19,7 @@ from npa.lifecycle_intent import OperationIntent, intent_boundary, json_stdout_c
 
 app = typer.Typer(
     name="storage",
-    help="Inspect and tear down npa-managed object storage.",
+    help="Inspect, configure, and tear down npa-managed object storage.",
     no_args_is_help=True,
 )
 
@@ -153,6 +153,85 @@ def list_buckets_cmd(
         typer.echo(f"{row['name'].ljust(width)}  {row['id']}{marker}")
     typer.echo("")
     typer.echo("Delete one with `npa storage bucket delete --name <bucket>`.")
+
+
+@bucket_app.command("cors")
+@intent_boundary(OperationIntent.MUTATE)
+@json_stdout_contract
+def configure_bucket_cors_cmd(
+    name: str = typer.Option(
+        "", "--name", help="Bucket name. Defaults to configured project storage."
+    ),
+    project: str = typer.Option(
+        "", "--project", "-p", help="NPA project alias holding the bucket."
+    ),
+    project_id: str = typer.Option(
+        "", "--project-id", help="Nebius project id holding the bucket."
+    ),
+    apply: bool = typer.Option(
+        False,
+        "--apply",
+        help="Apply the planned CORS update using Nebius bucket-admin credentials.",
+    ),
+    output_json: bool = typer.Option(
+        False, "--json", help="Emit one machine-readable result."
+    ),
+) -> None:
+    """Check or configure the app.rerun.io browser CORS contract.
+
+    The default is read-only. ``--apply`` updates only the bucket CORS field,
+    preserving unrelated rules. This control-plane operation requires a Nebius
+    identity with bucket-administration permission; the scoped object key made
+    by ``npa configure`` is intentionally never used or elevated.
+    """
+
+    import json
+
+    from npa.clients.nebius import RERUN_BROWSER_CORS_RULE_ID, RERUN_BROWSER_ORIGIN
+    from npa.rerun import configure_browser_cors
+
+    try:
+        plan = configure_browser_cors(
+            target_bucket=name.strip(),
+            target_project=project or None,
+            target_project_id=project_id,
+            apply=apply,
+        )
+    except Exception as exc:
+        raise typer.BadParameter(
+            "Could not inspect or update bucket CORS with the active Nebius "
+            f"bucket-admin identity: {exc}"
+        ) from exc
+
+    if apply:
+        status = "updated" if plan.changed else "already_configured"
+    else:
+        status = "update_required" if plan.changed else "configured"
+    payload = {
+        "status": status,
+        "apply": apply,
+        "cors_rule_id": RERUN_BROWSER_CORS_RULE_ID,
+        "allowed_origin": RERUN_BROWSER_ORIGIN,
+        "preserved_rule_count": plan.preserved_rule_count,
+    }
+    if output_json:
+        typer.echo(json.dumps(payload, sort_keys=True))
+        return
+    if status == "update_required":
+        command = "npa storage bucket cors --apply"
+        if project:
+            command += f" --project {project}"
+        elif project_id:
+            command += f" --project-id {project_id}"
+        if name:
+            command += f" --name {name}"
+        typer.echo("Rerun browser CORS needs an additive bucket-admin update.")
+        typer.echo(f"Apply it with: `{command}`")
+        return
+    if status == "updated":
+        typer.echo("Configured and verified the Rerun browser CORS rule.")
+        return
+    typer.echo("Rerun browser CORS is already configured.")
 
 
 def _storage_service_account_record(

--- a/npa/src/npa/clients/nebius.py
+++ b/npa/src/npa/clients/nebius.py
@@ -2028,6 +2028,141 @@ def ensure_access_key(
 
 DEFAULT_BUCKET_BASENAME = "npa-bucket"
 DEFAULT_BUCKET_STORAGE_CLASS = "standard"
+RERUN_BROWSER_CORS_RULE_ID = "npa-rerun-app"
+RERUN_BROWSER_ORIGIN = "https://app.rerun.io"
+
+
+@dataclass(frozen=True)
+class BucketCorsPlan:
+    """A lossless plan for reconciling the Rerun browser CORS rule."""
+
+    bucket_id: str
+    resource_version: str
+    current_rules: tuple[dict[str, Any], ...]
+    desired_rules: tuple[dict[str, Any], ...]
+    changed: bool
+
+    @property
+    def preserved_rule_count(self) -> int:
+        return sum(
+            1
+            for rule in self.current_rules
+            if str(rule.get("id") or "") != RERUN_BROWSER_CORS_RULE_ID
+        )
+
+
+def rerun_browser_cors_rule() -> dict[str, Any]:
+    """Return the least-privilege CORS rule needed by the Rerun web viewer."""
+
+    return {
+        "id": RERUN_BROWSER_CORS_RULE_ID,
+        "allowed_origins": [RERUN_BROWSER_ORIGIN],
+        "allowed_methods": ["GET"],
+        "allowed_headers": ["Range"],
+        "expose_headers": ["Accept-Ranges", "Content-Length", "Content-Range"],
+        "max_age_seconds": 3600,
+    }
+
+
+def _bucket_cors_rules(item: dict[str, Any]) -> list[dict[str, Any]]:
+    spec = item.get("spec")
+    if not isinstance(spec, dict):
+        raise NebiusError("exact bucket lookup returned no resource spec")
+    cors = spec.get("cors")
+    if cors in (None, {}):
+        return []
+    if not isinstance(cors, dict):
+        raise NebiusError("exact bucket lookup returned schema-invalid CORS data")
+    rules = cors.get("rules", [])
+    if not isinstance(rules, list) or not all(isinstance(rule, dict) for rule in rules):
+        raise NebiusError("exact bucket lookup returned schema-invalid CORS rules")
+    return [dict(rule) for rule in rules]
+
+
+def _rule_values(rule: Mapping[str, Any], field: str) -> set[str]:
+    values = rule.get(field, [])
+    if not isinstance(values, list):
+        return set()
+    return {str(value).strip().lower() for value in values if str(value).strip()}
+
+
+def bucket_cors_supports_rerun(rule: Mapping[str, Any]) -> bool:
+    """Return whether one provider rule satisfies the browser fetch contract."""
+
+    origins = _rule_values(rule, "allowed_origins")
+    methods = _rule_values(rule, "allowed_methods")
+    headers = _rule_values(rule, "allowed_headers")
+    exposed = _rule_values(rule, "expose_headers")
+    required_exposed = {"accept-ranges", "content-length", "content-range"}
+    return bool(
+        (RERUN_BROWSER_ORIGIN.lower() in origins or "*" in origins)
+        and "get" in methods
+        and ("range" in headers or "*" in headers)
+        and (required_exposed <= exposed or "*" in exposed)
+    )
+
+
+def plan_bucket_rerun_cors(project_id: str, bucket_name: str) -> BucketCorsPlan:
+    """Read and merge a Rerun rule without discarding unrelated bucket CORS."""
+
+    item = get_bucket_by_name(project_id, bucket_name)
+    if item is None:
+        raise NebiusError("the configured object-storage bucket does not exist")
+    metadata = item.get("metadata")
+    if not isinstance(metadata, dict):
+        raise NebiusError("exact bucket lookup returned no resource metadata")
+    bucket_id = str(metadata.get("id") or "").strip()
+    if not bucket_id:
+        raise NebiusError("exact bucket lookup returned no resource ID")
+    resource_version = str(metadata.get("resource_version") or "").strip()
+    current = _bucket_cors_rules(item)
+    if any(bucket_cors_supports_rerun(rule) for rule in current):
+        desired = list(current)
+    else:
+        desired = [
+            rule
+            for rule in current
+            if str(rule.get("id") or "") != RERUN_BROWSER_CORS_RULE_ID
+        ]
+        desired.append(rerun_browser_cors_rule())
+    return BucketCorsPlan(
+        bucket_id=bucket_id,
+        resource_version=resource_version,
+        current_rules=tuple(current),
+        desired_rules=tuple(desired),
+        changed=current != desired,
+    )
+
+
+def apply_bucket_rerun_cors(project_id: str, bucket_name: str) -> BucketCorsPlan:
+    """Reconcile the browser rule through bucket-admin control-plane credentials."""
+
+    plan = plan_bucket_rerun_cors(project_id, bucket_name)
+    if not plan.changed:
+        return plan
+    args = [
+        "storage",
+        "bucket",
+        "update",
+        "--id",
+        plan.bucket_id,
+        "--cors-rules",
+        json.dumps(list(plan.desired_rules), separators=(",", ":"), sort_keys=True),
+    ]
+    if plan.resource_version:
+        args.extend(["--resource-version", plan.resource_version])
+    _run_json(args)
+
+    verified = plan_bucket_rerun_cors(project_id, bucket_name)
+    if verified.changed:
+        raise NebiusError("bucket CORS update completed but read-back verification failed")
+    return BucketCorsPlan(
+        bucket_id=verified.bucket_id,
+        resource_version=verified.resource_version,
+        current_rules=plan.current_rules,
+        desired_rules=verified.desired_rules,
+        changed=True,
+    )
 
 
 def normalize_bucket_storage_class(value: str) -> str:

--- a/npa/src/npa/rerun/__init__.py
+++ b/npa/src/npa/rerun/__init__.py
@@ -41,7 +41,14 @@ def configure_browser_cors(
     if project_id and not target_bucket:
         raise ValueError("target_bucket is required with target_project_id")
     if not project_id:
-        project_id = resolve_environment(target_project).project_id
+        environment = resolve_environment(target_project)
+        project_id = str(getattr(environment, "project_id", "") or "").strip()
+    if not project_id:
+        alias = f" for target_project {target_project!r}" if target_project else ""
+        raise ValueError(
+            f"Target project is not configured{alias}. Pass target_project_id, "
+            "or run `npa configure` to configure the project."
+        )
     configured = target_bucket
     if not configured:
         storage = resolve_project_storage(target_project)

--- a/npa/src/npa/rerun/__init__.py
+++ b/npa/src/npa/rerun/__init__.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
+from npa.clients.config import resolve_environment, resolve_project_storage
+from npa.clients.nebius import (
+    BucketCorsPlan,
+    apply_bucket_rerun_cors,
+    plan_bucket_rerun_cors,
+)
+from npa.clients.scoped_credentials import bucket_from_s3_uri
 from npa.cli.rerun import (
     MAX_TTL_HOURS,
     RerunHostResult,
@@ -14,6 +21,42 @@ from npa.cli.rerun import (
     revoke_share,
     share_recording,
 )
+
+
+def configure_browser_cors(
+    *,
+    target_bucket: str = "",
+    target_project: str | None = None,
+    target_project_id: str = "",
+    apply: bool = False,
+) -> BucketCorsPlan:
+    """Plan or apply the bucket-admin CORS rule required by app.rerun.io.
+
+    This uses the Nebius control-plane identity selected by the active CLI
+    profile. It deliberately never uses the scoped S3 object credentials that
+    :func:`host` and :func:`share` use for recording data.
+    """
+
+    project_id = target_project_id.strip()
+    if project_id and not target_bucket:
+        raise ValueError("target_bucket is required with target_project_id")
+    if not project_id:
+        project_id = resolve_environment(target_project).project_id
+    configured = target_bucket
+    if not configured:
+        storage = resolve_project_storage(target_project)
+        configured = storage.checkpoint_bucket
+    bucket = (
+        bucket_from_s3_uri(configured)
+        if configured.startswith("s3://")
+        else configured.split("/", 1)[0]
+    )
+    if not bucket:
+        raise ValueError(
+            "Target bucket is not configured. Pass target_bucket or configure project storage."
+        )
+    operation = apply_bucket_rerun_cors if apply else plan_bucket_rerun_cors
+    return operation(project_id, bucket)
 
 
 def host(
@@ -112,4 +155,4 @@ def revoke(
     )
 
 
-__all__ = ["host", "share", "list_shares", "revoke"]
+__all__ = ["configure_browser_cors", "host", "share", "list_shares", "revoke"]

--- a/npa/tests/test_rerun_cors.py
+++ b/npa/tests/test_rerun_cors.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from email.message import Message
+from urllib.error import HTTPError
+
+import pytest
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.cli.rerun import RerunHostError, _verify_browser_cors
+from npa.clients.config import EnvironmentConfig, StorageConfig
+from npa.clients.nebius import (
+    BucketCorsPlan,
+    RERUN_BROWSER_CORS_RULE_ID,
+    RERUN_BROWSER_ORIGIN,
+    apply_bucket_rerun_cors,
+    plan_bucket_rerun_cors,
+    rerun_browser_cors_rule,
+)
+
+
+runner = CliRunner()
+
+
+def _bucket(*rules: dict, version: str = "7") -> dict:
+    return {
+        "metadata": {
+            "id": "storagebucket-synthetic",
+            "name": "bucket-synthetic",
+            "resource_version": version,
+        },
+        "spec": {"cors": {"rules": list(rules)}},
+    }
+
+
+def test_plan_adds_least_privilege_rule_and_preserves_unrelated(mocker) -> None:
+    unrelated = {
+        "id": "existing-app",
+        "allowed_origins": ["https://viewer.example"],
+        "allowed_methods": ["GET", "HEAD"],
+        "allowed_headers": ["Content-Type"],
+    }
+    mocker.patch(
+        "npa.clients.nebius.get_bucket_by_name", return_value=_bucket(unrelated)
+    )
+
+    plan = plan_bucket_rerun_cors("project-synthetic", "bucket-synthetic")
+
+    assert plan.changed is True
+    assert plan.preserved_rule_count == 1
+    assert list(plan.desired_rules) == [unrelated, rerun_browser_cors_rule()]
+    assert rerun_browser_cors_rule() == {
+        "id": RERUN_BROWSER_CORS_RULE_ID,
+        "allowed_origins": [RERUN_BROWSER_ORIGIN],
+        "allowed_methods": ["GET"],
+        "allowed_headers": ["Range"],
+        "expose_headers": ["Accept-Ranges", "Content-Length", "Content-Range"],
+        "max_age_seconds": 3600,
+    }
+
+
+def test_plan_replaces_only_stale_npa_rule(mocker) -> None:
+    unrelated = {
+        "id": "existing-app",
+        "allowed_origins": ["https://viewer.example"],
+        "allowed_methods": ["GET"],
+        "allowed_headers": ["Range"],
+    }
+    stale = {
+        "id": RERUN_BROWSER_CORS_RULE_ID,
+        "allowed_origins": ["*"],
+        "allowed_methods": ["PUT"],
+        "allowed_headers": ["*"],
+    }
+    mocker.patch(
+        "npa.clients.nebius.get_bucket_by_name",
+        return_value=_bucket(unrelated, stale),
+    )
+
+    plan = plan_bucket_rerun_cors("project-synthetic", "bucket-synthetic")
+
+    assert list(plan.desired_rules) == [unrelated, rerun_browser_cors_rule()]
+
+
+def test_plan_accepts_an_existing_compatible_rule_without_mutation(mocker) -> None:
+    compatible = {
+        "id": "operator-managed",
+        "allowed_origins": [RERUN_BROWSER_ORIGIN],
+        "allowed_methods": ["GET", "HEAD"],
+        "allowed_headers": ["Range", "Content-Type"],
+        "expose_headers": ["Accept-Ranges", "Content-Length", "Content-Range"],
+    }
+    mocker.patch(
+        "npa.clients.nebius.get_bucket_by_name", return_value=_bucket(compatible)
+    )
+
+    plan = plan_bucket_rerun_cors("project-synthetic", "bucket-synthetic")
+
+    assert plan.changed is False
+    assert plan.desired_rules == plan.current_rules
+
+
+def test_apply_uses_optimistic_version_and_read_back_verification(mocker) -> None:
+    unrelated = {
+        "id": "existing-app",
+        "allowed_origins": ["https://viewer.example"],
+        "allowed_methods": ["GET"],
+        "allowed_headers": ["Range"],
+    }
+    updated = _bucket(unrelated, rerun_browser_cors_rule(), version="8")
+    get_bucket = mocker.patch(
+        "npa.clients.nebius.get_bucket_by_name",
+        side_effect=[_bucket(unrelated), updated],
+    )
+    run = mocker.patch("npa.clients.nebius._run_json", return_value={})
+
+    result = apply_bucket_rerun_cors("project-synthetic", "bucket-synthetic")
+
+    assert result.changed is True
+    assert get_bucket.call_count == 2
+    argv = run.call_args.args[0]
+    assert argv[:6] == [
+        "storage",
+        "bucket",
+        "update",
+        "--id",
+        "storagebucket-synthetic",
+        "--cors-rules",
+    ]
+    assert argv[-2:] == ["--resource-version", "7"]
+    assert "existing-app" in argv[6]
+    assert RERUN_BROWSER_CORS_RULE_ID in argv[6]
+
+
+class _CorsResponse:
+    status = 200
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = Message()
+        for key, value in headers.items():
+            self.headers[key] = value
+
+    def getcode(self) -> int:
+        return self.status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+
+def test_browser_probe_sends_and_validates_range_preflight(mocker) -> None:
+    response = _CorsResponse(
+        {
+            "Access-Control-Allow-Origin": RERUN_BROWSER_ORIGIN,
+            "Access-Control-Allow-Methods": "GET",
+            "Access-Control-Allow-Headers": "Range",
+            "Access-Control-Expose-Headers": "Accept-Ranges, Content-Length, Content-Range",
+        }
+    )
+    urlopen = mocker.patch("npa.cli.rerun.urlopen", return_value=response)
+
+    _verify_browser_cors(
+        "https://storage.example/object?signature=secret",
+        bucket="bucket-synthetic",
+        project="project-synthetic",
+    )
+
+    request = urlopen.call_args.args[0]
+    assert request.get_method() == "OPTIONS"
+    assert request.get_header("Origin") == RERUN_BROWSER_ORIGIN
+    assert request.get_header("Access-control-request-method") == "GET"
+    assert request.get_header("Access-control-request-headers") == "Range"
+
+
+def test_browser_probe_403_gives_admin_remedy_without_signed_url(mocker) -> None:
+    signed_url = "https://storage.example/object?signature=secret"
+    mocker.patch(
+        "npa.cli.rerun.urlopen",
+        side_effect=HTTPError(signed_url, 403, "Forbidden", Message(), None),
+    )
+
+    with pytest.raises(RerunHostError) as raised:
+        _verify_browser_cors(
+            signed_url,
+            bucket="bucket-synthetic",
+            project="project-synthetic",
+        )
+
+    message = str(raised.value)
+    assert "HTTP 403" in message
+    assert "npa storage bucket cors --apply" in message
+    assert "scoped S3 object key" in message
+    assert "rerun <recording.rrd>" in message
+    assert signed_url not in message
+    assert "signature=secret" not in message
+
+
+def test_storage_cors_cli_is_plan_only_by_default(mocker) -> None:
+    plan = BucketCorsPlan(
+        bucket_id="storagebucket-synthetic",
+        resource_version="7",
+        current_rules=(),
+        desired_rules=(rerun_browser_cors_rule(),),
+        changed=True,
+    )
+    configure = mocker.patch(
+        "npa.rerun.configure_browser_cors", return_value=plan
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "storage",
+            "bucket",
+            "cors",
+            "--project",
+            "project-synthetic",
+            "--name",
+            "bucket-synthetic",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "needs an additive bucket-admin update" in result.output
+    configure.assert_called_once_with(
+        target_bucket="bucket-synthetic",
+        target_project="project-synthetic",
+        target_project_id="",
+        apply=False,
+    )
+
+
+def test_storage_cors_cli_apply_has_stable_json(mocker) -> None:
+    plan = BucketCorsPlan(
+        bucket_id="storagebucket-synthetic",
+        resource_version="8",
+        current_rules=(),
+        desired_rules=(rerun_browser_cors_rule(),),
+        changed=True,
+    )
+    mocker.patch("npa.rerun.configure_browser_cors", return_value=plan)
+
+    result = runner.invoke(
+        app,
+        ["storage", "bucket", "cors", "--apply", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.count("{") == 1
+    assert '"status": "updated"' in result.output
+
+
+def test_sdk_routes_configured_project_to_control_plane(mocker) -> None:
+    from npa import rerun
+
+    mocker.patch(
+        "npa.rerun.resolve_environment",
+        return_value=EnvironmentConfig("project-synthetic", "tenant-synthetic", "us-central1"),
+    )
+    mocker.patch(
+        "npa.rerun.resolve_project_storage",
+        return_value=StorageConfig("s3://bucket-synthetic/prefix", "https://storage.example"),
+    )
+    operation = mocker.patch(
+        "npa.rerun.apply_bucket_rerun_cors",
+        return_value=BucketCorsPlan("id", "7", (), (), False),
+    )
+
+    rerun.configure_browser_cors(target_project="project-synthetic", apply=True)
+
+    operation.assert_called_once_with("project-synthetic", "bucket-synthetic")
+
+
+def test_sdk_explicit_project_id_and_bucket_do_not_resolve_scoped_storage(mocker) -> None:
+    from npa import rerun
+
+    storage = mocker.patch("npa.rerun.resolve_project_storage")
+    environment = mocker.patch("npa.rerun.resolve_environment")
+    operation = mocker.patch(
+        "npa.rerun.plan_bucket_rerun_cors",
+        return_value=BucketCorsPlan("id", "7", (), (), False),
+    )
+
+    rerun.configure_browser_cors(
+        target_project_id="project-synthetic",
+        target_bucket="bucket-synthetic",
+    )
+
+    storage.assert_not_called()
+    environment.assert_not_called()
+    operation.assert_called_once_with("project-synthetic", "bucket-synthetic")

--- a/npa/tests/test_rerun_cors.py
+++ b/npa/tests/test_rerun_cors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from email.message import Message
+import json
 from urllib.error import HTTPError
 
 import pytest
@@ -244,12 +245,21 @@ def test_storage_cors_cli_apply_has_stable_json(mocker) -> None:
 
     result = runner.invoke(
         app,
-        ["storage", "bucket", "cors", "--apply", "--json"],
+        ["storage", "bucket", "cors", "--apply", "--output", "json"],
     )
 
     assert result.exit_code == 0, result.output
-    assert result.output.count("{") == 1
-    assert '"status": "updated"' in result.output
+    assert json.loads(result.stdout) == {
+        "allowed_origin": RERUN_BROWSER_ORIGIN,
+        "apply": True,
+        "cors_rule_id": RERUN_BROWSER_CORS_RULE_ID,
+        "preserved_rule_count": 0,
+        "status": "updated",
+    }
+    assert result.stdout == (
+        json.dumps(json.loads(result.stdout), indent=2, sort_keys=True) + "\n"
+    )
+    assert "command diagnostics were separated from JSON stdout" not in result.stderr
 
 
 def test_sdk_routes_configured_project_to_control_plane(mocker) -> None:
@@ -257,11 +267,18 @@ def test_sdk_routes_configured_project_to_control_plane(mocker) -> None:
 
     mocker.patch(
         "npa.rerun.resolve_environment",
-        return_value=EnvironmentConfig("project-synthetic", "tenant-synthetic", "us-central1"),
+        return_value=EnvironmentConfig(
+            project_id="project-synthetic",
+            tenant_id="tenant-synthetic",
+            region="us-central1",
+        ),
     )
     mocker.patch(
         "npa.rerun.resolve_project_storage",
-        return_value=StorageConfig("s3://bucket-synthetic/prefix", "https://storage.example"),
+        return_value=StorageConfig(
+            checkpoint_bucket="s3://bucket-synthetic/prefix",
+            endpoint_url="https://storage.example",
+        ),
     )
     operation = mocker.patch(
         "npa.rerun.apply_bucket_rerun_cors",
@@ -273,11 +290,39 @@ def test_sdk_routes_configured_project_to_control_plane(mocker) -> None:
     operation.assert_called_once_with("project-synthetic", "bucket-synthetic")
 
 
+@pytest.mark.parametrize("target_project", [None, "typoed-alias"])
+def test_sdk_missing_project_configuration_is_actionable(
+    mocker, target_project: str | None
+) -> None:
+    from npa import rerun
+
+    mocker.patch("npa.rerun.resolve_environment", return_value=None)
+    storage = mocker.patch("npa.rerun.resolve_project_storage")
+    operation = mocker.patch("npa.rerun.plan_bucket_rerun_cors")
+
+    with pytest.raises(ValueError, match="Target project is not configured") as raised:
+        rerun.configure_browser_cors(target_project=target_project)
+
+    message = str(raised.value)
+    assert "target_project_id" in message
+    assert "npa configure" in message
+    if target_project:
+        assert repr(target_project) in message
+    storage.assert_not_called()
+    operation.assert_not_called()
+
+
 def test_sdk_explicit_project_id_and_bucket_do_not_resolve_scoped_storage(mocker) -> None:
     from npa import rerun
 
-    storage = mocker.patch("npa.rerun.resolve_project_storage")
-    environment = mocker.patch("npa.rerun.resolve_environment")
+    storage = mocker.patch(
+        "npa.rerun.resolve_project_storage",
+        side_effect=AssertionError("explicit target must bypass storage resolution"),
+    )
+    environment = mocker.patch(
+        "npa.rerun.resolve_environment",
+        side_effect=AssertionError("explicit target must bypass environment resolution"),
+    )
     operation = mocker.patch(
         "npa.rerun.plan_bucket_rerun_cors",
         return_value=BucketCorsPlan("id", "7", (), (), False),

--- a/npa/tests/test_rerun_host.py
+++ b/npa/tests/test_rerun_host.py
@@ -19,6 +19,11 @@ from npa.errors import ScopedCredentialError
 runner = CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def _browser_cors_succeeds(mocker):
+    return mocker.patch("npa.cli.rerun._verify_browser_cors")
+
+
 class RerunHostFakeS3:
     def __init__(self) -> None:
         self.objects: dict[tuple[str, str], dict] = {}
@@ -91,7 +96,7 @@ def _rrd(tmp_path: Path, body: bytes = b"recording") -> tuple[Path, str]:
 
 
 def test_local_file_uploads_with_sha_metadata_and_generates_versioned_url(
-    tmp_path: Path, mocker
+    tmp_path: Path, mocker, _browser_cors_succeeds
 ) -> None:
     mocker.patch("npa.cli.rerun.resolve_project_storage", return_value=_storage())
     path, sha = _rrd(tmp_path)
@@ -109,6 +114,7 @@ def test_local_file_uploads_with_sha_metadata_and_generates_versioned_url(
     assert result.rrd_s3_uri == f"s3://target/{key}"
     assert result.sha256 == sha
     assert result.rerun_version == RERUN_VERSION
+    assert result.browser_cors_verified is True
     assert result.ttl_expires_at == "2026-05-11T23:30:00Z"
     assert result.share_url.startswith(
         f"https://app.rerun.io/version/{RERUN_VERSION}/?url="
@@ -116,6 +122,9 @@ def test_local_file_uploads_with_sha_metadata_and_generates_versioned_url(
     assert s3.objects[("target", key)]["Metadata"] == {"sha256": sha}
     assert s3.put_calls == [("target", key, {"sha256": sha})]
     assert s3.presign_calls[-1]["ExpiresIn"] == 3600
+    _browser_cors_succeeds.assert_called_once_with(
+        result.presigned_url, bucket="target", project=None
+    )
 
 
 def test_s3_file_with_matching_metadata_skips_upload(mocker) -> None:
@@ -171,6 +180,26 @@ def test_missing_file_is_clear_error(tmp_path: Path, mocker) -> None:
             s3_client=RerunHostFakeS3(),
             host_s3_client=RerunHostFakeS3(),
         )
+
+
+def test_failed_browser_preflight_stops_before_upload(
+    tmp_path: Path, mocker, _browser_cors_succeeds
+) -> None:
+    mocker.patch("npa.cli.rerun.resolve_project_storage", return_value=_storage())
+    path, _ = _rrd(tmp_path)
+    s3 = RerunHostFakeS3()
+    _browser_cors_succeeds.side_effect = RerunHostError("CORS unavailable")
+
+    with pytest.raises(RerunHostError, match="CORS unavailable"):
+        host_recording(
+            str(path),
+            target_bucket="target",
+            s3_client=s3,
+            host_s3_client=RerunHostFakeS3(),
+        )
+
+    assert s3.put_calls == []
+    assert s3.head_calls == []
 
 
 def test_missing_scoped_creds_without_flag_raises_scoped_credential_error(
@@ -255,10 +284,12 @@ def test_json_output_contains_full_schema(tmp_path: Path, mocker) -> None:
         "ttl_expires_at",
         "sha256",
         "rerun_version",
+        "browser_cors_verified",
     }
     assert data["sha256"] == sha
     assert data["rrd_s3_uri"] == f"s3://target/rerun-shared/{sha}.rrd"
     assert data["rerun_version"] == RERUN_VERSION
+    assert data["browser_cors_verified"] is True
     assert "app.rerun.io" in data["share_url"]
     assert "version" in data["share_url"]
 

--- a/npa/tests/test_rerun_share.py
+++ b/npa/tests/test_rerun_share.py
@@ -24,6 +24,11 @@ from npa.clients.config import StorageConfig
 runner = CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def _browser_cors_succeeds(mocker):
+    return mocker.patch("npa.cli.rerun._verify_browser_cors")
+
+
 class RerunShareFakeS3:
     def __init__(self) -> None:
         self.objects: dict[tuple[str, str], dict] = {}
@@ -108,7 +113,9 @@ def _rrd(tmp_path: Path, body: bytes = b"recording") -> tuple[Path, str]:
     return path, hashlib.sha256(body).hexdigest()
 
 
-def test_share_default_ttl_generates_seven_day_url(tmp_path: Path, mocker) -> None:
+def test_share_default_ttl_generates_seven_day_url(
+    tmp_path: Path, mocker, _browser_cors_succeeds
+) -> None:
     mocker.patch("npa.cli.rerun.resolve_project_storage", return_value=_storage())
     path, sha = _rrd(tmp_path)
     s3 = RerunShareFakeS3()
@@ -124,6 +131,9 @@ def test_share_default_ttl_generates_seven_day_url(tmp_path: Path, mocker) -> No
     assert result.rrd_s3_uri == f"s3://target/rerun-shares/default/{sha}.rrd"
     assert result.ttl_expires_at == "2026-05-18T22:30:00Z"
     assert s3.presign_calls[-1]["ExpiresIn"] == MAX_TTL_HOURS * 3600
+    _browser_cors_succeeds.assert_called_once_with(
+        result.presigned_url, bucket="target", project=None
+    )
 
 
 def test_share_label_is_stored_in_metadata(tmp_path: Path, mocker) -> None:
@@ -252,6 +262,25 @@ def test_share_ttl_over_limit_fails_before_s3_calls() -> None:
             s3_client=NoCallS3(),
             host_s3_client=NoCallS3(),
         )
+
+
+def test_share_failed_browser_preflight_stops_before_upload(
+    tmp_path: Path, mocker, _browser_cors_succeeds
+) -> None:
+    mocker.patch("npa.cli.rerun.resolve_project_storage", return_value=_storage())
+    path, _ = _rrd(tmp_path)
+    s3 = RerunShareFakeS3()
+    _browser_cors_succeeds.side_effect = RerunHostError("CORS unavailable")
+
+    with pytest.raises(RerunHostError, match="CORS unavailable"):
+        share_recording(
+            str(path),
+            target_bucket="target",
+            s3_client=s3,
+            host_s3_client=RerunShareFakeS3(),
+        )
+
+    assert s3.put_calls == []
 
 
 def test_list_shares_json_cli_outputs_programmatic_schema(mocker) -> None:

--- a/npa/tests/test_rerun_share.py
+++ b/npa/tests/test_rerun_share.py
@@ -35,6 +35,7 @@ class RerunShareFakeS3:
         self.put_calls: list[tuple[str, str, dict[str, str]]] = []
         self.delete_calls: list[tuple[str, str]] = []
         self.presign_calls: list[dict] = []
+        self.events: list[str] = []
 
     def add(
         self,
@@ -51,6 +52,7 @@ class RerunShareFakeS3:
         }
 
     def head_object(self, *, Bucket: str, Key: str):
+        self.events.append("head")
         item = self.objects.get((Bucket, Key))
         if item is None:
             raise ClientError(
@@ -65,6 +67,7 @@ class RerunShareFakeS3:
     def put_object(
         self, *, Bucket: str, Key: str, Body: bytes, Metadata: dict[str, str]
     ) -> None:
+        self.events.append("put")
         self.put_calls.append((Bucket, Key, dict(Metadata)))
         self.add(Bucket, Key, Body, Metadata)
 
@@ -87,6 +90,7 @@ class RerunShareFakeS3:
         self.objects.pop((Bucket, Key), None)
 
     def generate_presigned_url(self, operation: str, *, Params: dict, ExpiresIn: int):
+        self.events.append("presign")
         self.presign_calls.append(
             {"operation": operation, "Params": Params, "ExpiresIn": ExpiresIn}
         )
@@ -134,6 +138,30 @@ def test_share_default_ttl_generates_seven_day_url(
     _browser_cors_succeeds.assert_called_once_with(
         result.presigned_url, bucket="target", project=None
     )
+
+
+def test_share_fresh_key_checks_cors_before_head_and_upload(
+    tmp_path: Path, mocker, _browser_cors_succeeds
+) -> None:
+    mocker.patch("npa.cli.rerun.resolve_project_storage", return_value=_storage())
+    path, sha = _rrd(tmp_path, body=b"fresh recording")
+    s3 = RerunShareFakeS3()
+
+    def record_preflight(*_args, **_kwargs) -> None:
+        assert ("target", f"rerun-shares/default/{sha}.rrd") not in s3.objects
+        s3.events.append("preflight")
+
+    _browser_cors_succeeds.side_effect = record_preflight
+
+    share_recording(
+        str(path),
+        target_bucket="target",
+        s3_client=s3,
+        host_s3_client=RerunShareFakeS3(),
+    )
+
+    assert s3.events == ["presign", "preflight", "head", "put"]
+    assert ("target", f"rerun-shares/default/{sha}.rrd") in s3.objects
 
 
 def test_share_label_is_stored_in_metadata(tmp_path: Path, mocker) -> None:

--- a/npa/tests/test_sdk_surface.py
+++ b/npa/tests/test_sdk_surface.py
@@ -62,7 +62,13 @@ def test_rerun_public_surface() -> None:
     """npa.rerun exposes hosted Rerun sharing commands."""
     from npa import rerun
 
-    assert rerun.__all__ == ["host", "share", "list_shares", "revoke"]
+    assert rerun.__all__ == [
+        "configure_browser_cors",
+        "host",
+        "share",
+        "list_shares",
+        "revoke",
+    ]
     for name in rerun.__all__:
         assert callable(getattr(rerun, name))
 

--- a/skills/tools/artifact-viz-share/SKILL.md
+++ b/skills/tools/artifact-viz-share/SKILL.md
@@ -73,6 +73,10 @@ silently truncated unless you set `--duration`.
 ## Sharing a recording
 
 ```bash
+# One-time bucket-admin setup (read-only plan, then explicit apply).
+npa storage bucket cors --project <alias>
+npa storage bucket cors --project <alias> --apply
+
 npa rerun host <path.rrd> --ttl-hours 1
 npa rerun share <path.rrd> --label <name> --workspace <ws> --ttl-hours 168
 npa rerun list-shares --output json
@@ -89,6 +93,20 @@ alias whose principal **reads** an `s3://` input, `--target-project` is the alia
 whose principal **writes** the upload, and `--target-bucket` overrides the
 destination (default: configured project storage). `--allow-host-creds` falls back
 to host credentials for the S3 operation — an explicit opt-in, not a default.
+
+The hosted viewer fetches the presigned object cross-origin and requests byte
+ranges. A bucket administrator must therefore configure CORS once. The setup
+command uses the active Nebius control-plane profile, preserves unrelated CORS
+rules, and adds only the `https://app.rerun.io` origin with `GET` and `Range`.
+The scoped object key created by `npa configure` remains object-only and cannot
+perform this operation. Running the setup command without `--apply` is a
+read-only plan.
+
+`host` and `share` exercise a real `OPTIONS` preflight against the presigned URL
+before returning it. A failed preflight exits nonzero with the bucket-admin
+setup command and does not print the signed URL. After applying the policy,
+retry the share. If bucket policy changes are not available, download the `.rrd`
+and open it locally with `rerun <recording.rrd>`.
 
 Revoke by label or sha256 when the work is no longer for sharing. `list-shares`
 is the only way to find what you left behind; presigned links do not appear in
@@ -118,6 +136,9 @@ rather than a dataset.
 - **These commands do not clean up after themselves.** Uploaded shares live in the
   bucket until revoked and count toward storage; include them in the audit in
   `skills/atomic/teardown-and-cost/SKILL.md`.
+- **Object access is not bucket administration.** Do not grant `PutBucketCORS`
+  to the workload key or use `--allow-host-creds` as a substitute for the
+  control-plane setup command.
 
 ## Verify
 


### PR DESCRIPTION
## What changed

- add `npa storage bucket cors` and `npa.rerun.configure_browser_cors()` as an explicit bucket-admin plan/apply surface
- reconcile one least-privilege `app.rerun.io` rule while preserving unrelated CORS rules and using optimistic resource-version updates plus read-back verification
- make `npa rerun host` and `share` exercise the browser's unauthenticated `OPTIONS` contract before upload/return, fail without leaking the signed URL, and report `browser_cors_verified`
- return an actionable SDK error when no project is configured or an alias cannot be resolved, while preserving the explicit project-id-and-bucket bypass
- make `npa storage bucket cors --output json` emit the canonical indented JSON document required by `json_stdout_contract`, without a false diagnostics warning
- document the privilege boundary, one-time setup, revocation, and native local Rerun fallback
- add CLI, SDK, reconciliation, error-redaction, fresh-key ordering, and upload-order coverage

## Why

A presigned `.rrd` object can return HTTP 200 directly while the browser viewer still fails: `app.rerun.io` sends a cross-origin preflight with a `Range` request header. The object-scoped key created by `npa configure` cannot and should not receive bucket-administration permission, so browser sharing needs an explicit administrator operation and a runtime check of the resulting contract.

## Developer and user impact

Administrators can inspect the additive change without mutation, then apply it once. Existing compatible operator-managed rules are accepted; unrelated rules are retained. Sharing remains object-scoped and now fails early with a safe remediation command when the bucket contract is absent. SDK callers receive an intentional configuration error instead of an `AttributeError`. Users without bucket-admin access retain the documented native `rerun <recording.rrd>` path.

## Validation

- `ruff check npa/src npa/tests`
- 114 CLI smoke tests passed
- 2,377 guardrail tests passed
- 53 focused Rerun/storage/SDK tests passed
- full non-live suite: 12,601 passed, 36 skipped, 12 deselected, 1 expected xpass
- generated CLI documentation is current
- aggregate diff confidentiality scan: 0 hits
- gitleaks over the PR commits: no leaks

The initial full-suite invocation found a stale user-level `rerun` launcher with its module absent; both exact failures passed after selecting the clone-local virtualenv launcher, and the complete suite then passed with the numeric result above.

## Preserved live evidence

No new live workload was launched for this follow-up. The prior owner-only evidence proves a successful browser preflight and subsequent full-object, byte-range, viewer-shell, and headless-viewer checks. Implementation history and hermetic coverage prove the operation order is presign, `OPTIONS` preflight, object existence check, then upload; the regression test also asserts that the content-addressed key is absent during preflight and present afterward.

The preserved live evidence does not contain an independent pre-share `HEAD` or listing observation for that exact content-addressed key. It therefore cannot conclusively prove that the prior live key had never been written before. This limitation is recorded explicitly rather than treating a unique generated artifact or later cleanup as proof of freshness.

## Limitations

- bucket CORS setup requires a separately authorized Nebius bucket administrator; this change intentionally does not elevate scoped object credentials
- the managed rule is deliberately limited to `https://app.rerun.io`, `GET`, `Range`, and the response headers Rerun needs
- presigned viewer URLs remain temporary credentials and should use the shortest practical TTL; durable shares still require explicit revocation
