### PR TITLE
docs: reconcile GHCR inventory with accepted releases

### DIFF
--- a/docs/security/container-golden-evals.md
+++ b/docs/security/container-golden-evals.md
@@ -303,10 +303,12 @@ pipeline. Key safety notes are condensed below.
   standalone BYO Job builders preserve uid/gid 1000; neither may override
   `runAsUser: 0`. The LanceDB image also runs as `ubuntu`; its narrow
   passwordless-sudo exemption exists only for SkyPilot's in-pod bootstrap and
-  does not enable sshd by default. `sonic` and `detection-training` retain root
-  from their upstream bases. `foxglove-embed` runs as `nobody` on a digest-pinned
-  caddy base. The remaining root images are candidates for a separate non-root
-  hardening pass.
+  does not enable sshd by default. The 2026-09-05 anonymous OCI config audit
+  found the accepted `sonic` Kubernetes release still declares `root`; the
+  other 31 current releases, including `detection-training`, declare non-root
+  users. `foxglove-embed` runs as `nobody` on a digest-pinned Caddy base.
+  SONIC remains a candidate for a separate non-root hardening pass; its current
+  Dockerfile does not retroactively change historical released bytes.
 - **Network exposure** — services that open ports (`lerobot` :8080, `cosmos`
   :8080, `lancedb` :8686, `detection-training` :8790, `robocasa` :8791, `fiftyone` :5151,
   `foxglove-embed` :8099) must be

--- a/docs/workbench/container-image-catalog.md
+++ b/docs/workbench/container-image-catalog.md
@@ -18,18 +18,37 @@ images. It and existing saved `container_registry` values do not repoint these
 repository-owned runtime defaults; select custom bytes with a complete image
 reference or an explicit workflow `--registry`.
 
-The accepted-release manifest was verified against the public GHCR tag and OCI
-manifest APIs on 2026-09-03. All 32 recorded release digests resolved
-anonymously. **Built** is the UTC build date of the newest listed variant;
-reproducible images that
-intentionally zero their OCI `created` field use the timestamp in the immutable
-tag and `npa.build_ts` label.
+The main-branch public plan and accepted-release manifest were verified against
+GHCR without credentials on **2026-09-05**. All **32 current release tags**
+resolved and matched their recorded digests. All **43 retained table references**
+(32 current pins and 11 historical aliases) resolved anonymously; manifest and
+OCI config hashes were checked, and every inspected runtime was `linux/amd64`.
+No missing or drifted accepted release required a build, promotion, or registry
+write. This audit did not execute new CPU/GPU workloads or repeat payload scans;
+capability results below retain their original exact-digest evidence.
 
-Prefer a full timestamped tag when selecting a hardware-specific variant. OCI
-tags can be moved, so resolve and retain the manifest digest as well when strict
-reproducibility is required.
+**Built** is the UTC build date of the newest listed variant, read from OCI
+`created`, or from the immutable timestamp/`npa.build_ts` when a reproducible
+image clears `created`. Rows are ordered by **Built**, then friendly name.
 
-Rows are ordered by **Built** date, then by friendly name.
+Prefer the current resolved pin from NPA. The additional aliases are retained
+for historical comparison and provenance, including superseded LeRobot and
+LanceDB releases; their availability does not establish current functional
+support. Resolve and retain the manifest digest for reproducibility.
+
+The build inventory has 34 packaging entries (33 redistribution-eligible and
+one restricted); the tool map has 35 entries (32 public-release members, one
+restricted tool, and two validation candidates). Foundation and derived
+Dockerfiles are not independent public releases. In particular, `loop-eval`
+uses `sim2real-eval/Dockerfile`, and `reference-policy` is a derived EnvGen
+image. Build sources, eligibility, publication, and functional validation are
+separate claims.
+
+LeRobot 0.6.0 remains selectable package support without an accepted public
+image pin/digest. Its official `npa-lerobot:0.6.0` tag returned
+`404 MANIFEST_UNKNOWN` in the separate optional-variant check; use a validated
+operator image for that version. It is not a missing member of the current
+public release plan.
 
 ## 2026-09-04 coherent Sim2Real publication
 
@@ -105,9 +124,9 @@ The main-branch publishing plan was compared with GHCR without credentials. Its
   rebuilt from main and full-layer scanned before publication.
 
 An independent anonymous verification then resolved all 26 exact plan tags.
-LTX-2.5 remains excluded because its required GPU validation is not complete;
-`cosmos3-serving` and `sonic-mujoco` remain excluded by the redistribution
-guard.
+At that audit date, LTX-2.5 was excluded pending GPU validation, and the old
+`cosmos3-serving` and `sonic-mujoco` bytes were restricted. Their accepted
+replacements are now included in the current table below.
 
 ## 2026-08-22 Content Agents publication
 
@@ -128,40 +147,40 @@ published, and anonymously pullable status for this exact digest only.
 
 | Friendly name | Image (`ghcr.io/nebius/nebius-physical-ai/...`) | Published tag(s) | Built | What it does |
 | --- | --- | --- | --- | --- |
-| Alpamayo 2 Super 34B | `npa-alpamayo2-super` | `0.1.0-cu128` | 2026-08-18 | Real surround-view VLA trajectory inference through NVIDIA's Apache-2.0 source. OpenMDW-1.1 weights and the separately gated/non-transferable PhysicalAI-AV sample data are fetched only at runtime under the operator's Hugging Face identity. The payload-clean image and real workflow were validated independently on B200 and RTX PRO 6000. See the [operator guide](alpamayo2-super.md). |
-| NVIDIA Content Agents 0.5.2 | `npa-content-agents` | `0.5.2-npa2` | 2026-08-22 | Public rigid-object material/physics/validation adapter containing Apache-2.0 source and zero OVRTX payload. Exact OVRTX 0.3.0.312915 is fetched directly from NVIDIA into the operator runtime cache. The exact public digest passed byte/layer scanning, anonymous resolution, and a real RTX PRO 6000 workflow. See [Content Agents](content-agents.md). |
 | SONIC Retargeting 0.1.1 | `npa-retargeting` | `0.1.1` | 2026-06-16 | CPU-only motion retargeting and motion-library conversion feeding SONIC locomotion training. A slim `python:3.11` image for the inexpensive preprocessing stage before GPU work. |
-| Rerun 0.31.4 | `npa-rerun-viewer` | `0.31.4-sim2real-coherent-20260904` | 2026-09-03 | Published non-root `ubuntu` SkyPilot worker and Rerun viewer/server on ports 9876/9090 for `.rrd` robotics traces. It includes the attested bootstrap contract and exact-source Sim2Real Stage 14 runtime, and bakes no models, datasets, credentials, or runtime caches. The coherent release converted an actual three-sample robot joint trace, reopened its RRD entity through the CLI, and served/read the artifact over HTTP. |
-| Sim2Real Controller 0.1.2 | `npa-sim2real-control` | `0.1.2-sim2real-coherent-20260904` | 2026-09-03 | Non-root CPU controller containing the canonical 14-stage orchestration capability. The coherent release expanded and validated both the checkpoint-promotion and loop-back decision branches; it contains no model weights, datasets, credentials, or runtime caches. |
 | LeRobot Policy Server 0.1.1 | `npa-lerobot-policy` | `0.1.1` | 2026-07-10 | Serves a trained LeRobot policy over HTTP for closed-loop inference (default `lerobot/diffusion_pusht`). This is the BYO-policy contract endpoint called by other workflow stages. |
 | BDD100K Detection Training | `npa-detection-training` | `bdd100k-golden-eval-smoke-20260614T210000Z` | 2026-07-22 | Object-detector train/eval service on port 8790 with torchvision detectors and COCO metrics. It provides the re-label and measurement stage in the data-factory loop. |
-| Lichtblick 1.26.0 | `npa-lichtblick` | `1.26.0` | 2026-07-23 | Fully open-source (MPL-2.0), Foxglove-compatible MCAP/ROS log viewer served by Caddy on port 8080. No account or proprietary component is required. |
 | GR00T N1.7-3B | `npa-groot` | `0.1.0` | 2026-08-01 | NVIDIA Isaac-GR00T humanoid foundation-model inference using public `nvidia/GR00T-N1.7-3B`; weights are pulled anonymously at runtime by default, with an optional Hugging Face token for rate limits or private overrides. GR00T inference itself does not require Isaac or EULA acceptance. |
-| Isaac Lab 3.0 beta 2 patch 1 (Isaac Sim 6.0.1) | `npa-isaac-lab` | `3.0.0b2.post1-sim2real-coherent-20260904` | 2026-09-03 | Payload-clean Isaac Lab RL simulation image: every proprietary NVIDIA runtime wheel is hash-pinned and fetched from `pypi.nvidia.com` only after the operator's run-scoped EULA acceptance. The coherent exact-source release preserves the runtime-fetch boundary and was validated with a real RTX/Vulkan render on RTX PRO 6000. Upstream still labels this release beta; see [Isaac Lab 3](isaac-lab-3.md) for the measured cold-start tradeoff. |
 | Cosmos 1.0 Diffusion 7B (Predict) | `npa-cosmos` | `1.0.9`, `cu128-torch27-sm100-1.0.9-20260803T002017Z` | 2026-08-03 | Cosmos world-model generation with `Cosmos-1.0-Diffusion-7B-Text2World`, plus the default self-hosted VLM image for workflows. Uses Torch 2.7 and CUDA 12.8 with flash-attn, NATTEN, and Transformer Engine. |
 | Cosmos Reason 2 / Predict 2.5 (3.0.1) | `npa-cosmos3-reason` | `3.0.1-genuine-sm120`, `cuda13-b300-3.0.1-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | VLM reasoning over video/images with `Cosmos-Reason2-8B` or `Cosmos-Reason2-2B`, serving as a judge/critic stage. Also wires Predict 2.5, Transfer 2.5, and Cosmos-Guardrail1 model IDs on a Blackwell-capable CUDA 13 base. |
-| Cosmos Transfer 2.5 | `npa-cosmos2-transfer` | `2.5.1-sim2real-coherent-20260904` | 2026-09-03 | Cosmos Transfer 2.5 Sim2Real video augmentation, built from source at an immutable commit with hash-locked dependencies. Gated weights and the pinned guardrail tokenizer data are fetched at runtime with `HF_TOKEN`; the NLTK-safe cache materialization keeps guardrails enabled, and baked-byte scans remain a release gate. |
 | Foxglove Embed SDK 0.58.0 | `npa-foxglove-embed` | `0.58.0` | 2026-08-03 | Static host for the pinned `@foxglove/embed` browser SDK (MIT) and shared NPA glue module used by the agent UI, on port 8099. Serves operator-mounted MCAP/bag recordings with CORS and byte ranges; the Foxglove app is not redistributed. |
 | Genesis 0.4.6 | `npa-genesis` | `0.4.6`, `cuda13-b300-0.4.6-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Genesis physics simulator for interactive simulation and development. It is the base image for the Sim2Real family: environment generation, evaluation, policies, and VLM-RL. |
 | LanceDB 0.30.3 + CLIP | `npa-lancedb` | `0.30.3`, `cuda13-b300-0.30.3-sm80-sm90-sm100-sm103-sm120-20260803T031514Z` | 2026-08-03 | CLIP embedding and LanceDB vector service on port 8686: the query index behind dataset-of-record search. Exact-source builds use a thin FastAPI layer on the shared CUDA/PyTorch base and include the snapshot-pinned non-root SkyPilot Kubernetes bootstrap needed by native insights workflow stages. |
 | LeRobot 0.5.1 | `npa-lerobot` | `0.5.1`, `cuda13-b300-0.5.1-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Hugging Face LeRobot training/evaluation service on port 8080 for manipulation policies. Includes CUDA and MuJoCo/EGL headless rendering; checkpoints and job state live on mounted volumes. |
-| LTX-2.5 2.5 | `npa-ltx2` | `2.5-rtfetch-20260817` | 2026-08-17 | Lightricks LTX-2.5 text-to-video, shipped with zero Lightricks bytes: source and gated weights are operator-entitled runtime fetches. The accepted digest passed the exact-layer payload scan, entitlement refusal, and real GPU text-to-video plus decoded-MP4 validation. |
 | LeRobot VLM-RL 0.1.1 | `npa-lerobot-vlm-rl` | `0.1.1`, `cuda13-b300-0.1.1-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | RL loop in which a VLM supplies reward or shaping signals for LeRobot policies. It is built on the Genesis image so simulation and policy execution share one container. |
-| Sim2Real EnvGen 0.1.2 | `npa-envgen` | `0.1.2-sim2real-coherent-20260904` | 2026-09-03 | Generates randomized Sim2Real environments and scenes on the Genesis base. The coherent exact-source release bakes the snapshot-pinned non-root SkyPilot Kubernetes bootstrap closure (`sudo`, SSH, and rsync) and was validated through real environment generation plus a Genesis CUDA physics step. It is built from `sim2real-envgen/Dockerfile`. |
 | Sim2Real Loop Eval 0.1.3 | `npa-loop-eval` | `0.1.3-genuine-sm120`, `cuda13-b300-0.1.3-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Batched closed-loop policy evaluation in Genesis (default 16 environments and 240 steps), providing the scoring stage of the Sim2Real loop. Exact-source workflow builds bake the same snapshot-pinned non-root SkyPilot Kubernetes bootstrap closure as EnvGen so Stage 14 can start without a privileged or moving bootstrap image. Built from `sim2real-eval/Dockerfile`; the tool key is `loop-eval`. |
 | Sim2Real Reference Policy 0.1.2 | `npa-reference-policy` | `0.1.2`, `cuda13-b300-0.1.2-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Reference BYO-compatible Sim2Real action policy and worked example of the policy-container contract. Includes the policy functional smoke for comparison with custom images. |
-| SONIC (GR00T-WholeBodyControl) | `npa-sonic` | `cuda13-b300-0.1.2-k8s-runtime-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` (active RTX PRO Kubernetes); `0.1.2` (quarantined L40S) | 2026-08-03 | Whole-body humanoid locomotion training and evaluation using `gear_sonic` (Apache-2.0 at a pinned commit). The public active image runtime-fetches Isaac and requires GPU Operator driver mounts. The old L40S and combined H100/H200 MuJoCo images are restricted and rejected; compute-only serverless use requires a separately validated custom image. |
-| SONIC MuJoCo | `npa-sonic-mujoco` | `0.2.0-runtime` | 2026-08-17 | Independently rebuilt from pinned Apache-2.0 SONIC source on a digest-pinned public Python base with a hash-locked PyTorch/MuJoCo closure. The exact accepted digest passed the real B200 Unitree G1 rollout and payload gates. |
-| Cosmos3-Super serving | `npa-cosmos3-serving` | `0.2.0-oss` | 2026-08-17 | Zero-payload non-root bootstrap on a digest-pinned public Python base. The serving closure, models, and guardrails are operator runtime fetches after terms and entitlement checks; the exact accepted digest passed guarded multi-GPU service boot and real inference. |
-| LeIsaac 0.4.0 | `npa-leisaac` | `0.4.0-20260817T231825Z` | 2026-08-17 | Browser teleoperation for the real upstream SO-101 LiftCube and PickOrange tasks, with secure agent-relay transport and immutable LeRobot episode recording. The image contains Apache-2.0 LeIsaac source and OSS dependencies only; Isaac Sim/Lab, NVIDIA's browser client, and task assets are runtime-fetched under the shared `ACCEPT_EULA` contract and are never baked into the image. Revalidate a digest before use. |
-| Cosmos 3 (`cosmos-framework` 1.2.2) | `npa-cosmos3` | current: `1.2.2-cu130-r6`; historical provenance: `1.2.2-cu130`, `1.2.2-cu130-r2`, `1.2.2-cu130-r5` | 2026-08-21 | Cosmos 3 omni-model generation: text-to-image, image-to-image, text-to-video, image-to-video, and video-to-video. Contains OpenMDW-1.1 source and a CUDA 13 venv only; checkpoints, Wan VAE, and guardrails download at runtime. The additive r6 image retains the attested SkyPilot worker bootstrap and adds auditable source-motion-preserving PAIDF publication while keeping every raw Cosmos video. |
-| Cosmos3-Nano native Ray Serve | `npa-cosmos3-ray-serve` | `ray1-cu130` | 2026-08-26 | Persistent authenticated Cosmos3-Nano serving through cosmos-framework's native `OmniModelDeployment` and `@ray.serve.batch` path. The image contains pinned OpenMDW source and the CUDA/Ray closure but no model or guardrail weights. The exact release digest passed payload/security/SBOM/provenance gates and independent guarded two-sample generation with durable S3 evidence on B200 `sm_100` and RTX PRO 6000 `sm_120`. |
-| Wan 2.2 TI2V-5B | `npa-wan2-2` | `2.2-ti2v5b-rtfetch-cu130-20260817` | 2026-08-17 | Wan 2.2 text/image-to-video generation from Apache-2.0 source on an OSS dependency base. CUDA PyTorch and `nvidia-*` wheels are runtime-fetched under their upstream package terms. The accepted exact digest passed the zero-payload, SPDX/SLSA, vulnerability, and single-GPU TI2V/MP4/Rerun gates; the current four-GPU path remains deferred. |
+| SONIC (GR00T-WholeBodyControl) | `npa-sonic` | `cuda13-b300-0.1.2-k8s-runtime-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | 2026-08-03 | Whole-body humanoid locomotion training and evaluation using `gear_sonic` (Apache-2.0 at a pinned commit). The public active image runtime-fetches Isaac and requires GPU Operator driver mounts. The old L40S and combined H100/H200 MuJoCo images are restricted and rejected; compute-only serverless use requires a separately validated custom image. |
+| Lichtblick 1.26.0 | `npa-lichtblick` | `1.26.0` | 2026-08-07 | Fully open-source (MPL-2.0), Foxglove-compatible MCAP/ROS log viewer served by Caddy on port 8080. No account or proprietary component is required. |
 | Cosmos Curator 0.1.2 | `npa-cosmos-curate` | `0.1.2-skypilot-v1-20260813T164700Z` | 2026-08-13 | Runs real `cosmos-curate` stages in process: download, fixed-stride extraction, clip transcode, motion-vector decode, motion filtering, and clip writing. GPU-stage models are fetched at runtime with the operator's Hugging Face token. |
-| Cosmos Evaluator 0.1.2 | `npa-cosmos-evaluator` | `0.1.2-skypilot-v1-20260813T164700Z-r2` | 2026-08-21 | Runs the upstream `HallucinationProcessor` quality gate on generated video using classical computer vision and no weights. The additive r2 image exposes the deterministic ranking/holdout attribute-sample policy consumed by PAIDF. Attribute verification calls an OpenAI-compatible endpoint; the LFS/EULA-gated obstacle checker is deliberately not fetched. |
 | FiftyOne 1.15.0.post1 (Voxel51) | `npa-fiftyone` | `1.15.0.post1` | 2026-08-13 | Dataset curation and visualization UI on port 5151, including uniqueness, similarity, and embedding visualization. Bundles a `mongod` binary so FiftyOne can launch its own metadata database. |
+| Cosmos3-Super serving | `npa-cosmos3-serving` | `0.2.0-oss` | 2026-08-17 | Zero-payload non-root bootstrap on a digest-pinned public Python base. The serving closure, models, and guardrails are operator runtime fetches after terms and entitlement checks; the exact accepted digest passed guarded multi-GPU service boot and real inference. |
+| LTX-2.5 2.5 | `npa-ltx2` | `2.5-rtfetch-20260817` | 2026-08-17 | Lightricks LTX-2.5 text-to-video, shipped with zero Lightricks bytes: source and gated weights are operator-entitled runtime fetches. The accepted digest passed the exact-layer payload scan, entitlement refusal, and real GPU text-to-video plus decoded-MP4 validation. |
+| SONIC MuJoCo | `npa-sonic-mujoco` | `0.2.0-runtime` | 2026-08-17 | Independently rebuilt from pinned Apache-2.0 SONIC source on a digest-pinned public Python base with a hash-locked PyTorch/MuJoCo closure. The exact accepted digest passed the real B200 Unitree G1 rollout and payload gates. |
+| Wan 2.2 TI2V-5B | `npa-wan2-2` | `2.2-ti2v5b-rtfetch-cu130-20260817` | 2026-08-17 | Wan 2.2 text/image-to-video generation from Apache-2.0 source on an OSS dependency base. CUDA PyTorch and `nvidia-*` wheels are runtime-fetched under their upstream package terms. The accepted exact digest passed the zero-payload, SPDX/SLSA, vulnerability, and single-GPU TI2V/MP4/Rerun gates; the current four-GPU path remains deferred. |
+| Alpamayo 2 Super 34B | `npa-alpamayo2-super` | `0.1.0-cu128` | 2026-08-18 | Real surround-view VLA trajectory inference through NVIDIA's Apache-2.0 source. OpenMDW-1.1 weights and the separately gated/non-transferable PhysicalAI-AV sample data are fetched only at runtime under the operator's Hugging Face identity. The payload-clean image and real workflow were validated independently on B200 and RTX PRO 6000. See the [operator guide](alpamayo2-super.md). |
+| LeIsaac 0.4.0 | `npa-leisaac` | `0.4.0-20260817T231825Z` | 2026-08-19 | Browser teleoperation for the real upstream SO-101 LiftCube and PickOrange tasks, with secure agent-relay transport and immutable LeRobot episode recording. The image contains Apache-2.0 LeIsaac source and OSS dependencies only; Isaac Sim/Lab, NVIDIA's browser client, and task assets are runtime-fetched under the shared `ACCEPT_EULA` contract and are never baked into the image. Revalidate a digest before use. |
+| Cosmos 3 (`cosmos-framework` 1.2.2) | `npa-cosmos3` | current: `1.2.2-cu130-r6`; historical provenance: `1.2.2-cu130`, `1.2.2-cu130-r2`, `1.2.2-cu130-r5` | 2026-08-21 | Cosmos 3 omni-model generation: text-to-image, image-to-image, text-to-video, image-to-video, and video-to-video. Contains OpenMDW-1.1 source and a CUDA 13 venv only; checkpoints, Wan VAE, and guardrails download at runtime. The additive r6 image retains the attested SkyPilot worker bootstrap and adds auditable source-motion-preserving PAIDF publication while keeping every raw Cosmos video. |
+| Cosmos Evaluator 0.1.2 | `npa-cosmos-evaluator` | `0.1.2-skypilot-v1-20260813T164700Z-r2` | 2026-08-21 | Runs the upstream `HallucinationProcessor` quality gate on generated video using classical computer vision and no weights. The additive r2 image exposes the deterministic ranking/holdout attribute-sample policy consumed by PAIDF. Attribute verification calls an OpenAI-compatible endpoint; the LFS/EULA-gated obstacle checker is deliberately not fetched. |
+| NVIDIA Content Agents 0.5.2 | `npa-content-agents` | `0.5.2-npa2` | 2026-08-22 | Public rigid-object material/physics/validation adapter containing Apache-2.0 source and zero OVRTX payload. Exact OVRTX 0.3.0.312915 is fetched directly from NVIDIA into the operator runtime cache. The exact public digest passed byte/layer scanning, anonymous resolution, and a real RTX PRO 6000 workflow. See [Content Agents](content-agents.md). |
+| Cosmos3-Nano native Ray Serve | `npa-cosmos3-ray-serve` | `ray1-cu130` | 2026-08-26 | Persistent authenticated Cosmos3-Nano serving through cosmos-framework's native `OmniModelDeployment` and `@ray.serve.batch` path. The image contains pinned OpenMDW source and the CUDA/Ray closure but no model or guardrail weights. The exact release digest passed payload/security/SBOM/provenance gates and independent guarded two-sample generation with durable S3 evidence on B200 `sm_100` and RTX PRO 6000 `sm_120`. |
+| Cosmos Transfer 2.5 | `npa-cosmos2-transfer` | `2.5.1-sim2real-coherent-20260904` | 2026-09-04 | Cosmos Transfer 2.5 Sim2Real video augmentation, built from source at an immutable commit with hash-locked dependencies. Gated weights and the pinned guardrail tokenizer data are fetched at runtime with `HF_TOKEN`; the NLTK-safe cache materialization keeps guardrails enabled, and baked-byte scans remain a release gate. |
+| Isaac Lab 3.0 beta 2 patch 1 (Isaac Sim 6.0.1) | `npa-isaac-lab` | `3.0.0b2.post1-sim2real-coherent-20260904` | 2026-09-04 | Payload-clean Isaac Lab RL simulation image: every proprietary NVIDIA runtime wheel is hash-pinned and fetched from `pypi.nvidia.com` only after the operator's run-scoped EULA acceptance. The coherent exact-source release preserves the runtime-fetch boundary and was validated with a real RTX/Vulkan render on RTX PRO 6000. Upstream still labels this release beta; see [Isaac Lab 3](isaac-lab-3.md) for the measured cold-start tradeoff. |
+| Rerun 0.31.4 | `npa-rerun-viewer` | `0.31.4-sim2real-coherent-20260904` | 2026-09-04 | Published non-root `ubuntu` SkyPilot worker and Rerun viewer/server on ports 9876/9090 for `.rrd` robotics traces. It includes the attested bootstrap contract and exact-source Sim2Real Stage 14 runtime, and bakes no models, datasets, credentials, or runtime caches. The coherent release converted an actual three-sample robot joint trace, reopened its RRD entity through the CLI, and served/read the artifact over HTTP. |
+| Sim2Real Controller 0.1.2 | `npa-sim2real-control` | `0.1.2-sim2real-coherent-20260904` | 2026-09-04 | Non-root CPU controller containing the canonical 14-stage orchestration capability. The coherent release expanded and validated both the checkpoint-promotion and loop-back decision branches; it contains no model weights, datasets, credentials, or runtime caches. |
+| Sim2Real EnvGen 0.1.2 | `npa-envgen` | `0.1.2-sim2real-coherent-20260904` | 2026-09-04 | Generates randomized Sim2Real environments and scenes on the Genesis base. The coherent exact-source release bakes the snapshot-pinned non-root SkyPilot Kubernetes bootstrap closure (`sudo`, SSH, and rsync) and was validated through real environment generation plus a Genesis CUDA physics step. It is built from `sim2real-envgen/Dockerfile`. |
 
-## Validated source-registry candidates pending public release
+## Candidates outside the supported public release plan
 
 `npa-openpi` is a zero-weight, zero-dataset public-image candidate for the
 pinned pi0.5 full-DROID runtime. It includes `rerun-sdk==0.31.4` in an isolated
@@ -173,14 +192,12 @@ immutable `dev-<full-git-sha>` channel; the supported tag remains explicitly
 `-unbuilt` until byte scans, anonymous pull, and the eight-node RTX PRO 6000
 qualification are recorded together.
 
-The supported worker defaults currently select additive Cosmos Transfer,
-FiftyOne, and Rerun releases with the immutable SkyPilot Kubernetes bootstrap
-closure. Those candidate tags are present in the maintainer source registry but
-were not anonymously available in the 2026-08-17 audit. The public resolver and
-publisher therefore retain the prior verified tags shown above. Moving any of
-these candidates to GHCR requires the separately authorized publication workflow
-and a successful unauthenticated manifest check; private availability and
-redistribution eligibility are not evidence of publication.
+FiftyOne is the remaining public-release tag override for an unpromoted worker
+candidate: public execution selects the verified `1.15.0.post1`, while an
+explicit custom registry can select the newer supported worker pin. Cosmos
+Transfer and Rerun now select their published coherent Sim2Real releases.
+Private availability and redistribution eligibility do not establish public
+release membership.
 
 ## Intentionally not published as separate images
 
@@ -196,25 +213,26 @@ redistribution eligibility are not evidence of publication.
   digest and GPU evidence are recorded.
   It is a non-root service image with no passwordless-sudo grant; workflow
   toolRefs call the deployed service from the standard task image.
-- **`npa-cosmos3-serving`** is `restricted` and build-your-own only. Its pinned
-  vLLM-Omni base embeds a runtime under NVIDIA's Deep Learning Container License;
-  the thin wrapper and anonymous GHCR distribution do not establish that
-  license's derived-distribution conditions. Operators build it into their own
-  registry; see [Cosmos3-Super serving](cosmos3-super-serving.md).
-- **`npa-sonic-mujoco`** is a SONIC variant, not a separate public-publish tool.
-  It ships through the `sonic` tool and SONIC image manifest rather than getting
-  an independent row in the public publishing plan.
+
+The historical SONIC L40S and inherited MuJoCo variants remain restricted and
+quarantined in `sonic_image_manifest.json`. The old SONIC `0.1.2` alias was
+inspected separately and is not an accepted alternative: its live digest differs
+from the historical quarantine record. It is excluded from the published-tag
+table. The independently rebuilt `sonic-mujoco:0.2.0-runtime` and zero-payload
+`cosmos3-serving:0.2.0-oss` each have their own accepted public-plan row.
 
 ## Verification scope
 
-The registry verification confirms repository visibility, exact tag spelling,
-manifest resolution, platform metadata, selected OCI labels, exposed ports,
-entrypoints, and build timestamps. It is descriptive, not a packaging-policy
-pass: for example, the active runtime-fetch `npa-sonic` image declares the `ubuntu` OCI user, while the
-timestamped Kubernetes pin declares `root` because its build sets
-`NPA_RUNTIME_USER=root`. Capability descriptions are cross-checked against the
-corresponding Dockerfiles, packaging contracts, golden evaluations, and workflow
-integrations on `main`.
+The registry verification confirms exact tag spelling, anonymous manifest and
+config access, content hashes, platform metadata, selected OCI labels, exposed
+ports, entrypoints, and build timestamps. It is not a new packaging-policy or
+functional-validation pass. The current accepted SONIC Kubernetes pin declares
+OCI user `root`; the other 31 current releases declare non-root users. SONIC's
+legacy runtime-user limitation remains documented in the
+[security review](../security/container-golden-evals.md); a current non-root
+Dockerfile does not retroactively change those accepted bytes. Source contracts
+and golden evaluations likewise do not prove that a historical image contains
+newer workflow code.
 
 Maintainers should use `skills/atomic/audit-container-docs/SKILL.md` to repeat
 the repository-inventory and anonymous-registry audit after container changes.

--- a/docs/workbench/container-packaging.md
+++ b/docs/workbench/container-packaging.md
@@ -13,7 +13,7 @@ entrypoint that forwards orchestrator arguments. Compliant first-party images
 record `org.nebius.npa.skypilot-bootstrap-contract=skypilot-0.12.2-v1` in OCI
 config, with Dockerfile behavior covered by build tests.
 
-The canonical `npa-groot:0.1.0` is not in that attested publication set. It has
+The accepted historical `npa-groot:0.1.0` artifact has
 the non-root `ubuntu` user, system Python, `rsync`, an SSH client, and
 passwordless sudo, but lacks `openssh-server`, runtime host-key generation, and
 an argument-forwarding entrypoint. `groot/Dockerfile.k8s-prereqs` is the exact
@@ -22,8 +22,10 @@ from `packaging-contract.yaml`, but its OCI label is only a declaration: because
 the canonical and repaired artifacts share the `npa-groot` repository, submit
 ignores label-backed (including cached) evidence and requires a capability probe
 against the selected immutable digest. Public-image verification continues to
-check only canonical Dockerfiles that independently satisfy the declared
-publication contract; GR00T is deliberately absent from that set.
+check canonical Dockerfiles that independently satisfy the declared
+publication contract. The current canonical GR00T source now includes that
+contract and is in the attested-tool inventory; this does not retroactively
+attest the historical release bytes.
 
 Submit resolves the selected tag to an immutable digest and validates metadata
 on that digest. Missing/mismatched first-party evidence fails before launch.
@@ -312,21 +314,27 @@ export DOCKER_CONFIG="$(mktemp -d)"
 crane manifest ghcr.io/nebius/nebius-physical-ai/npa-lerobot:dev-<full-git-sha> >/dev/null
 ```
 
-### The plan is what we build, not what is pushed
+### Publication intent and registry state
 
-The publish plan is derived from the packaging contract, which records what this repo
-**builds**. The registry holds what someone actually **pushed**. Those two diverge every
-time a new tool lands — Dockerfile, contract entry and version pin merge together, while
-building and pushing the image is a separate manual step (there is no build-and-push
-automation). A brand-new tool is therefore *expected* to be absent from the registry for a
-while, and the preflight reports it as `NAME_UNKNOWN`.
+The packaging contract records build sources and redistribution eligibility.
+The public plan selects `publicly_publishable_tools()` and each resolved public
+release pin; restricted tools and validation candidates are excluded. A
+Dockerfile or `redistribution: public` alone does not put an image in that plan.
+The manually dispatched `publish-public-images.yml` workflow builds selected
+development images and separately promotes validated digests. Registry state
+must still be checked: source availability is not proof of publication.
 
-By default that blocks the publish, which is the right default: silently mirroring a subset
+The 2026-09-05 anonymous audit resolved all 32 current public-plan tags and
+matched all 32 accepted release digests. It required no build or registry write.
+See the [public image catalog](container-image-catalog.md) for retained aliases,
+exclusions, and the distinction between current source and released bytes.
+
+A missing planned source blocks publication by default: silently mirroring a subset
 would make a pin regression that dropped an image look exactly like success. When the gap is
 known and intended, publish the ready images anyway:
 
 ```bash
-python -m npa.deploy.publish_public --skip-missing            # or the workflow's skip_missing input
+npa/.venv/bin/python -m npa.deploy.publish_public --skip-missing
 ```
 
 It drops only the images the registry has no copy of, prints each one with the reason, and
@@ -351,7 +359,7 @@ defaults select the public release channel directly:
 docker pull ghcr.io/nebius/nebius-physical-ai/npa-retargeting:0.1.1
 ```
 
-Both development and release tags must pass the unauthenticated check:
+Check accepted release tags without relying on retained development tags:
 
 ```bash
 npa/.venv/bin/python -m npa.deploy.publish_public --verify-accepted-releases
@@ -366,8 +374,9 @@ release-byte verdict.
 Never add a `restricted` image to official GHCR.
 `publish_public` and `development_image_for_tool` refuse every member of the
 general restricted-image inventory. Separately, license-eligible candidates
-remain in `UNVALIDATED_PUBLICATION_TOOLS` until exact-digest GPU evidence is
-recorded, so a classification change alone cannot create a supported release.
+remain in `UNVALIDATED_PUBLICATION_TOOLS` or `VALIDATION_CANDIDATE_TOOLS`
+until their required exact-digest evidence is recorded, so a classification
+change alone cannot create a supported release.
 
 > **Publishing is a business decision.** The engineering makes publication defensible —
 > the images contain no NVIDIA-proprietary bytes, and NVIDIA delivers Isaac to each

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -147,7 +147,7 @@ Choose the digest-pinned Isaac image now, then warm a shared RWX cache. The
 template is the authoritative PVC/security/bootstrap contract:
 
 ```bash
-export NPA_ISAAC_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-isaac-lab@sha256:0a64ffb940a62c639c00a160a21081e7c7200f1d1d740c655616e2c9a967b544'
+export NPA_ISAAC_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-isaac-lab@sha256:e321e8631c7e318b5012dad210d9cd1001b7dc833cbff0369e420c5c12657ab6'
 sed "s|image: ghcr.io/nebius/nebius-physical-ai/npa-isaac-lab@sha256:<64-hex-digest>|image: ${NPA_ISAAC_IMAGE}|" \
   npa/docker/workbench/common/warm-isaac-cache.yaml | kubectl apply -f -
 kubectl wait --for=condition=complete job/npa-warm-isaac-cache --timeout=-1s
@@ -181,15 +181,17 @@ Relevant build entrypoints are
 `npa/docker/workbench/isaac-lab/build.sh`. Follow
 [build and push](../container-packaging.md) when images are absent.
 
-Put the six references in shell variables, then reproduce the actual manifest
+The five image digests below are the accepted coherent release set, built from
+`c164fd3480f8a9ea8f9df9ccb9509502fd527996` and verified anonymously on
+2026-09-05. Put them in shell variables, then reproduce the actual manifest
 pulls with the same config used by submit:
 
 ```bash
-export CONTROLLER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-sim2real-control@sha256:7ee326f49cf1a52fc1007dccbac02db7862246ab688bf5ec35ef14a727e33136'
-export TRANSFER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-cosmos2-transfer@sha256:47bfe492b6d56f4141f5a6da8accbbdec7cdf2d9b02311c802e3b3b5b1ba5caf'
-export ENVGEN_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-envgen@sha256:33d49af4703c479a3be71cae6f0a4735ea6f63629b870b946c43929037304f72'
+export CONTROLLER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-sim2real-control@sha256:87fe8530710eea43364a21ad76dbe4b4c2d60e4b49705824fcdb62dc7d185af7'
+export TRANSFER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-cosmos2-transfer@sha256:0caddf68ccac1b69bd9fe3fb089bcc325a111059065452d31fdf0576629895d3'
+export ENVGEN_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-envgen@sha256:08eb75118f5a04194d33a60308212db7706dd9c339d74afc5471a58608bf0422'
 export ISAAC_IMAGE="${NPA_ISAAC_IMAGE}"
-export VIEWER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-rerun-viewer@sha256:8fc0a76f3df441fd6662e3eb5d893c9996ea66e6c61fcc815de79576f12b8160'
+export VIEWER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-rerun-viewer@sha256:4c09c9cf3c14606db8e45c8ee564388888cd3261448f7c3f1304bfdfb1b9e5b2'
 export SPEC=npa/workflows/workbench/npa-workflows/sim2real.yaml
 export SOURCE_SHA=c164fd3480f8a9ea8f9df9ccb9509502fd527996
 

--- a/docs/workbench/image-gpu-compatibility-matrix.md
+++ b/docs/workbench/image-gpu-compatibility-matrix.md
@@ -2,7 +2,8 @@
 
 Every Workbench container image against every Nebius GPU platform, and — separately — which of those cells has actually been run on real hardware.
 
-**Last measured:** 2026-08-26
+**Last measured:** see the dated runs and exact-digest records below.
+**Publication/evidence reconciliation:** 2026-09-05; no new GPU execution in this audit.
 
 Two things are deliberately kept apart here, because conflating them is how "Blackwell ready" claims go wrong:
 
@@ -65,13 +66,13 @@ The old `npa-cosmos:1.0.9` cu126 image stopped at Hopper. Its additive cu128/tor
 | `npa-lancedb` | supported | **verified** [26] | **verified** [27] | **verified** [24] | **verified** [25] |
 | `npa-detection-training` | supported | **verified** [29] | **verified** [30] | **verified** [28] | **verified** [31] |
 | `npa-robocasa` | supported (cu124) | supported (cu124) | blocked (needs cu130) | blocked (needs cu130) | blocked (needs cu130) |
-| `npa-cosmos3` | supported | supported | **verified** [59] | supported | supported |
-| `npa-cosmos3-serving` (build-your-own) | blocked (8-GPU memory floor) | **verified** (8xH200) | supported (8 GPUs) | supported (8 GPUs) | supported (8 GPUs) |
-| `npa-cosmos3-super-benchmark` (operator-private) | blocked (8-GPU benchmark contract) | supported (8 GPUs) | supported (8 GPUs) | pending full benchmark | supported (8 GPUs) |
+| `npa-cosmos3` | supported | supported | **historical evidence** [59] (r2 measurement; not current r6 evidence) | supported | supported |
+| `npa-cosmos3-serving` (public zero-payload bootstrap) | blocked (8-GPU memory floor) | historical predecessor only; current digest unverified | unverified (8 GPUs) | **verified** [accepted records](#accepted-release-evidence) (8 GPUs) | unverified (8 GPUs) |
+| `npa-cosmos3-super-benchmark` (operator-private) | blocked (8-GPU benchmark contract) | supported (8 GPUs) | supported (8 GPUs) | **verified** [private benchmark record](#accepted-release-evidence) | supported (8 GPUs) |
 | `npa-cosmos3-ray-serve` | supported | supported | **verified** [66] | **verified** [65] | supported (same-major `sm_100` coverage; not measured) |
 | `npa-content-agents` | supported (RT cores) | blocked (no RT cores) | **verified** [64] | blocked (no RT cores) | blocked (no RT cores) |
-| `npa-wan2-2` | supported | supported | **historical evidence** [60] | **historical evidence** [61] | supported |
-| `npa-ltx2` | built, no GPU result | built, no GPU result | built, no GPU result | built, no GPU result | built, no GPU result |
+| `npa-wan2-2` | supported | supported | **verified** [accepted records](#accepted-release-evidence) | **historical evidence** [61]; current distributed path unqualified | supported |
+| `npa-ltx2` | unverified runtime | unverified runtime | **verified** [accepted records](#accepted-release-evidence) | unverified runtime | unverified runtime |
 | `npa-openpi` | blocked (RTX-only runtime contract) | blocked (RTX-only runtime contract) | pending exact-digest full-DROID qualification | blocked (`sm_120`-only probe/runtime contract) | blocked (`sm_120`-only probe/runtime contract) |
 | `npa-alpamayo2-super` | supported | supported | **verified** [63] | **verified** [62] | supported (same-major `sm_100` coverage; not measured) |
 | `npa-cosmos3-reason` | supported | **verified** [38] | **verified** [43] | **verified** [36] | **verified** [37] |
@@ -85,7 +86,7 @@ The old `npa-cosmos:1.0.9` cu126 image stopped at Hopper. Its additive cu128/tor
 | `npa-isaac-lab` | supported | supported (headless) | supported | blocked | blocked |
 | `npa-leisaac` | not routed or validated by the current launcher | blocked (no RT cores) | supported (current hard-selected target) | blocked (no RT cores) | blocked (no RT cores) |
 | `npa-sonic` | supported | supported (headless) | supported | blocked | blocked |
-| `npa-sonic-mujoco` | supported | supported (headless) | supported | blocked | blocked |
+| `npa-sonic-mujoco` | unverified | unverified (headless) | supported | **verified** [accepted records](#accepted-release-evidence) | unverified |
 | `npa-groot` | supported | supported | supported | blocked | blocked |
 | `npa-cosmos-curate` | CPU | CPU | CPU | CPU | CPU |
 | `npa-cosmos-evaluator` | CPU | CPU | CPU | CPU | CPU |
@@ -179,7 +180,7 @@ Managed-Kubernetes nodes were placed successfully for both B200 in us-central1 a
 | 57 | 2026-08-03 | same final `npa-loop-eval` | NVIDIA B300 SXM6 AC (`sm_103`) | same scored two-environment CUDA rollout | `DATACENTER_CHILD_VALIDATION_PASSED` |
 | 58 | 2026-08-03 | same final `npa-loop-eval` | NVIDIA H100 80GB HBM3 (`sm_90`) | same scored two-environment CUDA rollout | `DATACENTER_CHILD_VALIDATION_PASSED` |
 | 59 | 2026-08-08 | historical `npa-cosmos3:1.2.2-cu130-r2` (index `sha256:c65712832f6a…`, amd64 `sha256:19dc6be7d2f9…`); current default is `1.2.2-cu130-r6` | NVIDIA RTX PRO 6000 Blackwell Server Edition (`sm_120`) | exact historical release bytes, non-root UID 1000, native `sm_120` SASS, public Cosmos3-Nano text-to-image generation with Xet enabled (`huggingface_hub 0.36.2`, `hf-xet 1.3.2`, `HF_HUB_DISABLE_XET` unset) | HISTORICAL PASS; 960×960 JPEG, 260,808 bytes, SHA-256 `e4f017a75266b937b7479a0a5090bf644ef442da6972cae59988d1d5b5daa861`; guardrail discovery still failed open as tracked in [#270](https://github.com/nebius/nebius-physical-ai/issues/270) |
-| 60 | 2026-08-09 | historical digest-pinned `npa-wan2-2` runtime-fetch candidate (Torch 2.7.1/CUDA 12.8) | RTX PRO 6000 Blackwell Server Edition (`sm_120`) | official Wan TI2V-5B generation with native PyTorch SDPA, full MP4 decode/variation validation, and verified Rerun postprocessing | HISTORICAL PASS; private validation record, 17 H.264 frames at 1280×704 and 24 fps; current Torch 2.13.0/CUDA 13.0 closure is not yet live-qualified |
+| 60 | 2026-08-09 | historical digest-pinned `npa-wan2-2` runtime-fetch candidate (Torch 2.7.1/CUDA 12.8) | RTX PRO 6000 Blackwell Server Edition (`sm_120`) | official Wan TI2V-5B generation with native PyTorch SDPA, full MP4 decode/variation validation, and verified Rerun postprocessing | HISTORICAL PASS; private validation record, 17 H.264 frames at 1280×704 and 24 fps; current single-GPU qualification is recorded separately below |
 | 61 | 2026-08-09 | same historical candidate (NCCL 2.27.7) | 4× NVIDIA B200 (`sm_100`) | official four-rank Wan path through the instrumented wrapper: NCCL, T5/DiT FULL_SHARD FSDP, Ulysses distributed attention/all-to-all, process-group teardown, MP4 validation, and verified Rerun postprocessing | HISTORICAL PASS; private validation record, world size 4 with ranks 0–3 on four unique devices; current NCCL 2.29.7 closure is not yet live-qualified |
 | 62 | 2026-08-18 | `npa-alpamayo2-super:0.1.0-cu128` (index `sha256:2164450f8baf…`) | NVIDIA B200 (`sm_100`) | exact pinned Alpamayo source loaded the real 34B OpenMDW checkpoint and gated PhysicalAI-AV sample at runtime, predicted a projected ego trajectory, and uploaded result JSON, trajectory JSON, and a calibrated-camera PNG | PASS; shape `[1, 1, 1, 64, 3]`, ADE 1.503835, FDE 4.357265; one wave with no recovery |
 | 63 | 2026-08-18 | same exact Alpamayo image | RTX PRO 6000 (`sm_120`) | independent runtime fetch and the same real upstream surround-view trajectory workflow, with GPU telemetry throughout inference | PASS; shape `[1, 1, 1, 64, 3]`, ADE 1.501321, FDE 4.351557; peak 71,447 MiB and 100% utilization; one wave with no recovery |
@@ -200,6 +201,25 @@ Runs 1, 2, 5, 6, and 8 used [`npa/scripts/blackwell-gpu-validation-job.yaml`](..
 The job runs non-root with dropped capabilities and a read-only root filesystem. flash-attn-4's CuTe kernels JIT-compile at runtime, so `HOME` and every torch/CUDA cache point at a scratch `emptyDir`; the H100 run above confirms the kernel still compiles and executes under those constraints.
 
 The original READY-set images were also tested before rebuild. The historical `npa-lancedb:0.30.3` CLIP path fails on a current transformers return type and is superseded by the corrected image in runs 24–27. The superseded `npa-lerobot:0.5.1` failed a torchcodec/FFmpeg mismatch, and the superseded Cosmos3 Reason image lacked the functional smoke module. The rebuilt SONIC image passes its native-SASS controls and reaches real environment construction after fixing two undeclared upstream dependencies, but both cold and warm fine-tune attempts fail inside Isaac's runtime-fetched URDF extension while opening a temporary pelvis USD layer, before a checkpoint. Those failures are recorded in `validation_evidence`; they were not converted into verified cells. The Cosmos kernel runs are not generated-video claims: checkpoint-backed Predict2 Video2World was attempted again during the extensive run and remains unverified because the available Hugging Face identity received HTTP 403 for NVIDIA's gated checkpoint.
+
+## Accepted release evidence
+
+These are existing workload records reconciled with the released digests on
+2026-09-05, not workloads executed by the registry audit. They supersede the
+older pending or historical cells only for the stated image and hardware.
+Other dated measurements above remain tied to the tags they actually ran.
+
+| Image and accepted digest | Hardware | Recorded capability result | Source of evidence |
+| --- | --- | --- | --- |
+| `npa-ltx2:2.5-rtfetch-20260817`, `sha256:c04b5b4e4c7f1c26e21671b3826ce8da75755c98bab2c54cd46137c609c2410b` | one RTX PRO 6000 | text-to-video and independent H.264 decode; 1536×1024, 121 frames, 1,994,625 bytes | `npa/src/npa/deploy/ltx2_image_manifest.json` |
+| `npa-wan2-2:2.2-ti2v5b-rtfetch-cu130-20260817`, `sha256:5780959ca6c6e7eb77ee7ea7d005fcf0f56db50783ce798dddee2809185eb837` | one RTX PRO 6000 | Torch 2.13.0/CUDA 13.0 native TI2V-5B; 1280×704, 17 decoded frames, 2,807,385 bytes; current distributed generation not claimed | `npa/src/npa/deploy/wan2_2_image_manifest.json` |
+| `npa-sonic-mujoco:0.2.0-runtime`, `sha256:2388d9e97269afaa414966e83a27f676a3f44d4271e9828c57bc13fbdce80f57` | B200 | real Unitree G1 MuJoCo rollout; 64 finite steps, fall rate 0 | `npa/src/npa/deploy/sonic_image_manifest.json` |
+| `npa-cosmos3-serving:0.2.0-oss`, `sha256:3342bbe44bd1c00ebf05ab4c9d7286058a94bb5ce90b49b164b23604d3acf180` | eight B200s | guarded service boot, readiness, real video inference and H.264 decode | `npa/docker/workbench/blackwell-dc-images.json` |
+| `npa-cosmos3-super-benchmark` (operator-private) | eight B200s | full four-cell benchmark, 96/96 technically valid MP4s; this wrapper remains restricted and excluded from public release | `npa/docker/workbench/blackwell-dc-images.json` |
+
+LTX and Cosmos3 serving carry no GPU runtime in their public bootstrap layers;
+these results cover their operator-fetched runtime on the listed hardware.
+Unverified cells make no new architecture or capability claim.
 
 ## The import check that lied
 

--- a/docs/workbench/oss-solution-catalog.md
+++ b/docs/workbench/oss-solution-catalog.md
@@ -1,8 +1,8 @@
 # OSS Physical AI Solution Candidates
 
 This catalog tracks open-source Physical AI projects that are being onboarded as
-Workbench registry candidates through BYOF. These entries are **not** first-class
-`npa workbench <tool>` commands yet. Promotion requires the pushed registry image
+Workbench registry candidates through BYOF, including entries subsequently
+promoted to native tools or public images as noted below. Promotion requires the pushed registry image
 to run in a real NPA/SkyPilot/Kubernetes E2E workflow and produce declared
 artifacts.
 
@@ -23,7 +23,7 @@ unique and must be tested with its own upstream-named capabilities.
 | DROID policy learning | `droid-dataset/droid_policy_learning` `9a29c832…` | `rlds_config_generator_contract` | `droid_rlds_config_generator.json` | `byof-droid-policy-learning.yaml` |
 | Open Dreamer (world model, **2-GPU min**) | `next-state/open-dreamer` `2b10640` | `dreamer4_tokenizer_train_two_gpu` | `open_dreamer_world_model_2gpu.json` | `byof-open-dreamer.yaml` |
 | Alibaba Wan 2.2 TI2V-5B | `Wan-Video/Wan2.2` `42bf4cf…` | `wan2.2_ti2v_5b_text_to_video` | capability JSON + runtime inventory + MP4 | `byof-wan2.2.yaml` |
-| Lightricks LTX-2.5 (**not built; licence-gated**) | `Lightricks/LTX-2` `fd4ded7f…` | `ltx2_5_text_to_video` | `ltx2_5_text_to_video.json` + provenance manifest + MP4 | `byof-ltx2.yaml` |
+| Lightricks LTX-2.5 (**accepted public image; entitled runtime fetch**) | `Lightricks/LTX-2` `fd4ded7f…` | `ltx2_5_text_to_video` | `ltx2_5_text_to_video.json` + provenance manifest + MP4 | `byof-ltx2.yaml` |
 | Alibaba Wan 2.2 TI2V-5B (**4-GPU distributed**) | same pinned source/checkpoint | `wan2.2_ti2v_5b_text_to_video_multigpu_fsdp_ulysses` | multi-GPU capability JSON + rank topology + runtime inventory + MP4 | `byof-wan2.2-multigpu.yaml` |
 
 ## Live capability results
@@ -215,9 +215,11 @@ contracts.
 
 Audio-video DiT foundation model, pinned to
 `Lightricks/LTX-2@fd4ded7f2d88d3da713abcdd4ad41ecc4a9314ca` with the gated
-`Lightricks/LTX-2.5` checkpoint set. **No status here is live**: the `npa-ltx2`
-image has not been built and nothing has run on a GPU. Every row below is
-therefore a declared contract awaiting evidence, not a result.
+`Lightricks/LTX-2.5` checkpoint set. The accepted public image is
+`npa-ltx2:2.5-rtfetch-20260817`; its exact digest and prior real RTX PRO 6000
+results are recorded in `npa/src/npa/deploy/ltx2_image_manifest.json`.
+The 2026-09-05 registry audit matched those released bytes anonymously; it did
+not rerun generation or establish additional capabilities.
 
 LTX-2.5 differs from every other candidate in this catalog in what it licenses.
 The LTX-2.x Community License Agreement (2026-08-11, not OSI) covers the
@@ -231,8 +233,8 @@ another machine learning model — is the operator's own responsibility.
 
 | Capability | Status | Upstream basis / NPA evidence |
 | --- | --- | --- |
-| `ltx2_5_text_to_video` | declared; no image built | `python -m ltx_pipelines.distilled` at the pinned ref, per upstream's own quick start |
-| `ltx2_5_decoded_mp4_validation` | declared; no image built | `npa/src/npa/workbench/ltx2/video_check.py`, unit-tested against real ffmpeg clips and copied into the image |
+| `ltx2_5_text_to_video` | accepted exact-digest evidence | pinned upstream distilled pipeline generated a real clip on one RTX PRO 6000; source and weights remained runtime fetches |
+| `ltx2_5_decoded_mp4_validation` | accepted exact-digest evidence | independently decoded H.264 MP4: 1536×1024, 121 frames, 1,994,625 bytes; digest and refusal evidence in the accepted image manifest |
 | `ltx2_5_image_to_video` | not claimed | upstream pipeline exists; no code path or evidence here |
 | `ltx2_5_audio_to_video` | not claimed | separate `A2VidPipelineTwoStage` inputs |
 | `ltx2_5_lora_fine_tuning` | not claimed | `ltx-trainer` is licensed material and training on Outputs is what Attachment A(18) restricts |
@@ -241,7 +243,7 @@ The primary JSON is `ltx2_5_text_to_video.json`. The run itself still proves the
 refusal first (`ltx-runtime assert-refusal`: exit 78 and empty caches before any
 fetch), but that is a property of the image rather than a graded capability. See
 [`ltx2.md`](ltx2.md) for the dev-VM runbook, the entitlement the run requires,
-and what has to happen before any of the above may be marked live.
+and the exact-digest validation record. A future image must earn fresh evidence.
 
 ## First-class Workbench tools (not BYOF)
 
@@ -250,10 +252,14 @@ package/image tags:
 
 | Version | Status | Notes |
 | --- | --- | --- |
-| `0.5.1` | default | `npa-lerobot:0.5.1` |
-| `0.6.0` | additional | `npa-lerobot:0.6.0`; lean extras + `env_eval_freq` |
+| `0.5.1` | default | Accepted CUDA 13 timestamped image pin in `lerobot_version_manifest.json`; plain `0.5.1` is historical |
+| `0.6.0` | additional package support | Requires a validated operator-built image for container execution; no accepted public tag/digest; lean extras + `env_eval_freq` |
 
-Select with `--lerobot-version`. Manifest:
+Select the package with `--lerobot-version`; serverless training accepts a
+custom container through `train --image`, while VM deployment installs the
+package. The 2026-09-05 anonymous audit returned `404 MANIFEST_UNKNOWN` for
+the official `npa-lerobot:0.6.0` tag; it is outside the public release plan.
+Manifest:
 `npa/src/npa/deploy/lerobot_version_manifest.json`. Upstream:
 https://huggingface.co/blog/lerobot-release-v060
 

--- a/skills/atomic/build-and-push-image/SKILL.md
+++ b/skills/atomic/build-and-push-image/SKILL.md
@@ -16,7 +16,7 @@ refusal conditions; this skill records NPA-specific build and GPU details.
    `ghcr.io/nebius/nebius-physical-ai`. A pre-release tag is exactly
    `dev-<full-git-sha>` on the normal `npa-<tool>` package.
 3. Require `redistribution: public` before any official push. Build restricted
-   images, including `cosmos3-serving`, only into an operator-controlled
+   images, including `cosmos3-super-benchmark`, only into an operator-controlled
    registry; neither a private package nor a development tag changes licensing.
 4. Run every pre-publication security, packaging, payload, provenance, SBOM,
    vulnerability, secret, non-root, base-pin, and bootstrap-contract gate before

--- a/skills/atomic/secure-image-build/SKILL.md
+++ b/skills/atomic/secure-image-build/SKILL.md
@@ -32,7 +32,10 @@ For live validation also load `skills/atomic/gpu-selection/SKILL.md`,
    development tags.
 2. Require `redistribution: public` in
    `npa/docker/workbench/packaging-contract.yaml`. Hard-refuse `restricted`
-   images, including `cosmos3-serving`, from every official GHCR tag.
+   images, including `cosmos3-super-benchmark`, from every official GHCR tag.
+   The current supported `cosmos3-serving` release is bound to its accepted,
+   payload-scanned and GPU-validated digest; historical restricted bytes remain
+   prohibited. Future development builds must pass the sequence below.
 3. Before any public push, run the repository packaging/license guards and
    inspect the locally built artifact, including layers, history, and OCI config.
    Refuse credentials, secrets, customer data, live infrastructure identifiers,

--- a/skills/atomic/solution-licensing/SKILL.md
+++ b/skills/atomic/solution-licensing/SKILL.md
@@ -280,8 +280,10 @@ The clean runtime-fetch `isaac-lab`, `sonic`, and `groot` images may therefore b
 classified `redistribution: public`. Historical SONIC L40S and inherited MuJoCo
 images remain restricted and quarantined because their built layers contain the
 old payload. The replacement MuJoCo architecture is built independently from a
-digest-pinned public Python base and must pass exact-layer scans plus real GPU
-validation before its digest can replace the quarantined variant.
+digest-pinned public Python base. Its accepted `0.2.0-runtime` digest passed
+exact-layer scans and a real B200 Unitree G1 rollout, as recorded in
+`npa/src/npa/deploy/sonic_image_manifest.json`. That evidence applies only to
+the replacement digest; the historical variants remain quarantined.
 
 Three things made that verdict defensible rather than merely plausible, and a new
 solution should expect to produce all three:
@@ -406,11 +408,13 @@ fetch alone while the weight path stays guarded). Any time several controls
 share an exit code, assume they are hiding each other until a mutant proves
 otherwise.
 
-**Do not publish on the strength of the classification alone.** The licence work
-concluded `redistribution: public`, and the pushed image has since been scanned
-by digest, but no GPU has run it — so `ltx2` sits in
-`UNVALIDATED_PUBLICATION_TOOLS` and `publish_public` refuses it by name.
-Eligible and proven are different claims.
+**Do not publish on the strength of the classification alone.** LTX-2.5's
+accepted `2.5-rtfetch-20260817` digest subsequently passed the payload,
+entitlement-refusal, and real RTX PRO 6000 text-to-video/decoded-MP4 gates.
+`npa/src/npa/deploy/ltx2_image_manifest.json` binds those results to the exact
+bytes, which are now in the public release plan. Future bytes must earn fresh
+evidence. OpenPI remains in `UNVALIDATED_PUBLICATION_TOOLS`; redistribution
+eligibility alone does not qualify its pending full-DROID image for release.
 
 ## Red Flags
 

--- a/skills/tools/lerobot/SKILL.md
+++ b/skills/tools/lerobot/SKILL.md
@@ -13,10 +13,15 @@ Use it as the data standard and policy interface layer, not as a managed-service
 
 | Version | Role | Image tag | Notes |
 | --- | --- | --- | --- |
-| **0.5.1** | **Default** | `npa-lerobot:0.5.1` | Current golden-eval pin; keep for GR00T N1.5 / sim2real policy image parity |
-| **0.6.0** | Additional | `npa-lerobot:0.6.0` | Lean extras (`training,evaluation,pusht,libero`); `--eval_freq` → `--env_eval_freq` |
+| **0.5.1** | **Default** | `npa-lerobot:cuda13-b300-0.5.1-sm80-sm90-sm100-sm103-sm120-20260803T034152Z` | Accepted public default; the plain `0.5.1` alias is historical |
+| **0.6.0** | Additional package support | Operator-built image required | No accepted public image pin/digest; lean extras (`training,evaluation,pusht,libero,diffusion,smolvla`); `--eval_freq` → `--env_eval_freq` |
 
-Select with `--lerobot-version` on deploy / serverless train, or override the image with `--image .../npa-lerobot:0.6.0`.
+Select the package with `--lerobot-version`. For serverless training on 0.6.0,
+supply a validated operator image through `train --image`; version selection
+alone does not publish an image. VM deployment installs the selected package
+and has no `--image` option. The anonymous 2026-09-05 audit returned
+`404 MANIFEST_UNKNOWN` for the official `npa-lerobot:0.6.0` tag. It is outside
+the current public release plan and must not be treated as an accepted release.
 
 Canonical manifest: `npa/src/npa/deploy/lerobot_version_manifest.json`.
 
@@ -36,21 +41,21 @@ CLI:
 
 ```bash
 npa workbench lerobot deploy
-npa workbench lerobot deploy --lerobot-version 0.6.0
+npa workbench lerobot deploy --runtime vm --lerobot-version 0.6.0
 npa workbench lerobot train
-npa workbench lerobot train --runtime serverless --lerobot-version 0.6.0 ...
+npa workbench lerobot train --runtime serverless --lerobot-version 0.6.0 --image '<validated-operator-image>@sha256:<digest>' ...
 npa workbench lerobot eval
 npa workbench lerobot serve
 npa workbench lerobot infer
 npa workbench lerobot list-checkpoints
 ```
 
-Build both image tags:
+Build operator/BYOF image variants (official publication has separate gates):
 
 ```bash
-npa/docker/workbench/lerobot/build.sh --all-versions
+npa/docker/workbench/lerobot/build.sh --registry '<operator-registry>' --all-versions
 # or
-npa/docker/workbench/lerobot/build.sh --version 0.6.0
+npa/docker/workbench/lerobot/build.sh --registry '<operator-registry>' --version 0.6.0
 ```
 
 The datacenter-Blackwell variant is `npa/docker/workbench/lerobot/Dockerfile.b300`.

--- a/skills/workflows/oss-solution-registry-onboard/SKILL.md
+++ b/skills/workflows/oss-solution-registry-onboard/SKILL.md
@@ -350,8 +350,9 @@ The candidate uses one RTX PRO 6000 Blackwell (`sm_120`), native
 with an explicit `sm_120` architecture check, and run-time model acquisition.
 No weights are baked, and the upstream native PyTorch SDPA fallback is used.
 
-Accepted historical hard-gate evidence, validated by a prior private record on
-one RTX PRO 6000 Blackwell (`sm_120`) using Torch 2.7.1/CUDA 12.8:
+Accepted current single-GPU evidence, bound to the exact public digest in
+`npa/src/npa/deploy/wan2_2_image_manifest.json`, on one RTX PRO 6000 Blackwell
+(`sm_120`) using Torch 2.13.0/CUDA 13.0:
 
 - `wan2.2_ti2v_5b_text_to_video` (real 1280x704 MP4)
 - `wan2.2_decoded_mp4_validation` (decode all frames; dimensions/count/fps and
@@ -376,11 +377,11 @@ qualification:
 The primary artifact is `wan2_2_ti2v_5b_text_to_video.json`; the MP4 is
 `wan2_2_ti2v_5b.mp4`, and the actual pulled image emits
 `wan2_2_runtime_inventory.json` with installed package/license metadata and a
-baked-checkpoint scan. All three are present in S3 for the acceptance run; its
-2,923,858-byte H.264 MP4 (SHA-256 `60001084…92328`) decoded as 17 1280x704
-frames at 24 fps and passed the non-uniform-content gates. Kubernetes observed
-the immutable accepted image digest as the running `imageID` in both fresh
-single- and four-GPU proofs; each fresh RRD embeds the exact generated MP4.
+baked-checkpoint scan. The current single-GPU acceptance record binds the
+runtime inventory, MP4, and verified RRD to the accepted digest. Its
+2,807,385-byte H.264 MP4 decoded as 17 1280x704 frames at 24 fps and passed
+the non-uniform-content gates. The prior four-GPU proof remains historical
+and does not qualify the current release's distributed path.
 
 Deferred: TI2V image-to-video until its own live input/output evidence; T2V and
 I2V A14B, S2V-14B, Animate-14B, and official training as separate contracts.
@@ -393,10 +394,11 @@ MP4 alongside static run evidence; see `skills/tools/wan2-2/SKILL.md` and
 
 Pinned upstream source:
 `Lightricks/LTX-2@fd4ded7f2d88d3da713abcdd4ad41ecc4a9314ca`; gated checkpoint
-set: `Lightricks/LTX-2.5`. **No capability here is live**: the image has been
-built, pushed, and scanned by digest, but no GPU has run it. The entry exists so
-the contract is reviewable before evidence, not so it can be mistaken for
-evidence.
+set: `Lightricks/LTX-2.5`. The accepted `2.5-rtfetch-20260817` release passed
+payload and entitlement-refusal gates plus real text-to-video generation and
+independent MP4 decoding on one RTX PRO 6000. The exact digest and 1536×1024,
+121-frame, 1,994,625-byte result are recorded in
+`npa/src/npa/deploy/ltx2_image_manifest.json`; new image bytes require new proof.
 
 Read this one before onboarding any non-OSI model, because it breaks the habit
 the other entries teach. The LTX-2.x Community License Agreement (2026-08-11)
@@ -476,7 +478,7 @@ A solution is registry-ready only after all applicable gates pass:
 | Documentation | Upstream docs read and cited for every claimed capability |
 | License | Upstream license and asset/model/data restrictions recorded, and the image's redistribution class set per `skills/atomic/solution-licensing/SKILL.md` |
 | Packaging | BYOF image builds and includes `npa_source_metadata.json` |
-| Registry | Redistributable candidate pushed to private GHCR with an immutable dev SHA, or restricted image pushed only to an operator-controlled registry |
+| Registry | Official public development image passes all pre-publication gates and uses `dev-<full-git-sha>`; BYOF or restricted images use only an operator-controlled registry |
 | Contract | Inputs, outputs, runtime, GPU, credentials, and failure modes documented |
 | Workflow | NPA workflow validates/plans if a workflow is part of the registry entry |
 | Smoke | Capability-level smoke commands pass in the container or service |


### PR DESCRIPTION
The image docs still classified accepted replacements as unpublished or restricted, listed incorrect build dates, and paired the Sim2Real guide's source SHA with older image digests. This reconciles the public catalog, packaging/security guidance, GPU evidence matrix, and related skills with main's accepted releases and anonymous GHCR observations on 2026-09-05.

All 32 current release tags match their accepted digests; all 43 retained catalog references resolve anonymously with verified manifest/config hashes. Seven build dates are corrected, the quarantined SONIC alias is removed from published alternatives, and the guide now selects five coherent digests whose OCI revision and baked source SHA match its declared source. LeRobot 0.6.0 remains package support requiring an operator image for serverless training: its unaccepted official tag returns 404 and is outside the public release plan.

No image build, publication, promotion, or workload deployment was needed. GPU capability statements cite existing exact-digest records; this audit performed no new GPU validation. The accepted SONIC Kubernetes image's legacy root-user limitation remains explicit. Runtime source, tests, image pins, and accepted manifests are unchanged.

Validation: complete anonymous accepted-release and public-plan checks; independent registry/config/source-parity and aggregate-diff review; repository lint, docs drift, skill validators, catalog/index and publication/licensing guardrails, test collection and onboarding checks; confidentiality and gitleaks scans. Private audit and review evidence is retained outside Git. Independent review used Codex; Claude Code was unavailable and is not claimed.
