### PR TITLE
Align Cosmos Ray batch admission capacity

### DIFF
--- a/docs/workbench/cosmos3-ray-serve.md
+++ b/docs/workbench/cosmos3-ray-serve.md
@@ -19,7 +19,7 @@ The container starts `npa workbench cosmos3 ray-serve`. Important settings:
 | Setting | Default | Meaning |
 | --- | --- | --- |
 | `NPA_COSMOS3_RAY_WORLD_SIZE` | `1` | GPUs used by one persistent model replica |
-| `NPA_COSMOS3_RAY_MAX_BATCH_SIZE` | `4` | Maximum samples coalesced by upstream Ray Serve |
+| `NPA_COSMOS3_RAY_MAX_BATCH_SIZE` | `4` | Maximum samples coalesced by upstream Ray Serve; also sets the model replica's admission capacity so the configured batch can form |
 | `NPA_COSMOS3_RAY_BATCH_WAIT_TIMEOUT_S` | `0.05` | Coalescing window in seconds |
 | `NPA_COSMOS3_RAY_PARALLELISM_PRESET` | `throughput` | Upstream Cosmos parallelism preset |
 | `NPA_COSMOS3_RAY_GUARDRAILS` | `true` | Guardrails remain on unless explicitly disabled |
@@ -49,7 +49,9 @@ exact access probe to pass before starting the client.
 
 The service exposes authenticated `GET /health`, model-backed `GET /ready`,
 `GET /models`, `GET /system-info`, `POST /v1/batches`, and artifact retrieval at
-`GET /v1/artifacts/{path}`.
+`GET /v1/artifacts/{path}`. Readiness reports both `max_batch_size` and
+`model_max_ongoing_requests`; they must match for this single-concurrent-batch
+deployment.
 
 ### Trusted batch callers and conditioning downloads
 

--- a/npa/src/npa/workbench/cosmos/ray_server.py
+++ b/npa/src/npa/workbench/cosmos/ray_server.py
@@ -99,6 +99,7 @@ def _run_server() -> None:
     guardrails = _env_bool("NPA_COSMOS3_RAY_GUARDRAILS", True)
     world_size = _env_int("NPA_COSMOS3_RAY_WORLD_SIZE", 1, minimum=1)
     max_batch_size = _env_int("NPA_COSMOS3_RAY_MAX_BATCH_SIZE", 4, minimum=1)
+    max_ongoing_requests = max_batch_size
     wait_timeout = _env_float("NPA_COSMOS3_RAY_BATCH_WAIT_TIMEOUT_S", 0.05, minimum=0.0)
     host = os.environ.get("NPA_COSMOS3_RAY_HOST", "0.0.0.0")
     port = _env_int("NPA_COSMOS3_RAY_PORT", 8000, minimum=1024)
@@ -131,6 +132,7 @@ def _run_server() -> None:
         cast(ray.serve.Deployment, OmniModelDeployment)
         .options(
             name=model_name,
+            max_ongoing_requests=max_ongoing_requests,
             user_config={
                 "max_batch_size": max_batch_size,
                 "batch_wait_timeout_s": wait_timeout,
@@ -201,6 +203,7 @@ def _run_server() -> None:
                 "guardrails": guardrails,
                 "world_size": world_size,
                 "max_batch_size": max_batch_size,
+                "model_max_ongoing_requests": max_ongoing_requests,
                 "batch_wait_timeout_s": wait_timeout,
                 "framework_revision": framework_revision,
                 "server_source_revision": source_revision,

--- a/npa/tests/e2e/test_cosmos3_ray_batch_live_e2e.py
+++ b/npa/tests/e2e/test_cosmos3_ray_batch_live_e2e.py
@@ -125,6 +125,7 @@ def test_guarded_batch_publishes_two_decodable_samples_and_rejects_incomplete_re
     ready = ray_serve.service_health()
     assert ready["status"] == "ready"
     assert ready["guardrails"] is True
+    assert ready["model_max_ongoing_requests"] == ready["max_batch_size"]
     storage = StorageClient.from_environment()
     request_id = uuid.uuid4().hex
     root = prefix + "/" + request_id

--- a/npa/tests/workbench/test_cosmos3_ray_serve.py
+++ b/npa/tests/workbench/test_cosmos3_ray_serve.py
@@ -289,6 +289,18 @@ def _capture_batch_router(monkeypatch, tmp_path):
     return captured["router"]
 
 
+def test_model_admission_capacity_can_form_configured_batch(monkeypatch, tmp_path):
+    import sys
+
+    monkeypatch.setenv("NPA_COSMOS3_RAY_MAX_BATCH_SIZE", "8")
+    _capture_batch_router(monkeypatch, tmp_path)
+
+    deployment = sys.modules[
+        "cosmos_framework.inference.ray.serve"
+    ].OmniModelDeployment
+    assert deployment.options.call_args.kwargs["max_ongoing_requests"] == 8
+
+
 def _rewritten_batch_api(router):
     import inspect
 

--- a/skills/tools/cosmos3-ray-serve/SKILL.md
+++ b/skills/tools/cosmos3-ray-serve/SKILL.md
@@ -48,6 +48,8 @@ npa workbench cosmos3 ray-serve --world-size 1 --max-batch-size 4
 
 Configuration is explicit: `--world-size` sets GPUs per replica;
 `--max-batch-size` and `--batch-wait-timeout-s` are upstream batching knobs;
+the service sets Ray's model-replica request admission capacity to the configured
+maximum batch size so batches above Ray 2.58's default capacity can form;
 `--parallelism-preset` is the Cosmos placement preset; and
 `--guardrails/--no-guardrails` is the explicit safety posture.
 


### PR DESCRIPTION
## Summary

- align the Cosmos3 native model replica Ray Serve admission capacity with the configured `max_batch_size`
- expose the aligned value through authenticated readiness
- add hermetic batch-size-eight coverage, an opt-in live assertion, and operator documentation

The default batch size of four is unchanged. Other API, CLI, SDK, toolRef, artifact, authentication, guardrail, and model contracts are unchanged.

## Scope and rebase

Rebased the one independent Serve commit onto current `main` (`7657b867`). The PR remains exactly five files: 22 insertions and two deletions.

## Validation

Post-rebase: 510 related tests and 2,700 guardrails passed; repository Ruff, docs drift, diff confidentiality (0 hits), Gitleaks, and whitespace checks passed. The required security selection produced 632 passes and eight expected skips under the repository Python 3.10 environment; its one unrelated cancellation-object-identity failure is unchanged from the old head. Prior passing evidence (470 affected tests, 2,703 guardrails, and the Python 3.12 required security job) is retained; the earlier clean-suite attempt was interrupted, not counted as a pass.

The previous GitHub `test (3.12)` failure occurred before checkout/repository setup because the Google Chrome APT index returned a hash mismatch while installing ffmpeg. The rebased push reruns it.

No cloud or GPU workload was run. This proves application configuration/readiness behavior, not worker-side coalescing, inference throughput, or generated-media quality.