### PR TITLE
Fix cuRobo metadata and hashing on Python 3.10

### DIFF
--- a/npa/docker/workbench/curobo/filter_cudnn_runtime.py
+++ b/npa/docker/workbench/curobo/filter_cudnn_runtime.py
@@ -81,8 +81,11 @@ def filter_cudnn_runtime(site_packages: Path) -> dict:
         csv.writer(stream).writerows(records)
     retained = {}
     for name in sorted(set(runtime) | {f"{dist_info}/licenses/License.txt"}):
+        digest = hashlib.sha256()
         with (root / name).open("rb") as stream:
-            retained[name] = hashlib.file_digest(stream, "sha256").hexdigest()
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        retained[name] = digest.hexdigest()
     return {
         "schema_version": "npa.curobo.cudnn-runtime.v1",
         "version": dist.version,

--- a/npa/docker/workbench/curobo/verify_image.py
+++ b/npa/docker/workbench/curobo/verify_image.py
@@ -174,7 +174,7 @@ def verify_image(tarball: Path, *, expected_image_id: str, contract: dict | None
         findings.append({"code": code, "layer_index": layer, "entry_index": entry})
 
     with tarball.open("rb") as stream:
-        archive_hash = hashlib.file_digest(stream, "sha256").hexdigest()
+        archive_hash, _ = _hash_stream(stream)
     with tarfile.open(tarball, "r:*") as archive:
         outer = archive.getmembers()
         members = {_path(member.name): member for member in outer}

--- a/npa/src/npa/workbench/curobo/runner.py
+++ b/npa/src/npa/workbench/curobo/runner.py
@@ -47,11 +47,14 @@ def _benchmark_module():
         )
     for filename, expected in DATASET_FILES.values():
         path = dataset / "robometrics/content/dataset" / filename
+        digest = hashlib.sha256()
         with path.open("rb") as stream:
-            if hashlib.file_digest(stream, "sha256").hexdigest() != expected:
-                raise CuroboError(
-                    "benchmark YAML bytes do not match the pinned inventory"
-                )
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        if digest.hexdigest() != expected:
+            raise CuroboError(
+                "benchmark YAML bytes do not match the pinned inventory"
+            )
     _activate_dataset_imports(dataset)
     spec = importlib.util.spec_from_file_location(
         "npa_curobo_upstream_benchmark", source / "benchmark/motion_plan_benchmark.py"

--- a/npa/tests/docker/test_curobo_cudnn_runtime.py
+++ b/npa/tests/docker/test_curobo_cudnn_runtime.py
@@ -61,6 +61,15 @@ def test_only_runtime_and_license_bytes_remain_identical(package):
     assert LIBRARY in recorded and LICENSE in recorded
 
 
+def test_retained_library_digest_covers_the_complete_file(package):
+    root, apply_filter, _, _ = package
+    data = b"\x7fELF" + b"synthetic runtime\n" * 200_000 + b"final bytes\n"
+    (root / LIBRARY).write_bytes(data)
+    report = apply_filter(root)
+    assert report["retained_sha256"][LIBRARY] == hashlib.sha256(data).hexdigest()
+    assert (root / LIBRARY).read_bytes() == data
+
+
 @pytest.mark.parametrize(
     "extra",
     ["nvidia/cudnn/include/unreviewed.hpp", "nvidia/cudnn/hidden/cudnn.h", "nvidia/other/cudnn.h"],

--- a/npa/tests/docker/test_curobo_package_metadata.py
+++ b/npa/tests/docker/test_curobo_package_metadata.py
@@ -3,7 +3,11 @@
 import hashlib
 import importlib.util
 from pathlib import Path
-import tomllib
+
+try:  # tomllib is part of the standard library from Python 3.11.
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 import pytest
 

--- a/npa/tests/workbench/test_curobo_dataset_imports.py
+++ b/npa/tests/workbench/test_curobo_dataset_imports.py
@@ -62,6 +62,22 @@ def test_scrubbed_pythonpath_loads_only_verified_raw_dataset(source_trees):
     assert all(path.read_bytes() == payload for path, payload in before.items())
 
 
+@pytest.mark.parametrize("changed_tail", [False, True])
+def test_dataset_hash_covers_the_complete_file(source_trees, monkeypatch, changed_tail):
+    _, dataset = source_trees
+    data = b"verified data\n" * 200_000 + b"final bytes\n"
+    expected = hashlib.sha256(data).hexdigest()
+    path = dataset / "robometrics/content/dataset/test.yaml"
+    path.write_bytes(data[:-1] + b"!" if changed_tail else data)
+    monkeypatch.setattr(runner, "DATASET_FILES", {"test": ("test.yaml", expected)})
+    if changed_tail:
+        with pytest.raises(CuroboError, match="YAML bytes"):
+            runner._benchmark_module()
+        assert "robometrics" not in sys.modules
+    else:
+        assert runner._benchmark_module().OBSERVED_DATA == data.decode()
+
+
 def test_ambient_import_path_cannot_shadow_verified_dataset(source_trees, tmp_path):
     _, dataset = source_trees
     shadow = tmp_path / "shadow"


### PR DESCRIPTION
Python 3.10 cannot collect the cuRobo package-metadata tests because `tomllib` was added in Python 3.11. Use the existing conditional `tomli` dependency on Python 3.10 and retain the standard-library parser on newer versions.

The related dataset, cuDNN runtime, and image-verification paths also used Python 3.11-only `hashlib.file_digest`. Stream complete files through SHA-256 instead, preserving checksum verification before dataset imports. Multi-chunk regression cases verify unchanged bytes and reject corruption at the end of a file. The change is limited to six files and preserves the supported Python versions, assertions, and coverage threshold.

Validation:

- 171 cuRobo tests passed on Python 3.10 and 3.12; Python 3.10 genuinely lacks both newer standard-library APIs. Another 35 related TOML tests, 2,628 guardrail tests, and 385 security regression tests passed. Lint, confidentiality, and secret scans passed.
- The real GPU benchmark completed all 5,200 cases across both datasets and planning modes: 20 invalid cases, 5,162 successful trajectories, and 350,282 trajectory samples. Benchmark artifacts were independently verified and task-owned compute was cleaned up. The final visualization stage failed in unchanged Rerun schema handling; no successful end-to-end visualization is claimed.

GitHub CI is the full-suite merge gate. The interrupted local Python 3.10 coverage attempt initially failed because its live integration backend lacked the WebSocket dependency; that dependency was installed and the targeted live integration rerun passed. A broader local Python 3.12 attempt was interrupted at 87% after skill and adapter timeouts on the oversubscribed host. The skill timeout reproduced on the unchanged base; the adapter pair passed in isolation on both revisions. Neither interrupted full local attempt is reported as passing.