### PR TITLE
docs: consolidate Workbench setup on the current workflow catalog

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -5,7 +5,8 @@
 > [docs/cli/README.md](docs/cli/README.md) and [npa/README.md](npa/README.md);
 > `npa --help` is always authoritative. Kept for historical context only.
 
-Complete reference for the `npa` command-line tool. Use this to generate correct commands.
+Use the generated [CLI reference](docs/cli/README.md) and the installed
+command's `--help` when writing commands. The snapshot below is historical.
 
 ## Command Hierarchy
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Workbench is meant to be operated by **your own coding agent**. Connect the
 agent to this checkout with terminal access, attach your cloud and model
 credentials through its private environment or secret manager, and ask it to
 configure, validate, provision, submit, and inspect workflows with you. The
-prompts below are a starting point; you do not need to learn every `npa` command
-before running something real.
+prompts in the [coding-agent guide](docs/workbench/agent-first-run.md) are a
+starting point; you do not need to learn every `npa` command before running
+something real.
 
 |                       |                                                                                                              |
 | --------------------- | ------------------------------------------------------------------------------------------------------------ |
@@ -54,6 +55,32 @@ before running something real.
 
 > Partners integrate independently. Teams assemble from open blueprints.
 > Nebius owns the infrastructure layer and compute substrate.
+
+### How workflows run
+
+```mermaid
+flowchart TB
+    operator["Coding agent or terminal"] --> npa["npa: configure, validate, plan, submit"]
+    yaml["Workflow YAML"] --> npa
+    npa --> run["SkyPilot: selected CPU and GPU tools"]
+    subgraph nebius["Nebius AI Cloud"]
+        run <--> s3["S3 inputs, checkpoints, reports, recordings"]
+        tf["Token Factory hosted inference"]
+    end
+    run -->|"When selected"| tf
+    s3 --> inspect["Inspect with CLI, Python, or supported viewers"]
+```
+
+Workbench submits workflow tasks through SkyPilot. Selected tools exchange
+inputs and outputs through S3; workflows can call Token Factory for hosted
+inference. Inspect artifacts through the CLI, Python, or a compatible Rerun or
+Foxglove viewer. This diagram describes workflow execution; the
+[Ray development guide](docs/testing/fast-source-iteration.md) covers direct
+development with native Ray Jobs.
+
+Python and HTTP coverage varies by tool. The
+[CLI / SDK walkthrough](docs/workbench/cli-sdk-yaml-walkthrough.md) explains
+typed clients, callback wrappers, and their return values.
 
 ---
 
@@ -109,133 +136,37 @@ gated, or temporarily unreachable providers do not prevent otherwise-valid
 configuration from being saved. Use `npa workbench health access` when access
 must be an enforcing gate.
 
-If an agent is operating the checkout, attach these values to its **private
-environment** instead of pasting token values into chat:
+Interactive configuration provisions object storage by default. First-time
+storage setup needs admin permission on the target project to create the
+service account, access key, and bucket-scoped IAM permissions.
 
-```bash
-NEBIUS_TENANT_ID=<your-tenant-id>
-NEBIUS_PROJECT_ID=<your-project-id>
-NEBIUS_REGION=<your-project-region>
-HF_TOKEN=<your-hugging-face-read-token>
-NGC_API_KEY=<your-ngc-api-key>
-NEBIUS_TOKEN_FACTORY_KEY=<your-token-factory-key>
-```
-
-The Hugging Face account behind `HF_TOKEN` must already have access to the
-models used by the workflow. A fine-grained token must include those repos.
-Gated terms can only be accepted by you on Hugging Face; the access check below
-prints every exact page still requiring action. NGC is part of the general
-Workbench setup even though the PAIDF + Cosmos 3 path below currently obtains
-its model weights from Hugging Face. Token Factory is required by that path for
-captioning and evaluation.
-
-First-time storage setup needs **admin permission on the target project**.
-`npa configure` creates a project service account, access key, and project-scoped
-IAM group with a bucket-scoped `storage.object-editor` permit. Tenant-wide admin
-permission and tenant-wide project listing are not required.
-
-Then give your agent this prompt:
-
-```text
-Set up Nebius Physical AI Workbench in this checkout. Read AGENTS.md and
-skills/index.yaml first and follow the relevant first-run, credential-preflight,
-and GPU guidance.
-
-Use NEBIUS_TENANT_ID, NEBIUS_PROJECT_ID, NEBIUS_REGION, HF_TOKEN, NGC_API_KEY,
-and NEBIUS_TOKEN_FACTORY_KEY from the private process environment. Never print
-secret values, put them in command arguments, or write them into the repository.
-Never run `env`, `printenv`, `set`, `export -p`, or another command that dumps
-the process environment; inspect only allowlisted names and report present or
-missing. Do not read credential files except through npa's credential APIs.
-Use NPA_PROJECT_ALIAS if it is set; otherwise use "workbench" as the local alias.
-
-Install or verify npa and its reported host prerequisites, including Terraform
-and, for SkyPilot Kubernetes on Debian/Ubuntu, socat. Verify the active Nebius
-CLI identity and configure the known tenant, project, and region
-non-interactively. Persist supported environment credentials with npa configure
---save-env-credentials and use explicit --provision to create or reuse writable
-project object storage. Without --provision, known-project setup must remain
-provider-free and leave storage unselected.
-Confirm the active identity can manage the project-scoped IAM objects that
-secure that storage. Then run npa configure --show,
-npa workbench health preflight --json,
-npa workbench health preflight --checks nebius --json, and
-npa workbench health access --capability paidf,cosmos3 --json.
-
-Do not bypass a failed gate or provision GPU resources yet. If Hugging Face
-access is missing, give me the exact model-page links, wait for me to accept the
-terms, and rerun the check. Finish only when project storage, credentials, and
-the PAIDF/Cosmos 3 model access checks pass, then guide me straight into my first
-workflow.
-```
-
-> Creating projects from the CLI, SSO/federation profiles, non-interactive
-> automation, and the full credential model live in
-> **[docs/quickstart.md](docs/quickstart.md)**.
+For project creation, SSO, non-interactive provisioning, credential names, and
+recovery, see [configuration](docs/configuration.md). Use the
+[coding-agent setup prompt](docs/workbench/agent-first-run.md#configure-the-project-and-model-access)
+to prepare the credentials and resources required by your selected task.
 
 ### 3. Run your first workload
 
-Check your credentials, then put them to work:
+Choose a GPU workload from the [guides](docs/workbench/guides/README.md), such
+as a robot policy or [NVIDIA Cosmos](docs/quickstart.md#standalone-cosmos-3-generation).
+You can also select individual tools from the [tool reference](docs/cli/workbench.md)
+and compose them into a workflow. Use the [coding-agent guide](docs/workbench/agent-first-run.md)
+to check the inputs, credentials, and resources your task needs.
 
-```bash
-npa workbench health preflight
-```
+For a worked video-augmentation example, use
+[PAIDF + Cosmos 3](docs/workbench/guides/paidf-cosmos3.md): supply a
+local H.264 MP4 or private S3 MP4 URI, generate source-conditioned variants,
+evaluate them, and curate accepted outputs. The
+[PAIDF workflow prompt](docs/workbench/agent-first-run.md#run-paidf-with-cosmos-3)
+guides your agent through project storage, model access, GPU planning, image
+checks, submission, recovery, and output inspection. The PAIDF guide's command
+examples validate and plan the workflow without running it.
 
-One PASS/WARN/FAIL/SKIP sweep over the credentials nearly every job needs —
-Hugging Face, NVIDIA NGC, Nebius object storage, and Token Factory. Add `--json`
-for machine-readable output.
-
-Once it comes back green, launch something real on Nebius GPUs. The flagship is
-[NVIDIA Cosmos](docs/quickstart.md#7-flagship-gpu-workload-nvidia-cosmos), and
-any robot guide below will take you from a public dataset to a trained and
-evaluated policy.
-
-**Do not stop at setup.** Keep the same agent in the loop and have it guide the
-first workflow from input selection through the final artifact. For the
-Physical AI Data Factory with real source-video-conditioned Cosmos 3, attach a
-local H.264 MP4 or set `PAIDF_INPUT_URI` to one private `s3://` MP4, then paste:
-
-```text
-Run my first Workbench workflow with me: the PAIDF Cosmos 3 video-conditioning
-workflow at workflows/main/paidf-cosmos3.yaml. Follow
-docs/workbench/guides/paidf-cosmos3.md and the repository skills. Use the
-configured Nebius project, region, writable bucket, and credentials. Use the
-attached local H.264 MP4, or PAIDF_INPUT_URI if it is set; if neither is
-available, ask me only for the input video before continuing. Keep all input and
-artifact locations private.
-
-Never run `env`, `printenv`, `set`, `export -p`, or another command that dumps
-the process environment. Inspect only allowlisted variable names and report
-present or missing; do not print secret values or read credential files directly.
-
-Re-run the credential and model-access gates for paidf,cosmos3. Validate and
-plan the spec with the real bucket and input, starting with one variant and one
-supported GPU. Honor configured TF_VAR_* topology and reserved-capacity settings.
-Bootstrap and verify SkyPilot, discover the accelerator name the target cluster
-advertises, and provision the required CPU/GPU resources if they are absent.
-Show me the validated plan and explain the resources it will create, then stage
-the input and preflight the selected images. If a selected image fails the
-SkyPilot bootstrap contract, build the repository's current compliant image,
-push it to an authorized private project registry at an immutable digest, and
-repeat preflight. Then submit with --runtime.
-Forward only secret names through --secret-env: HF_TOKEN,
-NEBIUS_TOKEN_FACTORY_KEY, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY; never put
-secret values in YAML or command arguments.
-
-Stay with the run until it reaches a terminal state. If it fails, diagnose the
-recorded stage and resume safely rather than starting an unrelated run. If it
-succeeds, show me the generated and curated artifacts and load the final Rerun
-recording when an agent viewer is available. A terminal quality rejection after
-the workflow's bounded refinement loop is a valid fail-closed result: do not
-lower the threshold or force promotion. Show me the generated video, evaluator
-report, quality disposition, and Rerun evidence, and explain that labeling and
-curation were intentionally skipped.
-```
-
-The workflow uses the independent
-[`paidf-cosmos3.yaml`](docs/workbench/guides/paidf-cosmos3.md) composition; the
-original Physical AI Data Factory workflow continues to use Cosmos Transfer
-2.5.
+Check the raw generated media as well as the published PAIDF composite, which
+blends source and generated frames (80% source by default). A quality rejection
+after bounded refinement skips labeling and curation; inspect the report before
+retrying. The original [Physical AI Data Factory](docs/workbench/guides/physical-ai-data-factory-deploy.md)
+continues to use Cosmos Transfer 2.5.
 
 ---
 
@@ -250,7 +181,7 @@ Short, copy-paste walkthroughs. Pick whichever sounds fun — they are independe
 | Train a Reachy 2 humanoid policy                 | [Reachy 2 + LeRobot](docs/workbench/guides/reachy2-lerobot-policy.md)                     | GPU cluster                |
 | Make a Unitree G1 walk                           | [G1 + SONIC](docs/workbench/guides/g1-humanoid-walk-sonic.md)                             | GPU cluster                |
 | Train a quadruped to run                         | [Quadruped + Isaac Lab](docs/workbench/guides/quadruped-isaac-lab.md)                     | RT-core GPU                |
-| Run the flagship GPU workload                    | [NVIDIA Cosmos](docs/quickstart.md#7-flagship-gpu-workload-nvidia-cosmos)                 | GPU cluster                |
+| Run the flagship GPU workload                    | [NVIDIA Cosmos](docs/quickstart.md#standalone-cosmos-3-generation)                 | GPU cluster                |
 | Augment robot video with PAIDF + Cosmos 3        | [PAIDF with Cosmos 3](docs/workbench/guides/paidf-cosmos3.md)                             | GPU cluster + S3           |
 | Run a real data pipeline, not a robot            | [Physical AI Data Factory](docs/workbench/guides/physical-ai-data-factory-deploy.md)      | GPU cluster + S3           |
 | Rebuild a real scene in 3D                       | [Neural reconstruction](docs/workbench/guides/neural-reconstruction.md)                   | RT-core GPU                |
@@ -276,7 +207,8 @@ A few highlights:
 - **`foxglove`** — packs run frames, metrics, and logs into MCAP for the
   embedded viewer ([CLI](docs/cli/foxglove.md) ·
   [export contract](docs/workbench/foxglove-export.md)).
-- **`golden-eval`** — runs per-container hello-world reruns as a CI gate.
+- **`golden-eval`** — defines and runs per-container checks; CI validates their
+  manifest, while execution results depend on the selected test and runtime.
 - **`trigger`** — watches S3-compatible prefixes and retriggers workflows.
 - **`sonic export`** — converts locomotion checkpoints to ONNX.
 
@@ -308,18 +240,12 @@ Author pipelines as declarative `npa.workflow/v0.0.1` specs — a state graph of
 Workbench `toolRef` steps with S3 handoffs, gates, and loops. The same YAML is
 what you validate, plan, and submit.
 
+These commands inspect an example locally. Its bucket and rollout paths are
+placeholders; the commands do not stage input or launch a workload.
+
 ```bash
-# Validate and plan (no submit)
 npa workbench workflow validate-spec workflows/testing/vlm-eval-single.yaml
-npa workbench workflow plan-spec     workflows/testing/vlm-eval-single.yaml --run-id demo
-
-# Launch on Nebius (after npa configure)
-npa workbench workflow submit workflows/testing/vlm-eval-single.yaml \
-  --run-id demo --registry registry.example/customer
-
-# Inspect the plan without launching
-npa workbench workflow submit workflows/testing/token-factory-caption.yaml \
-  --plan-only --run-id demo
+npa workbench workflow plan-spec workflows/testing/vlm-eval-single.yaml --run-id demo
 ```
 
 |                         |                                                                                    |
@@ -331,11 +257,17 @@ npa workbench workflow submit workflows/testing/token-factory-caption.yaml \
 | **Authoring guide**     | [npa-workflow-guide.md](docs/workbench/npa-workflow-guide.md)                        |
 | **What submit does**    | [Run lifecycle](docs/run-lifecycle.md) — gates, run identity, restart safety, status |
 
-Prefer these specs for new pipelines. Parallel fan-out and a few specialized
-paths remain outside `v0.0.1` scope — see the catalog README for exceptions. The
-**Sim2Real 14-stage engine** is a separate path
-([skill](skills/workbench/sim2real-engine/SKILL.md)) using `sim2real/runbook.yaml`
-plus Python stage glue.
+For execution, follow a complete workload guide with your actual bucket,
+prepared input, credentials, and resources. Use `submit --runtime` for parallel
+groups and decisions evaluated during the run. The canonical
+[14-stage Sim2Real workflow](docs/workbench/guides/sim2real-workflow.md) uses
+this standard runtime at [`workflows/main/sim2real.yaml`](workflows/main/sim2real.yaml).
+The older `sim2real/runbook.yaml` is a legacy path. See the
+[workflow guide](docs/workbench/npa-workflow-guide.md) for supported graph
+structures and limitations.
+
+Image preflight can create and delete a temporary probe pod when an image
+lacks bootstrap evidence; see the [run lifecycle](docs/run-lifecycle.md).
 
 ---
 
@@ -387,23 +319,30 @@ npa/docker/workbench/lerobot/build.sh --registry "$NPA_REGISTRY" --push
 | [SONIC image catalog](docs/workbench/sonic-image-catalog.md) | Manifest-driven SONIC variant routing per GPU |
 | [Image reproducibility](docs/security/image-reproducibility.md) | The two-tag strategy (`cuda12`, `cuda13-b300`) and how tags are pinned |
 
-Each image declares a `redistribution` class that decides whether it may leave
-the owning org. Public images may be mirrored to GHCR; restricted images stay
-build-your-own (`cosmos3-serving` is restricted because its pinned base embeds a
-runtime under NVIDIA's Deep Learning Container License). Set the class when you
-add an image — the packaging-contract test fails a build that bakes a
-non-redistributable runtime while claiming `public`.
+Each image declares a `redistribution` class in the packaging contract. Public
+images may be mirrored to GHCR; restricted images remain private. Some public
+images download vendor runtimes or model weights when the workload starts;
+their access requirements and terms still apply.
+
+`cosmos3-serving` uses a public Python base and fetches its runtime at startup.
+Content Agents also fetches OVRTX at runtime. The `cosmos3-super-benchmark`
+image remains restricted. The [packaging contract](docs/workbench/container-packaging.md)
+describes the redistribution classes and image contents.
 
 ---
 
 ## Validated on Nebius
 
-Eight Workbench tools are validated end to end on Nebius today: LanceDB,
-FiftyOne, LeRobot, Genesis, Isaac Lab, Cosmos, GR00T, and SONIC.
+Validation is recorded by workload, image, and GPU. The
+[compatibility matrix](docs/workbench/image-gpu-compatibility-matrix.md)
+distinguishes recorded hardware tests from expected compatibility. A manifest
+check establishes test coverage definitions; a successful capability test
+establishes only what that test exercised. Neither establishes full training
+or workflow success for every configuration.
 
 | Reference | What it tells you |
 | --- | --- |
-| [B300 validation matrix](docs/b300-validation-matrix.md) | Which tools pass on B300 vs which are vendor-paced or upstream-blocked |
+| [Historical B300 validation](docs/b300-validation-matrix.md) | May results, with links to later image evidence |
 | [LeRobot GPU benchmarks](docs/workbench/cookbooks/lerobot-gpu-benchmarks.md) | Steps/s across H200 · B300 · L40S · RTX PRO 6000 by policy type |
 | [NVIDIA architecture coverage](docs/nvidia-platform-architecture-coverage.md) | CUDA 12.8 x86_64 vs CUDA 13 aarch64 tool coverage |
 | [Partner roadmap](docs/architecture/partner-skills-roadmap.md) | NVIDIA Omniverse / CAD-to-SimReady capabilities on the way — not yet shipped |
@@ -442,7 +381,8 @@ solutions are additive and never rename or nest it. See
 
 | Topic | Where to look |
 | --- | --- |
-| Install & auth | [quickstart.md](docs/quickstart.md) · [install.md](docs/install.md) |
+| Install & auth | [quickstart.md](docs/quickstart.md) · [install.md](docs/install.md) · [configuration.md](docs/configuration.md) |
+| Coding-agent first run | [Setup and workload prompts](docs/workbench/agent-first-run.md) |
 | Workbench setup | [getting-started.md](docs/workbench/getting-started.md) |
 | Beginner robot guides | [guides/README.md](docs/workbench/guides/README.md) |
 | Physical AI Data Factory | [deploy runbook](docs/workbench/guides/physical-ai-data-factory-deploy.md) · [concepts](docs/workbench/guides/physical-ai-data-factory.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@
 primary solution: tools and declarative workflows for data curation, simulation,
 synthetic data, policy training, and evaluation on Nebius.
 
+[Configuration](configuration.md) covers credentials, project storage, and SSO.
+Use the [coding-agent first run](workbench/agent-first-run.md) for guided setup
+and PAIDF + Cosmos 3 execution.
+
 ## Start with your task
 
 | I want to… | Start here | Continue with |

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -8,8 +8,10 @@ OpenAI-compatible provider, Sim Assets and Cameras panels, an
 embedded [Rerun](https://www.rerun.io) viewer for `.rrd` recordings, and
 draft/validate/plan/submit endpoints for `npa.workflow/v0.0.1` specs.
 
-It is **optional**. Workflows submit and run without it; the agent is where you
-go to look at what they produced.
+This deployment is optional. An existing coding agent can configure, submit,
+and inspect workflows through the terminal using the
+[first-run guide](workbench/agent-first-run.md). Deploy the browser workbench
+when you need its chat, workflow endpoints, or embedded viewers.
 
 These public defaults replace the models retired in the
 [August 2026 Token Factory notice](https://docs.tokenfactory.nebius.com/august-2026-deprecation-notice).

--- a/docs/b300-validation-matrix.md
+++ b/docs/b300-validation-matrix.md
@@ -1,4 +1,12 @@
-# B300 Validation Matrix
+# Historical B300 validation matrix
+
+> **Historical record from May 2026.** The findings below describe the images
+> and workloads tested then. Use the current
+> [image and GPU compatibility matrix](workbench/image-gpu-compatibility-matrix.md)
+> for hardware selection. Its August 3 Genesis record reports B300 kernel and
+> physics tests passing; that supersedes the upstream-blocked status below for
+> the tested image and scope. It does not establish every training or rendering
+> workload on B300.
 
 B300 is validated for the `cuda13-b300` base image and the LeRobot ACT smoke-training workload listed below. SONIC is not yet validated on B300 because its current Isaac Sim / Isaac Lab dependency path does not preserve the CUDA 13 / PyTorch 2.9 x86_64 base contract. Cosmos, GR00T, and Isaac Lab remain vendor-paced, while Genesis remains upstream-blocked on Taichi Blackwell support.
 
@@ -97,7 +105,7 @@ docker run --gpus all --rm \
 
 - CUDA 13 Blackwell support: <https://developer.nvidia.com/blog/whats-new-and-important-in-cuda-toolkit-13-0/>
 - TensorRT-LLM release notes: <https://nvidia.github.io/TensorRT-LLM/release-notes.html>
-- Cosmos prerequisites: <https://docs.nvidia.com/cosmos/latest/latest/prerequisites.html>
+- Cosmos prerequisites: <https://docs.nvidia.com/cosmos/latest/prerequisites.html>
 - Cosmos Reason2: <https://github.com/nvidia-cosmos/cosmos-reason2>
 - Cosmos Predict2.5: <https://github.com/nvidia-cosmos/cosmos-predict2.5>
 - Cosmos Transfer2.5: <https://github.com/nvidia-cosmos/cosmos-transfer2.5>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,433 @@
+# Configure credentials and project storage
+
+Start with [installation and first-run setup](quickstart.md). This reference
+covers authentication, project storage, credential names, and model access.
+
+For credential setup, `npa` has one user-authored file:
+
+```text
+~/.npa/credentials.yaml
+```
+
+Do not choose between multiple NPA credential files. Put user-level secrets in
+`~/.npa/credentials.yaml` only. Deploy commands may create or update
+`~/.npa/config.yaml` for machine-managed project, workbench, endpoint, SSH,
+storage, and Terraform state metadata; do not manually populate
+`~/.npa/config.yaml` as part of credential setup.
+
+Environment variables can override file values for a single shell. They are
+useful for temporary tests, but the canonical repeatable setup is
+`~/.npa/credentials.yaml`. `NPA_CREDENTIALS_PATH` is not supported.
+`NPA_CONFIG_DIR` overrides the shared NPA configuration directory, including
+the location of `credentials.yaml`.
+
+Remote Workbench commands resolve configuration from explicit CLI flags,
+environment variables, the credential store, then machine-managed project and
+Workbench configuration. See each command's help for its supported overrides.
+
+Create and secure the credentials file:
+
+```bash
+mkdir -p ~/.npa
+chmod 700 ~/.npa
+touch ~/.npa/credentials.yaml
+chmod 600 ~/.npa/credentials.yaml
+```
+
+<a id="4a-nebius-account-authentication"></a>
+
+## Nebius account authentication
+
+Nebius account authentication is handled by the `nebius` CLI profile, not by a
+long-lived `NEBIUS_TOKEN` in `~/.npa/credentials.yaml`.
+
+Before running `npa configure`, sign up for Nebius AI Cloud, note your tenant ID
+and exact `project-...` ID, and create a project in the target region. Supplying
+the project ID when NPA creates the CLI profile avoids tenant-wide project
+discovery, so profiles authorized through a project-scoped IAM group work
+without broader tenant permissions. An Object Storage bucket is
+optional. Interactive `npa configure` offers storage provisioning by default.
+On a fresh setup, pressing Enter at the bucket prompt generates a collision-safe
+name containing a UTC timestamp, a short project-identity hash, and a random
+suffix. Enter an exact existing bucket name only when you explicitly intend to
+reuse it. New buckets default to **standard** storage and can use `enhanced`
+storage or a custom size. To reuse your own bucket, create one first; see
+[Creating a tenant](https://docs.nebius.com/iam/create-tenants),
+[Manage projects](https://docs.nebius.com/iam/manage-projects), and
+[Manage buckets](https://docs.nebius.com/object-storage/buckets/manage).
+
+### Creating a project from the CLI (tenant administrator)
+
+Creating a project is a privileged action outside NPA. A tenant administrator
+(or another principal permitted to create projects under the tenant) can use the
+pinned CLI's official `iam v2 project` surface instead of the web console. The
+list and get commands are read-only and safe verification steps; the console
+path linked above remains equivalent.
+
+```bash
+TENANT_ID="tenant-id"
+PROJECT_NAME="project-name"
+REGION=eu-north1
+command -v jq >/dev/null
+
+# Optional read-only parent verification before creating anything.
+nebius iam v2 project list --parent-id "$TENANT_ID" --all --format json
+
+# Creates the external project and captures its immutable ID from structured
+# output (no parsing of a human table). Review tenant/name/region first.
+PROJECT_JSON="$(nebius iam v2 project create --parent-id "$TENANT_ID" \
+  --name "$PROJECT_NAME" --region "$REGION" --format json)"
+PROJECT_ID="$(printf '%s' "$PROJECT_JSON" | jq -er '.metadata.id')"
+export PROJECT_ID
+test -n "$PROJECT_ID"
+
+# Read-only identity verification.
+nebius iam v2 project get --id "$PROJECT_ID" --format json
+
+# Bind the active CLI profile, then continue with NPA under a local alias.
+nebius config set tenant-id "$TENANT_ID"
+nebius config set parent-id "$PROJECT_ID"
+PROJECT_ALIAS="local-npa-alias"
+npa configure --no-interactive --no-provision --tenant-id "$TENANT_ID" \
+  --project-id "$PROJECT_ID" --region "$REGION" \
+  --project-alias "$PROJECT_ALIAS"
+```
+
+### Federation or SSO profiles with many tenants
+
+For an SSO or federation profile without `tenant-id` / `parent-id`, bind the
+profile to the project you want **before**
+`npa configure`, so discovery targets the right place instead of listing every
+tenant:
+
+```bash
+nebius config set tenant-id <id>
+nebius config set parent-id <project-id>
+```
+
+Say **yes** to the object-storage prompt: the agent VM and the Physical AI Data
+Factory both need an S3 bucket and access key.
+
+### Non-interactive setup
+
+If you already know the IDs, skip browser flow and tenant discovery with
+`npa configure --no-interactive` (shown above). This saves local project state
+without contacting the provider. A valid non-interactive Nebius profile or
+service-account credential is required only when you add explicit
+`--provision`.
+
+**No secret-value flags are accepted or shown by `npa configure --help`.**
+Automation supplies values through protected environment variables and adds the
+boolean `--save-env-credentials`; NPA atomically persists only supported
+variables in its owner-only credential store. Prompt-free known-project setup is
+project-only by default: it does not contact Nebius, Hugging Face, or NGC,
+inspect saved storage, or adopt an old bucket. Add `--provision` when storage
+mutation is intended. Credential import remains composable with the
+machine-readable view: `npa configure --show --env --save-env-credentials`
+sends only non-secret shell assignments to stdout and sends import/access
+diagnostics to stderr. The provisioning path reuses already-selected S3
+credentials only when exact project provenance and a write/read probe
+both verify them; otherwise it generates a fresh collision-safe name without
+listing or rotating unrelated access keys.
+
+Run interactive setup in a terminal. `npa configure` creates or reuses your
+Nebius CLI profile first. When creating one, it asks for the project ID before
+browser authentication. It then prompts for your tenant ID, confirms the project
+ID and region, and guides you to reuse an explicitly named exact bucket or create
+a freshly named bucket (standard storage, configurable size limit in GB). It also
+asks for a local **project alias** (default = region; used later as
+`-p <alias>`).
+
+`npa configure` is idempotent: re-run it any time to update keys or properties.
+On a re-run every prompt is pre-filled with the value already saved in
+`~/.npa/config.yaml` / `~/.npa/credentials.yaml`, so pressing Enter through the
+flow keeps your current setup unchanged, and typing a new value updates just
+that field. When object storage is already configured it defaults to keeping the
+existing bucket and S3 key (so a re-run does not mint a new access key); decline
+that prompt to re-provision. It then writes `~/.npa/credentials.yaml` and
+`~/.npa/config.yaml`. Provisioning setup performs bounded live checks through
+the same Hugging Face model/dataset and NGC repository-entitlement paths as
+`npa workbench health access`, and prints a one-line `[NOTE]` summary. The note
+is advisory so a transient upstream outage does not undo otherwise valid local
+setup. Use the health command to enforce access requirements; see
+[§4e](#4e-prepare-and-verify-gated-model-access):
+
+```bash
+npa configure
+```
+
+Workbench images resolve from the anonymous
+`ghcr.io/nebius/nebius-physical-ai` mirror by default, so configure does not ask
+for or save a container registry. Existing `container_registry` entries and
+`NPA_REGISTRY` remain available to build/BYOF compatibility paths but do not
+repoint repository-owned runtime defaults. Pass a complete image or a workflow's
+explicit `--registry` when intentionally running private or modified bytes.
+
+Storage is committed after its declared write/read capability probe succeeds.
+Delete is best-effort probe cleanup and is reported independently. The declared
+runtime actions are `GetObject`, `HeadObject`, `PutObject`, `DeleteObject`, and
+`ListObjectsV2`; NPA binds `storage.object-editor` to a project-scoped NPA group
+at the exact bucket. Initial auto-provisioning therefore requires the active
+profile to have `admin` permission on the target project so it can manage that
+project's IAM group, membership, and access permit. Tenant-wide project listing
+and tenant-wide `admin` permission are not required. A provider-verified existing
+`editors` membership is
+accepted for older installations. Creating `editors` is an explicit compatibility
+fallback only when Nebius reports the narrow role unsupported. Unknown,
+unreadable, or insufficient IAM stops before key creation and probing.
+Set `NPA_ALLOW_EDITORS_STORAGE_FALLBACK=1` only for that explicit fallback;
+otherwise a provider rejection remains terminal. The custom group name is
+derived from the exact project ID rather than its mutable alias. Newly
+created or changed bindings receive bounded, typed propagation retries against
+the same identity, including when an existing active key is reused. If a
+provider step or the probe fails, configure prints **Setup incomplete**, keeps
+owner-only creation provenance in `~/.npa/credentials.yaml`, and prints the
+restart-safe recovery command:
+
+```bash
+npa provision-if-absent --project <PROJECT_ALIAS> --skip-k8s
+```
+
+That recovery reconciles storage before any cluster work. It rolls back only
+resources conclusively created by the failing invocation; reused, shared, or
+ownership-unproven resources are preserved.
+
+Credentials are stored under
+`project_credentials.projects.<exact-project-id>` with the alias retained only
+as metadata. Atomic locked 0600 writes keep two projects on one host isolated.
+The legacy top-level `storage`, `storage_iam`, and `nebius` keys are derived
+compatibility views for the selected exact project. NPA migrates an older global
+record only when its project ownership is exact and unique; otherwise it leaves
+the record recoverable and fails closed.
+
+You do not need to run `nebius profile create` manually; the Nebius CLI binary
+must still be installed because `npa` invokes it internally.
+
+With the target IDs known, skip browser login, discovery, and tenant selection
+entirely:
+
+```bash
+npa configure --no-interactive --no-provision \
+  --tenant-id "$YOUR_TENANT_ID" --project-id "$YOUR_PROJECT_ID" \
+  --region "$NEBIUS_REGION" --project-alias "$PROJECT_ALIAS"
+```
+
+This is provider-free project configuration. Add `--provision` to the same
+command only when it should also create or reuse verified writable storage.
+
+For a newly created bucket, automation may also select its create-only storage
+class and size cap without putting credentials on the command line:
+
+```bash
+npa configure --no-interactive \
+  --tenant-id "$YOUR_TENANT_ID" --project-id "$YOUR_PROJECT_ID" \
+  --region "$NEBIUS_REGION" --project-alias "$PROJECT_ALIAS" \
+  --provision \
+  --bucket-storage-class enhanced --bucket-size-gb 100
+```
+
+The generated name includes a UTC timestamp and random suffix. In the unlikely
+event of an exact collision, NPA reports it and stops without adopting or
+changing the old bucket; re-run configure to generate another fresh name.
+Create-only class and cap options never alter an existing bucket.
+
+These are non-secret identifiers; do not pass IAM, S3, Token Factory, HF, or NGC
+secrets on the command line. The command reuses existing storage only after the
+same write/read capability probe deployment uses. Without `--provision`, the
+prompt-free command saves only project configuration and supported environment
+credentials; `--no-provision` makes that provider-free intent explicit and
+reports that HF/NGC access probes were skipped.
+
+Gate: after interactive setup, `nebius iam get-access-token` exits successfully.
+
+`npa agent preflight`, `agent setup`, and `agent fresh-setup` share this exact
+storage decision. Once configure has health-verified the bucket/key, agent setup
+reuses it and provisions only the separately named VM service account; it does
+not list, create, or rotate object-storage access keys. If revalidation is ever
+needed, provider output stays field-allowlisted and secret-redacted.
+
+Keep these non-secret values handy for later workbench deploys:
+
+- `<YOUR_PROJECT_ID>`: copy it from the Nebius console project selector or list
+  projects with the Nebius CLI.
+- `<YOUR_TENANT_ID>`: copy it from the Nebius console tenant selector. The
+  Nebius docs also show CLI options:
+  <https://docs.nebius.com/iam/get-tenants>.
+- `<NEBIUS_REGION>`: the region where the project exists, for example
+  `eu-north1`.
+- `<PROJECT_ALIAS>`: the local profile key `npa configure` prompts for (default
+  = region, for example `eu-north1`). It becomes `default_project` in
+  `~/.npa/config.yaml`. Pass it as `-p <PROJECT_ALIAS>` to workbench commands
+  (or omit `-p` to use the default).
+
+<a id="4b-required-credential-key-names"></a>
+
+## Required credential key names
+
+Use these canonical keys in `~/.npa/credentials.yaml`.
+
+| Need | `credentials.yaml` key | Environment override | Required when |
+|---|---|---|---|
+| Hugging Face token | `tokens.HF_TOKEN` | `HF_TOKEN` | Downloading gated Hugging Face models, datasets, or weights |
+| Nebius Token Factory key | `tokens.NEBIUS_TOKEN_FACTORY_KEY` | `NEBIUS_TOKEN_FACTORY_KEY` | Hosted text generation, captioning, and scene reasoning through Token Factory |
+| NGC API key | `ngc.api_key` | `NGC_API_KEY` | Pulling an entitlement-controlled NGC image or model, including NuRec NRE |
+| NGC organization | `ngc.org` | `NGC_ORG` | Your NGC key is organization-scoped |
+| NGC team | `ngc.team` | `NGC_TEAM` | Your NGC key is team-scoped |
+| BYOVM SSH host | `ssh.host` | `NPA_BYOVM_HOST`, `NPA_SSH_HOST` | BYOVM commands need a default host |
+| BYOVM SSH user | `ssh.user` | `NPA_BYOVM_SSH_USER`, `NPA_SSH_USER` | BYOVM commands need a default SSH user |
+| BYOVM SSH private key | `ssh.key_path` | `NPA_BYOVM_SSH_KEY`, `NPA_SSH_KEY` | BYOVM commands need a default private key |
+| Object-storage access key | `storage.aws_access_key_id` | `AWS_ACCESS_KEY_ID` | BYOVM, existing storage, or cross-project S3 workflows need explicit storage credentials |
+| Object-storage secret key | `storage.aws_secret_access_key` | `AWS_SECRET_ACCESS_KEY` | BYOVM, existing storage, or cross-project S3 workflows need explicit storage credentials |
+| Object-storage endpoint | `storage.endpoint_url` | `AWS_ENDPOINT_URL`, `NEBIUS_S3_ENDPOINT`, `NPA_STORAGE_ENDPOINT` | S3-compatible storage is not supplied by managed project config |
+| Object-storage bucket | `storage.bucket` | `NPA_CHECKPOINT_BUCKET`, `NEBIUS_S3_BUCKET` | Default checkpoint/artifact location, supplied as `s3://<bucket>/<prefix>/` |
+
+**How to create each token** (step-by-step, including where to click):
+
+- Hugging Face: [docs/workbench/huggingface-token.md](workbench/huggingface-token.md)
+- NVIDIA NGC: [docs/workbench/ngc-api-key.md](workbench/ngc-api-key.md)
+- Nebius Token Factory: [docs/workbench/token-factory-key.md](workbench/token-factory-key.md)
+
+`npa configure` links these inline at each prompt, normalizes pasted values
+(stripping stray quotes or a `Bearer` prefix), and warns if a Token Factory key
+does not look like a `v1.` key.
+
+When `tokens.HF_TOKEN` is loaded, `npa` forwards it to remote services as both
+`HF_TOKEN` and `HUGGING_FACE_HUB_TOKEN`.
+
+`NPA_STORAGE_ENDPOINT` is accepted as a convenience alias. For eu-north1
+workbench clusters, use:
+
+```bash
+export NPA_STORAGE_ENDPOINT=storage.eu-north1.nebius.cloud
+```
+
+<a id="4c-populate-npacredentialsyaml"></a>
+
+## Populate `~/.npa/credentials.yaml`
+
+Use this example and omit keys you do not need yet:
+
+```yaml
+tokens:
+  HF_TOKEN: <YOUR_HUGGING_FACE_TOKEN>
+  NEBIUS_TOKEN_FACTORY_KEY: <YOUR_TOKEN_FACTORY_KEY>
+
+ngc:
+  api_key: <YOUR_NGC_API_KEY>
+  # org: <YOUR_NGC_ORG>
+  # team: <YOUR_NGC_TEAM>
+
+# Optional defaults for BYOVM commands only.
+ssh:
+  host: <BYOVM_HOST_OR_IP>
+  user: ubuntu
+  key_path: ~/.ssh/id_ed25519
+
+# Optional shared object-storage credentials for BYOVM or existing storage.
+storage:
+  aws_access_key_id: <YOUR_S3_ACCESS_KEY_ID>
+  aws_secret_access_key: <YOUR_S3_SECRET_ACCESS_KEY>
+  endpoint_url: https://storage.<NEBIUS_REGION>.nebius.cloud
+  bucket: s3://<YOUR_BUCKET>/<PREFIX>/
+```
+
+Omit keys you do not have yet. Do not leave placeholder token values in a file
+you plan to use for model downloads.
+
+Secure the file after editing:
+
+```bash
+chmod 600 ~/.npa/credentials.yaml
+```
+
+<a id="4d-cross-project-storage-workflows"></a>
+
+## Cross-project storage workflows
+
+If you submit `npa` workloads from an orchestrator that reads resources from one
+project and writes outputs to another, pass explicit project aliases for each
+side of the S3 boundary:
+
+```python
+from npa import demo
+
+demo.stage(
+    source_project="project-a-where-source-artifacts-live",
+    target_project="project-b-customer-bucket",
+    target_bucket="s3://customer-bucket/demo-artifacts/",
+)
+```
+
+Each project resolves credentials independently. If a scoped principal is
+missing access on either side, `ScopedCredentialError` names the specific
+project, operation, and bucket that failed.
+
+For development workflows where host credentials are acceptable:
+
+```bash
+npa demo stage --source-project project-a --target-project project-b \
+  --target-bucket s3://customer-bucket/demo-artifacts/ --allow-host-creds
+```
+
+<a id="4e-prepare-and-verify-gated-model-access"></a>
+
+## Prepare and verify gated model access
+
+Some capability selections pull **gated** Hugging Face models or entitlement-controlled
+NGC artifacts. Complete access upstream on the owning account. NPA does not invent a
+second acceptance flag: the account token plus a successful exact-revision payload-byte
+authorization probe is the automated access preflight. Repository metadata is public
+for many gated assets and is never entitlement proof; the upstream licence still
+governs use.
+
+Workbench remains usable without either provider. To explicitly audit the full
+current catalog, including newly added gated artifacts, run:
+
+```bash
+npa configure --prepare-catalog-access
+```
+
+The interactive audit groups missing resources by provider and asks before
+opening official pages. NPA never clicks an acceptance control or submits legal
+assent. After completing user-bound steps, run the printed resume command to
+re-check exact upstream access. `Ready` means only that the provider authorized a
+representative payload fetch at the pinned revision; it never means NPA accepted terms
+or established legal assent. A previous Ready result is reused only while the
+credential, artifact revision, payload probe, and terms evidence are unchanged.
+
+For a selected capability, verify the exact assets it will use:
+
+```bash
+npa workbench health access --prepare
+# or export keys and persist them without putting secret values in argv:
+export HF_TOKEN='<your-token>' NGC_API_KEY='<your-key>'
+npa workbench health access --save-env-credentials
+# Check access for one capability online:
+npa workbench health access --capability groot --prepare
+# Check credential presence offline; this does not verify model access:
+npa workbench health access --capability groot --offline
+```
+
+In JSON or another non-interactive context, `--prepare --json` never prompts or
+opens a browser. It returns Ready/Pending/Denied/Unavailable evidence, official
+links, and an exact safe resume command. Workflow execution performs the same
+selected-toolRef closure check before provisioning or submission; unrelated
+capabilities remain available when one dependency is blocked. For the broader
+credential preflight (presence/format plus basic HF, S3, and Token Factory
+connectivity), use `npa workbench health preflight`.
+
+## Tool-specific credentials
+
+These requirements depend on the selected model and runtime:
+
+- Cosmos: requires `HF_TOKEN` during deploy to download gated Hugging Face Cosmos models.
+- GR00T: requires `HF_TOKEN` for gated Hugging Face GR00T models; optional `ngc.api_key` or `NGC_API_KEY` is written to the server env for NGC-backed model paths and readiness displays.
+- LeRobot: may need `HF_TOKEN` for gated Hugging Face datasets or models.
+- FiftyOne: may need `HF_TOKEN` for gated Hugging Face datasets.
+- Isaac Lab and Genesis: no token is required by default.
+
+For compatibility, `NGC_API_KEY`, `NGC_ORG`, and `NGC_TEAM` are also
+accepted inside the legacy `tokens:` map. Keep the credentials file private
+with `chmod 600 ~/.npa/credentials.yaml`; Workbench warns if other users can
+read it. Loaded tokens are forwarded to remote workbench SSH commands as
+environment variables.

--- a/docs/demos/bdd100k-demo-walkthrough.md
+++ b/docs/demos/bdd100k-demo-walkthrough.md
@@ -7,11 +7,10 @@ exact FiftyOne (Voxel51) UI steps and commands for technical viewers.
 - **Companion writeup (the full story):** [bdd100k-lancedb-demo.md](bdd100k-lancedb-demo.md)
 - **Pipeline + how to run/reproduce:** [../workbench/cookbooks/bdd100k-pipeline.md](../workbench/cookbooks/bdd100k-pipeline.md)
 - **Narrated slideshow video (built from live captures):** [assets/bdd100k/bdd100k-demo.mp4](assets/bdd100k/bdd100k-demo.mp4)
-- **Unedited live session recording (real FiftyOne UI):** [assets/bdd100k/bdd100k-live-session.mp4](assets/bdd100k/bdd100k-live-session.mp4)
 - **Architecture diagram:** [assets/bdd100k/architecture.png](assets/bdd100k/architecture.png)
 - **Reproduced from (LanceDB):** [Unifying the AV ML Stack blog](https://www.lancedb.com/blog/unifying-the-av-ml-stack-lancedb) · [lancedb/training object-detection](https://github.com/lancedb/training/tree/main/object-detection)
 
-> The `live-*.png` screenshots and `bdd100k-live-session.mp4` were captured from
+> The `live-*.png` screenshots were captured from
 > the deployed FiftyOne app (`bdd100k-real-data-demo`) running on the
 > `npa-workbench-eu-north1` cluster.
 
@@ -129,10 +128,9 @@ There are three options, in increasing order of "live":
    npa/.venv/bin/python docs/demos/build_bdd100k_demo_video.py
    ```
 
-2. **Unedited live session (committed):**
-   [assets/bdd100k/bdd100k-live-session.mp4](assets/bdd100k/bdd100k-live-session.mp4)
-   — a headless-browser recording of the real FiftyOne app cycling the three
-   saved views. Reproduce against a reachable FiftyOne endpoint with Playwright:
+2. **Record a live session:** no unedited session video is included in this
+   repository. To capture the three saved views, use Playwright against a
+   reachable FiftyOne endpoint you operate:
 
    ```bash
    npa/.venv/bin/pip install playwright

--- a/docs/hackathon-isaac-token-factory.md
+++ b/docs/hackathon-isaac-token-factory.md
@@ -189,6 +189,6 @@ environment origin.
 ## Related docs
 
 - [hackathon-cosmos3-reasoner.md](hackathon-cosmos3-reasoner.md) — Token Factory only (no sim)
-- [composing-cloud-and-token-factory.md](../workbench/composing-cloud-and-token-factory.md) — general compute + TF composition
-- [tokenfactory-compute-combos.md](../workbench/cookbooks/tokenfactory-compute-combos.md) — LeRobot combo workflows
+- [Compose cloud and Token Factory workloads](workbench/composing-cloud-and-token-factory.md).
+- [Combine LeRobot and Token Factory](workbench/cookbooks/tokenfactory-compute-combos.md).
 - Isaac Lab tool skill: `skills/tools/isaac-lab/SKILL.md`

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,8 +35,8 @@ If it is older than 3.10 (or missing):
   [pyenv](https://github.com/pyenv/pyenv).
 - **Debian/Ubuntu:** the interpreter is usually current; also install the venv
   module (shipped separately): `sudo apt-get install -y python3 python3-venv`.
-- **Windows:** install from [python.org](https://www.python.org/downloads/)
-  (check "Add python.exe to PATH"), or from the Microsoft Store.
+- **Windows:** use the Debian/Ubuntu commands inside WSL2 Ubuntu. A native
+  Windows Python installation is not used by this setup.
 
 ## 2. Clone the repository and create a virtual environment
 
@@ -118,27 +118,8 @@ Actual removal requires both explicit flags:
 npa uninstall --remove-environment --yes
 ```
 
-NPA refuses system, conda, pipx, user-wide, externally managed, symlinked,
-arbitrary, dirty-overlapping, active, and identity-mismatched environments. The
-command writes a mode-0600 one-time receipt, prints and flushes the status path,
-then launches a base-Python helper outside the target. The helper waits for the
-parent process to exit and revalidates the exact realpath, device/inode,
-`pyvenv.cfg` digest, repository markers, nonce, and other-process use before
-descriptor-relative removal. Source, `.git`, credentials, user data, and
-unrelated caches are never in the plan.
-
-If deferred deletion fails, the target and failure receipt remain. While the
-environment still exists, inspect or retry with the exact commands printed in
-the receipt:
-
-```bash
-npa uninstall --status <receipt-id>
-npa uninstall --remove-environment --yes --retry <receipt-id>
-```
-
-Successful removal naturally removes that environment's `npa` executable; the
-receipt remains under `~/.npa/uninstall-receipts/` for direct inspection or for
-`npa uninstall --status` after reinstalling NPA.
+For removal safeguards, failure receipts, and retries, see
+[environment removal and recovery](teardown.md#repository-local-environment-removal-and-recovery).
 
 ## 4. Nebius CLI (required)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,7 +28,7 @@ are required.
 - Python 3.10 or newer. The package metadata requires `>=3.10`.
 - Git, `python3 -m venv`, and `pip`.
 - **macOS**, **Linux**, or **Windows via WSL2** (Ubuntu). `npa` cloud workflows
-  (S3 / SkyPilot / Kubernetes) assume a POSIX environment — on Windows run
+  (S3 / SkyPilot / Kubernetes) assume a POSIX environment. On Windows, run
   everything from WSL2 (see [docs/install.md](install.md)).
 - **Required:** a Nebius AI Cloud account with billing enabled. Start with the
   Nebius signup guide: <https://docs.nebius.com/signup-billing/sign-up>.
@@ -82,7 +82,7 @@ without requiring Nebius, Hugging Face, NGC, Kubernetes, or S3 credentials.
 
 - **Windows:** use **WSL2 Ubuntu**. `npa` cloud workflows (S3 / SkyPilot /
   Kubernetes) assume a POSIX environment; run everything from WSL2.
-- **Debian/Ubuntu:** install the venv module first —
+- **Debian/Ubuntu:** install the venv module first:
   `sudo apt-get install -y python3-venv`.
 - **Need Python 3.10+, or a faster installer?** [`uv`](https://docs.astral.sh/uv/)
   can install Python and create the env:
@@ -90,7 +90,7 @@ without requiring Nebius, Hugging Face, NGC, Kubernetes, or S3 credentials.
 - **Out of scope (needs extra steps):** Alpine/musl, brand-new Python before
   wheels exist, and air-gapped machines.
 
-Full per-platform steps — Nebius CLI, WSL2 setup, operator tools:
+For the Nebius CLI, WSL2 setup, and operator tools, see:
 [docs/install.md](install.md).
 </details>
 
@@ -109,409 +109,48 @@ pip install -e "npa[sonic]"     # SONIC ONNX export/runtime (GPU, local)
 pip install -e "npa[dev]"       # tests, lint (pytest, ruff); see Section 6
 ```
 
-The GPU wheels above are only needed to run those engines **locally** — cloud
+The GPU wheels above are only needed to run those engines **locally**; cloud
 jobs execute them inside the Nebius images they launch. To run cloud workloads
-(Sections 5+) the base install is enough; you also need the Nebius CLI —
+(Sections 5+) the base install is enough; you also need the Nebius CLI:
 see [docs/install.md § Nebius CLI](install.md#4-nebius-cli-required).
 
 ## 4. Configure credentials
 
-For credential setup, `npa` has one user-authored file:
-
-```text
-~/.npa/credentials.yaml
-```
-
-Do not choose between multiple NPA credential files. Put user-level secrets in
-`~/.npa/credentials.yaml` only. Deploy commands may create or update
-`~/.npa/config.yaml` for machine-managed project, workbench, endpoint, SSH,
-storage, and Terraform state metadata; do not manually populate
-`~/.npa/config.yaml` as part of credential setup.
-
-Environment variables can override file values for a single shell. They are
-useful for temporary tests, but the canonical repeatable setup is
-`~/.npa/credentials.yaml`. The current source does not read
-`NPA_CREDENTIALS_PATH`; it resolves credentials from
-`Path.home() / ".npa" / "credentials.yaml"`.
-
-Create and secure the credentials file:
-
-```bash
-mkdir -p ~/.npa
-chmod 700 ~/.npa
-touch ~/.npa/credentials.yaml
-chmod 600 ~/.npa/credentials.yaml
-```
-
-### 4a. Nebius account authentication
-
-Nebius account authentication is handled by the `nebius` CLI profile, not by a
-long-lived `NEBIUS_TOKEN` in `~/.npa/credentials.yaml`.
-
-Before running `npa configure`, sign up for Nebius AI Cloud, note your tenant ID
-and exact `project-...` ID, and create a project in the target region. Supplying
-the project ID when NPA creates the CLI profile avoids tenant-wide project
-discovery, so profiles authorized through a project-scoped IAM group work
-without broader tenant permissions. An Object Storage bucket is
-optional. Interactive `npa configure` offers storage provisioning by default.
-On a fresh setup, pressing Enter at the bucket prompt generates a collision-safe
-name containing a UTC timestamp, a short project-identity hash, and a random
-suffix. Enter an exact existing bucket name only when you explicitly intend to
-reuse it. New buckets default to **standard** storage and can use `enhanced`
-storage or a custom size. To reuse your own bucket, create one first; see
-[Creating a tenant](https://docs.nebius.com/iam/create-tenants),
-[Manage projects](https://docs.nebius.com/iam/manage-projects), and
-[Manage buckets](https://docs.nebius.com/object-storage/buckets/manage).
-
-#### Creating a project from the CLI (tenant administrator)
-
-Creating a project is a privileged action outside NPA. A tenant administrator
-(or another principal permitted to create projects under the tenant) can use the
-pinned CLI's official `iam v2 project` surface instead of the web console. The
-list and get commands are read-only and safe verification steps; the console
-path linked above remains equivalent.
-
-```bash
-TENANT_ID="tenant-id"
-PROJECT_NAME="project-name"
-REGION=eu-north1
-command -v jq >/dev/null
-
-# Optional read-only parent verification before creating anything.
-nebius iam v2 project list --parent-id "$TENANT_ID" --all --format json
-
-# Creates the external project and captures its immutable ID from structured
-# output (no parsing of a human table). Review tenant/name/region first.
-PROJECT_JSON="$(nebius iam v2 project create --parent-id "$TENANT_ID" \
-  --name "$PROJECT_NAME" --region "$REGION" --format json)"
-PROJECT_ID="$(printf '%s' "$PROJECT_JSON" | jq -er '.metadata.id')"
-export PROJECT_ID
-test -n "$PROJECT_ID"
-
-# Read-only identity verification.
-nebius iam v2 project get --id "$PROJECT_ID" --format json
-
-# Bind the active CLI profile, then continue with NPA under a local alias.
-nebius config set tenant-id "$TENANT_ID"
-nebius config set parent-id "$PROJECT_ID"
-PROJECT_ALIAS="local-npa-alias"
-npa configure --no-interactive --no-provision --tenant-id "$TENANT_ID" \
-  --project-id "$PROJECT_ID" --region "$REGION" \
-  --project-alias "$PROJECT_ALIAS"
-```
-
-#### Federation or SSO profiles with many tenants
-
-If your Nebius CLI profile has no `tenant-id` / `parent-id` set — common for
-SSO and federation logins — bind it to the project you want **before**
-`npa configure`, so discovery targets the right place instead of listing every
-tenant:
-
-```bash
-nebius config set tenant-id <id>
-nebius config set parent-id <project-id>
-```
-
-Say **yes** to the object-storage prompt: the agent VM and the Physical AI Data
-Factory both need an S3 bucket and access key.
-
-#### Non-interactive setup
-
-If you already know the IDs, skip browser flow and tenant discovery with
-`npa configure --no-interactive` (shown above). This saves local project state
-without contacting the provider. A valid non-interactive Nebius profile or
-service-account credential is required only when you add explicit
-`--provision`.
-
-**No secret-value flags are accepted or shown by `npa configure --help`.**
-Automation supplies values through protected environment variables and adds the
-boolean `--save-env-credentials`; NPA atomically persists only supported
-variables in its owner-only credential store. Prompt-free known-project setup is
-project-only by default: it does not contact Nebius, Hugging Face, or NGC,
-inspect saved storage, or adopt an old bucket. Add `--provision` when storage
-mutation is intended. Credential import remains composable with the
-machine-readable view: `npa configure --show --env --save-env-credentials`
-sends only non-secret shell assignments to stdout and sends import/access
-diagnostics to stderr. The provisioning path reuses already-selected S3
-credentials only when exact project provenance and a write/read/delete probe
-both verify them; otherwise it generates a fresh collision-safe name without
-listing or rotating unrelated access keys.
-
-Run interactive setup in a terminal. `npa configure` creates or reuses your
-Nebius CLI profile first. When creating one, it asks for the project ID before
-browser authentication. It then prompts for your tenant ID, confirms the project
-ID and region, and guides you to reuse an explicitly named exact bucket or create
-a freshly named bucket (standard storage, configurable size limit in GB). It also
-asks for a local **project alias** (default = region; used later as
-`-p <alias>`).
-
-`npa configure` is idempotent: re-run it any time to update keys or properties.
-On a re-run every prompt is pre-filled with the value already saved in
-`~/.npa/config.yaml` / `~/.npa/credentials.yaml`, so pressing Enter through the
-flow keeps your current setup unchanged, and typing a new value updates just
-that field. When object storage is already configured it defaults to keeping the
-existing bucket and S3 key (so a re-run does not mint a new access key); decline
-that prompt to re-provision. It then writes `~/.npa/credentials.yaml` and
-`~/.npa/config.yaml`. Provisioning setup performs bounded live checks through
-the same Hugging Face model/dataset and NGC repository-entitlement paths as
-`npa workbench health access`, and prints a one-line `[NOTE]` summary. The note
-is advisory so a transient upstream outage does not undo otherwise valid local
-setup; use the health command as the access gate — see
-[§4e](#4e-prepare-and-verify-gated-model-access):
+Run `npa configure` to select your tenant, project, and region and save
+credentials. Interactive setup provisions object storage by default. First-time
+storage setup needs admin permission on the target project; tenant-wide admin
+permission and tenant-wide project listing are not required.
 
 ```bash
 npa configure
+npa configure --show
 ```
 
-Workbench images resolve from the anonymous
-`ghcr.io/nebius/nebius-physical-ai` mirror by default, so configure does not ask
-for or save a container registry. Existing `container_registry` entries and
-`NPA_REGISTRY` remain available to build/BYOF compatibility paths but do not
-repoint repository-owned runtime defaults. Pass a complete image or a workflow's
-explicit `--registry` when intentionally running private or modified bytes.
+Keep secret values in the private environment or `~/.npa/credentials.yaml`.
+Let NPA manage `~/.npa/config.yaml`. Use `npa configure --no-provision` for
+provider-free project and token setup with storage deliberately unselected.
 
-Storage is committed after its declared write/read capability probe succeeds.
-Delete is best-effort probe cleanup and is reported independently. The declared
-runtime actions are `GetObject`, `HeadObject`, `PutObject`, `DeleteObject`, and
-`ListObjectsV2`; NPA binds `storage.object-editor` to a project-scoped NPA group
-at the exact bucket. Initial auto-provisioning therefore requires the active
-profile to have `admin` permission on the target project so it can manage that
-project's IAM group, membership, and access permit. Tenant-wide project listing
-and tenant-wide `admin` permission are not required. A provider-verified existing
-`editors` membership is
-accepted for older installations. Creating `editors` is an explicit compatibility
-fallback only when Nebius reports the narrow role unsupported. Unknown,
-unreadable, or insufficient IAM stops before key creation and probing. Newly
-Set `NPA_ALLOW_EDITORS_STORAGE_FALLBACK=1` only for that explicit fallback;
-otherwise a provider rejection remains terminal. The custom group name is
-derived from the exact project ID rather than its mutable alias. Newly
-created or changed bindings receive bounded, typed propagation retries against
-the same identity, including when an existing active key is reused. If a
-provider step or the probe fails, configure prints **Setup incomplete**, keeps
-owner-only creation provenance in `~/.npa/credentials.yaml`, and prints the
-restart-safe recovery command:
+For an existing coding agent, use the [coding-agent guide](workbench/agent-first-run.md).
+Choose your task first, then configure the credentials and resources its tools
+need. The guide includes PAIDF + Cosmos 3 as a worked example.
 
-```bash
-npa provision-if-absent --project <PROJECT_ALIAS> --skip-k8s
-```
+<a id="4a-nebius-account-authentication"></a>
+<a id="creating-a-project-from-the-cli-tenant-administrator"></a>
+<a id="federation-or-sso-profiles-with-many-tenants"></a>
+<a id="non-interactive-setup"></a>
+<a id="4b-required-credential-key-names"></a>
+<a id="4c-populate-npacredentialsyaml"></a>
+<a id="4d-cross-project-storage-workflows"></a>
+<a id="4e-prepare-and-verify-gated-model-access"></a>
 
-That recovery reconciles storage before any cluster work. It rolls back only
-resources conclusively created by the failing invocation; reused, shared, or
-ownership-unproven resources are preserved.
+Detailed setup has moved to [configuration](configuration.md):
 
-Credentials are stored under
-`project_credentials.projects.<exact-project-id>` with the alias retained only
-as metadata. Atomic locked 0600 writes keep two projects on one host isolated.
-The legacy top-level `storage`, `storage_iam`, and `nebius` keys are derived
-compatibility views for the selected exact project. NPA migrates an older global
-record only when its project ownership is exact and unique; otherwise it leaves
-the record recoverable and fails closed.
-
-You do not need to run `nebius profile create` manually; the Nebius CLI binary
-must still be installed because `npa` invokes it internally.
-
-With the target IDs known, skip browser login, discovery, and tenant selection
-entirely:
-
-```bash
-npa configure --no-interactive --no-provision \
-  --tenant-id "$YOUR_TENANT_ID" --project-id "$YOUR_PROJECT_ID" \
-  --region "$NEBIUS_REGION" --project-alias "$PROJECT_ALIAS"
-```
-
-This is provider-free project configuration. Add `--provision` to the same
-command only when it should also create or reuse verified writable storage.
-
-For a newly created bucket, automation may also select its create-only storage
-class and size cap without putting credentials on the command line:
-
-```bash
-npa configure --no-interactive \
-  --tenant-id "$YOUR_TENANT_ID" --project-id "$YOUR_PROJECT_ID" \
-  --region "$NEBIUS_REGION" --project-alias "$PROJECT_ALIAS" \
-  --provision \
-  --bucket-storage-class enhanced --bucket-size-gb 100
-```
-
-The generated name includes a UTC timestamp and random suffix. In the unlikely
-event of an exact collision, NPA reports it and stops without adopting or
-changing the old bucket; re-run configure to generate another fresh name.
-Create-only class and cap options never alter an existing bucket.
-
-These are non-secret identifiers; do not pass IAM, S3, Token Factory, HF, or NGC
-secrets on the command line. The command reuses existing storage only after the
-same write/read capability probe deployment uses. Without `--provision`, the
-prompt-free command saves only project configuration and supported environment
-credentials; `--no-provision` makes that provider-free intent explicit and
-reports that HF/NGC access probes were skipped.
-
-Gate: after interactive setup, `nebius iam get-access-token` exits successfully.
-
-`npa agent preflight`, `agent setup`, and `agent fresh-setup` share this exact
-storage decision. Once configure has health-verified the bucket/key, agent setup
-reuses it and provisions only the separately named VM service account; it does
-not list, create, or rotate object-storage access keys. If revalidation is ever
-needed, provider output stays field-allowlisted and secret-redacted.
-
-Keep these non-secret values handy for later workbench deploys:
-
-- `<YOUR_PROJECT_ID>`: copy it from the Nebius console project selector or list
-  projects with the Nebius CLI.
-- `<YOUR_TENANT_ID>`: copy it from the Nebius console tenant selector. The
-  Nebius docs also show CLI options:
-  <https://docs.nebius.com/iam/get-tenants>.
-- `<NEBIUS_REGION>`: the region where the project exists, for example
-  `eu-north1`.
-- `<PROJECT_ALIAS>`: the local profile key `npa configure` prompts for (default
-  = region, for example `eu-north1`). It becomes `default_project` in
-  `~/.npa/config.yaml`. Pass it as `-p <PROJECT_ALIAS>` to workbench commands
-  (or omit `-p` to use the default).
-
-### 4b. Required credential key names
-
-Use these canonical keys in `~/.npa/credentials.yaml`.
-
-| Need | `credentials.yaml` key | Environment override | Required when |
-|---|---|---|---|
-| Hugging Face token | `tokens.HF_TOKEN` | `HF_TOKEN` | Downloading gated Hugging Face models, datasets, or weights |
-| Nebius Token Factory key | `tokens.NEBIUS_TOKEN_FACTORY_KEY` | `NEBIUS_TOKEN_FACTORY_KEY` | Hosted text generation, captioning, and scene reasoning through Token Factory |
-| NGC API key | `ngc.api_key` | `NGC_API_KEY` | Pulling an entitlement-controlled NGC image or model, including NuRec NRE |
-| NGC organization | `ngc.org` | `NGC_ORG` | Your NGC key is organization-scoped |
-| NGC team | `ngc.team` | `NGC_TEAM` | Your NGC key is team-scoped |
-| BYOVM SSH host | `ssh.host` | `NPA_BYOVM_HOST`, `NPA_SSH_HOST` | BYOVM commands need a default host |
-| BYOVM SSH user | `ssh.user` | `NPA_BYOVM_SSH_USER`, `NPA_SSH_USER` | BYOVM commands need a default SSH user |
-| BYOVM SSH private key | `ssh.key_path` | `NPA_BYOVM_SSH_KEY`, `NPA_SSH_KEY` | BYOVM commands need a default private key |
-| Object-storage access key | `storage.aws_access_key_id` | `AWS_ACCESS_KEY_ID` | BYOVM, existing storage, or cross-project S3 workflows need explicit storage credentials |
-| Object-storage secret key | `storage.aws_secret_access_key` | `AWS_SECRET_ACCESS_KEY` | BYOVM, existing storage, or cross-project S3 workflows need explicit storage credentials |
-| Object-storage endpoint | `storage.endpoint_url` | `AWS_ENDPOINT_URL`, `NEBIUS_S3_ENDPOINT`, `NPA_STORAGE_ENDPOINT` | S3-compatible storage is not supplied by managed project config |
-| Object-storage bucket | `storage.bucket` | `NPA_CHECKPOINT_BUCKET`, `NEBIUS_S3_BUCKET` | Default checkpoint/artifact location, supplied as `s3://<bucket>/<prefix>/` |
-
-**How to create each token** (step-by-step, including where to click):
-
-- Hugging Face — [docs/workbench/huggingface-token.md](workbench/huggingface-token.md)
-- NVIDIA NGC — [docs/workbench/ngc-api-key.md](workbench/ngc-api-key.md)
-- Nebius Token Factory — [docs/workbench/token-factory-key.md](workbench/token-factory-key.md)
-
-`npa configure` links these inline at each prompt, normalizes pasted values
-(stripping stray quotes or a `Bearer` prefix), and warns if a Token Factory key
-does not look like a `v1.` key.
-
-When `tokens.HF_TOKEN` is loaded, `npa` forwards it to remote services as both
-`HF_TOKEN` and `HUGGING_FACE_HUB_TOKEN`.
-
-`NPA_STORAGE_ENDPOINT` is accepted as a convenience alias. For eu-north1
-workbench clusters, use:
-
-```bash
-export NPA_STORAGE_ENDPOINT=storage.eu-north1.nebius.cloud
-```
-
-### 4c. Populate `~/.npa/credentials.yaml`
-
-Use this example and omit keys you do not need yet:
-
-```yaml
-tokens:
-  HF_TOKEN: <YOUR_HUGGING_FACE_TOKEN>
-  NEBIUS_TOKEN_FACTORY_KEY: <YOUR_TOKEN_FACTORY_KEY>
-
-ngc:
-  api_key: <YOUR_NGC_API_KEY>
-  # org: <YOUR_NGC_ORG>
-  # team: <YOUR_NGC_TEAM>
-
-# Optional defaults for BYOVM commands only.
-ssh:
-  host: <BYOVM_HOST_OR_IP>
-  user: ubuntu
-  key_path: ~/.ssh/id_ed25519
-
-# Optional shared object-storage credentials for BYOVM or existing storage.
-storage:
-  aws_access_key_id: <YOUR_S3_ACCESS_KEY_ID>
-  aws_secret_access_key: <YOUR_S3_SECRET_ACCESS_KEY>
-  endpoint_url: https://storage.<NEBIUS_REGION>.nebius.cloud
-  bucket: s3://<YOUR_BUCKET>/<PREFIX>/
-```
-
-Omit keys you do not have yet. Do not leave placeholder token values in a file
-you plan to use for model downloads.
-
-Secure the file after editing:
-
-```bash
-chmod 600 ~/.npa/credentials.yaml
-```
-
-### 4d. Cross-project storage workflows
-
-If you submit `npa` workloads from an orchestrator that reads resources from one
-project and writes outputs to another, pass explicit project aliases for each
-side of the S3 boundary:
-
-```python
-from npa import demo
-
-demo.stage(
-    source_project="project-a-where-source-artifacts-live",
-    target_project="project-b-customer-bucket",
-    target_bucket="s3://customer-bucket/demo-artifacts/",
-)
-```
-
-Each project resolves credentials independently. If a scoped principal is
-missing access on either side, `ScopedCredentialError` names the specific
-project, operation, and bucket that failed.
-
-For development workflows where host credentials are acceptable:
-
-```bash
-npa demo stage --source-project project-a --target-project project-b \
-  --target-bucket s3://customer-bucket/demo-artifacts/ --allow-host-creds
-```
-
-### 4e. Prepare and verify gated model access
-
-Some capability selections pull **gated** Hugging Face models or entitlement-controlled
-NGC artifacts. Complete access upstream on the owning account. NPA does not invent a
-second acceptance flag: the account token plus a successful exact-revision payload-byte
-authorization probe is the automated access preflight. Repository metadata is public
-for many gated assets and is never entitlement proof; the upstream licence still
-governs use.
-
-Workbench remains usable without either provider. To explicitly audit the full
-current catalog, including newly added gated artifacts, run:
-
-```bash
-npa configure --prepare-catalog-access
-```
-
-The interactive audit groups missing resources by provider and asks before
-opening official pages. NPA never clicks an acceptance control or submits legal
-assent. After completing user-bound steps, run the printed resume command to
-re-check exact upstream access. `Ready` means only that the provider authorized a
-representative payload fetch at the pinned revision; it never means NPA accepted terms
-or established legal assent. A previous Ready result is reused only while the
-credential, artifact revision, payload probe, and terms evidence are unchanged.
-
-For a selected capability, verify the exact assets it will use:
-
-```bash
-npa workbench health access --prepare
-# or export keys and persist them without putting secret values in argv:
-export HF_TOKEN='<your-token>' NGC_API_KEY='<your-key>'
-npa workbench health access --save-env-credentials
-# scope to one capability, or run offline (presence-only):
-npa workbench health access --capability groot --prepare
-```
-
-In JSON or another non-interactive context, `--prepare --json` never prompts or
-opens a browser. It returns Ready/Pending/Denied/Unavailable evidence, official
-links, and an exact safe resume command. Workflow execution performs the same
-selected-toolRef closure check before provisioning or submission; unrelated
-capabilities remain available when one dependency is blocked. For the broader
-credential preflight (presence/format plus basic HF, S3, and Token Factory
-connectivity), use `npa workbench health preflight`.
+- [Nebius authentication](configuration.md#4a-nebius-account-authentication),
+  including project creation, SSO profiles, and non-interactive provisioning.
+- [Credential names](configuration.md#4b-required-credential-key-names) and
+  [credential-file layout](configuration.md#4c-populate-npacredentialsyaml).
+- [Cross-project storage](configuration.md#4d-cross-project-storage-workflows).
+- [Gated model access](configuration.md#4e-prepare-and-verify-gated-model-access).
 
 ## 5. First platform checks
 
@@ -542,7 +181,7 @@ require it; resource creation still needs permission on the target project.
 
 ### 5a. Hosted text generation with Nebius Token Factory
 
-For GPU image generation, continue to [Cosmos](#7-flagship-gpu-workload-nvidia-cosmos).
+For standalone GPU image generation, see [Cosmos 3](#standalone-cosmos-3-generation).
 For text generation, image captioning, or scene reasoning, use
 [Token Factory](https://tokenfactory.nebius.com/). Hosted inference needs its own
 `NEBIUS_TOKEN_FACTORY_KEY`; a Nebius IAM token cannot replace it. Local inputs and
@@ -553,7 +192,7 @@ npa workbench token-factory verify
 npa workbench token-factory models
 ```
 
-Generate a completion against a hosted model — write a prompt and run:
+Write a prompt and generate a completion against a hosted model:
 
 ```bash
 printf 'Explain sim-to-real transfer in one sentence.\n' > /tmp/prompts.txt
@@ -573,10 +212,12 @@ Read the JSONL result before using it downstream. `--dry-run` still calls the
 hosted model; it only skips the output write.
 
 More Token Factory capabilities (image captioning, physical-scene reasoning) and
-the checked-in SkyPilot templates:
+the checked-in workflow specifications:
 [docs/workbench/token-factory.md](workbench/token-factory.md).
 
-### 5b. The same capability, three coherent ways
+<a id="5b-the-same-capability-three-coherent-ways"></a>
+
+### 5b. Token Factory from Python or a workflow
 
 Token Factory exposes CLI commands, SDK wrappers, and workflow toolRefs for the
 same operations. Use the CLI or SDK directly for hosted inference; use a
@@ -613,26 +254,46 @@ SkyPilot. This mode needs the configured cluster and S3 runtime described in
 
 ## 6. Developing and testing npa
 
-To work on `npa` itself, install the dev extra into your activated venv and use
-the `make` targets from the repo root:
+Contributors can follow the [package development instructions](../npa/README.md#developing-and-testing-npa).
+For your first workload, continue below.
 
-```bash
-pip install -e "npa[dev]"   # pytest, pytest-mock, pytest-cov, pytest-timeout, ruff
+<a id="7-flagship-gpu-workload-nvidia-cosmos"></a>
 
-make test PYTHON="$(pwd)/.venv/bin/python"        # unit suite
-make test-smoke PYTHON="$(pwd)/.venv/bin/python"  # onboarding CLI checks
-make lint PYTHON="$(pwd)/.venv/bin/python"        # ruff
-```
+## 7. Choose your workload
 
-Use an **absolute** interpreter path: the recipes change into `npa/` before
-running. Without an override, Make prefers the contributor environment
-`npa/.venv/bin/python`, then `python3` on `PATH`. Live and GPU tests are
-deselected from `make test`; `make test-e2e` is the explicit live-infrastructure
-target and needs the relevant credentials and resources.
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full test layout and PR
-conventions (branch → PR → squash, one approval, never self-approve).
+Choose a [workload guide](workbench/guides/README.md) for simulation, training,
+video augmentation, or another supported task. You can also use individual
+tools from the [CLI reference](cli/workbench.md) or compose them with the
+[workflow guide](workbench/npa-workflow-guide.md).
 
-## 7. Flagship GPU workload: NVIDIA Cosmos
+Follow the selected tools' requirements for input formats, model access,
+storage, and compute. A task may use GPU jobs, CPU tools, hosted inference, or
+a combination. The [coding-agent guide](workbench/agent-first-run.md) helps you
+choose and prepare a path for your task.
+
+### Worked example: PAIDF with Cosmos 3
+
+Use [PAIDF + Cosmos 3](workbench/guides/paidf-cosmos3.md) to generate video
+variants conditioned on your source clip, evaluate them, and curate accepted
+outputs. Provide a local H.264 MP4 or a private S3 MP4 URI. You need writable
+project storage, compatible GPU resources, SkyPilot, Hugging Face model access,
+and Token Factory credentials for captioning and evaluation.
+
+Follow the [coding-agent workflow prompt](workbench/agent-first-run.md#run-paidf-with-cosmos-3)
+to validate and plan with the actual bucket and input, review resources,
+prepare input and images, and submit with `--runtime`. The PAIDF guide's
+command examples cover validation and planning only.
+Image preflight may create and delete a temporary probe pod.
+
+Inspect generated media, evaluator reports, quality disposition, and Rerun
+evidence. A quality rejection can be a valid terminal result after bounded
+refinement; labeling and curation are then skipped. The published PAIDF composite
+blends source and generated frames (80% source by default); use the raw Cosmos output to assess
+generation quality. The original
+[Physical AI Data Factory](workbench/guides/physical-ai-data-factory-deploy.md)
+continues to use Cosmos Transfer 2.5.
+
+### Standalone Cosmos 3 generation
 
 Start with [Cosmos 3 generation](workbench/cosmos3-generate.md). Its
 `cosmos3-generate.yaml` workflow runs the containerized model and publishes an
@@ -661,14 +322,13 @@ are distinct from the Cosmos 3 generation workflow.
 
 ## 8. Do more with npa
 
-With install → `npa configure` → your first GPU workload on Nebius AI Cloud
-(Section 7) done, build outward:
+Use the guides below as your task requires:
 
-- **Run workbench workloads** — NVIDIA Cosmos (Section 7), vlm-eval, sim2real,
+- **Run Workbench workloads:** PAIDF + Cosmos 3 (Section 7), VLM evaluation, Sim2Real,
   and more. See [Workbench Getting Started](workbench/getting-started.md) for
   Kubernetes, SkyPilot, registry, and S3 setup, and the
   [robot guides](workbench/guides/README.md).
-- **Deploy the self-hosted agent** — `npa agent` is a browser workbench VM. It
+- **Deploy the self-hosted agent:** `npa agent` is a browser workbench VM. It
   builds on the setup above and additionally needs Terraform, an SSH key pair, a
   Token Factory key, and writable S3. Operator docs:
   [skills/tools/npa-agent/SKILL.md](../skills/tools/npa-agent/SKILL.md).
@@ -764,8 +424,7 @@ serverless `deploy`) create Nebius AI Jobs. If the principal behind your active
 `nebius` profile is a service account that lacks the AI Jobs role, the submit is
 rejected with `PermissionDenied: service iam ... appbox-...` even though
 authentication, capacity lookup, subnet discovery, and S3 all succeed. This is
-an authorization gap, not stale credentials — `nebius iam get-access-token`
-still works. Grant that service account a role that permits creating and
+an authorization gap: `nebius iam get-access-token` still works. Grant that service account a role that permits creating and
 managing AI Jobs on the project, or switch to a profile whose principal has it
 (`nebius profile activate <profile>`), then retry the same command.
 

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -8,15 +8,19 @@ If you just want to launch something, start with
 [Physical AI Data Factory runbook](workbench/guides/physical-ai-data-factory-deploy.md).
 This page is the reference for what those paths are doing underneath.
 
-## Everything is verified before the run starts
+<a id="everything-is-verified-before-the-run-starts"></a>
 
-`submit` repeats its deterministic checks **before** input or source staging, so
-a missing image or an identity mismatch is caught locally rather than after the
-~1,225-file source tree has been uploaded and a cluster is waiting. It prints
-**everything** still missing in one list, each with the command that fixes it, so
-you are not discovering prerequisites one failed run at a time.
+## Checks before submission
 
-The read-only gates are meant to be run in this order:
+`submit` repeats prerequisite checks **before** input or source staging, so
+detected image and identity problems can be resolved before uploading the run's
+inputs and source. It reports
+detected prerequisites together with remediation commands. These checks do not
+prove that the workload will complete or produce usable artifacts.
+
+Run specification validation, planning, and image checks in this order.
+Validation and planning do not launch a workload. Image checks can create and
+delete a temporary Kubernetes probe pod when bootstrap evidence is absent:
 
 ```bash
 npa workbench workflow validate-spec    <spec.yaml>

--- a/docs/security/container-golden-evals.md
+++ b/docs/security/container-golden-evals.md
@@ -1,8 +1,7 @@
 # Container safety review & golden evals
 
-This document is the safety + Physical AI usefulness review for every Workbench
-container image, and the contract for each container's **golden eval** — the
-minimal "does this container actually work" / "hello world" tested rerun.
+This page describes container safety requirements and golden evaluations:
+the repeatable checks defined for each Workbench image.
 
 The machine-readable source of truth is
 [`npa/src/npa/smoke/golden_evals.yaml`](../../npa/src/npa/smoke/golden_evals.yaml).
@@ -15,19 +14,19 @@ and enforced by `npa/docker/workbench/packaging-contract.yaml`.
 
 ## How it is enforced
 
-- **Completeness/consistency gate** —
+- **Manifest checks:**
   `npa/tests/smoke/test_golden_eval_manifest.py` runs in the standard unit suite
   and fails CI if any container in `npa.deploy.images.CONTAINER_IMAGE_NAMES` is
   missing an entry, references a missing Dockerfile, an unimportable smoke
   module, or omits a safety / Physical AI field.
-- **Nightly run** — the workflow at `docs/ci/golden-evals-nightly.yml` runs at
-  04:00 UTC once installed to `.github/workflows/` (it ships under `docs/ci/`
-  because the author credential lacked the GitHub `workflow` scope). The
-  `validate-manifest` and `cpu-evals` jobs run on GitHub-hosted runners; the GPU
-  golden evals run on a self-hosted GPU runner via `workflow_dispatch`
-  (`run_gpu_evals: true`).
-- **Image CVE / config scanning** — handled separately by the weekly
+- **Nightly template:** `docs/ci/golden-evals-nightly.yml` is staged documentation,
+  not an active GitHub Actions workflow. It defines scheduled CPU checks and
+  an optional GPU job. Its presence does not establish nightly GPU validation.
+- **Image CVE / config scanning:** handled separately by the weekly
   `image-security-scan.yml` (Trivy config scan + base-image CVE matrix).
+
+The active [GPU e2e preflight](../../.github/workflows/e2e.yml) collects tests
+and checks shell syntax. It does not execute GPU workloads.
 
 ## CLI
 
@@ -46,8 +45,9 @@ npa workbench golden-eval run genesis --serverless --gpu h100
 `--serverless` submits the golden eval as a **Nebius Serverless AI Job** that
 pulls the tool's real container image (resolved via
 `npa.deploy.images.container_image_for_tool`) and runs the eval command on a
-GPU, then waits for the PASS/FAIL result. This is the path the nightly GPU job
-uses — no self-hosted GPU runner required, only Nebius + storage credentials.
+GPU, then waits for the PASS/FAIL result. This CLI mode requires Nebius and
+storage credentials. It does not require a self-hosted GitHub runner or activate
+the staged nightly workflow.
 
 Each eval's GPU is taken from `golden_eval.serverless_gpu` in the manifest
 (falling back to `l40s`, since Nebius Jobs always require a GPU preset) and can
@@ -58,8 +58,11 @@ The same logic is available as a script for CI:
 
 ## Golden-eval capability chart
 
-Each container's golden eval proves specific **capabilities** (not just `--help` or
-import). Registry tags come from ``pyproject.toml`` → ``[tool.npa.supported-tools]``.
+The manifest defines tests with different scopes: import and CLI checks,
+service checks, and GPU capability tests. A definition is not a recorded pass.
+Use the [image and GPU matrix](../workbench/image-gpu-compatibility-matrix.md)
+for dated hardware results. Registry tags come from
+`pyproject.toml` under `[tool.npa.supported-tools]`.
 
 ```bash
 npa/.venv/bin/python npa/scripts/run_golden_evals.py list --capabilities

--- a/docs/teardown.md
+++ b/docs/teardown.md
@@ -243,3 +243,30 @@ unrelated caches stay outside the plan.
 - [Physical AI Data Factory deploy runbook §8](workbench/guides/physical-ai-data-factory-deploy.md) — teardown in the context of one full run
 - [teardown-and-cost skill](../skills/atomic/teardown-and-cost/SKILL.md) — the operator/agent version of this page
 - [Run lifecycle](run-lifecycle.md) — run identity and status semantics that cancellation depends on
+
+## Repository-local environment removal and recovery
+
+Preview and remove a supported checkout environment with the
+[uninstall commands](install.md#safely-uninstall-the-repository-local-environment).
+
+NPA refuses system, conda, pipx, user-wide, externally managed, symlinked,
+arbitrary, dirty-overlapping, active, and identity-mismatched environments. The
+command writes a mode-0600 one-time receipt, prints and flushes the status path,
+then launches a base-Python helper outside the target. The helper waits for the
+parent process to exit and revalidates the exact realpath, device/inode,
+`pyvenv.cfg` digest, repository markers, nonce, and other-process use before
+descriptor-relative removal. Source, `.git`, credentials, user data, and
+unrelated caches are never in the plan.
+
+If deferred deletion fails, the target and failure receipt remain. While the
+environment still exists, inspect or retry with the exact commands printed in
+the receipt:
+
+```bash
+npa uninstall --status <receipt-id>
+npa uninstall --remove-environment --yes --retry <receipt-id>
+```
+
+Successful removal naturally removes that environment's `npa` executable; the
+receipt remains under `~/.npa/uninstall-receipts/` for direct inspection or for
+`npa uninstall --status` after reinstalling NPA.

--- a/docs/workbench/README.md
+++ b/docs/workbench/README.md
@@ -6,6 +6,10 @@ Workbench is the primary solution in Nebius Physical AI. Use
 through object storage. Python wrappers and service APIs are available according
 to each tool's documented contract.
 
+For guided setup with an existing coding agent, use the
+[first-run prompts](agent-first-run.md). Detailed project and credential setup
+is in [configuration](../configuration.md).
+
 ## From a first run to an inspected result
 
 1. [Install and configure npa](../quickstart.md), including credentials and

--- a/docs/workbench/agent-first-run.md
+++ b/docs/workbench/agent-first-run.md
@@ -1,0 +1,156 @@
+# Use Workbench with a coding agent
+
+Use your existing coding agent with terminal access to this checkout. Install
+`npa` and the Nebius CLI using the [quickstart](../quickstart.md). Describe the
+task you want to complete, then select individual tools or compose a workflow.
+The [self-hosted browser agent](../agent.md)
+is optional and requires a separate deployment.
+
+## Choose tools for your task
+
+Start with the [workload guides](guides/README.md) or the
+[tool reference](../cli/workbench.md). Ask your agent to inspect the current
+`skills/index.yaml`, relevant guides, and command help before choosing a path.
+Existing examples are starting points; available tools and their contracts
+determine what you can run or combine. If the task needs an unsupported
+capability, have the agent explain the gap.
+
+The setup prompt below applies to the task you choose. The PAIDF + Cosmos 3
+prompt later in this guide is a worked video-augmentation example.
+
+## Configure the project and model access
+
+Supply the project values and any credentials needed by your selected tools
+through the agent's **private environment**. Keep token values out of chat.
+Supported names include:
+
+```text
+NEBIUS_TENANT_ID=<your-tenant-id>
+NEBIUS_PROJECT_ID=<your-project-id>
+NEBIUS_REGION=<your-project-region>
+HF_TOKEN=<your-hugging-face-read-token>
+NGC_API_KEY=<your-ngc-api-key>
+NEBIUS_TOKEN_FACTORY_KEY=<your-token-factory-key>
+```
+
+Credential requirements depend on the selected tools. For gated Hugging Face
+assets, the account behind `HF_TOKEN` needs access and a fine-grained token must
+include the required repositories. Accept gated terms yourself on Hugging Face.
+NGC credentials apply to tools that fetch entitlement-controlled NGC artifacts.
+Token Factory credentials apply to hosted inference, including the captioning
+and evaluation stages in the PAIDF example below. See
+[configuration](../configuration.md#required-credential-key-names) for the
+credential names and when each is needed.
+
+First-time storage setup needs **admin permission on the target project**.
+`npa configure` creates a project service account, access key, and project-scoped
+IAM group with a bucket-scoped `storage.object-editor` permit. Tenant-wide admin
+permission and tenant-wide project listing are not required.
+
+Then give your agent this prompt:
+
+```text
+Set up Nebius Physical AI Workbench for the task I described. If I have not
+given you a task, ask what I want to accomplish before choosing tools. Read
+AGENTS.md and skills/index.yaml, then inspect the relevant guides and command
+help. Select tools or a workflow that fit my inputs and intended output. Explain
+their requirements and any unsupported parts of the task.
+
+Use project values and the credentials required by the selected tools from
+the private process environment. Never print secret values, put them in command
+arguments, or write them into the repository.
+Never run `env`, `printenv`, `set`, `export -p`, or another command that dumps
+the process environment; inspect only allowlisted names and report present or
+missing. Do not read credential files except through npa's credential APIs.
+Use NPA_PROJECT_ALIAS if it is set; otherwise use "workbench" as the local alias.
+
+Install or verify npa and the host prerequisites for the selected runtime.
+Managed deployments need Terraform; SkyPilot Kubernetes on Debian/Ubuntu also
+needs socat. Configure the known tenant, project, and region non-interactively
+when the task uses a Nebius project. Persist supported environment credentials
+with npa configure --save-env-credentials. Use --no-provision for provider-free
+setup. If the task needs S3, explain the storage it needs before using explicit
+--provision to create or reuse writable project storage. First confirm that the
+active identity can manage the project-scoped IAM objects that secure it.
+
+Inspect npa configure --show. Run credential preflight checks for the selected
+services, including --checks nebius before cloud provisioning. Use npa workbench
+health access for the selected capabilities and their required model assets.
+
+Do not bypass a failed gate or provision GPU resources yet. If Hugging Face
+access is missing, give me the exact model-page links, wait for me to accept the
+terms, and rerun the check. Finish setup when the selected task's prerequisites
+pass, then guide me into running it.
+```
+
+For project creation, federation or SSO profiles, non-interactive setup, and
+credential recovery, see [configuration](../configuration.md).
+
+## Run the selected task
+
+Follow the relevant tool or workflow guide with your actual inputs. For a
+workflow, validate its specification and inspect the plan before provisioning
+compute, staging data, checking images, and submitting. For an individual tool,
+use its documented command and runtime requirements. Check the resulting
+artifacts against your intended output and follow the applicable recovery and
+cleanup instructions.
+
+<a id="run-paidf-with-cosmos-3"></a>
+
+## Worked example: PAIDF with Cosmos 3
+
+Use the same agent from input selection through output inspection. For the
+Physical AI Data Factory with real source-video-conditioned Cosmos 3, attach a
+local H.264 MP4 or set `PAIDF_INPUT_URI` to one private `s3://` MP4, then paste:
+
+```text
+Run my first Workbench workflow with me: the PAIDF Cosmos 3 video-conditioning
+workflow at workflows/main/paidf-cosmos3.yaml. Follow
+docs/workbench/guides/paidf-cosmos3.md and the repository skills. Use the
+configured Nebius project, region, writable bucket, and credentials. Use the
+attached local H.264 MP4, or PAIDF_INPUT_URI if it is set; if neither is
+available, ask me only for the input video before continuing. Keep all input and
+artifact locations private.
+
+Never run `env`, `printenv`, `set`, `export -p`, or another command that dumps
+the process environment. Inspect only allowlisted variable names and report
+present or missing; do not print secret values or read credential files directly.
+
+Re-run the credential and model-access gates for paidf,cosmos3. Validate and
+plan the spec with the real bucket and input, starting with one variant and one
+supported GPU. Honor configured TF_VAR_* topology and reserved-capacity settings.
+Show me the validated plan and explain the required CPU/GPU resources before
+provisioning. Bootstrap and verify SkyPilot, provision any required resources
+that are absent, and discover the accelerator name the target cluster advertises.
+Use that name in the resource overrides and revalidate the plan. Then stage the
+input and preflight the selected images. If a selected image fails the
+SkyPilot bootstrap contract, build the repository's current compliant image,
+push it to an authorized private project registry at an immutable digest, and
+repeat preflight. Then submit with --runtime.
+Forward only secret names through --secret-env: HF_TOKEN,
+NEBIUS_TOKEN_FACTORY_KEY, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY; never put
+secret values in YAML or command arguments.
+
+Stay with the run until it reaches a terminal state. If it fails, diagnose the
+recorded stage and resume safely rather than starting an unrelated run. If it
+succeeds, show me the generated and curated artifacts and load the final Rerun
+recording when an agent viewer is available. A terminal quality rejection after
+the workflow's bounded refinement loop is a valid fail-closed result: do not
+lower the threshold or force promotion. Show me the generated video, evaluator
+report, quality disposition, and Rerun evidence, and explain that labeling and
+curation were intentionally skipped.
+```
+
+The workflow uses the independent
+[`paidf-cosmos3.yaml`](guides/paidf-cosmos3.md) composition; the
+original Physical AI Data Factory workflow continues to use Cosmos Transfer
+2.5.
+
+The [PAIDF + Cosmos 3 guide](guides/paidf-cosmos3.md) defines the source-video
+conditioning, required images, model access, and output locations. Its PAIDF
+published composite blends source and generated frames (80% source by default); inspect the raw Cosmos
+output separately when evaluating generation quality.
+
+Image preflight can create and delete a temporary probe pod when bootstrap
+evidence is absent. Review the [run lifecycle](../run-lifecycle.md) before
+running it. Once finished, follow [teardown](../teardown.md) for resources you own.

--- a/docs/workbench/agent-workflow-operations.md
+++ b/docs/workbench/agent-workflow-operations.md
@@ -26,10 +26,14 @@ using subprocesses must invoke only the fixed `npa ...` operations below. It
 must not invoke an execution backend, a cluster client, a terminal multiplexer,
 or an arbitrary shell command.
 
-## Read-only preparation
+<a id="read-only-preparation"></a>
+
+## Validate, plan, and check images
 
 Run these checks in order. Keep the same YAML file and config overrides for the
-plan and eventual submission.
+plan and eventual submission. `preflight-images` may create and delete a
+temporary Kubernetes probe pod when image bootstrap evidence is absent.
+Authorize that probe before running the image check.
 
 ```console
 npa workbench workflow validate-spec <workflow.yaml> --json

--- a/docs/workbench/cookbooks/README.md
+++ b/docs/workbench/cookbooks/README.md
@@ -16,9 +16,9 @@ workflows with Nebius Physical AI Workbench.
   Kubernetes cluster, GPU node groups, and in-cluster LanceDB/detection-training
   services, then run the BDD100K ingest, UDF backfill, CLIP embedding,
   materialized-view, training, and evaluation pipeline.
-- [Sim-To-Real Pipeline](sim-to-real-pipeline.md): CLI, SDK, raw SkyPilot, BYO
-  policy image, BYO S3 endpoint, eval, feedback, artifact, and teardown details
-  behind the one-command H100 quickstart.
+- [PushT sim-to-real guide](../guides/pusht-sim-to-real.md): train and evaluate
+  a policy for the PushT task. For the canonical 14-stage workflow, see the
+  [Sim2Real guide](../guides/sim2real-workflow.md).
 - [VLM-Eval Loop Runbook](vlm-eval-loop-runbook.md): serve a VLM with vLLM,
   score rollout directories with `vlm-eval`, and write a task-success report.
 - [Token Factory + Nebius compute combos](tokenfactory-compute-combos.md): two

--- a/docs/workbench/guides/README.md
+++ b/docs/workbench/guides/README.md
@@ -93,18 +93,21 @@ managed-K8s + BYOF; for a serverless capacity retry use `--gpu-type gpu-l40s-d`.
 
 SONIC G1 (MuJoCo) is documented from its cookbook and not yet re-run here.
 
-## Bring your own everything
+<a id="bring-your-own-everything"></a>
 
-These guides use public datasets and the shipped robots so you can reproduce
-them, but the workbench is built to be swapped:
+## Use your own data, policy, or robot
 
-- **Bring your own dataset** — point any guide at an S3 `LeRobotDataset` URI.
-- **Bring your own policy image** — swap the container, keep the contract.
-- **Bring your own robot** — Franka, Reachy 2, Unitree G1, quadrupeds, and more
-  are all just configs over the same train / eval / serve / infer commands.
+Check the selected tool's contract before substituting inputs:
 
-When you're ready for the production recipes, head to the
-[cookbooks](../cookbooks/README.md).
+- Datasets must match the required format and observation/action schemas.
+  LeRobotDataset is supported by the LeRobot paths; other guides use video,
+  motion, scene, or tool-specific inputs.
+- A custom policy image must implement the selected tool's input, output,
+  and runtime contract.
+- A different robot may need assets, simulator support, observation and action
+  mappings, and training configuration. Available commands vary by tool.
+
+See the [cookbooks](../cookbooks/README.md) for detailed recipes.
 
 ## Physical AI Data Factory (video data augmentation)
 

--- a/docs/workbench/guides/paidf-cosmos3.md
+++ b/docs/workbench/guides/paidf-cosmos3.md
@@ -85,15 +85,20 @@ supported.
 
 ## Validate, plan, and render
 
+From the repository root, activate the virtual environment created during
+[installation](../../install.md). These examples check the spec and render plans
+with placeholder inputs; they do not launch the workflow. For execution, use the
+[coding-agent workflow prompt](../agent-first-run.md#run-paidf-with-cosmos-3),
+which covers real inputs, resource planning, image checks, submission, and output
+inspection.
+
 ```bash
 SPEC=workflows/main/paidf-cosmos3.yaml
-npa/.venv/bin/npa workbench workflow validate-spec "$SPEC" --json
-npa/.venv/bin/npa workbench workflow plan-spec "$SPEC" --run-id demo \
+npa workbench workflow validate-spec "$SPEC" --json
+npa workbench workflow plan-spec "$SPEC" --run-id demo \
   --assume-decision promote_checkpoint --var bucket=example-bucket --json
-npa/.venv/bin/npa workbench workflow plan-spec "$SPEC" --run-id demo \
+npa workbench workflow plan-spec "$SPEC" --run-id demo \
   --assume-decision loop_back --var bucket=example-bucket --json
-npa/.venv/bin/npa workbench workflow submit "$SPEC" --run-id demo --runtime \
-  --assume-decision promote_checkpoint --var bucket=example-bucket --plan-only
 ```
 
 For execution, pass only secret names to the generic workflow submit surface:

--- a/npa/README.md
+++ b/npa/README.md
@@ -8,7 +8,7 @@ executed through SkyPilot.
 
 Start with the [Workbench guide](../docs/workbench/README.md), choose a workload,
 and follow [installation](../docs/install.md) and
-[project setup](../docs/quickstart.md) before provisioning its GPU resources.
+[project setup](../docs/configuration.md) before provisioning its GPU resources.
 The [command reference](../docs/cli/workbench.md) lists the installed tools;
 `npa workbench <tool> --help` exposes each tool's actual commands.
 
@@ -177,58 +177,13 @@ export NPA_TEST_BYOVM_S3_PREFIX=s3://my-bucket/test-artifacts/
 pytest tests/test_multi_gpu -m multi_gpu
 ```
 
-## Config
+<a id="config"></a>
 
-Remote workbench commands resolve config from:
+## Configuration
 
-1. CLI flags
-2. Environment variables
-3. `~/.npa/credentials.yaml` for user-level secrets
-4. `~/.npa/config.yaml` for projects and workbenches
-
-See [`src/npa/config/sample_config.yaml`](src/npa/config/sample_config.yaml) for the expected layout.
-
-`~/.npa/config.yaml` is machine-managed by deploy commands. Keep user tokens
-out of it and store those credentials in `~/.npa/credentials.yaml`:
-
-```yaml
-tokens:
-  HF_TOKEN: hf_REPLACE_ME
-ngc:
-  api_key: nvapi_REPLACE_ME
-  # org: optional-ngc-org
-  # team: optional-ngc-team
-```
-
-Standard environment variables override values in `credentials.yaml`, so this
-also works for one-off runs:
-
-```bash
-export HF_TOKEN=hf_REPLACE_ME
-export NGC_API_KEY=nvapi_REPLACE_ME
-npa workbench cosmos deploy ...
-```
-
-For compatibility, `NGC_API_KEY`, `NGC_ORG`, and `NGC_TEAM` are also accepted
-inside the legacy `tokens:` map.
-
-Recommended permissions:
-
-```bash
-chmod 600 ~/.npa/credentials.yaml
-```
-
-If the file is readable by other users, `npa workbench ...` prints a warning.
-Loaded tokens are forwarded to remote workbench SSH commands as environment
-variables.
-
-Token requirements by workbench:
-
-- Cosmos: requires `HF_TOKEN` during deploy to download gated Hugging Face Cosmos models.
-- GR00T: requires `HF_TOKEN` for gated Hugging Face GR00T models; optional `ngc.api_key` or `NGC_API_KEY` is written to the server env for NGC-backed model paths and readiness displays.
-- LeRobot: may need `HF_TOKEN` for gated Hugging Face datasets or models.
-- FiftyOne: may need `HF_TOKEN` for gated Hugging Face datasets.
-- Isaac Lab and Genesis: no token is required by default.
+See [configuration](../docs/configuration.md) for project setup, credential
+precedence, the credential-file layout, token access, and cross-project storage.
+Use the [first-run prompts](../docs/workbench/agent-first-run.md) with a coding agent.
 
 Terraform remote state for managed workbenches is stored in the Nebius S3
 bucket under:
@@ -311,3 +266,25 @@ from npa.clients.http import HTTPClient
 - `npa.orchestration.npa_workflow`: specification loading, planning, execution,
   durable state, and recovery
 - `npa.workflows`: workflow implementations and artifact discovery
+
+## Developing and testing npa
+
+To work on `npa` itself, create the contributor environment and use the `make`
+targets from the repo root:
+
+```bash
+python3 -m venv npa/.venv
+npa/.venv/bin/python -m pip install -e "npa[dev,adapter]"
+
+make test PYTHON="$(pwd)/npa/.venv/bin/python"        # unit suite
+make test-smoke PYTHON="$(pwd)/npa/.venv/bin/python"  # onboarding CLI checks
+make lint PYTHON="$(pwd)/npa/.venv/bin/python"        # ruff
+```
+
+Use an **absolute** interpreter path: the recipes change into `npa/` before
+running. Without an override, Make prefers the contributor environment
+`npa/.venv/bin/python`, then `python3` on `PATH`. Live and GPU tests are
+deselected from `make test`; `make test-e2e` is the explicit live-infrastructure
+target and needs the relevant credentials and resources.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full test layout and PR
+conventions (branch → PR → squash, one approval, never self-approve).

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,7 +1,8 @@
 # NPA workflow specs (`apiVersion: npa.workflow/v0.0.1`)
 
-Customer-facing authoring DSL for chaining Workbench tools. Author and submit
-these specs; do not hand-edit scheduler YAML.
+YAML specifications for composing Workbench tools. Each `toolRef` names a
+catalog operation. Author, validate, and submit these specs; NPA renders the
+scheduler YAML.
 
 Agent skills: `skills/workflows/author-npa-workflow/SKILL.md` (edit) and
 `skills/workflows/generate-npa-workflow/SKILL.md` (design new pipelines).
@@ -106,7 +107,7 @@ describes the real component and artifact contracts.
 | [`cosmos3-reason.yaml`](testing/cosmos3-reason.yaml) | Cosmos3 reason |
 | [`cosmos3-checkpoint-eval.yaml`](testing/cosmos3-checkpoint-eval.yaml) | B200-only guarded Cosmos3 still-image checkpoint evaluation |
 | [`paidf-cosmos3.yaml`](main/paidf-cosmos3.yaml) | Independent dynamic PAIDF: generic LeRobot/video input → real Cosmos 3 video2video variants → evaluator gate/refinement → real Curator + FiftyOne Brain + Rerun |
-| [`content-agents-rigid-object.yaml`](testing/content-agents-rigid-object.yaml) | Restricted operator-built NVIDIA Content Agents: source USD → real Material/Physics Agents + OVRTX → upstream validation → rigid Isaac object USDZ/adapter ([guide](../docs/workbench/content-agents.md)) |
+| [`content-agents-rigid-object.yaml`](testing/content-agents-rigid-object.yaml) | NVIDIA Content Agents with a public image and runtime-fetched OVRTX: source USD → real Material/Physics Agents + OVRTX → upstream validation → rigid Isaac object USDZ/adapter ([guide](../docs/workbench/content-agents.md)) |
 | [`byof.yaml`](testing/byof.yaml) | BYOF via `run_byof_repo.py` |
 | [`byof-maniskill.yaml`](testing/byof-maniskill.yaml) | OSS registry: ManiSkill pinned image + PickCube smoke |
 | [`byof-mujoco-playground.yaml`](testing/byof-mujoco-playground.yaml) | OSS registry: MuJoCo Playground pinned image + Cartpole smoke |


### PR DESCRIPTION
## Summary

Consolidate project and credential setup into `docs/configuration.md` and coding-agent setup and execution prompts into `docs/workbench/agent-first-run.md`. Keep existing quickstart anchors so inbound links continue to work.

Reconcile the documentation with the current workflow catalog: PAIDF and Sim2Real use `workflows/main/`, other examples use `workflows/testing/`, and catalog wording lives in `workflows/README.md`. Preserve current main's README overview, navigation, tool inventory, architecture image, repository layout, and Workbench documentation.

The remaining improvements clarify parallel runtime submission, distinguish offline planning from execution and image probes, explain the limits of recorded GPU and golden-eval evidence, correct image packaging descriptions, consolidate environment-removal recovery, and repair documentation links. The README also includes a Mermaid diagram of workflow execution.

This is one documentation commit touching 21 Markdown files, based on `2c325500ef39b39e1b8de89525d5f90ff6480e7d`. Changes already present in #402 and #394 are excluded. No product code, workflow specifications, images, or skills change.

## Validation

- Ruff passed over `npa/`.
- Both Mermaid diagrams rendered. Of 39 public URLs checked, 38 are reachable and Hugging Face token settings requires sign-in.
- Aggregate confidentiality passed with zero hits; Gitleaks found no leaks in the one-commit PR range.
- Verified 439 local links/images, 14 full workflow references, and all previous quickstart anchors across the 21 changed Markdown files.
- Passed 17 isolated offline CLI/help/validation/planning checks, including the VLM example and both PAIDF decision paths.
- All 2,546 guardrail checks passed on the final head.
- CLI documentation drift passed (`scripts/build_docs.sh --check`).
- All seven GitHub checks passed: Ruff, confidentiality, Gitleaks, guardrails, browser, docs drift, and the full Python 3.12 test job. [Full CI results](https://github.com/nebius/nebius-physical-ai/actions/runs/34063044370/job/101566886803): 15,623 passed, 389 skipped, 1 xpassed; coverage 74.96% (60% required). CLI installation and e2e shell syntax checks also passed.

No live GPU workload, provider provisioning, or image publication was performed. Offline plans and source tests do not establish live execution success.

## Skill maintenance

- [x] Documentation corrections only; no behavior change requiring new skill guidance.
