### PR TITLE
fix(workflow): validate sealed splits and scope Cosmos2 access

### DIFF
--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -400,6 +400,15 @@ change the strict 5 cm metric or sealed gold contract. Do not add arbitrary run
 deadlines; `--max-wait-seconds 0` keeps durable status in
 `s3://<bucket>/sim2real/<run-id>/npa-workflow/runtime.json`.
 
+Keep every evaluation request within its sealed split. Submit computes the same
+bounded, stratified train/validation/gold allocation as EnvGen and checks
+`rollout_count` against training rows, `validation_count` against validation
+rows, and `gold_count` against gold rows before GPU work. For 64 requested rows
+at each boundary, `env_count=640` and
+`train_fraction=0.8` produce 512 training, 64 validation, and 64 gold scenarios.
+Smaller profiles are valid only when all three requested counts fit their
+respective split.
+
 ## Resume and verify
 
 ```bash

--- a/docs/workbench/sim2real-pr387-update.md
+++ b/docs/workbench/sim2real-pr387-update.md
@@ -1,0 +1,47 @@
+# PR #387: unique scope after the current-main audit
+
+The rebased PR retains the Sim2Real submit check that rejects rollout,
+validation, or gold requests exceeding their deterministic sealed splits before
+GPU work. Focused regression tests cover all three consumers and the supported
+boundary. The [operator guide](guides/sim2real-workflow.md) explains split
+sizing: 640 environments at a training fraction of 0.8 provide 512 training,
+64 validation, and 64 gold rows, supporting 64 requested rows at each boundary.
+
+The remaining access delta adds the Guardrail1 and Predict2.5-2B dependencies
+to the direct `cosmos2` capability. PAIDF submission keeps its deliberately
+narrow exact-checkpoint probe rather than inheriting the two additional
+`cosmos2` dependencies; a submit/access regression test protects that scope.
+Additive path-free classification tests cover the existing vendor diagnostics.
+
+The following work is already merged to `main` and is excluded from this PR's
+aggregate diff:
+
+| Merged PR | Existing behavior preserved |
+| --- | --- |
+| #378 | Sim2Real Guardrail1 and Predict2.5-2B access checks. |
+| #379 | Cosmos Transfer vendor-error diagnostics. |
+| #380 | Existing-cluster adoption, registry credentials, `source_sha`, and resume/retry guidance. |
+| #373 | Refreshed coherent images and runtime fixes, superseding the earlier image release associated with #387. |
+
+The guide preserves current main's `SOURCE_SHA` export and explanation. The
+shared workflow CLI also preserves #370's terminal plan-migration flags,
+arguments, and behavior while applying the PAIDF exclusion. Historical audit
+reports remain historical records; this update describes the reduced PR scope.
+
+## Reused workload evidence and limits
+
+The earlier PR #387 run completed all 21 rendered jobs: Cosmos Transfer,
+eight EnvGen shards producing 640 environments, 64 Isaac rollout episodes,
+64 hosted Cosmos evaluations, 200 PPO updates, 64 validation episodes, and
+64 sealed gold episodes. Durable read-back found JSON, JSONL, MP4, checkpoint,
+MCAP, and RRD artifacts. Strict 5 cm gold success was 0/64, and the workflow
+correctly took its loop-back branch with early exit disabled. Completion
+demonstrated orchestration, not policy efficacy.
+
+This evidence predates #373's refreshed images and point-cloud fix. The rebase
+reuses it without claiming a workload rerun of the current head or current
+images. The prior record also notes target-specific cache-volume and Isaac
+CUDA failures, and stale global storage configuration despite successful
+project-scoped storage probes. No new GPU workload or image build is part of
+this deduplication pass. Fresh repository validation is recorded in the PR's
+checks and validation summary.

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -1418,7 +1418,17 @@ def submit_cmd(
                     ["npa", "workbench", "workflow", "submit", str(yaml_path)]
                 ),
                 excluded_repos=(
-                    frozenset({"nvidia/Cosmos-Transfer2.5-2B"})
+                    # PAIDF deliberately checks only its selected Transfer
+                    # checkpoint, even though the tool also routes to cosmos2.
+                    frozenset(
+                        {
+                            "nvidia/Cosmos-Transfer2.5-2B",
+                            "nvidia/Cosmos-Guardrail1",
+                            "nvidia/Cosmos-Predict2.5-2B",
+                        }
+                    )
+                    if checkpoint_access_required and is_paidf_spec
+                    else frozenset({"nvidia/Cosmos-Transfer2.5-2B"})
                     if checkpoint_access_required
                     else frozenset()
                 ),

--- a/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
+++ b/npa/src/npa/orchestration/npa_workflow/sim2real_preflight.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 import json
+import math
 import re
 from typing import Any
 
@@ -79,6 +80,57 @@ def static_prerequisites(
                 "--var isaac_cache_pvc=<bound-rwx-pvc>",
             )
         )
+
+    # Rollout, validation, and gold evaluation use three distinct sealed splits.
+    # Catch undersized reduced-proof profiles before Transfer/EnvGen spend GPU time.
+    try:
+        env_count = int(str(config["env_count"]))
+        train_fraction = float(str(config["train_fraction"]))
+        rollout_count = int(str(config["rollout_count"]))
+        validation_count = int(str(config["validation_count"]))
+        gold_count = int(str(config["gold_count"]))
+    except (KeyError, TypeError, ValueError):
+        issues.append(
+            (
+                "Sim2Real train/validation/gold split inputs are missing or not numeric",
+                "set integer env_count, rollout_count, validation_count, and gold_count "
+                "with a numeric train_fraction",
+            )
+        )
+    else:
+        requested_train = (
+            int(round(env_count * train_fraction))
+            if math.isfinite(train_fraction) and 0.0 < train_fraction < 1.0
+            else -1
+        )
+        # EnvGen retains at least one train, validation, and gold row in each of
+        # its three difficulty strata, then divides the heldout remainder evenly.
+        train_count = min(env_count - 6, max(3, requested_train))
+        validation_rows = (env_count - train_count) // 2
+        gold_rows = env_count - train_count - validation_rows
+        if (
+            env_count < 9
+            or not math.isfinite(train_fraction)
+            or not 0.0 < train_fraction < 1.0
+            or rollout_count <= 0
+            or validation_count <= 0
+            or gold_count <= 0
+            or rollout_count > train_count
+            or validation_count > validation_rows
+            or gold_count > gold_rows
+        ):
+            issues.append(
+                (
+                    "Sim2Real evaluation counts exceed the sealed train/validation/gold "
+                    "splits or their split inputs are invalid "
+                    f"(env_count={env_count}, train_fraction={train_fraction}, "
+                    f"available={train_count}/{validation_rows}/{gold_rows}, "
+                    f"requested={rollout_count}/{validation_count}/{gold_count})",
+                    "choose positive counts with 0 < train_fraction < 1 and keep each "
+                    "request within its computed split; for example, env_count=640 and "
+                    "train_fraction=0.8 support 64 rollout, validation, and gold rows",
+                )
+            )
 
     requested = {str(name).strip() for name in requested_secret_envs}
     not_forwarded = [name for name in _REQUIRED_SECRET_ENVS if name not in requested]

--- a/npa/src/npa/workbench/model_access.py
+++ b/npa/src/npa/workbench/model_access.py
@@ -213,7 +213,7 @@ WORKBENCH_ASSETS: tuple[GatedAsset, ...] = (
     GatedAsset(
         "nvidia/Cosmos-Guardrail1",
         HF,
-        ("cosmos3", "sim2real"),
+        ("cosmos2", "cosmos3", "sim2real"),
         True,
         revision="d6d4bfa899a71454a700907664f3e88f503950cf",
         probe_path="video_content_safety_filter/safety_filter.pt",
@@ -223,7 +223,7 @@ WORKBENCH_ASSETS: tuple[GatedAsset, ...] = (
     GatedAsset(
         "nvidia/Cosmos-Predict2.5-2B",
         HF,
-        ("sim2real",),
+        ("cosmos2", "sim2real"),
         True,
         revision="85f8ae7bfe8f5525c8d103429524dcf12f98bf7b",
         probe_path="tokenizer.pth",

--- a/npa/tests/cli/test_workflow_submit_preflight.py
+++ b/npa/tests/cli/test_workflow_submit_preflight.py
@@ -322,9 +322,24 @@ def test_paidf_placement_fails_before_storage_or_staging_without_explicit_infra(
     stage_source.assert_not_called()
 
 
+@pytest.mark.parametrize("control", ["edge", "vis", "seg"])
 def test_paidf_existing_target_orders_placement_exact_access_then_image(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    control: str,
 ) -> None:
+    from npa.orchestration.npa_workflow.spec import load_spec
+
+    # The selected Transfer tool routes through cosmos2, so catalog expansion
+    # must not broaden PAIDF's deliberately narrow submit-time access fence.
+    assert {
+        item.repo for item in workflow_cli._workflow_access_requirements(load_spec(SPEC))
+    } == {
+        "nvidia/Cosmos-Transfer2.5-2B",
+        "nvidia/Cosmos-Guardrail1",
+        "nvidia/Cosmos-Predict2.5-2B",
+    }
+    monkeypatch.setenv("NPA_ACCESS_APPROVAL_STATE_PATH", str(tmp_path / "access.json"))
     events: list[str] = []
     for name in (
         "NEBIUS_TOKEN_FACTORY_KEY",
@@ -385,6 +400,8 @@ def test_paidf_existing_target_orders_placement_exact_access_then_image(
             "--no-deploy-if-absent",
             "--var",
             "bucket=real-bucket",
+            "--var",
+            f"augment_control={control}",
             "--assume-decision",
             "promote_checkpoint",
             "--secret-env",
@@ -400,7 +417,85 @@ def test_paidf_existing_target_orders_placement_exact_access_then_image(
 
     assert result.exit_code == 1
     assert isinstance(result.exception, RuntimeError)
-    assert events == ["placement", "exact:edge", "image"]
+    assert events == ["placement", f"exact:{control}", "image"]
+
+
+@pytest.mark.parametrize(
+    ("count_name", "count"),
+    [("rollout_count", "513"), ("validation_count", "65"), ("gold_count", "65")],
+)
+def test_sim2real_submit_rejects_oversized_sealed_split_before_images_or_launch(
+    monkeypatch: pytest.MonkeyPatch, mocker, count_name: str, count: str
+) -> None:
+    from types import SimpleNamespace
+
+    secret_names = (
+        "NEBIUS_TOKEN_FACTORY_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "HF_TOKEN",
+    )
+    for name in secret_names:
+        monkeypatch.setenv(name, "redacted")
+    mocker.patch("npa.cli.workbench.workflow._submit_prerequisites", return_value=[])
+    mocker.patch(
+        "npa.orchestration.npa_workflow.sim2real_preflight.kubernetes_prerequisites",
+        return_value=[],
+    )
+    mocker.patch(
+        "npa.clients.huggingface.validate_hf_access", return_value=SimpleNamespace(ok=True)
+    )
+    mocker.patch(
+        "npa.clients.token_factory.validate_model_access",
+        return_value=SimpleNamespace(ok=True),
+    )
+    images = mocker.patch("npa.cli.workbench.workflow._preflight_submit_images")
+    launch = mocker.patch("npa.orchestration.skypilot.workflow.submit_workflow")
+    runtime = mocker.patch("npa.cli.workbench.workflow._run_npa_workflow_runtime")
+    stage = mocker.patch("npa.cli.workbench.workflow._stage_npa_src_for_submit")
+    config = {
+        "bucket": "test-bucket",
+        "source_sha": "a" * 40,
+        "isaac_cache_pvc": "test-isaac-cache",
+        "env_count": "640",
+        "train_fraction": "0.8",
+        "rollout_count": "64",
+        "validation_count": "64",
+        "gold_count": "64",
+        **{
+            key: "ghcr.io/example/test@sha256:" + "a" * 64
+            for key in (
+                "controller_image",
+                "transfer_image",
+                "envgen_image",
+                "isaac_image",
+                "viewer_image",
+            )
+        },
+        count_name: count,
+    }
+    result = runner.invoke(
+        app,
+        [
+            "workbench",
+            "workflow",
+            "submit",
+            str(SIM2REAL_SPEC),
+            "--run-id",
+            "sim2real-split-preflight",
+            "--no-deploy-if-absent",
+            *[arg for key, value in config.items() for arg in ("--var", f"{key}={value}")],
+            *[arg for name in secret_names for arg in ("--secret-env", name)],
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "sealed train/validation/gold" in result.output
+    assert "available=512/64/64" in result.output
+    images.assert_not_called()
+    launch.assert_not_called()
+    runtime.assert_not_called()
+    stage.assert_not_called()
 
 
 def test_sim2real_submit_propagates_explicit_kubernetes_target(

--- a/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
+++ b/npa/tests/orchestration/npa_workflow/test_sim2real_preflight.py
@@ -22,6 +22,11 @@ def _config(**overrides):
         "viewer_image": digest,
         "isaac_cache_pvc": "npa-isaac-cache",
         "cosmos3_model": "nvidia/Cosmos3-Super-Reasoner",
+        "env_count": "10000",
+        "train_fraction": "0.8",
+        "rollout_count": "64",
+        "validation_count": "64",
+        "gold_count": "64",
     }
     config.update(overrides)
     return config
@@ -108,6 +113,108 @@ def test_static_preflight_rejects_unresolved_token_factory_key():
         token_factory_validator=lambda *_args: pytest.fail("missing key must not be probed"),
     )
     assert "could not be resolved" in "\n".join(item for item, _ in issues)
+
+
+@pytest.mark.parametrize(
+    ("env_count", "train_fraction", "rollout_count", "validation_count", "gold_count"),
+    [
+        ("64", "0.8", "64", "6", "7"),
+        ("80", "nan", "64", "8", "8"),
+        ("80", "inf", "64", "8", "8"),
+        ("640", "1e308", "64", "64", "64"),
+        ("640", "-1e308", "64", "64", "64"),
+        ("80", "1.0", "64", "3", "3"),
+        ("80", "0.8", "0", "8", "8"),
+        ("80", "0.8", "64", "9", "8"),
+        ("80", "0.8", "64", "8", "9"),
+        ("9", "0.8", "4", "3", "3"),
+        ("24", "0.8", "19", "3", "3"),
+        ("8", "0.8", "2", "3", "3"),
+    ],
+)
+def test_static_preflight_rejects_counts_larger_than_sealed_splits(
+    env_count, train_fraction, rollout_count, validation_count, gold_count
+):
+    issues = static_prerequisites(
+        _config(
+            env_count=env_count,
+            train_fraction=train_fraction,
+            rollout_count=rollout_count,
+            validation_count=validation_count,
+            gold_count=gold_count,
+        ),
+        requested_secret_envs=[
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "HF_TOKEN",
+            "NEBIUS_TOKEN_FACTORY_KEY",
+        ],
+        secret_values={"HF_TOKEN": "redacted", "NEBIUS_TOKEN_FACTORY_KEY": "redacted"},
+        hf_validator=lambda _token, repo: SimpleNamespace(ok=True, repo=repo),
+        token_factory_validator=lambda _key, model: SimpleNamespace(ok=True, model=model),
+    )
+
+    rendered = "\n".join(item for item, _ in issues)
+    assert "train/validation/gold" in rendered
+    assert "env_count=640" in "\n".join(fix for _, fix in issues)
+
+
+@pytest.mark.parametrize(
+    ("env_count", "train_fraction", "rollout_count", "validation_count", "gold_count"),
+    [
+        ("640", "0.8", "64", "64", "64"),
+        ("80", "0.8", "64", "8", "8"),
+        ("64", "0.8", "51", "6", "7"),
+        ("9", "0.8", "3", "3", "3"),
+        ("24", "0.8", "18", "3", "3"),
+        ("24", "0.01", "3", "10", "11"),
+    ],
+)
+def test_static_preflight_accepts_counts_that_fit_all_sealed_splits(
+    env_count, train_fraction, rollout_count, validation_count, gold_count
+):
+    issues = static_prerequisites(
+        _config(
+            env_count=env_count,
+            train_fraction=train_fraction,
+            rollout_count=rollout_count,
+            validation_count=validation_count,
+            gold_count=gold_count,
+        ),
+        requested_secret_envs=[
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "HF_TOKEN",
+            "NEBIUS_TOKEN_FACTORY_KEY",
+        ],
+        secret_values={"HF_TOKEN": "redacted", "NEBIUS_TOKEN_FACTORY_KEY": "redacted"},
+        hf_validator=lambda _token, repo: SimpleNamespace(ok=True, repo=repo),
+        token_factory_validator=lambda _key, model: SimpleNamespace(ok=True, model=model),
+    )
+
+    assert not any("train/validation/gold" in item for item, _ in issues)
+
+
+@pytest.mark.parametrize(
+    "key", ["env_count", "train_fraction", "rollout_count", "validation_count", "gold_count"]
+)
+@pytest.mark.parametrize("invalid_value", [None, "invalid"])
+def test_static_preflight_rejects_unparseable_split_inputs(key, invalid_value):
+    config = _config()
+    if invalid_value is None:
+        config.pop(key)
+    else:
+        config[key] = invalid_value
+
+    issues = static_prerequisites(
+        config,
+        requested_secret_envs=[],
+        secret_values={},
+        hf_validator=lambda *_args: pytest.fail("no token supplied"),
+        token_factory_validator=lambda *_args: pytest.fail("no key supplied"),
+    )
+
+    assert any("split inputs are missing or not numeric" in item for item, _ in issues)
 
 
 def _nodes(*, cpu="10", memory="40Gi", gpu="0", taints=None):

--- a/npa/tests/workbench/test_cosmos_transfer_input.py
+++ b/npa/tests/workbench/test_cosmos_transfer_input.py
@@ -743,6 +743,7 @@ def test_run_cosmos_transfer_names_gated_access_denial_without_leaking_prompt(
     (repo / "examples").mkdir(parents=True)
     monkeypatch.setattr(tx, "cosmos_transfer_repo", lambda: repo)
     monkeypatch.setattr(tx, "ensure_env", lambda _repo: Path("/usr/bin/python3"))
+    monkeypatch.setattr(tx, "prepare_guardrail_nltk_data", lambda **_kwargs: 0)
     monkeypatch.setenv("HF_TOKEN", "unit-test-placeholder")
     secret_prompt = "a secret prompt that must never reach the raised message"
 
@@ -767,6 +768,29 @@ def test_run_cosmos_transfer_names_gated_access_denial_without_leaking_prompt(
     assert "gated Hugging Face repository access denied" in message
     assert "exit 1" in message
     assert secret_prompt not in message
+
+
+@pytest.mark.parametrize(
+    ("vendor_output", "classification"),
+    [
+        ("GatedRepoError", "Hugging Face authentication/authorization failed"),
+        ("torch.cuda.OutOfMemoryError", "CUDA out of memory"),
+        ("OSError: No space left on device", "no space left on device"),
+        ("CUDA driver version is insufficient", "CUDA/GPU error"),
+        (
+            "unexpected internal vendor failure",
+            "unrecognized vendor failure; inspect GPU/model access and retry",
+        ),
+    ],
+)
+def test_vendor_failure_classification_is_fixed_and_path_free(
+    vendor_output: str, classification: str
+) -> None:
+    result = tx._classify_vendor_failure(
+        f"/operator/private/input.mp4: {vendor_output}\nprompt: confidential example"
+    )
+
+    assert result == classification
 
 
 def test_run_cosmos_transfer_content_guardrail_opt_out_is_explicit(

--- a/npa/tests/workbench/test_model_access.py
+++ b/npa/tests/workbench/test_model_access.py
@@ -99,6 +99,37 @@ def test_sim2real_access_includes_cosmos_transfer_runtime_dependencies() -> None
     assert guardrail.gated and tokenizer.gated
 
 
+@pytest.mark.parametrize(
+    "denied_repo", ["nvidia/Cosmos-Guardrail1", "nvidia/Cosmos-Predict2.5-2B"]
+)
+def test_cosmos2_access_checks_auxiliary_runtime_dependencies(denied_repo: str) -> None:
+    observed = {}
+
+    def validate(_token, repo, _repo_type, revision, probe_path):
+        observed[repo] = (revision, probe_path)
+        return _HFResult(
+            ok=repo != denied_repo, status_code=403 if repo == denied_repo else 200
+        )
+
+    results = check_workbench_access(
+        hf_token="synthetic-token",
+        ngc_key="",
+        hf_validator=validate,
+        capabilities=["cosmos2"],
+        gated_only=True,
+    )
+
+    assert observed["nvidia/Cosmos-Guardrail1"] == (
+        "d6d4bfa899a71454a700907664f3e88f503950cf",
+        "video_content_safety_filter/safety_filter.pt",
+    )
+    assert observed["nvidia/Cosmos-Predict2.5-2B"] == (
+        "85f8ae7bfe8f5525c8d103429524dcf12f98bf7b",
+        "tokenizer.pth",
+    )
+    assert {result.name for result in results if result.status == FAIL} == {denied_repo}
+
+
 def test_hf_gated_warns_without_token() -> None:
     result = check_hf_asset(_gated_asset(), "", hf_validator=None)
     assert result.status == WARN


### PR DESCRIPTION
Reject Sim2Real rollout, validation, and gold counts that exceed their deterministic sealed splits before image work or GPU submission. Direct `cosmos2` access checks also gain the existing pinned Guardrail1 and Predict2.5 tokenizer requirements, while PAIDF retains its selected-checkpoint-only access fence.

The regression coverage exercises each oversized count through submit, split boundaries and malformed inputs, direct Cosmos2 access denial, PAIDF's real submit/access routing, and five safe diagnostic classifications. The operator guide adds split-sizing guidance; a concise audit update records the reduced scope and historical evidence.

## Deduplication

Rebased onto current `main` and consolidated the unique changes into one commit. Removed the duplicated Sim2Real access work from #378, Transfer diagnostic implementation from #379, and adoption/registry/source/resume documentation from #380. Earlier image work superseded by #373 remains excluded. Main's `SOURCE_SHA` exports/explanation and #370's workflow migration and cancellation behavior are preserved. The existing Sim2Real access test and historical audit report are unchanged.

## Validation

- Exact-head GitHub CI (`d244209d3084053ceff407995fe8ed2b9139ed94`): all seven checks passed — Ruff, gitleaks, confidentiality scan, guardrails, docs drift, browser tests, and Python 3.12.
- Python 3.12 CI: 13,131 passed, 389 skipped, 1 xpassed; 73.61% coverage against the 60% gate. CLI installation, e2e shell syntax, and source-drift steps also passed.
- Ruff: passed.
- Onboarding smoke: 114 passed.
- Affected tests: 312 passed; final split-preflight recheck: 35 passed (overlapping suites).
- Local full non-live invocation: 13,114 passed, 1 failed, 36 skipped, 1 xpassed. The sole failure was a guardrail finding a temporary test fixture under the checkout; that artifact issue was corrected and the final guardrail rerun passed all 2,447 tests.
- Canonical spec validation and 42-wave offline loop-back plan: passed.
- CLI docs drift, aggregate confidentiality scan, and gitleaks: passed.

The final rebase picked up documentation-only changes from #391. Python source/tests are identical to the locally tested tree; guardrails were rerun after that rebase, and the full GitHub suite passed on the final pushed head.

## Reused live evidence and limitations

The earlier 21-job canonical run covered Transfer, eight EnvGen shards (640 environments), 64 rollout/hosted-evaluation/validation/gold rows, 200 PPO updates, and durable final artifacts. Gold success was 0/64: this proved orchestration, not policy efficacy. It predates #373's refreshed images and point-cloud fix and is reused as historical evidence, not an exact-head or current-image rerun. No new expensive workload or image build was launched in this deduplication pass. #373's later exact-image attempt failed closed before launch when its configured hosted evaluator was unavailable.
