### PR TITLE
docs: link coding agent guide under README Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ typed clients, callback wrappers, and their return values.
 
 ## Quickstart
 
+[Use Workbench with a coding agent](docs/workbench/agent-first-run.md).
+
 Three steps from a clone to a real result on Nebius.
 
 ### 1. Install `npa`


### PR DESCRIPTION
Adds a link to “Use Workbench with a coding agent” immediately below the root README’s Quickstart heading, making the existing first-run guide easier to find.

Validation: link target exists, `git diff --check` passed, and confidentiality and Gitleaks scans passed. Ruff and pytest collection could not run because the repository virtualenv lacks those modules.
