### PR TITLE
Test planner failure feedback persistence and deployed queue contract

### DIFF
--- a/npa/tests/cli/test_agent_improvement_planner_routing.py
+++ b/npa/tests/cli/test_agent_improvement_planner_routing.py
@@ -1,0 +1,159 @@
+"""Persist real planner failures under their configured action-loop owner."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from npa.agent_backend.actions import run_action_loop
+from npa.agent_backend.improvement_routes import ImprovementRuntime
+from npa.agent_backend.improvements import ImprovementScope, ImprovementStore
+from npa.agent_backend.sim2real_loop import drive_sim2real_loop
+
+
+def _store(root, components):
+    repository = root / "source"
+    repository.mkdir(exist_ok=True)
+    return ImprovementStore(
+        root / "queue", repository=repository, evidence_directory=root / "evidence",
+        scopes=[
+            ImprovementScope(
+                scope_id=component, component=component, files=(component + ".py",),
+                base_revision="a" * 40, required_checks=("reproducer",),
+            )
+            for component in components
+        ],
+        reviewers=(),
+    )
+
+
+def _record(root, result, components):
+    store = _store(root, components)
+    feedback = ImprovementRuntime(lambda: store).record(
+        result, {"request_id": "synthetic-routing-episode", "lessons": []},
+    )
+    assert feedback["status"] == "recorded"
+    reopened = _store(root, components)
+    items = reopened.list_items()
+    assert feedback["item_ids"] == [item["id"] for item in items]
+    return reopened, items
+
+
+def _planner(*plans):
+    responses = iter(plans)
+
+    def call(*args, **kwargs):
+        return {"choices": [{"message": {"content": json.dumps(next(responses))}}]}
+
+    return call
+
+
+@pytest.mark.parametrize("failure", ["unavailable", "malformed"])
+def test_planner_failure_persists_with_only_action_loop_configured(tmp_path, failure):
+    planner_calls = []
+    tool_calls = []
+
+    def planner(*args, **kwargs):
+        planner_calls.append(1)
+        if failure == "unavailable":
+            raise RuntimeError("synthetic planner unavailable")
+        return {"choices": [{"message": {"content": "invalid action JSON"}}]}
+
+    result = run_action_loop(
+        "inspect available evidence",
+        tools={"retrieval_search": lambda args: tool_calls.append(args)},
+        model_call=planner,
+    )
+    assert result["ok"] is False
+    assert result["stopped_reason"] == ("error" if failure == "unavailable" else "no_plan")
+    assert len(planner_calls) == (1 if failure == "unavailable" else 2)
+    assert tool_calls == []
+    assert len(result["steps"]) == 1
+    step = result["steps"][0]
+    assert step["phase"] == "plan" and step["status"] == "error"
+    assert "tool" not in step
+
+    store, items = _record(tmp_path, result, ("action-loop",))
+    assert [item["component"] for item in items] == ["action-loop"]
+    assert items[0]["kind"] == "tool_error"
+    assert items[0]["scope"]["files"] == ["action-loop.py"]
+    history = store.history(items[0]["id"])
+    assert len(history["occurrences"]) == 1
+    assert history["occurrences"][0]["event_index"] == 0
+    assert history["occurrences"][0]["evidence"] == step
+
+
+def test_explicit_failed_tool_keeps_its_own_scope(tmp_path):
+    result = run_action_loop(
+        "inspect available evidence",
+        tools={"retrieval_search": lambda args: {"error": "synthetic retrieval failure"}},
+        model_call=_planner(
+            {"tool": "retrieval_search", "args": {"query": "evidence"}},
+            {"final": "The retrieval failed."},
+        ),
+    )
+    store, items = _record(tmp_path, result, ("action-loop", "sim2real-drive", "retrieval_search"))
+    assert [item["component"] for item in items] == ["retrieval_search"]
+    assert store.history(items[0]["id"])["occurrences"][0]["evidence"]["args"] == {"query": "evidence"}
+
+
+@pytest.mark.parametrize("stage,kind", [
+    ("gate", "drive_error"),
+    ("adjust", "drive_adjust_error"),
+    ("diagnose", "drive_diagnosis_error"),
+])
+def test_real_drive_iterations_keep_sim2real_fallback(tmp_path, stage, kind):
+    def failed(*args):
+        raise RuntimeError("synthetic drive component failure")
+
+    callbacks = {
+        "gate": lambda *args: {"success_rate": 0.2, "threshold": 0.8},
+        "diagnose": lambda *args: {"failure_mode": "synthetic"},
+        "adjust": lambda config, diagnosis: config,
+    }
+    callbacks[stage] = failed
+    result = drive_sim2real_loop(
+        "evaluate a synthetic rollout", config={"run_id": "synthetic-run"},
+        launch=lambda config: {"run_id": "synthetic-run"},
+        status=lambda run: {
+            "ok": True, "run": {"run_id": run},
+            "sim_viz": {"run_id": run, "stage": "evaluation"},
+        },
+        confirm_token="synthetic-consent", session_token="synthetic-consent", **callbacks,
+    )
+    assert "tool" not in result["iterations"][0]
+    _, items = _record(tmp_path, result, ("action-loop", "sim2real-drive"))
+    assert [(item["component"], item["kind"]) for item in items] == [("sim2real-drive", kind)]
+
+
+@pytest.mark.parametrize("case", ["success", "recovered", "terminal_empty", "confirmation"])
+def test_successful_and_terminal_actions_do_not_create_findings(tmp_path, case):
+    if case == "terminal_empty":
+        result = run_action_loop(
+            "list available runs", tools={"insights_query": lambda args: {"count": 0, "records": []}},
+            model_call=_planner({"tool": "insights_query", "args": {}}),
+        )
+        assert any(step.get("terminal_observation") for step in result["steps"])
+    elif case == "confirmation":
+        result = run_action_loop(
+            "launch a workflow", tools={"sim2real_submit": lambda args: pytest.fail("unconfirmed tool ran")},
+            model_call=_planner({"tool": "sim2real_submit", "args": {}}),
+        )
+        assert result["needs_confirmation"] is True
+    else:
+        outputs = iter([
+            {"error": "synthetic temporary retrieval failure"} if case == "recovered" else {"answer": "evidence"},
+            {"answer": "recovered evidence"},
+        ])
+        plans = [{"tool": "retrieval_search", "args": {"query": "evidence"}}]
+        if case == "recovered":
+            plans.append({"tool": "retrieval_search", "args": {"query": "broader evidence"}})
+        plans.append({"final": "Evidence retrieved."})
+        result = run_action_loop(
+            "inspect available evidence", tools={"retrieval_search": lambda args: next(outputs)},
+            model_call=_planner(*plans),
+        )
+        assert result["ok"] is True
+    _, items = _record(tmp_path, result, ("action-loop", "sim2real-drive", "retrieval_search", "insights_query", "sim2real_submit"))
+    assert items == []

--- a/npa/tests/e2e/test_agent_improvement_planner_routing_live.py
+++ b/npa/tests/e2e/test_agent_improvement_planner_routing_live.py
@@ -1,0 +1,135 @@
+"""Opt-in zero-token planner routing with real deployed queue and review receipts.
+
+The coordinator supplies an owner-only bundle after verifying the deployment's
+improvements.py hash and an action-loop-only queue configuration. The bundle
+contains agent_url, deployment, deployed_source_sha256, components, scope,
+item_id, ownership, validation_refs and review_ref. The item must already await
+review for the clean local candidate before this test records new observations.
+Receipts come from actual candidate checks and an independently obtained review;
+this test neither creates nor attests them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import uuid
+
+import pytest
+
+from npa.agent_backend import improvements
+from npa.agent_backend.actions import run_action_loop
+from npa.agent_backend.improvements import _digest, _read_private, _relative_file
+from npa.cli.agent_deployment import build_deployment_manifest
+from .agent_live_helpers import load_agent_live_context
+
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.agent_live,
+    pytest.mark.skipif(
+        os.environ.get("NPA_AGENT_LIVE") != "1"
+        or os.environ.get("NPA_INTEGRATION_E2E") != "1"
+        or os.environ.get("NPA_AGENT_IMPROVEMENT_LIVE") != "1",
+        reason="Enable the approved deployed planner queue lifecycle explicitly.",
+    ),
+]
+
+
+def _result(response):
+    assert response.status_code == 200, "deployed planner feedback request failed"
+    payload = response.json()
+    assert payload.get("grounded") is True
+    assert payload.get("usage", {}).get("total_tokens") == 0
+    assert payload.get("status") == "ready", "dedicated planner queue is not enabled"
+    return payload["result"]
+
+
+def test_deployed_planner_failure_routing_and_review_lifecycle():
+    bundle_path = os.environ.get("NPA_AGENT_IMPROVEMENT_PLANNER_LIVE_BUNDLE", "")
+    assert bundle_path, "supply the protected coordinator deployment and lifecycle bundle"
+    bundle = json.loads(_read_private(Path(bundle_path)))
+    ctx = load_agent_live_context()
+    assert bundle["agent_url"].rstrip("/") == ctx.api_base, "deployment source proof targets another agent"
+    assert bundle["deployed_source_sha256"] == hashlib.sha256(
+        Path(improvements.__file__).read_bytes()
+    ).hexdigest(), "coordinator must verify the exact candidate module on the deployment"
+    assert bundle["components"] == ["action-loop"], "require an approved action-loop-only queue"
+    assert bundle["validation_refs"], "real candidate check receipts are required"
+    assert bundle["review_ref"], "an independently produced review receipt is required"
+
+    repository = Path(improvements.__file__).resolve().parents[4]
+    deployment = bundle["deployment"]
+    expected_deployment = build_deployment_manifest(
+        project_alias=deployment["project_alias"], name=deployment["deployment_name"],
+        workspace_label=deployment["workspace_label"], repo_root=repository,
+        bootstrap_timestamp=deployment["bootstrap_timestamp"],
+    )
+    assert deployment == expected_deployment, "bundle does not identify the clean local candidate"
+    response = ctx.get("/api/deployment")
+    assert response.status_code == 200, "deployed source identity is unavailable"
+    assert response.json() == expected_deployment, "the running deployment differs from the candidate"
+
+    item_id = bundle["item_id"]
+    initial = _result(ctx.get(f"/api/agent/improvements/{item_id}"))["item"]
+    assert initial["state"] == "ready_for_review", "prepare real checks before recording more observations"
+    assert initial["component"] == "action-loop" and initial["kind"] == "tool_error"
+    scope = bundle["scope"]
+    assert initial["scope"] == scope and scope["component"] == "action-loop"
+    assert "npa/src/npa/agent_backend/improvements.py" in scope["files"]
+    snapshot = {
+        "base_revision": scope["base_revision"],
+        "files": [
+            {"path": name, "sha256": hashlib.sha256(_relative_file(repository, name).read_bytes()).hexdigest()}
+            for name in scope["files"]
+        ],
+    }
+    assert initial["candidate_sha256"] == _digest(snapshot), "receipts describe different candidate source"
+    assert initial["owner"] == bundle["ownership"]["owner"]
+    assert initial["generation"] == bundle["ownership"]["generation"]
+
+    for failure in ("unavailable", "malformed"):
+        calls = []
+
+        def planner(*args, **kwargs):
+            calls.append(1)
+            if failure == "unavailable":
+                raise RuntimeError("synthetic dedicated planner unavailable")
+            return {"choices": [{"message": {"content": "invalid action JSON"}}]}
+
+        result = run_action_loop(
+            "inspect available evidence", tools={}, model_call=planner,
+        )
+        assert result["ok"] is False and result["tokens"] == 0
+        assert len(calls) == (1 if failure == "unavailable" else 2)
+        assert result["steps"][0]["phase"] == "plan"
+        payload = {"episode_id": "planner-probe-" + uuid.uuid4().hex, "result": result}
+        first = _result(ctx.post("/api/agent/improvements/reconcile", json=payload))
+        assert len(first) == 1, "planner failure was dropped by the scoped deployed queue"
+        item = first[0]
+        assert item["component"] == "action-loop" and item["kind"] == "tool_error"
+        assert item["id"] == bundle["item_id"], "receipts must belong to the planner failure item"
+        replay = _result(ctx.post("/api/agent/improvements/reconcile", json=payload))
+        assert replay[0]["id"] == item["id"]
+        assert replay[0]["occurrences"] == item["occurrences"]
+        history = _result(ctx.get(f"/api/agent/improvements/{item['id']}"))
+        assert any(
+            occurrence["evidence"] == result["steps"][0]
+            for occurrence in history["occurrences"]
+        ), "the deployed store did not retain the real planner failure"
+
+    for reference in bundle["validation_refs"]:
+        state = _result(ctx.post(f"/api/agent/improvements/{item_id}/validation", json={
+            **bundle["ownership"], "evidence_ref": reference,
+        }))
+    assert state["state"] == "ready_for_review"
+    verified = _result(ctx.post(f"/api/agent/improvements/{item_id}/review", json={
+        "evidence_ref": bundle["review_ref"],
+    }))
+    assert verified["state"] == "verified"
+    lessons = _result(ctx.get("/api/agent/improvements/lessons?target=action-loop"))
+    assert any(lesson["item_id"] == item_id for lesson in lessons)
+    history = _result(ctx.get(f"/api/agent/improvements/{item_id}"))
+    assert history["item"]["review"]["identity_provenance"] == "coordinator-attested-external-review"


### PR DESCRIPTION
Planner failures can occur before the action loop selects a tool. Add regression coverage proving that an action-loop-only improvement queue retains these failures after reopening its SQLite store.

This test-only change adds exactly two files:

- Ten unit cases exercise unavailable and malformed planners, explicit tool ownership, Sim2Real gate/adjust/diagnosis fallback, successful recovery, terminal empty discovery, and confirmation without false findings. Existing mixed-scope planner cases on main are not duplicated.
- An opt-in live test reconciles locally generated planner failures through deployed queue APIs, checks deduplication and retained evidence, verifies candidate identity, and consumes actual validation and independent review receipts before retrieving a verified lesson.

Rebuilt as one commit directly on current main. The production routing behavior is already on main; no production changes or deployment setup are included.

Validation on current main (`2c325500ef39b39e1b8de89525d5f90ff6480e7d`):

- Related regression tests: 67 passed, including all 10 new planner cases; one opt-in live test skipped.
- Onboarding smoke: 114 passed. Local guardrails: 2,545 passed.
- Full Ruff, docs drift, range confidentiality (zero hits), and gitleaks (one commit, no leaks) passed.
- Full Python 3.12 CI suite: 15,632 passed, 390 skipped, one XPASS; package coverage 74.96% (60% required).
- All seven GitHub checks passed, including 146 mocked browser tests.

Full-suite evidence is from CI. The duplicate local full run was stopped after that gate completed; its partial report is retained and is not claimed as a completed pass.

Live limitation: the protected coordinator deployment/lifecycle bundle is unavailable in this maintenance environment, so deployed lifecycle validation has not run. The live test covers deployed queue reconciliation and review, not deployed planner dispatch. No live success is claimed.
