### PR TITLE
Validate Sim2Real reasoner images and preserve resume status

### DIFF
--- a/docs/workbench/container-image-catalog.md
+++ b/docs/workbench/container-image-catalog.md
@@ -83,6 +83,12 @@ arguments before cleanup. This is a coherent image and capability release, not
 a claim that the complete 14-stage workflow ran; the canonical run was blocked
 before launch because the required hosted Cosmos3 model was stopped upstream.
 
+This historical set predates the current MiniMax-compatible Stage 8/9 evaluator
+contract. It remains anonymously pullable, but cannot run the current canonical
+Sim2Real workflow with its MiniMax-M3 default. Select a newer coherent image set
+for that workflow; the [operator runbook](guides/sim2real-workflow.md#5-buildpush-once-and-prove-the-exact-image-pulls)
+explains explicit Cosmos 3 selection and the baked evaluator compatibility check.
+
 ## 2026-09-02 private-registry isolation audit
 
 All 31 accepted release tags and recorded digests resolved through anonymous

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -454,6 +454,11 @@ respective split.
 
 ## Resume and verify
 
+Resume planning preserves the recorded S3 run location and prior launch evidence.
+If a later preflight fails, status still resolves the existing runtime and its
+completed waves. To inspect a run from another operator machine, supply its exact
+`s3://<bucket>/sim2real/<run-id>/npa-workflow` URI to `workflow status`.
+
 ```bash
 npa/.venv/bin/npa workbench workflow status "${RUN_ID}" --project "${NPA_PROJECT}" --watch
 # after an operator/controller restart:

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -27,6 +27,22 @@ usable with an authorized endpoint serving it. Start a new run when changing
 models or upgrading this evaluator contract; Stage 9 verifies model identity,
 family, request accounting, and exact Stage 7 rollout coverage before PPO.
 
+Select the model explicitly with one of these submit overrides:
+
+```bash
+# Current public Token Factory default:
+--var cosmos3_model=MiniMaxAI/MiniMax-M3
+# An authorized endpoint that serves this exact Cosmos 3 model ID:
+--var cosmos3_model=nvidia/Cosmos3-Super-Reasoner
+```
+
+For a custom endpoint, set `NEBIUS_TOKEN_FACTORY_BASE_URL` privately and also
+pass `--secret-env NEBIUS_TOKEN_FACTORY_BASE_URL` to submit. This keeps the
+local access check and the remote evaluator on the same endpoint. Verify its
+key-scoped model list first. NPA never silently substitutes another model.
+The `cosmos3_model` name is retained for compatibility; it does not mean that a
+MiniMax evaluation is a Cosmos 3 evaluation.
+
 Isaac runtime warming and execution additionally require the operator to review
 the [NVIDIA Omniverse terms](https://docs.omniverse.nvidia.com/usd/latest/common/NVIDIA_Omniverse_License_Agreement.html),
 [Isaac Sim additional licenses](https://docs.isaacsim.omniverse.nvidia.com/latest/common/licenses.html),
@@ -159,7 +175,7 @@ Choose the digest-pinned Isaac image now, then warm a shared RWX cache. The
 template is the authoritative PVC/security/bootstrap contract:
 
 ```bash
-export NPA_ISAAC_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-isaac-lab@sha256:e321e8631c7e318b5012dad210d9cd1001b7dc833cbff0369e420c5c12657ab6'
+export NPA_ISAAC_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-isaac-lab@sha256:<selected-64-hex-digest>'
 sed "s|image: ghcr.io/nebius/nebius-physical-ai/npa-isaac-lab@sha256:<64-hex-digest>|image: ${NPA_ISAAC_IMAGE}|" \
   npa/docker/workbench/common/warm-isaac-cache.yaml | kubectl apply -f -
 kubectl wait --for=condition=complete job/npa-warm-isaac-cache --timeout=-1s
@@ -193,19 +209,26 @@ Relevant build entrypoints are
 `npa/docker/workbench/isaac-lab/build.sh`. Follow
 [build and push](../container-packaging.md) when images are absent.
 
-The five image digests below are the accepted coherent release set, built from
-`c164fd3480f8a9ea8f9df9ccb9509502fd527996` and verified anonymously on
-2026-09-05. Put them in shell variables, then reproduce the actual manifest
-pulls with the same config used by submit:
+Choose five images built from the same source commit containing the current
+Stage 8/9 hosted evaluator contract. The historical September 4 coherent release
+at `c164fd3480f8a9ea8f9df9ccb9509502fd527996` predates that contract: its
+Stage 8 only accepts Cosmos 3 and fails with the current MiniMax default.
+Anonymous pullability and a matching source SHA alone do not establish evaluator
+compatibility. Do not combine those historical digests with this workflow's
+current evaluator contract.
+
+Resolve the selected release or development tags to immutable digests, record
+their common source SHA, then reproduce the manifest pulls with the same config
+used by submit:
 
 ```bash
-export CONTROLLER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-sim2real-control@sha256:87fe8530710eea43364a21ad76dbe4b4c2d60e4b49705824fcdb62dc7d185af7'
-export TRANSFER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-cosmos2-transfer@sha256:0caddf68ccac1b69bd9fe3fb089bcc325a111059065452d31fdf0576629895d3'
-export ENVGEN_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-envgen@sha256:08eb75118f5a04194d33a60308212db7706dd9c339d74afc5471a58608bf0422'
+export CONTROLLER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-sim2real-control@sha256:<selected-64-hex-digest>'
+export TRANSFER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-cosmos2-transfer@sha256:<selected-64-hex-digest>'
+export ENVGEN_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-envgen@sha256:<selected-64-hex-digest>'
 export ISAAC_IMAGE="${NPA_ISAAC_IMAGE}"
-export VIEWER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-rerun-viewer@sha256:4c09c9cf3c14606db8e45c8ee564388888cd3261448f7c3f1304bfdfb1b9e5b2'
+export VIEWER_IMAGE='ghcr.io/nebius/nebius-physical-ai/npa-rerun-viewer@sha256:<selected-64-hex-digest>'
 export SPEC=workflows/main/sim2real.yaml
-export SOURCE_SHA=c164fd3480f8a9ea8f9df9ccb9509502fd527996
+export SOURCE_SHA='<selected-full-40-character-source-sha>'
 
 npa/.venv/bin/npa workbench workflow preflight-images "${SPEC}" \
   --project "${NPA_PROJECT}" \
@@ -223,6 +246,12 @@ npa/.venv/bin/npa workbench workflow preflight-images "${SPEC}" \
 `NPA_IMAGE_SOURCE_SHA` in every selected Sim2Real image. Supply the SHA attested
 by the coherent image set you selected; do not assume the current repository
 checkout matches those image bytes.
+
+The generated setup executes a network-free evaluator check using each image's
+baked interpreter. The first CPU stage verifies support for the exact selected
+model and rejection of an empty Stage 8/9 boundary before any GPU wave starts.
+An incompatible image fails with the model ID and migration guidance. This
+check makes no hosted inference request and does not modify the image source.
 
 Expected: every image is pullable and bootstrap-compatible. `not_found` means
 build/push the printed image; `forbidden` means fix the exact-host registry

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -300,24 +300,14 @@ def prepare_run_cmd(
             workflow_identity=spec.name,
             resume_run=requested,
         )
-        from npa.orchestration.npa_workflow.submission_state import (
-            update_submission_state,
-        )
+        from npa.orchestration.npa_workflow.submission_state import record_submission_plan
 
-        update_submission_state(
+        record_submission_plan(
             project or "default",
             prepared.run_id,
-            {
-                "launch_state": "reserved",
-                "workflow": {
-                    "name": spec.name,
-                    "kind": "npa.workflow/v0.0.1",
-                },
-                "planning": {
-                    "state": "durable",
-                    "source": "prepare-run",
-                },
-            },
+            workflow={"name": spec.name, "kind": "npa.workflow/v0.0.1"},
+            planning={"state": "durable", "source": "prepare-run"},
+            launch_state="reserved",
         )
     except Exception as exc:
         _fail(str(exc))
@@ -1622,27 +1612,17 @@ def submit_cmd(
                     new_run_id="" if resume else resolved_run_id,
                     persist=True,
                 )
-                from npa.orchestration.npa_workflow.submission_state import (
-                    update_submission_state,
-                )
+                from npa.orchestration.npa_workflow.submission_state import record_submission_plan
 
-                update_submission_state(
+                record_submission_plan(
                     project or "default",
                     resolved_run_id,
-                    {
-                        "launch_state": "planned",
-                        "workflow": {
-                            "name": workflow_identity,
-                            "kind": "npa.workflow/v0.0.1",
-                        },
-                        "planning": {
-                            "state": "durable",
-                            "source_action": source_action,
-                            "input_action": "planned"
-                            if is_paidf_spec
-                            else "not-required",
-                            "infra_context": infra_context,
-                        },
+                    workflow={"name": workflow_identity, "kind": "npa.workflow/v0.0.1"},
+                    planning={
+                        "state": "durable",
+                        "source_action": source_action,
+                        "input_action": "planned" if is_paidf_spec else "not-required",
+                        "infra_context": infra_context,
                     },
                 )
             except Exception as exc:
@@ -2644,6 +2624,12 @@ def _run_npa_workflow_runtime(
         runtime_env.update(dict.fromkeys(STORAGE_ENDPOINT_ENV_NAMES, endpoint))
     previous_env = {name: os.environ.get(name) for name in runtime_env}
     try:
+        # Record entry into the runtime before it can launch a wave. A runtime
+        # receipt has multiple job identities in S3, so no single job ID belongs here.
+        update_submission_state(
+            project or "default", run_id,
+            {"launch": {"status": "launching", "kind": "runtime"}},
+        )
         os.environ.update(runtime_env)
         try:
             report = run_workflow_runtime(

--- a/npa/src/npa/orchestration/npa_workflow/sim2real_evaluator_probe.py
+++ b/npa/src/npa/orchestration/npa_workflow/sim2real_evaluator_probe.py
@@ -1,0 +1,44 @@
+"""Render a network-free evaluator compatibility check for baked Sim2Real images."""
+
+from __future__ import annotations
+
+import textwrap
+
+
+def render_evaluator_probe(model: str) -> str:
+    """Check the selected evaluator in the image before the first GPU wave.
+
+    Args:
+        model: Exact operator-selected hosted model ID.
+
+    Returns:
+        Python source executed by the image's baked NPA interpreter.
+
+    Raises:
+        None.
+    """
+    return textwrap.dedent(f"""\
+        try:
+            from npa.workbench.cosmos.reason import hosted_rollout_model_family
+            from npa.workflows.sim2real.stage9_evaluator import (
+                EvaluatorContractError, validate_hosted_evaluator,
+            )
+            family = hosted_rollout_model_family({model!r})
+            try:
+                validate_hosted_evaluator(
+                    stage7={{}}, evaluator={{}}, stage8_record={{}},
+                    expected_model={model!r}, expected_source_sha=actual,
+                    evaluator_uri='', outer_iteration=0, inner_iteration=0,
+                )
+            except EvaluatorContractError:
+                pass
+            else:
+                raise RuntimeError('evaluator accepted an empty Stage 8 boundary')
+        except (ImportError, ValueError, RuntimeError, TypeError) as exc:
+            raise SystemExit(
+                'Sim2Real evaluator image is incompatible with the selected model '
+                + {model!r} + ': ' + str(exc) + '. Select a coherent image set '
+                'with the current Stage 8/9 evaluator contract and use a new run ID.'
+            ) from exc
+        print('baked Sim2Real evaluator verified', {model!r}, family)
+        """)

--- a/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
+++ b/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
@@ -1591,6 +1591,16 @@ def render_setup_for_tool(
             raise NpaWorkflowError(
                 "config.baked_npa_import must be a dotted Python module name"
             )
+        evaluator_probe = ""
+        if baked_import == "npa.workflows.sim2real.workflow_stage":
+            from npa.orchestration.npa_workflow.sim2real_evaluator_probe import (
+                render_evaluator_probe,
+            )
+            from npa.workflows.sim2real.constants import DEFAULT_COSMOS3_MODEL
+
+            evaluator_probe = render_evaluator_probe(
+                str(config.get("cosmos3_model") or DEFAULT_COSMOS3_MODEL).strip()
+            )
         return (
             "set -e\n"
             'npa_baked_python="${NPA_BAKED_PYTHON:-}"\n'
@@ -1622,6 +1632,7 @@ def render_setup_for_tool(
             "expected = os.environ.get('NPA_SIM2REAL_SOURCE_SHA', '').strip().lower()\n"
             "if len(actual) != 40 or actual != expected:\n"
             "    raise SystemExit('baked NPA source attestation does not match workflow source SHA')\n"
+            f"{evaluator_probe}"
             "print('immutable baked NPA runtime verified', actual)\n"
             "PY\n"
             "printf '%s\\n' \"$npa_baked_python\" > /tmp/npa-python\n"

--- a/npa/src/npa/orchestration/npa_workflow/submission_state.py
+++ b/npa/src/npa/orchestration/npa_workflow/submission_state.py
@@ -320,3 +320,34 @@ def update_submission_state(
         return _update(submission_state_path(project, run_id))
     with submission_lock(project, run_id) as path:
         return _update(path)
+
+
+def record_submission_plan(
+    project: str, run_id: str, *, workflow: Mapping[str, Any],
+    planning: Mapping[str, Any], launch_state: str = "planned",
+) -> dict[str, Any]:
+    """Save planning metadata without erasing an earlier run's location or launch.
+
+    Args:
+        project: Selected project alias.
+        run_id: Exact run being prepared or resumed.
+        workflow: Partial workflow identity from the planning phase.
+        planning: Non-secret planning evidence.
+        launch_state: Initial state for a run without launch evidence.
+
+    Returns:
+        The updated submission receipt.
+
+    Raises:
+        ValueError: Metadata contains secrets or changes the workflow identity.
+        OSError: The locked receipt cannot be persisted.
+    """
+    with submission_lock(project, run_id):
+        previous = load_submission_state(project, run_id)
+        recorded = previous.get("workflow") or {}
+        if recorded.get("name") and recorded["name"] != workflow.get("name"):
+            raise ValueError("submission planning cannot change the workflow identity")
+        updates = {"workflow": {**recorded, **workflow}, "planning": dict(planning)}
+        if "launch" not in previous:
+            updates["launch_state"] = launch_state
+        return update_submission_state(project, run_id, updates, locked=True)

--- a/npa/tests/cli/test_workflow_runtime_cli.py
+++ b/npa/tests/cli/test_workflow_runtime_cli.py
@@ -201,6 +201,15 @@ def fake_runtime(mocker, satisfied_preflight):
     captured: dict[str, object] = {}
 
     def _run(spec, **kwargs):
+        from npa.orchestration.npa_workflow.submission_state import (
+            load_submission_state, submission_proves_never_launched,
+        )
+
+        receipt = load_submission_state(kwargs["options"].project, kwargs["run_id"])
+        assert receipt["launch"] == {"status": "launching", "kind": "runtime"}
+        assert not submission_proves_never_launched(
+            receipt, project=kwargs["options"].project, run_id=kwargs["run_id"],
+        )
         captured["spec"] = spec
         captured.update(kwargs)
         return RuntimeReport(

--- a/npa/tests/guardrails/test_e2e_gate_reachability.py
+++ b/npa/tests/guardrails/test_e2e_gate_reachability.py
@@ -16,7 +16,8 @@ RUNNER_FILES = (
 # These specialized suites intentionally remain operator-invoked. The reason is
 # machine-reviewed here instead of letting an environment gate silently rot.
 MANUAL_GATES = {
-    "NPA_RAY_CLIP_RESULTS": "requires operator-selected downloaded native Ray CLIP CUDA result artifacts",
+    "NPA_RAY_CLIP_RESULTS": (
+        "requires operator-selected downloaded native Ray CLIP CUDA result artifacts"
     ),
     "NPA_FLEET_KUBERAY_LIVE_CONFIG": (
         "native Ray worker execution requires an operator-selected CPU Fleet, exact kubeconfig and private evidence"

--- a/npa/tests/orchestration/npa_workflow/test_run_resolution.py
+++ b/npa/tests/orchestration/npa_workflow/test_run_resolution.py
@@ -264,6 +264,37 @@ def test_runtime_ledger_recovers_exact_active_wave_identity(
     assert lookups == [(f"{run_id}-02-curate", "41")]
 
 
+def test_resume_planning_preserves_exact_runtime_location(resolver_env: ExactS3) -> None:
+    from npa.orchestration.npa_workflow.submission_state import record_submission_plan
+
+    run_id = "resumed-custom-prefix"
+    prefix = f"custom/sim2real/{run_id}"
+    update_submission_state("demo", run_id, {"workflow": {
+        "name": "sim2real", "run_prefix_uri": f"s3://alias-bucket/{prefix}",
+    }})
+    resolver_env.put_json("alias-bucket", f"{prefix}/npa-workflow/runtime.json", {
+        "schema_version": "npa.workflow.runtime.v1", "workflow": "sim2real",
+        "run_id": run_id, "status": "failed", "waves": [{
+            "key": "wave-01", "states": ["trigger"], "status": "succeeded",
+            "job_id": "40", "job_name": f"{run_id}-01-trigger",
+        }],
+    })
+    # A failed preflight on resume must retain the pre-existing runtime location,
+    # including for older receipts that did not record entry into the runtime.
+    record_submission_plan(
+        "demo", run_id, workflow={"name": "sim2real"}, planning={"state": "durable"},
+    )
+
+    resolved = resolve_run(run_id, project="demo", allow_local_not_submitted=True)
+
+    assert resolved.found
+    assert not resolved.not_submitted
+    assert resolved.workflow_name == "sim2real"
+    assert resolved.job_id == "40"
+    assert resolved.runtime_state["status"] == "failed"
+    assert resolved.run_prefix_uri == f"s3://alias-bucket/{prefix}"
+
+
 def test_project_alias_selects_bucket_endpoint_and_canonical_nested_prefix(
     resolver_env: ExactS3, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/npa/tests/orchestration/npa_workflow/test_sim2real_evaluator_probe.py
+++ b/npa/tests/orchestration/npa_workflow/test_sim2real_evaluator_probe.py
@@ -1,0 +1,53 @@
+"""Exercise model selection and old-image rejection without hosted inference."""
+
+import sys
+import subprocess
+
+import pytest
+
+from npa.orchestration.npa_workflow.sim2real_evaluator_probe import render_evaluator_probe
+
+
+def _run_probe(model, *, preparation=""):
+    script = preparation + "\nactual = 'a' * 40\n" + render_evaluator_probe(model)
+    return subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+
+
+@pytest.mark.parametrize("model", ["MiniMaxAI/MiniMax-M3", "nvidia/Cosmos3-Super-Reasoner"])
+def test_current_baked_evaluator_accepts_explicit_model(model):
+    result = _run_probe(model)
+    assert result.returncode == 0, result.stderr
+    assert f"baked Sim2Real evaluator verified {model}" in result.stdout
+
+
+def test_old_image_fails_before_a_hosted_request():
+    result = _run_probe("MiniMaxAI/MiniMax-M3", preparation=(
+        "import sys\nfrom types import ModuleType\n"
+        "sys.modules['npa.workbench.cosmos.reason'] = ModuleType('legacy')\n"
+    ))
+    assert result.returncode != 0
+    assert "image is incompatible with the selected model MiniMaxAI/MiniMax-M3" in result.stderr
+
+
+def test_probe_refuses_an_evaluator_that_accepts_an_empty_boundary():
+    result = _run_probe("MiniMaxAI/MiniMax-M3", preparation=(
+        "from npa.workflows.sim2real import stage9_evaluator\n"
+        "stage9_evaluator.validate_hosted_evaluator = lambda **_: {}\n"
+    ))
+    assert result.returncode != 0
+    assert "accepted an empty Stage 8 boundary" in result.stderr
+
+
+def test_unsupported_model_is_not_substituted():
+    result = _run_probe("unsupported/model")
+    assert result.returncode != 0
+    assert "image is incompatible" in result.stderr
+
+
+def test_model_is_a_literal_in_generated_code(tmp_path):
+    marker = tmp_path / "injected"
+    model = f"'); __import__('pathlib').Path({str(marker)!r}).touch(); #"
+    result = _run_probe(model)
+    assert result.returncode != 0
+    assert "image is incompatible" in result.stderr
+    assert not marker.exists()

--- a/npa/tests/orchestration/npa_workflow/test_submission_state.py
+++ b/npa/tests/orchestration/npa_workflow/test_submission_state.py
@@ -9,10 +9,45 @@ from npa.orchestration.npa_workflow.submission_state import (
     audit_project_submissions,
     inspect_submission_state,
     load_submission_state,
+    record_submission_plan,
     submission_lock,
+    submission_proves_never_launched,
     submission_state_path,
     update_submission_state,
 )
+
+
+def test_resume_planning_preserves_run_location_and_launch(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    workflow = {"name": "sim2real", "run_prefix_uri": "s3://bucket/custom/run-1"}
+    launch = {"status": "launching", "kind": "runtime"}
+    update_submission_state("demo", "run-1", {
+        "workflow": workflow, "launch": launch, "launch_state": "submitted",
+    })
+
+    receipt = record_submission_plan(
+        "demo", "run-1", workflow={"name": "sim2real"},
+        planning={"state": "durable"}, launch_state="reserved",
+    )
+
+    assert receipt["workflow"] == workflow
+    assert receipt["launch"] == launch
+    assert receipt["launch_state"] == "submitted"
+    assert not submission_proves_never_launched(receipt, project="demo", run_id="run-1")
+    assert audit_project_submissions("demo").outcome == "launch_evidence"
+
+
+def test_new_plan_proves_no_launch_and_rejects_identity_change(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    receipt = record_submission_plan(
+        "demo", "run-1", workflow={"name": "sim2real"}, planning={"state": "durable"},
+    )
+    assert submission_proves_never_launched(receipt, project="demo", run_id="run-1")
+    with pytest.raises(ValueError, match="workflow identity"):
+        record_submission_plan(
+            "demo", "run-1", workflow={"name": "other"}, planning={"state": "durable"},
+        )
+    assert load_submission_state("demo", "run-1") == receipt
 
 
 def test_submission_state_is_owner_only_and_restart_safe(

--- a/npa/tests/workflows/test_sim2real_compositional_workflow.py
+++ b/npa/tests/workflows/test_sim2real_compositional_workflow.py
@@ -940,6 +940,19 @@ def test_baked_raw_module_setup_probes_the_executed_module() -> None:
         "importlib.import_module('npa.workflows.sim2real.workflow_stage')" in setup
     )
     assert "npa.cli.main" not in setup
+    assert "baked Sim2Real evaluator verified" in setup
+
+
+@pytest.mark.parametrize("model", ["MiniMaxAI/MiniMax-M3", "nvidia/Cosmos3-Super-Reasoner"])
+def test_baked_sim2real_setup_keeps_the_selected_evaluator(model):
+    setup = render_setup_for_tool(
+        "",
+        config={"require_baked_npa": "1", "cosmos3_model": model},
+        options=SkypilotRenderOptions(),
+        command=["python3", "-m", "npa.workflows.sim2real.workflow_stage"],
+    )
+    assert f"hosted_rollout_model_family({model!r})" in setup
+    assert "validate_hosted_evaluator(" in setup
 
 
 def test_exact_source_and_per_state_immutable_images_reach_rendered_tasks() -> None:
@@ -976,6 +989,7 @@ def test_exact_source_and_per_state_immutable_images_reach_rendered_tasks() -> N
         assert task["envs"]["NPA_SIM2REAL_SOURCE_SHA"] == source_sha
         assert task["envs"]["NPA_TASK_IMAGE"] == image
         assert "immutable baked NPA runtime verified" in task["setup"]
+        assert "baked Sim2Real evaluator verified" in task["setup"]
         assert (
             "importlib.import_module('npa.workflows.sim2real.workflow_stage')"
             in task["setup"]

--- a/workflows/main/sim2real.yaml
+++ b/workflows/main/sim2real.yaml
@@ -70,6 +70,9 @@ config:
   capture_width: "640"
   capture_height: "480"
   png_compress_level: "2"
+  # Exact Stage 8 model ID. The former public Cosmos3 endpoint retired August 31;
+  # select nvidia/Cosmos3-Super-Reasoner explicitly on an endpoint serving it.
+  # Forward a custom endpoint with --secret-env NEBIUS_TOKEN_FACTORY_BASE_URL.
   cosmos3_model: MiniMaxAI/MiniMax-M3
 
   # Required live inputs. The controller image is the purpose-built CPU-only


### PR DESCRIPTION
Consolidated into #436, which contains every commit from this PR and targets main.

Sim2Real's default changed to `MiniMaxAI/MiniMax-M3`, but the operator runbook still selected a Cosmos 3-only image set. A run could complete Transfer, environment generation, and Isaac rollouts before failing in Stage 8 with `token_factory backend requires a Cosmos3 model`.

The generated baked-runtime setup now checks the exact selected model and the Stage 8/9 evaluator boundary in the first CPU stage, before GPU waves. It rejects incompatible images with migration guidance. The check uses the baked interpreter, makes no inference request, and preserves source attestation. Explicit `nvidia/Cosmos3-Super-Reasoner` selection remains supported when the selected endpoint serves it; no model substitution occurs.

Resume planning also retains the recorded run location and launch evidence. Previously, a failed preflight on resume could erase the runtime location and make status report NOT_SUBMITTED after an earlier wave had succeeded. Runtime entry now records its launch boundary before any wave can start.

The runbook documents both model choices and custom endpoint forwarding, and identifies the September 4 image set as incompatible with the current evaluator contract. This PR also repairs an existing unmatched parenthesis in the live-gate inventory that prevented repository validation.

Validation:
- 187 evaluator-focused tests and 112 resume/submit tests passed. The latest revision passed 114 onboarding smoke tests and 2,701 guardrail tests; workflow/preset validation passed.
- Real Kubernetes CPU probes: the legacy immutable controller image rejected the current evaluator contract; the replacement immutable controller image accepted MiniMax-M3. Probe ownership was checked before cleanup. These checks establish evaluator compatibility, not completion of the 14-stage workflow.
- Replacement Isaac image passed offline, read-only cache attestation; the public LeRobot seed was staged and independently read back.
- Ruff, Gitleaks, and diff-scoped built-in confidentiality checks passed.
- Latest full Linux suite: 18,078 passed, 16 skipped, 1 xpassed.
- Before the resume-status follow-up, the CI unit/coverage gate passed: 18,092 passed, 431 skipped, 1 xpassed, 76% coverage. CI browser tests, guardrails, docs drift, Ruff, Gitleaks, and confidentiality checks passed.
- Real scanner regression fixtures passed on Linux. Both local and CI base/candidate scanner comparisons stop on the pre-existing syntax error in `npa/tests/guardrails/test_e2e_gate_reachability.py` at the base revision. The repair is included here; the security gate remains unchanged and failing, so this PR stays draft.
- Hosted API checks: 7 passed and 3 failed with server disconnects/connect timeouts during intermittent connectivity. No successful 14-stage run is claimed. The replacement run completed its first two stages and is entering the Transfer GPU stage.

The retained run is preserved because successful output provenance cannot be migrated to different runtime images. A replacement run uses a new output root, the same pinned public dataset, and the same workload settings.
