### PR TITLE
Fix LeRobot episode selection for PAIDF Cosmos 3

### DIFF
--- a/docs/workbench/guides/paidf-cosmos3.md
+++ b/docs/workbench/guides/paidf-cosmos3.md
@@ -41,13 +41,26 @@ for planning previews; execution requires actual evaluator decisions.
 
 ## Inputs and configuration
 
-Choose `input_kind: video` and set `input_video_uri` to one MP4, or choose
+For `workflow submit`, use `--input-video` / `--input-uri` for MP4, or
+`--lerobot-uri` with `--lerobot-camera`, `--lerobot-episode`, and
+`--require-explicit-lerobot-selection`. The setup guide includes a complete
+[LeRobot submission and pinned public example](../../../workflows/guides/paidf-cosmos3.md#r3a-augment-one-lerobot-episode-and-camera).
+The LeRobot CLI selector takes an S3 dataset prefix; upload local files while
+preserving the dataset directory layout first.
+
+For direct stage configuration, choose `input_kind: video` and set
+`input_video_uri` to one MP4, or choose
 `input_kind: lerobot` and set `lerobot_dataset_uri`, `input_episode`, and
 `input_camera`. Dataset URIs may point to generic LeRobot v2.x or v3.x directory
-trees. A full feature name such as `observation.images.front`, or an unambiguous
-camera suffix such as `front`, is accepted. Shared v3 video files are trimmed
+trees. Use a full feature name such as `observation.images.front` for submission.
+The local direct-stage selector also accepts an unambiguous camera suffix.
+The S3 worker reads metadata and fetches only the selected video. Metadata
+shards are searched independently of episode numbering. Shared v3 video files are trimmed
 using the episode metadata timestamps; per-episode v2 video layouts are also
 supported.
+
+The result is augmented video and review artifacts for one episode/camera, not
+a reconstructed LeRobot dataset containing action/state records.
 
 The committed `example-bucket` and run-scoped fixture path are placeholders.
 The generic workflow submit command stages a verified, pinned starter video

--- a/npa/src/npa/workflows/data_factory_input.py
+++ b/npa/src/npa/workflows/data_factory_input.py
@@ -1290,8 +1290,8 @@ def _read_lerobot_episode_record(
 
     if chunks_size < 1:
         raise PaidfInputError("LeRobot chunks_size must be a positive integer")
-    chunk = episode // chunks_size
-    marker = f"{prefix}meta/episodes/chunk-{chunk:03d}/"
+    # V3 metadata files are packed by file size, independently of episode IDs.
+    marker = f"{prefix}meta/episodes/"
     try:
         candidates = sorted(
             key

--- a/npa/src/npa/workflows/paidf_cosmos3.py
+++ b/npa/src/npa/workflows/paidf_cosmos3.py
@@ -403,12 +403,21 @@ def _select_lerobot_video(
     row = next(
         (item for item in rows if int(item.get("episode_index", -1)) == episode), {}
     )
-    if rows and not row:
+    if (rows or version.startswith("v3")) and not row:
         raise PaidfCosmos3Error(
             "selected LeRobot episode is absent from episode metadata"
         )
+    source = _lerobot_video_path(root, info, row, episode, feature)
+    timestamps = _lerobot_episode_timestamps(row, feature, required=version.startswith("v3"))
+    return source, timestamps, feature
+
+
+def _lerobot_video_path(
+    root: Path, info: Mapping[str, Any], row: Mapping[str, Any], episode: int, feature: str,
+) -> Path:
     chunk_index = int(row.get(f"videos/{feature}/chunk_index", 0) or 0)
-    file_index = int(row.get(f"videos/{feature}/file_index", episode) or episode)
+    raw_file_index = row.get(f"videos/{feature}/file_index")
+    file_index = episode if raw_file_index is None else int(raw_file_index)
     pattern = str(
         info.get("video_path")
         or "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
@@ -436,21 +445,50 @@ def _select_lerobot_video(
     source = next((path for path in candidates if path.is_file()), None)
     if source is None:
         raise PaidfCosmos3Error("selected LeRobot episode/camera video is missing")
+    return source
+
+
+def _lerobot_episode_timestamps(
+    row: Mapping[str, Any], feature: str, *, required: bool,
+) -> tuple[float, float] | None:
     start = row.get(f"videos/{feature}/from_timestamp")
     end = row.get(f"videos/{feature}/to_timestamp")
-    timestamps: tuple[float, float] | None = None
-    if start is not None or end is not None:
-        if (
-            start is None
-            or end is None
-            or float(start) < 0
-            or float(end) <= float(start)
-        ):
-            raise PaidfCosmos3Error(
-                "LeRobot episode video timestamps are incomplete or invalid"
+    if not required and start is None and end is None:
+        return None
+    try:
+        start, end = float(start), float(end)
+        if not math.isfinite(start) or not math.isfinite(end) or start < 0 or end <= start:
+            raise ValueError
+    except (TypeError, ValueError) as exc:
+        raise PaidfCosmos3Error(
+            "LeRobot episode video timestamps are incomplete or invalid"
+        ) from exc
+    return start, end
+
+
+def _prepare_lerobot_source(
+    uri: str, root: Path, episode: int, camera: str, storage: Any | None,
+) -> tuple[Path, tuple[float, float] | None, str]:
+    if _is_s3(uri):
+        from npa.workflows.data_factory_input import (
+            PaidfInputError,
+            _materialize_lerobot_episode,
+        )
+
+        source = root / "selected.mp4"
+        try:
+            _materialize_lerobot_episode(
+                storage or _storage(), lerobot_uri=uri, camera=camera,
+                episode=episode, explicit_selection=bool(camera), destination=source,
             )
-        timestamps = (float(start), float(end))
-    return source, timestamps, feature
+        except PaidfInputError as exc:
+            raise PaidfCosmos3Error(str(exc)) from exc
+        # The shared selector has already trimmed this episode from its video.
+        return source, None, camera
+    dataset = _download_source(uri, root / "dataset", storage=storage)
+    if dataset.is_file():
+        raise PaidfCosmos3Error("LeRobot dataset URI must resolve to a directory")
+    return _select_lerobot_video(dataset, episode, camera)
 
 
 def _normalize_video(
@@ -561,13 +599,8 @@ def prepare_input(
                     )
                 source = videos[0]
         else:
-            dataset = _download_source(selected_uri, root / "dataset", storage=client)
-            if dataset.is_file():
-                raise PaidfCosmos3Error(
-                    "LeRobot dataset URI must resolve to a directory"
-                )
-            source, timestamps, feature = _select_lerobot_video(
-                dataset, episode_index, camera
+            source, timestamps, feature = _prepare_lerobot_source(
+                selected_uri, root, episode_index, camera, client
             )
         canonical = root / "source.mp4"
         timeline = None

--- a/npa/tests/e2e/test_paidf_cosmos3_lerobot_live.py
+++ b/npa/tests/e2e/test_paidf_cosmos3_lerobot_live.py
@@ -1,0 +1,65 @@
+"""Verify the guide's completed public LeRobot v3 run from durable artifacts.
+
+Run the guide's R3a command first, then set NPA_INTEGRATION_E2E=1,
+NPA_E2E_PAIDF_LEROBOT_RUN_URI and NPA_E2E_PROJECT. This test reads the completed
+run; it does not submit jobs or change their inputs. The pinned example is
+episode 1, camera observation.images.top, from the simulated ALOHA dataset.
+"""
+
+import json
+import os
+from urllib.parse import urlparse
+
+import pytest
+
+from .test_npa_workflow_submit_live_e2e import _assert_paidf_live_artifacts
+
+
+pytestmark = [pytest.mark.e2e, pytest.mark.e2e_skypilot, pytest.mark.gpu]
+
+
+def test_completed_public_lerobot_v3_pipeline() -> None:
+    uri = os.environ.get("NPA_E2E_PAIDF_LEROBOT_RUN_URI", "")
+    if os.environ.get("NPA_INTEGRATION_E2E") != "1" or not uri:
+        pytest.skip("Requires the guide's completed LeRobot v3 run")
+    from npa.clients.project_credentials import s3_client_for_project
+
+    parsed = urlparse(uri)
+    assert parsed.scheme == "s3" and parsed.netloc
+    prefix = parsed.path.strip("/") + "/"
+    run_id = prefix.strip("/").split("/")[-1]
+    assert prefix == f"paidf-cosmos3/{run_id}/"
+    project = os.environ.get("NPA_E2E_PROJECT") or None
+    client = s3_client_for_project(project, allow_host_creds=True)
+
+    def read(relative):
+        response = client.get_object(Bucket=parsed.netloc, Key=prefix + relative)
+        with response["Body"] as body:
+            return json.loads(body.read())
+
+    runtime = read("npa-workflow/runtime.json")
+    assert runtime["status"] == "succeeded" and runtime["run_id"] == run_id
+    assert all(wave["status"] == "succeeded" for wave in runtime["waves"])
+    provenance = read("input/provenance.json")
+    assert provenance["source_kind"] == "lerobot_dataset"
+    assert provenance["episode"] == 1
+    assert provenance["camera"] == "observation.images.top"
+    _assert_example_timeline(read)
+    _assert_paidf_live_artifacts(
+        spec="paidf-cosmos3.yaml", waves=runtime["waves"], bucket=parsed.netloc,
+        run_id=run_id, e2e_project=project,
+    )
+
+
+def _assert_example_timeline(read) -> None:
+    timeline = read("input/timeline.json")
+    assert timeline["original"]["duration_seconds"] == pytest.approx(8.0)
+    assert timeline["original"]["decoded_frames"] == 400
+    assert timeline["prepared"]["duration_seconds"] == pytest.approx(8.0)
+    assert timeline["prepared"]["decoded_frames"] == 192
+    augment = read("cosmos_augmented/manifest.json")
+    assert len(augment["variants"]) == 2
+    for variant in augment["variants"]:
+        transfer = read(f"cosmos_augmented/{variant['clip']}/transfer.json")
+        assert transfer["native_chunks"] > 1
+        assert transfer["source_frames"] == 192

--- a/npa/tests/workflows/test_data_factory_input.py
+++ b/npa/tests/workflows/test_data_factory_input.py
@@ -407,10 +407,14 @@ def test_lerobot_rejects_unsafe_format_fields_and_nonfinite_timestamps(
         )
 
 
+@pytest.mark.parametrize("metadata_chunk", [0, 2])
+@pytest.mark.parametrize("file_index", [0, 2])
 def test_lerobot_v3_selects_and_trims_one_episode_from_shared_video(
     tmp_path: Path,
     fake_media_pipeline: None,
     monkeypatch: pytest.MonkeyPatch,
+    metadata_chunk: int,
+    file_index: int,
 ) -> None:
     import pyarrow as pa
     import pyarrow.parquet as pq
@@ -432,7 +436,7 @@ def test_lerobot_v3_selects_and_trims_one_episode_from_shared_video(
             {
                 "episode_index": 7,
                 f"videos/{feature}/chunk_index": 0,
-                f"videos/{feature}/file_index": 2,
+                f"videos/{feature}/file_index": file_index,
                 f"videos/{feature}/from_timestamp": 1.25,
                 f"videos/{feature}/to_timestamp": 2.75,
             }
@@ -440,10 +444,9 @@ def test_lerobot_v3_selects_and_trims_one_episode_from_shared_video(
     )
     parquet = tmp_path / "episodes.parquet"
     pq.write_table(table, parquet)
-    storage.s3.objects[
-        ("artifacts", prefix + "meta/episodes/chunk-000/file-000.parquet")
-    ] = parquet.read_bytes()
-    shared_key = prefix + f"videos/{feature}/chunk-000/file-002.mp4"
+    metadata_key = prefix + f"meta/episodes/chunk-{metadata_chunk:03d}/file-000.parquet"
+    storage.s3.objects[("artifacts", metadata_key)] = parquet.read_bytes()
+    shared_key = prefix + f"videos/{feature}/chunk-000/file-{file_index:03d}.mp4"
     storage.s3.objects[("artifacts", shared_key)] = b"shared-video"
     trim_args: list[tuple[float, float]] = []
 
@@ -464,11 +467,11 @@ def test_lerobot_v3_selects_and_trims_one_episode_from_shared_video(
     assert result.selection == "lerobot_dataset"
     assert trim_args == [(1.25, 2.75)]
     assert [key for _bucket, key in storage.s3.downloads] == [
-        prefix + "meta/episodes/chunk-000/file-000.parquet",
+        metadata_key,
         shared_key,
     ]
     assert storage.s3.list_requests == [
-        ("artifacts", prefix + "meta/episodes/chunk-000/")
+        ("artifacts", prefix + "meta/episodes/")
     ]
 
 

--- a/npa/tests/workflows/test_paidf_cosmos3.py
+++ b/npa/tests/workflows/test_paidf_cosmos3.py
@@ -58,8 +58,9 @@ def _tiny_video(path: Path, *, color: str = "blue") -> Path:
 
 @requires_ffmpeg
 @pytest.mark.parametrize("version", ["v2.1", "v3.0"])
+@pytest.mark.parametrize("episode", [0, 1])
 def test_prepare_input_selects_generic_lerobot_v2_and_v3(
-    tmp_path: Path, version: str
+    tmp_path: Path, version: str, episode: int
 ) -> None:
     dataset = tmp_path / "dataset"
     camera = "observation.images.front"
@@ -77,7 +78,7 @@ def test_prepare_input_selects_generic_lerobot_v2_and_v3(
             pa.Table.from_pylist(
                 [
                     {
-                        "episode_index": 0,
+                        "episode_index": episode,
                         f"videos/{camera}/chunk_index": 0,
                         f"videos/{camera}/file_index": 0,
                         f"videos/{camera}/from_timestamp": 0.0,
@@ -88,14 +89,14 @@ def test_prepare_input_selects_generic_lerobot_v2_and_v3(
             episodes / "file-000.parquet",
         )
     else:
-        source = dataset / "videos" / "chunk-000" / camera / "episode_000000.mp4"
+        source = dataset / "videos" / "chunk-000" / camera / f"episode_{episode:06d}.mp4"
     _tiny_video(source)
 
     result = c3.prepare_input(
         "lerobot",
         "",
         str(dataset),
-        0,
+        episode,
         "front",
         str(tmp_path / "run" / "input"),
         str(tmp_path / "run" / "input" / "provenance.json"),
@@ -105,6 +106,7 @@ def test_prepare_input_selects_generic_lerobot_v2_and_v3(
     assert result["status"] == "prepared"
     assert result["source_kind"] == "lerobot_dataset"
     assert result["camera"] == camera
+    assert result["episode"] == episode
     assert result["video_bytes"] > 0
     assert (tmp_path / "run" / "input" / "source.mp4").stat().st_size > 0
     assert list((tmp_path / "run" / "input").glob("frame-*.png"))

--- a/npa/tests/workflows/test_paidf_cosmos3_lerobot.py
+++ b/npa/tests/workflows/test_paidf_cosmos3_lerobot.py
@@ -1,0 +1,120 @@
+"""Verify selective LeRobot worker input using real episode video decoding."""
+
+from io import BytesIO
+import json
+from pathlib import Path
+import shutil
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from botocore.exceptions import ClientError
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from npa.workflows import paidf_cosmos3 as c3
+from npa.workflows.paidf_cosmos3_media import probe_video
+
+
+def _storage(objects: dict[str, bytes]):
+    s3 = Mock(spec=["head_object", "get_object", "list_objects_v2", "download_file"])
+
+    def head(*, Bucket, Key):
+        if Key not in objects:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "HeadObject")
+        return {"ContentLength": len(objects[Key])}
+
+    s3.head_object.side_effect = head
+    s3.get_object.side_effect = lambda **kw: {"Body": BytesIO(objects[kw["Key"]])}
+    s3.list_objects_v2.side_effect = lambda **kw: {
+        "Contents": [{"Key": key} for key in objects if key.startswith(kw["Prefix"])]
+    }
+    s3.download_file.side_effect = lambda bucket, key, path: Path(path).write_bytes(objects[key])
+    return SimpleNamespace(
+        s3=s3,
+        download_path=Mock(side_effect=AssertionError("Do not download the dataset tree")),
+    )
+
+
+def _shared_video(path: Path) -> bytes:
+    subprocess.run([
+        "ffmpeg", "-v", "error", "-f", "lavfi", "-i", "color=red:s=64x64:r=24:d=1",
+        "-f", "lavfi", "-i", "color=blue:s=64x64:r=24:d=1",
+        "-filter_complex", "[0:v][1:v]concat=n=2:v=1:a=0", "-c:v", "libx264",
+        "-pix_fmt", "yuv420p", str(path),
+    ], check=True)
+    return path.read_bytes()
+
+
+def _dataset(tmp_path: Path, version: str, camera: str) -> tuple[dict[str, bytes], str]:
+    prefix = "dataset/"
+    objects = {prefix + "meta/info.json": json.dumps({
+        "codebase_version": version, "total_episodes": 2, "chunks_size": 1000,
+        "features": {camera: {"dtype": "video"}},
+    }).encode()}
+    if version.startswith("v3"):
+        key = prefix + f"videos/{camera}/chunk-000/file-000.mp4"
+        metadata = tmp_path / "episodes.parquet"
+        pq.write_table(pa.Table.from_pylist([{
+            "episode_index": 1, f"videos/{camera}/chunk_index": 0,
+            f"videos/{camera}/file_index": 0, f"videos/{camera}/from_timestamp": 1.0,
+            f"videos/{camera}/to_timestamp": 2.0,
+        }]), metadata)
+        objects[prefix + "meta/episodes/chunk-002/file-000.parquet"] = metadata.read_bytes()
+    else:
+        key = prefix + f"videos/chunk-000/{camera}/episode_000001.mp4"
+    objects[key] = _shared_video(tmp_path / "shared.mp4")
+    objects[prefix + "videos/unselected.mp4"] = b"must never be downloaded"
+    return objects, key
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="FFmpeg is required")
+@pytest.mark.parametrize("version", ["v2.1", "v3.0"])
+def test_s3_worker_selects_one_episode_without_fetching_dataset(
+    tmp_path: Path, version: str,
+) -> None:
+    camera = "observation.images.front"
+    objects, selected_key = _dataset(tmp_path, version, camera)
+    storage = _storage(objects)
+    output = tmp_path / "input"
+    result = c3.prepare_input(
+        "lerobot", "", "s3://example-bucket/dataset/", 1, camera,
+        str(output), str(output / "provenance.json"), "unit-run",
+        storage=storage, conditioning_fps=24,
+    )
+    assert result["source_kind"] == "lerobot_dataset"
+    assert result["episode"] == 1 and result["camera"] == camera
+    storage.download_path.assert_not_called()
+    downloads = [call.args[1] for call in storage.s3.download_file.call_args_list]
+    assert [key for key in downloads if key.endswith(".mp4")] == [selected_key]
+    expected_frames = 24 if version.startswith("v3") else 48
+    assert probe_video(output / "source.mp4")["decoded_frames"] == expected_frames
+    if version.startswith("v3"):
+        pixel = subprocess.check_output([
+            "ffmpeg", "-v", "error", "-i", str(output / "source.mp4"),
+            "-vf", "scale=1:1", "-frames:v", "1", "-pix_fmt", "rgb24", "-f", "rawvideo", "-",
+        ])
+        assert pixel[2] > pixel[0] + 100, "Episode 1 must contain the blue second interval"
+
+
+@pytest.mark.parametrize("start,end", [(None, None), (0.0, None), (0.0, float("nan"))])
+def test_local_v3_refuses_missing_or_nonfinite_episode_timestamps(
+    tmp_path: Path, start: float | None, end: float | None,
+) -> None:
+    camera = "observation.images.front"
+    (tmp_path / "meta").mkdir()
+    (tmp_path / "meta/info.json").write_text(json.dumps({
+        "codebase_version": "v3.0", "features": {camera: {"dtype": "video"}},
+    }))
+    metadata = tmp_path / "meta/episodes/chunk-000"
+    metadata.mkdir(parents=True)
+    pq.write_table(pa.Table.from_pylist([{
+        "episode_index": 1, f"videos/{camera}/file_index": 0,
+        f"videos/{camera}/from_timestamp": start, f"videos/{camera}/to_timestamp": end,
+    }]), metadata / "file-000.parquet")
+    video = tmp_path / "videos" / camera / "chunk-000/file-000.mp4"
+    video.parent.mkdir(parents=True)
+    video.touch()
+    with pytest.raises(c3.PaidfCosmos3Error, match="timestamps"):
+        c3._select_lerobot_video(tmp_path, 1, camera)

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -10,6 +10,10 @@ For PAIDF with Cosmos 3 on Nebius, follow the
 credentials, current CLI installation, runtime submission, monitoring recovery,
 and output inspection, including full-video structural conditioning, aligned
 evaluation, configurable quality acceptance and per-variant caption coverage.
+Its [LeRobot instructions](guides/paidf-cosmos3.md#r3a-augment-one-lerobot-episode-and-camera)
+include a pinned public v3 example, S3 staging, explicit episode/camera selection,
+and the full submission command. One run augments one selected video; it does
+not produce a reconstructed LeRobot action/state dataset.
 
 Agent skills: [author a workflow](../skills/workflows/author-npa-workflow/SKILL.md)
 and [design a new pipeline](../skills/workflows/generate-npa-workflow/SKILL.md).

--- a/workflows/guides/paidf-cosmos3.md
+++ b/workflows/guides/paidf-cosmos3.md
@@ -898,6 +898,8 @@ preflights passed against live services. S5's new-cluster command was validated
 with a live `--dry-run`; execution used an existing RTX PRO 6000 Blackwell
 cluster and did not create a cluster.
 
+### Starter MP4
+
 The full runtime completed all 15 stages at revision `1fb58217` on September 11,
 2026, using the starter input and the shipped generation and quality settings.
 Its 169-frame source
@@ -937,12 +939,39 @@ colored borders in one variant. These exploratory acceptance settings do not
 certify physical fidelity or suitability for training. Review your own outputs
 against the task's visual and motion requirements before using them as data.
 
+### LeRobot v3 episode and multiple generation windows
+
+R3a's pinned simulated ALOHA example was exercised at revision `4b09042f` on
+September 11, 2026, with the shipped settings. Episode 1 occupies seconds 8–16
+of the selected camera's shared `file-000.mp4`. The staged original contains
+400 frames at 50 fps; independently comparing every decoded frame with that
+upstream interval confirmed the correct episode was selected. Preparation
+produced 192 frames at 24 fps, retaining the eight-second duration.
+
+Each of the two generated variants used three native generation windows. Both
+published videos fully decode to the reference's 192 frames, dimensions, and
+eight-second timeline, with zero timestamp error. Native control readback and
+text/video guardrails passed. The evaluator accepted both on the first pass:
+aggregate score `0.675465` against `0.2`, and attribute scores `0.5` each against
+`0.25`. All eight attribute answers were complete; four attributes matched.
+The thresholds were unchanged for this run.
+
+Matched-time inspection, including generation-window boundaries, showed the
+recognizable cube-transfer action with altered gripper details and lighting
+artifacts. One variant visibly changes lighting at a window boundary. Matching
+timestamps and passing these exploratory criteria do not establish physical
+fidelity or make the outputs a trainable LeRobot dataset.
+
+### Automated checks and remaining scope
+
 Automated checks cover media corruption and alignment failures, native control
 pixels and guardrail processing, incomplete evaluator responses, runtime
 routing, every accepted variant's captions, and final artifact validation.
-Concurrent two-GPU variants, longer videos requiring multiple native chunks,
-fresh-cluster provisioning, a fresh macOS installation, and the desktop Rerun UI
-have not been validated by this run. Rejection-route adapter checks passed
+Concurrent two-GPU variants, fresh-cluster provisioning, a fresh macOS
+installation, and the desktop Rerun UI have not been validated by these runs.
+LeRobot v2 and metadata in a different chunk are covered by real-video
+regression tests; the live example uses v3 metadata in chunk zero.
+Rejection-route adapter checks passed
 against retained live reports; a full rejected runtime replay was not completed.
 
 ## Inspect the outputs

--- a/workflows/guides/paidf-cosmos3.md
+++ b/workflows/guides/paidf-cosmos3.md
@@ -507,12 +507,91 @@ For your own video, add **one** of these input options to the submit command:
 
 - `--input-video /absolute/path/source.mp4` for a local H.264 MP4.
 - `--input-uri 's3://<your-bucket>/<your-prefix>/source.mp4'` for a stored MP4.
+- `--lerobot-uri 's3://<your-bucket>/<dataset-prefix>/'` with the episode and
+  camera options in R3a for a LeRobot dataset.
 
 The workflow retains the selected original and prepares a constant-rate,
 letterboxed reference. Native edge controls cover the complete prepared video;
 generation and evaluation verify its frame count and timestamps. Inspect the
 resulting action and contacts as well as the quality report. For episode/camera selection and the
 generation contract, see the [Cosmos 3 workflow guide](../../docs/workbench/guides/paidf-cosmos3.md).
+
+### R3a. Augment one LeRobot episode and camera
+
+LeRobot v2.x and v3.x video datasets use the same full pipeline. Choose one
+episode and the **full camera feature name** declared in `meta/info.json`, such
+as `observation.images.top`. The submit command accepts an S3 dataset prefix;
+upload a local dataset's metadata and video files there first, preserving their
+relative paths. Do not combine `--lerobot-uri` with either MP4 input option.
+
+The selector reads metadata and downloads only the chosen camera's video file.
+In v3, multiple episodes can share that MP4: episode metadata supplies the file
+indices and the exact start/end timestamps. A later episode can legitimately
+use file index zero. Metadata chunk numbers do not have to match episode
+numbers. Both the submitter and worker trim the selected episode; neither
+downloads the whole dataset. V3 episode metadata and finite start/end timestamps
+are required. V2 uses its per-episode video layout.
+
+To try a public v3 example, download the following unchanged files from
+[LeRobot's simulated ALOHA cube-transfer dataset](https://huggingface.co/datasets/lerobot/aloha_sim_transfer_cube_human/tree/6a43d500f101255823a9d2b9dc244eeb01a2cd31).
+The dataset card declares the MIT license; retain its README with the sample.
+This example selects episode `1`, camera `observation.images.top`: an eight-second
+simulation episode occupying seconds 8–16 in shared `file-000.mp4`.
+
+```bash
+DATASET_REVISION=6a43d500f101255823a9d2b9dc244eeb01a2cd31
+LEROBOT_DIR="$HOME/Downloads/paidf-lerobot-example/$DATASET_REVISION"
+DATASET_BASE="https://huggingface.co/datasets/lerobot/aloha_sim_transfer_cube_human/resolve/$DATASET_REVISION"
+for file in README.md meta/info.json meta/episodes/chunk-000/file-000.parquet \
+  videos/observation.images.top/chunk-000/file-000.mp4; do
+  mkdir -p "$(dirname "$LEROBOT_DIR/$file")"
+  curl --fail --location "$DATASET_BASE/$file" --output "$LEROBOT_DIR/$file" || exit 1
+done
+LEROBOT_URI="s3://$BUCKET/datasets/aloha-sim-transfer-cube-$DATASET_REVISION"
+aws s3 sync "$LEROBOT_DIR/" "$LEROBOT_URI/" --profile nebius
+```
+
+For your own dataset, set `LEROBOT_DIR` and `LEROBOT_URI` to your local directory
+and destination, then use the same `aws s3 sync` command. An existing S3 dataset
+needs no upload. This workflow needs `meta/info.json`, v3 episode metadata under
+`meta/episodes/`, and the referenced video files; action/state Parquet tables are
+not consumed for video augmentation.
+
+Complete R1 and R2 for a fresh run, then use this full submission command in
+place of R3. Keep the default seeds and exploratory thresholds for the example.
+Change the explicit camera and episode when using your own dataset.
+
+```bash
+npa workbench workflow submit "$SPEC" \
+  --run-id "$RUN_ID" \
+  --var bucket="$BUCKET" \
+  --var caption_model="$CAPTION_MODEL" \
+  --lerobot-uri "$LEROBOT_URI/" \
+  --lerobot-camera observation.images.top \
+  --lerobot-episode 1 \
+  --require-explicit-lerobot-selection \
+  --runtime \
+  --infra "k8s/$KUBE_CONTEXT" \
+  --secret-env NEBIUS_TOKEN_FACTORY_KEY \
+  --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY \
+  --secret-env HF_TOKEN \
+  --project "$PROJECT_ALIAS" \
+  --durable-s3
+```
+
+Follow R4 and **Inspect the outputs** below to verify all stages. The run's
+`input/provenance.json` must report `source_kind: lerobot_dataset`, episode `1`,
+and the selected camera. `input/original_source.mp4` is the selected episode,
+not the whole shared MP4; `input/source.mp4` is its normalized reference.
+Generated videos must match that reference's decoded frame count and timestamps.
+
+Outputs are augmented MP4s, captions, quality reports, curated clips, and Rerun
+recordings. This workflow does not rebuild a trainable LeRobot dataset or copy
+actions/states onto generated observations. It processes one episode/camera per
+run; use a fresh run ID for each further selection. Physical fidelity and
+training suitability still require review, and a complete quality rejection
+can stop a run.
 
 ### R4. Monitor and recover
 


### PR DESCRIPTION
LeRobot v3 can store a later episode in shared `file-000.mp4`, with its metadata in a chunk unrelated to the episode number. PAIDF Cosmos 3 could select the wrong file or miss that episode. This change preserves zero-valued file indices, locates the episode across metadata chunks, and uses the existing selective S3 materializer to fetch and trim only the selected camera video.

The guide now includes a pinned public LeRobot example and the complete runtime submission command. It explains episode timestamps, camera selection, expected artifacts, and the boundary between video augmentation and rebuilding a trainable LeRobot dataset. V2 per-episode videos remain supported; malformed v3 timestamps fail before generation.

Validation:

- 135 focused tests, 2,815 guardrails, 114 onboarding tests, and 647 security runtime tests passed.
- Lint, guide shell syntax and links, confidentiality scanning, scanner fixtures, and base/candidate security comparison passed.
- Real FFmpeg regression tests verify that episode 1 uses the second interval of shared file zero, including metadata in a different chunk, without downloading unselected videos.
- Full Linux unit suite: 20,055 passed, 110 skipped, one unexpected pass, using a private temporary directory outside Git.
- The pinned public LeRobot v3 example completed all 15 live runtime stages on an RTX PRO 6000 Blackwell GPU, with one attempt per stage. The normal documented command used the shipped seeds and thresholds.
- Both generated videos fully decode to 192 frames at 24 fps and eight seconds, matching the prepared source with zero timestamp error. Each used three native generation windows; control readback and model guardrails passed.
- Both variants passed evaluation on the first pass: aggregate score `0.675465` against `0.2`, attribute scores `0.5` each against `0.25`, with complete responses and passing required checks. Annotation produced 16 nonempty captions bound to the evaluated videos.
- Cosmos Curator produced six fully decoded clips covering both complete videos: three-, three-, and two-second segments per variant, with no reported errors or warnings. FiftyOne kept both variant samples and flagged both for redundancy review; its uniqueness method was `embedding-fallback`.
- Finalization reported 147 artifacts. The committed completed-run artifact test passed; independent checks decoded both Rerun recordings and matched their embedded videos, all frame timestamps, provenance, and evaluator report. All ten downloaded run videos match their recorded SHA-256.
- The validation controller and local API were removed. Direct readback confirmed the completed run and artifacts remained available, and existing nodes, controllers, and PVCs were preserved.

This follows merged PR #447. It retains the existing generation settings, exploratory quality thresholds, runtime routing, and acceptance guards.

The live run used revision `4b09042f`; after rebasing onto current main, the PR's pipeline source and workflow spec are unchanged from that revision. The additional upstream chart tests also passed. Eight CI checks are green; the full Python coverage job is still running.

Visual review found recognizable cube-transfer motion alongside altered gripper details and lighting artifacts, including a change at a generation-window boundary. The guide records these limits. Exploratory acceptance does not certify physical fidelity or produce a trainable LeRobot dataset with synchronized actions and states.
