### PR TITLE
Fix PAIDF Cosmos3 degraded-result refinement

### DIFF
--- a/npa/src/npa/workflows/paidf_cosmos3.py
+++ b/npa/src/npa/workflows/paidf_cosmos3.py
@@ -538,7 +538,10 @@ def prepare_input(
 def _complete_evaluator_report(report: Any) -> dict[str, Any]:
     if not isinstance(report, dict):
         raise PaidfCosmos3Error("prior evaluator report is not a JSON object")
-    if report.get("status") != "completed" or not isinstance(
+    # ``degraded`` is a terminal fail-closed evaluator result.  It must never
+    # promote, but its explicit boolean decision and score are valid inputs to
+    # the next refinement attempt.
+    if report.get("status") not in {"completed", "degraded"} or not isinstance(
         report.get("passed"), bool
     ):
         raise PaidfCosmos3Error(

--- a/npa/tests/workflows/test_paidf_cosmos3.py
+++ b/npa/tests/workflows/test_paidf_cosmos3.py
@@ -180,8 +180,9 @@ def _generation_inputs(tmp_path: Path) -> dict[str, Path]:
 
 
 @requires_ffmpeg
+@pytest.mark.parametrize("prior_status", ["completed", "degraded"])
 def test_generate_variants_runs_real_runner_contract_and_changes_retry(
-    tmp_path: Path,
+    tmp_path: Path, prior_status: str,
 ) -> None:
     paths = _generation_inputs(tmp_path)
     storage = _MemoryStorage()
@@ -244,7 +245,7 @@ def test_generate_variants_runs_real_runner_contract_and_changes_retry(
     assert metadata["motion_preservation"] is None
 
     (paths["scores"] / "cosmos_evaluator.json").write_text(
-        json.dumps({"status": "completed", "passed": False, "score": 0.4}),
+        json.dumps({"status": prior_status, "passed": False, "score": 0.4}),
         encoding="utf-8",
     )
     calls.clear()


### PR DESCRIPTION
A PAIDF Cosmos3 run that receives a terminal degraded evaluator report correctly selects loop_back, but the next generate-variants attempt rejected that same report as incomplete. This change accepts degraded reports as refinement inputs only when they still contain an explicit boolean passed result and numeric score; degraded reports remain unable to promote through the quality gate.

Validation:
- 115 focused PAIDF and execution-preflight tests passed
- 114 onboarding smoke tests passed
- 2,676 guardrail tests passed
- Ruff and diff-scoped confidentiality scan passed
- The broader macOS suite reached 13,884 passing tests; Linux-specific controller and GNU-coreutils tests failed on missing /proc and BSD utility behavior, and a multi-node socket test timed out
