### PR TITLE
Preserve fractional source FPS in G1 visualizations

### DIFF
--- a/npa/src/npa/viz/lerobot.py
+++ b/npa/src/npa/viz/lerobot.py
@@ -88,7 +88,7 @@ class RenderInputs:
     skeleton_data: np.ndarray
     predictions_data: np.ndarray | None
     duration_s: float
-    source_fps: int
+    source_fps: float
     title: str
     frame_indices: np.ndarray
 
@@ -166,7 +166,7 @@ def load_render_inputs(
     )
 
 
-def load_lerobot_state_vectors(root: Path) -> tuple[np.ndarray, int, str]:
+def load_lerobot_state_vectors(root: Path) -> tuple[np.ndarray, float, str]:
     """Read ``observation.state`` rows from a standard LeRobotDataset directory."""
     root = Path(root)
     if not root.exists():
@@ -213,7 +213,10 @@ def load_lerobot_state_vectors(root: Path) -> tuple[np.ndarray, int, str]:
         raise VizDataError(f"Expected {G1_STATE_DIM}D Unitree G1 state vectors, got {state.shape[1]}D")
 
     info = _read_info(root)
-    fps = int(info.get("fps") or DEFAULT_FPS)
+    raw_fps = info.get("fps") or DEFAULT_FPS
+    # Preserve numeric fractional rates while retaining legacy coercion/errors
+    # for strings, unsupported metadata types, and nonfinite numbers.
+    fps = raw_fps if isinstance(raw_fps, float) and np.isfinite(raw_fps) else int(raw_fps)
     if fps <= 0:
         fps = DEFAULT_FPS
     title = _read_task_title(root) or str(info.get("task") or info.get("robot_type") or root.name)
@@ -223,7 +226,7 @@ def load_lerobot_state_vectors(root: Path) -> tuple[np.ndarray, int, str]:
 def resolve_duration_s(
     *,
     frame_count: int,
-    source_fps: int,
+    source_fps: float,
     requested_duration_s: float | None,
     duration_cap_s: float = DEFAULT_DURATION_CAP_S,
 ) -> float:
@@ -241,7 +244,7 @@ def resolve_duration_s(
 def select_frames(
     data: np.ndarray,
     *,
-    source_fps: int,
+    source_fps: float,
     output_fps: int,
     duration_s: float,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -265,7 +268,7 @@ def select_frames(
 def load_predictions_skeleton(
     path: Path,
     *,
-    source_fps: int,
+    source_fps: float,
     output_fps: int,
     duration_s: float,
     target_joint_count: int,

--- a/npa/tests/test_viz_fractional_source_cadence.py
+++ b/npa/tests/test_viz_fractional_source_cadence.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from rerun.recording import load_recording
+
+from npa.adapter.isaac_lab_lerobot import G1_STATE_DIM, G1_STATE_NAMES_43
+from npa.viz.adapters.lerobot_to_rerun import lerobot_to_rerun
+from npa.viz.lerobot import (
+    VizDataError,
+    g1_state_vectors_to_skeleton,
+    load_lerobot_state_vectors,
+    load_render_inputs,
+)
+
+
+def _dataset(root: Path, info: object, *, frames: int = 61) -> np.ndarray:
+    """Write distinguishable G1 states out of order in real Parquet files."""
+    states = np.arange(frames * G1_STATE_DIM, dtype=np.float32).reshape(frames, G1_STATE_DIM) / 10000
+    data = root / "data" / "chunk-000"
+    data.mkdir(parents=True)
+    for part, indices in enumerate((np.arange(frames - 1, -1, -2), np.arange(frames - 2, -1, -2))):
+        pq.write_table(
+            pa.table({"index": indices, "observation.state": states[indices].tolist()}),
+            data / f"file-{part:03d}.parquet",
+        )
+    meta = root / "meta"
+    meta.mkdir()
+    (meta / "info.json").write_text(json.dumps(info))
+    return states
+
+
+@pytest.mark.parametrize("fps", [29.97, 59.94, 0.5, 30])
+def test_source_cadence_preserves_numeric_states_and_render_duration(tmp_path: Path, fps: float) -> None:
+    states = _dataset(tmp_path, {"fps": fps, "task": "Synthetic G1 cadence"})
+
+    loaded_states, source_fps, title = load_lerobot_state_vectors(tmp_path)
+
+    np.testing.assert_array_equal(loaded_states, states)
+    assert source_fps == fps
+    assert title == "Synthetic G1 cadence"
+    rendered = load_render_inputs(tmp_path, output_fps=30)
+    duration = min(len(states) / fps, 10.0)
+    assert rendered.source_fps == fps
+    assert rendered.duration_s == pytest.approx(duration)
+    # Preserve the established selection across the full source under a cap.
+    indices = np.rint(np.linspace(0, len(states) - 1, round(duration * 30))).astype(np.int64)
+    np.testing.assert_array_equal(rendered.frame_indices, indices)
+    np.testing.assert_array_equal(rendered.skeleton_data, g1_state_vectors_to_skeleton(states[indices]))
+
+
+def test_fractional_source_resampling_holds_last_frame_at_requested_output_rate(tmp_path: Path) -> None:
+    states = _dataset(tmp_path, {"fps": 2.5}, frames=3)
+
+    rendered = load_render_inputs(tmp_path, duration_s=2.0, output_fps=5)
+
+    assert rendered.duration_s == 2.0
+    assert rendered.source_fps == 2.5
+    indices = np.array([0, 0, 1, 1, 2, 2, 2, 2, 2, 2])
+    np.testing.assert_array_equal(rendered.frame_indices, indices)
+    np.testing.assert_array_equal(rendered.skeleton_data, g1_state_vectors_to_skeleton(states[indices]))
+
+
+@pytest.mark.parametrize("info", [{}, {"fps": None}, {"fps": 0}, {"fps": -1}, {"fps": -0.5},
+                                  {"fps": ""}, {"fps": False}, {"fps": []}, [], None])
+def test_missing_or_nonpositive_metadata_keeps_default_cadence(tmp_path: Path, info: object) -> None:
+    _dataset(tmp_path, info, frames=3)
+    assert load_lerobot_state_vectors(tmp_path)[1] == 30
+    assert load_render_inputs(tmp_path).duration_s == pytest.approx(0.1)
+
+
+def test_absent_metadata_keeps_default_cadence(tmp_path: Path) -> None:
+    _dataset(tmp_path, {}, frames=3)
+    (tmp_path / "meta" / "info.json").unlink()
+    assert load_lerobot_state_vectors(tmp_path)[1] == 30
+
+
+@pytest.mark.parametrize("fps, expected", [("30", 30), (True, 1), (30.0, 30)])
+def test_existing_integer_metadata_coercion(tmp_path: Path, fps: object, expected: int) -> None:
+    _dataset(tmp_path, {"fps": fps})
+    assert load_lerobot_state_vectors(tmp_path)[1] == expected
+
+
+@pytest.mark.parametrize("fps, error", [("invalid", ValueError), ("29.97", ValueError),
+                                       (float("nan"), ValueError), (float("inf"), OverflowError),
+                                       (-float("inf"), OverflowError), ([30], TypeError),
+                                       ({"value": 30}, TypeError)])
+def test_invalid_metadata_keeps_existing_rejection(tmp_path: Path, fps: object, error: type[Exception]) -> None:
+    _dataset(tmp_path, {"fps": fps})
+    with pytest.raises(error):
+        load_lerobot_state_vectors(tmp_path)
+
+
+def test_malformed_metadata_keeps_existing_error(tmp_path: Path) -> None:
+    _dataset(tmp_path, {})
+    (tmp_path / "meta" / "info.json").write_text("{")
+    with pytest.raises(VizDataError, match="Invalid LeRobotDataset info.json"):
+        load_lerobot_state_vectors(tmp_path)
+
+
+@pytest.mark.parametrize("fps, indices", [(29.97, list(range(7))), (59.94, list(range(7))),
+                                         (0.5, [0, 6]), (30, list(range(7)))])
+def test_g1_rrd_decodes_recorded_cadence_and_selected_states(
+    tmp_path: Path, fps: float, indices: list[int],
+) -> None:
+    dataset = tmp_path / "dataset"
+    states = _dataset(dataset, {"fps": fps}, frames=7)
+    output = tmp_path / "synthetic-g1.rrd"
+
+    lerobot_to_rerun(dataset, output)
+
+    chunks = list(load_recording(output).chunks())
+    joint_name = "left_shoulder_pitch_joint"
+    angle_rows = []
+    skeleton_rows = []
+    for chunk in chunks:
+        if chunk.is_static:
+            continue
+        batch = chunk.to_record_batch()
+        times = batch.column("frame_time").cast(pa.int64()).to_pylist()
+        if str(chunk.entity_path) == f"/world/skeleton/angles/{joint_name}":
+            angle_rows.extend(zip(times, batch.column("Scalars:scalars").to_pylist(), strict=True))
+        if str(chunk.entity_path) == "/world/skeleton/joints":
+            skeleton_rows.extend(zip(times, batch.column("Points3D:positions").to_pylist(), strict=True))
+    angle_rows.sort(key=lambda row: row[0])
+    skeleton_rows.sort(key=lambda row: row[0])
+    expected_times = np.arange(len(indices)) / fps * 1_000_000_000
+    np.testing.assert_allclose([row[0] for row in angle_rows], expected_times, rtol=0, atol=1)
+    np.testing.assert_allclose([row[0] for row in skeleton_rows], expected_times, rtol=0, atol=1)
+    np.testing.assert_array_equal(
+        np.asarray([row[1] for row in angle_rows]).ravel(),
+        states[indices, list(G1_STATE_NAMES_43).index(joint_name)],
+    )
+    np.testing.assert_array_equal(
+        np.asarray([row[1] for row in skeleton_rows], dtype=np.float32),
+        g1_state_vectors_to_skeleton(states[indices]),
+    )


### PR DESCRIPTION
G1 LeRobot visualization loading truncated recorded frame rates such as 29.97 and 59.94 to integers and replaced 0.5 FPS with the default 30 FPS. That changed rendered duration, resampling, and skeleton Rerun timestamps.

Preserve finite numeric source FPS and update its type annotations. Existing output FPS, frame selection, metadata defaults, and invalid-value rejection remain covered by regression tests.

Validation:

- New regression: 7 failures on main; all 31 cases pass with the fix.
- Focused visualization coverage: 67 passed; onboarding smoke: 114 passed; guardrails: 2,482 passed.
- Full unit suite: 13,614 passed, 38 skipped, 1 xpassed; full lint and staged privacy/secret scans passed.
- Four actual synthetic G1 RRDs were verified and decoded against source Parquet, including timestamps, joint angles, and skeleton coordinates. This is local conversion validation.
