### PR TITLE
Fix agent deployment recovery and NuRec image startup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,18 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+        # Runner vendor repositories (such as Chrome) can publish inconsistent
+        # indexes. Media-validator prerequisites come from Ubuntu's signed sources.
+        run: |
+          test -s /etc/apt/sources.list.d/ubuntu.sources
+          apt_options=(
+            -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources
+            -o Dir::Etc::sourceparts=-
+          )
+          sudo apt-get "${apt_options[@]}" update
+          sudo apt-get "${apt_options[@]}" install -y --no-install-recommends ffmpeg
+          ffmpeg -version
+          ffprobe -version
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   # An open PR already receives pull_request runs, so feature-branch pushes do
   # not need a second copy. Cancel older tests when that PR advances.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -196,6 +196,20 @@ final Terraform/SSH response, repeating the exact same command adopts a matching
 healthy VM or resumes its first incomplete phase. It does not replace a healthy
 VM because a response went missing.
 
+A completed service installer writes a private receipt before credential staging.
+On an interrupted retry, NPA reuses that install when the verified owner and
+rendered installer match, then restages credentials and verifies deployment
+identity and health. A changed revision, setting, or authentication value requires
+installation again. A normal bootstrap of a healthy agent also reinstalls services.
+The [live recovery test](../skills/workflows/agent-fresh-operate/SKILL.md)
+documents `NPA_AGENT_RECOVERY_LIVE_CONFIG` for testing this behavior on an isolated
+VM through deploy, injected interruption, resume, and destroy.
+
+For SSH reachability failures, check the route to the VM before changing ingress.
+A VPN subnet route may use a different egress address from an internet IP-check
+service. Set `ssh_cidr_block` and `application_cidr_block` for the source address
+used on that route, then follow the exact operation's recovery instructions.
+
 When an agent fails before its final config record is written,
 `npa agent status --project <alias> --name <name> --json` reads the operation
 journal instead. It reports the typed partial state, the exact created-resource

--- a/docs/workbench/container-packaging.md
+++ b/docs/workbench/container-packaging.md
@@ -29,8 +29,15 @@ attest the historical release bytes.
 
 Submit resolves the selected tag to an immutable digest and validates metadata
 on that digest. Missing/mismatched first-party evidence fails before launch.
-Arbitrary unattested images get one bounded exact-context capability pod; probe
-cleanup failure also fails closed. Cache keys use digest plus contract version,
+Arbitrary unattested vendor images get an exact-context capability pod that
+reproduces SkyPilot's Kubernetes shell override and installs missing SSH, rsync,
+and service packages through the image's package manager. This supports vendor
+entrypoints such as NuRec's `/app/run` without invoking that application with
+shell arguments. Root or passwordless sudo, successful package installation,
+and all worker capabilities must still be verified. Runtime-prepared evidence
+is not cached as proof of baked image contents; first-party image probes and
+attestation requirements remain unchanged. Probe cleanup failure also fails
+closed. Cache keys use digest plus contract version,
 never a tag. Image-byte licensing scans remain mandatory before registry push.
 For a multi-tool spec, repeat `--image-override TOOL_REF=IMAGE` to select each
 tool's artifact independently; the preflight and renderer share that same map.

--- a/npa/src/npa/cli/agent.py
+++ b/npa/src/npa/cli/agent.py
@@ -157,6 +157,7 @@ from npa.cli.agent_site import (
     DEFAULT_LICHTBLICK_PORT,
     nginx_agent_site_body as _nginx_agent_site_body,
 )
+from npa.cli.agent_service_install import install_agent_services
 from npa.cli.agent_deployment import (
     DeploymentIdentityError,
     assert_remote_owner_if_present,
@@ -867,6 +868,7 @@ def _bootstrap_agent_stack(
     foxglove_cloud_import_timeout_seconds: str = "",
     deployment: dict[str, str] | None = None,
     preload_stock_demo: bool = True,
+    resume_services: bool = False,
 ) -> None:
     foxglove_env = agent_foxglove_config.bootstrap_env_values(
         embed_src=foxglove_embed_src,
@@ -907,12 +909,14 @@ def _bootstrap_agent_stack(
         name=agent_name,
         require_clean=False,
     )
-    deployment_json = json.dumps(deployment, sort_keys=True)
-    deployment_b64 = base64.b64encode(deployment_json.encode("utf-8")).decode("ascii")
     # This check runs before staging source, writing manifests, or restarting
     # services. A stale/missing local record cannot authorize overwriting a VM
     # that is still advertising a different immutable owner.
-    assert_remote_owner_if_present(ssh, deployment, backend_port=backend_port)
+    installed = assert_remote_owner_if_present(ssh, deployment, backend_port=backend_port)
+    if resume_services and installed.get("bootstrap_timestamp"):
+        deployment = {**deployment, "bootstrap_timestamp": installed["bootstrap_timestamp"]}
+    deployment_json = json.dumps(deployment, sort_keys=True)
+    deployment_b64 = base64.b64encode(deployment_json.encode("utf-8")).decode("ascii")
     preload_stock_demo_value = "1" if preload_stock_demo else "0"
     llm_models = _normalize_llm_models(list(llm_models))
     default_llm_models_json = json.dumps(llm_models)
@@ -9146,17 +9150,11 @@ sudo systemctl enable --now npa-lichtblick 2>/dev/null || echo "npa-lichtblick s
             rendered_agent_ui_from_record(_agent_record(project_alias, agent_name)),
         )
     )
-    # Use a unique remote path so concurrent bootstrap runs cannot clobber each other.
-    remote_setup_script = f"/tmp/npa-agent-bootstrap-{secrets.token_hex(6)}.sh"
-    try:
-        _stage_agent_npa_source(ssh)
-        ssh.upload_private_text(setup_script, remote_setup_script)
-        ssh.run_or_raise(
-            f"chmod 700 {shlex.quote(remote_setup_script)} && {shlex.quote(remote_setup_script)}",
-            label="run agent bootstrap",
-        )
-    finally:
-        ssh.run(f"rm -f {shlex.quote(remote_setup_script)}")
+    if install_agent_services(
+        ssh, setup_script=setup_script, stage_source=_stage_agent_npa_source,
+        resuming=resume_services,
+    ):
+        typer.echo("  Reusing completed agent service installation; restaging credentials.")
     agent_llm_config.write_agent_llm_env(
         ssh,
         api_key=llm_api_key or tf_api_key,

--- a/npa/src/npa/cli/agent_errors.py
+++ b/npa/src/npa/cli/agent_errors.py
@@ -41,19 +41,19 @@ def _agent_deploy_failure_hint(detail: str) -> str:
     if "cloud-init status: error" in runtime or "cloud-init finished with status" in runtime:
         return (
             "The agent VM booted but its cloud-init bootstrap failed (cloud-init "
-            "status: error), so the deploy rolled the VM back. The failing "
+            "status: error). The failing "
             "bootstrap step is named in the `cloud-init status --long` output "
-            "that streamed above; because the VM is gone, capture that output "
-            "(or SSH in during a re-run and read "
-            "/var/log/npa-agent-cloud-init.log) before retrying."
+            "that streamed above. Check `npa agent status` and the operation's "
+            "recovery instructions for the retained VM before retrying; inspect "
+            "/var/log/npa-agent-cloud-init.log over verified SSH when available."
         )
     if "never authenticated" in runtime:
         # The wait distinguishes a closed port from a refused key; when tcp/22 did
         # open, reachability is not the problem.
         return (
             "The agent VM booted and its tcp/22 was reachable, but SSH never "
-            "authenticated, so the deploy timed out and rolled the VM back. This is "
-            "the key or the login user, not the network:\n"
+            "authenticated before the deploy timed out. Check `npa agent status` "
+            "and the operation's recovery instructions before retrying:\n"
             "  - does the private key next to --ssh-public-key-path match the public "
             "key the VM was created with?\n"
             "  - is --ssh-user right for this image (Nebius Ubuntu images use "
@@ -61,12 +61,14 @@ def _agent_deploy_failure_hint(detail: str) -> str:
         )
     return (
         "The agent VM booted (RUNNING, with a public IP) but its tcp/22 never "
-        "opened from this machine, so the deploy timed out and rolled the VM back. "
-        "This is almost always local reachability, not the VM:\n"
+        "opened from this machine before the deploy timed out. Check `npa agent "
+        "status` and the operation's recovery instructions before retrying:\n"
         "  - can this host reach the VM's tcp/22? (corporate VPN / split-tunnel / "
         "firewall commonly block outbound SSH to fresh public IPs, even when they "
         "allow SSH to known hosts such as github.com)\n"
-        "  - does the security group allow tcp/22 from your address?\n"
+        "  - do ssh_cidr_block and application_cidr_block allow the source address "
+        "actually used to reach this VM? A VPN subnet route can use a different "
+        "egress address from an internet IP-check service.\n"
         "Deploy from a host with direct network access to the VM; the full "
         "provisioner log streamed above."
     )

--- a/npa/src/npa/cli/agent_service_install.py
+++ b/npa/src/npa/cli/agent_service_install.py
@@ -1,0 +1,79 @@
+"""Checkpoint completed agent service installation before credential staging."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import hashlib
+import logging
+import secrets
+import shlex
+import sys
+
+from npa.clients.ssh import SSHClient, SSHError
+
+
+_INSTALL_RECEIPT = "/opt/npa-agent/services-installed.sha256"
+_LOG = logging.getLogger(__name__)
+
+
+def _receipt_script(digest: str) -> str:
+    return f"""
+(
+set -eu
+stage="$(sudo mktemp /opt/npa-agent/.services-installed.XXXXXXXX)"
+trap 'sudo rm -f -- "$stage"' EXIT
+builtin printf '%s\\n' {shlex.quote(digest)} | sudo tee "$stage" >/dev/null
+sudo mv -fT -- "$stage" {_INSTALL_RECEIPT}
+)
+"""
+
+
+def _remove_installer(ssh: SSHClient, remote_path: str) -> None:
+    primary_error = sys.exc_info()[1]
+    try:
+        ssh.run(f"rm -f -- {shlex.quote(remote_path)}")
+    except SSHError:
+        if primary_error is None:
+            raise
+        _LOG.warning(
+            "Removing the private installer also failed over SSH; preserving the original error."
+        )
+
+
+def install_agent_services(
+    ssh: SSHClient,
+    *,
+    setup_script: str,
+    stage_source: Callable[[SSHClient], None],
+    resuming: bool,
+) -> bool:
+    """Install services unless an exact completed installer can be resumed.
+
+    Args:
+        ssh: Independently authenticated SSH connection to the owned agent VM.
+        setup_script: Fully rendered installer, including source identity and settings.
+        stage_source: Stage the source archive before running a new installer.
+        resuming: Allow reuse only during recovery of an interrupted bootstrap.
+
+    Returns:
+        True when a matching completed installation was reused.
+
+    Raises:
+        SSHError: The receipt cannot be read or installation/cleanup fails.
+    """
+    digest = hashlib.sha256(setup_script.encode("utf-8")).hexdigest()
+    if resuming:
+        code, stdout, _stderr = ssh.run(f"sudo cat {_INSTALL_RECEIPT} 2>/dev/null")
+        if code == 0 and stdout.strip() == digest:
+            return True
+    remote_path = f"/tmp/npa-agent-bootstrap-{secrets.token_hex(6)}.sh"
+    try:
+        stage_source(ssh)
+        ssh.upload_private_text(setup_script + _receipt_script(digest), remote_path)
+        ssh.run_or_raise(
+            f"chmod 700 {shlex.quote(remote_path)} && {shlex.quote(remote_path)}",
+            label="run agent bootstrap",
+        )
+    finally:
+        _remove_installer(ssh, remote_path)
+    return False

--- a/npa/src/npa/cli/agent_service_install.py
+++ b/npa/src/npa/cli/agent_service_install.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import hashlib
 import logging
+from pathlib import PurePosixPath
 import secrets
 import shlex
 import sys
@@ -17,13 +18,14 @@ _LOG = logging.getLogger(__name__)
 
 
 def _receipt_script(digest: str) -> str:
+    parent = shlex.quote(str(PurePosixPath(_INSTALL_RECEIPT).parent))
     return f"""
 (
 set -eu
-stage="$(sudo mktemp /opt/npa-agent/.services-installed.XXXXXXXX)"
+stage="$(sudo mktemp {parent}/.services-installed.XXXXXXXX)"
 trap 'sudo rm -f -- "$stage"' EXIT
 builtin printf '%s\\n' {shlex.quote(digest)} | sudo tee "$stage" >/dev/null
-sudo mv -fT -- "$stage" {_INSTALL_RECEIPT}
+sudo mv -fT -- "$stage" {shlex.quote(_INSTALL_RECEIPT)}
 )
 """
 
@@ -66,7 +68,8 @@ def install_agent_services(
         code, stdout, _stderr = ssh.run(f"sudo cat {_INSTALL_RECEIPT} 2>/dev/null")
         if code == 0 and stdout.strip() == digest:
             return True
-    remote_path = f"/tmp/npa-agent-bootstrap-{secrets.token_hex(6)}.sh"
+    # SSH and SFTP start in the authenticated user's home, outside shared /tmp.
+    remote_path = f"./.npa-agent-bootstrap-{secrets.token_hex(6)}.sh"
     try:
         stage_source(ssh)
         ssh.upload_private_text(setup_script + _receipt_script(digest), remote_path)

--- a/npa/src/npa/cli/agent_setup_convergence.py
+++ b/npa/src/npa/cli/agent_setup_convergence.py
@@ -168,6 +168,7 @@ def converge_remote_agent_setup(
             )
         remote_kwargs = dict(bootstrap_kwargs)
         remote_kwargs.pop("instance_id", None)
+        remote_kwargs["resume_services"] = resuming
         try:
             with operation_heartbeats(
                 operation, phase="remote_bootstrap", emit=progress

--- a/npa/src/npa/cli/workbench/workflow/__init__.py
+++ b/npa/src/npa/cli/workbench/workflow/__init__.py
@@ -3182,6 +3182,7 @@ def _preflight_image_bootstrap_contracts(
                         image=image,
                         digest=digest,
                         context=context,
+                        runtime_bootstrap=True,
                         kubeconfig=str(os.environ.get("KUBECONFIG") or ""),
                         image_pull_secrets=tuple(
                             (pull_secrets_by_image or {}).get(image, ())
@@ -3199,7 +3200,10 @@ def _preflight_image_bootstrap_contracts(
                 f"image bootstrap contract {CONTRACT_VERSION} failed for "
                 f"{evidence.image}: {evidence.detail or evidence.state}"
             )
-        if evidence.source == "ephemeral_capability_probe":
+        if evidence.source in {
+            "ephemeral_capability_probe",
+            "ephemeral_runtime_bootstrap_probe",
+        }:
             typer.echo(
                 json.dumps(
                     {

--- a/npa/src/npa/orchestration/skypilot/image_bootstrap_contract.py
+++ b/npa/src/npa/orchestration/skypilot/image_bootstrap_contract.py
@@ -271,6 +271,26 @@ def _observe_terminal_phase(
     )
 
 
+def _runtime_bootstrap_script() -> str:
+    """Prepare the packages SkyPilot installs after overriding a vendor entrypoint."""
+
+    return """set -eu
+if [ "$(id -u)" != 0 ]; then command -v sudo; sudo -n true; fi
+as_root() {
+    if [ "$(id -u)" = 0 ]; then "$@"; else sudo -n "$@"; fi
+}
+packages=""
+command -v rsync >/dev/null || packages="$packages rsync"
+(command -v sshd >/dev/null || test -x /usr/sbin/sshd) || packages="$packages openssh-server"
+command -v service >/dev/null || packages="$packages init-system-helpers"
+if [ -n "$packages" ]; then
+    command -v apt-get
+    as_root apt-get update
+    as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y $packages
+fi
+"""
+
+
 def probe_image_capabilities(
     *,
     image: str,
@@ -278,12 +298,29 @@ def probe_image_capabilities(
     context: str,
     kubeconfig: str = "",
     image_pull_secrets: tuple[str, ...] = (),
+    runtime_bootstrap: bool = False,
     observation_timeout_seconds: int = DEFAULT_PROBE_TIMEOUT_SECONDS,
     runner: Runner = _run,
     terminal_observer: TerminalObserver = _observe_terminal_phase,
     nonce_factory: Callable[[], str] = lambda: secrets.token_hex(8),
 ) -> ImageContractEvidence:
-    """Run and exactly clean one bounded capability pod for an unattested image."""
+    """Verify worker capabilities and clean up the exact probe pod.
+
+    Args:
+        image, digest: Registry reference and immutable bytes to inspect.
+        context, kubeconfig: Exact Kubernetes target and credentials file.
+        image_pull_secrets: Existing registry authentication Secret names.
+        runtime_bootstrap: Reproduce SkyPilot's shell override and package
+            installation for vendor images; first-party byte probes stay strict.
+        observation_timeout_seconds: Watch deadline; zero waits indefinitely.
+        runner, terminal_observer, nonce_factory: Injectable execution boundaries.
+
+    Returns:
+        Capability evidence including verified cleanup.
+
+    Raises:
+        ImageBootstrapContractError: An input reference or target is invalid.
+    """
 
     immutable = immutable_image_reference(image, digest)
     if observation_timeout_seconds < 0:
@@ -313,6 +350,10 @@ def probe_image_capabilities(
         "if [ \"$(id -u)\" != 0 ]; then command -v sudo; sudo -n true; fi; "
         "test \"$(/bin/sh -c 'printf %s forwarded' sentinel)\" = forwarded"
     )
+    command_override = ["--command"] if runtime_bootstrap else []
+    shell = "/bin/bash" if runtime_bootstrap else "/bin/sh"
+    if runtime_bootstrap:
+        script = _runtime_bootstrap_script() + script
     common = ["kubectl", "--context", context]
     name = ""
     probe_id = ""
@@ -352,8 +393,9 @@ def probe_image_capabilities(
                     f"--image={immutable}",
                     f"--labels={labels}",
                     *overrides,
+                    *command_override,
                     "--",
-                    "/bin/sh",
+                    shell,
                     "-c",
                     script,
                 ],
@@ -519,7 +561,11 @@ def probe_image_capabilities(
         digest=digest,
         contract_version=CONTRACT_VERSION,
         state="compatible",
-        source="ephemeral_capability_probe",
+        source=(
+            "ephemeral_runtime_bootstrap_probe"
+            if runtime_bootstrap
+            else "ephemeral_capability_probe"
+        ),
         checks=(
             "effective_user",
             "passwordless_sudo_or_root",
@@ -527,7 +573,9 @@ def probe_image_capabilities(
             "rsync",
             "service_init",
             "writable_locations",
-            "entrypoint_argument_forwarding",
+            "kubernetes_command_override"
+            if runtime_bootstrap
+            else "entrypoint_argument_forwarding",
         ),
         cleanup=cleanup,
     )
@@ -648,6 +696,10 @@ def load_cached_evidence(path: Path, digest: str) -> ImageContractEvidence | Non
 
 
 def store_cached_evidence(path: Path, evidence: ImageContractEvidence) -> None:
+    # Runtime-installed packages depend on the selected cluster's live mirrors,
+    # so this result must never become an attestation of the image's own bytes.
+    if evidence.source == "ephemeral_runtime_bootstrap_probe":
+        return
     if not evidence.ok or evidence.cleanup == "failed":
         return
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -3634,9 +3634,17 @@ def test_agent_dry_run_counts_only_its_exact_healthy_project_record() -> None:
 
 
 def test_bootstrap_uses_unique_remote_setup_script_path() -> None:
+    from unittest.mock import Mock
+    from npa.cli.agent_service_install import install_agent_services
 
-    source = _agent_source()
-    assert "npa-agent-bootstrap-{secrets.token_hex" in source
+    ssh = Mock()
+    for _ in range(2):
+        install_agent_services(
+            ssh, setup_script="set -eu\n", stage_source=Mock(), resuming=False
+        )
+    paths = [call.args[1] for call in ssh.upload_private_text.call_args_list]
+    assert len(set(paths)) == 2
+    assert all(path.startswith("/tmp/npa-agent-bootstrap-") for path in paths)
 
 
 def test_rrd_publish_uses_request_unique_atomic_temp_path() -> None:
@@ -5049,6 +5057,9 @@ def test_agent_deploy_failure_hint_diagnoses_ssh_unreachable() -> None:
     assert "tcp/22 never opened" in hint
     assert "split-tunnel" in hint
     assert "authenticated" not in hint
+    assert "rolled the VM back" not in hint
+    assert "npa agent status" in hint
+    assert "egress address" in hint
 
 
 def test_agent_deploy_failure_hint_separates_a_key_problem_from_the_network() -> None:
@@ -5066,6 +5077,8 @@ def test_agent_deploy_failure_hint_separates_a_key_problem_from_the_network() ->
     assert "never authenticated" in hint
     assert "--ssh-public-key-path" in hint
     assert "VPN" not in hint
+    assert "rolled the VM back" not in hint
+    assert "npa agent status" in hint
 
 
 def test_agent_deploy_failure_hint_diagnoses_cloud_init_error() -> None:
@@ -5082,6 +5095,9 @@ def test_agent_deploy_failure_hint_diagnoses_cloud_init_error() -> None:
     hint = _agent_deploy_failure_hint(detail)
     assert "cloud-init bootstrap failed" in hint
     assert "SSH never became reachable" not in hint
+    assert "rolled the VM back" not in hint
+    assert "VM is gone" not in hint
+    assert "npa agent status" in hint
 
 
 def test_agent_deploy_failure_hint_empty_for_unrelated_errors() -> None:

--- a/npa/tests/cli/test_agent.py
+++ b/npa/tests/cli/test_agent.py
@@ -3644,7 +3644,7 @@ def test_bootstrap_uses_unique_remote_setup_script_path() -> None:
         )
     paths = [call.args[1] for call in ssh.upload_private_text.call_args_list]
     assert len(set(paths)) == 2
-    assert all(path.startswith("/tmp/npa-agent-bootstrap-") for path in paths)
+    assert all(path.startswith("./.npa-agent-bootstrap-") for path in paths)
 
 
 def test_rrd_publish_uses_request_unique_atomic_temp_path() -> None:

--- a/npa/tests/cli/test_agent_service_install.py
+++ b/npa/tests/cli/test_agent_service_install.py
@@ -1,0 +1,198 @@
+"""Interrupted installers must resume safely without hiding their first failure."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from npa.cli import agent_service_install as subject
+from npa.clients.ssh import SSHError
+
+
+def _install(ssh, script="set -eu\necho install\n", *, resuming=True, stage=None):
+    return subject.install_agent_services(
+        ssh, setup_script=script, stage_source=stage or Mock(), resuming=resuming
+    )
+
+
+def test_exact_receipt_skips_source_staging_and_installer() -> None:
+    script = "set -eu\necho install\n"
+    digest = hashlib.sha256(script.encode()).hexdigest()
+    ssh = Mock()
+    ssh.run.return_value = (0, digest + "\n", "")
+    stage = Mock()
+    assert _install(ssh, script, stage=stage) is True
+    stage.assert_not_called()
+    ssh.upload_private_text.assert_not_called()
+    ssh.run_or_raise.assert_not_called()
+
+
+@pytest.mark.parametrize("receipt", [(1, "", "missing"), (0, "other-digest", "")])
+def test_missing_or_changed_receipt_runs_complete_install(receipt) -> None:
+    ssh = Mock()
+    ssh.run.return_value = receipt
+    stage = Mock()
+    assert _install(ssh, stage=stage) is False
+    stage.assert_called_once_with(ssh)
+    ssh.run_or_raise.assert_called_once()
+
+
+def test_explicit_bootstrap_runs_even_with_matching_receipt() -> None:
+    ssh = Mock()
+    assert _install(ssh, resuming=False) is False
+    assert "services-installed.sha256" not in str(ssh.run.call_args_list)
+    ssh.run_or_raise.assert_called_once()
+
+
+def test_unreadable_receipt_does_not_authorize_installation() -> None:
+    ssh = Mock()
+    ssh.run.side_effect = SSHError("connection lost")
+    with pytest.raises(SSHError, match="connection lost"):
+        _install(ssh)
+    ssh.upload_private_text.assert_not_called()
+
+
+def test_lost_final_ssh_response_preserves_remote_receipt() -> None:
+    ssh = Mock()
+    script = "set -eu\necho install\n"
+    digest = hashlib.sha256(script.encode()).hexdigest()
+    ssh.run.return_value = (1, "", "missing")
+
+    def completed_before_transport_loss(*_args, **_kwargs):
+        uploaded, _path = ssh.upload_private_text.call_args.args
+        assert uploaded.startswith(script)
+        assert digest in uploaded[len(script) :]
+        ssh.run.return_value = (0, digest + "\n", "")
+        raise SSHError("lost final response")
+
+    ssh.run_or_raise.side_effect = completed_before_transport_loss
+    with pytest.raises(SSHError, match="lost final response"):
+        _install(ssh, script)
+    assert _install(ssh, script) is True
+    assert ssh.run_or_raise.call_count == 1
+
+
+def test_cleanup_transport_error_does_not_hide_install_failure(caplog) -> None:
+    ssh = Mock()
+    original = SSHError("installer failed")
+    ssh.run_or_raise.side_effect = original
+    ssh.run.side_effect = SSHError("cleanup failed")
+    with pytest.raises(SSHError) as caught:
+        _install(ssh, resuming=False)
+    assert caught.value is original
+    assert "preserving the original error" in caplog.text
+
+
+def test_cleanup_failure_after_success_remains_an_error() -> None:
+    ssh = Mock()
+    ssh.run.side_effect = SSHError("cleanup failed")
+    with pytest.raises(SSHError, match="cleanup failed"):
+        _install(ssh, resuming=False)
+
+
+@pytest.fixture
+def bootstrap_harness(monkeypatch):
+    from npa.cli import agent
+
+    manifest = {"bootstrap_timestamp": "first-attempt", "commit": "source-one"}
+    ssh = Mock()
+    ssh.run.return_value = (1, "", "missing")
+
+    def installed(*_args, **_kwargs):
+        script = ssh.upload_private_text.call_args.args[0]
+        digest = re.findall(r"builtin printf '%s\\n' ([a-f0-9]{64})", script)[-1]
+        ssh.run.return_value = (0, digest, "")
+
+    ssh.run_or_raise.side_effect = installed
+    monkeypatch.setattr(agent, "SSHClient", lambda **_kwargs: ssh)
+    monkeypatch.setattr(
+        agent, "resolve_ssh_config", lambda **_kw: SimpleNamespace(ssh={})
+    )
+    monkeypatch.setattr(agent, "build_deployment_manifest", Mock(return_value=manifest))
+    monkeypatch.setattr(
+        agent, "assert_remote_owner_if_present", Mock(return_value=manifest)
+    )
+    stage = Mock()
+    monkeypatch.setattr(agent, "_stage_agent_npa_source", stage)
+    llm = Mock()
+    monkeypatch.setattr(agent.agent_llm_config, "write_agent_llm_env", llm)
+    for writer in (
+        "_write_agent_s3_env",
+        "_write_agent_artifact_sources_env",
+        "_write_agent_operator_profile",
+        "_record_remote_setup_ready",
+    ):
+        monkeypatch.setattr(agent, writer, Mock())
+    credentials = Mock(side_effect=[SSHError("staging interrupted"), None])
+    monkeypatch.setattr(agent, "_write_agent_nebius_env", credentials)
+    monkeypatch.setattr(agent, "verify_remote_deployment", Mock())
+    return agent, manifest, stage, credentials, llm
+
+
+@pytest.mark.parametrize("change_password", [False, True])
+def test_bootstrap_retry_restages_credentials_and_honors_changed_settings(
+    bootstrap_harness, change_password
+) -> None:
+    agent, manifest, stage, credentials, llm = bootstrap_harness
+    kwargs = dict(
+        host="192.0.2.10",
+        ssh_user="ubuntu",
+        ssh_key_path="/tmp/key",
+        project_alias="test",
+        agent_name="agent",
+        project_id="project-test",
+        tenant_id="tenant-test",
+        region="test-region",
+        auth_user="npa",
+        auth_password="first-password",
+        agent_port=8088,
+        backend_port=8787,
+        rerun_port=9090,
+    )
+    with pytest.raises(SSHError, match="staging interrupted"):
+        agent._bootstrap_agent_stack(**kwargs)
+    agent.build_deployment_manifest.return_value = {
+        **manifest,
+        "bootstrap_timestamp": "retry",
+    }
+    if change_password:
+        kwargs["auth_password"] = "changed-password"
+    agent._bootstrap_agent_stack(**kwargs, resume_services=True)
+    assert stage.call_count == (2 if change_password else 1)
+    assert credentials.call_count == llm.call_count == 2
+    assert agent.verify_remote_deployment.call_args.args[1] == manifest
+
+
+@pytest.mark.parametrize("exit_code", [0, 7])
+def test_receipt_is_atomic_private_and_written_only_after_success(
+    tmp_path, monkeypatch, exit_code
+) -> None:
+    import os
+    import subprocess
+
+    sudo = tmp_path / "sudo"
+    sudo.write_text('#!/bin/sh\nexec "$@"\n')
+    sudo.chmod(0o700)
+    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+    receipt_script = (
+        subject._receipt_script("test-digest")
+        .replace("/opt/npa-agent", str(tmp_path))
+        .replace("mv -fT", "mv -f")
+    )  # BSD mv has no -T; target is a regular file.
+    result = subprocess.run(
+        ["bash", "-c", f"set -eu\n(exit {exit_code})\n" + receipt_script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == exit_code
+    receipt = tmp_path / "services-installed.sha256"
+    assert receipt.exists() is (exit_code == 0)
+    if exit_code == 0:
+        assert receipt.read_text() == "test-digest\n"
+        assert receipt.stat().st_mode & 0o777 == 0o600
+    assert not list(tmp_path.glob(".services-installed.*"))

--- a/npa/tests/cli/test_agent_service_install.py
+++ b/npa/tests/cli/test_agent_service_install.py
@@ -135,13 +135,13 @@ def bootstrap_harness(monkeypatch):
 
 @pytest.mark.parametrize("change_password", [False, True])
 def test_bootstrap_retry_restages_credentials_and_honors_changed_settings(
-    bootstrap_harness, change_password
+    bootstrap_harness, change_password, tmp_path
 ) -> None:
     agent, manifest, stage, credentials, llm = bootstrap_harness
     kwargs = dict(
         host="192.0.2.10",
         ssh_user="ubuntu",
-        ssh_key_path="/tmp/key",
+        ssh_key_path=str(tmp_path / "id_ed25519"),
         project_alias="test",
         agent_name="agent",
         project_id="project-test",

--- a/npa/tests/cli/test_agent_setup_convergence.py
+++ b/npa/tests/cli/test_agent_setup_convergence.py
@@ -180,6 +180,22 @@ def test_identity_refusal_is_never_reconciled_as_transport_success() -> None:
     assert reconciled is False
 
 
+@pytest.mark.parametrize("resuming", [False, True])
+def test_only_interrupted_bootstrap_may_reuse_service_install(resuming) -> None:
+    from unittest.mock import Mock
+
+    bootstrap = Mock()
+    result = agent_setup_convergence.converge_remote_agent_setup(
+        operation=None, resuming=resuming, bootstrap=bootstrap,
+        reconcile=lambda **_kwargs: {"state": "incomplete"},
+        bootstrap_kwargs={"instance_id": "instance-test"}, reconcile_kwargs={},
+        persist_pending=lambda _state: None, status=lambda _text: None,
+        progress=lambda _event: None, transport_errors=(RuntimeError,),
+    )
+    bootstrap.assert_called_once_with(resume_services=resuming)
+    assert result.evidence["state"] == "incomplete"
+
+
 def test_blocking_calls_emit_structured_secret_free_heartbeats(
     monkeypatch, tmp_path
 ) -> None:

--- a/npa/tests/cli/test_submit_preflight_and_accelerators.py
+++ b/npa/tests/cli/test_submit_preflight_and_accelerators.py
@@ -894,16 +894,22 @@ def test_image_bootstrap_probe_paths_share_observing_progress_helper(
             source="oci_attestation",
         ),
     )
-    monkeypatch.setattr(
-        "npa.orchestration.skypilot.image_bootstrap_contract.probe_image_capabilities",
-        lambda **_kwargs: ImageContractEvidence(
+    probes = []
+
+    def probe(**kwargs):
+        probes.append(kwargs)
+        return ImageContractEvidence(
             image=immutable,
             digest=digest,
             contract_version=CONTRACT_VERSION,
             state="compatible",
             source="ephemeral_capability_probe",
             cleanup="verified",
-        ),
+        )
+
+    monkeypatch.setattr(
+        "npa.orchestration.skypilot.image_bootstrap_contract.probe_image_capabilities",
+        probe,
     )
     progress: list[tuple[str, int]] = []
     monkeypatch.setattr(
@@ -920,6 +926,8 @@ def test_image_bootstrap_probe_paths_share_observing_progress_helper(
     )
 
     assert progress == [(digest, 1800)]
+    assert len(probes) == 1
+    assert probes[0].get("runtime_bootstrap", False) is not runtime_probe_required
 
 
 def test_groot_label_and_label_backed_cache_cannot_bypass_runtime_probe(

--- a/npa/tests/e2e/test_agent_recovery_live.py
+++ b/npa/tests/e2e/test_agent_recovery_live.py
@@ -31,6 +31,17 @@ def _invoke(args: list[str], evidence: Path, label: str):
     return result
 
 
+def _destroy_test_agent(project, name, evidence, keep_iam):
+    args = ["agent", "destroy", "--project", project, "--name", name, "--yes", "--json"]
+    if keep_iam:
+        args.append("--keep-iam")
+    cleanup = _invoke(args, evidence, "destroy")
+    assert cleanup.exit_code == 0, (
+        "Exact-agent cleanup failed; inspect private destroy.log"
+    )
+    assert json.loads(cleanup.stdout)["infrastructure_absent"] is True
+
+
 @pytest.fixture
 def deployment():
     config_path = Path(os.environ["NPA_AGENT_RECOVERY_LIVE_CONFIG"])
@@ -40,20 +51,14 @@ def deployment():
     assert args[:2] == ["agent", "deploy"]
     project, name = (args[args.index(flag) + 1] for flag in ("--project", "--name"))
     assert not agent._agent_record(project, name), "Choose an unused agent name"
+    keep_iam = bool(agent.resolve_project_agents(project))
     evidence = Path(config["evidence_dir"])
     evidence.mkdir(mode=0o700, parents=True, exist_ok=True)
     assert evidence.stat().st_mode & 0o077 == 0, "Evidence must be owner-only"
     try:
         yield args, project, name, evidence
     finally:
-        cleanup = _invoke(
-            ["agent", "destroy", "--project", project, "--name", name, "--yes"],
-            evidence,
-            "destroy",
-        )
-        assert cleanup.exit_code == 0, (
-            "Exact-agent cleanup failed; inspect private destroy.log"
-        )
+        _destroy_test_agent(project, name, evidence, keep_iam)
 
 
 def test_interrupted_credentials_resume_without_reinstalling(deployment, monkeypatch):
@@ -73,6 +78,10 @@ def test_interrupted_credentials_resume_without_reinstalling(deployment, monkeyp
     assert agent._agent_record(project, name)["instance_id"] == instance_id
     assert stage_source.call_count == 1, "Resume reran source/service installation"
     assert "Reusing completed agent service installation" in resumed.output
+    _verify_recovered_agent(project, name, evidence, stage_source.call_count)
+
+
+def _verify_recovered_agent(project, name, evidence, installations):
     status = _invoke(
         ["agent", "status", "--project", project, "--name", name, "--json"],
         evidence,
@@ -86,7 +95,7 @@ def test_interrupted_credentials_resume_without_reinstalling(deployment, monkeyp
         json.dumps(
             {
                 "same_instance": True,
-                "service_installations": stage_source.call_count,
+                "service_installations": installations,
                 "credential_resume": True,
                 "authenticated_health": True,
             },

--- a/npa/tests/e2e/test_agent_recovery_live.py
+++ b/npa/tests/e2e/test_agent_recovery_live.py
@@ -1,0 +1,96 @@
+"""Deploy, interrupt credential staging, resume the exact VM, and tear it down."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from npa.cli import agent
+from npa.cli.main import app
+from npa.clients.ssh import SSHError
+
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.agent_live,
+    pytest.mark.skipif(
+        not os.environ.get("NPA_AGENT_RECOVERY_LIVE_CONFIG"),
+        reason="Requires private configuration for an isolated agent deploy/resume/destroy cycle.",
+    ),
+]
+
+
+def _invoke(args: list[str], evidence: Path, label: str):
+    result = CliRunner().invoke(app, args)
+    (evidence / f"{label}.log").write_text(result.output)
+    return result
+
+
+@pytest.fixture
+def deployment():
+    config_path = Path(os.environ["NPA_AGENT_RECOVERY_LIVE_CONFIG"])
+    assert config_path.stat().st_mode & 0o077 == 0, "Live config must be owner-only"
+    config = json.loads(config_path.read_text())
+    args = config["deploy_args"]
+    assert args[:2] == ["agent", "deploy"]
+    project, name = (args[args.index(flag) + 1] for flag in ("--project", "--name"))
+    assert not agent._agent_record(project, name), "Choose an unused agent name"
+    evidence = Path(config["evidence_dir"])
+    evidence.mkdir(mode=0o700, parents=True, exist_ok=True)
+    assert evidence.stat().st_mode & 0o077 == 0, "Evidence must be owner-only"
+    try:
+        yield args, project, name, evidence
+    finally:
+        cleanup = _invoke(
+            ["agent", "destroy", "--project", project, "--name", name, "--yes"],
+            evidence,
+            "destroy",
+        )
+        assert cleanup.exit_code == 0, (
+            "Exact-agent cleanup failed; inspect private destroy.log"
+        )
+
+
+def test_interrupted_credentials_resume_without_reinstalling(deployment, monkeypatch):
+    args, project, name, evidence = deployment
+    stage_source = Mock(wraps=agent._stage_agent_npa_source)
+    monkeypatch.setattr(agent, "_stage_agent_npa_source", stage_source)
+    write_credentials = agent._write_agent_nebius_env
+    interrupted = Mock(side_effect=SSHError("injected credential transport loss"))
+    monkeypatch.setattr(agent, "_write_agent_nebius_env", interrupted)
+    first = _invoke(args, evidence, "interrupted")
+    assert first.exit_code != 0
+    interrupted.assert_called_once()
+    instance_id = agent._agent_record(project, name)["instance_id"]
+    monkeypatch.setattr(agent, "_write_agent_nebius_env", write_credentials)
+    resumed = _invoke(args, evidence, "resumed")
+    assert resumed.exit_code == 0, "Resume failed; inspect private resumed.log"
+    assert agent._agent_record(project, name)["instance_id"] == instance_id
+    assert stage_source.call_count == 1, "Resume reran source/service installation"
+    assert "Reusing completed agent service installation" in resumed.output
+    status = _invoke(
+        ["agent", "status", "--project", project, "--name", name, "--json"],
+        evidence,
+        "status",
+    )
+    assert status.exit_code == 0
+    payload = json.loads(status.stdout)
+    assert payload["health"] is True
+    assert payload["basic_auth_enforced"] is True
+    (evidence / "result.json").write_text(
+        json.dumps(
+            {
+                "same_instance": True,
+                "service_installations": stage_source.call_count,
+                "credential_resume": True,
+                "authenticated_health": True,
+            },
+            indent=2,
+        )
+        + "\n"
+    )

--- a/npa/tests/e2e/test_image_bootstrap_terminal_probe_live.py
+++ b/npa/tests/e2e/test_image_bootstrap_terminal_probe_live.py
@@ -32,7 +32,7 @@ def test_image_bootstrap_terminal_probe_live() -> None:
     )
 
     assert evidence.state in {"compatible", "incompatible"}
-    assert evidence.cleanup == "verified_deleted"
+    assert evidence.cleanup == "verified"
     assert evidence.detail or evidence.checks
 
 
@@ -62,4 +62,4 @@ def test_vendor_image_runtime_bootstrap_live() -> None:
     assert evidence.ok, evidence.detail
     assert evidence.source == "ephemeral_runtime_bootstrap_probe"
     assert "kubernetes_command_override" in evidence.checks
-    assert evidence.cleanup == "verified_deleted"
+    assert evidence.cleanup == "verified"

--- a/npa/tests/e2e/test_image_bootstrap_terminal_probe_live.py
+++ b/npa/tests/e2e/test_image_bootstrap_terminal_probe_live.py
@@ -34,3 +34,32 @@ def test_image_bootstrap_terminal_probe_live() -> None:
     assert evidence.state in {"compatible", "incompatible"}
     assert evidence.cleanup == "verified_deleted"
     assert evidence.detail or evidence.checks
+
+
+def test_vendor_image_runtime_bootstrap_live() -> None:
+    """Require a real vendor image to pass prepared worker checks and cleanup."""
+
+    image = os.environ.get("NPA_E2E_IMAGE_PROBE_IMAGE", "").strip()
+    digest = os.environ.get("NPA_E2E_IMAGE_PROBE_DIGEST", "").strip()
+    context = os.environ.get("NPA_E2E_KUBECONTEXT", "").strip()
+    if not (image and digest and context):
+        pytest.skip("Requires an operator-selected vendor image and exact cluster")
+
+    evidence = probe_image_capabilities(
+        image=image,
+        digest=digest,
+        context=context,
+        kubeconfig=os.environ.get("KUBECONFIG", "").strip(),
+        image_pull_secrets=tuple(
+            name.strip()
+            for name in os.environ.get("NPA_E2E_IMAGE_PULL_SECRETS", "").split(",")
+            if name.strip()
+        ),
+        runtime_bootstrap=True,
+        observation_timeout_seconds=0,
+    )
+
+    assert evidence.ok, evidence.detail
+    assert evidence.source == "ephemeral_runtime_bootstrap_probe"
+    assert "kubernetes_command_override" in evidence.checks
+    assert evidence.cleanup == "verified_deleted"

--- a/npa/tests/guardrails/test_e2e_gate_reachability.py
+++ b/npa/tests/guardrails/test_e2e_gate_reachability.py
@@ -16,8 +16,8 @@ RUNNER_FILES = (
 # These specialized suites intentionally remain operator-invoked. The reason is
 # machine-reviewed here instead of letting an environment gate silently rot.
 MANUAL_GATES = {
+    "NPA_AGENT_RECOVERY_LIVE_CONFIG": "creates and destroys an isolated operator-selected agent VM while injecting a credential staging failure",
     "NPA_RAY_CLIP_RESULTS": "requires operator-selected downloaded native Ray CLIP CUDA result artifacts",
-    ),
     "NPA_FLEET_KUBERAY_LIVE_CONFIG": (
         "native Ray worker execution requires an operator-selected CPU Fleet, exact kubeconfig and private evidence"
     ),

--- a/npa/tests/orchestration/skypilot/test_image_bootstrap_contract.py
+++ b/npa/tests/orchestration/skypilot/test_image_bootstrap_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import subprocess
 import threading
@@ -18,6 +19,7 @@ from npa.orchestration.skypilot.image_bootstrap_contract import (
     immutable_image_reference,
     is_trusted_npa_image,
     _observe_terminal_phase,
+    _runtime_bootstrap_script,
     load_cached_evidence,
     parse_oci_reference,
     probe_image_capabilities,
@@ -178,6 +180,93 @@ def test_probe_allows_cold_workbench_image_pull_to_finish() -> None:
 
     assert evidence.ok
     assert "--request-timeout=1800s" in observed[0]
+
+
+def test_vendor_probe_overrides_application_entrypoint_and_is_not_cached(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+    evidence = probe_image_capabilities(
+        image=IMAGE,
+        digest=DIGEST,
+        context="ctx-exact",
+        runtime_bootstrap=True,
+        runner=_successful_runner(calls),
+        terminal_observer=_terminal_observer(),
+        nonce_factory=lambda: "b" * 16,
+    )
+
+    command = calls[0]
+    assert command.index("--command") < command.index("--")
+    assert command[command.index("--") + 1] == "/bin/bash"
+    assert evidence.ok and evidence.cleanup == "verified"
+    assert evidence.source == "ephemeral_runtime_bootstrap_probe"
+    assert "kubernetes_command_override" in evidence.checks
+    cache = tmp_path / "cache.json"
+    store_cached_evidence(cache, evidence)
+    assert not cache.exists()
+
+
+def _bootstrap_environment(tmp_path: Path, *, uid: str = "0", apt_exit: int = 0):
+    directory = tmp_path / "bin"
+    directory.mkdir()
+    (directory / "env").symlink_to("/usr/bin/env")
+    scripts = {
+        "id": f"printf '%s\\n' {uid}\n",
+        "sudo": "exit 1\n",
+        "apt-get": (
+            'printf "%s\\n" "$*" >> "$PROBE_APT_LOG"\n'
+            f"exit {apt_exit}\n"
+        ),
+    }
+    for name, script in scripts.items():
+        path = directory / name
+        path.write_text("#!/bin/sh\n" + script)
+        path.chmod(0o755)
+    return {
+        **os.environ,
+        "PATH": str(directory),
+        "PROBE_APT_LOG": str(tmp_path / "apt.log"),
+    }
+
+
+@pytest.mark.parametrize("uid,apt_exit", [("1000", 0), ("0", 23)])
+def test_vendor_bootstrap_refuses_privilege_or_package_failures(
+    tmp_path: Path, uid: str, apt_exit: int
+) -> None:
+    environment = _bootstrap_environment(tmp_path, uid=uid, apt_exit=apt_exit)
+    result = subprocess.run(
+        ["/bin/sh", "-c", _runtime_bootstrap_script()],
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    if uid != "0":
+        assert not (tmp_path / "apt.log").exists()
+    else:
+        assert (tmp_path / "apt.log").read_text().splitlines() == ["update"]
+
+
+def test_vendor_bootstrap_still_requires_installed_capabilities(tmp_path: Path) -> None:
+    environment = _bootstrap_environment(tmp_path)
+    calls: list[list[str]] = []
+    probe_image_capabilities(
+        image=IMAGE,
+        digest=DIGEST,
+        context="ctx-exact",
+        runtime_bootstrap=True,
+        runner=_successful_runner(calls),
+        terminal_observer=_terminal_observer(),
+    )
+    result = subprocess.run(
+        ["/bin/sh", "-c", calls[0][-1]],
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "install -y" in (tmp_path / "apt.log").read_text()
 
 
 def test_probe_observation_timeout_is_configurable_and_zero_means_no_deadline() -> None:

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -974,6 +974,8 @@ skills:
     path: skills/workflows/agent-fresh-operate/SKILL.md
     smoke:
       - type: file_exists
+        path: npa/tests/e2e/test_agent_recovery_live.py
+      - type: file_exists
         path: npa/scripts/agent_fresh_setup_loop.sh
       - type: cli_help
         args: ["agent", "fresh-setup", "--help"]

--- a/skills/tools/npa-agent/SKILL.md
+++ b/skills/tools/npa-agent/SKILL.md
@@ -122,6 +122,14 @@ transport, reconcile the exact remote setup marker and authenticated
 `/api/models`: adopt matching healthy evidence, resume incomplete phases, and
 preserve ambiguous/mismatched evidence without replacing the VM.
 
+If service installation completed before credential staging lost its SSH
+connection, a retry can reuse the private remote installer receipt. Reuse requires
+the same verified owner and an identical rendered installer (source revision,
+settings, and authentication included); the original bootstrap timestamp is
+preserved. Credentials are restaged and deployment identity and health are checked
+again. Missing or changed receipts run installation normally, and an explicit
+bootstrap of a healthy agent still reinstalls services.
+
 Agent VM creation is credential-free: Terraform/cloud-init receives no S3 HMAC
 keys, product tokens, or basic-auth password. After the exact VM identity and SSH
 channel are verified, bootstrap stages runtime credentials with owner-only SFTP

--- a/skills/workflows/agent-fresh-operate/SKILL.md
+++ b/skills/workflows/agent-fresh-operate/SKILL.md
@@ -31,11 +31,26 @@ For chat UX, API shapes, and Rerun iframe behavior, use `npa-agent`. For
   resume its first incomplete phase. Do not use `--replace` solely because the
   final Terraform/SSH response was lost; mismatched or unavailable evidence is
   indeterminate and resumable.
+- A completed service installer writes a private receipt before credentials are
+  staged. Interrupted bootstrap retries reuse that install only when its rendered
+  contents match exactly, then restage credentials and verify health. Changed
+  source/settings or a missing receipt require installation again.
 - `npa/scripts/agent_mature_verify_loop.sh` — bootstrap-first mature loop (existing agents; not fresh deploy)
 
 All `npa agent …` and `nebius` commands run on the **operator/dev VM** with
 the selected NPA configuration root (`NPA_CONFIG_DIR`, default `~/.npa`).
 Use the authorized checkout and branch for live tests.
+
+The committed recovery regression is
+`npa/tests/e2e/test_agent_recovery_live.py`. Set
+`NPA_AGENT_RECOVERY_LIVE_CONFIG` to an owner-only JSON file containing
+`deploy_args` (the argument array beginning with `agent`, `deploy`, including an
+unused `--name`, exact project, `--agent-only`, and ingress settings) and
+`evidence_dir` (an owner-only directory outside the checkout). Use isolated
+`NPA_CONFIG_DIR` and `NPA_OPERATION_JOURNAL_DIR`, run credential/capacity preflights,
+then run that test with the checkout's own Python. It injects an SSH failure during
+credential staging, requires one service install across both attempts, verifies
+authenticated health on the same VM, and destroys that exact test agent.
 
 ## Procedure
 

--- a/skills/workflows/agent-fresh-operate/SKILL.md
+++ b/skills/workflows/agent-fresh-operate/SKILL.md
@@ -51,6 +51,9 @@ unused `--name`, exact project, `--agent-only`, and ingress settings) and
 then run that test with the checkout's own Python. It injects an SSH failure during
 credential staging, requires one service install across both attempts, verifies
 authenticated health on the same VM, and destroys that exact test agent.
+When the project already has agent records, cleanup uses `--keep-iam` to preserve
+their shared identity and still requires provider-verified absence of the test
+agent's infrastructure.
 
 ## Procedure
 

--- a/skills/workflows/agent-fresh-operate/SKILL.md
+++ b/skills/workflows/agent-fresh-operate/SKILL.md
@@ -55,6 +55,14 @@ When the project already has agent records, cleanup uses `--keep-iam` to preserv
 their shared identity and still requires provider-verified absence of the test
 agent's infrastructure.
 
+After setting the private configuration and completing the preflights, enable
+the common E2E gate as well as the recovery-specific configuration:
+
+```bash
+NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest \
+  npa/tests/e2e/test_agent_recovery_live.py -q
+```
+
 ## Procedure
 
 For an explicitly authorized existing bucket in another project, save its exact

--- a/skills/workflows/neural-reconstruction/SKILL.md
+++ b/skills/workflows/neural-reconstruction/SKILL.md
@@ -91,6 +91,12 @@ preflighted image/digest, `NPA_E2E_KUBECONTEXT`, `KUBECONFIG`, and any existing
 pull Secret names through `NPA_E2E_IMAGE_PULL_SECRETS` (comma separated). It
 requires compatible worker capabilities and verified deletion of its probe pod.
 
+```bash
+NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest \
+  npa/tests/e2e/test_image_bootstrap_terminal_probe_live.py \
+  -k vendor_image_runtime_bootstrap -q
+```
+
 ## Real Entrypoints
 
 Every stage is a real command; nothing here is a manifest stub.

--- a/skills/workflows/neural-reconstruction/SKILL.md
+++ b/skills/workflows/neural-reconstruction/SKILL.md
@@ -78,6 +78,19 @@ Use the **`-ga`** repositories. `npa workbench nurec check` reports
 `ngc_image: entitlement-required` rather than failing opaquely when a
 non-GA reference is configured.
 
+Image startup preflight overrides the vendor entrypoint with `/bin/bash`, as
+SkyPilot does, and installs missing SSH, rsync, and service helpers before
+checking worker capabilities. NRE's `/app/run` entrypoint cannot forward an
+arbitrary shell probe. Prepared results are never cached as image attestations;
+they depend on package access from the selected cluster. First-party image
+attestations and strict runtime byte probes keep their existing requirements.
+
+The live regression is `test_vendor_image_runtime_bootstrap_live` in
+`npa/tests/e2e/test_image_bootstrap_terminal_probe_live.py`. Select the exact
+preflighted image/digest, `NPA_E2E_KUBECONTEXT`, `KUBECONFIG`, and any existing
+pull Secret names through `NPA_E2E_IMAGE_PULL_SECRETS` (comma separated). It
+requires compatible worker capabilities and verified deletion of its probe pod.
+
 ## Real Entrypoints
 
 Every stage is a real command; nothing here is a manifest stub.


### PR DESCRIPTION
An SSH interruption during agent credential staging now resumes the completed service install on the same verified VM. Reuse requires an identical rendered installer and private completion receipt; credentials are restaged and identity and authenticated health are checked again. Temporary installers live in the SSH user’s private home directory.

NuRec vendor image preflight now reproduces SkyPilot’s Bash entrypoint override and installs missing worker prerequisites before verifying capabilities. Runtime-prepared results are never cached as image attestations; first-party attestation and strict runtime checks retain their requirements.

The test workflow grants only `contents: read` and installs ffmpeg from Ubuntu’s signed package sources. An inconsistent Chrome repository index can no longer prevent media-validator setup, and both ffmpeg and ffprobe must execute successfully.

Validation:

- Security CI: **zero new source, workflow, or dependency findings**; **640 hostile-input/checkpoint tests passed**.
- Final Linux CI: **18,103 passed**, **433 skipped**, **1 xpassed**, **75.81% coverage**; CLI install smoke: **11 passed**.
- Browser tests, docs drift, Ruff, guardrails, confidentiality, and gitleaks passed.
- Live agent interruption/recovery/cleanup: **1 passed**, with one service install, the same VM, authenticated health, and provider-verified cleanup of the temporary infrastructure.
- Live NuRec startup: **1 passed**, including worker capabilities and verified probe deletion.
- Agent UI: chat, discovery of **224** actual NuRec artifacts, exact recording-byte comparison, and a visible Rerun canvas passed.

Updated operation skills, the skill index, and documentation. Private operational evidence remains outside the repository. The malformed baseline Python entry was repaired on main at `7657b867`, and the required security comparison now runs against that actual target revision.
