### PR TITLE
Document supported Ray paths in Workbench

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ The source of truth is `skills/index.yaml`. The tree is organized as:
 - `skills/tools/golden-eval/SKILL.md`: prove a container image actually works — per-container hello-world manifest, dry-run/local/serverless tiers, batch runs, and the offline manifest validation that gates CI.
 - `skills/tools/alpamayo2-super/SKILL.md`: real Alpamayo 2 Super VLA inference, separate OpenMDW model and gated PhysicalAI-AV dataset terms, runtime-fetch packaging, and B200/RTX PRO 6000 validation.
 - `skills/tools/cosmos3-ray-serve/SKILL.md`: persistent Cosmos3-Nano serving through cosmos-framework's native Ray Serve batching path, authenticated readiness, S3 provenance, and independent B200/RTX PRO 6000 validation.
+- `skills/tools/ray-workbench/SKILL.md`: route Ray requests to the supported native Jobs/Core, Train V2, Cosmos3 native Serve, or fixed CPU KubeRay paths and state unsupported library boundaries.
 - `skills/tools/cosmos3-super-benchmark/SKILL.md`: reproduce the fixed Cosmos3-Super vLLM-Omni serving sweep on one eight-GPU B200 or H200 node, or validate the isolated one-H200 TP-1 path, with strict MP4 validity and scope-correct throughput accounting.
 - `skills/tools/burst/SKILL.md`: one gang-scheduled multi-node GPU job with torchrun rendezvous, deliberately not a workflow surface.
 - `skills/tools/gpu-cluster-provisioning/SKILL.md`: managed-image vs GPU-Operator driver strategy (operator mode is unsafe on NVSwitch), the post-apply health gates (fabric, CUDA vectorAdd, stability window), accelerator-name discovery, and triage for nodes whose GPUs do not work.

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Workbench submits workflow tasks through SkyPilot. Selected tools exchange
 inputs and outputs through S3; workflows can call Token Factory for hosted
 inference. Inspect artifacts through the CLI, Python, or a compatible Rerun or
 Foxglove viewer. This diagram describes workflow execution; the
-[Ray development guide](docs/testing/fast-source-iteration.md) covers direct
-development with native Ray Jobs.
+[Workbench Ray guide](docs/workbench/ray.md) routes direct native Jobs/Core,
+Train, Serve, and KubeRay use to the supported paths.
 
 Python and HTTP coverage varies by tool. The
 [CLI / SDK walkthrough](docs/workbench/cli-sdk-yaml-walkthrough.md) explains

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ and PAIDF + Cosmos 3 execution.
 | Run my first GPU workload | [Quickstart](quickstart.md) for installation, project setup, and credential checks | [Workbench guides](workbench/guides/README.md) to choose a workload and inspect its result |
 | Find an existing pipeline | [Workflow catalog](../workflows/README.md) | [Workflow guide](workbench/npa-workflow-guide.md) for validation, planning, and submission |
 | Prepare compute for my workload | [Workbench setup](workbench/getting-started.md) after the quickstart | [Managed Kubernetes](workbench/kubernetes.md) for cluster-backed runs |
+| Run an application with Ray | [Workbench Ray guide](workbench/ray.md) | Choose native Jobs/Core, Train, Cosmos Serve, or fixed CPU KubeRay |
 | Call a tool from a shell or Python | [CLI reference](cli/README.md) and [CLI / SDK walkthrough](workbench/cli-sdk-yaml-walkthrough.md) | [SDK errors](sdk/errors.md); check the selected tool's supported modes |
 | Inspect or recover a run | [Run lifecycle](run-lifecycle.md) | [Known failure modes](workbench/troubleshooting/known-footguns.md) and [safe teardown](teardown.md) |
 | Use the browser workbench and viewers | [NPA agent](agent.md) | [Rerun sharing](workbench/rerun-sharing.md) |
@@ -33,6 +34,7 @@ details, use [Install npa](install.md).
 | [workbench/guides/physical-ai-data-factory-deploy.md](workbench/guides/physical-ai-data-factory-deploy.md) | **Physical AI Data Factory** — copy-paste quickstart to stage input frames and run the annotate → Cosmos augment → curate → visualize blueprint |
 | [workbench/](workbench/) | Workbench solution docs, including getting started, cookbooks, and troubleshooting |
 | [workbench/kubernetes.md](workbench/kubernetes.md) | User setup and operational guide for running Workbench on managed Kubernetes |
+| [workbench/ray.md](workbench/ray.md) | Supported Ray entry points, exact lifecycle commands, artifact boundaries, recovery, and library limitations |
 | [workbench/cosmos3-generate.md](workbench/cosmos3-generate.md) | Cosmos 3 generation (`npa-cosmos3`) — build, run via CLI/SDK/workflow, and the runtime-credential posture that keeps weights out of the image |
 | [workbench/cosmos3-b200-checkpoint-evaluation-20260814.md](workbench/cosmos3-b200-checkpoint-evaluation-20260814.md) | Reserved-B200 Cosmos3 still-image checkpoint benchmark, blind three-seed review, and recommendation |
 | [workbench/cosmos3-super-serving.md](workbench/cosmos3-super-serving.md) | Cosmos3-Super serving (`npa-cosmos3-serving`), an 8-GPU single-node endpoint: build, run, readiness window, and guardrail posture |

--- a/docs/workbench/README.md
+++ b/docs/workbench/README.md
@@ -41,6 +41,7 @@ For Python or HTTP integration, start with the
 | Path | Purpose |
 | --- | --- |
 | [getting-started.md](getting-started.md) | Runtime and storage setup after the platform quickstart |
+| [ray.md](ray.md) | Supported Ray Jobs, Core, Train, Serve, and KubeRay paths, plus explicit Data and Tune limitations |
 | [guides/README.md](guides/README.md) | Choose a robot, generation, reconstruction, or data workflow |
 | [npa-workflow-guide.md](npa-workflow-guide.md) | Author, validate, plan, submit, and resume declarative workflows |
 | [container-image-catalog.md](container-image-catalog.md) | Verified public GHCR image names, exact published tags, build dates, and capabilities |
@@ -82,6 +83,7 @@ For Python or HTTP integration, start with the
 | Customer running their first Workbench workload | [Quickstart](../quickstart.md), then [guides](guides/README.md) |
 | Customer or operator using managed Kubernetes | [kubernetes.md](kubernetes.md) |
 | Anyone choosing between CLI, SDK, and YAML | [cli-sdk-yaml-walkthrough.md](cli-sdk-yaml-walkthrough.md) |
+| Developer or operator using Ray | [ray.md](ray.md) |
 | Partner onboarding an OSS repo | [../architecture/oss-onboarding-ladder.md](../architecture/oss-onboarding-ladder.md) |
 | Engineer packaging or hardening a container | [container-packaging.md](container-packaging.md) |
 | Operator watching the same weights download every run | [model-weight-cache.md](model-weight-cache.md) |

--- a/docs/workbench/ray.md
+++ b/docs/workbench/ray.md
@@ -1,0 +1,166 @@
+# Use Workbench with Ray
+
+Workbench uses Ray through a small set of explicit paths. There is no `npa ray`
+command and no NPA wrapper around Ray Jobs. Use the native `ray` CLI for
+application submission and control; use `npa` only for the infrastructure,
+Workbench service, or workflow surface listed below.
+
+| Need | Supported path | Start here |
+| --- | --- | --- |
+| Edit and run a distributed GPU application | SkyPilot hosts plus native Ray Jobs and Core | [GPU Ray Jobs guide](../testing/fast-source-iteration.md) |
+| Exercise multi-node GPU training and recovery | Guarded Ray Train V2 synthetic reference | [Ray Train reference](../../npa/workflows/workbench/ray-train-synthetic/README.md) |
+| Keep Cosmos3-Nano loaded for repeated batches | `npa workbench cosmos3 ray-serve` and `ray-batch` | [Cosmos3 native Ray Serve](cosmos3-ray-serve.md) |
+| Provision a fixed CPU RayCluster | `npa fleet` KubeRay policy, then native Ray Jobs | [Fleet KubeRay guide](../fleet-kuberay.md) |
+| Use Ray Data | No first-class Workbench path | Submit your own trusted Ray application through a Jobs path above. |
+| Use Ray Tune | No first-class Workbench path | Submit your own trusted Ray application; Workbench ships no Tune recipe or artifact contract. |
+
+The CLIP and Train examples are guarded application references outside the
+`npa.workflow` catalog. The Cosmos batch client is the only Ray-backed path in a
+checked-in `npa.workflow` spec (`workflows/testing/cosmos3-ray-batch.yaml`), and
+its persistent service must already be ready. KubeRay is infrastructure policy,
+not a workflow runtime or Jobs controller.
+
+## Common native Jobs lifecycle
+
+The detailed guides create the cluster and a loopback tunnel differently, but
+application control is always native Ray Jobs. Use the client version pinned by
+the selected guide, choose a unique submission ID, and keep ambient Ray address
+variables from overriding the explicit endpoint.
+
+```bash
+unset RAY_ADDRESS RAY_API_SERVER_ADDRESS
+export RAY_API=http://127.0.0.1:8265
+ray job list --address "$RAY_API"
+export JOB_ID=clip-baseline
+ray job status --address "$RAY_API" "$JOB_ID"
+ray job logs --address "$RAY_API" "$JOB_ID"
+ray job stop --address "$RAY_API" "$JOB_ID"
+```
+
+`job stop` is a request, not completion evidence. Poll `job status` until the
+exact submission is terminal. Ray Jobs accepts trusted code with the runtime's
+permissions, so keep the dashboard and GCS private and use an authenticated SSH
+or Kubernetes loopback forward rather than a public load balancer.
+
+For the SkyPilot-hosted references, bootstrap the repository-pinned engine and
+invoke its returned binary rather than `sky` from `PATH`:
+
+```bash
+npa skypilot bootstrap
+export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+```
+
+Follow each reference for its exact `launch`, tunnel, and application command.
+Application Ray is separate from SkyPilot's management Ray; do not use ambient
+discovery or a broad `ray stop`.
+
+## Shortest useful paths
+
+### Ray Jobs and Core
+
+Use the [CLIP development guide](../testing/fast-source-iteration.md). It starts
+a GPU service task with SkyPilot, submits `embed.py` with `ray job submit`, and
+downloads checksummed Parquet, Lance, preview, retrieval, and report artifacts.
+Its shortest application submission, from the example directory, is:
+
+```bash
+ray job submit --address "$RAY_API" --submission-id clip-baseline \
+  --working-dir . -- \
+  python embed.py --output-path /tmp/ray-clip-results/baseline
+```
+
+Python edits travel through `--working-dir` without an image rebuild. The
+[advanced recipe](../../npa/workflows/workbench/ray-clip-development/README.md)
+adds actor recovery, partial-checkpoint reuse, cancellation, and factual Rerun
+conversion. Completed results can be moved to immutable S3 storage with the
+[archive companion](../testing/ray-clip-archive.md).
+
+### Ray Train
+
+Use the [two-host synthetic reference](../../npa/workflows/workbench/ray-train-synthetic/README.md).
+Its real submission is native Jobs:
+
+```bash
+cd npa/workflows/workbench/ray-train-synthetic
+ray job submit --address "$RAY_API" --submission-id train-baseline \
+  --working-dir . -- /opt/npa-ray-train/env/bin/python train.py \
+  --storage-path "$TRAIN_STORAGE_URI" --run-name baseline \
+  --output-dir /opt/npa-ray-train/exports/train-baseline
+```
+
+The reference uses Ray Train V2 and writes native checkpoints under the selected
+S3 storage path. Its final export contains `state.pt`, `metrics.json`,
+`metrics.rrd`, `result.json`, and `SHA256SUMS`; the checksum manifest is
+published last and every object is read back. Retry a failed export from the
+preserved host directory with `inspect_results.py --publish` instead of
+retraining. Training recovery reuses the same `RunConfig(name, storage_path)`;
+do not apply Ray Train V1 restore APIs.
+
+### Ray Serve
+
+Cosmos3-Nano has the only first-class Workbench Ray Serve path. Before starting
+GPU work, verify credentials, model access, and the accepted image definition:
+
+```bash
+npa workbench health preflight --checks hf,ngc,s3 --json
+npa workbench health access --capability cosmos3 --json
+npa workbench golden-eval show cosmos3-ray-serve
+```
+
+Inside the digest-pinned service image, start the model and upstream batching
+implementation with:
+
+```bash
+npa workbench cosmos3 ray-serve --world-size 1 --max-batch-size 4
+```
+
+Then submit a durable batch from a CPU client:
+
+```bash
+npa workbench cosmos3 ray-batch \
+  --input-path s3://<bucket>/<prefix>/batch.json \
+  --output-path s3://<bucket>/<prefix>/outputs/ \
+  --endpoint http://<private-service>:8000
+```
+
+The bearer token comes from `NPA_COSMOS3_RAY_TOKEN`, not the command line. The
+client verifies the response and publishes `request.json`, `response.json`,
+generated media, and `provenance.json`. If client validation fails after model
+execution, preserve the failed result and original native output directory
+before retrying. See the [service guide](cosmos3-ray-serve.md) for readiness,
+input schema, guardrails, GPU qualification, and recovery.
+
+### KubeRay
+
+Fleet can install one fixed, CPU-only RayCluster from a reviewed KubeRay recipe.
+Start with `npa/examples/fleet/kuberay/cpu-raycluster.yaml`, copy it outside the
+repository, and run:
+
+```bash
+npa workbench health preflight --checks nebius --json
+npa fleet plan --spec /path/to/private-fleet.yaml
+npa fleet deploy --spec /path/to/private-fleet.yaml --no-create-projects --yes
+```
+
+Forward `service/ray-cluster-head-svc` to loopback and use native `ray job`
+commands as shown in the [Fleet KubeRay guide](../fleet-kuberay.md). This path
+supports fixed CPU workers only: no GPU workers, RayService, autoscaling,
+arbitrary image, Ray Train guarantee, or durable application artifact layer.
+Save logs and outputs before teardown because the Ray object store and `/tmp`
+are ephemeral.
+
+## Artifacts, failure, and cleanup
+
+| Path | Durable boundary | Recovery boundary |
+| --- | --- | --- |
+| CLIP Jobs/Core | Downloaded checksummed result; optional immutable S3 archive | Reuse only validated committed shards; an interrupted job is not a completed dataset. |
+| Ray Train | Native S3 checkpoints plus checksum-bound S3 export | Train V2 restarts from its matching run; retry preserved export bytes separately. |
+| Cosmos Ray Serve | Verified S3 request, response, media, and provenance | Preserve failed client/native output evidence; fix access or contract errors before resubmission. |
+| Fleet KubeRay | Nothing by default | Save application outputs outside the cluster before owned teardown. |
+
+Do not remove hosting resources while an application job is active. Stop every
+exact native Jobs submission and confirm terminal state, then cancel the exact
+SkyPilot service task or destroy the owned Fleet target. Preserve shared
+Kubernetes clusters, SkyPilot APIs, controllers, projects, and storage unless
+you separately own their lifecycle. The detailed guides contain the precise
+cleanup commands for each ownership model.

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -29,6 +29,19 @@ licenses:
     applies_to:
       - physical-ai-data-factory
 skills:
+  - name: ray-workbench
+    category: tools
+    when_to_use: "Choose or operate a supported Ray path: native Jobs/Core, guarded Train V2, Cosmos3 native Serve, or fixed CPU KubeRay; identify unsupported Ray libraries."
+    path: skills/tools/ray-workbench/SKILL.md
+    smoke:
+      - type: file_exists
+        path: docs/workbench/ray.md
+      - type: cli_help
+        args: ["workbench", "cosmos3", "ray-batch", "--help"]
+        contains: "durable SDG batch"
+      - type: cli_help
+        args: ["fleet", "plan", "--help"]
+        contains: "resolved deployment plan"
   - name: ray-train-synthetic
     category: tools
     when_to_use: "Run native Ray Train distributed CUDA synthetic regression, S3 checkpoints, optimizer recovery and factual Rerun metrics."

--- a/skills/tools/ray-workbench/SKILL.md
+++ b/skills/tools/ray-workbench/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: ray-workbench
+description: "Choose and operate the supported Ray paths in Nebius Physical AI: native Jobs/Core development, guarded Train V2, Cosmos3 native Serve, or Fleet KubeRay."
+---
+
+# Ray in Workbench
+
+Start with the [consolidated guide](../../../docs/workbench/ray.md). Use this
+skill to route a Ray request to behavior that current code actually supports.
+
+## Route the request
+
+- Native Jobs or Ray Core GPU development: use
+  `docs/testing/fast-source-iteration.md` and the guarded CLIP application under
+  `npa/workflows/workbench/ray-clip-development/`.
+- Ray Train: load `skills/tools/ray-train-synthetic/SKILL.md`. The shipped path
+  is a synthetic Ray Train V2 application submitted through native Jobs, not an
+  NPA Train service or workflow.
+- Ray Serve: load `skills/tools/cosmos3-ray-serve/SKILL.md`. Only Cosmos3-Nano
+  has a first-class native Ray Serve path.
+- KubeRay: load `skills/tools/fleet/SKILL.md`. Fleet supports only the reviewed,
+  fixed CPU RayCluster policy documented in `docs/fleet-kuberay.md`.
+- Ray Data or Ray Tune: state that no first-class Workbench recipe, CLI, service,
+  workflow, or artifact contract exists. A trusted user may submit their own Ray
+  application through a supported native Jobs environment; do not imply that
+  this makes Data or Tune a supported Workbench capability.
+
+There is no `npa ray` or NPA Jobs controller. Native `ray job` owns application
+submission, list, status, logs, and stop. SkyPilot owns the CLIP and Train hosts
+and long-running service task. Fleet owns KubeRay infrastructure. The Cosmos
+client owns verified S3 batch publication. Keep these lifecycle identities
+separate.
+
+## Operating rules
+
+1. Before provisioning, use `npa workbench health preflight --checks nebius
+   --json`; add the selected capability's storage and model-access checks.
+2. For SkyPilot references, run `npa skypilot bootstrap` and resolve
+   `NPA_SKYPILOT_BIN` from `npa skypilot status --bin-path`. Never use ambient
+   management Ray discovery or `sky` from `PATH`.
+3. Keep Jobs and GCS on private networking behind an authenticated loopback
+   tunnel. Ray accepts trusted code and a namespace is not a tenant boundary.
+4. Use unique native submission IDs. `ray job stop` must reach terminal status
+   before hosting teardown.
+5. Preserve the path-specific artifact boundary before cleanup: checksummed
+   CLIP output, Train checkpoints/exports, verified Cosmos S3 publications, or
+   explicitly copied KubeRay application output.
+6. Cancel exact application jobs before the exact SkyPilot service task or owned
+   Fleet target. Preserve shared clusters, APIs, controllers, projects, and
+   storage unless their ownership is separately established.
+
+Do not add Ray Data/Tune examples, GPU KubeRay, RayService, a Jobs wrapper, or a
+new `npa.workflow` surface without implementation and live evidence. Do not
+describe multiple GPUs on one node as multi-node proof; require actual Ray node
+and physical-host evidence.
+
+## Verify
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_skills_index.py -q
+npa/.venv/bin/python -m pytest --collect-only -q
+```


### PR DESCRIPTION
## What changed

- Add a consolidated Workbench guide that routes Ray Jobs/Core, Train V2, Cosmos3 Ray Serve, and fixed CPU KubeRay to their supported entry points and native lifecycle commands.
- Document each path's artifact boundary, recovery and cleanup order, and the unsupported Ray Data/Tune boundary.
- Register the `ray-workbench` agent routing skill and link the guide from existing documentation indexes.

This is documentation and skill guidance only; it changes no runtime, API, workflow, or infrastructure behavior.

## Scope

- One commit based directly on current `main` (`7657b867ab50ec4c3a7d738e5f175ff697aaee67`).
- Seven guide/skill files: 248 insertions and 2 deletions.

## Local validation

- Ruff: passed.
- Ray-focused tests: 730 passed.
- Full guardrails: 2,703 passed.
- Full collection smoke: 18,508 tests collected.
- CLI docs drift, explicit skill help checks, affected relative links, diff integrity, built-in confidentiality, and Gitleaks: passed.

All nine GitHub checks pass. The fresh Python 3.12 unit run completed with 18,086 passed, 431 skipped, 1 xpassed, and 76% coverage; its CLI install smoke passed 11/11. This resolves the previous runner-side Google Chrome APT index hash mismatch, which occurred before Python/package setup or tests.

## Limits

- No first-class Ray Data/Tune recipe, NPA Jobs wrapper, GPU KubeRay, RayService, or new `npa.workflow` surface is added.
- No cloud resources were created or exercised.
