### PR TITLE
Close Matplotlib render figures after failures

### DIFF
--- a/npa/src/npa/viz/backends/matplotlib.py
+++ b/npa/src/npa/viz/backends/matplotlib.py
@@ -54,66 +54,68 @@ def render(
     width, height = resolution
     dpi = 100
     fig = plt.figure(figsize=(width / dpi, height / dpi), dpi=dpi, facecolor=BACKGROUND)
-    fig.suptitle(title or "LeRobot trajectory", color=TEXT_COLOR, fontsize=18, y=0.98)
+    try:
+        fig.suptitle(title or "LeRobot trajectory", color=TEXT_COLOR, fontsize=18, y=0.98)
 
-    axes_3d, trace_ax = _build_layout(fig, layout)
-    bounds_data = [skeleton]
-    if predictions is not None:
-        bounds_data.append(predictions)
-    limits = _axis_limits(bounds_data)
+        axes_3d, trace_ax = _build_layout(fig, layout)
+        bounds_data = [skeleton]
+        if predictions is not None:
+            bounds_data.append(predictions)
+        limits = _axis_limits(bounds_data)
 
-    artists: list[_SkeletonArtists] = []
-    if layout == "side-by-side":
-        input_artists = _add_skeleton(axes_3d[0], skeleton[0], joint_connections, INPUT_COLOR, "Input")
-        pred_artists = _add_skeleton(axes_3d[1], predictions[0], joint_connections, PREDICTION_COLOR, "Predictions")
-        artists.extend([input_artists, pred_artists])
-        _style_3d_axis(axes_3d[0], "Isaac Lab input", limits)
-        _style_3d_axis(axes_3d[1], "GR00T predictions", limits)
-    else:
-        input_artists = _add_skeleton(axes_3d[0], skeleton[0], joint_connections, INPUT_COLOR, "Input")
-        artists.append(input_artists)
-        if layout == "overlay" and predictions is not None:
-            pred_artists = _add_skeleton(axes_3d[0], predictions[0], joint_connections, PREDICTION_COLOR, "Predictions")
-            artists.append(pred_artists)
-        _style_3d_axis(axes_3d[0], "Overlay" if layout == "overlay" else "Trajectory", limits)
-
-    time_marker = _add_motion_trace(trace_ax, skeleton, predictions, fps=fps, duration_s=duration_s)
-    fig.subplots_adjust(left=0.035, right=0.965, top=0.90, bottom=0.08, hspace=0.16, wspace=0.04)
-
-    def update(frame: int) -> list[object]:
-        _update_skeleton(artists[0], skeleton[frame], joint_connections)
+        artists: list[_SkeletonArtists] = []
         if layout == "side-by-side":
-            if frame < int(predictions.shape[0]):
-                _set_skeleton_visible(artists[1], True)
-                _update_skeleton(artists[1], predictions[frame], joint_connections)
-            else:
-                _set_skeleton_visible(artists[1], False)
-        elif layout == "overlay" and predictions is not None and len(artists) > 1:
-            if frame < int(predictions.shape[0]):
-                _set_skeleton_visible(artists[1], True)
-                _update_skeleton(artists[1], predictions[frame], joint_connections)
-            else:
-                _set_skeleton_visible(artists[1], False)
-        time_marker.set_xdata([frame / fps, frame / fps])
-        updated: list[object] = [time_marker]
-        for skeleton_artists in artists:
-            updated.extend(skeleton_artists.all)
-        return updated
+            input_artists = _add_skeleton(axes_3d[0], skeleton[0], joint_connections, INPUT_COLOR, "Input")
+            pred_artists = _add_skeleton(axes_3d[1], predictions[0], joint_connections, PREDICTION_COLOR, "Predictions")
+            artists.extend([input_artists, pred_artists])
+            _style_3d_axis(axes_3d[0], "Isaac Lab input", limits)
+            _style_3d_axis(axes_3d[1], "GR00T predictions", limits)
+        else:
+            input_artists = _add_skeleton(axes_3d[0], skeleton[0], joint_connections, INPUT_COLOR, "Input")
+            artists.append(input_artists)
+            if layout == "overlay" and predictions is not None:
+                pred_artists = _add_skeleton(axes_3d[0], predictions[0], joint_connections, PREDICTION_COLOR, "Predictions")
+                artists.append(pred_artists)
+            _style_3d_axis(axes_3d[0], "Overlay" if layout == "overlay" else "Trajectory", limits)
 
-    ani = animation.FuncAnimation(
-        fig,
-        update,
-        frames=skeleton.shape[0],
-        interval=1000 / fps,
-        blit=False,
-        repeat=False,
-    )
-    writer = animation.FFMpegWriter(fps=fps, bitrate=5000)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    ani.save(str(output_path), writer=writer, dpi=dpi)
-    if hasattr(ani, "_draw_was_started"):
-        ani._draw_was_started = True
-    plt.close(fig)
+        time_marker = _add_motion_trace(trace_ax, skeleton, predictions, fps=fps, duration_s=duration_s)
+        fig.subplots_adjust(left=0.035, right=0.965, top=0.90, bottom=0.08, hspace=0.16, wspace=0.04)
+
+        def update(frame: int) -> list[object]:
+            _update_skeleton(artists[0], skeleton[frame], joint_connections)
+            if layout == "side-by-side":
+                if frame < int(predictions.shape[0]):
+                    _set_skeleton_visible(artists[1], True)
+                    _update_skeleton(artists[1], predictions[frame], joint_connections)
+                else:
+                    _set_skeleton_visible(artists[1], False)
+            elif layout == "overlay" and predictions is not None and len(artists) > 1:
+                if frame < int(predictions.shape[0]):
+                    _set_skeleton_visible(artists[1], True)
+                    _update_skeleton(artists[1], predictions[frame], joint_connections)
+                else:
+                    _set_skeleton_visible(artists[1], False)
+            time_marker.set_xdata([frame / fps, frame / fps])
+            updated: list[object] = [time_marker]
+            for skeleton_artists in artists:
+                updated.extend(skeleton_artists.all)
+            return updated
+
+        ani = animation.FuncAnimation(
+            fig,
+            update,
+            frames=skeleton.shape[0],
+            interval=1000 / fps,
+            blit=False,
+            repeat=False,
+        )
+        writer = animation.FFMpegWriter(fps=fps, bitrate=5000)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        ani.save(str(output_path), writer=writer, dpi=dpi)
+        if hasattr(ani, "_draw_was_started"):
+            ani._draw_was_started = True
+    finally:
+        plt.close(fig)
 
 
 def _validate_inputs(

--- a/npa/tests/test_matplotlib_render_cleanup.py
+++ b/npa/tests/test_matplotlib_render_cleanup.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import av
+import matplotlib
+import numpy as np
+import pytest
+
+from npa.viz.backends import matplotlib as backend
+
+
+matplotlib.use("Agg", force=True)
+import matplotlib.animation as animation  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Animation was deleted without rendering anything:UserWarning"
+)
+
+
+@pytest.fixture
+def caller_figure():
+    existing = set(plt.get_fignums())
+    fig = plt.figure()
+    yield fig
+    for number in set(plt.get_fignums()) - existing:
+        plt.close(number)
+
+
+def _render(output_path: Path) -> None:
+    skeleton = np.array(
+        [[[0, 0, 0], [0, 0, 1]], [[0, 0, 0], [0.5, 0, 1]], [[0, 0, 0], [1, 0, 1]]],
+        dtype=np.float32,
+    )
+    backend.render(skeleton, None, "single", output_path, (320, 240), 3, 1.0, "Synthetic motion", [(0, 1)])
+
+
+@pytest.mark.parametrize("failure_stage", ["layout", "frame", "save"])
+def test_render_failure_closes_only_its_figure(tmp_path, monkeypatch, caller_figure, failure_stage):
+    expected_figures = set(plt.get_fignums())
+    error = RuntimeError(f"{failure_stage} failed")
+
+    def fail(*args, **kwargs):
+        raise error
+
+    def save(self, *args, **kwargs):
+        self._func(0)
+
+    if failure_stage == "layout":
+        monkeypatch.setattr(backend, "_build_layout", fail)
+    elif failure_stage == "frame":
+        monkeypatch.setattr(backend, "_update_skeleton", fail)
+        monkeypatch.setattr(animation.Animation, "save", save)
+    else:
+        monkeypatch.setattr(animation.Animation, "save", fail)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _render(tmp_path / "failed.mp4")
+
+    assert excinfo.value is error
+    assert set(plt.get_fignums()) == expected_figures
+    assert plt.figure(caller_figure.number) is caller_figure
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="FFmpeg is required")
+def test_repeated_ffmpeg_failures_do_not_accumulate_figures(tmp_path, caller_figure):
+    output = tmp_path / "directory.mp4"
+    output.mkdir()
+    expected_figures = set(plt.get_fignums())
+    observed_figures = []
+
+    for _ in range(2):
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            _render(output)
+        assert excinfo.value.returncode != 0
+        assert excinfo.value.cmd[-1] == str(output)
+        assert "Is a directory" in excinfo.value.stderr
+        observed_figures.append(set(plt.get_fignums()))
+
+    assert observed_figures == [expected_figures, expected_figures]
+    assert plt.figure(caller_figure.number) is caller_figure
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="FFmpeg is required")
+def test_successful_mp4_is_decodable_and_preserves_caller_figure(tmp_path, caller_figure):
+    output = tmp_path / "motion.mp4"
+    expected_figures = set(plt.get_fignums())
+
+    _render(output)
+
+    assert set(plt.get_fignums()) == expected_figures
+    assert plt.figure(caller_figure.number) is caller_figure
+    with av.open(str(output)) as container:
+        stream = container.streams.video[0]
+        assert (stream.width, stream.height) == (320, 240)
+        assert stream.average_rate == 3
+        frames = list(container.decode(video=0))
+    assert len(frames) == 3
+    assert [float(frame.pts * frame.time_base) for frame in frames] == pytest.approx([0, 1 / 3, 2 / 3])
+    images = [frame.to_ndarray(format="rgb24") for frame in frames]
+    assert all(image.std() > 0 for image in images)
+    assert not np.array_equal(images[0], images[-1])


### PR DESCRIPTION
A failed Matplotlib layout update or FFmpeg encode leaves its figure registered in pyplot, so repeated conversions accumulate figures. Close the renderer-owned figure in `finally`, preserve caller-owned figures, and propagate the original error.

Validation: the new regression suite reproduced four failures on main and passes all five tests with the fix. Passed 39 focused tests, 114 onboarding smoke tests, 2,482 guardrail tests, and the full suite (13,643 passed, 38 skipped, 1 xpassed). Lint, docs drift, confidentiality, and secret scans passed. Two real FFmpeg output-open failures leave no extra figures; successful baseline and fixed MP4s are byte-identical and decode to three frames at 3 FPS and 320×240 pixels.
