### PR TITLE
Fix standalone Isaac Lab live submission

### DIFF
--- a/docs/workbench/cookbooks/byof-isaac-lab/README.md
+++ b/docs/workbench/cookbooks/byof-isaac-lab/README.md
@@ -158,6 +158,8 @@ export AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud
 
 NPA_SKYPILOT_BIN="${NPA_SKYPILOT_BIN}" \
 npa/.venv/bin/python npa/scripts/run_isaac_lab_rl.py \
+  --project <project-alias> \
+  --context <kubernetes-context> \
   --yaml npa/src/npa/workflows/byof/profiles/isaac-lab-rl-train.yaml \
   --image "${BYOF_IMAGE}" \
   --task Isaac-Cartpole-v0 \
@@ -220,6 +222,8 @@ export RUN_ID_B="w10-byof-image-and-cmd-$(date -u +%Y%m%dT%H%M%SZ)"
 
 NPA_SKYPILOT_BIN="${NPA_SKYPILOT_BIN}" \
 npa/.venv/bin/python npa/scripts/run_isaac_lab_rl.py \
+  --project <project-alias> \
+  --context <kubernetes-context> \
   --yaml /tmp/isaac-lab-byof-command.yaml \
   --image "${BYOF_IMAGE}" \
   --task Isaac-Cartpole-v0 \

--- a/npa/scripts/run_isaac_lab_rl.py
+++ b/npa/scripts/run_isaac_lab_rl.py
@@ -146,6 +146,9 @@ def render_workflow(
         if multiple and variant:
             prefix += f"{variant}/"
         envs["S3_OUTPUT_PREFIX"] = prefix
+        envs["NPA_EXECUTION_OUTPUTS"] = json.dumps(
+            [{"uri": prefix, "kind": "directory"}]
+        )
         if image:
             resources = doc.setdefault("resources", {})
             if isinstance(resources, dict):

--- a/npa/scripts/run_isaac_lab_rl.py
+++ b/npa/scripts/run_isaac_lab_rl.py
@@ -15,7 +15,11 @@ from typing import Any
 
 import yaml
 
-from npa.workflows.byof.live import resolve_byof_profile_path
+from npa.workflows.byof.live import (
+    resolve_byof_kubernetes_target,
+    resolve_byof_profile_path,
+    resolve_byof_project,
+)
 from npa.orchestration.skypilot import (
     WorkflowResult,  # noqa: F401 - kept for tests and downstream wrapper imports.
     cleanup_all_for_run,
@@ -201,6 +205,7 @@ def _submit_and_wait(args: argparse.Namespace) -> int:
         print(json.dumps({"run_id": run_id, "rendered_yaml": str(rendered_yaml), "outputs": outputs}, indent=2))
         return 0
 
+    project, context = _execution_scope(args)
     with tempfile.TemporaryDirectory(prefix=f"npa-isaac-lab-rl-{run_id}-") as tmp:
         rendered_yaml = Path(tmp) / "isaac-lab-rl.rendered.yaml"
         _write_yaml_documents(rendered_yaml, docs)
@@ -220,6 +225,8 @@ def _submit_and_wait(args: argparse.Namespace) -> int:
             result = submit_workflow(
                 rendered_yaml,
                 run_id,
+                project=project,
+                infra=f"k8s/{context}",
                 isolated_config_dir=args.isolated_config_dir,
                 config_path=args.config_path,
                 sky_bin=sky_bin,
@@ -276,6 +283,21 @@ def _submit_and_wait(args: argparse.Namespace) -> int:
         return 1 if teardown.errors else return_code
 
 
+def _execution_scope(args: argparse.Namespace) -> tuple[str, str]:
+    """Resolve the explicit project and Kubernetes context for live submission."""
+
+    project = args.project.strip() or resolve_byof_project()
+    target = resolve_byof_kubernetes_target(project or None)
+    context = args.context.strip() or target.context
+    if not project:
+        raise ValueError("live submission requires --project or a configured NPA project")
+    if not context:
+        raise ValueError(
+            "live submission requires --context, KUBECONTEXT, or a configured Kubernetes context"
+        )
+    return project, context
+
+
 def _load_yaml_documents(path: Path) -> list[dict[str, Any]]:
     with path.open("r", encoding="utf-8") as handle:
         docs = [doc for doc in yaml.safe_load_all(handle) if doc is not None]
@@ -316,6 +338,16 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--wandb-mode", default="offline")
     parser.add_argument("--checkpoint-s3-uri", default="")
     parser.add_argument("--checkpoint-s3-endpoint-url", default="")
+    parser.add_argument(
+        "--project",
+        default="",
+        help="Configured NPA project alias. Defaults to the selected BYOF project.",
+    )
+    parser.add_argument(
+        "--context",
+        default="",
+        help="Exact Kubernetes context. Defaults to BYOF project configuration or KUBECONTEXT.",
+    )
     parser.add_argument("--sky-bin", default="")
     parser.add_argument(
         "--secret-env",

--- a/npa/src/npa/orchestration/skypilot/local_api.py
+++ b/npa/src/npa/orchestration/skypilot/local_api.py
@@ -106,10 +106,18 @@ def _identity_files(environment: Mapping[str, str], *, config: Mapping[str, Any]
     home = Path(environment.get("HOME") or "").expanduser()
     kube_paths = [Path(item).expanduser() for item in environment.get("KUBECONFIG", "").split(os.pathsep) if item]
     paths = [*kube_paths, home / ".aws" / "config", home / ".aws" / "credentials"]
-    for directory in (home / ".nebius", Path(environment.get("NEBIUS_CONFIG_DIR") or home / ".nebius"),
-                      Path(environment.get("NPA_CONFIG_DIR") or home / ".npa")):
-        paths.extend(directory / name for name in ("config.yaml", "credentials.yaml", "credentials.json",
+    nebius_directories = {
+        home / ".nebius",
+        Path(environment.get("NEBIUS_CONFIG_DIR") or home / ".nebius"),
+    }
+    for directory in nebius_directories:
+        # Nebius SDK refreshes credentials.yaml in place as its short-lived token
+        # cache. Immutable config and service-account sources still bind identity.
+        paths.extend(directory / name for name in ("config.yaml", "credentials.json",
                      "NEBIUS_IAM_TOKEN.txt", "NEBIUS_TENANT_ID.txt", "NEBIUS_DOMAIN.txt"))
+    npa_directory = Path(environment.get("NPA_CONFIG_DIR") or home / ".npa")
+    paths.extend(npa_directory / name for name in ("config.yaml", "credentials.yaml", "credentials.json",
+                 "NEBIUS_IAM_TOKEN.txt", "NEBIUS_TENANT_ID.txt", "NEBIUS_DOMAIN.txt"))
     for key in ("AWS_CONFIG_FILE", "AWS_SHARED_CREDENTIALS_FILE", "NPA_NEBIUS_IAM_TOKEN_FILE", "NEBIUS_IAM_TOKEN_FILE"):
         if environment.get(key):
             paths.append(Path(environment[key]).expanduser())
@@ -151,6 +159,22 @@ def _identity_files(environment: Mapping[str, str], *, config: Mapping[str, Any]
         except OSError:
             raise IsolatedApiError("executing credential/configuration file identity cannot be inspected") from None
     return result
+
+
+def _immutable_identity_files(files: Mapping[str, str]) -> dict[str, str]:
+    """Discard legacy Nebius token-cache entries from an identity snapshot."""
+
+    return {
+        path: digest
+        for path, digest in files.items()
+        if not (Path(path).parent.name == ".nebius" and Path(path).name == "credentials.yaml")
+    }
+
+
+def _same_identity_files(left: Mapping[str, str], right: Mapping[str, str]) -> bool:
+    """Compare immutable identity files across current and legacy snapshots."""
+
+    return _immutable_identity_files(left) == _immutable_identity_files(right)
 
 
 def _session_members(record: Mapping[str, Any]) -> list[int]:
@@ -252,7 +276,9 @@ def _process(record: Mapping[str, Any], *, verify_files: bool = True) -> dict[st
                 config_path = Path(decoded.get("SKYPILOT_GLOBAL_CONFIG") or "")
                 if not config_path.is_file() or hashlib.sha256(config_path.read_bytes()).hexdigest() != record["config_sha256"]:
                     raise IsolatedApiError("isolated SkyPilot API verified configuration changed on disk")
-            if verify_files and record.get("identity_files") and _identity_files(decoded) != record["identity_files"]:
+            if verify_files and record.get("identity_files") and not _same_identity_files(
+                _identity_files(decoded), record["identity_files"]
+            ):
                 raise IsolatedApiError("isolated SkyPilot API credential configuration changed after verification")
             matches.append({"pid": int(directory.name), "start_ticks": int(stat_fields[19])})
         except (FileNotFoundError, ProcessLookupError):
@@ -395,14 +421,19 @@ def ensure_isolated_api(
         if process:
             if record.get("interpreter") != interpreter or record.get("config_sha256") != config_hash:
                 raise IsolatedApiError("running isolated SkyPilot API has a different verified configuration; preserve its jobs before restarting")
-            if record["environment_binding"] != binding or record.get("identity_files") != files:
+            if record["environment_binding"] != binding or not _same_identity_files(
+                record.get("identity_files", {}), files
+            ):
                 raise IsolatedApiError("running isolated SkyPilot API has a different executing identity or changed credential configuration")
         else:
             # No process with this marker exists; starting the same persistent
             # API database recovers controller/job identity, never submits again.
             if _session_members(record):
                 raise IsolatedApiError("owned SkyPilot API children survived their leader; finish its process-session cleanup before recovery")
-            if record.get("environment_binding") and (record["environment_binding"] != binding or record.get("identity_files") != files):
+            if record.get("environment_binding") and (
+                record["environment_binding"] != binding
+                or not _same_identity_files(record.get("identity_files", {}), files)
+            ):
                 raise IsolatedApiError("isolated SkyPilot API recovery requires the original executing identity and credential configuration")
             for port in (record["port"], record["queue_port"], record["metrics_port"]):
                 with socket.socket() as listener:

--- a/npa/src/npa/workflows/byof/profiles/README.md
+++ b/npa/src/npa/workflows/byof/profiles/README.md
@@ -39,6 +39,9 @@ For a live standalone Isaac Lab submission, pass `--project` and `--context`; th
 runner otherwise resolves them from the selected BYOF project and `KUBECONTEXT`.
 The exact context is forwarded to NPA's submission preflight rather than trusted
 as ambient `kubectl` state.
+Rendered Isaac Lab tasks also declare their run-scoped S3 prefix through
+`NPA_EXECUTION_OUTPUTS`, allowing the preflight to verify the exact directory
+ownership and write access before a controller or GPU pod is created.
 
 ## Do not add a multi-stage pipeline here
 

--- a/npa/src/npa/workflows/byof/profiles/README.md
+++ b/npa/src/npa/workflows/byof/profiles/README.md
@@ -35,6 +35,10 @@ Selection lives in `npa/src/npa/workflows/byof/live.py::resolve_byof_resource_ya
 (env override → project config → profile default), and the runners
 (`npa/scripts/run_isaac_lab_rl.py`, `run_byof_datagen.py`,
 `run_byof_container_verify.py`) take `--yaml` so a customer can supply their own.
+For a live standalone Isaac Lab submission, pass `--project` and `--context`; the
+runner otherwise resolves them from the selected BYOF project and `KUBECONTEXT`.
+The exact context is forwarded to NPA's submission preflight rather than trusted
+as ambient `kubectl` state.
 
 ## Do not add a multi-stage pipeline here
 

--- a/npa/tests/orchestration/skypilot/test_local_api.py
+++ b/npa/tests/orchestration/skypilot/test_local_api.py
@@ -284,6 +284,20 @@ def test_default_nebius_aws_profile_mutation_is_not_same_principal(local_runtime
         api.ensure_isolated_api(**local_runtime)
 
 
+def test_nebius_short_lived_token_cache_refresh_preserves_identity(local_runtime):
+    token_cache = Path(local_runtime["environment"]["HOME"]) / ".nebius" / "credentials.yaml"
+    token_cache.parent.mkdir()
+    token_cache.write_text("tokens:\n  fixture: first-short-lived-token\n")
+
+    api.ensure_isolated_api(**local_runtime)
+    original = _record(local_runtime)
+    token_cache.write_text("tokens:\n  fixture: refreshed-short-lived-token\n")
+
+    api.ensure_isolated_api(**local_runtime)
+
+    assert _record(local_runtime)["pid"] == original["pid"]
+
+
 def test_invalid_credential_yaml_diagnostic_does_not_include_source_secret():
     with pytest.raises(api.IsolatedApiError) as raised:
         api._yaml_document("credentials: [fixture-secret-token")

--- a/npa/tests/workflows/test_isaac_lab_rl.py
+++ b/npa/tests/workflows/test_isaac_lab_rl.py
@@ -6,6 +6,7 @@ import stat
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -150,6 +151,10 @@ def test_isaac_lab_runner_renders_and_submits(monkeypatch, tmp_path, capsys) -> 
             "Isaac-Cartpole-v0",
             "--iterations",
             "3",
+            "--project",
+            "test-project",
+            "--context",
+            "test-context",
             "--output-root",
             "s3://bucket/isaac-lab-rl",
             "--image",
@@ -167,6 +172,8 @@ def test_isaac_lab_runner_renders_and_submits(monkeypatch, tmp_path, capsys) -> 
     output = json.loads(capsys.readouterr().out)
     assert output["outputs"]["checkpoint"] == "s3://bucket/isaac-lab-rl/isaac-test-run/npa_isaac_lab_checkpoint.pt"
     assert captured["run_id"] == "isaac-test-run"
+    assert captured["kwargs"]["project"] == "test-project"
+    assert captured["kwargs"]["infra"] == "k8s/test-context"
     rendered_task = captured["docs"][1]
     assert rendered_task["envs"]["ISAAC_LAB_ITERATIONS"] == "3"
     assert rendered_task["envs"]["S3_OUTPUT_PREFIX"] == "s3://bucket/isaac-lab-rl/isaac-test-run/"
@@ -214,3 +221,29 @@ def test_isaac_lab_runner_render_only_keeps_rendered_yaml(capsys) -> None:
     assert rendered.is_file()
     docs = [doc for doc in yaml.safe_load_all(rendered.read_text(encoding="utf-8")) if doc is not None]
     assert docs[1]["envs"]["NPA_ISAAC_LAB_RUN_ID"] == "isaac-render-only"
+
+
+def test_isaac_lab_runner_requires_live_context_before_teardown(monkeypatch, tmp_path) -> None:
+    wrapper = _load_wrapper_module()
+    monkeypatch.setattr(wrapper, "resolve_byof_project", lambda: "test-project")
+    monkeypatch.setattr(
+        wrapper,
+        "resolve_byof_kubernetes_target",
+        lambda _project: type("Target", (), {"context": ""})(),
+    )
+
+    args = wrapper._parse_args(
+        [
+            "--yaml",
+            str(SINGLE_YAML),
+            "--run-id",
+            "missing-context",
+            "--isolated-config-dir",
+            str(tmp_path / "sky"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="live submission requires --context"):
+        wrapper._submit_and_wait(args)
+
+    assert not (tmp_path / "sky").exists()

--- a/npa/tests/workflows/test_isaac_lab_rl.py
+++ b/npa/tests/workflows/test_isaac_lab_rl.py
@@ -177,6 +177,12 @@ def test_isaac_lab_runner_renders_and_submits(monkeypatch, tmp_path, capsys) -> 
     rendered_task = captured["docs"][1]
     assert rendered_task["envs"]["ISAAC_LAB_ITERATIONS"] == "3"
     assert rendered_task["envs"]["S3_OUTPUT_PREFIX"] == "s3://bucket/isaac-lab-rl/isaac-test-run/"
+    assert json.loads(rendered_task["envs"]["NPA_EXECUTION_OUTPUTS"]) == [
+        {
+            "uri": "s3://bucket/isaac-lab-rl/isaac-test-run/",
+            "kind": "directory",
+        }
+    ]
     assert rendered_task["resources"]["image_id"] == "docker:registry.example/npa-isaac-lab:test"
     assert rendered_task["envs"]["AWS_ENDPOINT_URL"] == "https://storage.eu-north1.nebius.cloud"
     assert rendered_task["envs"]["NEBIUS_S3_ENDPOINT"] == "https://storage.eu-north1.nebius.cloud"


### PR DESCRIPTION
## What

- Forward the selected NPA project and exact Kubernetes context from the standalone Isaac Lab runner into the hardened workflow submission preflight.
- Declare the run-scoped S3 output directory in `NPA_EXECUTION_OUTPUTS`.
- Treat the Nebius SDK's short-lived token cache as mutable when reusing an isolated SkyPilot API, while continuing to reject changes to immutable identity sources.

## Why

A real RTX Sim2Real validation exposed three blockers after the workflow rendered successfully: the standalone runner omitted its selected cluster scope, raw storage output was undeclared, and a normal token-cache refresh made the same isolated API reject its next client call.

## Impact

Standalone Isaac Lab submissions retain fail-closed project/context and output validation, and post-submit monitoring can reuse the verified isolated API across normal token refreshes. Kubeconfig, NPA credentials, Nebius configuration and service-account credentials, and AWS profiles remain identity-bound.

## Validation

- Full reproducible repository gate (`make check`) in a clean Python 3.12 environment.
- Focused orchestration and Isaac runner tests.
- Strict live two-worker CUDA, GLX/EGL, and Vulkan validation on the already-correct RTX operator-driver profile.
- Real Isaac Lab Cartpole RSL-RL training: 64 environments, 10 iterations, 10 independently verified checkpoints and summary/log artifacts.
- Run-scoped workload and controller cleanup followed by a cluster health re-audit.

## Limitations

One requested audit scope had no current cluster resource. The other scope's sole cluster already had the exact repository-defined driver fix, so no cluster rebuild was necessary or performed.
