### PR TITLE
Honor selected configuration for workflow submission state

### DIFF
--- a/npa/src/npa/orchestration/npa_workflow/submission_state.py
+++ b/npa/src/npa/orchestration/npa_workflow/submission_state.py
@@ -19,6 +19,8 @@ import tempfile
 from dataclasses import dataclass
 from typing import Any, Iterator, Literal, Mapping
 
+from npa.clients import config
+
 
 SCHEMA_VERSION = "npa.workflow.submission.v1"
 _SECRET_KEY = re.compile(
@@ -64,9 +66,14 @@ def _safe_component(value: str, fallback: str) -> str:
 
 
 def submission_state_path(project: str, run_id: str) -> Path:
-    """Return the per-project/run ledger path below the current user's config."""
+    """Return the per-project/run ledger path below the selected NPA config."""
 
-    root = Path(os.environ.get("NPA_CONFIG_DIR", "").strip() or Path.home() / ".npa")
+    # Honor an explicitly selected config, including selection before this
+    # module is imported. Otherwise retain dynamic environment/home resolution.
+    if config.CONFIG_PATH != config.NPA_CONFIG_DIR / "config.yaml":
+        root = config.CONFIG_PATH.parent
+    else:
+        root = Path(os.environ.get("NPA_CONFIG_DIR", "").strip() or Path.home() / ".npa")
     return (
         root
         / "workflow-submissions"

--- a/npa/tests/orchestration/npa_workflow/test_artifact_load.py
+++ b/npa/tests/orchestration/npa_workflow/test_artifact_load.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from npa.clients import config
 from npa.orchestration.npa_workflow.artifact_load import (
     discover_final_rerun_artifact,
     load_final_artifact_into_agent,
@@ -72,6 +73,7 @@ def test_load_posts_exact_uri_then_verifies_and_persists(
     monkeypatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(config, "CONFIG_PATH", tmp_path / ".npa/config.yaml")
     _patch_agent(monkeypatch, tmp_path)
     artifact = "s3://bucket/physical-ai-data-factory/paidf-1/reports/sim2real.rrd"
     client = FakeS3({artifact.removeprefix("s3://bucket/")})

--- a/npa/tests/orchestration/npa_workflow/test_submission_config_isolation.py
+++ b/npa/tests/orchestration/npa_workflow/test_submission_config_isolation.py
@@ -1,0 +1,273 @@
+"""Exercise config selection at real process startup, without inherited imports."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Iterator
+
+import pytest
+
+from npa.clients import config
+from npa.orchestration.npa_workflow import submission_state
+
+
+_PROCESS = """
+from dataclasses import asdict
+import fcntl
+import json
+import os
+from pathlib import Path
+import sys
+from npa.clients import config
+
+request = json.loads(sys.stdin.readline())
+if "config_path" in request:
+    config.CONFIG_PATH = Path(request["config_path"])
+from npa.orchestration.npa_workflow import submission_state as state
+
+for name, value in request.get("after_import_environment", {}).items():
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+project = request.get("project", "demo")
+run_id = "same-run"
+operation = request["operation"]
+if operation == "update":
+    result = state.update_submission_state(project, run_id, request["updates"])
+elif operation == "load":
+    result = state.load_submission_state(project, run_id)
+elif operation == "inspect":
+    result = asdict(state.inspect_submission_state(project, run_id))
+elif operation == "audit":
+    result = asdict(state.audit_project_submissions(project))
+elif operation == "path":
+    result = {"receipt": str(state.submission_state_path(project, run_id)),
+              "config": str(config.CONFIG_PATH)}
+elif operation == "hold_lock":
+    with state.submission_lock(project, run_id):
+        print(json.dumps({"held": True}), flush=True)
+        sys.stdin.readline()
+    result = {"released": True}
+elif operation == "probe_lock":
+    # Keep the production lock context and the real kernel lock, but report
+    # contention immediately so a broken cross-config lock cannot hang pytest.
+    flock = fcntl.flock
+    def nonblocking(fd, operation):
+        if operation == fcntl.LOCK_EX:
+            operation |= fcntl.LOCK_NB
+        return flock(fd, operation)
+    fcntl.flock = nonblocking
+    try:
+        with state.submission_lock(project, run_id):
+            result = {"acquired": True}
+    except BlockingIOError:
+        result = {"acquired": False}
+print(json.dumps(result), flush=True)
+"""
+
+
+def _environment(home: Path, root: str | Path | None) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(HOME=str(home), USERPROFILE=str(home))
+    env.pop("NPA_CONFIG_DIR", None)
+    if root is not None:
+        env["NPA_CONFIG_DIR"] = str(root)
+    return env
+
+
+def _run(home: Path, root: str | Path | None, operation: str, **values: object) -> dict:
+    completed = subprocess.run(
+        [sys.executable, "-c", _PROCESS],
+        input=json.dumps({"operation": operation, **values}) + "\n",
+        env=_environment(home, root),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+@contextmanager
+def _held_lock(home: Path, root: Path) -> Iterator[None]:
+    with subprocess.Popen(
+        [sys.executable, "-c", _PROCESS],
+        env=_environment(home, root),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ) as holder:
+        assert holder.stdin is not None
+        assert holder.stdout is not None
+        holder.stdin.write(json.dumps({"operation": "hold_lock"}) + "\n")
+        holder.stdin.flush()
+        try:
+            assert json.loads(holder.stdout.readline()) == {"held": True}
+            yield
+        finally:
+            stdout, stderr = holder.communicate("release\n")
+            assert holder.returncode == 0, stderr
+            assert json.loads(stdout) == {"released": True}
+
+
+def test_receipt_writes_are_isolated_between_config_roots(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    first, second = tmp_path / "first", tmp_path / "second"
+    _run(home, first, "update", updates={"first_only": True})
+    _run(home, second, "update", updates={"second_only": True})
+
+    first_state = _run(home, first, "load")
+    second_state = _run(home, second, "load")
+    assert first_state["first_only"] is True
+    assert "second_only" not in first_state
+    assert second_state["second_only"] is True
+    assert "first_only" not in second_state
+    for root in (first, second):
+        receipt = root / "workflow-submissions" / "demo" / "same-run.json"
+        assert receipt.stat().st_mode & 0o777 == 0o600
+        assert receipt.parent.stat().st_mode & 0o777 == 0o700
+        assert receipt.with_suffix(".lock").stat().st_mode & 0o777 == 0o600
+    assert not (home / ".npa").exists()
+
+
+@pytest.mark.parametrize("operation", ["load", "inspect"])
+def test_receipt_reads_do_not_cross_config_roots(tmp_path: Path, operation: str) -> None:
+    home = tmp_path / "home"
+    first, second = tmp_path / "first", tmp_path / "second"
+    _run(home, first, "update", updates={"launch": {"status": "launching"}})
+
+    result = _run(home, second, operation)
+
+    if operation == "load":
+        assert result == {}
+    else:
+        assert result == {"outcome": "absent", "payload": {}, "error": ""}
+    assert not second.exists()
+
+
+def test_project_audits_use_only_the_selected_config_root(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    first, second = tmp_path / "first", tmp_path / "second"
+    _run(home, first, "update", updates={"launch_state": "reserved"})
+    _run(home, second, "update", updates={"launch": {"status": "launching"}})
+    _run(home, first, "update", project="other", updates={"launch": {}})
+
+    assert _run(home, first, "audit") == {
+        "outcome": "not_submitted", "ledger_count": 1, "error": ""
+    }
+    assert _run(home, second, "audit") == {
+        "outcome": "launch_evidence", "ledger_count": 1, "error": ""
+    }
+    assert _run(home, tmp_path / "empty", "audit") == {
+        "outcome": "absent", "ledger_count": 0, "error": ""
+    }
+
+
+@pytest.mark.parametrize("same_root", [False, True], ids=["distinct-roots", "same-root"])
+def test_submission_locks_are_scoped_to_config_root(tmp_path: Path, same_root: bool) -> None:
+    home = tmp_path / "home"
+    first = tmp_path / "first"
+    contender = first if same_root else tmp_path / "second"
+
+    with _held_lock(home, first):
+        assert _run(home, contender, "probe_lock") == {"acquired": not same_root}
+
+    assert _run(home, contender, "probe_lock") == {"acquired": True}
+
+
+@pytest.mark.parametrize("root", [None, "", " \t "], ids=["unset", "empty", "whitespace"])
+def test_default_config_keeps_home_submission_state(tmp_path: Path, root: str | None) -> None:
+    home = tmp_path / "home"
+    expected = home / ".npa"
+    paths = _run(home, root, "path")
+    assert Path(paths["config"]) == expected / "config.yaml"
+    assert Path(paths["receipt"]) == expected / "workflow-submissions" / "demo" / "same-run.json"
+    _run(home, root, "update", updates={"launch_state": "reserved"})
+    assert _run(home, root, "inspect")["outcome"] == "found"
+    assert _run(home, root, "audit")["outcome"] == "not_submitted"
+
+
+@pytest.mark.parametrize("initial_configured", [False, True], ids=["default-start", "configured-start"])
+@pytest.mark.parametrize(
+    "updated_root", [None, "", " \t ", "replacement"],
+    ids=["unset", "empty", "whitespace", "replacement"],
+)
+def test_unselected_config_tracks_environment_changes_after_import(
+    tmp_path: Path, initial_configured: bool, updated_root: str | None
+) -> None:
+    initial_home = tmp_path / "initial-home"
+    updated_home = tmp_path / "updated-home"
+    initial_root = tmp_path / "initial-config" if initial_configured else None
+    root = str(tmp_path / updated_root) if updated_root == "replacement" else updated_root
+    expected = Path(root) if root and root.strip() else updated_home / ".npa"
+
+    _run(
+        initial_home,
+        initial_root,
+        "update",
+        after_import_environment={
+            "HOME": str(updated_home),
+            "USERPROFILE": str(updated_home),
+            "NPA_CONFIG_DIR": root,
+        },
+        updates={"launch_state": "reserved"},
+    )
+
+    receipt = expected / "workflow-submissions" / "demo" / "same-run.json"
+    assert receipt.is_file()
+    assert receipt.with_suffix(".lock").is_file()
+    assert _run(updated_home, root, "inspect")["outcome"] == "found"
+    assert not (initial_home / ".npa").exists()
+    if initial_root is not None:
+        assert not initial_root.exists()
+
+
+def test_config_selected_before_submission_import_takes_precedence(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    selected = tmp_path / "selected"
+    startup_root = tmp_path / "startup-config"
+    ambient = tmp_path / "ambient-config"
+    selection = {
+        "config_path": str(selected / "custom.yaml"),
+        "after_import_environment": {"NPA_CONFIG_DIR": str(ambient)},
+    }
+
+    _run(home, startup_root, "update", **selection, updates={"launch_state": "reserved"})
+
+    receipt = selected / "workflow-submissions" / "demo" / "same-run.json"
+    assert receipt.is_file()
+    assert receipt.with_suffix(".lock").is_file()
+    assert _run(home, startup_root, "inspect", **selection)["outcome"] == "found"
+    assert _run(home, startup_root, "audit", **selection)["outcome"] == "not_submitted"
+    assert not startup_root.exists()
+    assert not ambient.exists()
+    assert not (home / ".npa").exists()
+
+
+def test_submission_state_reuses_selected_config_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selected = tmp_path / "selected"
+    ambient = tmp_path / "ambient"
+    monkeypatch.setattr(config, "CONFIG_PATH", selected / "config.yaml")
+    monkeypatch.setenv("NPA_CONFIG_DIR", str(ambient))
+
+    submission_state.update_submission_state("demo", "same-run", {"launch_state": "reserved"})
+
+    assert submission_state.submission_state_path("demo", "same-run") == (
+        selected / "workflow-submissions" / "demo" / "same-run.json"
+    )
+    receipt = selected / "workflow-submissions" / "demo" / "same-run.json"
+    assert receipt.is_file()
+    assert receipt.with_suffix(".lock").is_file()
+    assert receipt.stat().st_mode & 0o777 == 0o600
+    assert receipt.with_suffix(".lock").stat().st_mode & 0o777 == 0o600
+    assert submission_state.inspect_submission_state("demo", "same-run").outcome == "found"
+    assert submission_state.audit_project_submissions("demo").outcome == "not_submitted"
+    assert not ambient.exists()

--- a/npa/tests/orchestration/npa_workflow/test_submission_runtime_isolation.py
+++ b/npa/tests/orchestration/npa_workflow/test_submission_runtime_isolation.py
@@ -4,11 +4,15 @@ from pathlib import Path
 
 import pytest
 
+from npa.clients import config
 from npa.orchestration.npa_workflow import submission_state as state
 
 
 @pytest.fixture
 def private_home(tmp_path, monkeypatch):
+    # Exercise dynamic environment selection without the autouse fixture's
+    # explicit CONFIG_PATH override taking precedence.
+    monkeypatch.setattr(config, "CONFIG_PATH", config.NPA_CONFIG_DIR / "config.yaml")
     root = tmp_path / "synthetic-home"
     root.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: root))


### PR DESCRIPTION
Submission receipts and locks now follow an explicitly selected `config.CONFIG_PATH`, including selection before submission-state import and monkeypatch overrides. When the config path retains its startup default, submission state preserves main's dynamic environment and home-directory resolution, including unset, empty, and whitespace-only `NPA_CONFIG_DIR` values.

One incremental commit on current main (`2c325500`), touching four files. Retains real process-startup write/read isolation, exact-project audits, owner-only permissions, and kernel lock scope/exclusion tests. Adds post-import environment changes and explicit config-selection precedence coverage; adjusts two test fixtures to make their intended config selection explicit.

Validation on head `0d42f988`:

- Local focused submission/config/artifact tests: **34 passed**.
- Both selected-config precedence regressions fail against main's unchanged submission-state implementation and pass with this fix.
- [Full Python 3.12 CI suite](https://github.com/nebius/nebius-physical-ai/actions/runs/34064924234/job/101571896222): **15,640 passed, 389 skipped, 1 xpassed**, 74.96% coverage (60% required). All 19 selected-config isolation tests passed within this run.
- [Guardrails](https://github.com/nebius/nebius-physical-ai/actions/runs/34064924172/job/101571895869): **2,544 passed**.
- All seven GitHub checks passed: unit/coverage, browser mocks, guardrails, Ruff, docs drift, confidentiality, and gitleaks. Local full source/test Ruff, staged/diff confidentiality, PR prose confidentiality, and PR-range gitleaks also passed.

Validation uses temporary local configurations and real filesystem/process locks. No cloud workflow or deployment was run. The complete full-suite result above is from CI; the redundant local full-suite run was stopped after CI passed.
