### PR TITLE
Promote validated NuRec reconstruction workflow to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,7 +360,7 @@ call a tool endpoint, and write the next S3 URI. The BDD100K pipeline in
 ## Workflow YAML Conventions
 The supported, customer-facing workflow catalog is the declarative
 `npa.workflow` spec set under `workflows/`. Keep `workflows/main/` limited to
-`sim2real.yaml` and `paidf-cosmos3.yaml`; author all other catalog workflows in
+`sim2real.yaml`, `paidf-cosmos3.yaml`, and `nurec-reconstruct.yaml`; author new catalog workflows in
 `workflows/testing/`. Keep catalog documentation in `workflows/README.md`.
 Do not add raw SkyPilot task templates to
 the package as a workflow catalog; the old catalog path is guardrail-retired.

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ npa/                       # Python package (CLI + SDK); install with `pip insta
   workflows/workbench/
     sim2real/              # Operator notes and legacy compatibility
 workflows/                 # Supported npa.workflow/v0.0.1 catalog; see README.md
-  main/                    # sim2real.yaml and paidf-cosmos3.yaml only
+  main/                    # sim2real.yaml, paidf-cosmos3.yaml, nurec-reconstruct.yaml
   testing/                 # All other catalog workflow specs
 docs/                      # Quickstart, architecture, workbench guides, cookbooks
 skills/                    # SKILL.md files for agents and contributors (source of truth)

--- a/docs/architecture/contributor-context.md
+++ b/docs/architecture/contributor-context.md
@@ -28,7 +28,7 @@ nebius-physical-ai/
 │   ├── workbench-yaml-guide.md   # SkyPilot YAML pipeline guide (living doc)
 │   └── demos/                    # Demo runbooks and assets
 ├── workflows/                    # Declarative workflow catalog and README
-│   ├── main/                     # sim2real.yaml and paidf-cosmos3.yaml only
+│   ├── main/                     # sim2real.yaml, paidf-cosmos3.yaml, nurec-reconstruct.yaml
 │   └── testing/                  # All other catalog workflow specs
 ├── npa/scripts/                  # Pipeline runner scripts
 ├── skills/                       # Root agent skills manifest and workflow/atomic/tool skills

--- a/docs/workbench-yaml-guide.md
+++ b/docs/workbench-yaml-guide.md
@@ -17,7 +17,7 @@ SkyPilot YAML, and a few tool-specific single-task examples or resource profiles
 remain in guarded locations. The supported catalog has two workflow directories:
 
 ```text
-workflows/main/     # sim2real.yaml and paidf-cosmos3.yaml only
+workflows/main/     # sim2real.yaml, paidf-cosmos3.yaml, nurec-reconstruct.yaml
 workflows/testing/  # All other catalog workflows; add new pipelines here
 ```
 

--- a/docs/workbench/guides/neural-reconstruction.md
+++ b/docs/workbench/guides/neural-reconstruction.md
@@ -29,7 +29,7 @@ photographed:
 
 ## The spec
 
-**`workflows/testing/nurec-reconstruct.yaml`**
+**`workflows/main/nurec-reconstruct.yaml`**
 
 Six stages, each a real `npa workbench nurec` command — no manifest stubs:
 
@@ -40,7 +40,7 @@ check ──▶ fetch ──▶ reconstruct ──▶ render ──▶ visualize
 
 | Stage | What it does |
 | --- | --- |
-| `check` | Entitlement, real HF download authorization, RT-core detection — before spending a 14 GB pull or a GPU-minute |
+| `check` | Rechecks entitlement, real HF download authorization, and RT-core detection inside the GPU worker; run the operator preflight below before submitting |
 | `fetch` | Downloads the NCore V4 shards and derives the `rig -> world` pose edge NRE demands |
 | `reconstruct` | Trains 3DGUT Gaussians, exports the USDZ and real PSNR/SSIM/LPIPS |
 | `render` | Renders **novel** views at an offset rig pose |
@@ -54,7 +54,7 @@ it:
 
 ```bash
 npa workbench workflow plan-spec \
-  workflows/testing/nurec-reconstruct.yaml
+  workflows/main/nurec-reconstruct.yaml
 ```
 
 Then the cheap real preflight (seconds, no image pull):
@@ -86,7 +86,7 @@ Submit:
 RUN_ID="nurec-$(date -u +%Y%m%dt%H%M%S)z"
 
 npa workbench workflow submit \
-  workflows/testing/nurec-reconstruct.yaml \
+  workflows/main/nurec-reconstruct.yaml \
   --run-id "$RUN_ID" \
   --infra k8s/<your-rt-core-context> \
   --var bucket=<your-bucket> \
@@ -133,6 +133,42 @@ npa workbench nurec status \
 ```
 
 Expect `PSNR ≈ 31`, `SSIM ≈ 0.83`, `LPIPS ≈ 0.27` on the default scene.
+
+## Promotion evidence
+
+The main workflow preserves the parsed YAML from the completed September 8,
+2026 multi-pod run; the move changes only the quickstart path comment. The saved
+testing YAML had SHA-256
+`a7d317382e05da80cd947bbeca2f3d0c4671d39e3bcd137678681ebca0880b0d`.
+The [readiness record](../../../workflows/main/nurec-reconstruct.readiness.json)
+binds planning checks to the promoted file and records future-run prerequisites.
+
+The public `struktur28` sample supplied the input photos. The run computed new
+outputs with NRE 26.4.149, using the vendor image digest
+`sha256:97f43e7130c5636ce3e80ea3184d97f56a87fdd989b05cce42230881dbdea284`:
+
+| Evidence | Observed result |
+| --- | --- |
+| Training | 30,000 steps, one RTX PRO 6000 Blackwell, checkpoint tensors on `cuda:0`, no resumed checkpoint |
+| Quality | PSNR 31.08336, SSIM 0.83245, LPIPS 0.26844 |
+| Run artifacts | 224 objects, including a 240,542,295-byte USDZ |
+| Novel views | 38 frames, rig translation `[0, 0.25, 0]`, training-view replication disabled; MP4 decoded successfully |
+| Viewer | 1,429,920-byte RRD decoded with required run entities; authenticated agent served the same recording hash |
+| Completion | Durable runtime and stage records succeeded; final report confirmed USDZ, novel views, and RRD |
+
+This evidence covers the default sample and single-GPU execution. L40S and
+other captures were not tested in this run, and GPU utilization history was not
+retained. The original controller endpoint was unavailable at the later status
+check; completion evidence comes from durable records and validated outputs.
+Raw operational evidence stays in access-controlled storage. Each new run still
+needs its own writable bucket, staged source, registry access, and healthy
+RT-core target. Promotion does not provision those prerequisites.
+
+On September 9, the promotion check listed the same 224 stored objects,
+verified seven retained artifact hashes, and downloaded the RRD, metrics, and
+final report again with matching hashes. The USDZ archive, MP4 decode, and RRD
+entity checks passed again. This was a read-only artifact check, not a new
+training run.
 
 ## When it breaks
 

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -40,7 +40,7 @@ npa workbench workflow list \
 
 Author and submit `npa.workflow/v0.0.1` specs from the
 [`workflow catalog`](../../workflows/README.md). `workflows/main/` contains only
-`sim2real.yaml` and `paidf-cosmos3.yaml`; all other catalog specs, including new
+`sim2real.yaml`, `paidf-cosmos3.yaml`, and `nurec-reconstruct.yaml`; other specs, including new
 workflows, belong in `workflows/testing/`.
 
 **No-image tools** (Token Factory specs): set

--- a/npa/src/npa/workbench/nurec/examples/README.md
+++ b/npa/src/npa/workbench/nurec/examples/README.md
@@ -8,7 +8,7 @@ The supported workflow authoring surface is the declarative `npa.workflow/v0.0.1
 spec:
 
 ```text
-workflows/testing/nurec-reconstruct.yaml
+workflows/main/nurec-reconstruct.yaml
 ```
 
 The spec runs each state in its own pod and hands artifacts over through S3. This

--- a/npa/tests/cli/test_agent_workflow.py
+++ b/npa/tests/cli/test_agent_workflow.py
@@ -35,6 +35,7 @@ from npa.cli.agent_workflow import (
     _TEMPLATES,
 )
 from npa.cli.main import app
+from npa.orchestration.npa_workflow.blueprints import resolve_npa_workflow_spec
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 EXAMPLE_YAML = (
@@ -42,6 +43,7 @@ EXAMPLE_YAML = (
 )
 
 _GOLDEN_YAMLS = [
+    "nurec-reconstruct.yaml",
     "byof.yaml",
     "rl-policy-training-sim-success.yaml",
     "sim2real-two-step-agent.yaml",
@@ -1426,10 +1428,8 @@ def test_generate_workflow_yaml_aliases() -> None:
 @pytest.mark.parametrize("yaml_name", _GOLDEN_YAMLS)
 def test_golden_yaml_validates(yaml_name: str) -> None:
     """All golden NPA workflow YAMLs in the repo should parse and validate."""
-    tier = "main" if yaml_name in {"sim2real.yaml", "paidf-cosmos3.yaml"} else "testing"
-    yaml_path = REPO_ROOT / "workflows" / tier / yaml_name
-    if not yaml_path.is_file():
-        pytest.skip(f"golden YAML not found: {yaml_name}")
+    yaml_path = resolve_npa_workflow_spec(yaml_name)
+    assert yaml_path is not None, f"golden YAML not found: {yaml_name}"
     yaml_text = yaml_path.read_text(encoding="utf-8")
     result = validate_workflow_yaml_text(yaml_text)
     assert result["ok"] is True, f"{yaml_name} failed: {result.get('error')}"
@@ -1438,10 +1438,8 @@ def test_golden_yaml_validates(yaml_name: str) -> None:
 @pytest.mark.parametrize("yaml_name", _GOLDEN_YAMLS)
 def test_golden_yaml_plan_spec_cli(yaml_name: str) -> None:
     """Golden YAMLs should plan successfully with the CLI."""
-    tier = "main" if yaml_name in {"sim2real.yaml", "paidf-cosmos3.yaml"} else "testing"
-    yaml_path = REPO_ROOT / "workflows" / tier / yaml_name
-    if not yaml_path.is_file():
-        pytest.skip(f"golden YAML not found: {yaml_name}")
+    yaml_path = resolve_npa_workflow_spec(yaml_name)
+    assert yaml_path is not None, f"golden YAML not found: {yaml_name}"
     result = runner.invoke(
         app,
         [

--- a/npa/tests/cli/test_workflow_access_approval.py
+++ b/npa/tests/cli/test_workflow_access_approval.py
@@ -14,8 +14,9 @@ from npa.workbench.model_access import GatedAsset, HF, NGC
 RUNNER = CliRunner()
 SPEC = (
     Path(__file__).resolve().parents[3]
-    / "workflows" / "testing" / "nurec-reconstruct.yaml"
+    / "workflows" / "main" / "nurec-reconstruct.yaml"
 )
+RAY_BATCH_SPEC = SPEC.parent.parent / "testing" / "cosmos3-ray-batch.yaml"
 
 
 def test_plan_reports_exact_toolref_dependency_without_provider_calls(
@@ -94,9 +95,8 @@ def test_public_unrelated_workflow_has_no_approval_gate() -> None:
 
 
 def test_ray_batch_plan_requires_native_guardrail_payload() -> None:
-    spec = SPEC.with_name("cosmos3-ray-batch.yaml")
     result = RUNNER.invoke(
-        app, ["workbench", "workflow", "plan-spec", str(spec), "--json"]
+        app, ["workbench", "workflow", "plan-spec", str(RAY_BATCH_SPEC), "--json"]
     )
     assert result.exit_code == 0, result.output
     requirements = json.loads(result.stdout)["access_requirements"]
@@ -121,7 +121,7 @@ def test_ray_batch_refuses_execution_without_native_guardrail_access(
     )
     result = RUNNER.invoke(
         app,
-        ["workbench", "workflow", "run-spec", str(SPEC.with_name("cosmos3-ray-batch.yaml")),
+        ["workbench", "workflow", "run-spec", str(RAY_BATCH_SPEC),
          "--execute", "--json"],
     )
     assert result.exit_code == 1

--- a/npa/tests/e2e/test_nurec_reconstruct_live_e2e.py
+++ b/npa/tests/e2e/test_nurec_reconstruct_live_e2e.py
@@ -39,7 +39,7 @@ WORKFLOW = (
     / "nurec-reconstruct.yaml"
 )
 SPEC = (
-    ROOT / "workflows" / "testing" / "nurec-reconstruct.yaml"
+    ROOT / "workflows" / "main" / "nurec-reconstruct.yaml"
 )
 CATEGORY = "neural-reconstruction"
 DEFAULT_IMAGE = "nvcr.io/nvidia/nre/nre-ga:26.04"

--- a/npa/tests/guardrails/test_shown_workflow_catalog.py
+++ b/npa/tests/guardrails/test_shown_workflow_catalog.py
@@ -51,7 +51,10 @@ def test_shown_catalog_has_npa_workflow_specs() -> None:
     specs = iter_npa_workflow_specs()
     assert specs, "expected npa.workflow specs under the shown catalog"
     assert all(detect_submit_format(path) == "npa.workflow" for path in specs)
-    assert [path.name for path in specs].count("sim2real.yaml") == 1
+    for name in ("sim2real.yaml", "paidf-cosmos3.yaml", "nurec-reconstruct.yaml"):
+        expected = NPA_WORKFLOWS / "main" / name
+        assert [path for path in specs if path.name == name] == [expected]
+        assert not (NPA_WORKFLOWS / "testing" / name).exists()
 
 
 def test_tool_catalog_is_reachable_or_explicitly_public_reusable() -> None:

--- a/npa/tests/orchestration/npa_workflow/test_skypilot_render.py
+++ b/npa/tests/orchestration/npa_workflow/test_skypilot_render.py
@@ -509,7 +509,7 @@ def test_public_plan_has_no_implicit_kubernetes_pull_authority() -> None:
 
 
 def test_nurec_plan_exposes_its_ngc_pull_authority_to_preflight() -> None:
-    spec = load_spec(NPA_SPECS / "nurec-reconstruct.yaml")
+    spec = load_spec(NPA_SPECS.parent / "main" / "nurec-reconstruct.yaml")
     plan = build_plan(spec, run_id="demo")
 
     authorities = plan_image_pull_secrets(

--- a/npa/tests/orchestration/npa_workflow/test_spec.py
+++ b/npa/tests/orchestration/npa_workflow/test_spec.py
@@ -11,6 +11,7 @@ from npa.orchestration.npa_workflow import (
     load_spec,
     validate_spec,
 )
+from npa.orchestration.npa_workflow.blueprints import resolve_npa_workflow_spec
 from npa.orchestration.npa_workflow.predicates import evaluate_predicate
 from npa.orchestration.npa_workflow.tokens import TokenError, resolve_tokens
 
@@ -24,6 +25,7 @@ SPECS = REPO_ROOT / "workflows" / "testing"
         "vlm-eval-single.yaml",
         "tokenfactory-rollout-judge.yaml",
         "sim2real.yaml",
+        "nurec-reconstruct.yaml",
         "bdd100k-pipeline.yaml",
         "tokenfactory-cosmos-gate.yaml",
         "av-night-scene-hardening.yaml",
@@ -32,8 +34,9 @@ SPECS = REPO_ROOT / "workflows" / "testing"
     ],
 )
 def test_example_specs_validate(name: str) -> None:
-    tier = "main" if name in {"sim2real.yaml", "paidf-cosmos3.yaml"} else "testing"
-    spec = load_spec(SPECS.parent / tier / name)
+    path = resolve_npa_workflow_spec(name)
+    assert path is not None, f"example YAML not found: {name}"
+    spec = load_spec(path)
     validate_spec(spec)
     assert spec.api_version == "npa.workflow/v0.0.1"
 

--- a/npa/tests/workbench/test_nurec_access.py
+++ b/npa/tests/workbench/test_nurec_access.py
@@ -29,7 +29,7 @@ WORKFLOW = (
 )
 SPEC = (
     REPO_ROOT
-    / "workflows" / "testing" / "nurec-reconstruct.yaml"
+    / "workflows" / "main" / "nurec-reconstruct.yaml"
 )
 
 #: GPUs with no RT cores. Reconstruction and rasterization are RT-core work, so a

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -1060,7 +1060,7 @@ skills:
           - npa/src/npa/workbench/nurec/examples/nurec-reconstruct.yaml
       - type: npa_workflow_yaml
         paths:
-          - workflows/testing/nurec-reconstruct.yaml
+          - workflows/main/nurec-reconstruct.yaml
   - name: generate-npa-workflow
     category: workflows
     when_to_use: "Design a new creative npa.workflow/v0.0.1 pipeline from the tool catalog (loops, gates, reference YAML)."

--- a/skills/workflows/author-npa-workflow/SKILL.md
+++ b/skills/workflows/author-npa-workflow/SKILL.md
@@ -12,7 +12,8 @@ Load when creating or editing **NPA workflow YAML** under
 transitions, or when helping agents/users convert SkyPilot bash pipelines into
 specs.
 
-Keep `workflows/main/` limited to `sim2real.yaml` and `paidf-cosmos3.yaml`.
+Keep `workflows/main/` limited to `sim2real.yaml`, `paidf-cosmos3.yaml`, and
+`nurec-reconstruct.yaml`.
 Add all other catalog specs under `workflows/testing/`; keep catalog
 documentation in `workflows/README.md`.
 

--- a/skills/workflows/neural-reconstruction/SKILL.md
+++ b/skills/workflows/neural-reconstruction/SKILL.md
@@ -118,7 +118,7 @@ npa workbench nurec status      # what a run prefix holds, stage by stage
 | CLI | `npa/src/npa/cli/nurec/__init__.py` |
 | SDK | `npa.sdk.workbench.nurec` (`check`, `fetch`, `reconstruct`, `render`, `visualize`, `finalize`, `status`); the framework-free API is re-exported from `npa.workbench.nurec` |
 | SkyPilot workflow | `npa/src/npa/workbench/nurec/examples/nurec-reconstruct.yaml` |
-| Declarative twin | `workflows/testing/nurec-reconstruct.yaml` |
+| Main declarative workflow | `workflows/main/nurec-reconstruct.yaml` |
 | Rerun recording | `npa.workflows.data_factory_viz.build_run_rrd` |
 
 ## Input Data
@@ -258,7 +258,7 @@ yourself; do not invent a workbench command for it.
 | Train a reconstruction from an NCore clip and get a USDZ | `npa workbench nurec reconstruct` |
 | Render novel views along a shifted rig trajectory | `npa workbench nurec render` |
 | Get a Rerun recording the NPA agent will display | `npa workbench nurec visualize` |
-| Run all of the above on a GPU as one pipeline | `workflows/testing/nurec-reconstruct.yaml` |
+| Run all of the above on a GPU as one pipeline | `workflows/main/nurec-reconstruct.yaml` |
 | Measure PSNR / SSIM / LPIPS | Already emitted -- `reconstruction/metrics.yaml`, and `gaussians/summary` in the `.rrd` |
 | Convert my *own* recording (drone, RGB-D, ROS 2 bag, ScanNet++) to NCore V4 | Upstream `ncore`. The workbench consumes NCore V4; it does not author it |
 | Serve frames to CARLA / Isaac Sim / a custom simulator | Upstream `nre` (`serve-grpc`) -- not wired, see Limitations |

--- a/skills/workflows/workbench-reference-workflows/SKILL.md
+++ b/skills/workflows/workbench-reference-workflows/SKILL.md
@@ -12,8 +12,9 @@ description: Use when working on NPA reference workflow specs, runner scripts, c
 > surfaces. SkyPilot remains the engine that executes rendered specs.
 
 The catalog has exactly two workflow directories: `workflows/main/` contains
-only `sim2real.yaml` and `paidf-cosmos3.yaml`; `workflows/testing/` contains all
-other catalog specs. Keep catalog documentation in `workflows/README.md` and
+`sim2real.yaml`, `paidf-cosmos3.yaml`, and `nurec-reconstruct.yaml`;
+`workflows/testing/` contains all other catalog specs.
+Keep catalog documentation in `workflows/README.md` and
 add new reference workflows under `workflows/testing/`.
 
 ## When To Use

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -60,8 +60,9 @@ Requires `NPA_REGISTRY` (or `NPA_E2E_REGISTRY`), and for cpu-tier twins
 
 ## Layout
 
-- `main/` contains only [sim2real.yaml](main/sim2real.yaml) and
-  [paidf-cosmos3.yaml](main/paidf-cosmos3.yaml), the two main workflows.
+- `main/` contains [sim2real.yaml](main/sim2real.yaml),
+  [paidf-cosmos3.yaml](main/paidf-cosmos3.yaml), and
+  [nurec-reconstruct.yaml](main/nurec-reconstruct.yaml).
 - `testing/` contains all other supported declarative workflow YAMLs, including
   examples, integration workflows, and component validation pipelines.
 - This README documents the catalog. The non-YAML robot specification example
@@ -106,6 +107,7 @@ describes the real component and artifact contracts.
 | [`groot-1-7-finetune.yaml`](testing/groot-1-7-finetune.yaml) | Real GR00T data → parameterized 1-to-many-GPU optimizer smoke → immutable checkpoint → aligned offline evaluation → outcome classification → RRD/MCAP → inspected S3 publication → NPA agent viewer handoff; no rollout or statistical-learning claim |
 | [`cosmos3-reason.yaml`](testing/cosmos3-reason.yaml) | Cosmos3 reason |
 | [`cosmos3-checkpoint-eval.yaml`](testing/cosmos3-checkpoint-eval.yaml) | B200-only guarded Cosmos3 still-image checkpoint evaluation |
+| [`nurec-reconstruct.yaml`](main/nurec-reconstruct.yaml) | Real NCore V4 capture → 3DGUT training on an RT-core GPU → USDZ → rig-offset novel views → Rerun; [guide and measured evidence](../docs/workbench/guides/neural-reconstruction.md#promotion-evidence), [readiness record](main/nurec-reconstruct.readiness.json) |
 | [`paidf-cosmos3.yaml`](main/paidf-cosmos3.yaml) | Independent dynamic PAIDF: generic LeRobot/video input → real Cosmos 3 video2video variants → evaluator gate/refinement → real Curator + FiftyOne Brain + Rerun |
 | [`content-agents-rigid-object.yaml`](testing/content-agents-rigid-object.yaml) | NVIDIA Content Agents with a public image and runtime-fetched OVRTX: source USD → real Material/Physics Agents + OVRTX → upstream validation → rigid Isaac object USDZ/adapter ([guide](../docs/workbench/content-agents.md)) |
 | [`curobo-benchmark.yaml`](testing/curobo-benchmark.yaml) | Complete pinned MotionBenchMaker and MPiNets benchmark in cuRobo V2 kinematic and payload-dynamics modes ([guide](../docs/workbench/curobo.md)) |

--- a/workflows/main/nurec-reconstruct.readiness.json
+++ b/workflows/main/nurec-reconstruct.readiness.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "workflow-readiness/v1",
+  "workflow_sha256": "12f80d0a169f442fe13d4ed61cfc7143f17d58734315f88d4acff4e98bb92dae",
+  "planning": {
+    "validation": {
+      "status": "verified",
+      "reason": "All four promoted-path CLI checks exited 0 on September 9, 2026: schema validation, plan-spec, scheduler preview, and submit --plan-only. These checks did not launch GPU work.",
+      "evidence": [
+        "npa workbench workflow validate-spec workflows/main/nurec-reconstruct.yaml --json",
+        "npa workbench workflow plan-spec workflows/main/nurec-reconstruct.yaml --run-id nurec-promotion --json",
+        "npa workbench workflow run-spec workflows/main/nurec-reconstruct.yaml --run-id nurec-promotion --plan-only --scheduler-plan --json",
+        "npa workbench workflow submit workflows/main/nurec-reconstruct.yaml --run-id nurec-promotion --plan-only"
+      ]
+    },
+    "task_fidelity": {
+      "status": "verified",
+      "reason": "The promoted YAML parses identically to the saved September 8, 2026 multi-pod workflow. Real input, GPU training, rig-offset rendering, and decoded run artifacts were verified for the default sample.",
+      "evidence": [
+        "docs/workbench/guides/neural-reconstruction.md#promotion-evidence"
+      ]
+    }
+  },
+  "prerequisites": {
+    "output_storage": {
+      "status": "unverified",
+      "reason": "The catalog uses example-bucket. A new run must supply a writable bucket and unique run prefix; historical S3 handoffs are proven only for the completed run.",
+      "evidence": [
+        "docs/workbench/guides/neural-reconstruction.md#promotion-evidence"
+      ]
+    },
+    "worker_input": {
+      "status": "verified",
+      "reason": "The completed run consumed the default public PhysicalAI-NuRec-PPISP struktur28 capture and published the NCore sequence across pods. Other dataset or scene overrides need separate checks.",
+      "evidence": [
+        "docs/workbench/guides/neural-reconstruction.md#promotion-evidence"
+      ]
+    },
+    "credentials": {
+      "status": "unverified",
+      "reason": "Each operator must supply S3 credentials, NGC image access and the matching Kubernetes pull secret. HF access is needed only for gated or private dataset overrides; historical authorization does not verify a future operator.",
+      "evidence": [
+        "docs/workbench/guides/neural-reconstruction.md#promotion-evidence"
+      ]
+    },
+    "source_image": {
+      "status": "unverified",
+      "reason": "The completed run used the NRE image digest recorded in the guide. A new run must stage its intended NPA source and verify the selected vendor image; the catalog still uses the existing 26.04 tag.",
+      "evidence": [
+        "docs/workbench/guides/neural-reconstruction.md#promotion-evidence"
+      ]
+    },
+    "target_runtime": {
+      "status": "unverified",
+      "reason": "The completed run used one RTX PRO 6000 Blackwell GPU. A future target needs RT cores, healthy SkyPilot workers, and the declared shared-memory and bootstrap configuration; L40S was not tested in this run.",
+      "evidence": [
+        "docs/workbench/guides/neural-reconstruction.md#promotion-evidence"
+      ]
+    }
+  }
+}

--- a/workflows/main/nurec-reconstruct.yaml
+++ b/workflows/main/nurec-reconstruct.yaml
@@ -22,7 +22,7 @@ kind: Workflow
 #   # 3. Submit. ~45 min end to end on one RTX PRO 6000 Blackwell.
 #   RUN_ID="nurec-$(date -u +%Y%m%dt%H%M%S)z"
 #   npa workbench workflow submit \
-#     workflows/testing/nurec-reconstruct.yaml \
+#     workflows/main/nurec-reconstruct.yaml \
 #     --run-id "$RUN_ID" \
 #     --infra k8s/<your-rt-core-context> \
 #     --var bucket=<your-bucket> \


### PR DESCRIPTION
Promote the validated NuRec reconstruction workflow from `workflows/testing` to `workflows/main`. The parsed YAML is unchanged; only its quickstart path comment changes. Update the catalog, documentation, skills, access tests, and existing live GPU test to use the promoted path, and require a single main-catalog entry. This uses the agent recovery and NuRec vendor startup fixes already merged in #435.

The hash-bound readiness record and guide retain the measured default-sample evidence: 30,000 training steps on one RTX PRO 6000, 224 artifacts, 38 novel-view frames, and a verified Rerun recording. A fresh read-only check confirmed stored artifact counts and downloaded hashes, plus valid USDZ, MP4, and RRD outputs. Future runs still need their own storage, source staging, credentials, and healthy RT-core target.

Validation on `37d164f060c3aebfdf637b58e7446e2f4e146f15`:
- All nine CI checks pass, including browser tests, docs drift, Ruff, guardrails, confidentiality, Gitleaks, and both security jobs.
- [Full Linux suite](https://github.com/nebius/nebius-physical-ai/actions/runs/34412387627/job/102669553339): 18,154 passed, 435 skipped, 1 xpassed; 75.81% package coverage. CLI installation checks: 11 passed, 0 failed.
- [Security runtime regressions](https://github.com/nebius/nebius-physical-ai/actions/runs/34412387610/job/102676112597): 641 passed. [Source, workflow, and dependency comparison](https://github.com/nebius/nebius-physical-ai/actions/runs/34412387610/job/102669632386): 0 new findings.
- Promoted-path validate-spec, plan-spec, scheduler preview, and submit --plan-only all exit 0.
- Focused local suite: 3,837 passed, 1 skipped; onboarding smoke: 114 passed.
- Built wheel contains the exact promoted YAML under main with no testing duplicate.
