### PR TITLE
Fix GR00T Rerun overlay frame alignment under duration caps

### DIFF
--- a/npa/src/npa/viz/adapters/groot_predictions_to_rerun.py
+++ b/npa/src/npa/viz/adapters/groot_predictions_to_rerun.py
@@ -46,7 +46,7 @@ def groot_predictions_to_rerun(
     predictions_color: tuple[int, int, int] = (255, 136, 0),
     duration_s: float | None = None,
 ) -> None:
-    """Write one Rerun ``.rrd`` with LeRobot input and GR00T predictions overlaid."""
+    """Overlay matching source prefixes, capped by duration at the native frame rate."""
     output_ref = str(output_rrd_path)
     with ExitStack() as stack:
         local_predictions = _materialize_predictions(predictions_path, stack)
@@ -82,6 +82,10 @@ def _write_groot_overlay_recording(
         fps=source_fps,
         duration_s=duration_s,
     )
+    # Use the shared duration budget, but retain a contiguous source prefix.
+    # Resampling the whole input would compare later states with earlier
+    # prediction frames and compress their source timestamps into the cap.
+    selected_input_states = input_states[: selected_input_states.shape[0]]
     input_skeleton = g1_state_vectors_to_skeleton(selected_input_states)
     prediction_skeleton, prediction_states = _load_prediction_frames(
         predictions_path,
@@ -101,10 +105,10 @@ def _write_groot_overlay_recording(
             "Prediction skeleton and angle state frame counts must match: "
             f"{prediction_skeleton.shape[0]} != {prediction_states.shape[0]}"
         )
-    if prediction_skeleton.shape[0] > input_skeleton.shape[0]:
+    if prediction_skeleton.shape[0] > input_states.shape[0]:
         raise RerunAdapterError(
-            "Prediction frame count cannot exceed input frame count after sampling: "
-            f"{prediction_skeleton.shape[0]} > {input_skeleton.shape[0]}"
+            "Prediction frame count cannot exceed input frame count: "
+            f"{prediction_skeleton.shape[0]} > {input_states.shape[0]}"
         )
 
     output_rrd_path = Path(output_rrd_path)

--- a/npa/tests/test_groot_overlay_frame_alignment.py
+++ b/npa/tests/test_groot_overlay_frame_alignment.py
@@ -1,0 +1,131 @@
+"""Decode real RRDs made from synthetic trajectories to check overlay alignment."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from npa.adapter.isaac_lab_lerobot import G1_BONE_PAIRS, G1_STATE_DIM, G1_STATE_NAMES_43, convert
+from npa.viz.adapters.groot_predictions_to_rerun import groot_predictions_to_rerun
+from npa.viz.adapters.lerobot_to_rerun import REPRESENTATIVE_JOINTS, RerunAdapterError
+from npa.viz.lerobot import g1_state_vectors_to_skeleton
+
+
+_DEFAULT_INDICES = list(range(50))
+_TWO_SECOND_INDICES = list(range(20))
+
+
+def _synthetic_dataset(root: Path, frames: int) -> tuple[Path, np.ndarray]:
+    # Every joint encodes its source frame, so a shifted overlay cannot pass by
+    # comparing two constant poses. These are synthetic states, not model output.
+    states = (
+        np.arange(frames, dtype=np.float32)[:, None] * 0.005
+        + np.arange(G1_STATE_DIM, dtype=np.float32)[None, :] * 0.001
+    )
+    episode = root / "raw" / "episode_000000"
+    episode.mkdir(parents=True)
+    np.save(episode / "state.npy", states)
+    np.save(episode / "actions.npy", states)
+    dataset = convert(episode.parent, root / "lerobot", fps=10, task="Synthetic overlay alignment")
+    return dataset, states
+
+
+def _predictions(root: Path, values: np.ndarray) -> Path:
+    path = root / "predictions.json"
+    path.write_text(json.dumps({"predicted_actions": values.tolist()}))
+    return path
+
+
+def _decoded_rows(chunks, entity: str, component: str) -> tuple[np.ndarray, np.ndarray]:
+    rows = []
+    for chunk in chunks:
+        if str(chunk.entity_path) != entity or chunk.is_static:
+            continue
+        batch = chunk.to_record_batch()
+        times = batch.column("frame_time").cast(pa.int64()).to_pylist()
+        rows.extend(zip(times, batch.column(component).to_pylist(), strict=True))
+    rows.sort(key=lambda row: row[0])
+    assert rows, f"No decoded rows for {entity}"
+    times, values = zip(*rows, strict=True)
+    return np.asarray(times), np.asarray(values)
+
+
+@pytest.mark.parametrize(
+    ("frames", "horizon", "duration", "source_indices"),
+    [
+        pytest.param(100, 100, None, _DEFAULT_INDICES, id="full-horizon-default-cap"),
+        pytest.param(100, 4, None, _DEFAULT_INDICES, id="short-prefix"),
+        pytest.param(100, 49, None, _DEFAULT_INDICES, id="prefix-below-display-count"),
+        pytest.param(100, 51, None, _DEFAULT_INDICES, id="prefix-longer-than-display-count"),
+        pytest.param(100, 100, 2.0, _TWO_SECOND_INDICES, id="custom-duration"),
+        pytest.param(100, 4, 2.0, _TWO_SECOND_INDICES, id="custom-duration-short-prefix"),
+        pytest.param(100, 100, 8.0, _DEFAULT_INDICES, id="duration-above-default-cap"),
+        pytest.param(100, 100, 0.01, [0], id="sub-frame-duration"),
+        pytest.param(10, 10, None, list(range(10)), id="short-episode-full-horizon"),
+        pytest.param(10, 4, None, list(range(10)), id="short-episode-prefix"),
+        pytest.param(1, 1, None, [0], id="single-frame"),
+    ],
+)
+def test_overlay_uses_matching_source_frames_and_times(
+    tmp_path: Path, frames: int, horizon: int, duration: float | None, source_indices: list[int]
+) -> None:
+    from rerun.recording import load_recording
+
+    dataset, states = _synthetic_dataset(tmp_path, frames)
+    predictions = _predictions(tmp_path, states[:horizon])
+    output = tmp_path / "synthetic-overlay.rrd"
+
+    groot_predictions_to_rerun(predictions, dataset, output, duration_s=duration)
+
+    assert output.stat().st_size > 0
+    chunks = list(load_recording(output).chunks())
+    skeleton = g1_state_vectors_to_skeleton(states)
+    for root, indices in (
+        ("/world/skeleton", source_indices),
+        ("/world/predictions", [index for index in source_indices if index < horizon]),
+    ):
+        # Check every timestamp and value across the native-time source prefix.
+        # A duration cap must not resample later source states onto earlier times.
+        expected_times = np.asarray(indices, dtype=np.int64) * 100_000_000
+        times, positions = _decoded_rows(chunks, f"{root}/joints", "Points3D:positions")
+        np.testing.assert_array_equal(times, expected_times)
+        np.testing.assert_allclose(positions, skeleton[indices])
+        times, bones = _decoded_rows(chunks, f"{root}/bones", "LineStrips3D:strips")
+        np.testing.assert_array_equal(times, expected_times)
+        np.testing.assert_allclose(bones, skeleton[indices][:, np.asarray(G1_BONE_PAIRS)])
+        for joint in REPRESENTATIVE_JOINTS:
+            times, angles = _decoded_rows(chunks, f"{root}/angles/{joint}", "Scalars:scalars")
+            np.testing.assert_array_equal(times, expected_times)
+            np.testing.assert_allclose(angles[:, 0], states[indices, G1_STATE_NAMES_43.index(joint)])
+
+
+@pytest.mark.parametrize(
+    ("shape", "message"),
+    [
+        ((101, G1_STATE_DIM), "Prediction frame count cannot exceed input frame count.*101 > 100"),
+        ((100, G1_STATE_DIM - 1), "Predictions must be either G1 state vectors"),
+        ((100, G1_STATE_DIM - 1, 3), "Prediction joint count must match input joint count"),
+    ],
+)
+def test_overlay_rejects_invalid_raw_predictions(tmp_path: Path, shape: tuple[int, ...], message: str) -> None:
+    dataset, _states = _synthetic_dataset(tmp_path, 100)
+    predictions = _predictions(tmp_path, np.zeros(shape, dtype=np.float32))
+    output = tmp_path / "invalid.rrd"
+
+    with pytest.raises(RerunAdapterError, match=message):
+        groot_predictions_to_rerun(predictions, dataset, output)
+
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("duration", [0.0, -1.0])
+def test_overlay_rejects_nonpositive_duration(tmp_path: Path, duration: float) -> None:
+    dataset, states = _synthetic_dataset(tmp_path, 10)
+    predictions = _predictions(tmp_path, states)
+
+    with pytest.raises(RerunAdapterError, match="duration_s must be positive"):
+        groot_predictions_to_rerun(predictions, dataset, tmp_path / "invalid.rrd", duration_s=duration)


### PR DESCRIPTION
## Summary

A 100-frame source episode with matching GR00T predictions was rejected when the Rerun duration cap reduced the recording to 50 frames. Short prediction prefixes could also be overlaid on different source states.

Keep a contiguous source prefix at its native frame rate and validate prediction length against the full source horizon. The existing duration cap now preserves alignment between input poses, predictions, joint angles, and timestamps. The diff contains one commit and two files: the overlay adapter and its regression tests.

## Verification

- 39 focused tests passed, including 16 new regressions. All 11 synthetic recordings passed real RRD decoding and `rerun rrd verify`; assertions check every emitted timestamp, joint position, bone, and representative joint angle.
- Two negative controls reproduce the full-horizon rejection and short-prefix frame shift on main and pass with this change.
- Local onboarding smoke: 114 passed. Local guardrails: 2,544 passed. Full ruff, diff confidentiality, and gitleaks passed with no findings.
- [Full Python 3.12 CI](https://github.com/nebius/nebius-physical-ai/actions/runs/34063719006/job/101568745618): 15,637 passed, 389 skipped, 1 xpassed; 74.97% coverage. All 16 new regressions and the eight cases that timed out locally passed. CLI installation checks: 10/10.
- All seven GitHub checks passed on `9b3a6b58`, including browser coverage, docs drift, ruff, guardrails, confidentiality, and gitleaks. The actual GitHub merge tree matches the tested head on current main `2c325500`.

The local full-suite attempt was interrupted after timeout and file-permission fixture failures. Correcting the umask and inherited pytest flags yielded 28 passing rechecks; one unrelated video-conversion case still exceeded the local 180-second timeout. The completed full-suite result is the GitHub gate linked above.

Validation uses synthetic local inputs and actual RRD files. No GR00T model inference or GPU workload was run.

## Skill Maintenance

- [x] Existing artifact conversion guidance already specifies the recording duration cap; this correction requires no additional operational guidance.
