### PR TITLE
Fix LeIsaac video range conversion and host-dependent test fixtures

### DIFF
--- a/npa/src/npa/workbench/leisaac/dataset.py
+++ b/npa/src/npa/workbench/leisaac/dataset.py
@@ -806,6 +806,7 @@ def _load_records(path: Path) -> list[dict[str, Any]]:
 
 def _encode_frames(frame_dir: Path, destination: Path, fps: int = FPS) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
+    # JPEG is full-range; convert samples as well as signaling limited-range H.264.
     command = [
         _ffmpeg_executable(),
         "-hide_banner",
@@ -817,10 +818,14 @@ def _encode_frames(frame_dir: Path, destination: Path, fps: int = FPS) -> None:
         "-i",
         str(frame_dir / "frame-%06d.jpg"),
         "-an",
+        "-vf",
+        "scale=in_range=pc:out_range=tv,format=yuv420p",
         "-c:v",
         "libx264",
         "-pix_fmt",
         "yuv420p",
+        "-color_range",
+        "tv",
         "-crf",
         "20",
         "-g",

--- a/npa/tests/unit/test_cluster_backends.py
+++ b/npa/tests/unit/test_cluster_backends.py
@@ -139,6 +139,10 @@ def test_standalone_and_one_target_fleet_share_complete_mig_contract(
 ) -> None:
     from npa.cluster_backends import mk8s_execution
 
+    def reject_host_resolution(_name):
+        raise AssertionError("mocked verification must not resolve a host executable")
+
+    monkeypatch.setattr(mk8s_execution, "_require_bin", reject_host_resolution)
     mapping = _legacy_mk8s_mapping()
     mapping["projects"][0]["clusters"] = [
         {
@@ -209,6 +213,7 @@ def test_standalone_and_one_target_fleet_share_complete_mig_contract(
 
     status_request = MK8sStatusRequest(
         kubeconfig=tmp_path / "kubeconfig",
+        kubectl_bin="mock-kubectl",
         mig_verifier=lambda **kwargs: calls.append(kwargs) or Report(),
     )
     assert backend.verify(standalone_desired, status_request) == backend.verify(
@@ -1222,16 +1227,23 @@ def test_preemptible_pool_requires_explicit_provider_true() -> None:
     assert mk8s_execution._provider_node_group_matches_pool(payload, pool) is True
 
 
-def test_full_cpu_validation_checks_exact_nodes_and_default_storage(tmp_path) -> None:
+def test_full_cpu_validation_checks_exact_nodes_and_default_storage(
+    tmp_path, monkeypatch
+) -> None:
     from types import SimpleNamespace
     from npa.cluster_backends import mk8s_execution
 
+    def reject_host_resolution(_name):
+        raise AssertionError("mocked verification must not resolve a host executable")
+
+    monkeypatch.setattr(mk8s_execution, "_require_bin", reject_host_resolution)
     desired = MK8sDesired(
         name="cpu",
         cpu_nodes=MK8sNodePool(count=1, platform="cpu-d3", preset="8vcpu-32gb"),
     )
 
     def capture(command, **_kwargs):
+        assert command[0] == "mock-kubectl"
         if command[2] == "nodes":
             return SimpleNamespace(
                 returncode=0,
@@ -1268,6 +1280,7 @@ def test_full_cpu_validation_checks_exact_nodes_and_default_storage(tmp_path) ->
     result = mk8s_execution.verify_cluster(
         cluster=desired,
         kubeconfig=tmp_path / "kubeconfig",
+        kubectl_bin="mock-kubectl",
         run_capture=capture,
         validation_policy="standalone-full",
         basic_validation_timeout_seconds=1,

--- a/npa/tests/workbench/test_leisaac_dataset.py
+++ b/npa/tests/workbench/test_leisaac_dataset.py
@@ -619,6 +619,44 @@ def _dual_episode_dir(root: Path) -> tuple[Path, dict]:
     return episode, metadata
 
 
+@pytest.mark.parametrize("packaged", [False, True])
+def test_encoder_converts_jpeg_range_without_crushing_black_or_white(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, packaged: bool
+) -> None:
+    import os
+    import subprocess
+
+    if packaged:
+        import imageio_ffmpeg
+
+        executable = imageio_ffmpeg.get_ffmpeg_exe()
+        monkeypatch.setattr(leisaac_dataset, "_ffprobe_executable", lambda: None)
+    else:
+        executable = leisaac_dataset.shutil.which("ffmpeg")
+        if executable is None:
+            if os.environ.get("NPA_REQUIRE_FFMPEG") == "1":
+                pytest.fail("NPA_REQUIRE_FFMPEG=1 but system FFmpeg is unavailable")
+            pytest.skip("system FFmpeg unavailable; packaged encoder tested separately")
+    monkeypatch.setattr(leisaac_dataset, "_ffmpeg_executable", lambda: executable)
+    frames = tmp_path / "frames"
+    frames.mkdir()
+    levels = (0, 127, 255)
+    for index, level in enumerate(levels):
+        (frames / f"frame-{index:06d}.jpg").write_bytes(_jpeg((level,) * 3))
+    video = tmp_path / "range.mp4"
+    leisaac_dataset._encode_frames(frames, video)
+    media = leisaac_dataset._probe_video(video, expected_frames=3, fps=16)
+    assert media["pix_fmt"] == "yuv420p"
+    decoded = subprocess.run(
+        [executable, "-v", "error", "-i", str(video), "-f", "rawvideo",
+         "-pix_fmt", "rgb24", "-"],
+        capture_output=True, check=True,
+    )
+    pixels = np.frombuffer(decoded.stdout, dtype=np.uint8).reshape(3, 720, 1280, 3)
+    for frame, level in zip(pixels, levels, strict=True):
+        assert np.abs(frame.astype(np.int16) - level).max() <= 3
+
+
 def test_s3_store_publishes_faststart_synchronized_two_camera_artifacts(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
<!-- register: public GitHub pull request | reader: Nebius Physical AI maintainers | consumed: code review -->

## Summary

LeIsaac recordings start as full-range JPEG frames. Requesting `yuv420p` alone can leave the encoded H.264 stream marked as full-range `yuvj420p`, which the dataset validator rejects. Convert the sample range explicitly and signal limited-range output, while preserving the strict validator.

- Add real-codec regressions for both system and packaged FFmpeg. They check the output format and decode black, gray and white frames to catch crushed or expanded levels.
- Inject the mocked `kubectl` executable in two cluster-backend tests and fail if either test attempts host executable resolution. Production executable discovery is unchanged.

No CLI, workflow, dependency or container configuration changes are included.

## Verification

- [x] Cluster-backend and LeIsaac dataset tests: 74 passed.
- [x] Repository contract tests (`npa/tests/guardrails`): 2,482 passed.
- [x] Both codec regression cases fail against the original encoder and pass with the range conversion.
- [x] Onboarding smoke tests: 114 passed.
- [x] Ruff, whitespace, leak and built-in confidentiality scans passed.
- [x] Standalone Python 3.12 CI-style suite: 13,601 passed, zero failed, 404 skipped and one xpassed; coverage 73.67% against the unchanged 60% requirement.

The full-suite result uses this three-file patch on `4539e93d`. These are local results; GitHub CI has not run on a submitted commit. No live CUDA validation is claimed.

## Skill Maintenance

- [x] This PR does not change behavior that needs new skill guidance. Existing media requirements and command usage are unchanged.
