### PR TITLE
test: add live RRD S3 regression proof and SDK edge cases

### DIFF
--- a/npa/tests/e2e/test_convert_rrd_s3_live_e2e.py
+++ b/npa/tests/e2e/test_convert_rrd_s3_live_e2e.py
@@ -1,0 +1,156 @@
+"""Live SDK upload/readback proof using a synthetic four-frame LeRobot dataset.
+
+Run with NPA_INTEGRATION_E2E=1 and NPA_E2E_CONVERT_RRD_S3_DESTINATIONS_FILE
+pointing to owner-only JSON with exact, unused ``dataset`` and ``predictions`` S3
+object URIs. Existing NPA storage credentials must permit GET and PUT on those
+two objects. No bucket or IAM resources are created. The caller owns cleanup of
+the retained RRD objects; repeated runs require fresh explicitly assigned keys.
+Keys must be assigned exclusively: the preflight read is not an atomic write
+guard. Failure reports omit private exceptions, captured output, and locals.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import stat
+import warnings
+from pathlib import Path
+from urllib.parse import urlparse
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from rerun.recording import load_recording
+
+from npa import convert
+from npa.adapter.isaac_lab_lerobot import G1_STATE_DIM
+from npa.clients.storage import StorageClient
+from npa.viz.adapters.lerobot_to_rerun import _storage_client
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture(scope="module")
+def destinations() -> dict[str, str]:
+    source = os.environ.get("NPA_E2E_CONVERT_RRD_S3_DESTINATIONS_FILE", "")
+    if os.environ.get("NPA_INTEGRATION_E2E") != "1" or not source:
+        pytest.skip("Requires live opt-in and explicit unused S3 destination keys")
+    try:
+        path = Path(source)
+        info = path.stat()
+        if info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) & 0o077:
+            pytest.fail("Destination file must be owner-only", pytrace=False)
+        values = json.loads(path.read_text())
+    except (OSError, ValueError):
+        pytest.fail("Cannot read the private destination file", pytrace=False)
+    if not isinstance(values, dict) or set(values) != {"dataset", "predictions"}:
+        pytest.fail("Destination file must map dataset and predictions to exact S3 object URIs", pytrace=False)
+    for value in values.values():
+        if not isinstance(value, str):
+            pytest.fail("Each destination must be an S3 URI string", pytrace=False)
+        try:
+            parsed = urlparse(value)
+        except ValueError:
+            pytest.fail("Invalid private destination URI", pytrace=False)
+        if (
+            not value.startswith("s3://")
+            or any(char.isspace() for char in value)
+            or parsed.scheme != "s3"
+            or not parsed.netloc
+            or parsed.netloc != parsed.hostname
+            or ":" in parsed.netloc
+            or "@" in parsed.netloc
+            or parsed.path in {"", "/.rrd"}
+            or not parsed.path.endswith(".rrd")
+            or parsed.query
+            or parsed.fragment
+        ):
+            pytest.fail("Each destination must be an exact S3 RRD object URI", pytrace=False)
+    if len(set(values.values())) != 2:
+        pytest.fail("Each conversion mode requires its own destination object", pytrace=False)
+    return values
+
+
+@pytest.mark.parametrize("mode", ["dataset", "predictions"])
+def test_sdk_rrd_s3_upload_and_readback(
+    tmp_path: Path, monkeypatch, record_property, destinations: dict[str, str], mode: str, capfd, caplog
+) -> None:
+    failure = ""
+    previous_logging_disable = logging.root.manager.disable
+    try:
+        # This is a confidentiality boundary: libraries may print credentials or
+        # private URIs before raising. Keep them out of console and JUnit reports.
+        logging.disable(logging.CRITICAL)
+        with warnings.catch_warnings(record=True):
+            _upload_and_readback(tmp_path, monkeypatch, record_property, destinations[mode], mode)
+    except pytest.fail.Exception as exc:
+        failure = str(exc)  # Only the fixed messages below use pytest.fail.
+    except Exception as exc:
+        failure = f"Private S3 upload/readback failed ({type(exc).__name__})"
+    finally:
+        logging.disable(previous_logging_disable)
+        capfd.readouterr()
+        caplog.clear()
+    if failure:
+        pytest.fail(failure, pytrace=False)
+
+
+def _upload_and_readback(tmp_path: Path, monkeypatch, record_property, destination: str, mode: str) -> None:
+    storage = _storage_client(destination)
+    if storage.read_bytes_with_etag(destination) is not None:
+        pytest.fail("Refusing to overwrite an existing destination object")
+
+    dataset = tmp_path / "synthetic-dataset"
+    data = dataset / "data" / "chunk-000" / "file-000.parquet"
+    data.parent.mkdir(parents=True)
+    states = np.zeros((4, G1_STATE_DIM), dtype=np.float32)
+    states[:, 6] = [0.0, 0.1, 0.2, 0.3]
+    pq.write_table(pa.table({"observation.state": states.tolist(), "index": [0, 1, 2, 3]}), data)
+    metadata = dataset / "meta" / "info.json"
+    metadata.parent.mkdir()
+    metadata.write_text(json.dumps({"fps": 4, "robot_type": "unitree_g1"}))
+    predictions = tmp_path / "synthetic-predictions.json"
+    predictions.write_text(json.dumps({"predicted_actions": states.tolist()}))
+    uploaded = []
+    original_upload = StorageClient.upload_file
+
+    def capture_real_upload(self, local_file: str, output_uri: str) -> str:
+        if output_uri != destination:
+            pytest.fail("SDK attempted an upload outside the assigned destination")
+        uploaded.append(Path(local_file).read_bytes())
+        return original_upload(self, local_file, output_uri)
+
+    monkeypatch.setattr(StorageClient, "upload_file", capture_real_upload)
+    monkeypatch.chdir(tmp_path)
+    returned = convert.lerobot_to_rrd(
+        input_path=dataset,
+        output_path=destination,
+        predictions_path=predictions if mode == "predictions" else None,
+    )
+    if returned != destination:
+        pytest.fail("SDK did not return the unchanged destination URI")
+    assert len(uploaded) == 1
+    assert not (tmp_path / "s3:").exists()
+    downloaded = tmp_path / "downloaded.rrd"
+    storage.download_file(destination, str(downloaded))
+    payload = downloaded.read_bytes()
+    assert payload and payload == uploaded[0]
+    digest = hashlib.sha256(payload).hexdigest()
+    assert digest == hashlib.sha256(uploaded[0]).hexdigest()
+
+    chunks = list(load_recording(downloaded).chunks())
+    roots = ["/world/skeleton"] + (["/world/predictions"] if mode == "predictions" else [])
+    for root in roots:
+        times = []
+        for chunk in chunks:
+            if str(chunk.entity_path) == f"{root}/joints" and not chunk.is_static:
+                times.extend(chunk.to_record_batch().column("frame_time").cast(pa.int64()).to_pylist())
+        assert sorted(times) == [0, 250_000_000, 500_000_000, 750_000_000]
+    record_property("rrd_sha256", digest)
+    record_property("rrd_bytes", len(payload))
+    record_property("decoded_frames_per_entity", 4)
+    record_property("decoded_joint_entities", len(roots))

--- a/npa/tests/test_convert_lerobot_to_rrd.py
+++ b/npa/tests/test_convert_lerobot_to_rrd.py
@@ -68,14 +68,45 @@ def test_sdk_rrd_s3_output_uploads_exact_uri(tmp_path: Path, monkeypatch, overla
 
 
 @pytest.mark.parametrize('overlay', [False, True], ids=['dataset', 'predictions'])
-def test_sdk_rrd_local_output_remains_path(tmp_path: Path, overlay: bool) -> None:
+@pytest.mark.parametrize('path_type', [str, Path], ids=['string', 'path'])
+def test_sdk_rrd_local_output_remains_path(tmp_path: Path, overlay: bool, path_type) -> None:
     dataset, predictions = _dataset(tmp_path)
     destination = tmp_path / 'reports' / 'conversion.rrd'
     result = convert.lerobot_to_rrd(
         input_path=dataset,
-        output_path=str(destination),
+        output_path=path_type(destination),
         predictions_path=predictions if overlay else None,
     )
     assert isinstance(result, Path)
     assert result == destination
     _assert_recording(destination, overlay=overlay)
+
+
+@pytest.mark.parametrize('overlay', [False, True], ids=['dataset', 'predictions'])
+def test_sdk_rrd_s3_upload_failure_propagates(tmp_path: Path, monkeypatch, overlay: bool) -> None:
+    dataset, predictions = _dataset(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    destination = 's3://synthetic-bucket/reports/conversion.rrd'
+    failure = OSError('synthetic upload failure')
+    uploaded = []
+
+    class Storage:
+        def upload_file(self, local_file: str, output_uri: str) -> str:
+            _assert_recording(Path(local_file), overlay=overlay)
+            uploaded.append(output_uri)
+            raise failure
+
+    name = 'groot_predictions_to_rerun' if overlay else 'lerobot_to_rerun'
+    adapter = importlib.import_module(f'npa.viz.adapters.{name}')
+    monkeypatch.setattr(adapter, '_storage_client', lambda *_args: Storage())
+
+    with pytest.raises(OSError, match='synthetic upload failure') as caught:
+        convert.lerobot_to_rrd(
+            input_path=dataset,
+            output_path=destination,
+            predictions_path=predictions if overlay else None,
+        )
+
+    assert caught.value is failure
+    assert uploaded == [destination]
+    assert not (tmp_path / 's3:').exists()

--- a/npa/tests/test_convert_rrd_s3_live_safety.py
+++ b/npa/tests/test_convert_rrd_s3_live_safety.py
@@ -1,0 +1,133 @@
+"""Exercise the live test's real encoder and reporting without network access."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from xml.etree import ElementTree
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+_LIVE_TEST = Path(__file__).parent / "e2e" / "test_convert_rrd_s3_live_e2e.py"
+_DESTINATIONS = {
+    "dataset": "s3://synthetic-private-bucket/private-dataset.rrd",
+    "predictions": "s3://synthetic-private-bucket/private-predictions.rrd",
+}
+_CONFIG_ERRORS = {
+    "missing-file": "Cannot read the private destination file",
+    "malformed-json": "Cannot read the private destination file",
+    "invalid-uri": "Each destination must be an exact S3 RRD object URI",
+    "permissions": "Destination file must be owner-only",
+    "duplicate": "Each conversion mode requires its own destination object",
+}
+
+
+@pytest.mark.parametrize("scenario", ["success", "existing", "read-error", "upload-error", "corrupt", *_CONFIG_ERRORS])
+def test_private_live_reports_and_storage_guards(pytester, monkeypatch, scenario: str) -> None:
+    pytester.makepyfile(test_private_live=_LIVE_TEST.read_text())
+    pytester.makeini("[pytest]\nmarkers = e2e: opted-in integration test\njunit_family = legacy\n")
+    destination_file = pytester.path / "destinations.json"
+    destination_file.write_text(json.dumps(_DESTINATIONS))
+    destination_file.chmod(0o600)
+    if scenario == "missing-file":
+        destination_file.unlink()
+    elif scenario == "malformed-json":
+        destination_file.write_text('{"dataset": "' + _DESTINATIONS["dataset"])
+    elif scenario == "invalid-uri":
+        destination_file.write_text(json.dumps({**_DESTINATIONS, "dataset": _DESTINATIONS["dataset"] + "?private"}))
+    elif scenario == "permissions":
+        destination_file.chmod(0o644)
+    elif scenario == "duplicate":
+        destination_file.write_text(json.dumps(dict.fromkeys(_DESTINATIONS, _DESTINATIONS["dataset"])))
+    monkeypatch.setenv("NPA_INTEGRATION_E2E", "1")
+    monkeypatch.setenv("NPA_E2E_CONVERT_RRD_S3_DESTINATIONS_FILE", str(destination_file))
+    monkeypatch.setenv("SYNTHETIC_RRD_SCENARIO", scenario)
+    pytester.makeconftest(
+        """
+import importlib
+import io
+import logging
+import os
+from pathlib import Path
+import warnings
+
+import pytest
+from botocore.exceptions import ClientError
+from botocore.response import StreamingBody
+from npa.clients.storage import StorageClient
+
+@pytest.fixture(autouse=True)
+def synthetic_storage(monkeypatch, request):
+    scenario = os.environ["SYNTHETIC_RRD_SCENARIO"]
+    calls = Path(__file__).with_name("upload-calls")
+    objects = {}
+
+    def noisy_failure(bucket, key):
+        uri = f"s3://{bucket}/{key}"
+        print(uri)
+        os.write(2, uri.encode())
+        logging.error(uri)
+        warnings.warn(uri)
+        raise OSError(uri)
+
+    class Transport:
+        def get_object(self, *, Bucket, Key):
+            if scenario == "existing":
+                return {"Body": io.BytesIO(b"existing"), "ETag": '"existing"'}
+            if scenario == "read-error":
+                noisy_failure(Bucket, Key)
+            if Key not in objects:
+                raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+            payload = b"invalid RRD bytes" if scenario == "corrupt" else objects[Key]
+            return {"Body": StreamingBody(io.BytesIO(payload), len(payload)), "ETag": '"synthetic"'}
+
+        def upload_file(self, local_file, bucket, key):
+            with calls.open("a") as stream:
+                stream.write("upload\\n")
+            if scenario == "upload-error":
+                noisy_failure(bucket, key)
+            objects[key] = Path(local_file).read_bytes()
+
+    storage = StorageClient.__new__(StorageClient)
+    storage._s3 = Transport()
+    monkeypatch.setattr(request.module, "_storage_client", lambda *_args: storage)
+    for name in ("lerobot_to_rerun", "groot_predictions_to_rerun"):
+        adapter = importlib.import_module(f"npa.viz.adapters.{name}")
+        monkeypatch.setattr(adapter, "_storage_client", lambda *_args: storage)
+"""
+    )
+    result = pytester.runpytest_subprocess(
+        "-q", "--showlocals", "--junitxml=report.xml", "-o", "junit_logging=all",
+        "-o", "log_cli=true", "-o", "log_cli_level=DEBUG",
+    )
+    if scenario == "success":
+        result.assert_outcomes(passed=2)
+    elif scenario in _CONFIG_ERRORS:
+        result.assert_outcomes(errors=2)
+        result.stdout.fnmatch_lines([f"*{_CONFIG_ERRORS[scenario]}*"])
+    else:
+        result.assert_outcomes(failed=2)
+    if scenario == "existing":
+        result.stdout.fnmatch_lines(["*Refusing to overwrite an existing destination object*"])
+    elif scenario in {"read-error", "upload-error", "corrupt"}:
+        error_type = "AssertionError" if scenario == "corrupt" else "OSError"
+        result.stdout.fnmatch_lines([f"*Private S3 upload/readback failed ({error_type})*"])
+    calls = pytester.path / "upload-calls"
+    assert (len(calls.read_text().splitlines()) if calls.exists() else 0) == (
+        0 if scenario in {"existing", "read-error", *_CONFIG_ERRORS} else 2
+    )
+    report = (pytester.path / "report.xml").read_text()
+    output = result.stdout.str() + result.stderr.str() + report
+    for private_value in (*_DESTINATIONS.values(), "synthetic-private-bucket", "private-dataset.rrd", "private-predictions.rrd"):
+        assert private_value not in output
+    if scenario == "success":
+        cases = ElementTree.fromstring(report).findall(".//testcase")
+        assert len(cases) == 2
+        for case in cases:
+            properties = {entry.attrib["name"]: entry.attrib["value"] for entry in case.findall("./properties/property")}
+            assert len(properties["rrd_sha256"]) == 64
+            assert int(properties["rrd_bytes"]) > 0
+            assert properties["decoded_frames_per_entity"] == "4"
+            assert properties["decoded_joint_entities"] == ("2" if "predictions" in case.attrib["name"] else "1")


### PR DESCRIPTION
Main already preserves S3 destination strings in the conversion SDK. This PR adds the remaining regression cases: local `Path` destinations and propagation of the original upload exception for both dataset conversion and prediction overlays. Existing success cases are preserved; no production code changes remain.

The opt-in live test encodes real four-frame RRD recordings, uploads through `StorageClient.upload_file`, downloads them, compares bytes and SHA-256, and decodes skeleton and prediction timelines. It accepts two exact destinations from an owner-only configuration file and refuses existing objects. Offline safety tests check overwrite refusal, storage/readback failures, invalid configuration, and destination privacy in console and JUnit reports.

Validation:

- Focused SDK, adapter, CLI, and reporting-safety tests: 55 passed.
- Full non-live suite: 15,616 passed, 17 skipped, 1 xpassed; 74.97% package coverage against the 60% floor. Parallel run with CI coverage settings and the repository's non-live selection.
- Guardrails: 2,545 passed. Scanner regression suite: 719 passed.
- Real S3: 2 upload/readback cases passed. Reusing both keys produced 2 expected overwrite refusals; independent downloads confirmed unchanged hashes and byte counts.
- Both recordings passed native Rerun verification and decoded four frames per joint entity. Destination tokens were absent from console/JUnit reports and raw/decoded recording evidence. Exact evidence is retained privately; the tested conversion path and test files are unchanged across the rebase.
- Ruff, docs drift, diff confidentiality, and gitleaks passed. All seven GitHub checks passed. [Serial CI](https://github.com/nebius/nebius-physical-ai/actions/runs/34065266159) reported 15,636 passed, 391 skipped, 1 xpassed, and 74.96% package coverage; the CLI install test also passed all 10 cases.

The preflight existence check is not atomic with upload, so destination keys must be assigned exclusively. The caller owns cleanup of retained live objects. The proof uses synthetic data and authorized existing storage; it creates no infrastructure or IAM resources.

Validation scope: the results above were measured on PR head `a21a3d03a42325e442a6fdc0604ce76fc36b0c34` with base `2c325500ef39b39e1b8de89525d5f90ff6480e7d`. They do not establish fresh live validation of subsequent main-branch adapter changes.
