### PR TITLE
fix(workflows): preserve RL run selection with checkpoint regressions

### DIFF
--- a/npa/src/npa/workflows/rl_sweep.py
+++ b/npa/src/npa/workflows/rl_sweep.py
@@ -274,17 +274,19 @@ def _publish_checkpoint(base_uri: str, search_root: str = "logs/rsl_rl") -> str:
     root = Path(search_root)
     if not root.exists():
         return ""
-    checkpoints = sorted(
-        root.rglob("model_*.pt"),
+    checkpoints = sorted(root.rglob("model_*.pt"))
+    if not checkpoints:
+        return ""
+    # Preserve full-path run selection, including nested directories.
+    selected_run = checkpoints[-1].parent
+    checkpoint = max(
+        (path for path in checkpoints if path.parent == selected_run),
         key=lambda path: (
-            path.parent,
             int(path.stem[6:]) if path.stem[6:].isdigit() else -1,
             path.name,
         ),
     )
-    if not checkpoints:
-        return ""
-    return _upload_file(checkpoints[-1], f"{base_uri}/checkpoint.pt")
+    return _upload_file(checkpoint, f"{base_uri}/checkpoint.pt")
 
 
 # --------------------------------------------------------------------- barrier

--- a/npa/tests/workflows/test_rl_sweep_checkpoint_order.py
+++ b/npa/tests/workflows/test_rl_sweep_checkpoint_order.py
@@ -30,3 +30,61 @@ def test_latest_run_directory_still_takes_precedence(tmp_path):
     (recent / 'model_9.pt').write_bytes(b'current-run')
     output = rl_sweep._publish_checkpoint(str(tmp_path / 'published'), str(tmp_path / 'logs'))
     assert Path(output).read_bytes() == b'current-run'
+
+
+def test_sparse_checkpoints_use_steps_not_write_order(tmp_path: Path) -> None:
+    run = tmp_path / "logs" / "run"
+    run.mkdir(parents=True)
+    for step in (100, 99, 12, 8):
+        (run / f"model_{step}.pt").write_bytes(str(step).encode())
+
+    published = rl_sweep._publish_checkpoint(
+        str(tmp_path / "published"), str(tmp_path / "logs")
+    )
+
+    assert Path(published).read_bytes() == b"100"
+
+
+def test_nested_directory_does_not_change_selected_run(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    nested = logs / "run" / "earlier-run"
+    nested.mkdir(parents=True)
+    (nested / "model_999.pt").write_bytes(b"nested run")
+    (logs / "run" / "model_9.pt").write_bytes(b"selected run")
+
+    published = rl_sweep._publish_checkpoint(str(tmp_path / "published"), str(logs))
+
+    assert Path(published).read_bytes() == b"selected run"
+
+
+@pytest.mark.parametrize(
+    ("names", "expected"),
+    [
+        (("model_0009.pt", "model_0049.pt"), "model_0049.pt"),
+        (("model_best.pt", "model_latest.pt"), "model_latest.pt"),
+    ],
+)
+def test_existing_checkpoint_filename_formats(
+    tmp_path: Path, names: tuple[str, ...], expected: str
+) -> None:
+    run = tmp_path / "logs" / "run"
+    run.mkdir(parents=True)
+    for name in names:
+        (run / name).write_bytes(name.encode())
+
+    published = rl_sweep._publish_checkpoint(
+        str(tmp_path / "published"), str(tmp_path / "logs")
+    )
+
+    assert Path(published).read_bytes() == expected.encode()
+
+
+@pytest.mark.parametrize("create_root", [False, True])
+def test_no_checkpoint_does_not_create_output(tmp_path: Path, create_root: bool) -> None:
+    logs = tmp_path / "logs"
+    if create_root:
+        logs.mkdir()
+    output = tmp_path / "published"
+
+    assert rl_sweep._publish_checkpoint(str(output), str(logs)) == ""
+    assert not output.exists()


### PR DESCRIPTION
Adds six checkpoint edge cases beyond the numeric-selection and latest-run tests already on `main`: sparse steps, nested directories, zero-padded filenames, named-checkpoint fallback, and missing or empty checkpoint roots. Existing main tests remain unchanged.

The nested-directory regression fails on main: `run/earlier-run/model_999.pt` displaces `run/model_9.pt`. The small source change preserves the original full-path run selection, then chooses the largest numeric step within that selected directory. The tests verify the bytes of the published checkpoint.

Validation:

- Before the source fix: 1 failed, 15 passed; the nested-directory test is the sole failure. After the fix: 16 focused tests passed.
- Local Ruff passed; onboarding smoke: 114 passed; guardrails: 2,544 passed.
- [Full Python CI and coverage](https://github.com/nebius/nebius-physical-ai/actions/runs/34066755825/job/101576753496): 15,627 passed, 389 skipped, 1 XPASS; coverage 74.96% against the 60% requirement. CLI install and shell-script checks also passed.
- All seven GitHub checks passed on the final signed commit, including docs drift and browser tests. Aggregate-diff and PR-prose confidentiality scans found 0 hits; gitleaks found no leaks.
- Independently merged with latest main in a private temporary index: zero conflicts, exactly the two intended files differ from main, and all 16 focused tests passed against the merged source. The branch adds one intentional commit with a verified GitHub signature.

No new GPU training or live S3 workload was run. This change affects local checkpoint selection; workflow specs, toolRefs, and public CLI/API surfaces are unchanged.
