### PR TITLE
fix(sim2real): surface the real Cosmos Transfer vendor failure, not a generic message

### DIFF
--- a/npa/src/npa/workbench/cosmos/transfer.py
+++ b/npa/src/npa/workbench/cosmos/transfer.py
@@ -612,6 +612,46 @@ def _spec_with_prompt(repo: Path, spec: str, prompt: str, *, tag: str = "") -> s
         return spec
 
 
+# Known, path/prompt-free vendor failure signatures worth naming exactly.
+# Order matters: the first matching pattern wins.
+_VENDOR_FAILURE_SIGNATURES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"Access denied\.\s*This repository requires approval", re.I),
+        "gated Hugging Face repository access denied",
+    ),
+    (
+        re.compile(r"401 Client Error|Repository Not Found|GatedRepoError", re.I),
+        "Hugging Face authentication/authorization failed",
+    ),
+    (
+        re.compile(r"CUDA out of memory|OutOfMemoryError", re.I),
+        "CUDA out of memory",
+    ),
+    (
+        re.compile(r"No space left on device", re.I),
+        "no space left on device",
+    ),
+    (
+        re.compile(r"CUDA error|CUDA driver version|no CUDA-capable device", re.I),
+        "CUDA/GPU error",
+    ),
+)
+
+
+def _classify_vendor_failure(vendor_tail: str) -> str:
+    """Name a known upstream failure signature without echoing prompt/path text.
+
+    ``vendor_tail`` may contain the effective prompt and local input path, which
+    must not be surfaced. Only a short, fixed, human-authored description is
+    returned; the caller never gets the raw vendor text back.
+    """
+
+    for pattern, description in _VENDOR_FAILURE_SIGNATURES:
+        if pattern.search(vendor_tail):
+            return description
+    return "unrecognized vendor failure; inspect GPU/model access and retry"
+
+
 def run_cosmos_transfer(
     *,
     run_id: str = "",
@@ -720,19 +760,31 @@ def run_cosmos_transfer(
         # Upstream progress output includes the effective prompt and local input
         # path. Keep it in an unnamed, process-local file that is destroyed at
         # completion; the retained task log reports only aggregate NPA evidence.
+        # On failure, classify a few known, path/prompt-free vendor signatures
+        # (gated-model denial, CUDA OOM, disk-full) so the raised message names
+        # the real cause instead of forcing a live re-run to find it.
         with tempfile.TemporaryFile() as vendor_log:
-            subprocess.run(
-                argv,
-                cwd=repo,
-                env=env,
-                check=True,
-                stdout=vendor_log,
-                stderr=subprocess.STDOUT,
-            )
-    except (OSError, subprocess.CalledProcessError):
+            try:
+                subprocess.run(
+                    argv,
+                    cwd=repo,
+                    env=env,
+                    check=True,
+                    stdout=vendor_log,
+                    stderr=subprocess.STDOUT,
+                )
+            except subprocess.CalledProcessError as exc:
+                vendor_log.seek(0)
+                tail = vendor_log.read().decode("utf-8", errors="replace")
+                raise RuntimeError(
+                    "Cosmos Transfer inference failed "
+                    f"(exit {exc.returncode}): "
+                    f"{_classify_vendor_failure(tail)}"
+                ) from None
+    except OSError as exc:
         raise RuntimeError(
             "Cosmos Transfer inference failed; inspect GPU/model access and retry"
-        ) from None
+        ) from exc
     finally:
         if temp_spec is not None:
             try:

--- a/npa/tests/workbench/test_cosmos_transfer_input.py
+++ b/npa/tests/workbench/test_cosmos_transfer_input.py
@@ -516,6 +516,39 @@ def test_run_cosmos_transfer_accepts_small_guardrailed_video(
     assert result["video_path"].endswith("small.mp4")
 
 
+def test_run_cosmos_transfer_names_gated_access_denial_without_leaking_prompt(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / "examples").mkdir(parents=True)
+    monkeypatch.setattr(tx, "cosmos_transfer_repo", lambda: repo)
+    monkeypatch.setattr(tx, "ensure_env", lambda _repo: Path("/usr/bin/python3"))
+    monkeypatch.setenv("HF_TOKEN", "unit-test-placeholder")
+    secret_prompt = "a secret prompt that must never reach the raised message"
+
+    def fake_run(cmd, *_args, **kwargs):
+        assert secret_prompt not in " ".join(cmd)
+        kwargs["stdout"].write(
+            (
+                f"generating for prompt: {secret_prompt}\n"
+                "Error: Access denied. This repository requires approval.\n"
+            ).encode("utf-8")
+        )
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(tx.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as raised:
+        tx.run_cosmos_transfer(
+            run_id="denied", spec="assets/custom.json", prompt=secret_prompt
+        )
+
+    message = str(raised.value)
+    assert "gated Hugging Face repository access denied" in message
+    assert "exit 1" in message
+    assert secret_prompt not in message
+
+
 def test_run_cosmos_transfer_content_guardrail_opt_out_is_explicit(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

`run_cosmos_transfer()` captured upstream `examples/inference.py`'s full stdout in an unnamed temporary file and, on any `subprocess.CalledProcessError`, discarded it and raised a fixed `"inspect GPU/model access and retry"` message with `from None`, destroying the real traceback entirely.

Found live: a real sim2real run failed Stage 3 with only that generic message. Diagnosing the actual cause (a missing gated-repo acceptance — see companion PR #378) required a second in-cluster reproduction via the image's own baked-in smoke test, because nothing durable retained the real vendor output.

## Fix

Classify a small set of known, path/prompt-free vendor failure signatures (gated-repo denial, HF auth failure, CUDA OOM, disk-full, CUDA/GPU error) from the captured output and name the match plus the subprocess exit code in the raised message. The vendor log itself is still never echoed back verbatim, so a caller-supplied prompt or local input path (the reason this was originally private) still cannot leak through the exception message — covered by a new regression test that plants the secret prompt in the fake vendor output and asserts it never appears in the raised message.

## Tests

New test: `test_run_cosmos_transfer_names_gated_access_denial_without_leaking_prompt`. Full `test_cosmos_transfer_input.py`: 60 passed, 2 skipped (unchanged pre-existing skips). Full guardrails suite: 2,456 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)