### PR TITLE
Test feedback reconciliation session identity

### DIFF
--- a/npa/tests/cli/test_agent_improvement_feedback_sessions.py
+++ b/npa/tests/cli/test_agent_improvement_feedback_sessions.py
@@ -1,0 +1,204 @@
+"""Reconciliation preserves persisted session provenance and evidence gates."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+import pytest
+
+from npa.agent_backend import improvement_routes
+from npa.agent_backend.improvements import ImprovementScope, ImprovementStore
+
+
+ACTION = {"ok": False, "steps": [{
+    "phase": "call", "tool": "retrieval_search", "status": "error",
+    "args": {"query": "synthetic regression"}, "error": "synthetic tool failure",
+}]}
+EPISODE = "synthetic-episode"
+SESSION = "synthetic-session"
+
+
+@pytest.fixture
+def feedback(tmp_path):
+    repository = tmp_path / "source"
+    repository.mkdir()
+    (repository / "candidate.py").write_text("result = 1\n")
+    store = ImprovementStore(
+        tmp_path / "queue", repository=repository,
+        evidence_directory=tmp_path / "evidence",
+        scopes=[ImprovementScope(
+            scope_id="synthetic-feedback", component="retrieval_search",
+            files=("candidate.py",), base_revision="a" * 40,
+            required_checks=("reproducer",), lesson_keys=("inspect_failed_tool_evidence",),
+        )], reviewers=("synthetic-reviewer",),
+    )
+    app = FastAPI()
+    improvement_routes.register_improvement_routes(
+        app, improvement_routes.ImprovementDeps(store=lambda: store), HTTPException,
+    )
+    with TestClient(app) as client:
+        yield store, client
+
+
+def _result(response):
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["grounded"] is True
+    assert body["usage"] == {"total_tokens": 0}
+    return body["result"]
+
+
+def _reconcile(client, **context):
+    return client.post("/agent/improvements/reconcile", json={
+        "result": ACTION, "episode_id": EPISODE, **context,
+    })
+
+
+def _history(client, item_id):
+    return _result(client.get(f"/agent/improvements/{item_id}"))
+
+
+def _lessons(client):
+    return _result(client.get("/agent/improvements/lessons", params={"target": "retrieval_search"}))
+
+
+def _verify(store, client, item):
+    claim = _result(client.post(f"/agent/improvements/{item['id']}/claim", json={
+        "owner": "synthetic-builder", "version": item["version"],
+    }))
+    ownership = {key: claim[key] for key in ("owner", "generation", "claim_token")}
+    candidate = store.begin_candidate(item["id"], changed_files=["candidate.py"], **ownership)
+    completed = subprocess.run(
+        [sys.executable, "-c", "from candidate import result; assert result == 1; print('synthetic check passed')"],
+        cwd=store.repository, capture_output=True, check=True,
+    )
+    receipt = store.write_validation_receipt(
+        candidate, check="reproducer", completed=completed, report=completed.stdout,
+    )
+    validated = _result(client.post(f"/agent/improvements/{item['id']}/validation", json={
+        **ownership, "evidence_ref": receipt,
+    }))
+    assert validated["state"] == "ready_for_review"
+    # Synthetic adapter evidence tests the receipt contract, not a live review.
+    review = store.write_review_receipt(
+        item["id"], reviewer="synthetic-reviewer", accepted=True,
+        lesson_key="inspect_failed_tool_evidence", report=b"Synthetic unit review fixture.\n",
+    )
+    verified = _result(client.post(f"/agent/improvements/{item['id']}/review", json={"evidence_ref": review}))
+    assert verified["state"] == "verified"
+    assert len(_lessons(client)) == 1
+    return verified
+
+
+def test_runtime_failure_replay_preserves_verified_lesson(feedback, monkeypatch):
+    store, client = feedback
+    monkeypatch.setattr(improvement_routes, "current_episode_id", lambda: EPISODE)
+    monkeypatch.setattr(improvement_routes, "current_session_id", lambda: SESSION)
+    runtime = improvement_routes.ImprovementRuntime(lambda: store)
+    recorded = runtime.record(ACTION)
+    assert recorded["status"] == "recorded"
+    item = _history(client, recorded["item_ids"][0])["item"]
+    verified = _verify(store, client, item)
+    before = _history(client, item["id"])
+    lessons = _lessons(client)
+
+    for _ in range(2):
+        replay = _result(_reconcile(client, session_id=SESSION))[0]
+        assert replay == verified
+        assert _history(client, item["id"]) == before
+        assert _lessons(client) == lessons
+
+    # A new store instance reads the same persisted occurrence and review.
+    reopened = ImprovementStore(
+        store.directory, repository=store.repository, evidence_directory=store.evidence_directory,
+        scopes=list(store.scopes.values()), reviewers=store.reviewers,
+    )
+    assert reopened.history(item["id"]) == before
+    occurrence = before["occurrences"][0]
+    assert occurrence["session_ref"] and occurrence["session_ref"] != SESSION
+    assert occurrence["episode_ref"] and occurrence["episode_ref"] != EPISODE
+
+
+def test_same_episode_in_distinct_sessions_revokes_verified_lesson(feedback):
+    store, client = feedback
+    first = _result(_reconcile(client, session_id=SESSION))[0]
+    _verify(store, client, first)
+    second = _result(_reconcile(client, session_id="another-synthetic-session"))[0]
+    assert second["id"] == first["id"]
+    assert second["occurrences"] == 2
+    assert second["state"] == "observed"
+    history = _history(client, first["id"])
+    assert len({row["session_ref"] for row in history["occurrences"]}) == 2
+    assert len({row["episode_ref"] for row in history["occurrences"]}) == 1
+    assert history["events"][-1]["event"] == "recurrence"
+    assert _lessons(client) == []
+    assert _result(_reconcile(client, session_id="another-synthetic-session"))[0] == second
+    assert _history(client, first["id"]) == history
+
+
+def test_omitted_session_matches_legacy_recording_and_empty_session(feedback):
+    store, client = feedback
+    first = store.observe_action(ACTION, episode_id=EPISODE)[0]
+    verified = _verify(store, client, first)
+    before = _history(client, first["id"])
+    assert _result(_reconcile(client))[0] == verified
+    assert _result(_reconcile(client, session_id=""))[0] == verified
+    assert _history(client, first["id"]) == before
+    assert before["occurrences"][0]["session_ref"] == ""
+    recurring = _result(_reconcile(client, episode_id="another-synthetic-episode"))[0]
+    assert recurring["occurrences"] == 2
+    assert recurring["state"] == "observed"
+    assert _lessons(client) == []
+
+
+def test_same_session_replay_does_not_restore_stale_source_evidence(feedback):
+    store, client = feedback
+    first = _result(_reconcile(client, session_id=SESSION))[0]
+    verified = _verify(store, client, first)
+    before = _history(client, first["id"])
+    (store.repository / "candidate.py").write_text("result = 2\n")
+    assert _lessons(client) == []
+    assert _result(_reconcile(client, session_id=SESSION))[0] == verified
+    assert _history(client, first["id"]) == before
+    assert _lessons(client) == []
+
+
+@pytest.mark.parametrize("missing", ["result", "episode_id"])
+def test_missing_required_context_returns_sanitized_error_without_recording(feedback, missing):
+    store, client = feedback
+    payload = {"result": ACTION, "episode_id": EPISODE, "session_id": SESSION}
+    del payload[missing]
+    response = client.post("/agent/improvements/reconcile", json=payload)
+    assert response.status_code == 409
+    assert response.json() == {"detail": "improvement scope, ownership or evidence check failed"}
+    assert store.list_items() == []
+
+
+def test_reconcile_storage_failure_returns_sanitized_error(feedback):
+    store, client = feedback
+    store.path.write_bytes(b"synthetic invalid SQLite database")
+    response = _reconcile(client, session_id=SESSION)
+    assert response.status_code == 503
+    assert response.json() == {"detail": "improvement storage unavailable"}
+
+
+@pytest.mark.parametrize("operation", ["validation", "review"])
+def test_reconciliation_does_not_accept_asserted_receipts(feedback, operation):
+    _, client = feedback
+    first = _result(_reconcile(client, session_id=SESSION))[0]
+    claim = _result(client.post(f"/agent/improvements/{first['id']}/claim", json={
+        "owner": "synthetic-builder", "version": first["version"],
+    }))
+    before = _history(client, first["id"])
+    ownership = {key: claim[key] for key in ("owner", "generation", "claim_token")}
+    response = client.post(f"/agent/improvements/{first['id']}/{operation}", json={
+        **ownership, "passed": True, "reviewer": "synthetic-reviewer",
+    })
+    assert response.status_code == 409
+    assert _result(_reconcile(client, session_id=SESSION))[0]["state"] == "claimed"
+    assert _history(client, first["id"]) == before
+    assert _lessons(client) == []

--- a/npa/tests/e2e/test_agent_improvement_feedback_sessions_live.py
+++ b/npa/tests/e2e/test_agent_improvement_feedback_sessions_live.py
@@ -1,0 +1,119 @@
+"""Opt-in deployed session reconciliation using externally prepared receipts.
+
+The dedicated lifecycle bundle extends NPA_AGENT_IMPROVEMENT_LIVE_BUNDLE with
+``result``, ``episode_id``, and ``session_id`` from the original runtime failure.
+A coordinator must prepare its validation_refs and independently obtained
+review_ref against the exact deployed candidate before this test runs. It
+preserves the verified lesson on replay, then deliberately invalidates that
+lesson with a new session in the dedicated queue. It never creates receipts.
+Run this file explicitly with its dedicated bundle, separately from other
+improvement lifecycle tests that consume their own review receipts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import uuid
+
+import pytest
+
+from npa.agent_backend.improvements import _digest, _read_private
+from npa.cli.agent_deployment import build_deployment_manifest
+from .agent_live_helpers import load_agent_live_context
+
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.agent_live,
+    pytest.mark.skipif(
+        any(os.environ.get(name) != "1" for name in (
+            "NPA_AGENT_LIVE", "NPA_INTEGRATION_E2E", "NPA_AGENT_IMPROVEMENT_LIVE",
+        )),
+        reason="Enable the dedicated deployed feedback-session lifecycle explicitly.",
+    ),
+]
+
+
+def _result(response):
+    assert response.status_code == 200, "deployed improvement request failed"
+    body = response.json()
+    assert body.get("grounded") is True
+    assert body.get("usage", {}).get("total_tokens") == 0
+    assert body.get("status") == "ready", "dedicated queue is not enabled"
+    return body["result"]
+
+
+def test_deployed_session_replay_preserves_review_until_distinct_recurrence():
+    component = os.environ.get("NPA_AGENT_IMPROVEMENT_LIVE_COMPONENT", "")
+    bundle_path = os.environ.get("NPA_AGENT_IMPROVEMENT_LIVE_BUNDLE", "")
+    assert component and bundle_path, "supply the approved component and protected lifecycle bundle"
+    bundle = json.loads(_read_private(Path(bundle_path)))
+    assert bundle["episode_id"] and bundle["session_id"], "the original runtime context is required"
+    assert bundle["validation_refs"] and bundle["review_ref"], "external receipts are required"
+    assert bundle["result"]["ok"] is False
+    assert any(step.get("tool") == component and step.get("status") == "error"
+               for step in bundle["result"]["steps"])
+
+    ctx = load_agent_live_context()
+    repository = Path(__file__).resolve().parents[3]
+    expected = build_deployment_manifest(project_alias=ctx.project, name=ctx.name, repo_root=repository)
+    response = ctx.get("/api/deployment")
+    assert response.status_code == 200, "deployed identity is unavailable"
+    deployed = response.json()
+    for field in ("deployment_id", "repository", "branch", "commit", "source_tree"):
+        assert deployed.get(field) == expected[field], "deployment must match the clean local candidate"
+
+    item_id = bundle["item_id"]
+    item_path = f"/api/agent/improvements/{item_id}"
+    initial = _result(ctx.get(item_path))
+    assert initial["item"]["component"] == component
+    assert initial["item"]["state"] == "ready_for_review", "prepare real validation and external review first"
+    occurrences = initial["occurrences"]
+    assert len(occurrences) == 1, "use an isolated queue with one original runtime failure"
+    assert occurrences[0]["episode_ref"] == _digest(bundle["episode_id"])
+    assert occurrences[0]["session_ref"] == _digest(bundle["session_id"])
+
+    scope = initial["item"]["scope"]
+    assert "npa/src/npa/agent_backend/improvement_routes.py" in scope["files"]
+    files = []
+    for name in scope["files"]:
+        source = (repository / name).resolve()
+        assert source.is_relative_to(repository), "candidate scope must remain in the source repository"
+        files.append({"path": name, "sha256": hashlib.sha256(source.read_bytes()).hexdigest()})
+    snapshot = {"base_revision": scope["base_revision"], "files": files}
+    assert initial["item"]["candidate_sha256"] == _digest(snapshot), "receipts must bind the current source bytes"
+
+    for reference in bundle["validation_refs"]:
+        validated = _result(ctx.post(item_path + "/validation", json={
+            **bundle["ownership"], "evidence_ref": reference,
+        }))
+        assert validated["state"] == "ready_for_review"
+    verified = _result(ctx.post(item_path + "/review", json={"evidence_ref": bundle["review_ref"]}))
+    assert verified["state"] == "verified"
+    before = _result(ctx.get(item_path))
+    assert before["item"]["review"]["identity_provenance"] == "coordinator-attested-external-review"
+    lessons_path = "/api/agent/improvements/lessons"
+    lessons = _result(ctx.get(lessons_path, params={"target": component}))
+    assert any(row["item_id"] == item_id for row in lessons)
+
+    payload = {key: bundle[key] for key in ("result", "episode_id", "session_id")}
+    for _ in range(2):
+        replay = _result(ctx.post("/api/agent/improvements/reconcile", json=payload))
+        assert len(replay) == 1 and replay[0] == verified
+        assert _result(ctx.get(item_path)) == before
+        assert _result(ctx.get(lessons_path, params={"target": component})) == lessons
+
+    payload["session_id"] = "live-recurrence-" + uuid.uuid4().hex
+    recurring = _result(ctx.post("/api/agent/improvements/reconcile", json=payload))
+    assert len(recurring) == 1 and recurring[0]["id"] == item_id
+    assert recurring[0]["state"] == "observed" and recurring[0]["occurrences"] == 2
+    after = _result(ctx.get(item_path))
+    assert len({row["session_ref"] for row in after["occurrences"]}) == 2
+    assert len({row["episode_ref"] for row in after["occurrences"]}) == 1
+    assert after["events"][-1]["event"] == "recurrence"
+    assert not any(row["item_id"] == item_id for row in _result(ctx.get(lessons_path, params={"target": component})))
+    assert _result(ctx.post("/api/agent/improvements/reconcile", json=payload)) == recurring
+    assert _result(ctx.get(item_path)) == after


### PR DESCRIPTION
Feedback reconciliation must preserve persisted session identity: replaying the same occurrence retains its verified lesson, while a failure in a distinct session records recurrence and revokes that lesson. The implementation already exists on `main`; this PR adds only two regression test files in one commit directly on current `main`.

The HTTP/store tests cover immutable replay history and lessons, persistence after reopening the store, verified recurrence across sessions, omitted/empty-session compatibility, stale-source evidence, sanitized errors, and rejection of asserted validation/review receipts. Existing unverified-session coverage on `main` is not repeated.

The dedicated opt-in deployed test checks the exact deployment and source snapshot, consumes externally prepared validation and independent review receipts, then exercises replay and recurrence through the deployed API. It contains no infrastructure setup or embedded deployment configuration.

Validation on the rewritten head:

- Focused session regressions plus catalog/three-tier contracts: 38 passed, 1 live test skipped.
- Full-repository Ruff, diff confidentiality, and branch-range gitleaks: passed.
- Onboarding smoke: 114 passed.
- GitHub guardrails: 2,545 passed; browser tests and docs drift also passed.
- [GitHub full Python coverage gate](https://github.com/nebius/nebius-physical-ai/actions/runs/34064451656/job/101570680569): 15,631 passed, 390 skipped, 1 xpassed; coverage 74.96% (60% required). All nine new unit cases passed; the dedicated live case skipped.
- All seven GitHub checks passed on `7550ebcd7d58cf6fba321304176609a91941369c`.

The completed full-suite result is from GitHub CI. Local full-suite attempts were interrupted after diagnosing clone file-permission failures and an existing parallel PID-marker race; after correcting local file permissions, all 719 image-byte tests passed serially, including every previously failing case. A redundant local full-suite retry was stopped when the exact-head CI gate passed.

Deployed lifecycle validation remains unrun: the runner has no dedicated live configuration or protected lifecycle bundle with independent receipts. The skipped test is not evidence of deployed success.
