### PR TITLE
Bind native Ray CLIP resumes to checkpoint layout

### DIFF
--- a/docs/testing/ray-clip-checkpoint-resume.md
+++ b/docs/testing/ray-clip-checkpoint-resume.md
@@ -5,6 +5,10 @@ can resume a partial driver result directory through another native Ray Job.
 Keep the same application, worker, validation and canonical UDF bytes, model
 snapshot, runtime, inputs, batch size and output path. Use a new submission ID.
 The original Job must be terminal before another Job writes that directory.
+The durable `execution.json` binds both the runtime fingerprint and checkpoint
+layout, so a changed record count or batch size fails instead of accepting a
+different shard tree. Actor count is not part of that layout and may change to
+match the GPUs available to the resumed Job.
 
 After the original Job has committed multiple shards, stop that exact Job and
 verify its terminal status:

--- a/npa/tests/workflows/test_ray_clip_checkpoint_resume.py
+++ b/npa/tests/workflows/test_ray_clip_checkpoint_resume.py
@@ -107,7 +107,13 @@ class _SessionFactory:
 
     def _create(self, count, cached, total=7):
         """Create real committed Parquet fixtures before a new invocation."""
-        arguments = SimpleNamespace(actors=count, model_revision="revision", output_path=str(self.path))
+        arguments = SimpleNamespace(
+            actors=count,
+            model_revision="revision",
+            output_path=str(self.path),
+            records=total,
+            batch_size=1,
+        )
         result = self.application._InferenceSession(arguments, [[index] for index in range(total)])
         result.fingerprint = "execution"
         prepared = [self.application.worker.preprocess_shard([index]) for index in range(total)]

--- a/npa/tests/workflows/test_ray_clip_development.py
+++ b/npa/tests/workflows/test_ray_clip_development.py
@@ -298,25 +298,33 @@ def test_checkpoint_replay_skips_actor_and_corruption_fails(recipe, tmp_path):
         recipe.application.submit_shard(forbidden_actor, shard, tmp_path, "revision", "execution")
 
 
-def test_output_root_requires_matching_execution_fingerprint(recipe, tmp_path):
-    """Output root requires matching execution fingerprint.
+def test_output_root_requires_matching_execution_identity(recipe, tmp_path, monkeypatch):
+    """Output root requires matching runtime and checkpoint-layout identity.
 
     Args:
         recipe: Isolated example modules and canonical source paths.
         tmp_path: Temporary directory owned by this test.
+        monkeypatch: Pytest fixture preventing application Ray discovery.
     Returns:
         None after the assertions pass.
     Raises:
         pytest.fail.Exception: An expected exception is not raised.
     """
-    recipe.validation.verify_execution(tmp_path, "first")
-    recipe.validation.verify_execution(tmp_path, "first")
+    layout = {"records": 8, "batch_size": 2}
+    recipe.validation.verify_execution(tmp_path, "first", layout)
+    recipe.validation.verify_execution(tmp_path, "first", layout)
     with pytest.raises(ValueError, match="different execution fingerprint"):
-        recipe.validation.verify_execution(tmp_path, "different")
+        recipe.validation.verify_execution(tmp_path, "different", layout)
+    with pytest.raises(ValueError, match="different checkpoint layout"):
+        recipe.validation.verify_execution(tmp_path, "first", {"records": 4, "batch_size": 2})
+    monkeypatch.setitem(sys.modules, "ray", SimpleNamespace())
+    changed = SimpleNamespace(output_path=str(tmp_path), records=4, batch_size=2)
+    with pytest.raises(ValueError, match="different checkpoint layout"):
+        recipe.application._InferenceSession(changed, [[0, 1], [2, 3]])
     (tmp_path / "execution.json").unlink()
     (tmp_path / "old-shard").write_bytes(b"old")
     with pytest.raises(ValueError, match="no execution fingerprint"):
-        recipe.validation.verify_execution(tmp_path, "first")
+        recipe.validation.verify_execution(tmp_path, "first", layout)
 
 
 def test_model_fingerprint_ignores_download_metadata_but_covers_model_bytes(recipe, tmp_path):

--- a/npa/workflows/workbench/ray-clip-development/application.py
+++ b/npa/workflows/workbench/ray-clip-development/application.py
@@ -566,7 +566,7 @@ def _arguments(argv):
     return parser.parse_args(argv)
 
 
-def _validate_output_directory(output):
+def _validate_output_directory(output, checkpoint_layout):
     """Keep durable output separate from Ray's cached application source."""
     if not output.is_absolute():
         raise ValueError("output-path must be an absolute run-owned driver path outside working_dir")
@@ -575,6 +575,7 @@ def _validate_output_directory(output):
     output.mkdir(parents=True, exist_ok=True)
     if (output / "report.json").exists():
         raise ValueError("Use a new output directory for each application job")
+    validation.verify_checkpoint_layout(output, checkpoint_layout)
 
 
 def _verify_actor_allocations(initializations, actors):
@@ -616,7 +617,11 @@ class _InferenceSession:
         self.arguments = arguments
         self.shards = shards
         self.output = Path(arguments.output_path)
-        _validate_output_directory(self.output)
+        self.checkpoint_layout = {
+            "records": arguments.records,
+            "batch_size": arguments.batch_size,
+        }
+        _validate_output_directory(self.output, self.checkpoint_layout)
         self.actors = []
         self.initializations = []
         self.barrier = None
@@ -649,7 +654,7 @@ class _InferenceSession:
         self.actors = [self._new_actor() for _ in range(self.arguments.actors)]
         self.initializations = self.ray.get([actor.status.remote() for actor in self.actors])
         self.fingerprint = _verify_actor_allocations(self.initializations, self.arguments.actors)
-        validation.verify_execution(self.output, self.fingerprint)
+        validation.verify_execution(self.output, self.fingerprint, self.checkpoint_layout)
         self.model_ready = time.perf_counter()
 
     def _commit_first_shard(self):

--- a/npa/workflows/workbench/ray-clip-development/validation.py
+++ b/npa/workflows/workbench/ray-clip-development/validation.py
@@ -139,12 +139,33 @@ def checkpoint_identity(shard: dict, model_revision: str, execution_fingerprint:
     }
 
 
-def verify_execution(directory: Path, fingerprint: str) -> None:
+def verify_checkpoint_layout(directory: Path, checkpoint_layout: dict) -> None:
+    """Reject an existing output whose shard boundaries differ.
+
+    Args:
+        directory: Existing driver-owned output directory.
+        checkpoint_layout: Record count and batch size defining shard boundaries.
+    Returns:
+        None when no execution exists yet or its layout matches.
+    Raises:
+        ValueError: Existing output belongs to another checkpoint layout.
+        OSError: Existing execution metadata cannot be read.
+    """
+    marker = directory / "execution.json"
+    if not marker.exists():
+        return
+    observed = json.loads(marker.read_text())
+    if observed.get("checkpoint_layout") != checkpoint_layout:
+        raise ValueError("Output directory belongs to a different checkpoint layout")
+
+
+def verify_execution(directory: Path, fingerprint: str, checkpoint_layout: dict) -> None:
     """Associate an output directory with exactly one execution identity.
 
     Args:
         directory: Existing driver-owned output directory.
         fingerprint: Expected source, model and runtime identity.
+        checkpoint_layout: Record count and batch size defining shard boundaries.
     Returns:
         None after the identity is verified or first recorded.
     Raises:
@@ -152,10 +173,15 @@ def verify_execution(directory: Path, fingerprint: str) -> None:
         OSError: Output metadata cannot be read or written.
     """
     marker = directory / "execution.json"
-    expected = {"execution_fingerprint": fingerprint}
+    expected = {
+        "execution_fingerprint": fingerprint,
+        "checkpoint_layout": checkpoint_layout,
+    }
     if marker.exists():
-        if json.loads(marker.read_text()) != expected:
+        observed = json.loads(marker.read_text())
+        if observed.get("execution_fingerprint") != fingerprint:
             raise ValueError("Output directory belongs to a different execution fingerprint")
+        verify_checkpoint_layout(directory, checkpoint_layout)
         return
     if any(directory.iterdir()):
         raise ValueError("Nonempty output directory has no execution fingerprint")


### PR DESCRIPTION
## Summary

- Bind native Ray CLIP partial results to the record count and batch size that define checkpoint shard boundaries.
- Reject incompatible resumes before Ray discovery or GPU model loading.
- Keep actor count adjustable between resume attempts.
- Document and test the checkpoint-layout contract.

## Validation

- 87 focused checkpoint/development tests passed.
- 842 non-live Ray-focused tests passed.
- 2,700 guardrails passed.
- Repository Ruff, docs drift, diff confidentiality, Gitleaks, and whitespace checks passed.
- Prior required hostile-input security selection: 640 passed.
- All nine fresh GitHub checks passed on the rebased head, including 18,083 Python 3.12 tests at 75.80% coverage and the security regression comparison.

An earlier full local xdist attempt was interrupted under shared-host contention after 17,081 passes; its log is retained privately. No live GPU run was performed because the owner-private Ray checkpoint configuration is unavailable; the changed preflight boundary is covered hermetically.
