### PR TITLE
Add provider-neutral PAIDF campaign and decision contracts

### DIFF
--- a/docs/workbench/guides/README.md
+++ b/docs/workbench/guides/README.md
@@ -97,6 +97,7 @@ tools.
 | --- | --- |
 | [physical-ai-data-factory-deploy.md](physical-ai-data-factory-deploy.md) | **Copy-paste runbook** — from zero to a running blueprint (includes a one-block Quick start that stages input frames and submits) |
 | [physical-ai-data-factory.md](physical-ai-data-factory.md) | Conceptual guide — blueprint→stage mapping, S3 layout, viewing results |
+| [paidf-campaign-reuse.md](paidf-campaign-reuse.md) | Reuse one immutable source, generation, and evaluation campaign across provider workshops |
 
 > **Fastest start:** the deploy runbook's [Quick start](physical-ai-data-factory-deploy.md#quick-start-copy-paste)
 > seeds captionable frames (no dataset needed) and submits an input-conditioned

--- a/docs/workbench/guides/paidf-campaign-reuse.md
+++ b/docs/workbench/guides/paidf-campaign-reuse.md
@@ -1,0 +1,120 @@
+<!-- register: operator runbook | reader: PAIDF workshop authors and provider-integration contributors | consumed: workshop preparation and derivative-run execution -->
+# Reuse one PAIDF campaign across provider workshops
+
+Build the expensive source, Cosmos generation, and evaluation stages once. Freeze their exact manifests as a base campaign. Each Encord, FiftyOne, Foxglove, Rerun, or simulation-provider workshop then becomes a derivative run that reads the base and writes to its own prefix.
+
+This is a small contract layer, not a provider plugin system. Provider execution remains in the relevant SDK, CLI, or workflow code.
+
+## The two run types
+
+A base campaign contains three required artifact references:
+
+- `source`: authoritative trajectories and their robot, task, timing, action, and state contracts
+- `generation`: Cosmos outputs, prompts, seeds, model identity, and source lineage
+- `evaluation`: deterministic and model-assisted quality evidence
+
+Every reference includes an exact S3 object URI, its SHA-256 digest, and its payload schema. `stage_fingerprints` provide one content identity per base stage, and every artifact digest must equal its stage fingerprint. A campaign with an extra, missing, or divergent base stage fails validation. Regeneration creates a new base campaign instead of silently changing an existing one.
+
+A partner run contains:
+
+- the base campaign ID, manifest URI, and canonical digest
+- the provider name and one role: `curation`, `observability`, or `simulation`
+- exact base stages and artifacts reused read-only
+- overlay stages that the partner run will execute
+- a hashed provider configuration artifact
+- credential references such as `secret://antioch/workshop`, never credential values
+- a separate S3 output prefix
+
+The contract rejects partner inputs that execute `source`, `generation`, or `evaluation`.
+
+## Common envelopes
+
+All partner integrations use the same three envelopes:
+
+| Envelope | Purpose |
+|---|---|
+| `npa.paidf.partner-input.v1` | Pins the base campaign, provider configuration, read set, planned overlay stages, and write prefix. |
+| `npa.paidf.execution-receipt.v1` | Accounts for every declared overlay stage and records a terminal status without claiming that the base changed. |
+| `npa.paidf.partner-result.v1` | Links terminal artifacts to the exact input and receipt digests and requires every output to remain under the derivative prefix. |
+
+The implementation is in `npa.workflows.paidf_campaign`. It is dependency-light and does not create cloud or provider resources.
+
+## Decision contracts
+
+Curation outputs flow through three provider-neutral artifacts, so no dataset identity couples to a specific provider:
+
+- `npa.paidf.candidates.v1`: one row per generated variant, each pinned by `candidate_id`, source episode and camera identity, and the exact output/source SHA-256 digests.
+- `npa.paidf.decisions.v1`: one `accept`, `reject`, or `review` per candidate. The provider object is exactly `name` plus a `curation` or `evaluation` role, and each decision carries exactly `candidate_id`, `decision`, `evidence`, `reason`, and a caller-supplied `decided_at` timestamp in canonical UTC-second form (`YYYY-MM-DDTHH:MM:SSZ`). Canonical builders never read the wall clock.
+- `npa.paidf.reconciliation.v1`: the authoritative keep/drop manifest. `accept` enters `keep`; `reject` and `review` enter `drop`. `review` is a valid but unresolved state: reconciliation reports its count and IDs explicitly, and it never enters accepted replacements.
+
+Provider exports reconcile to the candidate manifest by exact external ID, and every terminal export row must carry a non-null `accept`, `reject`, or `review` decision. The accepted-replacement manifest is derived only after the reconciliation is proven to cover every candidate exactly once with consistent states.
+
+## Object-storage layout
+
+```text
+paidf/
+  campaigns/
+    <campaign-id>/
+      campaign.json
+      source/
+      generation/
+      evaluation/
+  derivatives/
+    encord/<run-id>/
+    fiftyone/<run-id>/
+    foxglove/<run-id>/
+    rerun/<run-id>/
+    antioch/<run-id>/
+```
+
+The directories illustrate ownership. The manifests contain exact object references, so a consumer does not infer authority from path names.
+
+## Antioch derivative run
+
+Antioch is a simulation overlay, not a curation adapter. Its first workshop should reuse the base robot, task, scenario, and evaluation contracts while producing new provider-specific simulation evidence.
+
+```python
+from npa.workflows.paidf_campaign import build_antioch_input
+
+partner_input = build_antioch_input(
+    campaign,
+    campaign_manifest_uri="s3://<bucket>/paidf/campaigns/<campaign-id>/campaign.json",
+    run_id="<antioch-run-id>",
+    provider_config={
+        "uri": "s3://<bucket>/paidf/config/antioch.json",
+        "sha256": "<64-lowercase-hex-characters>",
+        "schema": "npa.paidf.antioch-config.v1",
+    },
+    credential_refs=("secret://antioch/workshop",),
+    output_prefix="s3://<bucket>/paidf/derivatives/antioch/<antioch-run-id>/",
+)
+```
+
+The generated plan runs only:
+
+1. `partner-simulation`
+2. `result-normalization`
+3. `comparison`
+
+It does not invoke Cosmos or replace the base source, generation, or evaluation manifests. Provider outputs should normalize into JSON, RRD, MCAP, or object references that Workbench can inspect without hidden provider state.
+
+Antioch's exact production API, authentication names, artifact schemas, and training-ready episode export remain discovery items. Keep those details inside the Antioch configuration and executor until live evidence proves a stable reusable boundary.
+
+## Workshop execution rule
+
+Start a derivative workshop with:
+
+1. one base campaign manifest URI
+2. one provider configuration artifact
+3. any required secret references
+4. one new derivative output prefix
+
+The workshop is repeatable when a clean run produces validated input, receipt, and result envelopes; reads the same base hashes; accounts for every declared stage; and writes nothing outside its derivative prefix.
+
+For Encord and FiftyOne, the overlay payload contains curation decisions. For Foxglove and Rerun, it contains observability indexes and recordings. For Antioch or another simulator, it contains rollout, telemetry, and comparison evidence. The envelope stays stable while the role-specific payload changes.
+
+## Deliberate limits
+
+Do not add a provider registry, plugin loader, cache service, data-versioning platform, or campaign-management daemon for the first two integrations. Implement the second provider against this envelope, compare the two real payloads, and extract another abstraction only when both require the same behavior.
+
+Do not add a workflow specification until its provider path can satisfy the repository's live execution and artifact proof requirements. The contract module and runbook support preparatory and fixture-based work without presenting it as a live provider integration.

--- a/npa/src/npa/workflows/paidf_campaign.py
+++ b/npa/src/npa/workflows/paidf_campaign.py
@@ -1,0 +1,1327 @@
+"""Provider-neutral contracts for reusing one PAIDF campaign across partners.
+
+The base campaign is immutable. Partner runs consume its exact artifact
+references and publish to a separate prefix. This module defines the handoff
+envelopes, the provider-neutral candidate/decision/reconciliation contracts,
+and accepted-replacement selection; provider execution remains in
+provider-specific code or workflow stages.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+from urllib.parse import urlparse
+
+
+CAMPAIGN_SCHEMA = "npa.paidf.campaign.v1"
+FROZEN_SOURCE_MANIFEST_SCHEMA = "npa.paidf.frozen-source-manifest.v1"
+PARTNER_INPUT_SCHEMA = "npa.paidf.partner-input.v1"
+EXECUTION_RECEIPT_SCHEMA = "npa.paidf.execution-receipt.v1"
+PARTNER_RESULT_SCHEMA = "npa.paidf.partner-result.v1"
+CANDIDATE_MANIFEST_SCHEMA = "npa.paidf.candidates.v1"
+DECISION_MANIFEST_SCHEMA = "npa.paidf.decisions.v1"
+RECONCILIATION_SCHEMA = "npa.paidf.reconciliation.v1"
+ACCEPTED_REPLACEMENTS_SCHEMA = "npa.paidf.accepted-variants.v1"
+
+BASE_STAGES = ("source", "generation", "evaluation")
+PARTNER_ROLES = frozenset({"curation", "observability", "simulation"})
+PROVIDER_ROLES = frozenset({"curation", "evaluation"})
+TERMINAL_STATUSES = frozenset({"completed", "failed"})
+DECISION_STATES = ("accept", "reject", "review")
+DECISION_FIELDS = frozenset(
+    {"candidate_id", "decision", "evidence", "reason", "decided_at"}
+)
+PROVIDER_FIELDS = frozenset({"name", "role"})
+VARIANT_IDENTITY_FIELDS = frozenset({"variant_id", "output_sha256", "source_sha256"})
+RECONCILIATION_TOTAL_FIELDS = frozenset(
+    {"candidates", "keep", "drop", "unresolved_review", "identity_gaps"}
+)
+
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_CREDENTIAL_REF = re.compile(r"^(?:env|secret)://[A-Za-z0-9._/-]+$")
+_UTC_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+class PaidfContractError(ValueError):
+    """Raised when a PAIDF campaign or partner envelope is unsafe or invalid."""
+
+
+def canonical_digest(value: Any) -> str:
+    """Return a stable SHA-256 digest for a JSON-compatible value."""
+
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_campaign(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and return an immutable-base campaign manifest.
+
+    The campaign carries exactly the three base stages; every stage artifact's
+    digest must equal its stage fingerprint, so a campaign cannot claim one
+    identity while pinning another.
+    """
+
+    campaign = _object(payload, "campaign")
+    _exact_schema(campaign, CAMPAIGN_SCHEMA, "campaign")
+    _identifier(campaign.get("campaign_id"), "campaign.campaign_id")
+
+    artifacts = _object(campaign.get("artifacts"), "campaign.artifacts")
+    fingerprints = _object(
+        campaign.get("stage_fingerprints"), "campaign.stage_fingerprints"
+    )
+    if set(artifacts) != set(BASE_STAGES):
+        raise PaidfContractError(
+            "campaign artifacts must contain exactly the base stages: "
+            + ", ".join(BASE_STAGES)
+        )
+    if set(fingerprints) != set(BASE_STAGES):
+        raise PaidfContractError(
+            "campaign stage fingerprints must contain exactly the base stages: "
+            + ", ".join(BASE_STAGES)
+        )
+    for stage in BASE_STAGES:
+        ref = _artifact_ref(artifacts[stage], f"campaign.artifacts.{stage}")
+        fingerprint = _sha256(
+            fingerprints[stage], f"campaign.stage_fingerprints.{stage}"
+        )
+        if ref["sha256"] != fingerprint:
+            raise PaidfContractError(
+                f"campaign artifact digest for {stage} does not match its "
+                "stage fingerprint"
+            )
+
+    return dict(campaign)
+
+
+def build_partner_input(
+    campaign: Mapping[str, Any],
+    *,
+    campaign_manifest_uri: str,
+    run_id: str,
+    provider: str,
+    role: str,
+    provider_config: Mapping[str, Any],
+    output_prefix: str,
+    executed_stages: Iterable[str],
+    credential_refs: Iterable[str] = (),
+    reused_stages: Iterable[str] = BASE_STAGES,
+) -> dict[str, Any]:
+    """Build a provider-neutral input envelope for a derivative partner run."""
+
+    base = validate_campaign(campaign)
+    reuse = _stage_list(list(reused_stages), "reused_stages")
+    execute = _stage_list(list(executed_stages), "executed_stages")
+    unknown_reuse = set(reuse) - set(BASE_STAGES)
+    if unknown_reuse:
+        raise PaidfContractError(
+            "partner input contains unknown base stages: "
+            + ", ".join(sorted(unknown_reuse))
+        )
+    artifacts = _object(base["artifacts"], "campaign.artifacts")
+    payload: dict[str, Any] = {
+        "schema": PARTNER_INPUT_SCHEMA,
+        "run_id": run_id,
+        "parent_campaign": {
+            "campaign_id": base["campaign_id"],
+            "manifest_uri": campaign_manifest_uri,
+            "sha256": canonical_digest(base),
+        },
+        "provider": {"name": provider, "role": role},
+        "provider_config": dict(provider_config),
+        "credential_refs": list(credential_refs),
+        "source_mode": "read-only",
+        "reuse": {
+            "stages": reuse,
+            "artifacts": {stage: artifacts[stage] for stage in reuse},
+        },
+        "execute": {"stages": execute},
+        "output_prefix": output_prefix,
+    }
+    return validate_partner_input(payload, campaign=base)
+
+
+def build_antioch_input(
+    campaign: Mapping[str, Any],
+    *,
+    campaign_manifest_uri: str,
+    run_id: str,
+    provider_config: Mapping[str, Any],
+    output_prefix: str,
+    credential_refs: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Build the thin Antioch overlay without rerunning base PAIDF stages."""
+
+    return build_partner_input(
+        campaign,
+        campaign_manifest_uri=campaign_manifest_uri,
+        run_id=run_id,
+        provider="antioch",
+        role="simulation",
+        provider_config=provider_config,
+        output_prefix=output_prefix,
+        executed_stages=(
+            "partner-simulation",
+            "result-normalization",
+            "comparison",
+        ),
+        credential_refs=credential_refs,
+        reused_stages=BASE_STAGES,
+    )
+
+
+def validate_partner_input(
+    payload: Mapping[str, Any], *, campaign: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Validate a derivative run against the exact immutable base campaign."""
+
+    base = validate_campaign(campaign)
+    partner_input = _object(payload, "partner input")
+    _exact_schema(partner_input, PARTNER_INPUT_SCHEMA, "partner input")
+    _identifier(partner_input.get("run_id"), "partner_input.run_id")
+
+    parent = _object(
+        partner_input.get("parent_campaign"), "partner_input.parent_campaign"
+    )
+    if parent.get("campaign_id") != base["campaign_id"]:
+        raise PaidfContractError("partner input references a different campaign ID")
+    _s3_uri(
+        parent.get("manifest_uri"),
+        "partner_input.parent_campaign.manifest_uri",
+        object_required=True,
+    )
+    if parent.get("sha256") != canonical_digest(base):
+        raise PaidfContractError("partner input campaign digest does not match")
+
+    provider = _object(partner_input.get("provider"), "partner_input.provider")
+    _identifier(provider.get("name"), "partner_input.provider.name")
+    if provider.get("role") not in PARTNER_ROLES:
+        raise PaidfContractError(
+            "partner_input.provider.role must be curation, observability, or simulation"
+        )
+    _artifact_ref(
+        partner_input.get("provider_config"), "partner_input.provider_config"
+    )
+    credential_refs = _list(
+        partner_input.get("credential_refs"), "partner_input.credential_refs"
+    )
+    for index, ref in enumerate(credential_refs):
+        if not isinstance(ref, str) or not _CREDENTIAL_REF.fullmatch(ref):
+            raise PaidfContractError(
+                "partner_input.credential_refs"
+                f"[{index}] must be an env:// or secret:// reference"
+            )
+    if partner_input.get("source_mode") != "read-only":
+        raise PaidfContractError("partner input must consume the base as read-only")
+
+    reuse = _object(partner_input.get("reuse"), "partner_input.reuse")
+    reused_stages = _stage_list(reuse.get("stages"), "partner_input.reuse.stages")
+    if not reused_stages:
+        raise PaidfContractError("partner input must reuse at least one base stage")
+    unknown_reuse = set(reused_stages) - set(BASE_STAGES)
+    if unknown_reuse:
+        raise PaidfContractError(
+            "partner input contains unknown base stages: "
+            + ", ".join(sorted(unknown_reuse))
+        )
+    reused_artifacts = _object(
+        reuse.get("artifacts"), "partner_input.reuse.artifacts"
+    )
+    if set(reused_artifacts) != set(reused_stages):
+        raise PaidfContractError(
+            "partner input reuse artifacts must exactly match reused stages"
+        )
+    base_artifacts = _object(base["artifacts"], "campaign.artifacts")
+    for stage in reused_stages:
+        _artifact_ref(
+            reused_artifacts.get(stage),
+            f"partner_input.reuse.artifacts.{stage}",
+        )
+        if reused_artifacts.get(stage) != base_artifacts[stage]:
+            raise PaidfContractError(
+                f"partner input changed the base artifact reference for {stage}"
+            )
+
+    execute = _object(partner_input.get("execute"), "partner_input.execute")
+    executed_stages = _stage_list(
+        execute.get("stages"), "partner_input.execute.stages"
+    )
+    if not executed_stages:
+        raise PaidfContractError("partner input must execute at least one overlay stage")
+    forbidden = set(executed_stages) & set(BASE_STAGES)
+    if forbidden:
+        raise PaidfContractError(
+            "partner runs cannot execute immutable base stages: "
+            + ", ".join(sorted(forbidden))
+        )
+    overlap = set(executed_stages) & set(reused_stages)
+    if overlap:
+        raise PaidfContractError(
+            "partner stages cannot be both reused and executed: "
+            + ", ".join(sorted(overlap))
+        )
+
+    output_prefix = _s3_uri(
+        partner_input.get("output_prefix"),
+        "partner_input.output_prefix",
+        object_required=False,
+    )
+    if not output_prefix.endswith("/"):
+        raise PaidfContractError("partner_input.output_prefix must end with '/'")
+    campaign_prefix = _s3_parent(parent["manifest_uri"])
+    if output_prefix.startswith(campaign_prefix) or campaign_prefix.startswith(
+        output_prefix
+    ):
+        raise PaidfContractError(
+            "partner output prefix must be separate from the base campaign"
+        )
+
+    return dict(partner_input)
+
+
+def build_execution_receipt(
+    partner_input: Mapping[str, Any],
+    *,
+    status: str,
+    stage_results: Mapping[str, str],
+) -> dict[str, Any]:
+    """Build a receipt that records which declared overlay stages ran."""
+
+    receipt: dict[str, Any] = {
+        "schema": EXECUTION_RECEIPT_SCHEMA,
+        "run_id": partner_input.get("run_id"),
+        "input_sha256": canonical_digest(partner_input),
+        "provider": partner_input.get("provider"),
+        "status": status,
+        "stage_results": dict(stage_results),
+        "source_mutated": False,
+    }
+    return validate_execution_receipt(receipt, partner_input=partner_input)
+
+
+def validate_execution_receipt(
+    payload: Mapping[str, Any], *, partner_input: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Validate execution evidence against the exact partner input envelope."""
+
+    receipt = _object(payload, "execution receipt")
+    _exact_schema(receipt, EXECUTION_RECEIPT_SCHEMA, "execution receipt")
+    if receipt.get("run_id") != partner_input.get("run_id"):
+        raise PaidfContractError("execution receipt run ID does not match input")
+    if receipt.get("input_sha256") != canonical_digest(partner_input):
+        raise PaidfContractError("execution receipt input digest does not match")
+    if receipt.get("provider") != partner_input.get("provider"):
+        raise PaidfContractError("execution receipt provider does not match input")
+    status = receipt.get("status")
+    if status not in TERMINAL_STATUSES:
+        raise PaidfContractError("execution receipt status must be completed or failed")
+    if receipt.get("source_mutated") is not False:
+        raise PaidfContractError("execution receipt must prove source_mutated is false")
+
+    stage_results = _object(
+        receipt.get("stage_results"), "execution_receipt.stage_results"
+    )
+    declared = _object(partner_input.get("execute"), "partner_input.execute").get(
+        "stages"
+    )
+    if set(stage_results) != set(_stage_list(declared, "partner_input.execute.stages")):
+        raise PaidfContractError(
+            "execution receipt must account for every declared overlay stage"
+        )
+    allowed_stage_statuses = {"completed", "failed", "skipped"}
+    if any(value not in allowed_stage_statuses for value in stage_results.values()):
+        raise PaidfContractError("execution receipt contains an invalid stage status")
+    if status == "completed" and any(
+        value != "completed" for value in stage_results.values()
+    ):
+        raise PaidfContractError(
+            "completed execution receipt requires every stage to be completed"
+        )
+    return dict(receipt)
+
+
+def build_partner_result(
+    partner_input: Mapping[str, Any],
+    execution_receipt: Mapping[str, Any],
+    *,
+    artifacts: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Build the terminal partner result without changing the base campaign."""
+
+    validate_execution_receipt(execution_receipt, partner_input=partner_input)
+    result: dict[str, Any] = {
+        "schema": PARTNER_RESULT_SCHEMA,
+        "run_id": partner_input.get("run_id"),
+        "input_sha256": canonical_digest(partner_input),
+        "execution_receipt_sha256": canonical_digest(execution_receipt),
+        "parent_campaign": partner_input.get("parent_campaign"),
+        "provider": partner_input.get("provider"),
+        "status": execution_receipt.get("status"),
+        "artifacts": dict(artifacts),
+        "source_mutated": False,
+    }
+    return validate_partner_result(
+        result,
+        partner_input=partner_input,
+        execution_receipt=execution_receipt,
+    )
+
+
+def validate_partner_result(
+    payload: Mapping[str, Any],
+    *,
+    partner_input: Mapping[str, Any],
+    execution_receipt: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate a partner result and its isolated artifact write surface."""
+
+    validate_execution_receipt(execution_receipt, partner_input=partner_input)
+    result = _object(payload, "partner result")
+    _exact_schema(result, PARTNER_RESULT_SCHEMA, "partner result")
+    if result.get("run_id") != partner_input.get("run_id"):
+        raise PaidfContractError("partner result run ID does not match input")
+    if result.get("input_sha256") != canonical_digest(partner_input):
+        raise PaidfContractError("partner result input digest does not match")
+    if result.get("execution_receipt_sha256") != canonical_digest(execution_receipt):
+        raise PaidfContractError("partner result receipt digest does not match")
+    for field in ("parent_campaign", "provider"):
+        if result.get(field) != partner_input.get(field):
+            raise PaidfContractError(f"partner result {field} does not match input")
+    if result.get("status") != execution_receipt.get("status"):
+        raise PaidfContractError("partner result status does not match receipt")
+    if result.get("source_mutated") is not False:
+        raise PaidfContractError("partner result must prove source_mutated is false")
+
+    output_prefix = str(partner_input.get("output_prefix"))
+    artifacts = _object(result.get("artifacts"), "partner_result.artifacts")
+    if result.get("status") == "completed" and not artifacts:
+        raise PaidfContractError("completed partner result requires artifacts")
+    for name, artifact in artifacts.items():
+        _identifier(name, f"partner_result.artifacts.{name}.name")
+        ref = _artifact_ref(artifact, f"partner_result.artifacts.{name}")
+        if not ref["uri"].startswith(output_prefix):
+            raise PaidfContractError(
+                f"partner result artifact {name} is outside the output prefix"
+            )
+    return dict(result)
+
+
+def validate_candidate_manifest(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a provider-neutral candidate manifest (one row per variant).
+
+    Every candidate carries a stable ``candidate_id`` and the exact source
+    identity it was generated from. Candidate IDs must be unique; source
+    episode, camera, variant, and evaluation references must be present.
+    """
+
+    manifest = _object(payload, "candidate manifest")
+    _exact_schema(manifest, CANDIDATE_MANIFEST_SCHEMA, "candidate manifest")
+    candidates = _list(manifest.get("candidates"), "candidate manifest.candidates")
+    seen: set[str] = set()
+    for index, raw in enumerate(candidates):
+        candidate = _object(raw, f"candidate manifest.candidates[{index}]")
+        candidate_id = _identifier(
+            candidate.get("candidate_id"),
+            f"candidate manifest.candidates[{index}].candidate_id",
+        )
+        if candidate_id in seen:
+            raise PaidfContractError(
+                f"duplicate candidate_id in candidate manifest: {candidate_id}"
+            )
+        seen.add(candidate_id)
+        _identifier(
+            candidate.get("source_episode_id"),
+            f"candidate {candidate_id}.source_episode_id",
+        )
+        _source_episode_index(
+            candidate.get("source_episode_index"),
+            f"candidate {candidate_id}.source_episode_index",
+        )
+        _identifier(
+            candidate.get("camera_key"), f"candidate {candidate_id}.camera_key"
+        )
+        variant = _object(candidate.get("variant"), f"candidate {candidate_id}.variant")
+        _identifier(variant.get("variant_id"), f"candidate {candidate_id}.variant.variant_id")
+        _sha256(
+            variant.get("output_sha256"),
+            f"candidate {candidate_id}.variant.output_sha256",
+        )
+        _sha256(
+            variant.get("source_sha256"),
+            f"candidate {candidate_id}.variant.source_sha256",
+        )
+        _object(candidate.get("evaluation"), f"candidate {candidate_id}.evaluation")
+    return dict(manifest)
+
+
+def build_candidate(
+    *,
+    candidate_id: str,
+    source_episode_id: str,
+    source_episode_index: int,
+    camera_key: str,
+    variant_id: str,
+    output_sha256: str,
+    source_sha256: str,
+    evaluation: Mapping[str, Any],
+    variant_extras: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one candidate record for a candidate manifest."""
+
+    candidate: dict[str, Any] = {
+        "candidate_id": _identifier(candidate_id, "candidate_id"),
+        "source_episode_id": _identifier(source_episode_id, "source_episode_id"),
+        "source_episode_index": _source_episode_index(
+            source_episode_index, "source_episode_index"
+        ),
+        "camera_key": _identifier(camera_key, "camera_key"),
+        "variant": {
+            "variant_id": _identifier(variant_id, "variant_id"),
+            "output_sha256": _sha256(output_sha256, "output_sha256"),
+            "source_sha256": _sha256(source_sha256, "source_sha256"),
+        },
+        "evaluation": _object(evaluation, "evaluation"),
+    }
+    if variant_extras:
+        extras = dict(variant_extras)
+        overlap = set(extras) & set(VARIANT_IDENTITY_FIELDS)
+        if overlap:
+            raise PaidfContractError(
+                "variant_extras cannot replace candidate identity fields: "
+                + ", ".join(sorted(overlap))
+            )
+        candidate["variant"].update(extras)
+    return candidate
+
+
+def validate_decision_manifest(
+    payload: Mapping[str, Any], *, candidates: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Validate a provider decision manifest against the exact candidate set.
+
+    The provider is exactly ``name`` plus a ``curation`` or ``evaluation``
+    role, and every decision carries exactly ``candidate_id``, ``decision``,
+    ``evidence``, ``reason``, and a caller-supplied ``decided_at`` in
+    canonical UTC-second form. Fail closed unless every candidate has exactly
+    one decision with an ``accept``, ``reject``, or ``review`` state, and no
+    decision names an unknown candidate.
+    """
+
+    validate_candidate_manifest(candidates)
+    manifest = _object(payload, "decision manifest")
+    _exact_schema(manifest, DECISION_MANIFEST_SCHEMA, "decision manifest")
+    _decision_provider(manifest.get("provider"), "decision manifest.provider")
+    expected = {
+        entry["candidate_id"]
+        for entry in _list(candidates["candidates"], "candidates")
+    }
+    decisions = _list(manifest.get("decisions"), "decision manifest.decisions")
+    seen: set[str] = set()
+    for index, raw in enumerate(decisions):
+        decision = _object(raw, f"decision manifest.decisions[{index}]")
+        candidate_id = _identifier(
+            decision.get("candidate_id"), f"decisions[{index}].candidate_id"
+        )
+        if candidate_id not in expected:
+            raise PaidfContractError(
+                f"decision names an unknown candidate: {candidate_id}"
+            )
+        if candidate_id in seen:
+            raise PaidfContractError(
+                f"candidate has more than one decision: {candidate_id}"
+            )
+        seen.add(candidate_id)
+        if set(decision) != set(DECISION_FIELDS):
+            raise PaidfContractError(
+                f"decision for {candidate_id} must contain exactly "
+                "candidate_id, decision, evidence, reason, and decided_at"
+            )
+        state = decision.get("decision")
+        if state not in DECISION_STATES:
+            raise PaidfContractError(
+                f"decision for {candidate_id} must be one of "
+                f"{', '.join(DECISION_STATES)}; got {state!r}"
+            )
+        _object(decision.get("evidence"), f"decisions[{index}].evidence")
+        if not isinstance(decision.get("reason"), str) or not decision["reason"]:
+            raise PaidfContractError(
+                f"decision for {candidate_id} requires a nonempty reason"
+            )
+        _utc_timestamp(decision.get("decided_at"), f"decisions[{index}].decided_at")
+    missing = expected - seen
+    if missing:
+        raise PaidfContractError(
+            "decisions are missing for candidates: "
+            + ", ".join(sorted(missing))
+        )
+    return dict(manifest)
+
+
+def reconcile_decisions(
+    candidates: Mapping[str, Any], decisions: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Reconcile decisions into the authoritative keep/drop manifest.
+
+    Only ``accept`` decisions enter the training set. ``review`` is a valid
+    but unresolved state: it is reported explicitly and excluded from the
+    training set so a later human process can resolve it without blocking the
+    headless run.
+    """
+
+    validate_decision_manifest(decisions, candidates=candidates)
+    by_id = {
+        decision["candidate_id"]: decision
+        for decision in decisions["decisions"]
+    }
+    keep: list[dict[str, Any]] = []
+    drop: list[dict[str, Any]] = []
+    unresolved: list[str] = []
+    for candidate in candidates["candidates"]:
+        candidate_id = candidate["candidate_id"]
+        decision = by_id[candidate_id]
+        record = {
+            "candidate_id": candidate_id,
+            "decision": decision["decision"],
+            "reason": decision["reason"],
+        }
+        if decision["decision"] == "accept":
+            keep.append(record)
+        else:
+            drop.append(record)
+            if decision["decision"] == "review":
+                unresolved.append(candidate_id)
+    return {
+        "schema": RECONCILIATION_SCHEMA,
+        "totals": {
+            "candidates": len(candidates["candidates"]),
+            "keep": len(keep),
+            "drop": len(drop),
+            "unresolved_review": len(unresolved),
+            "identity_gaps": 0,
+        },
+        "keep": keep,
+        "drop": drop,
+        "unresolved_review_candidate_ids": unresolved,
+        "provider": decisions.get("provider"),
+    }
+
+
+def reconcile_provider_export(
+    candidates: Mapping[str, Any],
+    export_items: Iterable[Mapping[str, Any]],
+    *,
+    external_id_field: str = "external_id",
+) -> dict[str, Any]:
+    """Reconcile a provider export to the candidate manifest by exact ID.
+
+    ``export_items`` are provider-side records; each must carry the Workbench
+    ``candidate_id`` in ``external_id_field`` and a non-null terminal decision
+    in ``accept``, ``reject``, or ``review``. This helper performs identity
+    and decision-state normalization only; provider, evidence, reason, and
+    timestamp are validated in the decision manifest. Fail closed on missing,
+    duplicate, orphan, or invalid-state identities.
+    """
+
+    candidate_manifest = validate_candidate_manifest(candidates)
+    expected = {
+        entry["candidate_id"] for entry in candidate_manifest["candidates"]
+    }
+    seen: dict[str, int] = {}
+    joined: list[dict[str, Any]] = []
+    for index, item in enumerate(export_items):
+        record = dict(item)
+        external = record.get(external_id_field)
+        if not isinstance(external, str) or not external:
+            raise PaidfContractError(
+                f"export item [{index}] is missing {external_id_field}"
+            )
+        if external in seen:
+            raise PaidfContractError(
+                f"export contains a duplicate {external_id_field}: {external}"
+            )
+        seen[external] = index
+        if external not in expected:
+            raise PaidfContractError(
+                f"export item {external} is an orphan with no candidate"
+            )
+        if record.get("decision") not in DECISION_STATES:
+            raise PaidfContractError(
+                f"export item {external} must carry a non-null accept, reject, "
+                f"or review decision; got {record.get('decision')!r}"
+            )
+        joined.append(record)
+    missing = sorted(expected - set(seen))
+    if missing:
+        raise PaidfContractError(
+            "export is missing candidates: " + ", ".join(missing)
+        )
+    return {
+        "schema": RECONCILIATION_SCHEMA,
+        "external_id_field": external_id_field,
+        "totals": {
+            "candidates": len(expected),
+            "export_items": len(joined),
+            "identity_gaps": 0,
+        },
+        "joined": joined,
+    }
+
+
+def load_frozen_source_manifest(
+    manifest_ref: str,
+    *,
+    expected_sha256: str,
+    expected_contract_sha256: str,
+) -> dict[str, Any]:
+    """Load the frozen Phase 0 source manifest and fail closed on any drift.
+
+    The manifest bytes must hash exactly to ``expected_sha256`` (the digest
+    pinned in the workflow config), the manifest must record the locked
+    source-contract digest, and its episodes must keep the train/held-out
+    trajectory-content split disjoint. This is the run-time half of the
+    source lock; the planning half lives in
+    ``npa.orchestration.npa_workflow.spec._validate_frozen_source_lock``.
+    """
+
+    raw = _read_artifact_bytes(manifest_ref)
+    if hashlib.sha256(raw).hexdigest() != expected_sha256:
+        raise PaidfContractError(
+            "frozen source manifest bytes do not match the locked digest "
+            f"({expected_sha256})"
+        )
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PaidfContractError(
+            f"frozen source manifest is not valid JSON: {exc}"
+        ) from exc
+    _exact_schema(manifest, FROZEN_SOURCE_MANIFEST_SCHEMA, "frozen source manifest")
+    contract = _object(
+        manifest.get("source_contract"), "frozen source manifest.source_contract"
+    )
+    if contract.get("sha256") != expected_contract_sha256:
+        raise PaidfContractError(
+            "frozen source manifest does not record the locked source-contract "
+            f"digest ({expected_contract_sha256})"
+        )
+    episodes = _list(manifest.get("episodes"), "frozen source manifest.episodes")
+    if not episodes:
+        raise PaidfContractError("frozen source manifest records no episodes")
+    for index, episode in enumerate(episodes):
+        record = _object(episode, f"frozen source manifest.episodes[{index}]")
+        _sha256(
+            record.get("trajectory_sha256"),
+            f"frozen source manifest episode {index}.trajectory_sha256",
+        )
+        if record.get("split") not in ("train", "heldout"):
+            raise PaidfContractError(
+                f"frozen source manifest episode {index} has an unknown split"
+            )
+    train = {
+        episode["trajectory_sha256"]
+        for episode in episodes
+        if episode["split"] == "train"
+    }
+    heldout = {
+        episode["trajectory_sha256"]
+        for episode in episodes
+        if episode["split"] == "heldout"
+    }
+    if train & heldout:
+        raise PaidfContractError(
+            "frozen source manifest has trajectory content overlap across splits"
+        )
+    return dict(manifest)
+
+
+def build_base_campaign(
+    campaign_id: str,
+    *,
+    stage_refs: Mapping[str, str],
+    stage_sha256s: Mapping[str, str],
+) -> dict[str, Any]:
+    """Build and validate the immutable base-campaign manifest.
+
+    ``stage_refs`` and ``stage_sha256s`` are keyed by base stage
+    (``source``, ``generation``, ``evaluation``). The artifact URIs are
+    pinned exactly as the producing stages published them.
+    """
+
+    if set(stage_refs) != set(BASE_STAGES):
+        raise PaidfContractError(
+            "base campaign requires exactly the stages: " + ", ".join(BASE_STAGES)
+        )
+    if set(stage_sha256s) != set(BASE_STAGES):
+        raise PaidfContractError(
+            "base campaign digest keys must contain exactly the stages: "
+            + ", ".join(BASE_STAGES)
+        )
+    artifacts = {
+        stage: {
+            "uri": stage_refs[stage],
+            "sha256": stage_sha256s[stage],
+            "schema": f"npa.paidf.{stage}-stage.v1",
+        }
+        for stage in BASE_STAGES
+    }
+    campaign = {
+        "schema": CAMPAIGN_SCHEMA,
+        "campaign_id": campaign_id,
+        "artifacts": artifacts,
+        "stage_fingerprints": dict(stage_sha256s),
+    }
+    return validate_campaign(campaign)
+
+
+def freeze_base_campaign_stage(
+    campaign_id: str,
+    *,
+    source_manifest_ref: str,
+    generation_manifest_ref: str,
+    evaluation_report_ref: str,
+    campaign_output_ref: str,
+) -> dict[str, Any]:
+    """Hash the three immutable base-stage artifacts and publish the campaign.
+
+    Each artifact is read (local path or ``s3://`` URI), hashed byte-for-byte,
+    and pinned into the campaign manifest, which is validated and written to
+    ``campaign_output_ref``. Derivative partner runs consume this manifest;
+    regenerating any base stage creates a new campaign instead.
+    """
+
+    stage_refs = {
+        "source": source_manifest_ref,
+        "generation": generation_manifest_ref,
+        "evaluation": evaluation_report_ref,
+    }
+    stage_sha256s = {
+        stage: hashlib.sha256(_read_artifact_bytes(ref)).hexdigest()
+        for stage, ref in stage_refs.items()
+    }
+    campaign = build_base_campaign(
+        campaign_id, stage_refs=stage_refs, stage_sha256s=stage_sha256s
+    )
+    payload = json.dumps(campaign, indent=2, sort_keys=True) + "\n"
+    _write_artifact_bytes(campaign_output_ref, payload.encode("utf-8"))
+    return campaign
+
+
+def build_candidates_stage(
+    augment_manifest_ref: str,
+    provenance_ref: str,
+    evaluator_report_ref: str,
+    disposition_ref: str,
+    output_ref: str,
+) -> dict[str, Any]:
+    """Build the provider-neutral candidate manifest from real PAIDF evidence.
+
+    One candidate per committed Cosmos 3 variant in the canonical augment
+    manifest. Source episode and camera identity come from the staged input
+    provenance the manifest's lineage names; output identity is the real
+    published video's byte digest. Fails closed on any missing evidence.
+    """
+
+    from npa.workflows.paidf_cosmos3 import validate_committed_augment_manifest
+
+    augment = validate_committed_augment_manifest(
+        json.loads(_read_artifact_bytes(augment_manifest_ref))
+    )
+    provenance = json.loads(_read_artifact_bytes(provenance_ref))
+    if provenance.get("schema") != "npa.paidf.cosmos3.input.v1":
+        raise PaidfContractError(
+            "input provenance schema must be npa.paidf.cosmos3.input.v1"
+        )
+    if provenance.get("episode") is None or not provenance.get("camera"):
+        raise PaidfContractError(
+            "candidate build requires a source dataset selection "
+            "(provenance episode and camera)"
+        )
+    episode_index = _source_episode_index(
+        provenance.get("episode"), "input provenance.episode"
+    )
+    camera_key = _identifier(provenance.get("camera"), "input provenance.camera")
+    source_sha256 = _sha256(provenance.get("sha256"), "input provenance.sha256")
+    evaluator = json.loads(_read_artifact_bytes(evaluator_report_ref))
+    if evaluator.get("schema") != "npa.cosmos_evaluator.report.v1":
+        raise PaidfContractError(
+            "evaluator report schema must be npa.cosmos_evaluator.report.v1"
+        )
+    clips_by_id = _evaluator_clips_by_id(evaluator)
+    disposition = json.loads(_read_artifact_bytes(disposition_ref))
+    if disposition.get("schema") != "npa.data_factory.quality_disposition.v1":
+        raise PaidfContractError(
+            "quality disposition schema must be npa.data_factory.quality_disposition.v1"
+        )
+    candidates = []
+    variant_ids = {str(variant["clip"]) for variant in augment}
+    unexpected_evaluator_ids = sorted(set(clips_by_id) - variant_ids)
+    if unexpected_evaluator_ids:
+        raise PaidfContractError(
+            "evaluator report names variants outside the committed augment set: "
+            + ", ".join(unexpected_evaluator_ids)
+        )
+    for variant in augment:
+        clip = str(variant["clip"])
+        video_uri = str(variant["augmented_video_uri"])
+        evaluation = clips_by_id.get(clip)
+        if evaluation is None:
+            raise PaidfContractError(
+                f"evaluator report has no evidence for variant {clip}"
+            )
+        candidate = build_candidate(
+            candidate_id=clip,
+            source_episode_id=f"episode_{episode_index:06d}",
+            source_episode_index=episode_index,
+            camera_key=camera_key,
+            variant_id=clip,
+            output_sha256=hashlib.sha256(_read_artifact_bytes(video_uri)).hexdigest(),
+            source_sha256=source_sha256,
+            evaluation={
+                "score": evaluation.get("score"),
+                "passed": evaluation.get("passed"),
+                "status": evaluation.get("status"),
+                "skipped": evaluation.get("skipped", []),
+                "quality_status": disposition.get("quality_status"),
+                "threshold": disposition.get("threshold"),
+            },
+            variant_extras={
+                "video_uri": video_uri,
+                "video_bytes": variant.get("video_bytes"),
+                "frame_count": variant.get("frame_count"),
+                "seed": variant.get("seed"),
+                "guidance": variant.get("guidance"),
+                "steps": variant.get("steps"),
+            },
+        )
+        candidates.append(candidate)
+    manifest = {
+        "schema": CANDIDATE_MANIFEST_SCHEMA,
+        "run_evidence": {
+            "augment_manifest_ref": augment_manifest_ref,
+            "quality_status": disposition.get("quality_status"),
+        },
+        "candidates": candidates,
+    }
+    validate_candidate_manifest(manifest)
+    _write_artifact_bytes(
+        output_ref,
+        (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+    )
+    return manifest
+
+
+def build_decisions_stage(
+    candidates_manifest_ref: str,
+    evaluator_report_ref: str,
+    disposition_ref: str,
+    output_ref: str,
+    *,
+    decided_at: str,
+) -> dict[str, Any]:
+    """Route each candidate to accept, reject, or review from real evidence.
+
+    A rejected run disposition routes every candidate to reject. Otherwise a
+    completed clip that passed the hard gates routes to accept, a completed
+    clip that failed routes to reject, and anything uncertain (a missing or
+    non-completed clip evaluation) routes to review, which stays excluded
+    from training. The provider is the automated evaluator with an
+    ``evaluation`` role, and every decision carries the caller-supplied
+    ``decided_at`` timestamp; this canonical builder never reads the wall
+    clock.
+    """
+
+    candidates = validate_candidate_manifest(
+        json.loads(_read_artifact_bytes(candidates_manifest_ref))
+    )
+    evaluator = json.loads(_read_artifact_bytes(evaluator_report_ref))
+    if evaluator.get("schema") != "npa.cosmos_evaluator.report.v1":
+        raise PaidfContractError(
+            "evaluator report schema must be npa.cosmos_evaluator.report.v1"
+        )
+    disposition = json.loads(_read_artifact_bytes(disposition_ref))
+    if disposition.get("schema") != "npa.data_factory.quality_disposition.v1":
+        raise PaidfContractError(
+            "quality disposition schema must be npa.data_factory.quality_disposition.v1"
+        )
+    decided_at = _utc_timestamp(decided_at, "decided_at")
+    clips_by_id = _evaluator_clips_by_id(evaluator)
+    candidate_ids = {
+        candidate["candidate_id"] for candidate in candidates["candidates"]
+    }
+    unexpected_evaluator_ids = sorted(set(clips_by_id) - candidate_ids)
+    if unexpected_evaluator_ids:
+        raise PaidfContractError(
+            "evaluator report names candidates outside the candidate manifest: "
+            + ", ".join(unexpected_evaluator_ids)
+        )
+    run_rejected = disposition.get("quality_status") == "rejected"
+    decisions = []
+    for candidate in candidates["candidates"]:
+        candidate_id = candidate["candidate_id"]
+        if run_rejected:
+            state, reason = "reject", "run quality disposition rejected the wave"
+        else:
+            clip = clips_by_id.get(candidate_id)
+            if clip is None:
+                state = "review"
+                reason = "no completed evaluator evidence for this variant"
+            elif str(clip.get("status")) != "completed":
+                state = "review"
+                reason = f"evaluator clip status is {clip.get('status')!r}"
+            elif clip.get("passed") is True:
+                state = "accept"
+                reason = "hard gates passed"
+            else:
+                state = "reject"
+                reason = "one or more hard gates failed"
+        decisions.append(
+            {
+                "candidate_id": candidate_id,
+                "decision": state,
+                "evidence": {
+                    "evaluator_score": (clips_by_id.get(candidate_id) or {}).get("score"),
+                    "quality_status": disposition.get("quality_status"),
+                },
+                "reason": reason,
+                "decided_at": decided_at,
+            }
+        )
+    manifest = {
+        "schema": DECISION_MANIFEST_SCHEMA,
+        "provider": {"name": "cosmos-evaluator", "role": "evaluation"},
+        "decisions": decisions,
+    }
+    validate_decision_manifest(manifest, candidates=candidates)
+    _write_artifact_bytes(
+        output_ref,
+        (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+    )
+    return manifest
+
+
+def accepted_replacements_stage(
+    candidates_manifest_ref: str,
+    reconciliation_ref: str,
+    output_ref: str,
+) -> dict[str, Any]:
+    """Derive the accepted replacement manifest by exact-ID reconciliation.
+
+    Joins the authoritative keep/drop reconciliation to the candidate
+    manifest and fails closed unless the reconciliation covers every
+    candidate exactly once with consistent states: ``keep`` holds only
+    ``accept``, ``drop`` holds only ``reject`` or ``review``, and no
+    unresolved ``review`` item reaches the replacements. Only accepted
+    replacements are emitted, carrying every field the downstream dataset
+    builder requires (episode index, camera key, video URI, and lineage).
+    """
+
+    candidates = validate_candidate_manifest(
+        json.loads(_read_artifact_bytes(candidates_manifest_ref))
+    )
+    reconciliation = json.loads(_read_artifact_bytes(reconciliation_ref))
+    if reconciliation.get("schema") != RECONCILIATION_SCHEMA:
+        raise PaidfContractError(
+            f"reconciliation schema must be {RECONCILIATION_SCHEMA}"
+        )
+    keep_states = _reconciliation_entries(
+        reconciliation.get("keep"), "reconciliation.keep"
+    )
+    drop_states = _reconciliation_entries(
+        reconciliation.get("drop"), "reconciliation.drop"
+    )
+    candidate_ids = {
+        candidate["candidate_id"] for candidate in candidates["candidates"]
+    }
+    covered = set(keep_states) | set(drop_states)
+    unknown = sorted(covered - candidate_ids)
+    if unknown:
+        raise PaidfContractError(
+            "reconciliation names unknown candidates: " + ", ".join(unknown)
+        )
+    missing = sorted(candidate_ids - covered)
+    if missing:
+        raise PaidfContractError(
+            "reconciliation is missing candidates: " + ", ".join(missing)
+        )
+    overlapping = sorted(set(keep_states) & set(drop_states))
+    if overlapping:
+        raise PaidfContractError(
+            "candidates appear in both keep and drop: " + ", ".join(overlapping)
+        )
+    inconsistent_keep = sorted(
+        candidate_id
+        for candidate_id, state in keep_states.items()
+        if state != "accept"
+    )
+    if inconsistent_keep:
+        raise PaidfContractError(
+            "reconciliation keeps candidates with a non-accept decision: "
+            + ", ".join(inconsistent_keep)
+        )
+    inconsistent_drop = sorted(
+        candidate_id
+        for candidate_id, state in drop_states.items()
+        if state not in ("reject", "review")
+    )
+    if inconsistent_drop:
+        raise PaidfContractError(
+            "reconciliation drops candidates with a non-terminal decision: "
+            + ", ".join(inconsistent_drop)
+        )
+    unresolved = _list(
+        reconciliation.get("unresolved_review_candidate_ids"),
+        "reconciliation.unresolved_review_candidate_ids",
+    )
+    unresolved_ids = [
+        _identifier(candidate_id, f"reconciliation.unresolved_review_candidate_ids[{index}]")
+        for index, candidate_id in enumerate(unresolved)
+    ]
+    if len(unresolved_ids) != len(set(unresolved_ids)):
+        raise PaidfContractError(
+            "reconciliation.unresolved_review_candidate_ids contains duplicates"
+        )
+    review_drop_ids = {
+        candidate_id for candidate_id, state in drop_states.items() if state == "review"
+    }
+    if set(unresolved_ids) != review_drop_ids:
+        missing_review = sorted(review_drop_ids - set(unresolved_ids))
+        extra_review = sorted(set(unresolved_ids) - review_drop_ids)
+        details = []
+        if missing_review:
+            details.append("missing " + ", ".join(missing_review))
+        if extra_review:
+            details.append("unexpected " + ", ".join(extra_review))
+        raise PaidfContractError(
+            "reconciliation unresolved review IDs must exactly match review drops: "
+            + "; ".join(details)
+        )
+    _decision_provider(reconciliation.get("provider"), "reconciliation.provider")
+    totals = _object(reconciliation.get("totals"), "reconciliation.totals")
+    if set(totals) != set(RECONCILIATION_TOTAL_FIELDS):
+        raise PaidfContractError(
+            "reconciliation.totals must contain exactly candidates, keep, drop, "
+            "unresolved_review, and identity_gaps"
+        )
+    expected_totals = {
+        "candidates": len(candidate_ids),
+        "keep": len(keep_states),
+        "drop": len(drop_states),
+        "unresolved_review": len(review_drop_ids),
+        "identity_gaps": 0,
+    }
+    for name, expected_total in expected_totals.items():
+        actual_total = totals.get(name)
+        if (
+            not isinstance(actual_total, int)
+            or isinstance(actual_total, bool)
+            or actual_total != expected_total
+        ):
+            raise PaidfContractError(
+                f"reconciliation.totals.{name} must equal {expected_total}"
+            )
+    by_id = {candidate["candidate_id"]: candidate for candidate in candidates["candidates"]}
+    replacements = []
+    for candidate_id in sorted(keep_states):
+        candidate = by_id[candidate_id]
+        variant = candidate["variant"]
+        video_uri = variant.get("video_uri")
+        if not video_uri:
+            raise PaidfContractError(
+                f"accepted candidate {candidate_id} records no video_uri"
+            )
+        replacements.append(
+            {
+                "episode_index": candidate["source_episode_index"],
+                "camera_key": candidate["camera_key"],
+                "video_uri": video_uri,
+                "lineage": {
+                    "candidate_id": candidate_id,
+                    "variant_id": variant["variant_id"],
+                    "output_sha256": variant["output_sha256"],
+                    "source_episode_id": candidate["source_episode_id"],
+                    "source_sha256": variant["source_sha256"],
+                },
+            }
+        )
+    manifest = {
+        "schema": ACCEPTED_REPLACEMENTS_SCHEMA,
+        "totals": {
+            "candidates": len(candidates["candidates"]),
+            "accepted": len(replacements),
+            "dropped_or_review": len(drop_states),
+        },
+        "replacements": replacements,
+    }
+    _write_artifact_bytes(
+        output_ref,
+        (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+    )
+    return manifest
+
+
+def _reconciliation_entries(
+    entries: Any, label: str
+) -> dict[str, Any]:
+    """Read reconciliation rows as ``candidate_id -> decision`` mappings.
+
+    Fails closed on non-object rows, unsafe candidate IDs, or duplicate
+    candidate IDs within one list.
+    """
+
+    rows = _list(entries, label)
+    states: dict[str, Any] = {}
+    for index, row in enumerate(rows):
+        record = _object(row, f"{label}[{index}]")
+        candidate_id = _identifier(
+            record.get("candidate_id"), f"{label}[{index}].candidate_id"
+        )
+        if candidate_id in states:
+            raise PaidfContractError(
+                f"{label} contains a duplicate candidate_id: {candidate_id}"
+            )
+        states[candidate_id] = record.get("decision")
+    return states
+
+
+def _decision_provider(value: Any, label: str) -> dict[str, Any]:
+    provider = _object(value, label)
+    if set(provider) != set(PROVIDER_FIELDS):
+        raise PaidfContractError(f"{label} must contain exactly name and role")
+    _identifier(provider.get("name"), f"{label}.name")
+    if provider.get("role") not in PROVIDER_ROLES:
+        raise PaidfContractError(f"{label}.role must be curation or evaluation")
+    return provider
+
+
+def _evaluator_clips_by_id(evaluator: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    raw_clips = evaluator.get("clips")
+    clips = _list([] if raw_clips is None else raw_clips, "evaluator report.clips")
+    by_id: dict[str, dict[str, Any]] = {}
+    for index, raw_clip in enumerate(clips):
+        clip = _object(raw_clip, f"evaluator report.clips[{index}]")
+        clip_id = _identifier(
+            clip.get("clip_id"), f"evaluator report.clips[{index}].clip_id"
+        )
+        if clip_id in by_id:
+            raise PaidfContractError(
+                f"evaluator report contains duplicate clip_id: {clip_id}"
+            )
+        by_id[clip_id] = clip
+    return by_id
+
+
+def _read_artifact_bytes(ref: str) -> bytes:
+    """Read artifact bytes from a local path or an ``s3://`` URI."""
+
+    if ref.startswith("s3://"):
+        from npa.clients.storage import LazyStorageClient
+
+        return bytes(LazyStorageClient().read_bytes_with_etag(ref)[0])
+    return Path(ref).read_bytes()
+
+
+def _write_artifact_bytes(ref: str, payload: bytes) -> None:
+    """Write artifact bytes to a local path or an ``s3://`` URI."""
+
+    if ref.startswith("s3://"):
+        from npa.clients.storage import LazyStorageClient
+
+        LazyStorageClient().put_bytes_conditional(payload, ref, if_none_match=True)
+        return
+    path = Path(ref)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise PaidfContractError(f"{label} must be an object")
+    return dict(value)
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise PaidfContractError(f"{label} must be a list")
+    return value
+
+
+def _exact_schema(value: Mapping[str, Any], expected: str, label: str) -> None:
+    if value.get("schema") != expected:
+        raise PaidfContractError(f"{label} schema must be {expected}")
+
+
+def _identifier(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER.fullmatch(value):
+        raise PaidfContractError(f"{label} must be a safe nonempty identifier")
+    return value
+
+
+def _sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not _SHA256.fullmatch(value):
+        raise PaidfContractError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _source_episode_index(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise PaidfContractError(
+            f"{label} must be a non-negative integer episode index"
+        )
+    return value
+
+
+def _utc_timestamp(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not _UTC_TIMESTAMP.fullmatch(value):
+        raise PaidfContractError(
+            f"{label} must be canonical UTC seconds in YYYY-MM-DDTHH:MM:SSZ form"
+        )
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as exc:
+        raise PaidfContractError(
+            f"{label} is not a real calendar time: {value!r}"
+        ) from exc
+    return value
+
+
+def _s3_uri(value: Any, label: str, *, object_required: bool) -> str:
+    if not isinstance(value, str):
+        raise PaidfContractError(f"{label} must be an S3 URI")
+    parsed = urlparse(value)
+    if parsed.scheme != "s3" or not parsed.netloc or not parsed.path.strip("/"):
+        raise PaidfContractError(f"{label} must include an S3 bucket and key")
+    if parsed.query or parsed.fragment:
+        raise PaidfContractError(f"{label} must not include a query or fragment")
+    if object_required and value.endswith("/"):
+        raise PaidfContractError(f"{label} must name an exact object")
+    return value
+
+
+def _s3_parent(uri: str) -> str:
+    return uri.rsplit("/", 1)[0] + "/"
+
+
+def _artifact_ref(value: Any, label: str) -> dict[str, Any]:
+    ref = _object(value, label)
+    _s3_uri(ref.get("uri"), f"{label}.uri", object_required=True)
+    _sha256(ref.get("sha256"), f"{label}.sha256")
+    schema = ref.get("schema")
+    if not isinstance(schema, str) or not schema.strip():
+        raise PaidfContractError(f"{label}.schema must be nonempty")
+    return ref
+
+
+def _stage_list(value: Any, label: str) -> list[str]:
+    stages = _list(value, label)
+    for index, stage in enumerate(stages):
+        _identifier(stage, f"{label}[{index}]")
+    if len(stages) != len(set(stages)):
+        raise PaidfContractError(f"{label} contains duplicate stages")
+    return stages

--- a/npa/tests/workflows/test_paidf_campaign.py
+++ b/npa/tests/workflows/test_paidf_campaign.py
@@ -1,0 +1,1326 @@
+"""Contract tests for reusable PAIDF campaigns and partner overlays."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from npa.workflows.paidf_campaign import (
+    BASE_STAGES,
+    FROZEN_SOURCE_MANIFEST_SCHEMA,
+    PaidfContractError,
+    accepted_replacements_stage,
+    build_antioch_input,
+    build_base_campaign,
+    build_candidates_stage,
+    build_decisions_stage,
+    build_execution_receipt,
+    build_partner_input,
+    build_partner_result,
+    canonical_digest,
+    freeze_base_campaign_stage,
+    load_frozen_source_manifest,
+    reconcile_decisions,
+    validate_campaign,
+    validate_partner_input,
+    validate_partner_result,
+)
+
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+SHA_C = "c" * 64
+
+DECIDED_AT = "2026-09-01T00:00:00Z"
+
+
+def _artifact(name: str, digest: str) -> dict[str, str]:
+    return {
+        "uri": f"s3://paidf-proof/campaigns/franka-001/{name}.json",
+        "sha256": digest,
+        "schema": f"npa.paidf.{name}.v1",
+    }
+
+
+def _campaign() -> dict:
+    return {
+        "schema": "npa.paidf.campaign.v1",
+        "campaign_id": "franka-001",
+        "artifacts": {
+            "source": _artifact("source", SHA_A),
+            "generation": _artifact("generation", SHA_B),
+            "evaluation": _artifact("evaluation", SHA_C),
+        },
+        "stage_fingerprints": {
+            "source": SHA_A,
+            "generation": SHA_B,
+            "evaluation": SHA_C,
+        },
+    }
+
+
+def _antioch_input(campaign: dict | None = None) -> dict:
+    return build_antioch_input(
+        campaign or _campaign(),
+        campaign_manifest_uri=(
+            "s3://paidf-proof/campaigns/franka-001/campaign.json"
+        ),
+        run_id="antioch-001",
+        provider_config={
+            "uri": "s3://paidf-proof/config/antioch-001.json",
+            "sha256": "d" * 64,
+            "schema": "npa.paidf.antioch-config.v1",
+        },
+        credential_refs=("secret://antioch/workshop",),
+        output_prefix="s3://paidf-proof/derivatives/antioch/antioch-001/",
+    )
+
+
+def test_campaign_validation_and_digest_are_stable() -> None:
+    campaign = _campaign()
+    reordered = {
+        "stage_fingerprints": campaign["stage_fingerprints"],
+        "artifacts": campaign["artifacts"],
+        "campaign_id": campaign["campaign_id"],
+        "schema": campaign["schema"],
+    }
+
+    assert validate_campaign(campaign) == campaign
+    assert canonical_digest(reordered) == canonical_digest(campaign)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("uri", "https://example.com/source.json"),
+        ("uri", "s3://paidf-proof/campaigns/franka-001/"),
+        ("sha256", "not-a-digest"),
+        ("schema", ""),
+    ],
+)
+def test_campaign_rejects_invalid_artifact_references(field: str, value: str) -> None:
+    campaign = _campaign()
+    campaign["artifacts"]["source"][field] = value
+
+    with pytest.raises(PaidfContractError):
+        validate_campaign(campaign)
+
+
+def test_campaign_rejects_extra_base_stage_keys() -> None:
+    campaign = _campaign()
+    campaign["artifacts"]["regeneration"] = _artifact("regeneration", SHA_A)
+    with pytest.raises(PaidfContractError, match="exactly the base stages"):
+        validate_campaign(campaign)
+
+    campaign = _campaign()
+    campaign["stage_fingerprints"]["regeneration"] = SHA_A
+    with pytest.raises(PaidfContractError, match="exactly the base stages"):
+        validate_campaign(campaign)
+
+
+def test_campaign_rejects_artifact_fingerprint_digest_divergence() -> None:
+    campaign = _campaign()
+    campaign["artifacts"]["generation"]["sha256"] = "e" * 64
+
+    with pytest.raises(PaidfContractError, match="does not match its stage fingerprint"):
+        validate_campaign(campaign)
+
+
+def test_antioch_overlay_reuses_base_and_never_executes_generation() -> None:
+    partner_input = _antioch_input()
+
+    assert partner_input["source_mode"] == "read-only"
+    assert partner_input["reuse"]["stages"] == list(BASE_STAGES)
+    assert set(partner_input["execute"]["stages"]).isdisjoint(BASE_STAGES)
+    assert partner_input["provider"] == {
+        "name": "antioch",
+        "role": "simulation",
+    }
+
+
+def test_partner_input_rejects_changed_campaign_or_reused_artifact() -> None:
+    campaign = _campaign()
+    partner_input = _antioch_input(campaign)
+    changed_campaign = copy.deepcopy(campaign)
+    changed_campaign["stage_fingerprints"]["evaluation"] = "e" * 64
+
+    with pytest.raises(PaidfContractError, match="digest"):
+        validate_partner_input(partner_input, campaign=changed_campaign)
+
+    altered_input = copy.deepcopy(partner_input)
+    altered_input["reuse"]["artifacts"]["source"]["sha256"] = "f" * 64
+    with pytest.raises(PaidfContractError, match="changed the base artifact"):
+        validate_partner_input(altered_input, campaign=campaign)
+
+
+def test_partner_input_rejects_base_stage_execution_and_plaintext_credentials() -> None:
+    campaign = _campaign()
+    partner_input = _antioch_input(campaign)
+    partner_input["execute"]["stages"].append("generation")
+
+    with pytest.raises(PaidfContractError, match="immutable base stages"):
+        validate_partner_input(partner_input, campaign=campaign)
+
+    partner_input = _antioch_input(campaign)
+    partner_input["credential_refs"] = ["a-secret-value"]
+    with pytest.raises(PaidfContractError, match="reference"):
+        validate_partner_input(partner_input, campaign=campaign)
+
+
+def test_partner_input_rejects_output_nested_inside_base_campaign() -> None:
+    campaign = _campaign()
+    partner_input = _antioch_input(campaign)
+    partner_input["output_prefix"] = (
+        "s3://paidf-proof/campaigns/franka-001/derivatives/antioch-001/"
+    )
+
+    with pytest.raises(PaidfContractError, match="separate"):
+        validate_partner_input(partner_input, campaign=campaign)
+
+
+def test_partner_builder_reports_unknown_reuse_as_a_contract_error() -> None:
+    with pytest.raises(PaidfContractError, match="unknown base stages"):
+        build_partner_input(
+            _campaign(),
+            campaign_manifest_uri=(
+                "s3://paidf-proof/campaigns/franka-001/campaign.json"
+            ),
+            run_id="provider-001",
+            provider="another-simulator",
+            role="simulation",
+            provider_config={
+                "uri": "s3://paidf-proof/config/provider-001.json",
+                "sha256": "d" * 64,
+                "schema": "npa.paidf.provider-config.v1",
+            },
+            output_prefix="s3://paidf-proof/derivatives/provider/provider-001/",
+            executed_stages=("partner-simulation",),
+            reused_stages=("source", "unknown-stage"),
+        )
+
+
+def test_receipt_and_result_account_for_stages_and_isolate_outputs() -> None:
+    partner_input = _antioch_input()
+    stage_results = {
+        stage: "completed" for stage in partner_input["execute"]["stages"]
+    }
+    receipt = build_execution_receipt(
+        partner_input,
+        status="completed",
+        stage_results=stage_results,
+    )
+    result = build_partner_result(
+        partner_input,
+        receipt,
+        artifacts={
+            "result-manifest": {
+                "uri": (
+                    "s3://paidf-proof/derivatives/antioch/antioch-001/"
+                    "result-manifest.json"
+                ),
+                "sha256": "1" * 64,
+                "schema": "npa.paidf.antioch-result.v1",
+            }
+        },
+    )
+
+    assert result["status"] == "completed"
+    assert result["source_mutated"] is False
+    assert validate_partner_result(
+        result,
+        partner_input=partner_input,
+        execution_receipt=receipt,
+    ) == result
+
+    escaped = copy.deepcopy(result)
+    escaped["artifacts"]["result-manifest"]["uri"] = (
+        "s3://paidf-proof/campaigns/franka-001/replaced.json"
+    )
+    with pytest.raises(PaidfContractError, match="outside the output prefix"):
+        validate_partner_result(
+            escaped,
+            partner_input=partner_input,
+            execution_receipt=receipt,
+        )
+
+
+def test_completed_receipt_requires_every_stage_to_complete() -> None:
+    partner_input = _antioch_input()
+    stage_results = {
+        stage: "completed" for stage in partner_input["execute"]["stages"]
+    }
+    stage_results["comparison"] = "skipped"
+
+    with pytest.raises(PaidfContractError, match="every stage"):
+        build_execution_receipt(
+            partner_input,
+            status="completed",
+            stage_results=stage_results,
+        )
+
+
+# ── Phase 0 integrity-correction builders (candidates, decisions, accepted
+#    replacements) ──────────────────────────────────────────────────────────
+
+
+def _augment_manifest(tmp_path: Path, video_names: list[str]) -> tuple[Path, list[Path]]:
+    """A canonical Cosmos 3 augment manifest over real local video files."""
+
+    videos = []
+    variants = []
+    total_bytes = 0
+    augment_root = tmp_path / "cosmos_augmented"
+    for index, name in enumerate(video_names):
+        clip_dir = augment_root / name
+        clip_dir.mkdir(parents=True, exist_ok=True)
+        video = clip_dir / "augmented_video.mp4"
+        video.write_bytes(f"variant-bytes-{name}".encode())
+        videos.append(video)
+        total_bytes += video.stat().st_size
+        variants.append(
+            {
+                "clip": name,
+                "augmented_video_uri": str(video),
+                "video_bytes": video.stat().st_size,
+                "frame_count": 10 + index,
+                "seed": 17 + index,
+                "guidance": 5.0,
+                "steps": 24,
+                "variables": {"look": name},
+                "motion_preservation": None,
+            }
+        )
+    manifest = {
+        "schema": "npa.paidf.cosmos3.augment.v1",
+        "engine": "nvidia-cosmos/cosmos-framework",
+        "status": "executed",
+        "mode": "video2video",
+        "input_conditioned": True,
+        "input_conditioning": "source-video",
+        "conditioned_input": "source.mp4",
+        "guardrails": True,
+        "weights_baked": False,
+        "lineage": {"input_provenance_uri": str(tmp_path / "provenance.json")},
+        "model": "Cosmos3-Nano",
+        "variant_count": len(variants),
+        "video_bytes": total_bytes,
+        "frame_count": sum(v["frame_count"] for v in variants),
+        "variants": variants,
+    }
+    path = tmp_path / "augment-manifest.json"
+    path.write_text(json.dumps(manifest, indent=2))
+    return path, videos
+
+
+def _builder_fixtures(tmp_path: Path, *, video_names: list[str]) -> dict[str, Path]:
+    augment, _videos = _augment_manifest(tmp_path, video_names)
+    provenance = tmp_path / "provenance.json"
+    provenance.write_text(
+        json.dumps(
+            {
+                "schema": "npa.paidf.cosmos3.input.v1",
+                "status": "prepared",
+                "source_kind": "lerobot_dataset",
+                "episode": 3,
+                "camera": "observation.images.workspace",
+                "staged_video_uri": "s3://bucket/run/input/source.mp4",
+                "conditioned_input": "source.mp4",
+                "sha256": "c" * 64,
+                "video_bytes": 123,
+                "frame_count": 8,
+                "run_id": "run-1",
+            }
+        )
+    )
+    clips = []
+    for index, name in enumerate(video_names):
+        clips.append(
+            {
+                "clip_id": name,
+                "score": 0.9 - 0.2 * index,
+                "passed": index == 0,
+                "input_conditioned": True,
+                "status": "completed",
+            }
+        )
+    evaluator = tmp_path / "cosmos_evaluator.json"
+    evaluator.write_text(
+        json.dumps(
+            {
+                "schema": "npa.cosmos_evaluator.report.v1",
+                "status": "completed",
+                "score": 0.9,
+                "passed": True,
+                "clips": clips,
+            }
+        )
+    )
+    disposition = tmp_path / "quality_disposition.json"
+    disposition.write_text(
+        json.dumps(
+            {
+                "schema": "npa.data_factory.quality_disposition.v1",
+                "quality_status": "accepted",
+                "decision": "promote_checkpoint",
+                "evaluator_status": "completed",
+                "score": 0.9,
+                "threshold": 0.75,
+                "hard_checks_passed": True,
+            }
+        )
+    )
+    return {
+        "augment": augment,
+        "provenance": provenance,
+        "evaluator": evaluator,
+        "disposition": disposition,
+    }
+
+
+class TestBuildCandidatesStage:
+    def test_builds_exact_identity_candidates_from_real_evidence(
+        self, tmp_path: Path
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a", "clip-b"])
+        out = tmp_path / "candidates.json"
+        manifest = build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(out),
+        )
+        assert [c["candidate_id"] for c in manifest["candidates"]] == ["clip-a", "clip-b"]
+        first = manifest["candidates"][0]
+        assert first["source_episode_id"] == "episode_000003"
+        assert first["source_episode_index"] == 3
+        assert first["camera_key"] == "observation.images.workspace"
+        video_bytes = Path(str(first["variant"]["video_uri"])).read_bytes()
+        assert first["variant"]["output_sha256"] == hashlib.sha256(video_bytes).hexdigest()
+        assert first["evaluation"]["passed"] is True
+        stored = json.loads(out.read_text())
+        assert stored["schema"] == "npa.paidf.candidates.v1"
+
+    def test_fails_closed_without_evaluator_evidence_for_a_variant(
+        self, tmp_path: Path
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a", "clip-b"])
+        report = json.loads(fixtures["evaluator"].read_text())
+        report["clips"] = report["clips"][:1]
+        fixtures["evaluator"].write_text(json.dumps(report))
+        with pytest.raises(PaidfContractError, match="no evidence for variant"):
+            build_candidates_stage(
+                str(fixtures["augment"]),
+                str(fixtures["provenance"]),
+                str(fixtures["evaluator"]),
+                str(fixtures["disposition"]),
+                str(tmp_path / "candidates.json"),
+            )
+
+    @pytest.mark.parametrize("bad_episode", ["3", 3.0, True, False, -1])
+    def test_rejects_coerced_provenance_episode_identity(
+        self, tmp_path: Path, bad_episode: object
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        provenance = json.loads(fixtures["provenance"].read_text())
+        provenance["episode"] = bad_episode
+        fixtures["provenance"].write_text(json.dumps(provenance))
+        output = tmp_path / "candidates.json"
+        with pytest.raises(PaidfContractError, match="input provenance.episode"):
+            build_candidates_stage(
+                str(fixtures["augment"]),
+                str(fixtures["provenance"]),
+                str(fixtures["evaluator"]),
+                str(fixtures["disposition"]),
+                str(output),
+            )
+        assert not output.exists()
+
+    @pytest.mark.parametrize("conflicting", [False, True])
+    def test_rejects_duplicate_evaluator_clip_ids(
+        self, tmp_path: Path, conflicting: bool
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        evaluator = json.loads(fixtures["evaluator"].read_text())
+        duplicate = dict(evaluator["clips"][0])
+        if conflicting:
+            duplicate["passed"] = not duplicate["passed"]
+        evaluator["clips"].append(duplicate)
+        fixtures["evaluator"].write_text(json.dumps(evaluator))
+        output = tmp_path / "candidates.json"
+        with pytest.raises(PaidfContractError, match="duplicate clip_id"):
+            build_candidates_stage(
+                str(fixtures["augment"]),
+                str(fixtures["provenance"]),
+                str(fixtures["evaluator"]),
+                str(fixtures["disposition"]),
+                str(output),
+            )
+        assert not output.exists()
+
+    def test_rejects_malformed_or_out_of_set_evaluator_rows(
+        self, tmp_path: Path
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        evaluator = json.loads(fixtures["evaluator"].read_text())
+        evaluator["clips"].append("not-an-object")
+        fixtures["evaluator"].write_text(json.dumps(evaluator))
+        with pytest.raises(PaidfContractError, match="must be an object"):
+            build_candidates_stage(
+                str(fixtures["augment"]),
+                str(fixtures["provenance"]),
+                str(fixtures["evaluator"]),
+                str(fixtures["disposition"]),
+                str(tmp_path / "malformed.json"),
+            )
+
+        evaluator["clips"][-1] = {
+            "clip_id": "clip-outside",
+            "status": "completed",
+            "passed": True,
+        }
+        fixtures["evaluator"].write_text(json.dumps(evaluator))
+        with pytest.raises(PaidfContractError, match="outside the committed augment set"):
+            build_candidates_stage(
+                str(fixtures["augment"]),
+                str(fixtures["provenance"]),
+                str(fixtures["evaluator"]),
+                str(fixtures["disposition"]),
+                str(tmp_path / "outside.json"),
+            )
+
+
+class TestBuildDecisionsStage:
+    def test_decisions_carry_the_fixed_provider_and_caller_timestamp(
+        self, tmp_path: Path
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        decisions = build_decisions_stage(
+            str(tmp_path / "candidates.json"),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "decisions.json"),
+            decided_at=DECIDED_AT,
+        )
+        assert decisions["provider"] == {"name": "cosmos-evaluator", "role": "evaluation"}
+        assert all(d["decided_at"] == DECIDED_AT for d in decisions["decisions"])
+
+    def test_requires_a_caller_supplied_decided_at(self, tmp_path: Path) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        with pytest.raises(TypeError):
+            build_decisions_stage(  # type: ignore[call-arg]
+                str(tmp_path / "candidates.json"),
+                str(fixtures["evaluator"]),
+                str(fixtures["disposition"]),
+                str(tmp_path / "decisions.json"),
+            )
+
+    def test_uncertain_evidence_routes_to_review(self, tmp_path: Path) -> None:
+        """A candidate whose evaluator evidence disappeared routes to review."""
+
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a", "clip-b", "clip-c"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        report = json.loads(fixtures["evaluator"].read_text())
+        report["clips"] = [c for c in report["clips"] if c["clip_id"] != "clip-c"]
+        fixtures["evaluator"].write_text(json.dumps(report))
+        decisions = build_decisions_stage(
+            str(tmp_path / "candidates.json"),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "decisions.json"),
+            decided_at=DECIDED_AT,
+        )
+        by_id = {d["candidate_id"]: d for d in decisions["decisions"]}
+        assert by_id["clip-a"]["decision"] == "accept"
+        assert by_id["clip-b"]["decision"] == "reject"
+        assert by_id["clip-c"]["decision"] == "review"
+
+    def test_incomplete_clip_status_routes_to_review(self, tmp_path: Path) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        report = json.loads(fixtures["evaluator"].read_text())
+        report["clips"][0]["status"] = "skipped"
+        fixtures["evaluator"].write_text(json.dumps(report))
+        decisions = build_decisions_stage(
+            str(tmp_path / "candidates.json"),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "decisions.json"),
+            decided_at=DECIDED_AT,
+        )
+        assert decisions["decisions"][0]["decision"] == "review"
+
+    def test_accepted_run_routes_by_clip_evidence(self, tmp_path: Path) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a", "clip-b"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        decisions = build_decisions_stage(
+            str(tmp_path / "candidates.json"),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "decisions.json"),
+            decided_at=DECIDED_AT,
+        )
+        by_id = {d["candidate_id"]: d for d in decisions["decisions"]}
+        assert by_id["clip-a"]["decision"] == "accept"
+        assert by_id["clip-b"]["decision"] == "reject"
+
+    def test_rejected_run_rejects_every_candidate(self, tmp_path: Path) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        disposition = json.loads(fixtures["disposition"].read_text())
+        disposition["quality_status"] = "rejected"
+        fixtures["disposition"].write_text(json.dumps(disposition))
+        decisions = build_decisions_stage(
+            str(tmp_path / "candidates.json"),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "decisions.json"),
+            decided_at=DECIDED_AT,
+        )
+        assert all(d["decision"] == "reject" for d in decisions["decisions"])
+
+    @pytest.mark.parametrize("conflicting", [False, True])
+    def test_rejects_duplicate_evaluator_clip_ids(
+        self, tmp_path: Path, conflicting: bool
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        evaluator = json.loads(fixtures["evaluator"].read_text())
+        duplicate = dict(evaluator["clips"][0])
+        if conflicting:
+            duplicate["passed"] = not duplicate["passed"]
+        evaluator["clips"].append(duplicate)
+        fixtures["evaluator"].write_text(json.dumps(evaluator))
+        output = tmp_path / "decisions.json"
+        with pytest.raises(PaidfContractError, match="duplicate clip_id"):
+            build_decisions_stage(
+                str(tmp_path / "candidates.json"),
+                str(fixtures["evaluator"]),
+                str(fixtures["disposition"]),
+                str(output),
+                decided_at=DECIDED_AT,
+            )
+        assert not output.exists()
+
+    def test_rejects_malformed_or_out_of_set_evaluator_rows(
+        self, tmp_path: Path
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        evaluator = json.loads(fixtures["evaluator"].read_text())
+        evaluator["clips"].append({"status": "completed", "passed": True})
+        fixtures["evaluator"].write_text(json.dumps(evaluator))
+        with pytest.raises(PaidfContractError, match="clip_id"):
+            build_decisions_stage(
+                str(tmp_path / "candidates.json"),
+                str(fixtures["evaluator"]),
+                str(fixtures["disposition"]),
+                str(tmp_path / "malformed-decisions.json"),
+                decided_at=DECIDED_AT,
+            )
+
+        evaluator["clips"][-1] = {
+            "clip_id": "clip-outside",
+            "status": "completed",
+            "passed": True,
+        }
+        fixtures["evaluator"].write_text(json.dumps(evaluator))
+        with pytest.raises(PaidfContractError, match="outside the candidate manifest"):
+            build_decisions_stage(
+                str(tmp_path / "candidates.json"),
+                str(fixtures["evaluator"]),
+                str(fixtures["disposition"]),
+                str(tmp_path / "outside-decisions.json"),
+                decided_at=DECIDED_AT,
+            )
+
+
+def _valid_reconciliation(
+    *,
+    keep: list[dict],
+    drop: list[dict],
+    unresolved: list[str] | None = None,
+) -> dict:
+    unresolved_ids = unresolved or []
+    return {
+        "schema": "npa.paidf.reconciliation.v1",
+        "provider": {"name": "human-curator", "role": "curation"},
+        "totals": {
+            "candidates": len(keep) + len(drop),
+            "keep": len(keep),
+            "drop": len(drop),
+            "unresolved_review": len(unresolved_ids),
+            "identity_gaps": 0,
+        },
+        "keep": keep,
+        "drop": drop,
+        "unresolved_review_candidate_ids": unresolved_ids,
+    }
+
+
+class TestAcceptedReplacementsStage:
+    def test_keeps_only_accepted_with_materializer_fields(self, tmp_path: Path) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a", "clip-b"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        build_decisions_stage(
+            str(tmp_path / "candidates.json"),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "decisions.json"),
+            decided_at=DECIDED_AT,
+        )
+        reconciliation = _valid_reconciliation(
+            keep=[{"candidate_id": "clip-a", "decision": "accept"}],
+            drop=[{"candidate_id": "clip-b", "decision": "reject"}],
+        )
+        recon_ref = tmp_path / "keep-drop.json"
+        recon_ref.write_text(json.dumps(reconciliation))
+        out = tmp_path / "accepted-variants.json"
+        manifest = accepted_replacements_stage(
+            candidates_manifest_ref=str(tmp_path / "candidates.json"),
+            reconciliation_ref=str(recon_ref),
+            output_ref=str(out),
+        )
+        assert manifest["totals"]["accepted"] == 1
+        replacement = manifest["replacements"][0]
+        assert replacement["episode_index"] == 3
+        assert replacement["camera_key"] == "observation.images.workspace"
+        assert replacement["video_uri"].endswith("clip-a/augmented_video.mp4")
+        assert replacement["lineage"]["output_sha256"]
+        stored = json.loads(out.read_text())
+        assert stored["schema"] == "npa.paidf.accepted-variants.v1"
+
+    def test_accepts_canonical_reconciliation_with_review_excluded(
+        self, tmp_path: Path
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a", "clip-b"])
+        candidates = build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        decisions = build_decisions_stage(
+            str(tmp_path / "candidates.json"),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "decisions.json"),
+            decided_at=DECIDED_AT,
+        )
+        decisions["decisions"][1]["decision"] = "review"
+        decisions["decisions"][1]["reason"] = "requires human review"
+        reconciliation = reconcile_decisions(candidates, decisions)
+        reconciliation_ref = tmp_path / "canonical-reconciliation.json"
+        reconciliation_ref.write_text(json.dumps(reconciliation))
+
+        manifest = accepted_replacements_stage(
+            str(tmp_path / "candidates.json"),
+            str(reconciliation_ref),
+            str(tmp_path / "accepted.json"),
+        )
+
+        assert [row["lineage"]["candidate_id"] for row in manifest["replacements"]] == [
+            "clip-a"
+        ]
+        assert reconciliation["unresolved_review_candidate_ids"] == ["clip-b"]
+
+    def test_fails_closed_on_unknown_keep_ids(self, tmp_path: Path) -> None:
+        reconciliation = {
+            "schema": "npa.paidf.reconciliation.v1",
+            "keep": [{"candidate_id": "ghost"}],
+            "drop": [],
+        }
+        recon_ref = tmp_path / "keep-drop.json"
+        recon_ref.write_text(json.dumps(reconciliation))
+        candidates_ref = tmp_path / "candidates.json"
+        candidates_ref.write_text(json.dumps({"schema": "npa.paidf.candidates.v1", "candidates": []}))
+        with pytest.raises(PaidfContractError, match="unknown candidates"):
+            accepted_replacements_stage(
+                candidates_manifest_ref=str(candidates_ref),
+                reconciliation_ref=str(recon_ref),
+                output_ref=str(tmp_path / "out.json"),
+            )
+
+    def test_reconciliation_must_cover_every_candidate_exactly_once(
+        self, tmp_path: Path
+    ) -> None:
+        candidates_ref = tmp_path / "candidates.json"
+        candidates_ref.write_text(
+            json.dumps(
+                {
+                    "schema": "npa.paidf.candidates.v1",
+                    "candidates": [
+                        {
+                            "candidate_id": "cand-1",
+                            "source_episode_id": "episode_0000",
+                            "source_episode_index": 0,
+                            "camera_key": "observation.images.workspace",
+                            "variant": {
+                                "variant_id": "var-1",
+                                "output_sha256": SHA_A,
+                                "source_sha256": SHA_B,
+                            },
+                            "evaluation": {},
+                        }
+                    ],
+                }
+            )
+        )
+        base = {"schema": "npa.paidf.reconciliation.v1"}
+
+        missing = dict(base)
+        missing["keep"] = []
+        missing["drop"] = []
+        (tmp_path / "missing.json").write_text(json.dumps(missing))
+        with pytest.raises(PaidfContractError, match="missing candidates"):
+            accepted_replacements_stage(
+                candidates_manifest_ref=str(candidates_ref),
+                reconciliation_ref=str(tmp_path / "missing.json"),
+                output_ref=str(tmp_path / "out.json"),
+            )
+
+        duplicate = dict(base)
+        duplicate["keep"] = [
+            {"candidate_id": "cand-1", "decision": "accept"},
+            {"candidate_id": "cand-1", "decision": "accept"},
+        ]
+        duplicate["drop"] = []
+        (tmp_path / "duplicate.json").write_text(json.dumps(duplicate))
+        with pytest.raises(PaidfContractError, match="duplicate candidate_id"):
+            accepted_replacements_stage(
+                candidates_manifest_ref=str(candidates_ref),
+                reconciliation_ref=str(tmp_path / "duplicate.json"),
+                output_ref=str(tmp_path / "out.json"),
+            )
+
+        overlapping = dict(base)
+        overlapping["keep"] = [{"candidate_id": "cand-1", "decision": "accept"}]
+        overlapping["drop"] = [{"candidate_id": "cand-1", "decision": "reject"}]
+        (tmp_path / "overlap.json").write_text(json.dumps(overlapping))
+        with pytest.raises(PaidfContractError, match="both keep and drop"):
+            accepted_replacements_stage(
+                candidates_manifest_ref=str(candidates_ref),
+                reconciliation_ref=str(tmp_path / "overlap.json"),
+                output_ref=str(tmp_path / "out.json"),
+            )
+
+    def test_review_cannot_enter_keep_and_states_must_be_consistent(
+        self, tmp_path: Path
+    ) -> None:
+        candidates_ref = tmp_path / "candidates.json"
+        candidates_ref.write_text(
+            json.dumps(
+                {
+                    "schema": "npa.paidf.candidates.v1",
+                    "candidates": [
+                        {
+                            "candidate_id": "cand-1",
+                            "source_episode_id": "episode_0000",
+                            "source_episode_index": 0,
+                            "camera_key": "observation.images.workspace",
+                            "variant": {
+                                "variant_id": "var-1",
+                                "output_sha256": SHA_A,
+                                "source_sha256": SHA_B,
+                            },
+                            "evaluation": {},
+                        }
+                    ],
+                }
+            )
+        )
+        base = {"schema": "npa.paidf.reconciliation.v1"}
+
+        review_in_keep = dict(base)
+        review_in_keep["keep"] = [{"candidate_id": "cand-1", "decision": "review"}]
+        review_in_keep["drop"] = []
+        (tmp_path / "review-keep.json").write_text(json.dumps(review_in_keep))
+        with pytest.raises(PaidfContractError, match="non-accept decision"):
+            accepted_replacements_stage(
+                candidates_manifest_ref=str(candidates_ref),
+                reconciliation_ref=str(tmp_path / "review-keep.json"),
+                output_ref=str(tmp_path / "out.json"),
+            )
+
+        bad_drop = dict(base)
+        bad_drop["keep"] = []
+        bad_drop["drop"] = [{"candidate_id": "cand-1", "decision": "maybe"}]
+        (tmp_path / "bad-drop.json").write_text(json.dumps(bad_drop))
+        with pytest.raises(PaidfContractError, match="non-terminal decision"):
+            accepted_replacements_stage(
+                candidates_manifest_ref=str(candidates_ref),
+                reconciliation_ref=str(tmp_path / "bad-drop.json"),
+                output_ref=str(tmp_path / "out.json"),
+            )
+
+        review_excluded = _valid_reconciliation(
+            keep=[],
+            drop=[{"candidate_id": "cand-1", "decision": "review"}],
+            unresolved=["cand-1"],
+        )
+        (tmp_path / "review-drop.json").write_text(json.dumps(review_excluded))
+        manifest = accepted_replacements_stage(
+            candidates_manifest_ref=str(candidates_ref),
+            reconciliation_ref=str(tmp_path / "review-drop.json"),
+            output_ref=str(tmp_path / "out.json"),
+        )
+        assert manifest["replacements"] == []
+
+    @pytest.mark.parametrize(
+        "unresolved_value",
+        [None, [], ["cand-1", "cand-1"], ["bad id"], ["cand-1", "ghost"]],
+    )
+    def test_review_ids_must_exactly_match_review_drops(
+        self, tmp_path: Path, unresolved_value: object
+    ) -> None:
+        candidates_ref = tmp_path / "candidates.json"
+        candidate = {
+            "schema": "npa.paidf.candidates.v1",
+            "candidates": [
+                {
+                    "candidate_id": "cand-1",
+                    "source_episode_id": "episode_0000",
+                    "source_episode_index": 0,
+                    "camera_key": "observation.images.workspace",
+                    "variant": {
+                        "variant_id": "var-1",
+                        "output_sha256": SHA_A,
+                        "source_sha256": SHA_B,
+                    },
+                    "evaluation": {},
+                }
+            ],
+        }
+        candidates_ref.write_text(json.dumps(candidate))
+        reconciliation = _valid_reconciliation(
+            keep=[],
+            drop=[{"candidate_id": "cand-1", "decision": "review"}],
+            unresolved=["cand-1"],
+        )
+        if unresolved_value is None:
+            del reconciliation["unresolved_review_candidate_ids"]
+        else:
+            reconciliation["unresolved_review_candidate_ids"] = unresolved_value
+        reconciliation_ref = tmp_path / "reconciliation.json"
+        reconciliation_ref.write_text(json.dumps(reconciliation))
+        with pytest.raises(PaidfContractError, match="unresolved|must be a list"):
+            accepted_replacements_stage(
+                str(candidates_ref),
+                str(reconciliation_ref),
+                str(tmp_path / "out.json"),
+            )
+
+    def test_unresolved_list_is_required_even_without_review(
+        self, tmp_path: Path
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        reconciliation = _valid_reconciliation(
+            keep=[{"candidate_id": "clip-a", "decision": "accept"}], drop=[]
+        )
+        del reconciliation["unresolved_review_candidate_ids"]
+        reconciliation_ref = tmp_path / "reconciliation.json"
+        reconciliation_ref.write_text(json.dumps(reconciliation))
+        with pytest.raises(PaidfContractError, match="must be a list"):
+            accepted_replacements_stage(
+                str(tmp_path / "candidates.json"),
+                str(reconciliation_ref),
+                str(tmp_path / "out.json"),
+            )
+
+    @pytest.mark.parametrize(
+        ("provider", "error"),
+        [
+            (None, "must be an object"),
+            ({"name": "curator"}, "exactly name and role"),
+            ({"name": "curator", "role": "simulation"}, "curation or evaluation"),
+            (
+                {"name": "curator", "role": "curation", "extra": True},
+                "exactly name and role",
+            ),
+        ],
+    )
+    def test_reconciliation_provider_is_exact(
+        self, tmp_path: Path, provider: object, error: str
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        reconciliation = _valid_reconciliation(
+            keep=[{"candidate_id": "clip-a", "decision": "accept"}], drop=[]
+        )
+        reconciliation["provider"] = provider
+        reconciliation_ref = tmp_path / "reconciliation.json"
+        reconciliation_ref.write_text(json.dumps(reconciliation))
+        with pytest.raises(PaidfContractError, match=error):
+            accepted_replacements_stage(
+                str(tmp_path / "candidates.json"),
+                str(reconciliation_ref),
+                str(tmp_path / "out.json"),
+            )
+
+    @pytest.mark.parametrize(
+        ("mutation", "error"),
+        [
+            (("remove", "identity_gaps", None), "must contain exactly"),
+            (("set", "extra", 0), "must contain exactly"),
+            (("set", "candidates", 2), "totals.candidates"),
+            (("set", "keep", 0), "totals.keep"),
+            (("set", "drop", 1), "totals.drop"),
+            (("set", "unresolved_review", 1), "totals.unresolved_review"),
+            (("set", "identity_gaps", 1), "totals.identity_gaps"),
+            (("set", "candidates", True), "totals.candidates"),
+        ],
+    )
+    def test_reconciliation_totals_are_exact_strict_integers(
+        self, tmp_path: Path, mutation: tuple[str, str, object], error: str
+    ) -> None:
+        fixtures = _builder_fixtures(tmp_path, video_names=["clip-a"])
+        build_candidates_stage(
+            str(fixtures["augment"]),
+            str(fixtures["provenance"]),
+            str(fixtures["evaluator"]),
+            str(fixtures["disposition"]),
+            str(tmp_path / "candidates.json"),
+        )
+        reconciliation = _valid_reconciliation(
+            keep=[{"candidate_id": "clip-a", "decision": "accept"}], drop=[]
+        )
+        action, key, value = mutation
+        if action == "remove":
+            del reconciliation["totals"][key]
+        else:
+            reconciliation["totals"][key] = value
+        reconciliation_ref = tmp_path / "reconciliation.json"
+        reconciliation_ref.write_text(json.dumps(reconciliation))
+        with pytest.raises(PaidfContractError, match=error):
+            accepted_replacements_stage(
+                str(tmp_path / "candidates.json"),
+                str(reconciliation_ref),
+                str(tmp_path / "out.json"),
+            )
+
+
+# ── Frozen-source lock (moved from the future workflow-composition tests) ──
+
+_SHA_T1 = "1" * 64
+_SHA_T2 = "2" * 64
+
+
+def _write_frozen_manifest(
+    path: Path,
+    *,
+    train_hashes: list[str],
+    heldout_hashes: list[str],
+    contract_sha256: str = SHA_B,
+    trajectory_override: str | None = None,
+) -> str:
+    episodes = [
+        {"episode_id": f"episode_{i:04d}", "split": split, "trajectory_sha256": traj}
+        for i, (split, traj) in enumerate(
+            [("train", t) for t in train_hashes]
+            + [("heldout", t) for t in heldout_hashes]
+        )
+    ]
+    if trajectory_override is not None:
+        episodes[0]["trajectory_sha256"] = trajectory_override
+    manifest = {
+        "schema": FROZEN_SOURCE_MANIFEST_SCHEMA,
+        "source_contract": {
+            "schema": "npa.genesis.lerobot-source.v1",
+            "sha256": contract_sha256,
+        },
+        "episodes": episodes,
+    }
+    payload = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+    path.write_bytes(payload)
+    return hashlib.sha256(payload).hexdigest()
+
+
+class TestLoadFrozenSourceManifest:
+    def test_accepts_bytes_matching_the_lock(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "source-manifest.json"
+        digest = _write_frozen_manifest(
+            manifest_path, train_hashes=[_SHA_T1], heldout_hashes=[_SHA_T2]
+        )
+        manifest = load_frozen_source_manifest(
+            str(manifest_path),
+            expected_sha256=digest,
+            expected_contract_sha256=SHA_B,
+        )
+        assert len(manifest["episodes"]) == 2
+
+    def test_rejects_bytes_that_do_not_match_the_locked_digest(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / "source-manifest.json"
+        digest = _write_frozen_manifest(
+            manifest_path, train_hashes=[_SHA_T1], heldout_hashes=[_SHA_T2]
+        )
+        with pytest.raises(PaidfContractError, match="locked digest"):
+            load_frozen_source_manifest(
+                str(manifest_path),
+                expected_sha256=SHA_A,
+                expected_contract_sha256=SHA_B,
+            )
+        assert digest != SHA_A
+
+    def test_rejects_manifest_pointing_at_a_different_source_contract(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / "source-manifest.json"
+        digest = _write_frozen_manifest(
+            manifest_path,
+            train_hashes=[_SHA_T1],
+            heldout_hashes=[_SHA_T2],
+            contract_sha256=SHA_C,
+        )
+        with pytest.raises(PaidfContractError, match="source-contract digest"):
+            load_frozen_source_manifest(
+                str(manifest_path),
+                expected_sha256=digest,
+                expected_contract_sha256=SHA_B,
+            )
+
+    def test_rejects_split_content_overlap(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "source-manifest.json"
+        digest = _write_frozen_manifest(
+            manifest_path, train_hashes=[_SHA_T1], heldout_hashes=[_SHA_T1]
+        )
+        with pytest.raises(PaidfContractError, match="overlap"):
+            load_frozen_source_manifest(
+                str(manifest_path),
+                expected_sha256=digest,
+                expected_contract_sha256=SHA_B,
+            )
+
+    def test_rejects_malformed_trajectory_hash(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "source-manifest.json"
+        digest = _write_frozen_manifest(
+            manifest_path,
+            train_hashes=[_SHA_T1],
+            heldout_hashes=[_SHA_T2],
+            trajectory_override="not-a-digest",
+        )
+        with pytest.raises(PaidfContractError, match="trajectory_sha256"):
+            load_frozen_source_manifest(
+                str(manifest_path),
+                expected_sha256=digest,
+                expected_contract_sha256=SHA_B,
+            )
+
+    def test_rejects_wrong_schema(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "source-manifest.json"
+        manifest = {"schema": "npa.paidf.something-else.v1", "episodes": []}
+        payload = (json.dumps(manifest) + "\n").encode("utf-8")
+        manifest_path.write_bytes(payload)
+        with pytest.raises(PaidfContractError, match="schema"):
+            load_frozen_source_manifest(
+                str(manifest_path),
+                expected_sha256=hashlib.sha256(payload).hexdigest(),
+                expected_contract_sha256=SHA_B,
+            )
+
+
+# ── Base-campaign freeze helper (moved from the workflow-composition tests) ──
+
+
+def _artifact_file(path: Path, payload: dict) -> tuple[str, str]:
+    data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    path.write_bytes(data)
+    return str(path), hashlib.sha256(data).hexdigest()
+
+
+class _LocalResolver:
+    """Map s3://phase0-fixture/<name> URIs onto real files in a tmp directory."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def __call__(self, ref: str) -> bytes:
+        if ref.startswith("s3://phase0-fixture/"):
+            return (self._root / ref.removeprefix("s3://phase0-fixture/")).read_bytes()
+        return Path(ref).read_bytes()
+
+
+@pytest.fixture()
+def local_s3_resolver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import npa.workflows.paidf_campaign as campaign_module
+
+    resolver = _LocalResolver(tmp_path)
+    monkeypatch.setattr(campaign_module, "_read_artifact_bytes", resolver)
+    return resolver
+
+
+class TestBaseCampaignFreeze:
+    def test_pins_exact_stage_bytes(
+        self, tmp_path: Path, local_s3_resolver: _LocalResolver
+    ) -> None:
+        digests = {}
+        for stage in ("source", "generation", "evaluation"):
+            _, digest = _artifact_file(tmp_path / f"{stage}.json", {"stage": stage})
+            digests[stage] = digest
+        campaign_ref = tmp_path / "campaign.json"
+        campaign = freeze_base_campaign_stage(
+            "paidf-phase0",
+            source_manifest_ref="s3://phase0-fixture/source.json",
+            generation_manifest_ref="s3://phase0-fixture/generation.json",
+            evaluation_report_ref="s3://phase0-fixture/evaluation.json",
+            campaign_output_ref=str(campaign_ref),
+        )
+        assert validate_campaign(campaign) == campaign
+        stored = json.loads(campaign_ref.read_text(encoding="utf-8"))
+        for stage in ("source", "generation", "evaluation"):
+            assert stored["stage_fingerprints"][stage] == digests[stage]
+            assert stored["artifacts"][stage]["sha256"] == digests[stage]
+            assert stored["artifacts"][stage]["uri"].startswith("s3://phase0-fixture/")
+
+    def test_rejects_incomplete_stage_set(self) -> None:
+        with pytest.raises(PaidfContractError, match="exactly the stages"):
+            build_base_campaign(
+                "paidf-phase0",
+                stage_refs={"source": "s3://bucket/source.json"},
+                stage_sha256s={"source": SHA_A},
+            )
+
+    @pytest.mark.parametrize(
+        "stage_refs",
+        [
+            {
+                "source": "s3://bucket/source.json",
+                "generation": "s3://bucket/generation.json",
+            },
+            {
+                "source": "s3://bucket/source.json",
+                "generation": "s3://bucket/generation.json",
+                "evaluation": "s3://bucket/evaluation.json",
+                "extra": "s3://bucket/extra.json",
+            },
+        ],
+    )
+    def test_rejects_missing_or_extra_stage_refs(self, stage_refs: dict[str, str]) -> None:
+        with pytest.raises(PaidfContractError, match="exactly the stages"):
+            build_base_campaign(
+                "paidf-phase0",
+                stage_refs=stage_refs,
+                stage_sha256s={
+                    "source": SHA_A,
+                    "generation": SHA_B,
+                    "evaluation": SHA_C,
+                },
+            )
+
+    @pytest.mark.parametrize(
+        "stage_sha256s",
+        [
+            {"source": SHA_A, "generation": SHA_B},
+            {
+                "source": SHA_A,
+                "generation": SHA_B,
+                "evaluation": SHA_C,
+                "extra": "d" * 64,
+            },
+        ],
+    )
+    def test_rejects_missing_or_extra_stage_digests(
+        self, stage_sha256s: dict[str, str]
+    ) -> None:
+        with pytest.raises(PaidfContractError, match="digest keys"):
+            build_base_campaign(
+                "paidf-phase0",
+                stage_refs={
+                    "source": "s3://bucket/source.json",
+                    "generation": "s3://bucket/generation.json",
+                    "evaluation": "s3://bucket/evaluation.json",
+                },
+                stage_sha256s=stage_sha256s,
+            )
+
+    def test_frozen_manifest_is_never_mutated_by_the_freeze(
+        self, tmp_path: Path, local_s3_resolver: _LocalResolver
+    ) -> None:
+        _, digest = _artifact_file(tmp_path / "source.json", {"stage": "source"})
+        _artifact_file(tmp_path / "generation.json", {"stage": "generation"})
+        _artifact_file(tmp_path / "evaluation.json", {"stage": "evaluation"})
+        campaign = freeze_base_campaign_stage(
+            "paidf-phase0",
+            source_manifest_ref="s3://phase0-fixture/source.json",
+            generation_manifest_ref="s3://phase0-fixture/generation.json",
+            evaluation_report_ref="s3://phase0-fixture/evaluation.json",
+            campaign_output_ref=str(tmp_path / "campaign.json"),
+        )
+        assert campaign["artifacts"]["source"]["sha256"] == digest
+        # The frozen artifact is consumed read-only: its bytes are unchanged.
+        assert hashlib.sha256((tmp_path / "source.json").read_bytes()).hexdigest() == digest

--- a/npa/tests/workflows/test_paidf_decisions.py
+++ b/npa/tests/workflows/test_paidf_decisions.py
@@ -1,0 +1,336 @@
+"""Tests for the provider-neutral curation-decision contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from npa.workflows.paidf_campaign import (
+    CANDIDATE_MANIFEST_SCHEMA,
+    DECISION_MANIFEST_SCHEMA,
+    RECONCILIATION_SCHEMA,
+    PaidfContractError,
+    build_candidate,
+    reconcile_decisions,
+    reconcile_provider_export,
+    validate_candidate_manifest,
+    validate_decision_manifest,
+)
+
+
+DECIDED_AT = "2026-09-01T00:00:00Z"
+
+
+def _candidate(candidate_id: str = "cand-001") -> dict:
+    return build_candidate(
+        candidate_id=candidate_id,
+        source_episode_id="episode_0000",
+        source_episode_index=0,
+        camera_key="observation.images.workspace",
+        variant_id=f"var-{candidate_id}",
+        output_sha256="a" * 64,
+        source_sha256="b" * 64,
+        evaluation={"checks": {"media_integrity": "pass"}},
+    )
+
+
+def _manifest() -> dict:
+    return {
+        "schema": CANDIDATE_MANIFEST_SCHEMA,
+        "candidates": [_candidate("cand-001"), _candidate("cand-002")],
+    }
+
+
+def _decisions(manifest: dict, states: dict[str, str]) -> dict:
+    return {
+        "schema": DECISION_MANIFEST_SCHEMA,
+        "provider": {"name": "human-curator", "role": "curation"},
+        "decisions": [
+            {
+                "candidate_id": candidate_id,
+                "decision": state,
+                "evidence": {"export": "final-decision-export.json"},
+                "reason": f"automated {state}",
+                "decided_at": DECIDED_AT,
+            }
+            for candidate_id, state in states.items()
+        ],
+    }
+
+
+class TestCandidateManifest:
+    def test_valid_manifest(self) -> None:
+        manifest = _manifest()
+        assert validate_candidate_manifest(manifest) == manifest
+
+    def test_duplicate_candidate_id_fails(self) -> None:
+        manifest = {
+            "schema": CANDIDATE_MANIFEST_SCHEMA,
+            "candidates": [_candidate("cand-001"), _candidate("cand-001")],
+        }
+        with pytest.raises(PaidfContractError, match="duplicate candidate_id"):
+            validate_candidate_manifest(manifest)
+
+    def test_missing_variant_hash_fails(self) -> None:
+        candidate = _candidate()
+        del candidate["variant"]["output_sha256"]
+        manifest = {"schema": CANDIDATE_MANIFEST_SCHEMA, "candidates": [candidate]}
+        with pytest.raises(PaidfContractError, match="output_sha256"):
+            validate_candidate_manifest(manifest)
+
+    @pytest.mark.parametrize("bad_index", ["0", 1.5, -1, True, None])
+    def test_non_integer_episode_index_fails(self, bad_index: object) -> None:
+        candidate = _candidate()
+        candidate["source_episode_index"] = bad_index
+        manifest = {"schema": CANDIDATE_MANIFEST_SCHEMA, "candidates": [candidate]}
+        with pytest.raises(PaidfContractError, match="source_episode_index"):
+            validate_candidate_manifest(manifest)
+
+    @pytest.mark.parametrize(
+        "reserved_field", ["variant_id", "output_sha256", "source_sha256"]
+    )
+    def test_variant_extras_cannot_replace_identity_fields(
+        self, reserved_field: str
+    ) -> None:
+        with pytest.raises(PaidfContractError, match="cannot replace"):
+            build_candidate(
+                candidate_id="cand-001",
+                source_episode_id="episode_0000",
+                source_episode_index=0,
+                camera_key="observation.images.workspace",
+                variant_id="var-cand-001",
+                output_sha256="a" * 64,
+                source_sha256="b" * 64,
+                evaluation={},
+                variant_extras={reserved_field: "same-or-different"},
+            )
+
+    def test_variant_extras_preserve_nonidentity_metadata(self) -> None:
+        candidate = build_candidate(
+            candidate_id="cand-001",
+            source_episode_id="episode_0000",
+            source_episode_index=0,
+            camera_key="observation.images.workspace",
+            variant_id="var-cand-001",
+            output_sha256="a" * 64,
+            source_sha256="b" * 64,
+            evaluation={},
+            variant_extras={"video_uri": "s3://bucket/cand-001.mp4"},
+        )
+        assert candidate["variant"]["video_uri"] == "s3://bucket/cand-001.mp4"
+        assert candidate["variant"]["output_sha256"] == "a" * 64
+
+
+class TestDecisionManifest:
+    def test_full_coverage_passes(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "reject"}
+        )
+        assert validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_review_is_a_valid_state(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "review", "cand-002": "accept"}
+        )
+        validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_missing_decision_fails_closed(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(manifest, {"cand-001": "accept"})
+        with pytest.raises(PaidfContractError, match="missing for candidates"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_unknown_candidate_fails(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest,
+            {"cand-001": "accept", "cand-002": "accept", "cand-999": "accept"},
+        )
+        with pytest.raises(PaidfContractError, match="unknown candidate"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_duplicate_decision_fails(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "accept"}
+        )
+        decisions["decisions"].append(dict(decisions["decisions"][0]))
+        with pytest.raises(PaidfContractError, match="more than one decision"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_invalid_state_fails(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "maybe", "cand-002": "accept"}
+        )
+        with pytest.raises(PaidfContractError, match="accept, reject, review"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_provider_must_have_exactly_name_and_role(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "accept"}
+        )
+        del decisions["provider"]["role"]
+        with pytest.raises(PaidfContractError, match="exactly name and role"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "accept"}
+        )
+        decisions["provider"]["mode"] = "automated"
+        with pytest.raises(PaidfContractError, match="exactly name and role"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_provider_role_must_be_curation_or_evaluation(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "accept"}
+        )
+        decisions["provider"]["role"] = "simulation"
+        with pytest.raises(PaidfContractError, match="curation or evaluation"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_missing_decided_at_fails(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "accept"}
+        )
+        del decisions["decisions"][0]["decided_at"]
+        with pytest.raises(PaidfContractError, match="exactly"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+    @pytest.mark.parametrize(
+        "bad_timestamp",
+        [
+            "2026-09-01 00:00:00Z",
+            "2026-09-01T00:00Z",
+            "2026-9-01T00:00:00Z",
+            "not-a-timestamp",
+            None,
+        ],
+    )
+    def test_malformed_decided_at_fails(self, bad_timestamp: object) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "accept"}
+        )
+        decisions["decisions"][0]["decided_at"] = bad_timestamp
+        with pytest.raises(PaidfContractError, match="canonical UTC seconds"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_non_calendar_decided_at_fails(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "accept"}
+        )
+        decisions["decisions"][0]["decided_at"] = "2026-02-30T00:00:00Z"
+        with pytest.raises(PaidfContractError, match="real calendar time"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+    def test_incomplete_decision_fields_fail(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "accept"}
+        )
+        del decisions["decisions"][0]["reason"]
+        with pytest.raises(PaidfContractError, match="must contain exactly"):
+            validate_decision_manifest(decisions, candidates=manifest)
+
+
+class TestReconcileDecisions:
+    def test_keep_drop_and_review_exclusion(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "review"}
+        )
+        result = reconcile_decisions(manifest, decisions)
+        assert result["schema"] == RECONCILIATION_SCHEMA
+        assert [entry["candidate_id"] for entry in result["keep"]] == ["cand-001"]
+        assert [entry["candidate_id"] for entry in result["drop"]] == ["cand-002"]
+        assert result["totals"]["unresolved_review"] == 1
+        assert result["unresolved_review_candidate_ids"] == ["cand-002"]
+        assert result["totals"]["identity_gaps"] == 0
+
+    def test_reject_excluded_from_training(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "reject", "cand-002": "reject"}
+        )
+        result = reconcile_decisions(manifest, decisions)
+        assert result["keep"] == []
+        assert result["totals"]["unresolved_review"] == 0
+
+    def test_reconciliation_carries_the_decision_provider(self) -> None:
+        manifest = _manifest()
+        decisions = _decisions(
+            manifest, {"cand-001": "accept", "cand-002": "reject"}
+        )
+        result = reconcile_decisions(manifest, decisions)
+        assert result["provider"] == decisions["provider"]
+
+
+class TestReconcileProviderExport:
+    def test_exact_join(self) -> None:
+        manifest = _manifest()
+        export = [
+            {"external_id": "cand-001", "data_hash": "dh-1", "decision": "accept"},
+            {"external_id": "cand-002", "data_hash": "dh-2", "decision": "review"},
+        ]
+        result = reconcile_provider_export(manifest, export)
+        assert result["totals"]["identity_gaps"] == 0
+        assert len(result["joined"]) == 2
+
+    def test_orphan_fails(self) -> None:
+        manifest = _manifest()
+        export = [
+            {"external_id": "cand-001", "decision": "accept"},
+            {"external_id": "cand-002", "decision": "reject"},
+            {"external_id": "ghost", "decision": "accept"},
+        ]
+        with pytest.raises(PaidfContractError, match="orphan"):
+            reconcile_provider_export(manifest, export)
+
+    def test_missing_export_item_fails(self) -> None:
+        manifest = _manifest()
+        export = [{"external_id": "cand-001", "decision": "accept"}]
+        with pytest.raises(PaidfContractError, match="missing candidates"):
+            reconcile_provider_export(manifest, export)
+
+    def test_duplicate_export_item_fails(self) -> None:
+        manifest = _manifest()
+        export = [
+            {"external_id": "cand-001", "decision": "accept"},
+            {"external_id": "cand-001", "decision": "accept"},
+            {"external_id": "cand-002", "decision": "reject"},
+        ]
+        with pytest.raises(PaidfContractError, match="duplicate"):
+            reconcile_provider_export(manifest, export)
+
+    def test_identity_only_row_without_decision_fails(self) -> None:
+        manifest = _manifest()
+        export = [
+            {"external_id": "cand-001", "data_hash": "dh-1"},
+            {"external_id": "cand-002", "data_hash": "dh-2"},
+        ]
+        with pytest.raises(PaidfContractError, match="non-null accept, reject,"):
+            reconcile_provider_export(manifest, export)
+
+    def test_invalid_decision_state_fails(self) -> None:
+        manifest = _manifest()
+        export = [
+            {"external_id": "cand-001", "decision": "accept"},
+            {"external_id": "cand-002", "decision": "deferred"},
+        ]
+        with pytest.raises(PaidfContractError, match="non-null accept, reject,"):
+            reconcile_provider_export(manifest, export)
+
+    def test_malformed_candidate_manifest_fails_before_join(self) -> None:
+        malformed = {
+            "schema": CANDIDATE_MANIFEST_SCHEMA,
+            "candidates": [{"candidate_id": "cand-001"}],
+        }
+        export = [{"external_id": "cand-001", "decision": "accept"}]
+        with pytest.raises(PaidfContractError, match="source_episode_id"):
+            reconcile_provider_export(malformed, export)

--- a/skills/workflows/physical-ai-data-factory/SKILL.md
+++ b/skills/workflows/physical-ai-data-factory/SKILL.md
@@ -578,6 +578,37 @@ npa workbench cosmos-curate curate-videos --input-dir ./clips --output-dir ./cur
   `workbench.nurec.visualize`, which the renderer pins to the prebuilt
   `npa-rerun-viewer` image. It never performs `pip install` at task runtime.
 
+## Immutable campaign reuse and provider derivatives
+
+The expensive source, generation, and evaluation stages are frozen once into an
+immutable base campaign (`npa.paidf.campaign.v1`), and every provider workshop
+becomes a derivative run that reads the base read-only and writes to its own
+prefix. The contracts live in `npa.workflows.paidf_campaign`
+(`docs/workbench/guides/paidf-campaign-reuse.md` is the runbook):
+
+- `build_partner_input` / `validate_partner_input` pin the base campaign ID,
+  manifest URI, and canonical digest; a derivative run cannot execute
+  `source`, `generation`, or `evaluation`, must declare a `curation`,
+  `observability`, or `simulation` role, credential *references* (never
+  values), and an output prefix separate from the base campaign.
+- `build_execution_receipt` / `build_partner_result` account for every
+  declared overlay stage and prove `source_mutated: false` with every output
+  under the derivative prefix.
+- Curation flows through provider-neutral candidates
+  (`npa.paidf.candidates.v1`), decisions (`npa.paidf.decisions.v1`), and
+  reconciliation (`npa.paidf.reconciliation.v1`). A decision provider is
+  exactly `name` plus a `curation` or `evaluation` role; each decision is
+  exactly `candidate_id`, `decision`, `evidence`, `reason`, and a
+  caller-supplied `decided_at` in `YYYY-MM-DDTHH:MM:SSZ` UTC-second form.
+  `accept` enters the training set, `reject` is dropped, and `review` is a
+  valid but unresolved state that is reported explicitly and never enters
+  accepted replacements. Provider exports reconcile by exact external ID and
+  every terminal row must carry a non-null decision state.
+- Regenerating any base stage creates a new campaign; existing campaigns are
+  never silently changed. This is a contract layer, not a provider plugin
+  system: provider execution stays in provider-specific code, and no live
+  second-provider integration is claimed until one runs.
+
 ## Testing (live-infra is a priority)
 
 Follow `skills/atomic/testing-conventions/SKILL.md` ("Live-Infra Testing Is A


### PR DESCRIPTION
<!-- register: public GitHub pull request | reader: Nebius Physical AI maintainers | consumed: code review -->

## Summary

PAIDF needs to reuse expensive source, generation, and evaluation work across provider-specific workshops without letting a provider redefine the base dataset. This change adds a dependency-light contract layer for that boundary.

One immutable base campaign records the exact source, generation, and evaluation artifacts and their digests. Encord, FiftyOne, Foxglove, Rerun, Antioch, or another provider can then consume those artifacts read-only and write a separate derivative result through the same input, receipt, and result envelopes.

## Contract behavior

- Base campaigns contain exactly the `source`, `generation`, and `evaluation` stages. Every artifact digest must match its stage fingerprint; extra, missing, or divergent stages fail validation.
- Partner inputs pin the base campaign and provider configuration, declare their read and write boundaries, and cannot execute a base stage. Execution receipts account for every declared overlay stage, and result artifacts must remain under the derivative prefix.
- Candidate, decision, and reconciliation manifests are provider-neutral. Candidates reconcile by exact identity, and missing, duplicate, conflicting, unknown, or malformed decisions fail closed.
- Decisions contain exactly `candidate_id`, `decision`, `evidence`, `reason`, and caller-supplied `decided_at`. Canonical builders do not read the wall clock.
- `accept` enters the replacement set. `reject` and unresolved `review` decisions remain excluded, and accepted-replacement construction revalidates exact coverage and state consistency.
- Frozen source manifests are checked against their locked bytes, schema, source-contract digest, episode indexes, trajectory digests, split labels, and cross-split content isolation.

The Antioch helper is a generic simulation-overlay example. Provider execution, authentication, and resource lifecycle remain in provider-specific SDK, CLI, or workflow code.

## Failure behavior

The validators reject drift before a derivative can claim a valid campaign result. This includes an altered base artifact, a provider write outside its prefix, an incomplete stage receipt, a non-terminal provider export row, or a reconciliation that omits or changes a candidate state.

## Verification

| Gate | Result |
| --- | --- |
| Campaign and decision tests | 107 passed |
| Repository guardrails | 2,412 passed |
| Onboarding smoke tests | 114 passed |
| Ruff and dependency integrity | Passed |
| Whitespace, confidentiality, English-only, and gitleaks scans | Passed |
| Full local unit suite | 12,953 passed; all 74 failure nodes reproduced on an equal-length, unmodified current-`main` lane, leaving no candidate-only failure |
| Collection accounting | 109 additional tests: 107 PR tests and two expected shipped-file guardrail instances; no tests lost |

GitHub's seven CI checks also pass on the submitted commit.

No live service, provider, or infrastructure call is required by these contracts.

## Skill maintenance

- [x] Updated `skills/workflows/physical-ai-data-factory/SKILL.md` with immutable campaign reuse and provider-derivative semantics. `skills/index.yaml` does not require a new entry.
