### PR TITLE
docs(skills): verify prompt content and preserve validation failures

### DIFF
--- a/skills/tools/token-factory/SKILL.md
+++ b/skills/tools/token-factory/SKILL.md
@@ -102,6 +102,17 @@ npa workbench token-factory generate \
 `--max-prompts 0` means all of them. Set a small non-zero value first: this is
 the command that turns a typo into a large token bill.
 
+Prompt parsing depends on the file extension. Keep plain prompt lines in a
+`.txt` file. Each nonempty `.jsonl` line must be a JSON string or an object with
+a `prompt`, `text`, or `instruction` field, not bare text. Use a JSON serializer
+when converting prompts, including prompts written by a workflow shell step.
+For a local, no-inference check, the installed
+`npa.workbench.token_factory._load_prompts(Path(...))` reader returns
+`(id, prompt)` pairs. Compare the prompt values and count with the requested
+input. This is an internal Python helper, not a CLI validation command;
+confirm it exists in the installed version before using it. It does not verify
+remote staging or model access.
+
 **Batch text generation** — same prompt file, same `generations.jsonl`, batch
 token rates, default model `openai/gpt-oss-120b`:
 

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -72,6 +72,18 @@ intended input, perform the requested operation, and produce the stated output?
 Valid syntax alone cannot establish this. Report a mismatch as incomplete work,
 not success, even when validation and planning commands pass.
 
+Preserve failures in authoring and validation commands as well as workflow steps.
+Run checks separately, or stop the command group at the first failure and return
+that exit code. A later successful command must not hide an earlier failure.
+If a search tool is unavailable, report its failure before using an available
+alternative in a separate command.
+
+Check input content with the consuming tool's local reader when available, not
+just file existence or YAML validation. For a step that creates its own input,
+check the generated format and prompt content without executing inference.
+Keep an unchecked input unverified in the readiness record; do not claim task
+fidelity from the workflow hash or planned command alone.
+
 When saving a workflow, read [the readiness template](references/readiness-record.md)
 and save `<workflow-stem>.readiness.json` beside it, within the authorized write
 scope. Bind the record to the final workflow bytes. Record planning results and


### PR DESCRIPTION
Follow-up to #399: update the workflow-authoring and Token Factory skills to catch incorrect inputs and preserve command failures.

- Keep failed authoring and validation commands visible, even when a later command succeeds.
- Compare parsed prompts and their count with the requested input. Valid JSONL can still contain the wrong prompt.
- Explain how file extensions control parsing and how to check the internal reader's `(id, prompt)` pairs. Local parsing does not verify remote input staging or model access.

Only two skill bodies change. CLI behavior, skill loading, discovery metadata and model defaults are unchanged.

Validation against main `402138a4767d09af66b33686465325f14d42e7da`:

- Linux Python 3.12 `make test`: 17,282 passed, zero failures/errors, 27 skipped and one expected-failure test passed (non-strict XPASS).
- Serial CI-style coverage: 17,310 passed, zero failures/errors, 424 skipped and one non-strict XPASS. Package coverage was 75.66%, above the 60% minimum.
- Mocked Cypress tests: 146 passed across eight spec files, with no failures or skips. CLI documentation drift passed.
- All 385 runtime security tests passed with CPU PyTorch 2.13.0.
- Also passed: 140 focused tests, 2,603 guardrails, 114 onboarding tests and 21 private negative-case tests. Counts overlap and must not be added. Ruff and diff-scoped confidentiality and secret scans passed.
- Three fresh hosted Codex subagent tasks completed authentication diagnosis, wrong-prompt correction and stale-readiness review. Independent checks confirmed the generated workflow's input, CLI validation and plan, and readiness record's workflow hash. These known-task checks do not establish general reliability or time/token savings.

Earlier environment failures were resolved without changing product code. All 190 Mac failure-case IDs and 35 error-case IDs match passed results in the final Linux log.

These are local results against the pinned revision. GitHub CI, including the scanner-comparison gate added to main afterward, remains to be verified on the proposed merge.

No workload inference, workflow submission or cloud-resource changes were performed.
