### PR TITLE
fix: promote attested rerun-viewer build to the public release channel

### DIFF
--- a/docs/workbench/container-image-catalog.md
+++ b/docs/workbench/container-image-catalog.md
@@ -19,7 +19,7 @@ repository-owned runtime defaults; select custom bytes with a complete image
 reference or an explicit workflow `--registry`.
 
 The accepted-release manifest was verified against the public GHCR tag and OCI
-manifest APIs on 2026-09-02. All 31 recorded release digests resolved
+manifest APIs on 2026-09-03. All 31 recorded release digests resolved
 anonymously. **Built** is the UTC build date of the newest listed variant;
 reproducible images that
 intentionally zero their OCI `created` field use the timestamp in the immutable
@@ -98,7 +98,7 @@ published, and anonymously pullable status for this exact digest only.
 | Alpamayo 2 Super 34B | `npa-alpamayo2-super` | `0.1.0-cu128` | 2026-08-18 | Real surround-view VLA trajectory inference through NVIDIA's Apache-2.0 source. OpenMDW-1.1 weights and the separately gated/non-transferable PhysicalAI-AV sample data are fetched only at runtime under the operator's Hugging Face identity. The payload-clean image and real workflow were validated independently on B200 and RTX PRO 6000. See the [operator guide](alpamayo2-super.md). |
 | NVIDIA Content Agents 0.5.2 | `npa-content-agents` | `0.5.2-npa2` | 2026-08-22 | Public rigid-object material/physics/validation adapter containing Apache-2.0 source and zero OVRTX payload. Exact OVRTX 0.3.0.312915 is fetched directly from NVIDIA into the operator runtime cache. The exact public digest passed byte/layer scanning, anonymous resolution, and a real RTX PRO 6000 workflow. See [Content Agents](content-agents.md). |
 | SONIC Retargeting 0.1.1 | `npa-retargeting` | `0.1.1` | 2026-06-16 | CPU-only motion retargeting and motion-library conversion feeding SONIC locomotion training. A slim `python:3.11` image for the inexpensive preprocessing stage before GPU work. |
-| Rerun 0.31.4 | `npa-rerun-viewer` | `0.31.4` | 2026-07-01 | Published Rerun viewer/server on port 9090 for `.rrd` robotics traces. Current source defines an as-yet-unpublished non-root `ubuntu` SkyPilot worker with ports 9090/9876 and an exact-source Sim2Real Stage 14 runtime; it bakes no models, datasets, credentials, or runtime caches. |
+| Rerun 0.31.4 | `npa-rerun-viewer` | `0.31.4-sim2real-coherent-20260903` | 2026-09-03 | Published non-root `ubuntu` SkyPilot worker and Rerun viewer/server on ports 9876/9090 for `.rrd` robotics traces. It includes the attested bootstrap contract and exact-source Sim2Real Stage 14 runtime, and bakes no models, datasets, credentials, or runtime caches. |
 | LeRobot Policy Server 0.1.1 | `npa-lerobot-policy` | `0.1.1` | 2026-07-10 | Serves a trained LeRobot policy over HTTP for closed-loop inference (default `lerobot/diffusion_pusht`). This is the BYO-policy contract endpoint called by other workflow stages. |
 | BDD100K Detection Training | `npa-detection-training` | `bdd100k-golden-eval-smoke-20260614T210000Z` | 2026-07-22 | Object-detector train/eval service on port 8790 with torchvision detectors and COCO metrics. It provides the re-label and measurement stage in the data-factory loop. |
 | Lichtblick 1.26.0 | `npa-lichtblick` | `1.26.0` | 2026-07-23 | Fully open-source (MPL-2.0), Foxglove-compatible MCAP/ROS log viewer served by Caddy on port 8080. No account or proprietary component is required. |

--- a/npa/docker/workbench/rerun-viewer/Dockerfile
+++ b/npa/docker/workbench/rerun-viewer/Dockerfile
@@ -15,6 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     NPA_BAKED_PYTHON=/opt/rerun/venv/bin/python \
     NPA_IMAGE_SOURCE_SHA=${NPA_SOURCE_SHA} \
     NPA_SKIP_EAGER_IMPORTS=1 \
+    NPA_LIGHT_WORKBENCH_TOOL=rerun-viewer \
     PYTHONPATH=/opt/npa/src \
     PYTHONUNBUFFERED=1 \
     RERUN_SDK_VERSION=${RERUN_SDK_VERSION}

--- a/npa/src/npa/cli/workbench/__init__.py
+++ b/npa/src/npa/cli/workbench/__init__.py
@@ -130,6 +130,40 @@ def _full_app() -> typer.Typer:
     return full
 
 
+def _default_light_app() -> typer.Typer:
+    """Cosmos2 plus the nurec visualize/finalize surface for viewer images.
+
+    The npa-rerun-viewer image bakes the light flag, but the workflow stages it
+    exists for (``workbench.nurec.visualize`` / ``workbench.nurec.finalize``)
+    live under ``npa workbench nurec`` — without this registration those stages
+    fail with "No such command 'nurec'" even though the image's setup installed
+    the nurec runtime deps. The nurec CLI chain imports only stdlib + typer, so
+    it is safe on the dependency-minimal surface.
+    """
+
+    from npa.cli.nurec import app as nurec_app
+    from npa.cli.workbench.cosmos2 import app as cosmos2_only_app
+
+    light = typer.Typer(
+        name="workbench",
+        help="Physical AI workbench tools.",
+        no_args_is_help=True,
+    )
+
+    @light.callback()
+    def main() -> None:
+        """Physical AI workbench tools."""
+
+        load_credentials(
+            warn=lambda msg: typer.echo(msg, err=True),
+            export_to_environment=True,
+        )
+
+    light.add_typer(cosmos2_only_app, name="cosmos2")
+    light.add_typer(nurec_app, name="nurec")
+    return light
+
+
 if _LIGHT_IMPORT:
     # Capability images need only this one command and deliberately omit the
     # unrelated platform SDK dependency tree. Preserve the historical Cosmos2
@@ -137,6 +171,6 @@ if _LIGHT_IMPORT:
     if _LIGHT_TOOL == "groot":
         app = _groot_light_app()
     else:
-        from npa.cli.workbench.cosmos2 import app
+        app = _default_light_app()
 else:
     app = _full_app()

--- a/npa/src/npa/cli/workbench/__init__.py
+++ b/npa/src/npa/cli/workbench/__init__.py
@@ -130,8 +130,8 @@ def _full_app() -> typer.Typer:
     return full
 
 
-def _default_light_app() -> typer.Typer:
-    """Cosmos2 plus the nurec visualize/finalize surface for viewer images.
+def _rerun_viewer_light_app() -> typer.Typer:
+    """Build the dependency-minimal nurec surface for the Rerun viewer image.
 
     The npa-rerun-viewer image bakes the light flag, but the workflow stages it
     exists for (``workbench.nurec.visualize`` / ``workbench.nurec.finalize``)
@@ -142,7 +142,6 @@ def _default_light_app() -> typer.Typer:
     """
 
     from npa.cli.nurec import app as nurec_app
-    from npa.cli.workbench.cosmos2 import app as cosmos2_only_app
 
     light = typer.Typer(
         name="workbench",
@@ -159,7 +158,6 @@ def _default_light_app() -> typer.Typer:
             export_to_environment=True,
         )
 
-    light.add_typer(cosmos2_only_app, name="cosmos2")
     light.add_typer(nurec_app, name="nurec")
     return light
 
@@ -170,7 +168,9 @@ if _LIGHT_IMPORT:
     # surface unless an image explicitly declares another narrow capability.
     if _LIGHT_TOOL == "groot":
         app = _groot_light_app()
+    elif _LIGHT_TOOL == "rerun-viewer":
+        app = _rerun_viewer_light_app()
     else:
-        app = _default_light_app()
+        from npa.cli.workbench.cosmos2 import app
 else:
     app = _full_app()

--- a/npa/src/npa/deploy/images.py
+++ b/npa/src/npa/deploy/images.py
@@ -145,7 +145,12 @@ PUBLICATION_QUARANTINE_TOOLS: frozenset[str] = (
 PUBLIC_RELEASE_TAG_OVERRIDES: dict[str, str] = {
     "cosmos2-transfer": "2.5.1-skypilot-ready-20260801T053000Z",
     "fiftyone": "1.15.0.post1",
-    "rerun-viewer": "0.31.4",
+    # 0.31.4 (plain) predates the bootstrap contract and cannot host a SkyPilot
+    # task: the container exits immediately, the provisioner's exec finds no
+    # ray-node container, and the stage retries forever. The 20260903 build is
+    # attested (org.nebius.npa.skypilot-bootstrap-contract=skypilot-0.12.2-v1)
+    # and anonymously pullable from GHCR.
+    "rerun-viewer": "0.31.4-sim2real-coherent-20260903",
 }
 
 # Release promotion for the rebuilt surfaces is bound to the exact manifests

--- a/npa/src/npa/deploy/public_release_manifest.json
+++ b/npa/src/npa/deploy/public_release_manifest.json
@@ -26,7 +26,7 @@
     "loop-eval": {"tag": "cuda13-b300-0.1.3-sm80-sm90-sm100-sm103-sm120-20260803T034152Z", "published_digest": "sha256:9cb111c56d9c1db8357b04f43e46790f6853213ff1a78fd0b2dae5ad337eb75a"},
     "ltx2": {"tag": "2.5-rtfetch-20260817", "published_digest": "sha256:c04b5b4e4c7f1c26e21671b3826ce8da75755c98bab2c54cd46137c609c2410b", "development_sha": "072952df62d23e8bc10d7e083230b3e2f2aeac52"},
     "reference-policy": {"tag": "cuda13-b300-0.1.2-sm80-sm90-sm100-sm103-sm120-20260803T034152Z", "published_digest": "sha256:58eb0d714f9d57fbae7fc8dfc56caf7f98f84699146c820dce18f2aaa2313cb6"},
-    "rerun-viewer": {"tag": "0.31.4", "published_digest": "sha256:9c78c5117bdd7de571a0b5ecd956b91d6690d8e02ce60672abb320c90e313fc7"},
+    "rerun-viewer": {"tag": "0.31.4-sim2real-coherent-20260903", "published_digest": "sha256:9517575558596e1b132a11fc623d3532014f3761d36d6b07a9b7f2342424b66b"},
     "retargeting": {"tag": "0.1.1", "published_digest": "sha256:e8782bd75084b59a82015a13c581fcd9520feeff6e00ea96367c820e7edfedff"},
     "sonic": {"tag": "cuda13-b300-0.1.2-k8s-runtime-sm80-sm90-sm100-sm103-sm120-20260803T034152Z", "published_digest": "sha256:c9ba0996b28f54b013e36da689638b386a7ef9c0c8c4413fc4b3c72ff1a808bb"},
     "sonic-mujoco": {"tag": "0.2.0-runtime", "published_digest": "sha256:2388d9e97269afaa414966e83a27f676a3f44d4271e9828c57bc13fbdce80f57", "development_sha": "5b5b5e69e9e686f8d5f305fd735a02f402f6da4b"},

--- a/npa/tests/cli/test_workbench_light_import.py
+++ b/npa/tests/cli/test_workbench_light_import.py
@@ -51,3 +51,22 @@ assert "--runtime" in result.output
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_rerun_viewer_light_workbench_exposes_only_nurec_parent() -> None:
+    result = _run_light_import(
+        """
+import sys
+from typer.testing import CliRunner
+from npa.cli.workbench import app
+assert "npa.cli.nurec" in sys.modules
+assert "npa.cli.workbench.cosmos2" not in sys.modules
+assert "npa.cli.groot" not in sys.modules
+result = CliRunner().invoke(app, ["nurec", "visualize", "--help"])
+assert result.exit_code == 0, result.output
+assert "--input-uri" in result.output
+""",
+        tool="rerun-viewer",
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/npa/tests/docker/test_rerun_viewer_image_contract.py
+++ b/npa/tests/docker/test_rerun_viewer_image_contract.py
@@ -17,6 +17,7 @@ def test_rerun_viewer_satisfies_skypilot_non_root_setup_contract() -> None:
         assert package in text
     assert "ubuntu ALL=(ALL) NOPASSWD:ALL" in text
     assert "USER ubuntu" in text
+    assert "NPA_LIGHT_WORKBENCH_TOOL=rerun-viewer" in text
     assert "rm -f /etc/ssh/ssh_host_*" in text
     assert (
         'org.nebius.npa.skypilot-bootstrap-contract="skypilot-0.12.2-v1"'


### PR DESCRIPTION
## Problem

The public GHCR channel pins `npa-rerun-viewer` to the plain `0.31.4` tag (`PUBLIC_RELEASE_TAG_OVERRIDES` in `npa/src/npa/deploy/images.py`). That digest predates the SkyPilot bootstrap contract and carries no `org.nebius.npa.skypilot-bootstrap-contract` label: the container exits immediately after start, SkyPilot's provisioner setup exec fails with `unable to upgrade connection: container not found ("ray-node")`, and the launch retries forever.

Observed live on a Living Lab participant cluster (us-central1, RTX PRO 6000): the `paidf-cosmos3` workflow's `visualize-quality-evidence` stage (toolRef `workbench.nurec.visualize`) silently looped `RUNNING → recreate` every ~3 minutes for **2h41m** with no terminal error. `preflight-images` correctly refuses this image (`missing bootstrap-contract attestation`) — the pin is what's wrong, not the check.

## Fix

Bump the public pin to `0.31.4-sim2real-coherent-20260903`, which:
- carries `org.nebius.npa.skypilot-bootstrap-contract=skypilot-0.12.2-v1` (verified via the OCI config on GHCR),
- is anonymously pullable from `ghcr.io/nebius/nebius-physical-ai`,
- makes `npa workbench workflow preflight-images npa/workflows/workbench/npa-workflows/paidf-cosmos3.yaml` pass end-to-end with `NPA_REGISTRY=ghcr.io/nebius/nebius-physical-ai` (previously hard-failed).

`npa-fiftyone:1.15.0.post1` (the other public override) already carries the attestation on its amd64 manifest — no change needed there.

## Validation

- [x] `preflight-images` over `paidf-cosmos3.yaml` passes against the public mirror with this pin
- [x] Attestation label verified directly on the GHCR OCI config for the new tag
- [ ] End-to-end `paidf-cosmos3` run through the visualize stages on a participant cluster — in flight at time of opening; will comment with the result

## Related follow-ups (not in this PR)

1. The `0.31.4` tag on GHCR remains a trap for anything else resolving it — consider retagging/republishing with the attested digest.
2. A pod whose container exits before SkyPilot setup currently retries indefinitely; failing the stage after N attempts with an image-compatibility hint would turn a silent multi-hour hang into a fast diagnosis.
3. Token Factory delisted `Qwen/Qwen2.5-VL-72B-Instruct` (2026-09-03), which is the `caption_model` default in `paidf-cosmos3.yaml` and `DEFAULT_VISION_MODEL` in `npa/clients/token_factory.py` — captioning/evaluator stages 404 out of the box; workaround is `--var caption_model=google/gemma-3-27b-it`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)