### PR TITLE
Reject impossible CPU KubeRay pod capacity

### DIFF
--- a/docs/fleet-kuberay.md
+++ b/docs/fleet-kuberay.md
@@ -39,7 +39,11 @@ cluster.validate()
 
 Counts and resources must be positive integers. A nonempty, explicit CPU pool
 is required. Size it for the head (1 CPU, 4 GiB), workers and Kubernetes system
-pods; Fleet does not scale infrastructure to satisfy Ray tasks. A per-cluster
+pods; Fleet rejects a head or worker larger than one declared CPU node and
+rejects fixed pod requests above the pool's nominal aggregate CPU or memory.
+Leave additional capacity for Kubernetes system pods because this validation is
+only an impossibility check, not an allocatable-resource readiness result. Fleet
+does not scale infrastructure to satisfy Ray tasks. A per-cluster
 `kuberay: {enabled: false}` replaces an enabled defaults block completely.
 Unknown fields, RayService, GPU workers, autoscaling and arbitrary image/chart
 values are rejected. A GPU pool may coexist, but these Ray pods select only the

--- a/npa/src/npa/cluster_backends/kuberay.py
+++ b/npa/src/npa/cluster_backends/kuberay.py
@@ -18,6 +18,11 @@ RAY_IMAGE = (
     "507464fe56b3d24cec2e812a25850db91b97d52752d63119fecf6914f7b0a37a"
 )
 KUBERAY_STATE_FILES = frozenset({"terraform.tfstate", "terraform.tfstate.backup"})
+_CPU_NODE_PRESET = re.compile(
+    r"(?P<cpus>[1-9][0-9]*)vcpu-(?P<memory_gib>[1-9][0-9]*)gb"
+)
+_HEAD_CPUS = 1
+_HEAD_MEMORY_GIB = 4
 
 
 @dataclass(frozen=True)
@@ -63,9 +68,42 @@ class KubeRaySpec:
         if cpu_nodes is None or cpu_nodes.count <= 0 or cpu_nodes.is_gpu():
             raise ValueError("kuberay requires a nonempty CPU node pool")
         if not re.fullmatch(r"cpu-[a-z0-9-]+", cpu_nodes.platform) or not re.fullmatch(
-            r"[1-9][0-9]*vcpu-[1-9][0-9]*gb", cpu_nodes.preset
+            _CPU_NODE_PRESET, cpu_nodes.preset
         ):
             raise ValueError("kuberay requires an explicit CPU platform and preset")
+        self._validate_fixed_pod_capacity(cpu_nodes)
+
+    def _validate_fixed_pod_capacity(self, cpu_nodes: Any) -> None:
+        """Reject Ray pod requests that exceed nominal declared CPU capacity."""
+
+        match = _CPU_NODE_PRESET.fullmatch(cpu_nodes.preset)
+        if match is None:  # The caller validates the preset before this helper.
+            raise ValueError("kuberay requires an explicit CPU platform and preset")
+        node_cpus = int(match.group("cpus"))
+        node_memory_gib = int(match.group("memory_gib"))
+        if _HEAD_CPUS > node_cpus or _HEAD_MEMORY_GIB > node_memory_gib:
+            raise ValueError(
+                f"kuberay head pod requests {_HEAD_CPUS} vCPU/{_HEAD_MEMORY_GIB} GiB, "
+                f"which exceeds one declared {node_cpus} vCPU/{node_memory_gib} GiB CPU node"
+            )
+        if self.worker_cpus > node_cpus or self.worker_memory_gib > node_memory_gib:
+            raise ValueError(
+                f"kuberay worker pod requests {self.worker_cpus} vCPU/"
+                f"{self.worker_memory_gib} GiB, which exceeds one declared "
+                f"{node_cpus} vCPU/{node_memory_gib} GiB CPU node"
+            )
+        pool_cpus = cpu_nodes.count * node_cpus
+        pool_memory_gib = cpu_nodes.count * node_memory_gib
+        requested_cpus = _HEAD_CPUS + self.worker_replicas * self.worker_cpus
+        requested_memory_gib = (
+            _HEAD_MEMORY_GIB + self.worker_replicas * self.worker_memory_gib
+        )
+        if requested_cpus > pool_cpus or requested_memory_gib > pool_memory_gib:
+            raise ValueError(
+                f"kuberay fixed pod requests {requested_cpus} vCPU/"
+                f"{requested_memory_gib} GiB, which exceeds the declared CPU pool's "
+                f"nominal {pool_cpus} vCPU/{pool_memory_gib} GiB capacity"
+            )
 
     def plan(self) -> dict[str, Any]:
         """Describe the policy and its pinned Ray runtime.

--- a/npa/tests/unit/test_fleet_kuberay.py
+++ b/npa/tests/unit/test_fleet_kuberay.py
@@ -96,6 +96,48 @@ def test_sdk_cannot_bypass_type_or_cpu_pool_validation():
         replace(cluster(KubeRaySpec(True)), backend="soperator").validate()
 
 
+@pytest.mark.parametrize(
+    "policy, message",
+    [
+        (KubeRaySpec(True, worker_cpus=17), "worker pod requests 17 vCPU/4 GiB"),
+        (KubeRaySpec(True, worker_memory_gib=65), "worker pod requests 2 vCPU/65 GiB"),
+        (KubeRaySpec(True, worker_replicas=8), "fixed pod requests 17 vCPU/36 GiB"),
+        (KubeRaySpec(True, worker_replicas=16, worker_cpus=1), "fixed pod requests 17 vCPU/68 GiB"),
+    ],
+)
+def test_sdk_rejects_kuberay_pods_that_cannot_fit_declared_cpu_pool(policy, message):
+    desired = replace(
+        cluster(policy),
+        cpu_nodes=NodePoolSpec(count=1, platform="cpu-d3", preset="16vcpu-64gb"),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        desired.validate()
+
+
+def test_yaml_rejects_kuberay_head_that_cannot_fit_declared_cpu_pool():
+    declaration = spec_from_mapping({
+        "name": "ray-example",
+        "defaults": {
+            "cpu_nodes": {"count": 1, "platform": "cpu-d3", "preset": "1vcpu-2gb"},
+            "kuberay": {"enabled": True},
+        },
+        "projects": [{"name": "example"}],
+    })
+
+    with pytest.raises(ValueError, match="head pod requests 1 vCPU/4 GiB"):
+        declaration.validate()
+
+
+def test_kuberay_capacity_validation_accepts_feasible_nominal_requests():
+    desired = replace(
+        cluster(KubeRaySpec(True, worker_replicas=2, worker_cpus=4, worker_memory_gib=8)),
+        cpu_nodes=NodePoolSpec(count=2, platform="cpu-d3", preset="8vcpu-32gb"),
+    )
+
+    desired.validate()
+
+
 def test_disable_replaces_default_policy_and_explicit_envelope_works():
     declaration = {
         "name": "example", "defaults": {

--- a/skills/tools/fleet/SKILL.md
+++ b/skills/tools/fleet/SKILL.md
@@ -30,7 +30,10 @@ Three-tier contract:
 Use `kuberay: {enabled: true, worker_replicas: 2, worker_cpus: 2,
 worker_memory_gib: 4}` in a cluster/default profile for a fixed CPU worker group.
 The shared backend validates strict types, explicit CPU placement and the exact
-reviewed recipe before provisioning. `KubeRaySpec` is exported by `npa.sdk.fleet`.
+reviewed recipe before provisioning. It also rejects head or worker pods larger
+than one declared CPU node and fixed requests above the pool's nominal aggregate
+CPU or memory; operators must still leave room for Kubernetes system pods.
+`KubeRaySpec` is exported by `npa.sdk.fleet`.
 A disabled block replaces enabled defaults atomically. Omitted policy remains off.
 Enabled deployments require the default local Terraform workspace without
 `TF_CLI_ARGS*` or `TF_DATA_DIR` overrides. Reapply rejects extra effective inputs


### PR DESCRIPTION
## Summary

- reject fixed KubeRay head or worker pods that cannot fit on one declared CPU node
- reject fixed head-plus-worker requests above the CPU pool's nominal aggregate CPU or memory
- document that operators must still reserve capacity for Kubernetes system pods

## Validation

- KubeRay unit module: 142 passed
- affected Fleet/MK8s/backend/skill selection: 938 passed
- onboarding smoke: 114 passed
- full guardrails: 2,700 passed
- scoped and repository-wide Ruff: passed
- docs drift: passed
- prior broad hermetic run retained: 18,075 passed with one unrelated adapter timeout under host contention; the timed-out test passed independently in 99.75 seconds
- confidentiality and Gitleaks: passed

No cloud resources or Ray Jobs were created. The opt-in live test was not run because owner-private live configuration is unavailable; this change rejects invalid declarations before provisioning.
