### PR TITLE
Cover zero and literal trigger override edge cases

### DIFF
--- a/npa/tests/orchestration/npa_workflow/test_trigger_config_overrides.py
+++ b/npa/tests/orchestration/npa_workflow/test_trigger_config_overrides.py
@@ -144,3 +144,53 @@ def test_workflow_identity_keeps_artifact_roles_and_resolved_trigger_values(
     setattr(component, field, value)
 
     assert _workflow_identity(spec) != identity
+
+
+def test_zero_max_polls_override_keeps_watcher_unbounded():
+    spec = load_spec_for_submit(SHIPPED, config_overrides={"inbox_max_polls": "0"})
+    # Readiness arrives after the shipped limit of 40 polls has elapsed.
+    listing_sizes = iter([0] * 41 + [1])
+    sleeps = []
+    result = wait_for_trigger(
+        spec.states["caption-inbox"],
+        _make_context(spec, run_id="trigger-test"),
+        waiter=s3_trigger_waiter(
+            lister=lambda bucket, prefix: ["frame"] * next(listing_sizes),
+            sleeper=sleeps.append,
+            max_wait_seconds=0,
+        ),
+    )
+    assert result["objects"] == 1
+    assert result["polls"] == 42
+    assert sleeps == [15] * 41
+
+
+def test_literal_trigger_fields_ignore_unrelated_config_overrides(tmp_path):
+    document = yaml.safe_load(SHIPPED.read_text())
+    document["states"]["caption-inbox"]["trigger"].update(
+        pollSeconds=15, maxPolls=40, minObjects=1
+    )
+    path = tmp_path / "literal-trigger.yaml"
+    path.write_text(yaml.safe_dump(document))
+    original = load_spec(path)
+    overrides = {
+        "inbox_poll_seconds": "2",
+        "inbox_max_polls": "4",
+        "inbox_min_objects": "9",
+    }
+    changed = merge_config_overrides(original, overrides)
+    assert {key: changed.config[key] for key in overrides} == overrides
+    assert changed.states["caption-inbox"].trigger == original.states["caption-inbox"].trigger
+    listing_sizes = iter([0] * 4 + [1])
+    sleeps = []
+    result = wait_for_trigger(
+        changed.states["caption-inbox"],
+        _make_context(changed, run_id="trigger-test"),
+        waiter=s3_trigger_waiter(
+            lister=lambda bucket, prefix: ["frame"] * next(listing_sizes),
+            sleeper=sleeps.append,
+        ),
+    )
+    assert result["objects"] == 1
+    assert result["polls"] == 5
+    assert sleeps == [15] * 4


### PR DESCRIPTION
Adds two missing trigger-override regressions:

- Overriding `maxPolls` to zero keeps the watcher unbounded: readiness arrives on poll 42, beyond the shipped 40-poll cap.
- Literal trigger threshold, interval, and poll cap ignore unrelated config overrides. The real watcher reaches readiness on poll five with the literal interval and threshold, beyond the conflicting config cap of four.

The incremental diff is one test file with 50 added lines and no production changes. Main already supplies the primary override and effective-trigger resume-identity coverage; those tests remain intact without duplicates. The branch contains one intentional commit and merges without conflicts with current main.

Validation at `03b4a11c8db9e1dd4a33784439652b7491892189`:

- [All seven GitHub checks passed](https://github.com/nebius/nebius-physical-ai/pull/400/checks), including Python coverage, browser tests, guardrails, docs drift, Ruff, confidentiality, and gitleaks.
- [Full Python gate](https://github.com/nebius/nebius-physical-ai/actions/runs/34065262875): 15,623 passed, 389 skipped, 1 xpassed; coverage 74.96%. All 16 trigger tests passed.
- Local checks: 16 trigger tests, 114 onboarding smoke tests, and 2,544 guardrails passed; Ruff, diff confidentiality, and gitleaks passed.

Local validation limitation: the earlier full-suite attempt was interrupted. After correcting isolated-clone file permissions, all 243 affected scanner cases passed. A separate final-head diagnostic rerun finished with 8 passed and 5 exceeding their existing timeouts in CLI help, adapter processing, and a mocked BDD100K pipeline. The complete GitHub gate passed; the local full suite is not claimed as passing.

Object listings and sleepers are injected. No live S3 watcher or SkyPilot workload was run.
