### PR TITLE
Prevent PAIDF Cosmos3 double-exposure video publication

### DIFF
--- a/docs/workbench/guides/paidf-cosmos3.md
+++ b/docs/workbench/guides/paidf-cosmos3.md
@@ -42,11 +42,15 @@ Generation behavior is configuration-driven through `cosmos3_checkpoint`,
 decouples appearance-profile sampling from the run ID for reproducible quality
 comparisons. Quality and retries use
 `grade_threshold`, `refinement_iterations`, `retry_seed_stride`,
-`retry_guidance_delta`, and `retry_steps_delta`. `source_motion_weight` controls
-the source-motion-preserving composite used for publication (the workflow uses
-`0.8`, retaining 20% of the real Cosmos appearance treatment). The unmodified
-Cosmos video is preserved beside the composite, so model output and post-process
-provenance remain independently auditable. The composition requires
+`retry_guidance_delta`, and `retry_steps_delta`. `source_motion_weight` is a
+compatibility setting that must be `0.0` (the default). Nonzero values fail
+before generation. Publication copies the model output bytes without blending,
+resizing, or changing the frame rate, and records their SHA-256 digest.
+The check lives in the shared generation implementation, so custom workflows
+using `workbench.cosmos3.generate_variants` and direct CLI callers receive the
+same protection for any dataset. Existing deployed images need the updated code;
+setting the workflow value to zero also disables blending in the older publisher.
+The composition requires
 `video2video`: selecting a text-to-video or image-to-video mode fails before GPU
 inference rather than producing a misleading source-conditioned claim.
 
@@ -55,6 +59,27 @@ pinned OpenMDW-1.1 framework source but no weights. The operator supplies
 `HF_TOKEN` at runtime after accepting the checkpoint, Wan VAE, and
 `nvidia/Cosmos-Guardrail1` terms. Tokens and model weights are never serialized
 into artifacts or Git.
+
+### Double exposure in older runs
+
+Older workflow defaults blended 80% source pixels with 20% generated pixels.
+Because the model can move the camera, cloth, or grippers, this superimposed
+different scenes and produced translucent duplicate objects. Alpha blending
+does not align motion. Existing run artifacts and their rejection reports stay
+unchanged; retrieve each variant's `raw_cosmos_video.mp4` into a fresh output
+location to inspect the unblended result without repeating GPU generation.
+Those bytes require their own evaluation before acceptance.
+
+Removing the blend does not correct model drift or establish full-episode
+augmentation. Framework [video2video defaults](https://github.com/NVIDIA/cosmos-framework/blob/5e67049cd94acb667786f1e6dd0dab821cb90c97/cosmos_framework/inference/args.py)
+condition on the first two latent
+frames and generate a fixed-length segment; passing a long source file alone
+does not provide structural controls across its full duration. For complete
+source-motion conditioning, see the separately deployed
+[Nano augmentation path](../../../npa/deploy/cosmos3-nano-video/README.md#source-conditioned-visual-augmentation),
+which uses matching source-edge controls for each interval. That deployment has
+its own media and guardrail contract. Keep the acceptance threshold unchanged
+and inspect duration, identity, motion, and contacts independently of decoding.
 
 ## Artifact contract
 
@@ -65,7 +90,6 @@ cosmos_augmented/
   manifest.json
   variant-0000/
     augmented_video.mp4
-    raw_cosmos_video.mp4
     frame-00001.png
     metadata.json
 ```
@@ -73,8 +97,9 @@ cosmos_augmented/
 Each metadata file records the real engine (`nvidia-cosmos/cosmos-framework`),
 `video2video` mode, source-video conditioning, checkpoint, seed, guidance,
 steps, attempt number, guardrail posture, non-baked weights, and input lineage.
-When motion preservation is enabled, it also records source/Cosmos weights and
-SHA-256 digests for both the raw model output and published composite.
+It records `motion_preservation: null` and the published model video's SHA-256
+digest. Older blended runs additionally contain `raw_cosmos_video.mp4` and
+compositing metadata; those are retained historical evidence.
 The run manifest records non-empty video bytes, variant count, actual GPU
 parallelism, and the same conditioning contract.
 
@@ -108,6 +133,15 @@ accelerator through the normal workflow resource override; do not put cluster
 names into the spec.
 
 ## Live validation scope
+
+The publication regression can reuse retained real GPU output without generating
+again. Run `npa/tests/e2e/test_paidf_cosmos3_publication_live.py` with
+`NPA_INTEGRATION_E2E=1`, `NPA_PAIDF_RAW_EVIDENCE_DIR` pointing to downloaded
+variant directories, `NPA_PAIDF_REPAIR_URI` set to a fresh S3 augment prefix, and
+`NPA_PAIDF_REPAIR_DIR` set to a private local readback directory. It requires
+saved raw-output hashes, uploads through the real publisher, and verifies exact
+bytes after S3 readback. This proves publication fidelity, not generation quality
+or training acceptance.
 
 The complete synthetic workflow has succeeded on reserved RTX PRO 6000, and
 real source-conditioned Cosmos 3 inference plus refinement semantics have

--- a/npa/src/npa/cli/workbench/cosmos3.py
+++ b/npa/src/npa/cli/workbench/cosmos3.py
@@ -390,8 +390,8 @@ def generate_variants_cmd(
         0.0,
         "--source-motion-weight",
         help=(
-            "Blend this source-video weight into the published variant while "
-            "preserving the unmodified Cosmos output; zero disables compositing."
+            "Compatibility option; must be zero. Source/model blending creates "
+            "ghosting, so variants publish unmodified model output."
         ),
     ),
 ) -> None:

--- a/npa/src/npa/workflows/paidf_cosmos3.py
+++ b/npa/src/npa/workflows/paidf_cosmos3.py
@@ -619,74 +619,37 @@ def _caption_text(payload: Any) -> str:
     return " ".join(captions[:4])
 
 
-def _preserve_source_motion(
-    source: Path,
-    generated: Path,
-    destination: Path,
-    *,
-    source_weight: float,
-) -> None:
-    """Composite Cosmos appearance onto the source motion and camera geometry.
-
-    Cosmos 3 Nano can produce a useful appearance treatment while drifting the
-    camera or foreground trajectory.  This post-process retains the generated
-    pixels, but anchors them to the source stream's resolution, frame cadence,
-    and motion.  The unmodified framework artifact is published beside the
-    composite so the transformation remains independently auditable.
-    """
-
-    if not 0.0 < source_weight < 1.0:
-        raise PaidfCosmos3Error(
-            "source motion weight must be strictly between 0 and 1"
-        )
-    ffmpeg = shutil.which("ffmpeg")
-    if not ffmpeg:
-        raise PaidfCosmos3Error(
-            "ffmpeg is required for source-motion-preserving publication"
-        )
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    cosmos_weight = 1.0 - source_weight
-    filter_graph = (
-        "[1:v][0:v]scale2ref[model][source];"
-        f"[source][model]blend=all_expr='A*{source_weight:.6f}+"
-        f"B*{cosmos_weight:.6f}':shortest=1[out]"
-    )
-    completed = subprocess.run(
-        [
-            ffmpeg,
-            "-y",
-            "-v",
-            "error",
-            "-i",
-            str(source),
-            "-i",
-            str(generated),
-            "-filter_complex",
-            filter_graph,
-            "-map",
-            "[out]",
-            "-an",
-            "-c:v",
-            "libx264",
-            "-pix_fmt",
-            "yuv420p",
-            str(destination),
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if (
-        completed.returncode
-        or not destination.is_file()
-        or destination.stat().st_size <= 0
-    ):
-        detail = str(
-            completed.stderr or completed.stdout or "ffmpeg produced no output"
-        )[:300]
-        raise PaidfCosmos3Error(
-            f"source-motion-preserving publication failed: {detail}"
-        )
+def _variant_metadata(
+    clip: str,
+    variables: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+    artifact: Path,
+    frame_count: int,
+) -> dict[str, Any]:
+    return {
+        "schema": MANIFEST_SCHEMA,
+        "status": "executed",
+        "engine": ENGINE,
+        "mode": VIDEO_MODE,
+        "clip": clip,
+        "variables": dict(variables),
+        "prompt": str(metadata["prompt"]),
+        "input_conditioned": True,
+        "input_conditioning": "source-video",
+        "conditioned_input": "source.mp4",
+        "model": str(metadata["model"]),
+        "seed": int(metadata["seed"]),
+        "guidance": float(metadata["guidance"]),
+        "steps": int(metadata["steps"]),
+        "guardrails": bool(metadata["guardrails"]),
+        "weights_baked": False,
+        "attempt": int(metadata["attempt"]),
+        "lineage": {"input_provenance_uri": str(metadata["input_provenance_uri"])},
+        "video_bytes": artifact.stat().st_size,
+        "frame_count": frame_count,
+        "motion_preservation": None,
+        "published_video_sha256": _sha256(artifact),
+    }
 
 
 def _publish_variant(
@@ -697,66 +660,21 @@ def _publish_variant(
     variables: Mapping[str, Any],
     metadata: Mapping[str, Any],
     storage: Any,
-    source_video: Path,
-    source_motion_weight: float,
 ) -> dict[str, Any]:
     if not _is_s3(output_uri):
         raise PaidfCosmos3Error(
             "PAIDF Cosmos 3 variant publication requires an s3:// output URI"
         )
     base = output_uri.rstrip("/") + f"/{clip}/"
-    raw_artifact = Path(str(result["output_path"]))
-    if not raw_artifact.is_file() or raw_artifact.stat().st_size <= 0:
+    artifact = Path(str(result["output_path"]))
+    if not artifact.is_file() or artifact.stat().st_size <= 0:
         raise PaidfCosmos3Error("Cosmos 3 returned an empty video artifact")
-    artifact = raw_artifact
-    postprocess: dict[str, Any] | None = None
-    if source_motion_weight:
-        artifact = raw_artifact.with_name("motion-preserved.mp4")
-        _preserve_source_motion(
-            source_video,
-            raw_artifact,
-            artifact,
-            source_weight=source_motion_weight,
-        )
-        raw_uri = base + "raw_cosmos_video.mp4"
-        storage.upload_file(str(raw_artifact), raw_uri)
-        postprocess = {
-            "engine": "ffmpeg-source-motion-composite",
-            "source_weight": source_motion_weight,
-            "cosmos_weight": 1.0 - source_motion_weight,
-            "raw_cosmos_video_uri": raw_uri,
-            "raw_cosmos_video_bytes": raw_artifact.stat().st_size,
-            "raw_cosmos_video_sha256": _sha256(raw_artifact),
-            "published_video_sha256": _sha256(artifact),
-        }
     storage.upload_file(str(artifact), base + "augmented_video.mp4")
     with tempfile.TemporaryDirectory(prefix="npa-paidf-c3-publish-") as tmp:
         frames = _extract_frames(artifact, Path(tmp) / "frames")
         for frame in frames:
             storage.upload_file(str(frame), base + frame.name)
-        clip_meta = {
-            "schema": MANIFEST_SCHEMA,
-            "status": "executed",
-            "engine": ENGINE,
-            "mode": VIDEO_MODE,
-            "clip": clip,
-            "variables": dict(variables),
-            "prompt": str(metadata["prompt"]),
-            "input_conditioned": True,
-            "input_conditioning": "source-video",
-            "conditioned_input": "source.mp4",
-            "model": str(metadata["model"]),
-            "seed": int(metadata["seed"]),
-            "guidance": float(metadata["guidance"]),
-            "steps": int(metadata["steps"]),
-            "guardrails": bool(metadata["guardrails"]),
-            "weights_baked": False,
-            "attempt": int(metadata["attempt"]),
-            "lineage": {"input_provenance_uri": str(metadata["input_provenance_uri"])},
-            "video_bytes": artifact.stat().st_size,
-            "frame_count": len(frames),
-            "motion_preservation": postprocess,
-        }
+        clip_meta = _variant_metadata(clip, variables, metadata, artifact, len(frames))
         _write_json(clip_meta, base + "metadata.json", storage=storage)
     return {
         "clip": clip,
@@ -767,7 +685,7 @@ def _publish_variant(
         "guidance": clip_meta["guidance"],
         "steps": clip_meta["steps"],
         "variables": dict(variables),
-        "motion_preservation": postprocess,
+        "motion_preservation": None,
     }
 
 
@@ -829,9 +747,10 @@ def generate_variants(
         raise PaidfCosmos3Error(
             "variant count, parallelism, and steps must be positive"
         )
-    if motion_weight and not 0.0 < motion_weight < 1.0:
+    if motion_weight != 0.0:
         raise PaidfCosmos3Error(
-            "source motion weight must be zero or strictly between 0 and 1"
+            "source_motion_weight must be 0: source/model blending creates "
+            "ghosting and does not preserve motion; publish unmodified model output"
         )
     client = storage or _storage()
     attempt, prior = _load_attempt(attempt_uri, scores_uri, storage=client)
@@ -925,8 +844,6 @@ def generate_variants(
                         "input_provenance_uri": input_provenance_uri,
                     },
                     storage=client,
-                    source_video=Path(local_input),
-                    source_motion_weight=motion_weight,
                 )
             )
     finally:

--- a/npa/tests/e2e/test_paidf_cosmos3_publication_live.py
+++ b/npa/tests/e2e/test_paidf_cosmos3_publication_live.py
@@ -1,0 +1,78 @@
+"""Verify unblended publication of retained real Cosmos outputs through S3.
+
+Set NPA_INTEGRATION_E2E=1, NPA_PAIDF_RAW_EVIDENCE_DIR (downloaded variant
+directories with raw_cosmos_video.mp4 and metadata.json), NPA_PAIDF_REPAIR_URI
+(a fresh S3 augment prefix), and NPA_PAIDF_REPAIR_DIR (private local readback).
+This exercises publication without submitting GPU generation or promoting data.
+"""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from npa.clients.credentials import load_credentials
+from npa.clients.storage import StorageClient
+from npa.workflows import paidf_cosmos3 as c3
+
+pytestmark = pytest.mark.e2e
+
+
+def _publication_inputs():
+    names = ("NPA_PAIDF_RAW_EVIDENCE_DIR", "NPA_PAIDF_REPAIR_URI", "NPA_PAIDF_REPAIR_DIR")
+    if os.environ.get("NPA_INTEGRATION_E2E") != "1" or any(
+        not os.environ.get(name) for name in names
+    ):
+        pytest.skip("requires retained real model output and a fresh private destination")
+    source, destination, readback = (os.environ[name] for name in names)
+    credentials = load_credentials()
+    storage = StorageClient.from_environment(
+        endpoint_url=credentials.s3_endpoint,
+        aws_access_key_id=credentials.s3_access_key_id,
+        aws_secret_access_key=credentials.s3_secret_access_key,
+    )
+    return Path(source), destination, Path(readback), storage
+
+
+def _publish_retained_clip(folder, destination, storage):
+    metadata = json.loads((folder / "metadata.json").read_text())
+    raw = folder / "raw_cosmos_video.mp4"
+    digest = hashlib.sha256(raw.read_bytes()).hexdigest()
+    assert metadata["engine"] == c3.ENGINE
+    assert digest == metadata["motion_preservation"]["raw_cosmos_video_sha256"]
+    assert not c3._list_keys(destination + "/" + folder.name, storage=storage)
+    metadata["input_provenance_uri"] = metadata["lineage"]["input_provenance_uri"]
+    variant = c3._publish_variant(
+        result={"output_path": str(raw)}, output_uri=destination,
+        clip=folder.name, variables=metadata["variables"], metadata=metadata,
+        storage=storage,
+    )
+    return variant, digest
+
+
+@pytest.mark.timeout(0)
+def test_retained_cosmos_outputs_publish_without_blending():
+    source, destination, readback, storage = _publication_inputs()
+    folders = sorted(path.parent for path in source.glob("*/raw_cosmos_video.mp4"))
+    assert folders, "requires real retained Cosmos generation artifacts"
+    receipts = []
+    for folder in folders:
+        variant, digest = _publish_retained_clip(folder, destination, storage)
+        local = readback / folder.name
+        local.mkdir(mode=0o700, parents=True, exist_ok=True)
+        video = local / "augmented_video.mp4"
+        storage.download_path(variant["augmented_video_uri"], str(video))
+        assert hashlib.sha256(video.read_bytes()).hexdigest() == digest
+        metadata_uri = variant["augmented_video_uri"].rsplit("/", 1)[0] + "/metadata.json"
+        storage.download_path(metadata_uri, str(local / "metadata.json"))
+        metadata = json.loads((local / "metadata.json").read_text())
+        assert metadata["motion_preservation"] is None
+        assert metadata["published_video_sha256"] == digest
+        assert variant["frame_count"] > 0
+        receipts.append({**variant, "published_video_sha256": digest})
+    (readback / "publication-evidence.json").write_text(json.dumps({
+        "variants": receipts, "gpu_generation_submitted": False,
+        "publication_verified": True, "training_approved": False,
+    }, indent=2) + "\n")

--- a/npa/tests/orchestration/npa_workflow/test_paidf_cosmos3_workflow.py
+++ b/npa/tests/orchestration/npa_workflow/test_paidf_cosmos3_workflow.py
@@ -89,6 +89,8 @@ def test_configuration_surface_and_privacy_defaults() -> None:
     ):
         assert key in config
     assert config["cosmos3_mode"] == "video2video"
+    assert float(config["source_motion_weight"]) == 0.0
+    assert float(config["grade_threshold"]) == 0.75
     assert config["augmentation_seed"] == ""
     assert (
         doc["states"]["generate-configs"]["run"]["argv"][-1]

--- a/npa/tests/workflows/test_paidf_cosmos3.py
+++ b/npa/tests/workflows/test_paidf_cosmos3.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import shutil
 import subprocess
@@ -187,12 +188,13 @@ def test_generate_variants_runs_real_runner_contract_and_changes_retry(
     paths = _generation_inputs(tmp_path)
     storage = _MemoryStorage()
     calls: list[dict] = []
+    generated_video = _tiny_video(tmp_path / "generated.mp4", color="red")
 
     def fake_generator(**kwargs):
         calls.append(kwargs)
         artifact = Path(kwargs["output_path"]) / kwargs["name"] / "vision.mp4"
         artifact.parent.mkdir(parents=True)
-        shutil.copy2(paths["source"], artifact)
+        shutil.copy2(generated_video, artifact)
         return {"output_path": str(artifact), "output_bytes": artifact.stat().st_size}
 
     args = (
@@ -243,6 +245,11 @@ def test_generate_variants_runs_real_runner_contract_and_changes_retry(
     assert metadata["conditioned_input"] == "source.mp4"
     assert metadata["weights_baked"] is False
     assert metadata["motion_preservation"] is None
+    generated_bytes = generated_video.read_bytes()
+    assert generated_bytes != paths["source"].read_bytes()
+    for variant in first["variants"]:
+        assert storage.objects[variant["augmented_video_uri"]] == generated_bytes
+    assert metadata["published_video_sha256"] == hashlib.sha256(generated_bytes).hexdigest()
 
     (paths["scores"] / "cosmos_evaluator.json").write_text(
         json.dumps({"status": prior_status, "passed": False, "score": 0.4}),
@@ -259,61 +266,6 @@ def test_generate_variants_runs_real_runner_contract_and_changes_retry(
     assert {call["seed"] for call in calls} == {110, 111}
     assert {call["guidance"] for call in calls} == {4.5}
     assert {call["num_steps"] for call in calls} == {22}
-
-
-@requires_ffmpeg
-def test_generate_variants_preserves_raw_cosmos_and_source_motion(tmp_path: Path) -> None:
-    paths = _generation_inputs(tmp_path)
-    storage = _MemoryStorage()
-
-    def fake_generator(**kwargs):
-        artifact = Path(kwargs["output_path"]) / kwargs["name"] / "vision.mp4"
-        _tiny_video(artifact, color="red")
-        return {"output_path": str(artifact), "output_bytes": artifact.stat().st_size}
-
-    manifest = c3.generate_variants(
-        str(paths["source"]),
-        str(paths["provenance"]),
-        str(paths["captions"]),
-        str(paths["configs"]),
-        "s3://example-bucket/run/cosmos_augmented/",
-        str(paths["scores"]),
-        str(paths["attempt"]),
-        "video2video",
-        "Cosmos3-Nano",
-        "Preserve the robot motion.",
-        "distortion",
-        10,
-        5.0,
-        20,
-        1,
-        1,
-        100,
-        -0.5,
-        2,
-        "latency",
-        True,
-        "test-run",
-        0.8,
-        storage=storage,
-        environ={"CUDA_VISIBLE_DEVICES": "0"},
-        generator=fake_generator,
-    )
-
-    variant = manifest["variants"][0]
-    motion = variant["motion_preservation"]
-    assert motion["engine"] == "ffmpeg-source-motion-composite"
-    assert motion["source_weight"] == 0.8
-    assert motion["cosmos_weight"] == pytest.approx(0.2)
-    assert motion["raw_cosmos_video_bytes"] > 0
-    assert len(motion["raw_cosmos_video_sha256"]) == 64
-    assert len(motion["published_video_sha256"]) == 64
-    assert motion["raw_cosmos_video_uri"] in storage.objects
-    assert variant["augmented_video_uri"] in storage.objects
-    assert (
-        storage.objects[motion["raw_cosmos_video_uri"]]
-        != storage.objects[variant["augmented_video_uri"]]
-    )
 
 
 @requires_ffmpeg
@@ -469,60 +421,23 @@ def test_extract_frames_reports_missing_ffmpeg_as_domain_error(
         c3._extract_frames(tmp_path / "video.mp4", tmp_path / "frames")
 
 
-@pytest.mark.parametrize("source_weight", [-0.1, 1.0, 1.1])
-def test_preserve_source_motion_rejects_out_of_range_weights(
-    tmp_path: Path, source_weight: float
+@pytest.mark.parametrize("source_weight", [-0.1, 0.2, 0.8, 1.0, 1.1, float("nan"), float("inf")])
+def test_generate_variants_rejects_blending_before_storage_or_gpu(
+    monkeypatch: pytest.MonkeyPatch, source_weight: float,
 ) -> None:
-    with pytest.raises(
-        c3.PaidfCosmos3Error,
-        match="source motion weight must be strictly between 0 and 1",
-    ):
-        c3._preserve_source_motion(
-            tmp_path / "source.mp4",
-            tmp_path / "generated.mp4",
-            tmp_path / "output.mp4",
-            source_weight=source_weight,
-        )
+    def unexpected_work(*_args, **_kwargs):
+        pytest.fail("invalid blend setting reached storage or GPU work")
 
-
-def test_preserve_source_motion_reports_missing_ffmpeg(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(c3.shutil, "which", lambda _binary: None)
-
-    with pytest.raises(
-        c3.PaidfCosmos3Error,
-        match="ffmpeg is required for source-motion-preserving publication",
-    ):
-        c3._preserve_source_motion(
-            tmp_path / "source.mp4",
-            tmp_path / "generated.mp4",
-            tmp_path / "output.mp4",
-            source_weight=0.5,
-        )
-
-
-def test_preserve_source_motion_reports_ffmpeg_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(c3.shutil, "which", lambda _binary: "/usr/bin/ffmpeg")
-    monkeypatch.setattr(
-        c3.subprocess,
-        "run",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
-            args=["ffmpeg"], returncode=1, stdout="", stderr="blend failed"
-        ),
-    )
-
-    with pytest.raises(
-        c3.PaidfCosmos3Error,
-        match="source-motion-preserving publication failed: blend failed",
-    ):
-        c3._preserve_source_motion(
-            tmp_path / "source.mp4",
-            tmp_path / "generated.mp4",
-            tmp_path / "output.mp4",
-            source_weight=0.5,
+    monkeypatch.setattr(c3, "_storage", unexpected_work)
+    monkeypatch.setattr(c3, "_visible_gpu_ids", unexpected_work)
+    with pytest.raises(c3.PaidfCosmos3Error, match="source_motion_weight must be 0"):
+        c3.generate_variants(
+            "missing.mp4", "provenance.json", "captions/", "configs/",
+            "s3://example-bucket/out/", "scores/", "attempt.json",
+            "video2video", "Cosmos3-Nano", "prompt", "",
+            1, 5.0, 24, 1, 1, 1000, -0.5, 4, "latency", True, "test-run",
+            source_motion_weight=source_weight,
+            generator=unexpected_work,
         )
 
 

--- a/skills/tools/workbench-tool/SKILL.md
+++ b/skills/tools/workbench-tool/SKILL.md
@@ -61,3 +61,24 @@ in sync. Prefer standardizing new tools on `--input-path`/`--output-path`.
 The full contract — literal-value rules, wrapper templates, reachability, image
 routing, and the local check that proves an argv can run — is in
 `skills/atomic/toolref-argv-contract/SKILL.md`.
+
+## Generated Video Publication
+
+Publish generated video bytes unchanged unless the tool explicitly declares a
+required transform, such as removing repeated conditioning frames at segment
+joins. Never alpha-blend source and generated frames to claim preservation of
+motion, geometry, or identity: unaligned scenes produce double exposures.
+Source-motion preservation belongs in model conditioning and quality validation.
+
+Keep source video, model output, and labeled comparison media distinct. Record
+any declared transform and retain its input artifacts. Validate the exact bytes
+delivered to downstream consumers; a source-heavy composite must not substitute
+for the model output in an acceptance evaluation. Test publication with model
+output that differs from the source, and verify artifact hashes after readback.
+
+The PAIDF Cosmos3 publisher enforces this through a zero-only legacy
+`source_motion_weight` setting and publishes an output SHA-256. The restriction
+applies to every workflow invoking `workbench.cosmos3.generate_variants`,
+independently of dataset, camera, prompt, or workflow name. Transfer 2.5 and the
+general Cosmos3 publisher already upload model videos directly; Nano augmentation
+removes duplicate conditioning prefixes and concatenates without blending.

--- a/workflows/main/paidf-cosmos3.yaml
+++ b/workflows/main/paidf-cosmos3.yaml
@@ -41,10 +41,9 @@ config:
   retry_seed_stride: "1000"
   retry_guidance_delta: "-0.5"
   retry_steps_delta: "4"
-  # Preserve source camera/motion while retaining 20% of the real Cosmos
-  # appearance treatment. The unmodified Cosmos video remains beside the
-  # published composite for evaluator and provenance audit.
-  source_motion_weight: "0.8"
+  # Publish unmodified model output. Blending unaligned source/model frames
+  # creates double exposures and cannot preserve source motion.
+  source_motion_weight: "0.0"
   grade_threshold: "0.75"
   # Cosmos Evaluator defaults to the ranking observation policy. Workflows that
   # perform a separate final selection override this per state with `holdout`.
@@ -187,8 +186,8 @@ states:
     description: >-
       Run one real npa-cosmos3/cosmos-framework video2video inference per variant.
       The source input, captions, prompt, model, seed, guardrails, and lineage are
-      recorded in per-variant metadata and the run manifest. The configured
-      source-motion composite keeps the raw Cosmos artifact for audit.
+      recorded in per-variant metadata and the run manifest. Publication
+      preserves the unmodified Cosmos artifact for evaluation.
     toolRef: workbench.cosmos3.generate_variants
     resources: gpu
     inputs:


### PR DESCRIPTION
PAIDF Cosmos3 published an 80% source / 20% model composite. When model-generated camera or object geometry diverged, the output showed translucent duplicate scenes. Publish the unmodified model video, record its SHA-256, reject nonzero `source_motion_weight` before storage or GPU inference, and default the workflow to zero.

The protection is in the shared generation implementation, so it applies to every dataset, custom workflow, and CLI caller using that stage. Document the same publication rule in the workbench tool skill. An audit found that the general Cosmos3 and Transfer 2.5 publishers already upload model videos directly; Nano augmentation concatenates intervals without blending.

Validation:

- 94 focused Cosmos3/PAIDF tests passed; 262 onboarding, skill, and PAIDF checks passed after the documentation update.
- 2,677 guardrail tests passed; Ruff, generated CLI docs, gitleaks, and confidentiality checks passed.
- The new live publication regression passed using two retained real GPU outputs: published S3 bytes matched the saved raw model hashes after readback. No GPU regeneration was needed.
- Independent evaluation of the unblended candidates scored 0.215294 against the unchanged 0.75 threshold; neither was accepted. Removing the composite does not fix model drift or establish full-episode structural conditioning.
- The local macOS security suite reported 337 passed, 8 skipped, 40 failed, and 35 setup/teardown errors. Representative `/proc` and GNU `mv -T` failures reproduce on the unchanged base commit. Linux CI remains the full platform check.

- The broad local run reached 17,066 passed, 71 skipped, 1 xpassed, 169 failed, and 35 errors before interruption after stalling at 99%. Its failures include missing Linux `unshare`/`memfd_create`/`flock`, Unix-socket path limits, and other host-dependent checks. This is not a clean full-suite result.

Existing deployed images need the updated code to enforce rejection of nonzero blend weights. Setting the workflow value to zero also disables blending in the older publisher. Existing rejected artifacts remain unchanged; recovered model outputs have separate publication and evaluation evidence.
