### PR TITLE
docs: simplify all maintained READMEs and verify user examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,15 @@
-# Contributing Workbench Tools
+# Contributing to Nebius Physical AI
+
+Start with the task you are changing. The detailed contracts below cover a new
+Workbench tool; small fixes can go directly to the relevant section.
+
+| Task | Start here |
+| --- | --- |
+| Improve a README or guide | [Documentation requirements](#documentation-requirements) and [documentation checks](npa/README.md#developing-and-testing-npa) |
+| Fix a CLI, SDK, or service | [Required interfaces](#required-interfaces) and [testing](#testing-requirements) |
+| Add a tool and container | [End-to-end contribution skill](skills/workflows/add-workbench-tool/SKILL.md) |
+| Add or adapt a workflow | [Workflow authoring](skills/workflows/author-npa-workflow/SKILL.md) |
+| Prepare a pull request | [Validation gates](skills/atomic/pre-pr-validation/SKILL.md) and [PR conventions](#commit-and-pr-conventions) |
 
 ## Contribution quality
 
@@ -495,14 +506,30 @@ a pull request; `requires-python` is `>=3.10`.
 
 ## Testing Requirements
 
-Create the virtualenv at `npa/.venv` and install the dev tooling once (this pulls
-in `pytest`, `pytest-mock`, `pytest-cov`, `pytest-timeout`, `pytest-xdist`,
-`ruff`, and the `server` extra so the suite collects):
+Create the contributor virtualenv at `npa/.venv` from the repository root using CPython 3.12.
+The development and adapter extras supply test, lint, and conversion dependencies:
 
 ```bash
 python3 -m venv npa/.venv
-npa/.venv/bin/pip install -e "npa[dev]"
+npa/.venv/bin/python -m pip install -e "npa[dev,adapter]"
 ```
+
+Run the full suite on **Linux**: native filesystem and controller tests use
+Linux-specific behavior, including `/proc`. macOS supports the CLI, documentation
+checks, and many focused tests, but does not reproduce the complete Linux gate.
+Use an interpreter with `os.memfd_create`; some Conda builds omit it.
+Install `ffmpeg`/`ffprobe` and the same CPU checkpoint/export runtime as CI:
+
+```bash
+npa/.venv/bin/python -m pip install --index-url https://download.pytorch.org/whl/cpu torch==2.13.0
+npa/.venv/bin/python -m pip install -e "npa[sonic]"
+export PATH="$PWD/npa/.venv/bin:$PATH"
+export NPA_REQUIRE_FFMPEG=1
+umask 077  # Publication handoff tests require private files.
+```
+
+This exercises real tensor serialization and ONNX export without GPU allocation.
+The [CI workflow](.github/workflows/test.yml) is the complete environment recipe.
 
 `npa/.venv` is the repo convention, not a preference: `AGENTS.md`, the guardrail
 CI jobs, and helper scripts such as `npa/scripts/start_golden_evals_tmux.sh` and
@@ -513,8 +540,8 @@ you must then point the tooling at it — `make test PYTHON=...`,
 Then use the `make` targets from the repo root:
 
 ```bash
-make check            # everything the PR gates block on: lint, docs-check, test
-make test             # full unit suite, no live/GPU/network (~11 min)
+make check            # local subset: lint, docs-check, unit tests
+make test             # full unit suite, live/GPU markers deselected
 make test-smoke       # quickest: onboarding CLI smoke tests only
 make test-guardrails  # repo guardrails: catalogs, specs, skills, docs, hygiene
 make lint             # ruff
@@ -541,7 +568,7 @@ just `--ignore=tests/e2e` — is what keeps the default suite hermetic.
 The equivalent raw command is:
 
 ```bash
-cd npa && python -m pytest tests/ --ignore=tests/e2e \
+cd npa && .venv/bin/python -m pytest tests/ --ignore=tests/e2e \
   -m "not e2e and not e2e_serverless and not e2e_skypilot and not e2e_pipeline and not gpu and not multi_gpu and not byovm_live and not ngc_e2e" \
   --timeout=180 -q
 ```
@@ -640,6 +667,18 @@ Add an agent skill under `skills/tools/`; examples are
 only when the platform architecture changes.
 ## Documentation Requirements
 A new tool needs human docs and agent docs.
+
+For README and guide changes, run the offline documentation contracts:
+
+```bash
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_documentation_examples.py -q
+```
+
+They check local links and heading anchors, shell/Python syntax, literal CLI names and
+options, declared workflow variables, and the executable package planning example.
+Keep prerequisites, first commands, expected artifacts, and cleanup together.
+Move optional operator details to linked references; retain the scope of historical
+measurements. Quote shell placeholders and mark abbreviated grammar as `text`.
 
 Human docs should cover the tool role, upstream project, runtime modes, GPU
 routing, image build path, credentials, input and output formats, S3 handoff

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 # Nebius Physical AI
 
-**One CLI, one SDK, one workflow layer for physical-AI workloads on Nebius —
-data curation, simulation, synthetic data, policy training, evaluation,
-observability, and cluster orchestration.**
+**Run robotics, simulation, and physical-AI workloads on Nebius.**
 
 <img src="docs/assets/workbench-architecture.png" alt="Nebius Physical AI Workbench architecture" width="820" />
 
@@ -24,56 +22,24 @@ observability, and cluster orchestration.**
 
 </div>
 
----
 
 ## What is `npa`?
 
-`npa` runs robotics and physical-AI workloads on Nebius: data curation,
-simulation, synthetic data, policy training, and evaluation. Workbench tools
-run in containers and exchange inputs, checkpoints, and results through S3.
-Use the CLI, a tool's Python interface, or a declarative workflow.
+`npa` runs robotics and physical-AI workloads on Nebius: simulate a robot,
+train or evaluate a policy, generate video, and curate datasets. Workbench tools
+run in containers; multi-stage workflows exchange inputs and results through S3.
+Use the CLI, Python, or a coding agent with access to this checkout.
 
-Bring your dataset, robot, or pipeline idea. Start with the
-[quickstart](docs/quickstart.md), or give your coding agent the
-[first-run prompts](docs/workbench/agent-first-run.md) and terminal access to
-this checkout. Keep credentials in its private environment or the NPA
-credential store.
-
-### How workflows run
-
-```mermaid
-flowchart TB
-    operator["Coding agent or terminal"] --> npa["npa: configure, validate, plan, submit"]
-    yaml["Workflow YAML"] --> npa
-    npa --> run["SkyPilot: selected CPU and GPU tools"]
-    subgraph nebius["Nebius AI Cloud"]
-        run <--> s3["S3 inputs, checkpoints, reports, recordings"]
-        tf["Token Factory hosted inference"]
-    end
-    run -->|"When selected"| tf
-    s3 --> inspect["Inspect with CLI, Python, or supported viewers"]
-```
-
-Workbench submits workflow tasks through SkyPilot. Selected tools exchange
-inputs and outputs through S3; workflows can call Token Factory for hosted
-inference. Inspect artifacts through the CLI, Python, or a compatible Rerun or
-Foxglove viewer. This diagram describes workflow execution; the
-[Workbench Ray guide](docs/workbench/ray.md) routes direct native Jobs/Core,
-Train, Serve, and KubeRay use to the supported paths.
-
-Python and HTTP coverage varies by tool. The
-[CLI / SDK walkthrough](docs/workbench/cli-sdk-yaml-walkthrough.md) explains
-typed clients, callback wrappers, and their return values.
-
----
+Start with a [workload guide](#pick-your-first-win). The guide tells you which
+data, model access, GPU, and output to expect. For agent-assisted setup, use the
+[first-run prompts](docs/workbench/agent-first-run.md).
 
 ## Quickstart
 
-[Use Workbench with a coding agent](docs/workbench/agent-first-run.md).
+### 1. Install
 
-### 1. Install `npa`
-
-Python **3.10+** on macOS, Linux, or WSL2 Ubuntu. Install from this repository:
+Use Python **3.10+** on macOS, Linux, or WSL2 Ubuntu. Clone the repository,
+then run the remaining commands from its root:
 
 ```bash
 git clone https://github.com/nebius/nebius-physical-ai.git
@@ -84,12 +50,13 @@ pip install -e npa
 npa --version
 ```
 
-See [installation](docs/install.md) for platform details and tools such as
-Terraform and `kubectl`, which are installed separately.
+You should see the installed `npa` version. Remote GPU workloads use their
+container dependencies; you do not need CUDA or a local GPU to use the CLI.
+[Installation](docs/install.md) covers platform setup and optional dependencies.
 
-### 2. Connect to Nebius
+### 2. Connect your project
 
-Install the tested Nebius CLI, then select your project:
+Install the tested Nebius CLI and configure your project:
 
 ```bash
 curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh \
@@ -99,251 +66,142 @@ npa configure
 npa workbench health preflight --checks nebius --json
 ```
 
-Interactive configuration provisions object storage by default; first-time
-storage setup needs admin permission on the target project. Use
-`npa configure --no-provision` to save project and token settings without
-storage provisioning. [Configuration](docs/configuration.md) covers account
-setup, SSO, model tokens, and non-interactive use.
+The preflight should report working Nebius authentication. It does not reserve
+GPUs or verify model access. Interactive configuration provisions object storage
+by default and needs project admin permission for that setup. Use
+`npa configure --no-provision` to save settings without creating storage.
+See [configuration](docs/configuration.md) for SSO, existing projects, and tokens.
 
-### 3. Run your first workload
+### 3. Run and inspect
 
-Choose a guide below, prepare its input and model access, then complete
-[Workbench setup](docs/workbench/getting-started.md). Follow the guide through
-submission and inspect its generated media, checkpoint, or report.
+Choose one guide below and follow it through input preparation, GPU setup,
+submission, and output inspection. [Workbench setup](docs/workbench/getting-started.md)
+provides the shared cluster and SkyPilot steps; complete them once per project.
+Keep the returned run ID: you use it to inspect logs, find artifacts, and resume.
 
-For video augmentation, [PAIDF + Cosmos 3](docs/workbench/guides/paidf-cosmos3.md)
-accepts your source clip and records generation, evaluation, and curation
-results. The [coding-agent prompt](docs/workbench/agent-first-run.md#run-paidf-with-cosmos-3)
-covers execution; the guide's examples validate and plan only.
+For video augmentation, the [PAIDF + Cosmos 3 runbook](workflows/guides/paidf-cosmos3.md)
+includes a public source-video example and full submission commands.
 
----
+<a id="pick-your-first-win"></a>
 
-## Pick your first win
+## Choose your first workload
 
-Choose by the result you need; each guide states its inputs and validation scope.
+| Result | Guide | Main requirement |
+| --- | --- | --- |
+| Generated images or video | [Cosmos 3 generation](docs/quickstart.md#standalone-cosmos-3-generation) | Compatible GPU and model access |
+| Augmented video with evaluation and curation reports | [PAIDF + Cosmos 3](workflows/guides/paidf-cosmos3.md) | Source video, GPU, S3, hosted inference |
+| A labeled video dataset | [Physical AI Data Factory](docs/workbench/guides/physical-ai-data-factory-deploy.md) | Source video, RT-core GPU, S3 |
+| A reconstructed 3D scene and novel views | [Neural reconstruction](docs/workbench/guides/neural-reconstruction.md) | Sensor capture and RT-core GPU |
+| A robot-policy training checkpoint | [Reachy 2 + LeRobot](docs/workbench/guides/reachy2-lerobot-policy.md) | Matching recorded dataset and GPU |
+| A Franka training and evaluation exercise | [Franka + Genesis](docs/workbench/guides/franka-pick-and-place-genesis.md) | GPU; recorded run did not solve the task |
+| Quadruped reinforcement learning | [Isaac Lab](docs/workbench/guides/quadruped-isaac-lab.md) | RT-core GPU |
+| A G1 locomotion evaluation or training path | [G1 + SONIC](docs/workbench/guides/g1-humanoid-walk-sonic.md) | Runtime-specific GPU and checkpoints |
+| A browser workbench and artifact viewer | [Deploy the agent](docs/agent.md) | Terraform and S3 |
 
-| I want to… | Go here | Needs |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------- | -------------------------- |
-| Pick and place with a Franka arm | [Franka + Genesis](docs/workbench/guides/franka-pick-and-place-genesis.md) | GPU cluster |
-| Inspect the PushT SDK | [PushT SDK smoke](docs/workbench/guides/pusht-sim-to-real.md) | Local dataset inspection |
-| Train a Reachy 2 humanoid policy | [Reachy 2 + LeRobot](docs/workbench/guides/reachy2-lerobot-policy.md) | GPU cluster |
-| Choose a G1 locomotion path | [G1 + SONIC](docs/workbench/guides/g1-humanoid-walk-sonic.md) | GPU cluster |
-| Train a quadruped to run | [Quadruped + Isaac Lab](docs/workbench/guides/quadruped-isaac-lab.md) | RT-core GPU |
-| Generate images or video | [NVIDIA Cosmos](docs/quickstart.md#standalone-cosmos-3-generation) | GPU cluster |
-| Augment robot video with PAIDF + Cosmos 3 | [PAIDF with Cosmos 3](docs/workbench/guides/paidf-cosmos3.md) | GPU cluster + S3 |
-| Build a labeled dataset | [Physical AI Data Factory](docs/workbench/guides/physical-ai-data-factory-deploy.md) | GPU cluster + S3 |
-| Rebuild a real scene in 3D | [Neural reconstruction](docs/workbench/guides/neural-reconstruction.md) | RT-core GPU |
-| Get a browser workbench with a Rerun viewer | [Deploy the `npa` agent](docs/agent.md) | Terraform + S3 (~20 min) |
-
-Full index: [docs/workbench/guides/README.md](docs/workbench/guides/README.md).
-Longer end-to-end recipes (BDD100K + LanceDB, Isaac-Lab BYOF, LeRobot GPU
-benchmarks): [cookbooks](docs/workbench/cookbooks/README.md).
-
----
-
-## What's in the box
-
-Use `npa workbench <tool> --help` for a tool's commands and options.
-
-| Task | Tools and guides |
-| --- | --- |
-| Simulate and train policies | [Robot guides](docs/workbench/guides/README.md): Genesis, Isaac Lab, LeRobot, GR00T, SONIC, and MJLab |
-| Generate or reconstruct scenes | [Generation and scene tools](docs/workbench/README.md#generation-and-scenes): Cosmos, NuRec, Content Agents, LTX-2, and Wan |
-| Curate and evaluate | [Data and evaluation](docs/workbench/README.md#data-and-evaluation): FiftyOne, LanceDB, detection training, VLM evaluation, and hosted Token Factory inference |
-| Inspect outputs | [Rerun sharing](docs/workbench/rerun-sharing.md), [Foxglove/MCAP](docs/workbench/foxglove-export.md), and the [browser workbench](docs/agent.md) |
-| Manage compute | [Kubernetes](docs/workbench/kubernetes.md), [SkyPilot](docs/orchestration/skypilot-setup.md), and [cluster backends](docs/cluster-backends.md) |
-
-Browse the [Workbench docs](docs/workbench/README.md) for usage guides or the
-[generated CLI reference](docs/cli/README.md) for the command inventory.
-
----
+The [guide index](docs/workbench/guides/README.md) records validation scope.
+[Cookbooks](docs/workbench/cookbooks/README.md) cover longer training and data
+pipelines. GPU names alone do not establish image compatibility; check the
+[image/GPU matrix](docs/workbench/image-gpu-compatibility-matrix.md) before provisioning.
 
 ## Compose it into a workflow
 
-Author pipelines as declarative `npa.workflow/v0.0.1` specs — a state graph of
-Workbench `toolRef` steps with S3 handoffs, gates, and loops. The same YAML is
-what you validate, plan, and submit.
+A workflow is a YAML state graph: each `toolRef` selects a Workbench operation;
+outputs become inputs to later stages. SkyPilot schedules the work on Nebius.
 
-These commands inspect an example locally. Its bucket and rollout paths are
-placeholders; the commands do not stage input or launch a workload.
+These commands validate and plan a checked-in example **locally**:
 
 ```bash
-npa workbench workflow validate-spec workflows/testing/vlm-eval-single.yaml
-npa workbench workflow plan-spec workflows/testing/vlm-eval-single.yaml --run-id demo
+npa workbench workflow validate-spec workflows/testing/cosmos3-generate.yaml
+npa workbench workflow plan-spec workflows/testing/cosmos3-generate.yaml --run-id demo
 ```
 
-|  |  |
-| ----------------------- | ------------------------------------------------------------------------------------ |
-| **Format** | `apiVersion: npa.workflow/v0.0.1` |
-| **CLI** | `validate-spec` · `plan-spec` · `run-spec` · `submit` |
-| **Workbench workflows** | [`workflows/`](workflows/) |
-| **Tool catalog** | [npa-workflow-tool-catalog.md](docs/workbench/npa-workflow-tool-catalog.md) |
-| **Authoring guide** | [npa-workflow-guide.md](docs/workbench/npa-workflow-guide.md) |
-| **What submit does** | [Run lifecycle](docs/run-lifecycle.md) — gates, run identity, restart safety, status |
+Expect a valid specification and a plan containing the `generate` stage.
+The example's storage values are placeholders. Planning creates no workload and
+does not prove its inputs, credentials, image, or GPU are ready for execution.
 
-For execution, follow a complete workload guide with your actual bucket,
-prepared input, credentials, and resources. Use `submit --runtime` for parallel
-groups and decisions evaluated during the run. The canonical
-[14-stage Sim2Real workflow](docs/workbench/guides/sim2real-workflow.md) uses
-this standard runtime at [`workflows/main/sim2real.yaml`](workflows/main/sim2real.yaml).
-The older `sim2real/runbook.yaml` is a legacy path. See the
-[workflow guide](docs/workbench/npa-workflow-guide.md) for supported graph
-structures and limitations.
+For a real run, follow the selected guide's `prepare-run`, image preflight,
+`submit --runtime`, and monitoring instructions with your own project and input.
+See the [workflow catalog](workflows/README.md),
+[authoring guide](docs/workbench/npa-workflow-guide.md), and
+[run lifecycle](docs/run-lifecycle.md). The canonical
+[14-stage Sim2Real pipeline](docs/workbench/guides/sim2real-workflow.md) uses this
+same runtime and requires its own prepared images, task data, and resource profiles.
 
-Image preflight can create and delete a temporary probe pod when an image
-lacks bootstrap evidence; see the [run lifecycle](docs/run-lifecycle.md).
+<a id="whats-in-the-box"></a>
 
----
+## Find a tool or integration
+
+| Task | Reference |
+| --- | --- |
+| Discover tools by task | [Workbench docs](docs/workbench/README.md) |
+| Find a command or option | [CLI index](docs/cli/README.md), then `npa workbench <tool> --help` |
+| Call a tool from Python or HTTP | [CLI / SDK walkthrough](docs/workbench/cli-sdk-yaml-walkthrough.md) — supported interfaces vary by tool |
+| Develop a native Ray application | [Ray guide](docs/workbench/ray.md) |
+| Inspect or share run outputs | [Rerun](docs/workbench/rerun-sharing.md) · [Foxglove/MCAP](docs/workbench/foxglove-export.md) |
+| Diagnose a failed run | [Troubleshooting](docs/workbench/troubleshooting/known-footguns.md) |
 
 ## When you're done, tear it down
 
-Preview cleanup for your project:
+Cancel active jobs before deleting their infrastructure. Preview project cleanup:
 
 ```bash
-npa destroy --project <alias> --all
+npa destroy --project "<alias>" --all
 ```
 
-This is read-only until you pass `--yes`. Review the plan and retain artifacts
-you need before deleting their storage. [Teardown](docs/teardown.md) covers
-canceling jobs before removing owned services and infrastructure. Local
-`npa cleanup` alone does not stop cloud resources.
-
----
+This is read-only until you pass `--yes`. Review the listed resources and save
+needed artifacts before deleting storage. [Teardown](docs/teardown.md) covers
+service, controller, cluster, and storage cleanup. Local `npa cleanup` alone
+does not stop cloud resources.
 
 ## Container images
 
-Every Workbench tool ships as a container image. The publicly redistributable
-subset is mirrored to GHCR, so the easiest path is to **pull instead of build**:
+Use the [public image catalog](docs/workbench/container-image-catalog.md) to pull
+available GHCR images. Repository-owned runtime defaults already select GHCR;
+`npa configure` needs no registry setup. Some images fetch separately licensed
+runtimes or model weights at startup, so check their access requirements too.
 
-```bash
-docker pull ghcr.io/nebius/nebius-physical-ai/npa-retargeting:0.1.1
-```
-
-The GHCR mirror is the runtime default; no registry setup is required in
-`npa configure`. Ambient `NPA_REGISTRY` and legacy saved registry values do not
-repoint repository-owned runtime defaults. Use your own registry only when you
-build private or locally modified images, then select those bytes with an
-explicit `--image` or workflow `--registry`:
-
-```bash
-docker login registry.example
-export NPA_REGISTRY=registry.example/customer
-npa/docker/workbench/lerobot/build.sh --registry "$NPA_REGISTRY" --push
-# Runtime example: npa workbench workflow submit <spec> --registry "$NPA_REGISTRY"
-```
-
-| Reference | What it tells you |
-| --- | --- |
-| [Public image catalog](docs/workbench/container-image-catalog.md) | Exact GHCR names, tags, pull commands, and intentional exclusions |
-| [Image ↔ GPU compatibility matrix](docs/workbench/image-gpu-compatibility-matrix.md) | Every image against every Nebius GPU platform, and which cells are hardware-verified |
-| [Packaging contract](docs/workbench/container-packaging.md) | Tiers, non-root users, ports, and redistribution classes |
-| [Golden evals](docs/security/container-golden-evals.md) | The real capability test each image must pass — not an import probe |
-| [Blackwell compatibility](docs/workbench/blackwell-datacenter-image-compatibility.md) | B200 / B300 build, tag, and validation runbook |
-| [SONIC image catalog](docs/workbench/sonic-image-catalog.md) | Manifest-driven SONIC variant routing per GPU |
-| [Image reproducibility](docs/security/image-reproducibility.md) | The two-tag strategy (`cuda12`, `cuda13-b300`) and how tags are pinned |
-| [Merge security gate](docs/security/merge-security-gate.md) | Reproduce source, workflow and dependency regression checks before contributing |
-
-Each image declares a `redistribution` class in the packaging contract. Public
-images may be mirrored to GHCR; restricted images remain private. Some public
-images download vendor runtimes or model weights when the workload starts;
-their access requirements and terms still apply.
-
-`cosmos3-serving` uses a public Python base and fetches its runtime at startup.
-Content Agents also fetches OVRTX at runtime. The `cosmos3-super-benchmark`
-image remains restricted. The [packaging contract](docs/workbench/container-packaging.md)
-describes the redistribution classes and image contents.
-
----
+For modified or private images, follow the
+[build and packaging guide](docs/workbench/container-packaging.md) and select
+the image explicitly. `NPA_REGISTRY` alone does not change runtime defaults.
 
 ## Validated on Nebius
 
-Validation is recorded by workload, image, and GPU. The
-[compatibility matrix](docs/workbench/image-gpu-compatibility-matrix.md)
-distinguishes recorded hardware tests from expected compatibility. A manifest
-check establishes test coverage definitions; a successful capability test
-establishes only what that test exercised. Neither establishes full training
-or workflow success for every configuration.
-
-| Reference | What it tells you |
-| --- | --- |
-| [Historical B300 validation](docs/b300-validation-matrix.md) | May results, with links to later image evidence |
-| [LeRobot GPU benchmarks](docs/workbench/cookbooks/lerobot-gpu-benchmarks.md) | Steps/s across H200 · B300 · L40S · RTX PRO 6000 by policy type |
-| [NVIDIA architecture coverage](docs/nvidia-platform-architecture-coverage.md) | CUDA 12.8 x86_64 vs CUDA 13 aarch64 tool coverage |
-| [Partner roadmap](docs/architecture/partner-skills-roadmap.md) | NVIDIA Omniverse / CAD-to-SimReady capabilities on the way — not yet shipped |
-
----
+The [image/GPU matrix](docs/workbench/image-gpu-compatibility-matrix.md) records
+hardware tests and distinguishes them from expected compatibility. Each guide
+states what its run established: a working container, a generated artifact, a
+training checkpoint, or measured task performance. A smoke test is not evidence
+of policy convergence. See also the
+[LeRobot benchmarks](docs/workbench/cookbooks/lerobot-gpu-benchmarks.md) and
+[planned partner capabilities](docs/architecture/partner-skills-roadmap.md).
 
 ## Repository layout
 
-```text
-npa/                       # Python package (CLI + SDK); install with `pip install -e npa`
-  src/npa/cli/             # Typer entry point and every top-level command
-  src/npa/workbench/       # Per-tool implementations (cosmos, lerobot, sonic, ...)
-  workflows/workbench/
-    sim2real/              # Operator notes and legacy compatibility
-workflows/                 # Supported npa.workflow/v0.0.1 catalog; see README.md
-  main/                    # sim2real.yaml, paidf-cosmos3.yaml, nurec-reconstruct.yaml
-  testing/                 # All other catalog workflow specs
-docs/                      # Quickstart, architecture, workbench guides, cookbooks
-skills/                    # SKILL.md files for agents and contributors (source of truth)
-deploy/                    # Terraform + cluster provisioning (uses Nebius solutions library)
-research/                  # LeRobot deploy research (older reference)
-workbench/mlflow/          # MLflow tracking-server compose stack
-```
-
-User secrets live in a versioned, exact-project map in `~/.npa/credentials.yaml`;
-machine-managed config lives in `~/.npa/config.yaml`. The repo supports multiple
-top-level solution namespaces, and Workbench is the current primary one — future
-solutions are additive and never rename or nest it. See
-[solutions model](docs/architecture/solutions-model.md) ·
-[CLI namespaces](docs/architecture/cli-namespaces.md) ·
-[contributor context](docs/architecture/contributor-context.md).
-
----
+| Directory | Contents |
+| --- | --- |
+| [`npa/`](npa/README.md) | Python package, CLI, SDK, and tests |
+| [`workflows/`](workflows/README.md) | Declarative workflow catalog and runbooks |
+| [`docs/`](docs/README.md) | Setup, tool guides, cookbooks, and references |
+| [`deploy/cluster/`](deploy/cluster/README.md) | Managed Kubernetes Terraform wrapper |
+| [`skills/`](skills/index.yaml) | Operating and contribution instructions for agents |
+| [`workbench/mlflow/`](workbench/mlflow/README.md) | Local MLflow and Postgres stack |
+| [`research/`](research/lerobot-deploy/README.md) | Historical standalone deployment research |
 
 ## Documentation
 
-| Topic | Where to look |
-| --- | --- |
-| Install & auth | [quickstart.md](docs/quickstart.md) · [install.md](docs/install.md) · [configuration.md](docs/configuration.md) |
-| Coding-agent first run | [Setup and workload prompts](docs/workbench/agent-first-run.md) |
-| Workbench setup | [getting-started.md](docs/workbench/getting-started.md) |
-| Beginner robot guides | [guides/README.md](docs/workbench/guides/README.md) |
-| Physical AI Data Factory | [deploy runbook](docs/workbench/guides/physical-ai-data-factory-deploy.md) · [concepts](docs/workbench/guides/physical-ai-data-factory.md) |
-| Cookbooks | [cookbooks/README.md](docs/workbench/cookbooks/README.md) — incl. [BDD100K + LanceDB](docs/workbench/cookbooks/bdd100k-pipeline.md) and [Isaac-Lab BYOF](docs/workbench/cookbooks/byof-isaac-lab/) |
-| Workflow authoring | [npa-workflow-guide.md](docs/workbench/npa-workflow-guide.md) · [tool catalog](docs/workbench/npa-workflow-tool-catalog.md) |
-| Python & HTTP access | [CLI / SDK walkthrough](docs/workbench/cli-sdk-yaml-walkthrough.md) · [SDK errors](docs/sdk/errors.md) — check each tool's supported surfaces |
-| What `submit` does | [run-lifecycle.md](docs/run-lifecycle.md) |
-| Self-hosted agent | [agent.md](docs/agent.md) · [operator skill](skills/tools/npa-agent/SKILL.md) · [fresh-operate](skills/workflows/agent-fresh-operate/SKILL.md) |
-| Teardown & cost | [teardown.md](docs/teardown.md) |
-| Container images | [catalog](docs/workbench/container-image-catalog.md) · [packaging contract](docs/workbench/container-packaging.md) |
-| Preemptible GPU VMs | [preemptible-vms.md](docs/workbench/preemptible-vms.md) |
-| Troubleshooting | [known-footguns.md](docs/workbench/troubleshooting/known-footguns.md) · [FIXME.md](FIXME.md) · [FTUE audit](FTUE-AUDIT.md) |
-| CLI reference | [cli/README.md](docs/cli/README.md) |
-| Extend Workbench | [Contributing](CONTRIBUTING.md) · [OSS onboarding ladder](docs/architecture/oss-onboarding-ladder.md) |
-| Documentation index | [docs/README.md](docs/README.md) |
-
----
+Use the [documentation index](docs/README.md) to find setup, operations, and
+contributor references. Report a broken example with its command, `npa` version,
+and redacted error in [GitHub Issues](https://github.com/nebius/nebius-physical-ai/issues).
+Keep credentials and private infrastructure identifiers out of issue text.
 
 ## Contributing
 
-We welcome PRs, issues, and workflow contributions.
-
-```bash
-pip install -e "npa[dev,adapter]"
-make test PYTHON="$(pwd)/.venv/bin/python"
-```
-
-Read [CONTRIBUTING.md](CONTRIBUTING.md) for the review checklist,
-skill-maintenance requirements, and repo hygiene rules. New behavior should have
-a matching root `skills/` entry — see [`skills/index.yaml`](skills/index.yaml).
-Security disclosures: [SECURITY.md](SECURITY.md). Support and community happen
-through GitHub [Issues](https://github.com/nebius/nebius-physical-ai/issues) and
-[Pull Requests](https://github.com/nebius/nebius-physical-ai/pulls).
-
----
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development environment, required
+checks, and PR process. [The package README](npa/README.md#developing-and-testing-npa)
+has the shortest test commands. Update the relevant documentation and
+[root skill](skills/index.yaml) when changing behavior.
+Security disclosures: [SECURITY.md](SECURITY.md).
 
 ## License
 
-Licensed under the [Apache License 2.0](LICENSE). Built by
-[Nebius](https://nebius.com) and the physical-AI community.
+[Apache License 2.0](LICENSE). Third-party software, models, and datasets retain
+their own licenses and access terms.

--- a/README.md
+++ b/README.md
@@ -28,46 +28,16 @@ observability, and cluster orchestration.**
 
 ## What is `npa`?
 
-`npa` is the CLI and SDK for **Nebius Physical AI**. Workbench is its primary
-solution: one command surface that composes data curation, simulation, synthetic
-data, policy training, evaluation, export, observability, and declarative
-workflows on Nebius object storage, managed Kubernetes, vLLM-compatible serving,
-and GPU clusters (H100 · H200 · L40S · B300 · RTX PRO 6000).
+`npa` runs robotics and physical-AI workloads on Nebius: data curation,
+simulation, synthetic data, policy training, and evaluation. Workbench tools
+run in containers and exchange inputs, checkpoints, and results through S3.
+Use the CLI, a tool's Python interface, or a declarative workflow.
 
-You bring a robot, a dataset, or a pipeline idea. `npa` brings the containers,
-the orchestration, and the preflight checks that catch a missing token before it
-stalls your run.
-
-Workbench is meant to be operated by **your own coding agent**. Connect the
-agent to this checkout with terminal access, attach your cloud and model
-credentials through its private environment or secret manager, and ask it to
-configure, validate, provision, submit, and inspect workflows with you. The
-prompts in the [coding-agent guide](docs/workbench/agent-first-run.md) are a
-starting point; you do not need to learn every `npa` command before running
-something real.
-
-|                       |                                                                                                              |
-| --------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **What you can do**   | Curate datasets · train and evaluate policies · render synthetic data · run sim-to-real loops · serve models  |
-| **Who it's for**      | Robotics teams, physical-AI researchers, and partners shipping on Nebius                                      |
-| **Where it runs**     | Nebius S3, managed Kubernetes, and GPU clusters                                                               |
-| **How you extend it** | Declarative `npa.workflow/v0.0.1` YAML specs and reusable Workbench tool refs                                 |
-
-For an existing Fleet, run `npa fleet verify-storage --spec <fleet.yaml>` to
-verify the shared filesystem on every CPU and GPU worker, including host mount
-capacity, cross-node PVC reads and writes, and cleanup. The command and Python
-SDK share one implementation; see [Fleet storage verification](docs/fleet-storage-verification.md)
-for selectors, private evidence, and automation-safe JSON.
-
-For an existing 8-GPU RTX rendering Fleet, run
-`npa fleet verify-graphics --spec <fleet.yaml>`. It fresh-verifies each
-registered target, observes cluster stability, and then proves CUDA vectorAdd,
-GLX, EGL, and Vulkan on every RTX worker. Exact receipts stay owner-private;
-text and JSON output contain only counts, failure categories, and evidence
-hashes. See the [GPU driver strategy](docs/workbench/mk8s-gpu-driver-strategy.md#qualifying-an-existing-rtx-fleet).
-
-> Partners integrate independently. Teams assemble from open blueprints.
-> Nebius owns the infrastructure layer and compute substrate.
+Bring your dataset, robot, or pipeline idea. Start with the
+[quickstart](docs/quickstart.md), or give your coding agent the
+[first-run prompts](docs/workbench/agent-first-run.md) and terminal access to
+this checkout. Keep credentials in its private environment or the NPA
+credential store.
 
 ### How workflows run
 
@@ -91,13 +61,6 @@ Foxglove viewer. This diagram describes workflow execution; the
 [Workbench Ray guide](docs/workbench/ray.md) routes direct native Jobs/Core,
 Train, Serve, and KubeRay use to the supported paths.
 
-The [daily dev VM test guide](docs/testing/dev-vm-daily.md) covers the daily and
-manual GitHub workflow, a dedicated VM with public SSH, pinned host keys, and
-isolated test execution. The workflow connects directly from GitHub without a
-VPN or an identity-federation service. The guide also covers selecting an
-external public address pool and updating trusted SSH settings after an address
-change.
-
 Python and HTTP coverage varies by tool. The
 [CLI / SDK walkthrough](docs/workbench/cli-sdk-yaml-walkthrough.md) explains
 typed clients, callback wrappers, and their return values.
@@ -108,11 +71,9 @@ typed clients, callback wrappers, and their return values.
 
 [Use Workbench with a coding agent](docs/workbench/agent-first-run.md).
 
-Three steps from a clone to a real result on Nebius.
-
 ### 1. Install `npa`
 
-Python **3.10+**. `npa` is not on PyPI — install it editable from the clone:
+Python **3.10+** on macOS, Linux, or WSL2 Ubuntu. Install from this repository:
 
 ```bash
 git clone https://github.com/nebius/nebius-physical-ai.git
@@ -123,91 +84,56 @@ pip install -e npa
 npa --version
 ```
 
-> **Windows:** use WSL2 Ubuntu. Per-platform steps are in
-> [docs/install.md](docs/install.md).
->
-> **Managed deployments** (such as `npa agent fresh-setup`) also need
-> **Terraform 1.x** on `PATH` — `pip install -e npa` does not install it. Check
-> with `terraform version`; agent bootstrap installs the tested 1.13.3 baseline
-> only when Terraform is missing entirely.
+See [installation](docs/install.md) for platform details and tools such as
+Terraform and `kubectl`, which are installed separately.
 
 ### 2. Connect to Nebius
 
-[Sign up](https://docs.nebius.com/signup-billing/sign-up), create a
-[tenant and project](https://docs.nebius.com/iam/manage-projects), install the
-Nebius CLI, then let `npa configure` write `~/.npa/credentials.yaml` and
-`~/.npa/config.yaml` for you:
+Install the tested Nebius CLI, then select your project:
 
 ```bash
 curl -fsSL https://storage.eu-north1.nebius.cloud/cli/install.sh \
   | NEBIUS_CLI_VERSION=0.12.254 bash
-export PATH="${HOME}/.nebius/bin:${PATH}"   # add to ~/.zshrc or ~/.bashrc
+export PATH="${HOME}/.nebius/bin:${PATH}"
 npa configure
+npa workbench health preflight --checks nebius --json
 ```
 
-`npa` is tested with Nebius CLI `0.12.254` (recommended) and `0.12.227`
-(compatible, with a warning). Anything else is blocked *before* provider calls,
-and the error prints the exact install command to run.
-
-`npa configure` also prompts for optional model and inference tokens, linking
-each setup guide inline: [Hugging Face](docs/workbench/huggingface-token.md) ·
-[NVIDIA NGC](docs/workbench/ngc-api-key.md) ·
-[Nebius Token Factory](docs/workbench/token-factory-key.md).
-Its Hugging Face and NGC access summary is informative: missing, rejected,
-gated, or temporarily unreachable providers do not prevent otherwise-valid
-configuration from being saved. Use `npa workbench health access` when access
-must be an enforcing gate.
-
-Interactive configuration provisions object storage by default. First-time
-storage setup needs admin permission on the target project to create the
-service account, access key, and bucket-scoped IAM permissions.
-
-For project creation, SSO, non-interactive provisioning, credential names, and
-recovery, see [configuration](docs/configuration.md). Use the
-[coding-agent setup prompt](docs/workbench/agent-first-run.md#configure-the-project-and-model-access)
-to prepare the credentials and resources required by your selected task.
+Interactive configuration provisions object storage by default; first-time
+storage setup needs admin permission on the target project. Use
+`npa configure --no-provision` to save project and token settings without
+storage provisioning. [Configuration](docs/configuration.md) covers account
+setup, SSO, model tokens, and non-interactive use.
 
 ### 3. Run your first workload
 
-Choose a GPU workload from the [guides](docs/workbench/guides/README.md), such
-as a robot policy or [NVIDIA Cosmos](docs/quickstart.md#standalone-cosmos-3-generation).
-You can also select individual tools from the [tool reference](docs/cli/workbench.md)
-and compose them into a workflow. Use the [coding-agent guide](docs/workbench/agent-first-run.md)
-to check the inputs, credentials, and resources your task needs.
+Choose a guide below, prepare its input and model access, then complete
+[Workbench setup](docs/workbench/getting-started.md). Follow the guide through
+submission and inspect its generated media, checkpoint, or report.
 
-For a worked video-augmentation example, use
-[PAIDF + Cosmos 3](docs/workbench/guides/paidf-cosmos3.md): supply a
-local H.264 MP4 or private S3 MP4 URI, generate source-conditioned variants,
-evaluate them, and curate accepted outputs. The
-[PAIDF workflow prompt](docs/workbench/agent-first-run.md#run-paidf-with-cosmos-3)
-guides your agent through project storage, model access, GPU planning, image
-checks, submission, recovery, and output inspection. The PAIDF guide's command
-examples validate and plan the workflow without running it.
-
-Check the raw generated media as well as the published PAIDF composite, which
-blends source and generated frames (80% source by default). A quality rejection
-after bounded refinement skips labeling and curation; inspect the report before
-retrying. The original [Physical AI Data Factory](docs/workbench/guides/physical-ai-data-factory-deploy.md)
-continues to use Cosmos Transfer 2.5.
+For video augmentation, [PAIDF + Cosmos 3](docs/workbench/guides/paidf-cosmos3.md)
+accepts your source clip and records generation, evaluation, and curation
+results. The [coding-agent prompt](docs/workbench/agent-first-run.md#run-paidf-with-cosmos-3)
+covers execution; the guide's examples validate and plan only.
 
 ---
 
 ## Pick your first win
 
-Short, copy-paste walkthroughs. Pick whichever sounds fun — they are independent.
+Choose by the result you need; each guide states its inputs and validation scope.
 
-| I want to…                                     | Go here                                                                                | Needs                    |
+| I want to… | Go here | Needs |
 | ------------------------------------------------ | ---------------------------------------------------------------------------------------- | -------------------------- |
-| Pick and place with a Franka arm                 | [Franka + Genesis](docs/workbench/guides/franka-pick-and-place-genesis.md)                | GPU cluster                |
-| Teach a robot to push a T                        | [PushT sim-to-real](docs/workbench/guides/pusht-sim-to-real.md)                           | GPU cluster                |
-| Train a Reachy 2 humanoid policy                 | [Reachy 2 + LeRobot](docs/workbench/guides/reachy2-lerobot-policy.md)                     | GPU cluster                |
-| Make a Unitree G1 walk                           | [G1 + SONIC](docs/workbench/guides/g1-humanoid-walk-sonic.md)                             | GPU cluster                |
-| Train a quadruped to run                         | [Quadruped + Isaac Lab](docs/workbench/guides/quadruped-isaac-lab.md)                     | RT-core GPU                |
-| Run the flagship GPU workload                    | [NVIDIA Cosmos](docs/quickstart.md#standalone-cosmos-3-generation)                 | GPU cluster                |
-| Augment robot video with PAIDF + Cosmos 3        | [PAIDF with Cosmos 3](docs/workbench/guides/paidf-cosmos3.md)                             | GPU cluster + S3           |
-| Run a real data pipeline, not a robot            | [Physical AI Data Factory](docs/workbench/guides/physical-ai-data-factory-deploy.md)      | GPU cluster + S3           |
-| Rebuild a real scene in 3D                       | [Neural reconstruction](docs/workbench/guides/neural-reconstruction.md)                   | RT-core GPU                |
-| Get a browser workbench with a Rerun viewer      | [Deploy the `npa` agent](docs/agent.md)                                                  | Terraform + S3 (~20 min)   |
+| Pick and place with a Franka arm | [Franka + Genesis](docs/workbench/guides/franka-pick-and-place-genesis.md) | GPU cluster |
+| Inspect the PushT SDK | [PushT SDK smoke](docs/workbench/guides/pusht-sim-to-real.md) | Local dataset inspection |
+| Train a Reachy 2 humanoid policy | [Reachy 2 + LeRobot](docs/workbench/guides/reachy2-lerobot-policy.md) | GPU cluster |
+| Choose a G1 locomotion path | [G1 + SONIC](docs/workbench/guides/g1-humanoid-walk-sonic.md) | GPU cluster |
+| Train a quadruped to run | [Quadruped + Isaac Lab](docs/workbench/guides/quadruped-isaac-lab.md) | RT-core GPU |
+| Generate images or video | [NVIDIA Cosmos](docs/quickstart.md#standalone-cosmos-3-generation) | GPU cluster |
+| Augment robot video with PAIDF + Cosmos 3 | [PAIDF with Cosmos 3](docs/workbench/guides/paidf-cosmos3.md) | GPU cluster + S3 |
+| Build a labeled dataset | [Physical AI Data Factory](docs/workbench/guides/physical-ai-data-factory-deploy.md) | GPU cluster + S3 |
+| Rebuild a real scene in 3D | [Neural reconstruction](docs/workbench/guides/neural-reconstruction.md) | RT-core GPU |
+| Get a browser workbench with a Rerun viewer | [Deploy the `npa` agent](docs/agent.md) | Terraform + S3 (~20 min) |
 
 Full index: [docs/workbench/guides/README.md](docs/workbench/guides/README.md).
 Longer end-to-end recipes (BDD100K + LanceDB, Isaac-Lab BYOF, LeRobot GPU
@@ -217,42 +143,18 @@ benchmarks): [cookbooks](docs/workbench/cookbooks/README.md).
 
 ## What's in the box
 
-Every tool lives under `npa workbench` (there is no `solutions` namespace).
-A few highlights:
+Use `npa workbench <tool> --help` for a tool's commands and options.
 
-- **`token-factory`** — hosted inference, captioning, and reasoning against your
-  own frames.
-- **`vlm-eval`** — scores rollouts with API or self-hosted vLLM backends; see
-  [`vlm-eval-single.yaml`](workflows/testing/vlm-eval-single.yaml).
-- **`health preflight`** — validates HF / NGC / S3 / Token Factory before a
-  deploy or a GPU job.
-- **`foxglove`** — packs run frames, metrics, and logs into MCAP for the
-  embedded viewer ([CLI](docs/cli/foxglove.md) ·
-  [export contract](docs/workbench/foxglove-export.md)).
-- **`golden-eval`** — defines and runs per-container checks; CI validates their
-  manifest, while execution results depend on the selected test and runtime.
-- **`trigger`** — watches S3-compatible prefixes and retriggers workflows.
-- **`sonic export`** — converts locomotion checkpoints to ONNX.
+| Task | Tools and guides |
+| --- | --- |
+| Simulate and train policies | [Robot guides](docs/workbench/guides/README.md): Genesis, Isaac Lab, LeRobot, GR00T, SONIC, and MJLab |
+| Generate or reconstruct scenes | [Generation and scene tools](docs/workbench/README.md#generation-and-scenes): Cosmos, NuRec, Content Agents, LTX-2, and Wan |
+| Curate and evaluate | [Data and evaluation](docs/workbench/README.md#data-and-evaluation): FiftyOne, LanceDB, detection training, VLM evaluation, and hosted Token Factory inference |
+| Inspect outputs | [Rerun sharing](docs/workbench/rerun-sharing.md), [Foxglove/MCAP](docs/workbench/foxglove-export.md), and the [browser workbench](docs/agent.md) |
+| Manage compute | [Kubernetes](docs/workbench/kubernetes.md), [SkyPilot](docs/orchestration/skypilot-setup.md), and [cluster backends](docs/cluster-backends.md) |
 
-<details>
-<summary><strong>Browse the full command inventory by category</strong></summary>
-
-| Category         | Workbench commands                                                                                                                                                                                                                                                                                     |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Data curation    | `npa workbench fiftyone curate`, `eval`, `load-dataset`, `datasets list`; `npa workbench lancedb deploy`, `create-table`, `import-lerobot`, `import-bdd100k`, `backfill`, `create-mv`, `refresh-mv`, `query-table`, `query`; `npa workbench detection-training train`, `eval`, `status`, `list`         |
-| Synthetic data   | `npa workbench cosmos infer`, `train`, `serve`, `status`; `npa workbench cosmos2 transfer`; `npa workbench cosmos3 reason`; `npa workbench genesis generate-demos`; specs such as [`bdd100k-pipeline.yaml`](workflows/testing/bdd100k-pipeline.yaml) |
-| Simulation      | `npa workbench isaac-lab train`, `eval`, `export-lerobot`, `export-onnx`; `npa workbench leisaac launch`, `status`, `destroy` (browser teleoperation); `npa workbench genesis train-teacher`, `generate-demos`, `eval-teacher`, `eval-student`, `diagnose`, `tune`; `npa workbench sonic retargeting run`, `workflow`                                                                    |
-| Eval            | `npa workbench vlm-eval run`, `benchmark`, `workflow`, `status`, `list`; `npa workbench mjlab eval`, `workflow`; `npa workbench sonic eval`; `npa workbench fiftyone eval`; `npa workbench isaac-lab eval`; `npa workbench genesis eval-student`; `npa workbench golden-eval run`, `run-all`, `validate` |
-| Robot policy    | `npa workbench lerobot train`, `eval`, `serve`, `infer`, `list-checkpoints`, `benchmark`, `profile-train`, `train-student`; `npa workbench groot download`, `finetune`, `eval`, `serve`, `infer`, `convert`; `npa workbench sonic train`, `serve`, `export`, `eval`, `status`, `list`                    |
-| World models    | `npa workbench cosmos deploy`, `serve`, `infer`, `train`, `finetune`, `optimize`, `autoscale`, `status`, `system-info`                                                                                                                                                                                   |
-| Hosted LLM      | `npa workbench token-factory caption`, `generate`, `reason`, `verify`, `models`, `workflow`, `status`                                                                                                                                                                                                    |
-| Workflows       | `npa workbench workflow validate-spec`, `plan-spec`, `run-spec`, `submit`; workbench workflows under [`workflows/`](workflows/)                                                                                                                                           |
-| Observability   | Tool-level `status`, `list`, and `system-info` commands; `npa workbench workflow status`, `logs`; `npa workbench health preflight`; `npa workbench foxglove convert-run`, `inspect`, `install-sdk`, `config`; `npa rerun host`, `share`, `list-shares`, `revoke`; `npa cluster status`, `list`                                                                                       |
-| Platform utils  | `npa configure` / `init`, `npa provision-if-absent`; `npa agent`, `npa skypilot bootstrap/status/verify`, `npa soperator`, `npa burst`, `npa cluster`, `npa network`, `npa adapter convert`, `npa convert lerobot-to-rrd/-mp4`, `npa viz`, `npa demo`                                                    |
-
-</details>
-
-Full CLI reference: [docs/cli/README.md](docs/cli/README.md).
+Browse the [Workbench docs](docs/workbench/README.md) for usage guides or the
+[generated CLI reference](docs/cli/README.md) for the command inventory.
 
 ---
 
@@ -270,14 +172,14 @@ npa workbench workflow validate-spec workflows/testing/vlm-eval-single.yaml
 npa workbench workflow plan-spec workflows/testing/vlm-eval-single.yaml --run-id demo
 ```
 
-|                         |                                                                                    |
+|  |  |
 | ----------------------- | ------------------------------------------------------------------------------------ |
-| **Format**              | `apiVersion: npa.workflow/v0.0.1`                                                    |
-| **CLI**                 | `validate-spec` · `plan-spec` · `run-spec` · `submit`                                |
-| **Workbench workflows** | [`workflows/`](workflows/)   |
-| **Tool catalog**        | [npa-workflow-tool-catalog.md](docs/workbench/npa-workflow-tool-catalog.md)          |
-| **Authoring guide**     | [npa-workflow-guide.md](docs/workbench/npa-workflow-guide.md)                        |
-| **What submit does**    | [Run lifecycle](docs/run-lifecycle.md) — gates, run identity, restart safety, status |
+| **Format** | `apiVersion: npa.workflow/v0.0.1` |
+| **CLI** | `validate-spec` · `plan-spec` · `run-spec` · `submit` |
+| **Workbench workflows** | [`workflows/`](workflows/) |
+| **Tool catalog** | [npa-workflow-tool-catalog.md](docs/workbench/npa-workflow-tool-catalog.md) |
+| **Authoring guide** | [npa-workflow-guide.md](docs/workbench/npa-workflow-guide.md) |
+| **What submit does** | [Run lifecycle](docs/run-lifecycle.md) — gates, run identity, restart safety, status |
 
 For execution, follow a complete workload guide with your actual bucket,
 prepared input, credentials, and resources. Use `submit --runtime` for parallel
@@ -295,17 +197,16 @@ lacks bootstrap evidence; see the [run lifecycle](docs/run-lifecycle.md).
 
 ## When you're done, tear it down
 
-Teardown is an **ordered** sequence — cancel jobs, destroy the agent, remove the
-shared controller, destroy the cluster, delete the bucket, remove storage IAM,
-then clear local state. Skipping a step leaves something billing.
+Preview cleanup for your project:
 
 ```bash
-npa cleanup                                  # report + the exact runbook for your machine
-npa destroy --project <alias> --all          # read-only until you add --yes
+npa destroy --project <alias> --all
 ```
 
-Every command, every guard, and how to finish a teardown you can no longer
-address by alias: **[docs/teardown.md](docs/teardown.md)**.
+This is read-only until you pass `--yes`. Review the plan and retain artifacts
+you need before deleting their storage. [Teardown](docs/teardown.md) covers
+canceling jobs before removing owned services and infrastructure. Local
+`npa cleanup` alone does not stop cloud resources.
 
 ---
 
@@ -429,8 +330,8 @@ solutions are additive and never rename or nest it. See
 We welcome PRs, issues, and workflow contributions.
 
 ```bash
-pip install -e "npa[dev]"
-make test
+pip install -e "npa[dev,adapter]"
+make test PYTHON="$(pwd)/.venv/bin/python"
 ```
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) for the review checklist,

--- a/deploy/cluster/README.md
+++ b/deploy/cluster/README.md
@@ -1,153 +1,150 @@
-# NPA Kubernetes Cluster Terraform
+# Managed Kubernetes for NPA
 
-This directory contains a thin Terraform wrapper around a vendored copy of the
-Nebius `k8s-training` solution from `nebius/nebius-solutions-library`.
+[Infrastructure docs](../../docs/cluster-backends.md) · [Workbench setup](../../docs/workbench/getting-started.md)
 
-The wrapper provisions a Managed Kubernetes cluster. The **default shape is a
-small FTUE / Physical AI Data Factory cluster**, not a training farm:
+This Terraform wrapper provisions Nebius Managed Kubernetes using the vendored
+`k8s-training` solution. Start with a workload's GPU and memory requirements,
+then use NPA to configure, provision, and validate its cluster.
 
-- **1× GPU node** (`gpu-rtx6000`, preset `1gpu-24vcpu-218gb`) — a single RTX PRO
-  6000 GPU.
-- **1× CPU node** (`cpu-d3`, preset `8vcpu-32gb`) for CPU stages — big enough to
-  schedule the shipped workflows' CPU requests (the Physical AI Data Factory asks
-  for 4 CPU / 16Gi, which a 4vcpu-16gb node cannot fit after kubelet reserve).
-- Nebius managed GPU driver image (`gpu_driver_mode = "auto"`) plus the
-  provider-managed NVIDIA device plugin. CPU-only pools do not receive GPU
-  driver settings.
-- Nebius Network Operator through the upstream solution.
-- **Shared Filesystem OFF by default** (`enable_filestore = false`). npa.workflow
-  stages — including the Physical AI Data Factory — hand off artifacts via S3
-  URIs, so no cross-node `/mnt/data` (and no Shared Filesystem SSD quota) is
-  required. The platform block-storage StorageClass stays the cluster default.
-- Optional strict GPU capacity-block reservation selector.
-- Grafana, Prometheus, Loki, KubeRay, and OPA Gatekeeper disabled by default.
-- Optional node-group service-account creation disabled by default, so the
-  wrapper does not mutate tenant IAM groups unless explicitly requested.
+## Prerequisites
 
-### Opt into a larger cluster or Shared Filesystem
+- [NPA installed](../../docs/install.md), a configured project, and an
+  authenticated Nebius CLI profile with permission to create its resources.
+- Terraform **1.12+**, `kubectl`, and an SSH public key available locally.
+- Quota and capacity for the requested CPU/GPU nodes, boot disks, and public IPs.
+- Model access checked before provisioning for a model-dependent workload.
 
-These remain available as explicit opt-in via `terraform.tfvars`, `TF_VAR_*`, or
-`-var` flags — they are just not the default:
+NPA installs neither Terraform nor `kubectl`. Use
+`NPA_TERRAFORM_BIN=/path/to/terraform` to select a compatible Terraform binary.
 
-- **More / bigger GPUs:** raise `gpu_nodes_count` and/or set a multi-GPU preset
-  (e.g. `gpu_nodes_preset = "8gpu-192vcpu-1744gb"`), and set
-  `enable_gpu_cluster = true` (with `infiniband_fabric`) for multi-node
-  InfiniBand training.
-- **Preemptible GPU nodes:** `gpu_nodes_preemptible = true` draws on the
-  preemptible capacity pool instead of on-demand. It does not bypass the hard
-  instance, boot-disk-count, `compute.disk.size.network-ssd` byte-capacity, or
-  public-IP allowances. The default 128 GiB CPU disk plus 1,023 GiB GPU disk
-  requires 1,151 GiB of incremental NETWORK_SSD capacity. `npa cluster up` checks all
-  cumulative hard quotas before `terraform apply`; capacity advice remains a
-  separate availability signal.
-- **Shared Filesystem:** set `enable_filestore = true` (optionally
-  `filestore_disk_size_gibibytes`) to create one, or `existing_filestore = <id>`
-  to attach an existing one (that alone implies `enable_filestore`). Either
-  promotes the filesystem CSI StorageClass to the cluster default.
+## Provision through NPA
 
-The vendored solution is based on upstream tag `main-v2026-05-25` with local
-patches for GPU node-group reservation policy, configurable managed-driver
-preset, and zero-CPU node-group omission so raw Terraform usage stays
-standalone.
-
-### GPU driver strategy and health gate
-
-`gpu_driver_mode` has three stable values:
-
-- `auto` (default) selects a Nebius managed-driver node image for every GPU
-  node group and leaves CPU-only clusters untouched.
-- `managed-image` explicitly requires that same safe path.
-- `operator` uses the recipe's in-cluster NVIDIA GPU Operator driver path. It
-  is an escape hatch for diagnostics and recipes that genuinely require it.
-
-The managed preset defaults to `cuda13.0` and is configurable through
-`managed_driver_preset`. Operator mode on an NVSwitch topology (a multi-GPU
-SXM/NVL preset or `enable_gpu_cluster = true`) is rejected unless
-`allow_unsafe_nvswitch_operator = true` is also set. That acknowledgement is
-deliberately noisy: the operator/Fabric Manager path can start before the
-Network Operator/MOFED has exposed host `/dev/infiniband/umad*` and `issm*`
-devices, leaving Fabric in progress and CUDA uninitialized.
-
-`npa cluster up` does not record the cluster as `RUNNING` merely because
-Terraform and kubeconfig creation succeeded. For GPU clusters it waits for the
-requested node topology to remain stable, verifies Ready nodes, boot IDs,
-`NebiusGPUError`, generalized `nvidia.com/gpu` allocatable capacity, exposed
-NVSwitch Fabric state, and mode-appropriate NVIDIA components, then runs CUDA
-vectorAdd on every requested GPU node. Use `--validation-timeout` and
-`--gpu-health-stabilization-seconds` to tune the wait; live validation can only
-be disabled explicitly with `--skip-validate` or the CUDA workload alone with
-`--skip-gpu-cuda-smoke`.
-
-Changing these settings does not repair nodes that have already booted with the
-operator-managed driver. Existing affected GPU pools require a controlled
-rolling node-group update or recreation under the managed-image setting so
-each replacement node boots from the new image. Follow workload disruption and
-capacity-reservation policy; a code or CLI upgrade by itself cannot retrofit
-the image on an existing node.
-
-## Usage
-
-**Terraform >= 1.12 is required.** The vendored modules declare
-`required_version >= 1.12.0` and use `ephemeral` blocks; Terraform loads every
-referenced module during `init`, including the ones this wrapper disables, so an
-older binary fails to initialise the directory. `npa cluster up` /
-`npa cluster down` check the version first and point at the upgrade; set
-`NPA_TERRAFORM_BIN=/path/to/terraform` to use a newer binary without changing
-`PATH`.
-
-Provider checksums are tracked for `linux_amd64`, `linux_arm64`,
-`darwin_amd64`, and `darwin_arm64`. `npa cluster up/down` verifies the current
-platform and the SHA-bound coverage metadata before authentication or provider
-download, runs `terraform init -lockfile=readonly`, and keeps both `TF_DATA_DIR`
-and the platform-scoped plugin cache outside this source directory. A mismatch
-is a stop condition: regenerate intentionally with Terraform's `providers lock
--platform=...` workflow in a clean checkout and review the diff; never remove
-the lock file or bypass checksum verification.
-
-Copy `terraform.tfvars.example` to `terraform.tfvars` and replace placeholders
-with local values. `terraform.tfvars` is ignored by git. The example ships the
-small default shape and shows the larger-cluster / Shared Filesystem opt-ins in
-comments. Leave `iam_token` commented out when driving Terraform through `npa`:
-the CLI mints a fresh token per run, and Terraform would prefer the pinned one
-in `terraform.tfvars` (so `npa cluster up` rejects that file outright).
-
-The default cluster needs **no** Shared Filesystem SSD quota, so
-`npa cluster up` / `npa provision-if-absent` succeed with zero SFS quota. Only
-when you opt in with `enable_filestore = true` and `existing_filestore = ""` does
-the CLI check Shared Filesystem SSD quota before `terraform apply`; if quota is
-not available, provide an existing filesystem ID or raise quota before running
-`up`.
-
-Set `capacity_block_group` only in private runtime configuration, such as a
-gitignored `terraform.tfvars`, `TF_VAR_capacity_block_group`, or a direct
-Terraform var:
+Run from the repository root. Replace the alias and cluster name, then inspect
+the plan against your workload's resource profiles:
 
 ```bash
-terraform apply -var capacity_block_group=<capacity-block-group-id>
+project_alias='<your-project-alias>'
+cluster_name='<your-cluster-name>'
+
+npa workbench health preflight --checks nebius --json
+npa provision-if-absent --project "$project_alias" \
+  --cluster-name "$cluster_name" --dry-run --output-format json
 ```
 
-Then run:
+Require a ready preflight, not just exit code zero. A preview can return
+`status: blocked`; its `preflight.reasons` identifies missing quota or access.
+Reserved GPUs still require sufficient boot-disk quota.
+
+When the project, region, and topology are correct, run the same command without
+`--dry-run`. It may create storage, networking, and a cluster. An existing
+external cluster needs explicit registration; see
+[use an existing cluster](../../docs/workbench/getting-started.md#verify-kubernetes-access).
+
+After successful provisioning:
 
 ```bash
-npa cluster up --terraform-dir deploy/cluster --capacity-block-group <capacity-block-group-id>
+npa cluster status --project "$project_alias" --name "$cluster_name"
+npa workbench workflow gpus --project "$project_alias" --cluster "$cluster_name" --json
 ```
 
-The command runs `terraform init`, `terraform apply -auto-approve`, writes a
-kubeconfig under `~/.npa/clusters/<cluster-name>/kubeconfig`, validates stable
-GPU health and CUDA execution with `kubectl`, and can run an additional
-SkyPilot Kubernetes GPU smoke test. See
-[`docs/workbench/mk8s-gpu-driver-strategy.md`](../../docs/workbench/mk8s-gpu-driver-strategy.md)
-for direct and Fleet configuration, recipe compatibility, diagnostics, and
-migration guidance.
+Expect Ready nodes and the requested GPU count. Use the kubeconfig reported by
+NPA and complete [SkyPilot setup](../../docs/orchestration/skypilot-setup.md)
+before submitting a workflow. A provider-created cluster is not yet proof that
+a model can run on it.
 
-To inspect Terraform outputs alongside the local cluster cache:
+## Default shape
+
+| Component | Default | Why |
+| --- | --- | --- |
+| GPU pool | One `gpu-rtx6000` node, `1gpu-24vcpu-218gb` | One RTX PRO 6000 GPU |
+| CPU pool | One `cpu-d3` node, `8vcpu-32gb` | Room for a 4 CPU / 16 GiB stage, the controller, and system pods |
+| GPU drivers | `auto`, managed `cuda13.0` image | Driver and device-plugin setup validated by NPA |
+| Shared filesystem | Disabled | Workflow stages normally exchange artifacts through S3 |
+| Monitoring, KubeRay, OPA Gatekeeper | Disabled | Enable only what the workload needs |
+| Node-group service account creation | Disabled | Avoid unnecessary tenant IAM changes |
+
+The default 128 GiB CPU disk plus 1,023 GiB GPU disk requires **1,151 GiB of
+NETWORK_SSD quota**, in addition to disk-count and instance quota. This is a
+small starter topology; it does not fit every workflow in the catalog.
+
+## Use this Terraform directory directly
+
+For explicit wrapper configuration, copy the example locally:
 
 ```bash
-npa cluster status --terraform-dir deploy/cluster
+cp deploy/cluster/terraform.tfvars.example deploy/cluster/terraform.tfvars
 ```
 
-To destroy a Terraform-managed cluster:
+Replace its tenant, project, region, subnet, cluster name, and public-key path.
+`terraform.tfvars` is gitignored; keep private infrastructure values there.
+Leave `iam_token` commented out when using NPA: the CLI supplies authentication
+and rejects a pinned token that Terraform would prefer over it.
 
 ```bash
-npa cluster down --terraform-dir deploy/cluster
+npa cluster up --project "$project_alias" --terraform-dir deploy/cluster
+npa cluster status --project "$project_alias" --terraform-dir deploy/cluster
 ```
+
+`cluster up` applies Terraform and validates the resulting cluster. It creates
+resources without a separate Terraform approval prompt. To use reserved GPU
+capacity, supply the exact authorized reservation through private configuration:
+
+```bash
+npa cluster up --project "$project_alias" --terraform-dir deploy/cluster \
+  --capacity-block-group '<capacity-block-group-id>'
+```
+
+The reservation uses strict placement. `TF_VAR_capacity_block_group` is the
+equivalent environment setting; an explicit CLI flag takes precedence.
+
+## Change the topology
+
+| Need | Configuration |
+| --- | --- |
+| More GPUs | Increase `gpu_nodes_count` and select a matching `gpu_nodes_preset`; a multi-GPU task must fit on one node |
+| Multi-node InfiniBand | Set `enable_gpu_cluster = true` and the matching `infiniband_fabric` for a supported topology |
+| Preemptible nodes | Set `gpu_nodes_preemptible = true`; this changes the capacity pool, while disk/IP/instance quotas still apply |
+| New shared filesystem | Set `enable_filestore = true` and its size; requires Shared Filesystem SSD quota and the approved CSI chart repository |
+| Existing shared filesystem | Set `existing_filestore`; it implies filesystem enablement and does not create a second filesystem |
+
+Shared filesystem enablement promotes its CSI StorageClass to the cluster
+default. Otherwise, platform block storage remains the default. See
+[filesystem verification](../../docs/fleet-storage-verification.md) before
+using a shared volume for multi-node work.
+
+## GPU health and driver changes
+
+The default `auto` and explicit `managed-image` strategies use a managed driver
+image. `operator` is a separate driver path; NVSwitch topologies reject it
+without the explicit unsafe-topology acknowledgement. For workloads that need
+operator-mounted graphics libraries, follow the
+[RTX rendering profile](../../docs/workbench/mk8s-gpu-driver-strategy.md).
+
+Before reporting GPU readiness, NPA checks stable Ready nodes, GPU allocatable
+capacity, driver components, exposed fabric state, and CUDA vectorAdd on every
+requested GPU node. Keep these checks enabled. Changing configuration alone
+does not change the image of already booted nodes; driver migration requires a
+controlled update or recreation. The driver guide covers that procedure and
+common failures.
+
+## Terraform reproducibility
+
+The vendored recipe is based on `main-v2026-05-25` with local reservation,
+managed-driver, and node-group patches. Provider checksums cover Linux and macOS
+on AMD64 and ARM64. NPA checks the SHA-bound platform metadata, initializes with
+`-lockfile=readonly`, and stores provider caches outside this source directory.
+On a lock mismatch, intentionally regenerate and review the provider lock;
+removing it would discard the verification contract.
+
+## Cleanup
+
+Stop active jobs and preserve needed outputs before removing this cluster:
+
+```bash
+npa cluster down --project "$project_alias" --terraform-dir deploy/cluster
+```
+
+Read the proposed scope before confirming. Cluster deletion does not mean all
+project storage or services are gone; follow the [teardown guide](../../docs/teardown.md)
+for those separately owned resources. Preserve Terraform state after an
+incomplete deletion so the exact operation can be resumed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,67 +1,52 @@
-# Nebius Physical AI Documentation
+# Nebius Physical AI documentation
 
-`npa` is the CLI and Python package for Nebius Physical AI. **Workbench** is its
-primary solution: tools and declarative workflows for data curation, simulation,
-synthetic data, policy training, and evaluation on Nebius.
+`npa` runs robotics and physical-AI tools on Nebius. Start with a workload,
+prepare its project and compute, then inspect the result.
 
-[Configuration](configuration.md) covers credentials, project storage, and SSO.
-Use the [coding-agent first run](workbench/agent-first-run.md) for guided setup
-and PAIDF + Cosmos 3 execution.
+## Start here
 
-## Start with your task
-
-| I want to… | Start here | Continue with |
-| --- | --- | --- |
-| Run my first GPU workload | [Quickstart](quickstart.md) for installation, project setup, and credential checks | [Workbench guides](workbench/guides/README.md) to choose a workload and inspect its result |
-| Find an existing pipeline | [Workflow catalog](../workflows/README.md) | [Workflow guide](workbench/npa-workflow-guide.md) for validation, planning, and submission |
-| Prepare compute for my workload | [Workbench setup](workbench/getting-started.md) after the quickstart | [Managed Kubernetes](workbench/kubernetes.md) for cluster-backed runs |
-| Run an application with Ray | [Workbench Ray guide](workbench/ray.md) | Choose native Jobs/Core, Train, Cosmos Serve, or fixed CPU KubeRay |
-| Call a tool from a shell or Python | [CLI reference](cli/README.md) and [CLI / SDK walkthrough](workbench/cli-sdk-yaml-walkthrough.md) | [SDK errors](sdk/errors.md); check the selected tool's supported modes |
-| Inspect or recover a run | [Run lifecycle](run-lifecycle.md) | [Known failure modes](workbench/troubleshooting/known-footguns.md) and [safe teardown](teardown.md) |
-| Use the browser workbench and viewers | [NPA agent](agent.md) | [Rerun sharing](workbench/rerun-sharing.md) |
-| Add a tool, workflow, or integration | [Contributing](../CONTRIBUTING.md) | [OSS onboarding ladder](architecture/oss-onboarding-ladder.md) and [container contract](workbench/container-packaging.md) |
-
-The [Workbench documentation index](workbench/README.md) collects tool guides,
-workflow references, and operator runbooks. For platform-specific installation
-details, use [Install npa](install.md).
-
-## Index
-
-| Path | Purpose |
+| Task | Read |
 | --- | --- |
-| [quickstart.md](quickstart.md) | Start here: install `npa`, configure Nebius, check access, and run a GPU workload |
-| [install.md](install.md) | Platform-specific installation and optional dependencies |
-| [workbench/guides/physical-ai-data-factory-deploy.md](workbench/guides/physical-ai-data-factory-deploy.md) | **Physical AI Data Factory** — copy-paste quickstart to stage input frames and run the annotate → Cosmos augment → curate → visualize blueprint |
-| [workbench/](workbench/) | Workbench solution docs, including getting started, cookbooks, and troubleshooting |
-| [workbench/kubernetes.md](workbench/kubernetes.md) | User setup and operational guide for running Workbench on managed Kubernetes |
-| [workbench/ray.md](workbench/ray.md) | Supported Ray entry points, exact lifecycle commands, artifact boundaries, recovery, and library limitations |
-| [workbench/cosmos3-generate.md](workbench/cosmos3-generate.md) | Cosmos 3 generation (`npa-cosmos3`) — build, run via CLI/SDK/workflow, and the runtime-credential posture that keeps weights out of the image |
-| [workbench/cosmos3-b200-checkpoint-evaluation-20260814.md](workbench/cosmos3-b200-checkpoint-evaluation-20260814.md) | Reserved-B200 Cosmos3 still-image checkpoint benchmark, blind three-seed review, and recommendation |
-| [workbench/cosmos3-super-serving.md](workbench/cosmos3-super-serving.md) | Cosmos3-Super serving (`npa-cosmos3-serving`), an 8-GPU single-node endpoint: build, run, readiness window, and guardrail posture |
-| [../workflows/README.md](../workflows/README.md) | **Workflow catalog** — find the right `npa.workflow` spec by what you want to do |
-| [architecture/solutions-model.md](architecture/solutions-model.md) | Platform model for adding and maintaining solutions |
-| [architecture/cli-namespaces.md](architecture/cli-namespaces.md) | CLI namespace conventions |
-| [cluster-backends.md](cluster-backends.md) | Shared Managed Kubernetes and soperator backend architecture, fleet specs, state ownership, and safe teardown |
-| [run-lifecycle.md](run-lifecycle.md) | What `workflow submit` checks before it spends a GPU-hour: gates, run identity, restart safety, and status semantics |
-| [agent.md](agent.md) | The self-hosted `npa agent` browser workbench VM — deploy, what it can see, and its artifact paging contract |
-| [teardown.md](teardown.md) | Stop spend safely: the ordered teardown sequence, what each phase guards, and receipt-based recovery |
-| [cli/README.md](cli/README.md) | CLI command reference index |
-| [cli-errors.md](cli-errors.md) | End-user CLI error formatting, exit codes, and JSON error output |
-| [sdk/errors.md](sdk/errors.md) | Typed exceptions for programmatic SDK consumers and agents |
-| [testing/e2e-serverless.md](testing/e2e-serverless.md) | E2E test conventions for serverless workloads |
-| [testing/e2e.md](testing/e2e.md) | General E2E test conventions |
-| [testing/dev-vm-daily.md](testing/dev-vm-daily.md) | Daily tests run on the dev VM over SSH from GitHub Actions |
-| [hackathon-isaac-token-factory.md](hackathon-isaac-token-factory.md) | Isaac Lab Franka simulation frames + Token Factory reasoner (workflow + SDK example) |
-| [hackathon-cosmos3-reasoner.md](hackathon-cosmos3-reasoner.md) | Hosted Cosmos3 reasoning through Token Factory |
+| Run a first GPU workload | [Quickstart](quickstart.md) → [workload guides](workbench/guides/README.md) |
+| Work with a coding agent | [First-run prompts](workbench/agent-first-run.md) |
+| Install host tools | [Installation](install.md) |
+| Connect a project and credentials | [Configuration](configuration.md) |
+| Prepare Kubernetes and SkyPilot | [Workbench setup](workbench/getting-started.md) |
+| Find a tool or pipeline | [Workbench docs](workbench/README.md) · [workflow catalog](../workflows/README.md) |
 
-## Audience
+## Run, integrate, and inspect
 
-| Reader | Start with |
+| Task | Read |
 | --- | --- |
-| Salesperson or evaluator | [Workflow catalog](../workflows/README.md) to see what the platform runs |
-| Customer running a first Workbench workload | [quickstart.md](quickstart.md), then [Workbench guides](workbench/guides/README.md) |
-| Operator connecting Workbench to Kubernetes | [workbench/kubernetes.md](workbench/kubernetes.md) |
-| Developer adding a solution | [Contributing](../CONTRIBUTING.md), then [architecture/solutions-model.md](architecture/solutions-model.md) |
-| SDK integrator or agent author | [CLI / SDK walkthrough](workbench/cli-sdk-yaml-walkthrough.md), then [sdk/errors.md](sdk/errors.md) |
-| Internal engineer triaging a failure | [cli-errors.md](cli-errors.md) |
-| Operator running e2e tests | [testing/e2e-serverless.md](testing/e2e-serverless.md) |
+| Author and submit YAML | [Workflow guide](workbench/npa-workflow-guide.md) · [toolRef catalog](workbench/npa-workflow-tool-catalog.md) |
+| Use CLI, Python, or HTTP | [CLI reference](cli/README.md) · [SDK walkthrough](workbench/cli-sdk-yaml-walkthrough.md) · [SDK errors](sdk/errors.md) |
+| Choose a direct deployment mode | [Runtime modes](workbench/runtime-modes.md) |
+| Understand status and resume | [Run lifecycle](run-lifecycle.md) |
+| View results in a browser | [Agent workbench](agent.md) · [Rerun shares](workbench/rerun-sharing.md) · [Foxglove export](workbench/foxglove-export.md) |
+| Diagnose failures | [Troubleshooting](workbench/troubleshooting/known-footguns.md) · [CLI errors](cli-errors.md) |
+| Remove owned resources | [Teardown](teardown.md) |
+
+## Operate infrastructure
+
+| Task | Read |
+| --- | --- |
+| Manage Kubernetes | [Kubernetes](workbench/kubernetes.md) · [GPU driver strategy](workbench/mk8s-gpu-driver-strategy.md) |
+| Configure workflow scheduling | [SkyPilot setup](orchestration/skypilot-setup.md) |
+| Manage fleets or Slurm | [Cluster backends](cluster-backends.md) · [Fleet storage verification](fleet-storage-verification.md) · [RTX MIG](fleet-rtx-pro-6000-mig.md) |
+| Choose an image and GPU | [Public image catalog](workbench/container-image-catalog.md) · [compatibility matrix](workbench/image-gpu-compatibility-matrix.md) |
+| Reuse model downloads | [Model-weight cache](workbench/model-weight-cache.md) |
+| Use preemptible VMs | [Preemptible capacity](workbench/preemptible-vms.md) |
+| Reproduce a workload | [Cookbooks](workbench/cookbooks/README.md) |
+
+## Contribute and verify
+
+| Task | Read |
+| --- | --- |
+| Add a tool or integration | [Contributing](../CONTRIBUTING.md) · [OSS onboarding ladder](architecture/oss-onboarding-ladder.md) |
+| Understand the platform | [Contributor context](architecture/contributor-context.md) · [solutions model](architecture/solutions-model.md) · [CLI namespaces](architecture/cli-namespaces.md) |
+| Package a container | [Container contract](workbench/container-packaging.md) · [image reproducibility](security/image-reproducibility.md) |
+| Run local and live checks | [Package test commands](../npa/README.md#developing-and-testing-npa) · [E2E](testing/e2e.md) · [serverless E2E](testing/e2e-serverless.md) · [daily dev VM](testing/dev-vm-daily.md) |
+| Verify release quality | [Golden evals](security/container-golden-evals.md) · [merge security gate](security/merge-security-gate.md) · [releasing](releasing.md) |
+
+Dated benchmark and audit pages record the stated image, GPU, and test scope.
+Use the current tool guide and compatibility matrix when preparing a new run.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,5 +1,7 @@
 # The self-hosted `npa` agent
 
+[Docs](README.md)
+
 `npa agent` deploys a **browser workbench VM** into one of your Nebius projects:
 an HTTPS UI behind basic-auth login, grounded chat with a Nebius Token Factory
 default (`nvidia/Nemotron-3_5-Lightning` for text and `MiniMaxAI/MiniMax-M3`

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -38,7 +38,7 @@ to type, because setup reuses the projects `configure` already saved:
 ```bash
 npa agent preflight   # includes a cleaned writable-S3 probe before any VM work
 npa agent setup       # pick a configured project → deploys the VM
-npa agent status --project <alias> --name agent
+npa agent status --project "<alias>" --name agent
 ```
 
 `npa agent setup` prompts when you have more than one configured project and
@@ -47,8 +47,8 @@ deploys into the one you pick.
 For scripted deploys, `npa agent fresh-setup` takes the identity explicitly:
 
 ```bash
-npa agent fresh-setup --project <alias> \
-  --project-id <project-id> --tenant-id <tenant-id> --region <region>
+npa agent fresh-setup --project "<alias>" \
+  --project-id "<project-id>" --tenant-id "<tenant-id>" --region "<region>"
 ```
 
 By default, the preflight also reserves quota for the canonical follow-on GPU
@@ -58,8 +58,8 @@ managed cluster has already been prepared, pass `--agent-only` to check and
 provision only the VM's capacity:
 
 ```bash
-npa agent fresh-setup --project <alias> \
-  --project-id <project-id> --tenant-id <tenant-id> --region <region> \
+npa agent fresh-setup --project "<alias>" \
+  --project-id "<project-id>" --tenant-id "<tenant-id>" --region "<region>" \
   --agent-only
 ```
 
@@ -145,7 +145,7 @@ Load it in the shell that will operate the agent, then ask `status` for the
 verified customer URL:
 
 ```bash
-PROJECT_ALIAS=<alias>
+PROJECT_ALIAS="<alias>"
 AGENT_NAME=agent
 AUTH_FILE="$HOME/.npa/agents/$PROJECT_ALIAS/$AGENT_NAME/auth.env"
 
@@ -189,7 +189,7 @@ heartbeats continue throughout, and the command prints an exact remote
 diagnostic to run from another shell:
 
 ```bash
-ssh -i <ssh-key-path> <user>@<public-ip> \
+ssh -i "<ssh-key-path>" "<user>@<public-ip>" \
   sudo journalctl -u cloud-final -u npa-agent-backend -n 100
 ```
 

--- a/docs/archive/workbench-backend-checks.md
+++ b/docs/archive/workbench-backend-checks.md
@@ -1,0 +1,36 @@
+# Historical Workbench backend checks
+
+[Current workload guides](../workbench/guides/README.md)
+
+This preserves the earlier guide-index evidence. It does not describe current
+capacity or establish new end-to-end validation. Use the current guide for
+your selected tool and GPU.
+
+## Recorded backend checks
+
+These entries record earlier checks against local and live backends. Each result
+applies to the stated runtime and scope; the table does not establish that every
+guide has completed end to end. Consult the selected tool's current guide and
+skill for implementation changes since these checks.
+
+| Path | Backend | Result |
+| --- | --- | --- |
+| `vlm-eval benchmark/run` (stub) | local, offline | works (`accuracy: 1.0`) |
+| `lerobot train --runtime serverless --smoke` | Nebius AI Job (H200) | works — produced a real ACT checkpoint (`model.safetensors`) in S3 |
+| `genesis train-teacher --runtime serverless` | Nebius AI Job (H100) | works, but is a **smoke** (import check + placeholder checkpoint); real Genesis training is local/VM |
+| `sim_to_real.local_smoke` | local, no cluster | runs the spine; reports `blocked` unless `lerobot` is installed locally |
+| `isaac-lab train --runtime serverless` | Nebius AI Job (`gpu-l40s-a`) | **capacity-blocked** — `NotEnoughResources` / VM schedule timeout |
+| `isaac-lab train --runtime serverless` | Nebius AI Job (`gpu-l40s-d`) | job schedules and completes; minimal run produced no artifact yet (small step budget / `W9-isaac-lab-e2e-fix`) |
+| `lerobot` / `fiftyone` deploy `--preemptible --dry-run` | Nebius Terraform VM path | CLI + dry-run OK; full apply needs IAM bootstrap on your project |
+| Preemptible VM flags and resume | — | [preemptible-vms.md](../workbench/preemptible-vms.md) |
+
+Isaac Lab needs RT cores, and serverless RT-core capacity varies by SKU: the
+default `gpu-l40s-a` pool failed to schedule, while `gpu-l40s-d` had capacity and
+ran to completion. `gpu-rtx6000` is **not** a serverless platform (use the
+managed-Kubernetes path). For real Isaac Lab training prefer an RT-core VM /
+managed-K8s + BYOF; for a serverless capacity retry use `--gpu-type gpu-l40s-d`.
+
+These are historical records, not current capacity recommendations. Newer
+[Genesis training evidence](../workbench/guides/franka-pick-and-place-genesis.md#go-bigger) records
+real serverless PPO training and a held-out quality result. Current SONIC
+capabilities and B200 MuJoCo evidence are in the [image catalog](../workbench/sonic-image-catalog.md).

--- a/docs/b300-validation-matrix.md
+++ b/docs/b300-validation-matrix.md
@@ -1,5 +1,7 @@
 # Historical B300 validation matrix
 
+[Docs](README.md)
+
 > **Historical record from May 2026.** The findings below describe the images
 > and workloads tested then. Use the current
 > [image and GPU compatibility matrix](workbench/image-gpu-compatibility-matrix.md)

--- a/docs/b300-validation-matrix.md
+++ b/docs/b300-validation-matrix.md
@@ -75,20 +75,20 @@ Unblocking signal: NVIDIA publishing CUDA 13 install paths for `Linux (x86_64)` 
 Pull and smoke the base image on a B300 host with NVIDIA driver 580 or newer:
 
 ```bash
-docker pull <your-registry>/<namespace>/npa-base:<cuda13-b300-tag>
+docker pull "<your-registry>/<namespace>/npa-base:<cuda13-b300-tag>"
 docker run --gpus all --rm \
-  <your-registry>/<namespace>/npa-base:<cuda13-b300-tag> \
+  "<your-registry>/<namespace>/npa-base:<cuda13-b300-tag>" \
   python -c "import torch; print(torch.cuda.get_device_capability(0)); import flash_attn; print(flash_attn.__version__)"
 ```
 
 Run the validated LeRobot workload:
 
 ```bash
-docker pull <your-registry>/<namespace>/npa-lerobot:<cuda13-b300-tag>
+docker pull "<your-registry>/<namespace>/npa-lerobot:<cuda13-b300-tag>"
 docker run --gpus all --rm \
   -e WANDB_MODE=disabled \
   -v /tmp/lerobot-b300:/output \
-  <your-registry>/<namespace>/npa-lerobot:<cuda13-b300-tag> \
+  "<your-registry>/<namespace>/npa-lerobot:<cuda13-b300-tag>" \
   lerobot-train \
     --policy.type=act \
     --policy.push_to_hub=false \

--- a/docs/cli-errors.md
+++ b/docs/cli-errors.md
@@ -1,5 +1,7 @@
 # NPA CLI Error Reference
 
+[Docs](README.md)
+
 The `npa` CLI formats known serverless failures as actionable errors instead
 of raw Python exceptions. Typed serverless errors exit with code `1`.
 Unexpected errors exit with code `2` and hide stack traces unless

--- a/docs/cluster-backends.md
+++ b/docs/cluster-backends.md
@@ -1,5 +1,7 @@
 # Cluster backends: standalone and fleet
 
+[Docs](README.md)
+
 `nebius mk8s` is the Nebius cloud-service CLI. NPA does not expose a primary
 `npa mk8s` command. The NPA standalone Managed Kubernetes surface is `npa
 cluster up` (and the agent `POST /api/infra/mk8s/provision` endpoint); `npa

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,38 +1,32 @@
 # Configure credentials and project storage
 
+[Docs](README.md)
+
 Start with [installation and first-run setup](quickstart.md). This reference
 covers authentication, project storage, credential names, and model access.
 
-For credential setup, `npa` has one user-authored file:
+Run `npa configure` for interactive setup. It selects the project and provisions
+storage by default; `--no-provision` saves project and token settings without
+storage. `npa configure --show` displays the current configuration.
 
-```text
-~/.npa/credentials.yaml
-```
+| Setting | Where it belongs |
+| --- | --- |
+| User secrets and project credentials | `~/.npa/credentials.yaml`, mode `0600` |
+| Temporary credential overrides | Private process environment |
+| Managed project, endpoint, SSH, and Terraform metadata | `~/.npa/config.yaml`; let NPA write it |
+| Alternate configuration directory | `NPA_CONFIG_DIR`; `NPA_CREDENTIALS_PATH` is unsupported |
 
-Do not choose between multiple NPA credential files. Put user-level secrets in
-`~/.npa/credentials.yaml` only. Deploy commands may create or update
-`~/.npa/config.yaml` for machine-managed project, workbench, endpoint, SSH,
-storage, and Terraform state metadata; do not manually populate
-`~/.npa/config.yaml` as part of credential setup.
+Command-specific flags take precedence over their documented defaults. A project
+alias is a local configuration name; it does not select a Nebius authentication
+profile. Use the exact project ID and region when binding a new alias.
 
-Environment variables can override file values for a single shell. They are
-useful for temporary tests, but the canonical repeatable setup is
-`~/.npa/credentials.yaml`. `NPA_CREDENTIALS_PATH` is not supported.
-`NPA_CONFIG_DIR` overrides the shared NPA configuration directory, including
-the location of `credentials.yaml`.
-
-Remote Workbench commands resolve configuration from explicit CLI flags,
-environment variables, the credential store, then machine-managed project and
-Workbench configuration. See each command's help for its supported overrides.
-
-Create and secure the credentials file:
-
-```bash
-mkdir -p ~/.npa
-chmod 700 ~/.npa
-touch ~/.npa/credentials.yaml
-chmod 600 ~/.npa/credentials.yaml
-```
+| Need | Section |
+| --- | --- |
+| Account, project, or SSO setup | [Nebius authentication](#4a-nebius-account-authentication) |
+| Non-interactive setup | [Provisioning](#non-interactive-setup) |
+| Credential names and file layout | [Keys](#4b-required-credential-key-names) · [file example](#4c-populate-npacredentialsyaml) |
+| Copy between projects | [Cross-project storage](#4d-cross-project-storage-workflows) |
+| Model access | [Prepare and verify](#4e-prepare-and-verify-gated-model-access) |
 
 <a id="4a-nebius-account-authentication"></a>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,11 @@ npa configure --no-interactive --no-provision --tenant-id "$TENANT_ID" \
   --project-alias "$PROJECT_ALIAS"
 ```
 
+Retain the create/get receipts privately. This project was created outside NPA,
+so `npa destroy --delete-project` cannot use NPA ownership records to delete it.
+Use NPA to remove its owned workloads and storage, then retire the empty project
+through the Nebius console or administrative CLI if you also own that lifecycle.
+
 ### Federation or SSO profiles with many tenants
 
 For an SSO or federation profile without `tenant-id` / `parent-id`, bind the
@@ -95,8 +100,8 @@ profile to the project you want **before**
 tenant:
 
 ```bash
-nebius config set tenant-id <id>
-nebius config set parent-id <project-id>
+nebius config set tenant-id "<id>"
+nebius config set parent-id "<project-id>"
 ```
 
 Say **yes** to the object-storage prompt: the agent VM and the Physical AI Data
@@ -179,7 +184,7 @@ owner-only creation provenance in `~/.npa/credentials.yaml`, and prints the
 restart-safe recovery command:
 
 ```bash
-npa provision-if-absent --project <PROJECT_ALIAS> --skip-k8s
+npa provision-if-absent --project "<PROJECT_ALIAS>" --skip-k8s
 ```
 
 That recovery reconciles storage before any cluster work. It rolls back only
@@ -425,3 +430,20 @@ accepted inside the legacy `tokens:` map. Keep the credentials file private
 with `chmod 600 ~/.npa/credentials.yaml`; Workbench warns if other users can
 read it. Loaded tokens are forwarded to remote workbench SSH commands as
 environment variables.
+
+## Terraform state for managed workbenches
+
+Terraform remote state for managed workbenches is stored in the Nebius S3
+bucket under:
+
+```text
+npa/terraform-state/<project-alias>/<workbench-name>/terraform.tfstate
+```
+
+Deploy saves the S3 backend bucket, endpoint, and access key under
+`projects.<alias>.terraform_state` in `~/.npa/config.yaml` and writes that file
+with `0600` permissions. Destroy reuses those exact backend credentials. If
+Terraform still fails with `AccessDenied` while saving state after destroy, the
+service account/access key used for `terraform_state` needs S3 `PutObject` on
+`arn:aws:s3:::<bucket>/npa/terraform-state/<project-alias>/<workbench-name>/terraform.tfstate`
+plus `GetObject` on that object and `ListBucket` on the bucket/prefix.

--- a/docs/demo/8gpu-h200.md
+++ b/docs/demo/8gpu-h200.md
@@ -96,7 +96,7 @@ configured project aliases, make the boundary explicit:
 
 ```bash
 npa demo stage \
-  --source-project <SOURCE_PROJECT_ALIAS> \
+  --source-project "<SOURCE_PROJECT_ALIAS>" \
   --target-project "$PROJECT_ALIAS" \
   --target-bucket "$TARGET_BUCKET_URI"
 ```

--- a/docs/demo/8gpu-h200.md
+++ b/docs/demo/8gpu-h200.md
@@ -1,5 +1,7 @@
 # Reproducing the 8-GPU H200 Physical AI Demo
 
+[Docs](../README.md)
+
 This runbook recreates the Cosmos, Isaac Lab, GR00T, and FiftyOne demo flow in
 your own Nebius project. It uses placeholders only; replace every value in
 angle brackets before running commands.

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,5 +1,7 @@
 # Demo Runbooks
 
+[Docs](../README.md)
+
 Reproducible demo guides:
 
 - [8-GPU H200 Physical AI workbench demo](8gpu-h200.md)

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,9 +1,23 @@
-# Demo Runbooks
+# Demo runbooks
 
 [Docs](../README.md)
 
-Reproducible demo guides:
+These are operator and presentation references for the multi-tool Workbench
+demo. They require prepared infrastructure and demo artifacts. For a first run
+from your own input, use the [workload guides](../workbench/guides/README.md).
 
-- [8-GPU H200 Physical AI workbench demo](8gpu-h200.md)
-- [Architect live pack (rtxpro / us-central1)](architect-live-rtxpro.md)
-- [Present on new agent UI (`workbench-demo`)](architect-live-agent-ui.md)
+| Task | Runbook | Before you start |
+| --- | --- | --- |
+| Recreate the multi-tool demo | [8-GPU H200 demo](8gpu-h200.md) | H200 inference host, separate RT-core simulation host, S3, and access to the selected artifact manifest |
+| Use the RTX PRO simulation variant | [Architect live pack](architect-live-rtxpro.md) | Your own project settings and compatible images; read its recorded runtime gaps |
+| Present prepared recordings in the browser | [Dedicated agent UI](architect-live-agent-ui.md) | A deployed agent and staged G1/GR00T recordings |
+
+Replace example aliases and infrastructure values with your own private
+configuration. The historical source-artifact manifest may need separate read
+access; use your own manifest if unavailable. The architecture pack records
+known failures, so it is not a guarantee that every demo component currently
+runs unchanged.
+
+For image/GPU selection, use the [compatibility matrix](../workbench/image-gpu-compatibility-matrix.md).
+After a demo, cancel active jobs and follow [teardown](../teardown.md) for only
+the resources you created.

--- a/docs/demo/architect-live-agent-ui.md
+++ b/docs/demo/architect-live-agent-ui.md
@@ -1,5 +1,7 @@
 # Present the workbench demo on a **new** agent UI
 
+[Docs](../README.md)
+
 Use a dedicated agent deployment — **not** an existing shared `rtxpro/agent`
 instance.
 

--- a/docs/demo/architect-live-rtxpro.md
+++ b/docs/demo/architect-live-rtxpro.md
@@ -1,5 +1,7 @@
 # Live Workbench Demo (Architect Pack)
 
+[Docs](../README.md)
+
 Operator runbook for reproducing the multi-tool Physical AI demo on live Nebius
 infrastructure for project alias `rtxpro`.
 

--- a/docs/demos/bdd100k-demo-walkthrough.md
+++ b/docs/demos/bdd100k-demo-walkthrough.md
@@ -1,5 +1,7 @@
 # BDD100K Demo — Step-by-Step Walkthrough (Exec + Technical)
 
+[Docs](../README.md)
+
 A presenter-ready script for showing the BDD100K failure-mode detection demo to a
 mixed audience. It pairs a plain-English narrative for execs and C-suite with the
 exact FiftyOne (Voxel51) UI steps and commands for technical viewers.

--- a/docs/demos/bdd100k-lancedb-demo.md
+++ b/docs/demos/bdd100k-lancedb-demo.md
@@ -1,4 +1,7 @@
 # BDD100K Failure-Mode Detection Demo
+
+[Docs](../README.md)
+
 ## Nebius Physical AI Workbench - LanceDB Reproduction
 
 > This demo reproduces LanceDB's autonomous-vehicle perception pipeline on

--- a/docs/demos/bdd100k-lancedb-demo.md
+++ b/docs/demos/bdd100k-lancedb-demo.md
@@ -154,7 +154,7 @@ service requires an output path:
 ```bash
 npa workbench detection-training deploy \
   --namespace workbench \
-  --output-path s3://<YOUR_BUCKET>/bdd100k-pipeline/
+  --output-path "s3://<YOUR_BUCKET>/bdd100k-pipeline/"
 ```
 
 The OSS LanceDB VM path is still operator-owned in this build. For local smoke,

--- a/docs/fleet-kuberay.md
+++ b/docs/fleet-kuberay.md
@@ -87,18 +87,21 @@ Select the exact Fleet-generated kubeconfig for this cluster. In one terminal:
 ```bash
 export KUBECONFIG=/path/to/owned-kubeconfig
 kubectl -n ray-cluster get rayclusters,pods,services
-kubectl -n ray-cluster port-forward service/ray-cluster-head-svc 8265:8265
+kubectl -n ray-cluster port-forward --address 127.0.0.1 service/ray-cluster-head-svc 8265:8265
 ```
 
-In another terminal, use a client environment with `ray[default]==2.58.0`.
-Choose a unique submission ID and submit the shipped deterministic application:
+In another terminal, activate a client environment with `ray[default]==2.58.0`
+and run from the repository root. Keep the first terminal's port-forward running.
+Choose a fresh submission ID and use the explicit local Jobs address:
 
 ```bash
-export RAY_ADDRESS=http://127.0.0.1:8265
-ray job submit --submission-id cpu-worker-proof \
+unset RAY_ADDRESS RAY_API_SERVER_ADDRESS
+export RAY_API=http://127.0.0.1:8265
+export RAY_JOB=cpu-worker-proof
+ray job submit --address "$RAY_API" --submission-id "$RAY_JOB" \
   --working-dir npa/examples/fleet/kuberay -- python verify_workers.py
-ray job status cpu-worker-proof
-ray job logs cpu-worker-proof
+ray job status --address "$RAY_API" "$RAY_JOB"
+ray job logs --address "$RAY_API" "$RAY_JOB"
 ```
 
 The result checks a different deterministic square-sum and SHA-256 on each
@@ -108,7 +111,11 @@ output is text-only verification, with no training or visualization artifact.
 Save logs and any application outputs outside the cluster before teardown:
 Ray's object store and `/tmp` are ephemeral.
 
-Stop any remaining application jobs using `ray job stop <submission-id>`, then
+Require native status `SUCCEEDED` and a `KUBERAY_RESULT=` log record with the
+expected worker count. The template's two workers share one physical CPU node.
+
+Stop any remaining application jobs using
+`ray job stop --address "$RAY_API" "$RAY_JOB"`, confirm a terminal state, then
 stop the exact port-forward process and destroy the owned fleet target:
 
 ```bash

--- a/docs/fleet-kuberay.md
+++ b/docs/fleet-kuberay.md
@@ -1,5 +1,7 @@
 # Opt-in CPU RayCluster on Fleet
 
+[Docs](README.md)
+
 Use `npa fleet` to provision a fixed CPU RayCluster alongside an existing
 Managed Kubernetes declaration. Ray's native Jobs and Core APIs run application
 code. Fleet owns the Kubernetes infrastructure and the vendored KubeRay

--- a/docs/fleet-rtx-pro-6000-mig.md
+++ b/docs/fleet-rtx-pro-6000-mig.md
@@ -1,5 +1,7 @@
 # RTX PRO 6000 hardware MIG fleets
 
+[Docs](README.md)
+
 NPA supports true NVIDIA MIG on Nebius Managed Kubernetes as an additive
 `npa.fleet/v0.0.1` policy. The first supported tuple is deliberately narrow and
 fail-closed:

--- a/docs/fleet-storage-verification.md
+++ b/docs/fleet-storage-verification.md
@@ -8,7 +8,7 @@ uses a temporary ReadWriteMany PVC and pods pinned to each exact worker to
 prove shared reads and writes across the cluster.
 
 ```bash
-npa fleet verify-storage --spec <private-fleet.yaml> --output json
+npa fleet verify-storage --spec "<private-fleet.yaml>" --output json
 ```
 
 Use the same owner-private spec used to deploy the Fleet. The command resolves
@@ -35,9 +35,9 @@ model weights, or GPU allocation.
 The existing Fleet selectors restrict verification before any probe is created:
 
 ```bash
-npa fleet verify-storage --spec <private-fleet.yaml> \
-  --only-projects <project-key> --only-clusters <cluster-name> \
-  --profile <operator-profile> --output json
+npa fleet verify-storage --spec "<private-fleet.yaml>" \
+  --only-projects "<project-key>" --only-clusters "<cluster-name>" \
+  --profile "<operator-profile>" --output json
 ```
 
 `--only-projects` accepts comma-separated project keys or display names.
@@ -93,8 +93,8 @@ for `--output`; JSON emits one document and verification failure exits nonzero.
 Provide an owner-private directory outside the checkout to retain exact evidence:
 
 ```bash
-npa fleet verify-storage --spec <private-fleet.yaml> \
-  --evidence-dir <owner-private-directory> --output json
+npa fleet verify-storage --spec "<private-fleet.yaml>" \
+  --evidence-dir "<owner-private-directory>" --output json
 ```
 
 Keep that directory outside Git and public collaboration surfaces. Share only
@@ -128,8 +128,8 @@ come from that declaration:
 
 ```bash
 NPA_INTEGRATION_E2E=1 NPA_FLEET_STORAGE_VERIFY=1 \
-  NPA_FLEET_STORAGE_VERIFY_SPEC=<private-fleet.yaml> \
-  NPA_FLEET_STORAGE_EVIDENCE_DIR=<owner-private-directory> \
+  NPA_FLEET_STORAGE_VERIFY_SPEC="<private-fleet.yaml>" \
+  NPA_FLEET_STORAGE_EVIDENCE_DIR="<owner-private-directory>" \
   npa/.venv/bin/python -m pytest \
   npa/tests/e2e/test_fleet_storage_verification_live.py -q
 ```

--- a/docs/fleet-storage-verification.md
+++ b/docs/fleet-storage-verification.md
@@ -1,5 +1,7 @@
 # Verify shared storage across a Fleet
 
+[Docs](README.md)
+
 `npa fleet verify-storage` proves that the filesystem declared by an existing
 Fleet works on every CPU and GPU worker. It checks the host mount first, then
 uses a temporary ReadWriteMany PVC and pods pinned to each exact worker to

--- a/docs/hackathon-cosmos3-reasoner.md
+++ b/docs/hackathon-cosmos3-reasoner.md
@@ -1,9 +1,11 @@
 # Hackathon Quickstart — Cosmos3 Reasoner on Nebius Token Factory (serverless)
 
+[Docs](README.md)
+
 > Historical Cosmos3 recipe: its public hosted model was retired under the
 > [August 2026 notice](https://docs.tokenfactory.nebius.com/august-2026-deprecation-notice).
-> Use the current [Token Factory guide](/docs/workbench/token-factory.md) and
-> [migration verification](/docs/workbench/token-factory-deprecation-verification.md)
+> Use the current [Token Factory guide](workbench/token-factory.md) and
+> [migration verification](workbench/token-factory-deprecation-verification.md)
 > for current defaults. Explicit legacy model IDs require a serving endpoint;
 > this page does not establish their current availability.
 

--- a/docs/hackathon-isaac-token-factory.md
+++ b/docs/hackathon-isaac-token-factory.md
@@ -1,9 +1,11 @@
 # Hackathon Guide — Isaac Lab Franka + Token Factory (sim visuals → serverless reasoner)
 
+[Docs](README.md)
+
 > Historical Cosmos3 recipe: its public hosted model was retired under the
 > [August 2026 notice](https://docs.tokenfactory.nebius.com/august-2026-deprecation-notice).
-> Use the current [Token Factory guide](/docs/workbench/token-factory.md) and
-> [migration verification](/docs/workbench/token-factory-deprecation-verification.md)
+> Use the current [Token Factory guide](workbench/token-factory.md) and
+> [migration verification](workbench/token-factory-deprecation-verification.md)
 > for current defaults. Explicit legacy model IDs require a serving endpoint;
 > this page does not establish their current availability.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,6 @@
-# Installing npa on every platform
+# Install npa
+
+[Docs](README.md)
 
 `npa` targets **macOS**, **Linux**, and **Windows via WSL2**, and works with
 **Python 3.10+**. It is not published to PyPI, so you always install it editable
@@ -77,24 +79,20 @@ source .venv/bin/activate
 uv pip install --python .venv/bin/python -e npa
 ```
 
-The base install is fully capable: a plain `pip install -e npa` already
-includes every non-GPU workbench dependency (dataframe/reporting, LanceDB, the
-Rerun viewer, and the local eval/agent server). There is no separate
-`npa[full]` step. Only these extras are opt-in:
+The base install includes dataframe/reporting tools, LanceDB, Rerun, and the
+local eval/agent server. Cloud engines run in their containers. Install extras
+only for local engines, tracing, or development:
 
 ```bash
 pip install -e "npa[genesis]"   # Genesis + distillation stages (GPU, local)
 pip install -e "npa[groot]"     # GR00T SDK (GPU, local)
 pip install -e "npa[sonic]"     # SONIC ONNX export/runtime (GPU, local)
-pip install -e "npa[agent-eval]"  # compatibility alias; eval validators are built in
 pip install -e "npa[agent-trace]" # Langfuse/OpenTelemetry tracing (optional)
 pip install -e "npa[dev]"       # tests, lint (pytest, ruff)
 ```
 
-The GPU/simulation wheels above are only needed when you run those engines
-**locally**; cloud jobs execute them inside the Nebius images they launch. The
-`full`, `data`, `lancedb`, `viz`, and `server` extras still resolve (as no-ops
-now folded into the base install) so older `npa[full]` commands keep working.
+The `full`, `data`, `lancedb`, `viz`, `server`, and `agent-eval` extras are
+compatibility aliases already covered by the base install.
 
 From the clone root, activate the venv in every new shell
 (`source .venv/bin/activate`), or call `.venv/bin/npa` directly without
@@ -192,3 +190,8 @@ These work but are not covered by the copy-paste path:
   yet): pin to the latest Python that has wheels, or build from source.
 - **Air-gapped machines:** pre-mirror the repo and a wheelhouse; `pip install -e`
   still needs the transitive dependencies available offline.
+
+## Next step
+
+[Configure your project](configuration.md), choose a [workload](workbench/guides/README.md),
+and prepare its [runtime](workbench/getting-started.md).

--- a/docs/nvidia-platform-architecture-coverage.md
+++ b/docs/nvidia-platform-architecture-coverage.md
@@ -1,5 +1,7 @@
 # NVIDIA Physical AI Platform Architecture Coverage
 
+[Docs](README.md)
+
 **Last verified:** 2026-08-02
 
 NVIDIA publishes different CUDA / PyTorch versions per host CPU architecture for its Physical AI stack. This shapes which Workbench tools can be validated on which Nebius hardware today.

--- a/docs/orchestration/skypilot-setup.md
+++ b/docs/orchestration/skypilot-setup.md
@@ -1,5 +1,7 @@
 # SkyPilot Isolated Venv Setup
 
+[Docs](../README.md)
+
 SkyPilot is an external CLI dependency for NPA orchestration. NPA calls the
 `sky` CLI through subprocess and does not install or import SkyPilot in NPA's
 Python environment.

--- a/docs/orchestration/skypilot-setup.md
+++ b/docs/orchestration/skypilot-setup.md
@@ -44,7 +44,7 @@ export PATH="$(dirname "$(npa skypilot status --bin-path)"):$PATH"
 
 ```bash
 test -x "$NPA_SKYPILOT_BIN"
-npa skypilot verify --cluster <npa-cluster-context>
+npa skypilot verify --cluster "<npa-cluster-context>"
 ```
 
 Passing the NPA cluster context is important on workstations that already use
@@ -61,10 +61,10 @@ built-in smoke task:
 
 ```bash
 npa provision-if-absent \
-  --project <project-alias> \
-  --cluster-name <npa-cluster-context> \
-  --context <npa-cluster-context> \
-  --kubeconfig <kubeconfig> \
+  --project "<project-alias>" \
+  --cluster-name "<npa-cluster-context>" \
+  --context "<npa-cluster-context>" \
+  --kubeconfig "<kubeconfig>" \
   --skip-s3 \
   --sky-smoke \
   --sky-bin "$NPA_SKYPILOT_BIN"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,68 +1,33 @@
 # npa Quickstart
 
-This is the platform entry point for Nebius Physical AI. Read this first to
-install the `npa` CLI/SDK and configure the single user-authored credential
-store. After credential setup, continue with
-[Workbench Getting Started](workbench/getting-started.md) for Kubernetes,
-SkyPilot, registry, S3, and first workload setup.
+[Docs](README.md)
+
+Install `npa`, connect a Nebius project, and choose a GPU workload. Each linked
+workload guide takes you through setup, execution, and inspecting its outputs.
+For guided terminal work, use the [coding-agent prompts](workbench/agent-first-run.md).
 
 ## 1. Platform overview
 
-`npa` is the Nebius Physical AI platform CLI/SDK. It provides a common command
-surface for physical AI workflows such as simulation, training, inference,
-visualization, dataset conversion, and storage handoff.
-
-Workbench is the main solution namespace. Its tools run in containerized jobs
-or services on Nebius, or call hosted inference through Token Factory. Pipelines
-exchange artifacts through S3-compatible storage. This page covers installation,
-credentials, and choosing your first workload; the linked guides cover execution.
-
-For a broader architecture map, see the repository [README](../README.md) and
-the package overview in [npa/README.md](../npa/README.md).
+`npa workbench` provides tools for simulation, policy training, generation,
+curation, and evaluation. Workflows run through SkyPilot and exchange artifacts
+through S3. [Token Factory](workbench/token-factory.md) provides hosted captioning,
+text generation, and reasoning for tools that use those capabilities.
 
 ## 2. Prerequisites
 
-`npa` runs cloud workloads on Nebius, so a Nebius account and the `nebius` CLI
-are required.
+- macOS, Linux, or Windows with WSL2 Ubuntu; Python 3.10+ and Git.
+- A Nebius account and access to a project in your workload's region.
+- The [Nebius CLI](install.md#4-nebius-cli-required) on `PATH`.
+- For managed infrastructure: Terraform; for Kubernetes: `kubectl` and the
+  [isolated SkyPilot runtime](orchestration/skypilot-setup.md).
 
-- Python 3.10 or newer. The package metadata requires `>=3.10`.
-- Git, `python3 -m venv`, and `pip`.
-- **macOS**, **Linux**, or **Windows via WSL2** (Ubuntu). `npa` cloud workflows
-  (S3 / SkyPilot / Kubernetes) assume a POSIX environment. On Windows, run
-  everything from WSL2 (see [docs/install.md](install.md)).
-- **Required:** a Nebius AI Cloud account with billing enabled. Start with the
-  Nebius signup guide: <https://docs.nebius.com/signup-billing/sign-up>.
-- **Required:** the Nebius AI Cloud CLI binary on `PATH`. Install it from
-  <https://docs.nebius.com/cli/install>; `npa configure` creates or reuses a
-  local profile for you (no manual `nebius profile create` step).
-- Terraform on `PATH` for later managed `deploy` and `--destroy` commands.
-- An SSH public key for later managed VM or BYOVM workbench commands. The
-  bundled Terraform defaults to `~/.ssh/id_ed25519.pub`; pass
-  `--tf-var ssh_public_key_path=<path>.pub` in deploy commands if you use a
-  different key.
-- Optional: a Hugging Face token for gated/private Cosmos models, private datasets,
-  or higher rate limits. Public GR00T N1.7, GEAR-SONIC, Cosmos Reason1/Nano, and
-  NuRec PPISP assets work anonymously:
-  <https://huggingface.co/settings/tokens>. Use a read-only token unless a
-  workflow explicitly needs write access.
-- Optional: an NVIDIA NGC API key for paths that actually pull NGC artifacts
-  (currently including the NuRec NRE image):
-  <https://ngc.nvidia.com/setup/api-key>.
-
-Quick checks:
-
-```bash
-python3 --version
-git --version
-nebius version
-nebius profile list
-terraform version
-```
+Model tokens, GPU requirements, and input formats depend on the workload.
+Follow its guide before provisioning. See [platform installation](install.md)
+for host tools and WSL2 setup.
 
 ## 3. Install npa
 
-`npa` works with **Python 3.10+**. It installs editable from a clone (it is not
-on PyPI):
+Install from the repository; `npa` is not published to PyPI:
 
 ```bash
 git clone https://github.com/nebius/nebius-physical-ai.git
@@ -70,69 +35,30 @@ cd nebius-physical-ai
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -e npa
+npa --version
+npa workbench --help
 ```
 
-Verify: `npa --version`.
-
-`npa --version` prints `npa <version>`, and `npa --help` prints the command tree
-without requiring Nebius, Hugging Face, NGC, Kubernetes, or S3 credentials.
-
-<details>
-<summary>Platform notes</summary>
-
-- **Windows:** use **WSL2 Ubuntu**. `npa` cloud workflows (S3 / SkyPilot /
-  Kubernetes) assume a POSIX environment; run everything from WSL2.
-- **Debian/Ubuntu:** install the venv module first:
-  `sudo apt-get install -y python3-venv`.
-- **Need Python 3.10+, or a faster installer?** [`uv`](https://docs.astral.sh/uv/)
-  can install Python and create the env:
-  `uv venv .venv && source .venv/bin/activate && uv pip install -e npa`.
-- **Out of scope (needs extra steps):** Alpine/musl, brand-new Python before
-  wheels exist, and air-gapped machines.
-
-For the Nebius CLI, WSL2 setup, and operator tools, see:
-[docs/install.md](install.md).
-</details>
-
-If you prefer not to activate the venv, call its interpreter directly with
-`./.venv/bin/npa`. The rest of this guide assumes the venv is activated.
-
-The base install is fully capable: a plain `pip install -e npa` already
-includes every non-GPU workbench dependency (dataframe/reporting, LanceDB, the
-Rerun viewer, and the local eval/agent server). There is no separate
-`npa[full]` step. Only these extras are opt-in:
-
-```bash
-pip install -e "npa[genesis]"   # Genesis + distillation stages (GPU, local)
-pip install -e "npa[groot]"     # GR00T SDK (GPU, local)
-pip install -e "npa[sonic]"     # SONIC ONNX export/runtime (GPU, local)
-pip install -e "npa[dev]"       # tests, lint (pytest, ruff); see Section 6
-```
-
-The GPU wheels above are only needed to run those engines **locally**; cloud
-jobs execute them inside the Nebius images they launch. To run cloud workloads
-(Sections 5+) the base install is enough; you also need the Nebius CLI:
-see [docs/install.md § Nebius CLI](install.md#4-nebius-cli-required).
+Both checks work without cloud credentials. In each new shell, return to the
+clone and run `source .venv/bin/activate`, or use `.venv/bin/npa` directly.
+The base package supports cloud operations; [local engine extras](install.md#3-install-npa-editable-from-the-clone)
+are needed only when running those engines in this Python environment.
 
 ## 4. Configure credentials
-
-Run `npa configure` to select your tenant, project, and region and save
-credentials. Interactive setup provisions object storage by default. First-time
-storage setup needs admin permission on the target project; tenant-wide admin
-permission and tenant-wide project listing are not required.
 
 ```bash
 npa configure
 npa configure --show
 ```
 
-Keep secret values in the private environment or `~/.npa/credentials.yaml`.
-Let NPA manage `~/.npa/config.yaml`. Use `npa configure --no-provision` for
-provider-free project and token setup with storage deliberately unselected.
+Select the intended tenant, project, and region. Interactive setup provisions
+object storage by default; first-time storage setup needs admin permission on
+that project. Use `npa configure --no-provision` to save project and token
+settings with storage deliberately unselected.
 
-For an existing coding agent, use the [coding-agent guide](workbench/agent-first-run.md).
-Choose your task first, then configure the credentials and resources its tools
-need. The guide includes PAIDF + Cosmos 3 as a worked example.
+Keep secrets in your private environment or `~/.npa/credentials.yaml` and let
+NPA manage `~/.npa/config.yaml`. The project alias is your local name for the
+project; it is different from the provider's project ID and region.
 
 <a id="4a-nebius-account-authentication"></a>
 <a id="creating-a-project-from-the-cli-tenant-administrator"></a>
@@ -143,340 +69,92 @@ need. The guide includes PAIDF + Cosmos 3 as a worked example.
 <a id="4d-cross-project-storage-workflows"></a>
 <a id="4e-prepare-and-verify-gated-model-access"></a>
 
-Detailed setup has moved to [configuration](configuration.md):
-
-- [Nebius authentication](configuration.md#4a-nebius-account-authentication),
-  including project creation, SSO profiles, and non-interactive provisioning.
-- [Credential names](configuration.md#4b-required-credential-key-names) and
-  [credential-file layout](configuration.md#4c-populate-npacredentialsyaml).
-- [Cross-project storage](configuration.md#4d-cross-project-storage-workflows).
-- [Gated model access](configuration.md#4e-prepare-and-verify-gated-model-access).
+See [configuration](configuration.md) for SSO, project creation, non-interactive
+setup, credential names, cross-project storage, and gated-model access.
 
 ## 5. First platform checks
 
-These commands should not provision cloud resources:
-
-```bash
-npa --help
-npa configure --show
-```
-
-Gate: both commands render local CLI output without requiring Kubernetes, S3,
-NGC, or Hugging Face network access. Note that a bare `npa configure` in a
-terminal is interactive and provisions object storage by default (it creates an
-S3 bucket and access key); use `npa configure --show` for a read-only view of
-the file layout, or `npa configure --no-provision` for provider-free project and
-token setup with storage deliberately unselected.
-
-Before provisioning cloud resources, verify the selected Nebius CLI profile:
+Before provisioning, verify the selected Nebius CLI profile:
 
 ```bash
 npa workbench health preflight --checks nebius --json
 ```
 
-This opt-in check verifies authentication. Hosted Token Factory calls do not
-require it; resource creation still needs permission on the target project.
+Expected: the authentication check passes. This does not prove project
+permissions, capacity, or model access. [Workbench setup](workbench/getting-started.md)
+adds the selected workload's storage, model, cluster, and image checks.
 
 <a id="5a-verify-the-path-works-zero-gpu-inference-nebius-token-factory"></a>
 
 ### 5a. Hosted text generation with Nebius Token Factory
 
-For standalone GPU image generation, see [Cosmos 3](#standalone-cosmos-3-generation).
-For text generation, image captioning, or scene reasoning, use
-[Token Factory](https://tokenfactory.nebius.com/). Hosted inference needs its own
-`NEBIUS_TOKEN_FACTORY_KEY`; a Nebius IAM token cannot replace it. Local inputs and
-outputs need no cluster or S3. Save the key with `npa configure`, then check access:
-
-```bash
-npa workbench token-factory verify
-npa workbench token-factory models
-```
-
-Write a prompt and generate a completion against a hosted model:
-
-```bash
-printf 'Explain sim-to-real transfer in one sentence.\n' > /tmp/prompts.txt
-npa workbench token-factory generate \
-  --input-path /tmp/prompts.txt \
-  --output-path /tmp/tf-generations.jsonl \
-  --output json
-```
-
-Gate: `verify` reports `authenticated: true` with a non-zero model count, and
-`generate` writes `/tmp/tf-generations.jsonl` with a nonempty completion. Model
-listing proves authentication; successful inference also proves the selected
-model is usable. If the default model is unavailable, pass `--model` with an
-appropriate text model returned by `models`.
-
-Read the JSONL result before using it downstream. `--dry-run` still calls the
-hosted model; it only skips the output write.
-
-More Token Factory capabilities (image captioning, physical-scene reasoning) and
-the checked-in workflow specifications:
-[docs/workbench/token-factory.md](workbench/token-factory.md).
+For hosted inference, save `NEBIUS_TOKEN_FACTORY_KEY` with `npa configure`, then
+run `npa workbench token-factory verify`. A Nebius IAM token cannot replace this
+key. Follow [Token Factory](workbench/token-factory.md) to generate and inspect
+a real completion or caption artifact. Direct calls with local inputs need no
+cluster or S3. Its `--dry-run` still calls the model and only skips output writes.
 
 <a id="5b-the-same-capability-three-coherent-ways"></a>
 
 ### 5b. Token Factory from Python or a workflow
 
-Token Factory exposes CLI commands, SDK wrappers, and workflow toolRefs for the
-same operations. Use the CLI or SDK directly for hosted inference; use a
-workflow when it belongs in a larger pipeline.
-
-**CLI** (shown above):
-
-```bash
-npa workbench token-factory generate --input-path /tmp/prompts.txt \
-  --output-path /tmp/tf-generations.jsonl --output json
-```
-
-**Python SDK:**
-
-```python
-from npa.sdk.workbench import token_factory
-
-token_factory.generate(
-    input_path="/tmp/prompts.txt",
-    output_path="/tmp/tf-generations.jsonl",
-    output="json",
-)
-```
-
-The SDK wrapper writes the artifact, prints the result, and returns `None`.
-The lower-level `npa.workbench.token_factory.generate_text` returns a dataclass;
-call `write_generations` explicitly if you use that API and need a saved result.
-
-**Workflow specs:** `npa.workflow/v0.0.1` runs these tools in CPU tasks through
-SkyPilot. This mode needs the configured cluster and S3 runtime described in
-[Workbench Getting Started](workbench/getting-started.md). For examples, see
-`workflows/testing/token-factory-generate.yaml` and
-[the workflows guide](workbench-yaml-guide.md).
+Use the [Token Factory CLI and SDK examples](workbench/token-factory.md), or
+choose a specification from the [workflow catalog](../workflows/README.md).
+Workflow execution needs the SkyPilot and storage setup described below.
 
 ## 6. Developing and testing npa
 
-Contributors can follow the [package development instructions](../npa/README.md#developing-and-testing-npa).
-For your first workload, continue below.
+For repository changes, use the separate
+[contributor environment and test commands](../npa/README.md#developing-and-testing-npa).
+For a first workload, continue below.
 
 <a id="7-flagship-gpu-workload-nvidia-cosmos"></a>
 
 ## 7. Choose your workload
 
-Choose a [workload guide](workbench/guides/README.md) for simulation, training,
-video augmentation, or another supported task. You can also use individual
-tools from the [CLI reference](cli/workbench.md) or compose them with the
-[workflow guide](workbench/npa-workflow-guide.md).
-
-Follow the selected tools' requirements for input formats, model access,
-storage, and compute. A task may use GPU jobs, CPU tools, hosted inference, or
-a combination. The [coding-agent guide](workbench/agent-first-run.md) helps you
-choose and prepare a path for your task.
-
-### Worked example: PAIDF with Cosmos 3
-
-Use [PAIDF + Cosmos 3](workbench/guides/paidf-cosmos3.md) to generate video
-variants conditioned on your source clip, evaluate them, and curate accepted
-outputs. Provide a local H.264 MP4 or a private S3 MP4 URI. You need writable
-project storage, compatible GPU resources, SkyPilot, Hugging Face model access,
-and Token Factory credentials for captioning and evaluation.
-
-Follow the [coding-agent workflow prompt](workbench/agent-first-run.md#run-paidf-with-cosmos-3)
-to validate and plan with the actual bucket and input, review resources,
-prepare input and images, and submit with `--runtime`. The PAIDF guide's
-command examples cover validation and planning only.
-Image preflight may create and delete a temporary probe pod.
-
-Inspect generated media, evaluator reports, quality disposition, and Rerun
-evidence. A quality rejection can be a valid terminal result after bounded
-refinement; labeling and curation are then skipped. The published PAIDF composite
-blends source and generated frames (80% source by default); use the raw Cosmos output to assess
-generation quality. The original
-[Physical AI Data Factory](workbench/guides/physical-ai-data-factory-deploy.md)
-continues to use Cosmos Transfer 2.5.
+| Goal | Guide | Result to inspect |
+| --- | --- | --- |
+| Generate an image or video | [Cosmos 3](#standalone-cosmos-3-generation) | Generated media and `generate.json` |
+| Augment your video | [PAIDF + Cosmos 3](workbench/guides/paidf-cosmos3.md) | Raw generated clips, evaluator reports, and accepted outputs |
+| Build a labeled dataset | [Physical AI Data Factory](workbench/guides/physical-ai-data-factory-deploy.md) | Augmented frames, labels, curation reports, and Rerun recording |
+| Train or evaluate a robot policy | [Robot guides](workbench/guides/README.md) | The guide's checkpoint, rollout, and evaluation artifacts |
+| Reconstruct a captured scene | [Neural reconstruction](workbench/guides/neural-reconstruction.md) | Renderable scene, novel views, and Rerun recording |
 
 ### Standalone Cosmos 3 generation
 
-Start with [Cosmos 3 generation](workbench/cosmos3-generate.md). Its
-`cosmos3-generate.yaml` workflow runs the containerized model and publishes an
-image or video plus `generate.json` to S3. The checked-in default is
-`text2image` with public Cosmos3-Nano on one H100, 16 CPU, and 80 GiB host memory.
-Choose a compatible model/image/GPU combination; Cosmos versions do not share a
-blanket GPU compatibility guarantee.
+The [Cosmos 3 guide](workbench/cosmos3-generate.md) uses
+`workflows/testing/cosmos3-generate.yaml`. Its default requests one H100,
+16 CPU, and 80 GiB host memory for public Cosmos3-Nano text-to-image generation.
+The requested guardrails additionally need access to gated Hugging Face weights.
+Check the guide's model/image/GPU compatibility and guardrail limitations.
 
-You need a configured project, writable S3, a GPU Kubernetes cluster, and
-SkyPilot. Guardrails are requested by default and require access to their gated
-Hugging Face weights even though Cosmos3-Nano itself is public. Follow
-[Workbench Getting Started](workbench/getting-started.md) for the ordered access,
-planning, cluster, and image checks, then the
-[Cosmos 3 guide](workbench/cosmos3-generate.md#workflow) for submission.
-
-After the run succeeds, inspect the generated media and manifest. A completed
-job alone does not prove usable output. The Cosmos guide records the known
-upstream guardrail limitations; `guardrails: true` records the requested setting,
-not proof that every safety model ran.
-
-The older `cosmos deploy --runtime serverless` endpoint has no supported
-serverless generated-media export to S3. Likewise,
-`cosmos train --runtime serverless --smoke` only checks job execution and writes
-a status `checkpoint.json`; it does not train a model or generate media. These
-are distinct from the Cosmos 3 generation workflow.
+Complete [Workbench setup](workbench/getting-started.md), then follow the
+[submission example](workbench/cosmos3-generate.md#workflow). Inspect the media
+and manifest after success; job completion alone does not establish usable output.
 
 ## 8. Do more with npa
 
-Use the guides below as your task requires:
-
-- **Run Workbench workloads:** PAIDF + Cosmos 3 (Section 7), VLM evaluation, Sim2Real,
-  and more. See [Workbench Getting Started](workbench/getting-started.md) for
-  Kubernetes, SkyPilot, registry, and S3 setup, and the
-  [robot guides](workbench/guides/README.md).
-- **Deploy the self-hosted agent:** `npa agent` is a browser workbench VM. It
-  builds on the setup above and additionally needs Terraform, an SSH key pair, a
-  Token Factory key, and writable S3. Operator docs:
-  [skills/tools/npa-agent/SKILL.md](../skills/tools/npa-agent/SKILL.md).
-
-Reference:
-
-- [CLI and package overview](../npa/README.md): package-level command and
-  development notes.
-- [Repository overview](../README.md): project map and current workbench list.
-- [Source sample config](../npa/src/npa/config/sample_config.yaml):
-  machine-managed `~/.npa/config.yaml` shape for reference only.
-- [Known onboarding and runtime gotchas](../FIXME.md): active follow-up list.
+- [Workflow guide](workbench/npa-workflow-guide.md): validate, plan, submit,
+  monitor, and resume your own pipeline.
+- [CLI / SDK walkthrough](workbench/cli-sdk-yaml-walkthrough.md): integrate a
+  tool from the shell, Python, or HTTP.
+- [Browser workbench](agent.md): deploy the optional agent and embedded viewers.
+- [Run lifecycle](run-lifecycle.md) and [teardown](teardown.md): recover runs
+  and remove owned resources in order.
 
 ## 9. Troubleshooting
 
-`npa: command not found`
+| Symptom | Next step |
+| --- | --- |
+| `npa: command not found` | From the clone root, activate `.venv` or run `.venv/bin/npa --help`. |
+| Missing Python module | Reinstall with `pip install -e npa` in the same environment; see [installation](install.md). |
+| Nebius authentication or project permission failure | Check the active profile and exact project; see [configuration](configuration.md#4a-nebius-account-authentication). |
+| Hugging Face `401` / `403` | Use the correct token and accept the exact model's access terms; see [model access](configuration.md#4e-prepare-and-verify-gated-model-access). |
+| NGC `401` | Check the [NGC key](workbench/ngc-api-key.md) and entitlement to the required artifact. |
+| S3 endpoint or write failure | Check the selected project's bucket, credentials, and regional endpoint in [configuration](configuration.md); AWS CLI calls need `--endpoint-url`. |
+| GPU job remains pending or image pull fails | Follow [runtime troubleshooting](workbench/troubleshooting/known-footguns.md). |
+| Credential file is readable by other users | Run `chmod 600 ~/.npa/credentials.yaml`. |
 
-Activate the virtualenv (or call its interpreter directly):
-
-```bash
-source .venv/bin/activate   # or: source ~/.venvs/npa/bin/activate
-npa --help
-```
-
-`pytest` fails to collect with `ModuleNotFoundError: No module named 'fastapi'`
-
-FastAPI is a base dependency. A missing import indicates an incomplete install
-or a different interpreter. Activate this checkout's environment and reinstall
-the package with test tooling:
-
-```bash
-pip install -e "npa[dev]"
-make test PYTHON="$(pwd)/.venv/bin/python"
-```
-
-`aws s3 ls` fails with `Could not connect to the endpoint URL`
-
-Nebius object storage is S3-compatible but is not AWS. Older `aws-cli` (v1)
-ignores the `AWS_ENDPOINT_URL` environment variable, so it tries the AWS
-endpoint and fails. Pass the endpoint explicitly, or use `aws-cli` v2:
-
-```bash
-aws s3 ls --endpoint-url https://storage.<your-region>.nebius.cloud
-```
-
-Configured workflow commands resolve storage settings and pass the endpoint
-to their S3 client. Direct Token Factory S3 calls need `AWS_ENDPOINT_URL` and
-AWS credentials in the process environment; see the
-[Token Factory guide](workbench/token-factory.md#generate-and-inspect-artifacts).
-
-Jobs land on the wrong cluster, or `kubectl`/`sky` target the wrong place
-
-Pin your Kubernetes context so submissions are unambiguous:
-
-```bash
-kubectl config get-contexts
-kubectl config use-context <your-workbench-context>
-```
-
-`403`/`denied` when pushing or pulling a container image
-
-Supported NPA images pull anonymously from
-`ghcr.io/nebius/nebius-physical-ai`. If an explicit BYOF override points at an
-operator-owned registry, authenticate to that exact host using the registry's
-documented standards-based mechanism and confirm the same immutable reference
-can be pulled from the execution environment.
-
-Capacity, quota, or `Not enough resources` errors
-
-These come from the cloud, not from `npa`. Retry in a few minutes, pick a
-different GPU type/region, or request a quota increase in the Nebius console.
-Run any command with `NPA_DEBUG=1` for a full traceback.
-
-`source repo is not reachable` from `npa workbench cosmos check`
-
-Cosmos checks the framework source repo with `git ls-remote`, injecting
-`GITHUB_TOKEN` as an auth header when that variable is set. A stale or invalid
-`GITHUB_TOKEN` makes even a public repo return `401`, so the check reports the
-source as unreachable. Clear the bad token (the public clone works
-anonymously) or export a valid one:
-
-```bash
-env -u GITHUB_TOKEN npa workbench cosmos check
-```
-
-SkyPilot pods do not inherit your shell's `GITHUB_TOKEN`, so the in-cluster
-clone is unaffected.
-
-`PermissionDenied` / `No permission` when submitting a serverless job
-
-Serverless workloads (`cosmos train --runtime serverless`, `cosmos infer`, and
-serverless `deploy`) create Nebius AI Jobs. If the principal behind your active
-`nebius` profile is a service account that lacks the AI Jobs role, the submit is
-rejected with `PermissionDenied: service iam ... appbox-...` even though
-authentication, capacity lookup, subnet discovery, and S3 all succeed. This is
-an authorization gap: `nebius iam get-access-token` still works. Grant that service account a role that permits creating and
-managing AI Jobs on the project, or switch to a profile whose principal has it
-(`nebius profile activate <profile>`), then retry the same command.
-
-`credentials.yaml` is missing or tokens are not loading
-
-Commands that need no tokens tolerate a missing credentials file, but
-token-dependent commands will behave as if no token exists. Create the file
-under your home directory and secure it:
-
-```bash
-mkdir -p ~/.npa
-touch ~/.npa/credentials.yaml
-chmod 600 ~/.npa/credentials.yaml
-```
-
-`credentials.yaml is readable by other users`
-
-Workbench subcommands warn when group or world permissions are present:
-
-```bash
-chmod 600 ~/.npa/credentials.yaml
-```
-
-`Warning: HF_TOKEN not found in ~/.npa/credentials.yaml`
-
-Add `tokens.HF_TOKEN` to `~/.npa/credentials.yaml` or export `HF_TOKEN` for the
-current shell. Cosmos and GR00T deploy dry-runs fail fast unless that token has
-actual upstream access to every gated runtime-fetched asset.
-
-`Error: HF_TOKEN does not have access to <repo>` or `401/403 from Hugging Face`
-
-Use a token from <https://huggingface.co/settings/tokens>, accept the gated
-model's terms on Hugging Face, then retry. Environment variable `HF_TOKEN`
-overrides the value in `credentials.yaml`.
-
-`NGC API error` or `401 from NGC`
-
-Use a current NGC key from <https://ngc.nvidia.com/setup/api-key>. Put it in
-`ngc.api_key` in `credentials.yaml` or export `NGC_API_KEY` for the current
-shell. If you use an organization or team-scoped key, also set `ngc.org` and
-`ngc.team`, or export `NGC_ORG` and `NGC_TEAM`.
-
-`nebius CLI not found on PATH`
-
-Install the Nebius CLI and restart the shell:
-<https://docs.nebius.com/cli/install>.
-
-`Nebius auth failed`
-
-Re-run `npa configure` in a terminal. If a profile exists but the wrong one is
-active, switch with `nebius profile activate <profile>` and retry.
-
-`terraform binary not found on PATH`
-
-Install Terraform and verify `terraform version` before running managed deploys.
+For a failed run, retain its run ID and inspect `workflow status`, `logs`, and
+`artifacts` before retrying. [CLI errors](cli-errors.md) explains JSON output,
+exit codes, and `NPA_DEBUG=1` tracebacks.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,5 +1,7 @@
 # Releasing `npa`
 
+[Docs](README.md)
+
 `npa` is distributed as a source checkout plus tagged releases with built
 artifacts. Every release is a git tag `vX.Y.Z` that matches the `version`
 field in `npa/pyproject.toml`; the `Release` workflow

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -25,10 +25,10 @@ Validation and planning do not launch a workload. Image checks can create and
 delete a temporary Kubernetes probe pod when bootstrap evidence is absent:
 
 ```bash
-npa workbench workflow validate-spec <spec.yaml>
-npa workbench workflow plan-spec <spec.yaml> --run-id <run-id> --var bucket=<bucket>
-npa workbench workflow preflight-images <spec.yaml> \
-  --project <alias> --infra k8s/<cluster> --var bucket=<bucket>
+npa workbench workflow validate-spec "<spec.yaml>"
+npa workbench workflow plan-spec "<spec.yaml>" --run-id "<run-id>" --var bucket="<bucket>"
+npa workbench workflow preflight-images "<spec.yaml>" \
+  --project "<alias>" --infra "k8s/<cluster>" --var bucket="<bucket>"
 ```
 
 Use the same target and overrides throughout; public images need no `--registry`.
@@ -161,7 +161,7 @@ npa workbench workflow status "$RUN_ID" --project "$PROJECT" \
 `kubectl` in your own shell, export it (the command prints this line for you):
 
 ```bash
-export KUBECONFIG=~/.npa/clusters/<context>/kubeconfig
+export KUBECONFIG="$HOME/.npa/clusters/<context>/kubeconfig"
 ```
 
 ## Related

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1,5 +1,7 @@
 # Run lifecycle: identity, gates, and status
 
+[Docs](README.md)
+
 What `npa workbench workflow submit` verifies before it launches, how a run keeps
 its identity across interruptions, and how to read the status it reports back.
 
@@ -23,10 +25,15 @@ Validation and planning do not launch a workload. Image checks can create and
 delete a temporary Kubernetes probe pod when bootstrap evidence is absent:
 
 ```bash
-npa workbench workflow validate-spec    <spec.yaml>
-npa workbench workflow plan-spec        <spec.yaml> --run-id "$RUN_ID"
-npa workbench workflow preflight-images <spec.yaml> --registry "$REGISTRY"
+npa workbench workflow validate-spec <spec.yaml>
+npa workbench workflow plan-spec <spec.yaml> --run-id <run-id> --var bucket=<bucket>
+npa workbench workflow preflight-images <spec.yaml> \
+  --project <alias> --infra k8s/<cluster> --var bucket=<bucket>
 ```
+
+Use the same target and overrides throughout; public images need no `--registry`.
+The [workflow quick start](workbench/npa-workflow-guide.md#quick-start) shows the
+complete sequence.
 
 `preflight-images` reports each image as `ok` / `not_found` / `forbidden` and
 prints the exact build command for anything missing. `submit` runs the same

--- a/docs/sdk/cosmos-serverless.md
+++ b/docs/sdk/cosmos-serverless.md
@@ -1,5 +1,7 @@
 # Cosmos serverless job via the SDK
 
+[Docs](../README.md)
+
 This is the Python SDK counterpart to:
 
 ```bash

--- a/docs/sdk/errors.md
+++ b/docs/sdk/errors.md
@@ -1,5 +1,7 @@
 # SDK Error Reference
 
+[Docs](../README.md)
+
 The serverless SDK exposes typed exceptions from
 `npa.clients.serverless`. Existing exception class names are stable and
 `str(exc)` returns only the message for backward compatibility.

--- a/docs/teardown.md
+++ b/docs/teardown.md
@@ -5,7 +5,7 @@
 Preview the cleanup plan for the project you intend to retire:
 
 ```bash
-npa destroy --project <alias> --all
+npa destroy --project "<alias>" --all
 ```
 
 The preview is read-only. Review its targets before adding `--yes`; the combined
@@ -30,29 +30,29 @@ than guessing. It **retains the Nebius project by default**.
 combined run stopped partway.
 
 ```bash
-npa workflow cancel <run-id> --project <alias> --json
-npa agent destroy --project <alias> --name <name> --yes
-npa skypilot cleanup-controller --project <alias> --context <context> --yes
-npa cluster down --project <alias> --force
-npa storage bucket delete --project <alias> --yes --wait
-npa storage service-account delete --project <alias> --dry-run
+npa workflow cancel "<run-id>" --project "<alias>" --json
+npa agent destroy --project "<alias>" --name "<name>" --yes
+npa skypilot cleanup-controller --project "<alias>" --context "<context>" --yes
+npa cluster down --project "<alias>" --force
+npa storage bucket delete --project "<alias>" --yes --wait
+npa storage service-account delete --project "<alias>" --dry-run
 # Only when the previous command reports missing ownership provenance:
-npa storage service-account reconcile --project <alias> --id <exact-id> --dry-run
-npa storage service-account reconcile --project <alias> --id <exact-id> \
+npa storage service-account reconcile --project "<alias>" --id "<exact-id>" --dry-run
+npa storage service-account reconcile --project "<alias>" --id "<exact-id>" \
   --reason '<legacy NPA setup evidence>' --attest-npa-created --yes
-npa storage service-account delete --project <alias> --dry-run
-npa storage service-account delete --project <alias> --yes
+npa storage service-account delete --project "<alias>" --dry-run
+npa storage service-account delete --project "<alias>" --yes
 # Retire any separately created private registry through its provider before
 # deleting the project. NPA has no top-level registry command.
 
 # NPA-created disposable projects may contain one provider-created default
 # topology. This command refuses any extra, shared, or non-default topology:
-npa network delete-project-default --project <alias> --project-id <project-id> \
-  --tenant-id <tenant-id> --yes
+npa network delete-project-default --project "<alias>" --project-id "<project-id>" \
+  --tenant-id "<tenant-id>" --yes
 # Optional and ownership-gated; omit to retain the project (the safe default):
-npa destroy --project <alias> --all --delete-project --yes --json
-npa cleanup --full --yes --project <alias>
-npa configure --forget-project <alias>
+npa destroy --project "<alias>" --all --delete-project --yes --json
+npa cleanup --full --yes --project "<alias>"
+npa configure --forget-project "<alias>"
 ```
 
 ## Cloud spend vs local clutter
@@ -72,12 +72,12 @@ id** before it rewrites configuration. If teardown must continue past that
 point, stay inside NPA and select the same immutable identity explicitly:
 
 ```bash
-RECEIPT=<id printed by npa configure --forget-project>
-npa agent destroy --receipt "$RECEIPT" --name <name> --yes
-npa skypilot cleanup-controller --receipt "$RECEIPT" --context <context> --yes
-npa cluster down --receipt "$RECEIPT" --context <context> --force
-npa storage service-account delete --receipt "$RECEIPT" --id <exact-id> --dry-run
-npa workflow cancel <run-id> --receipt "$RECEIPT" --json
+RECEIPT="<id printed by npa configure --forget-project>"
+npa agent destroy --receipt "$RECEIPT" --name "<name>" --yes
+npa skypilot cleanup-controller --receipt "$RECEIPT" --context "<context>" --yes
+npa cluster down --receipt "$RECEIPT" --context "<context>" --force
+npa storage service-account delete --receipt "$RECEIPT" --id "<exact-id>" --dry-run
+npa workflow cancel "<run-id>" --receipt "$RECEIPT" --json
 # Optional, after every exact child cleanup has converged:
 npa destroy --receipt "$RECEIPT" --all --delete-project --yes --json
 ```
@@ -225,7 +225,7 @@ reverting to `unknown` on an idempotent retry.
 
 ```bash
 npa cleanup --list-receipts
-npa cleanup --prune-receipts --receipt-retention-days <days> --yes
+npa cleanup --prune-receipts --receipt-retention-days "<days>" --yes
 ```
 
 Prune only old, fully terminal receipts, and only explicitly.
@@ -270,8 +270,8 @@ environment still exists, inspect or retry with the exact commands printed in
 the receipt:
 
 ```bash
-npa uninstall --status <receipt-id>
-npa uninstall --remove-environment --yes --retry <receipt-id>
+npa uninstall --status "<receipt-id>"
+npa uninstall --remove-environment --yes --retry "<receipt-id>"
 ```
 
 Successful removal naturally removes that environment's `npa` executable; the

--- a/docs/teardown.md
+++ b/docs/teardown.md
@@ -1,14 +1,22 @@
-# Tear it all down
+# Tear down owned resources
 
-Stopping spend is an **ordered sequence**, and skipping a step leaves a hung
-job, a credential, or a cache behind:
+[Docs](README.md)
 
-> cancel managed jobs → destroy the agent → remove the shared controller →
-> destroy the cluster → delete the bucket → remove NPA-owned storage IAM →
-> drop the project entry → clear local state
+Preview the cleanup plan for the project you intend to retire:
 
-`npa cleanup` prints a report plus the exact runbook for your machine. Start
-there if you are not sure what is still running.
+```bash
+npa destroy --project <alias> --all
+```
+
+The preview is read-only. Review its targets before adding `--yes`; the combined
+command retains the Nebius project unless you also request `--delete-project`.
+Save outputs you need before deleting their bucket. Shared resources require
+their owner's coordination.
+
+Cleanup follows this order: cancel jobs → agent → controller → cluster → bucket
+→ owned storage IAM → project entry → local state. Keep recovery identity until
+cloud cleanup is verified. `npa cleanup` reports local residue and recovery
+instructions; it never deletes cloud resources.
 
 ## Two ways in
 
@@ -34,10 +42,9 @@ npa storage service-account reconcile --project <alias> --id <exact-id> \
   --reason '<legacy NPA setup evidence>' --attest-npa-created --yes
 npa storage service-account delete --project <alias> --dry-run
 npa storage service-account delete --project <alias> --yes
-# If validation created a project-local registry, delete its exact artifact DAG
-# and registry using the immutable ID/name recorded at creation:
-npa registry delete --project <alias> --project-id <project-id> \
-  --tenant-id <tenant-id> --id <registry-id> --name <registry-name> --yes
+# Retire any separately created private registry through its provider before
+# deleting the project. NPA has no top-level registry command.
+
 # NPA-created disposable projects may contain one provider-created default
 # topology. This command refuses any extra, shared, or non-default topology:
 npa network delete-project-default --project <alias> --project-id <project-id> \

--- a/docs/workbench-yaml-guide.md
+++ b/docs/workbench-yaml-guide.md
@@ -234,10 +234,10 @@ toolRefs.
 Run these from the repository root:
 
 ```bash
-npa/.venv/bin/npa workbench workflow validate-spec <spec.yaml> --json
-npa/.venv/bin/npa workbench workflow plan-spec <spec.yaml> --run-id preview --json
-npa/.venv/bin/npa workbench workflow submit <spec.yaml> --run-id preview --plan-only
-npa/.venv/bin/npa workbench workflow submit <spec.yaml> --run-id <run-id>
+npa/.venv/bin/npa workbench workflow validate-spec "<spec.yaml>" --json
+npa/.venv/bin/npa workbench workflow plan-spec "<spec.yaml>" --run-id preview --json
+npa/.venv/bin/npa workbench workflow submit "<spec.yaml>" --run-id preview --plan-only
+npa/.venv/bin/npa workbench workflow submit "<spec.yaml>" --run-id "<run-id>"
 ```
 
 For a dynamic branch, add `--assume-decision promote_checkpoint` while planning.
@@ -256,7 +256,7 @@ and artifact commands instead of adding per-spec log upload code:
 
 ```bash
 npa/.venv/bin/npa workbench workflow status "s3://<bucket>/<prefix>/"
-npa/.venv/bin/npa workbench workflow logs "s3://<bucket>/<prefix>/" --stage <state>
+npa/.venv/bin/npa workbench workflow logs "s3://<bucket>/<prefix>/" --stage "<state>"
 npa/.venv/bin/npa workbench workflow artifacts "s3://<bucket>/<prefix>/"
 ```
 

--- a/docs/workbench-yaml-guide.md
+++ b/docs/workbench-yaml-guide.md
@@ -1,5 +1,7 @@
 # Nebius Physical AI Workbench — Pipeline Authoring Guide
 
+[Docs](README.md)
+
 > Living document. Updated as new pipeline patterns are introduced.
 > Last updated: 2026-08-03
 

--- a/docs/workbench/README.md
+++ b/docs/workbench/README.md
@@ -1,97 +1,69 @@
-# Workbench Documentation
+# Workbench documentation
 
-Workbench is the primary solution in Nebius Physical AI. Use
-`npa workbench <tool> <command>` to run individual capabilities, and
-`npa workbench workflow` to compose them into pipelines. Tools exchange data
-through object storage. Python wrappers and service APIs are available according
-to each tool's documented contract.
+[All docs](../README.md) · [Quickstart](../quickstart.md) · [CLI reference](../cli/workbench.md)
 
-For guided setup with an existing coding agent, use the
-[first-run prompts](agent-first-run.md). Detailed project and credential setup
-is in [configuration](../configuration.md).
+Use `npa workbench <tool> <command>` for a capability and
+`npa workbench workflow` for a pipeline. Tools exchange artifacts through S3;
+Python and HTTP access follow each tool's documented contract.
 
-## From a first run to an inspected result
+## Start and operate a run
 
-1. [Install and configure npa](../quickstart.md), including credentials and
-   model-access checks. Use [platform installation details](../install.md) when
-   needed.
-2. Choose a GPU workload from the [guides](guides/README.md) or the
-   [workflow catalog](../../workflows/README.md).
-   Follow that workload's input, model, and GPU requirements.
-3. Prepare its runtime using [Workbench setup](getting-started.md) and, for
-   cluster-backed runs, [managed Kubernetes](kubernetes.md).
-4. [Validate, plan, and submit the workflow](npa-workflow-guide.md). The
-   [run lifecycle](../run-lifecycle.md) explains preflight gates, run identity,
-   status, and restart behavior.
-5. Inspect the outputs described by the selected guide.
-   `npa workbench workflow artifacts` lists durable run outputs. For a successful PAIDF run,
-   `load-artifact` retries the final viewer load without rerunning stages. The
-   [agent viewer](../agent.md) and [Rerun sharing](rerun-sharing.md) provide
-   viewing paths for supported artifacts.
-6. Use [troubleshooting](troubleshooting/known-footguns.md) to resolve failures,
-   then follow [safe teardown](../teardown.md) for resources you own.
-
-For Python or HTTP integration, start with the
-[CLI / SDK walkthrough](cli-sdk-yaml-walkthrough.md). To extend Workbench, read
-[Contributing](../../CONTRIBUTING.md) and the
-[OSS onboarding ladder](../architecture/oss-onboarding-ladder.md).
-
-## Index
-
-| Path | Purpose |
+| Task | Guide |
 | --- | --- |
-| [getting-started.md](getting-started.md) | Runtime and storage setup after the platform quickstart |
-| [ray.md](ray.md) | Supported Ray Jobs, Core, Train, Serve, and KubeRay paths, plus explicit Data and Tune limitations |
-| [guides/README.md](guides/README.md) | Choose a robot, generation, reconstruction, or data workflow |
-| [PAIDF Cosmos 3 setup and run guide](../../workflows/guides/paidf-cosmos3.md) | Account and cluster setup, Cosmos 3 submission, troubleshooting, and output inspection |
-| [npa-workflow-guide.md](npa-workflow-guide.md) | Author, validate, plan, submit, and resume declarative workflows |
-| [container-image-catalog.md](container-image-catalog.md) | Verified public GHCR image names, exact published tags, build dates, and capabilities |
-| [container-packaging.md](container-packaging.md) | Container packaging tiers, security baseline, and feature exposure contract |
-| [ncore-oci-publication.md](ncore-oci-publication.md) | NCore committed OCI builds, prepublication gates, exact graph transfer, and pending RTX acceptance |
-| [isaac-lab-3.md](isaac-lab-3.md) | Isaac Lab 3 beta pin, payload-clean runtime bootstrap, hardened RL sweep, and generation 2 comparison method |
-| [model-weight-cache.md](model-weight-cache.md) | Durable cache for model weights and reviewed SDKs the public images do not bake, so a second run is a cache hit |
-| [rerun-sharing.md](rerun-sharing.md) | Time-boxed Rerun browser shares, one-time least-privilege bucket CORS setup, and native local fallback |
-| [cosmos3-b200-checkpoint-evaluation-20260814.md](cosmos3-b200-checkpoint-evaluation-20260814.md) | Reserved-B200, 72-image Cosmos3 checkpoint evaluation and three-seed investment decision |
-| [cosmos3-ray-serve.md](cosmos3-ray-serve.md) | Persistent Cosmos3-Nano serving through native Ray Serve batching with durable S3 outputs |
-| [leisaac-teleoperation.md](leisaac-teleoperation.md) | Capability-gated LeIsaac agent tab, RT-core launch, keyboard teleoperation, and cleanup |
-| [../architecture/oss-onboarding-ladder.md](../architecture/oss-onboarding-ladder.md) | OSS → BYOF → workflow → first-class tool promotion ladder |
-| [npa-workflow-tool-catalog.md](npa-workflow-tool-catalog.md) | `toolRef` catalog for declarative `npa.workflow` specs |
-| [agent-workflow-operations.md](agent-workflow-operations.md) | Provider-neutral, bounded NPA operations for agents authoring and running Workbench workflows |
-| [kubernetes.md](kubernetes.md) | User setup and operational checklist for running Workbench services and SkyPilot workflows on Kubernetes |
-| [mk8s-gpu-driver-strategy.md](mk8s-gpu-driver-strategy.md) | Managed GPU driver modes, fail-closed post-deploy health validation, recipe compatibility, and existing-pool migration |
-| [../../workflows/README.md](../../workflows/README.md) | **Workflow catalog** — find the right `npa.workflow` spec by what you want to do |
-| [oss-solution-catalog.md](oss-solution-catalog.md) | OSS Physical AI registry candidates with pinned refs, cloud-fit notes, and E2E gates |
-| [cli-sdk-yaml-walkthrough.md](cli-sdk-yaml-walkthrough.md) | Detection-training CLI, Python, and HTTP examples; check each tool's supported surfaces |
-| [guides/physical-ai-data-factory-deploy.md](guides/physical-ai-data-factory-deploy.md) | **Physical AI Data Factory** — copy-paste runbook (stage input frames, submit) for the annotate → Cosmos augment → curate → visualize blueprint |
-| [../quickstart.md](../quickstart.md) | Full `npa` CLI quickstart |
-| [../cli/README.md](../cli/README.md) | CLI command reference index |
-| [../cli-errors.md](../cli-errors.md) | End-user CLI error formatting, exit codes, and JSON error output |
-| [../sdk/errors.md](../sdk/errors.md) | Typed exceptions for programmatic SDK consumers and agents |
-| [../run-lifecycle.md](../run-lifecycle.md) | Run identity, preflight checks, status, and restart safety |
-| [../teardown.md](../teardown.md) | Cancel and clean up owned resources in the required order |
-| [../../CONTRIBUTING.md](../../CONTRIBUTING.md) | Implementation patterns, registration, documentation, and validation for contributors |
-| [cookbooks/README.md](cookbooks/README.md) | Reproducibility cookbooks for specific workloads |
-| [cookbooks/vlm-eval-loop-runbook.md](cookbooks/vlm-eval-loop-runbook.md) | Sim-to-real VLM-eval loop: self-hosted VLM serving, rollout scoring, and task-success reporting |
-| [cookbooks/lerobot-gpu-benchmarks.md](cookbooks/lerobot-gpu-benchmarks.md) | Reproducing the May 2026 LeRobot GPU benchmark research |
-| [troubleshooting/known-footguns.md](troubleshooting/known-footguns.md) | Known Workbench operational footguns and mitigations |
-| [../testing/e2e-serverless.md](../testing/e2e-serverless.md) | E2E test conventions for serverless workloads |
-| [../testing/e2e.md](../testing/e2e.md) | General E2E test conventions |
+| Choose a workload | [Robot and workflow guides](guides/README.md) · [workflow catalog](../../workflows/README.md) |
+| Use your coding agent | [First-run prompts](agent-first-run.md) · [workflow operations](agent-workflow-operations.md) |
+| Prepare the runtime | [Workbench setup](getting-started.md) · [Kubernetes](kubernetes.md) · [direct runtime modes](runtime-modes.md) |
+| Author and submit | [Workflow guide](npa-workflow-guide.md) · [toolRef catalog](npa-workflow-tool-catalog.md) |
+| Integrate from Python or HTTP | [CLI / SDK walkthrough](cli-sdk-yaml-walkthrough.md) · [SDK errors](../sdk/errors.md) |
+| Inspect or recover | [Run lifecycle](../run-lifecycle.md) · [troubleshooting](troubleshooting/known-footguns.md) · [CLI errors](../cli-errors.md) |
+| Finish | [Teardown](../teardown.md) |
 
-## Audience
+## Generation and scenes
 
-| Reader | Start with |
+| Capability | Guide |
 | --- | --- |
-| Salesperson or evaluator | [Workflow catalog](../../workflows/README.md) to see what the platform runs |
-| Customer running their first Workbench workload | [Quickstart](../quickstart.md), then [guides](guides/README.md) |
-| Customer or operator using managed Kubernetes | [kubernetes.md](kubernetes.md) |
-| Anyone choosing between CLI, SDK, and YAML | [cli-sdk-yaml-walkthrough.md](cli-sdk-yaml-walkthrough.md) |
-| Developer or operator using Ray | [ray.md](ray.md) |
-| Partner onboarding an OSS repo | [../architecture/oss-onboarding-ladder.md](../architecture/oss-onboarding-ladder.md) |
-| Engineer packaging or hardening a container | [container-packaging.md](container-packaging.md) |
-| Operator watching the same weights download every run | [model-weight-cache.md](model-weight-cache.md) |
-| Customer running the compositional Sim2Real workflow | [guides/sim2real-workflow.md](guides/sim2real-workflow.md) |
-| Operator reproducing a workload | [cookbooks/README.md](cookbooks/README.md) |
-| SDK integrator or agent author | [cli-sdk-yaml-walkthrough.md](cli-sdk-yaml-walkthrough.md), then [../sdk/errors.md](../sdk/errors.md) |
-| Automation agent operating a workflow | [agent-workflow-operations.md](agent-workflow-operations.md) |
-| Internal engineer triaging a failure | [../cli-errors.md](../cli-errors.md) |
-| Operator running e2e tests | [../testing/e2e-serverless.md](../testing/e2e-serverless.md) |
+| Cosmos 3 batch generation | [Generate](cosmos3-generate.md) · [access preflight](cosmos3-access-preflight.md) |
+| Cosmos 3 persistent serving | [Nano with Ray Serve](cosmos3-ray-serve.md) · [Super serving](cosmos3-super-serving.md) |
+| Video augmentation and dataset production | [PAIDF + Cosmos 3](guides/paidf-cosmos3.md) · [Cosmos Transfer data factory](guides/physical-ai-data-factory-deploy.md) · [concepts](guides/physical-ai-data-factory.md) · [campaign reuse](guides/paidf-campaign-reuse.md) |
+| Scene reconstruction | [NuRec](guides/neural-reconstruction.md) · [living-lab fan-out](guides/living-lab-nurec-fanout.md) |
+| USD object preparation | [Content Agents](content-agents.md) |
+| Other video models | [Wan 2.2](wan2.2.md) · [LTX-2](ltx2.md) |
+
+## Robotics and simulation
+
+| Capability | Guide |
+| --- | --- |
+| Robot policy walkthroughs | [Franka / Genesis](guides/franka-pick-and-place-genesis.md) · [PushT SDK smoke](guides/pusht-sim-to-real.md) · [Reachy 2 / LeRobot](guides/reachy2-lerobot-policy.md) |
+| Locomotion | [G1 / SONIC](guides/g1-humanoid-walk-sonic.md) · [quadruped / Isaac Lab](guides/quadruped-isaac-lab.md) |
+| GR00T fine-tuning | [GR00T N1.7](cookbooks/groot-1-7-training.md) |
+| OpenPI policy training | [Pi0.5 / Polaris](openpi-pi05-polaris.md) |
+| Simulation-to-policy pipeline | [Sim2Real runbook](guides/sim2real-workflow.md) · [data contracts](guides/sim2real-data-contracts.md) · [customer assets](guides/sim2real-customer-assets.md) · [robot spec](guides/sim2real-robot-spec.md) |
+| Browser teleoperation | [LeIsaac](leisaac-teleoperation.md) · [latency measurement](guides/leisaac-transport-latency.md) |
+| Motion planning | [cuRobo](curobo.md) |
+| Isaac Lab versions | [Isaac Lab 3](isaac-lab-3.md) |
+
+## Data and evaluation
+
+| Capability | Guide |
+| --- | --- |
+| Curation, vector search, and detection training | [BDD100K pipeline](cookbooks/bdd100k-pipeline.md) · [LanceDB search](cookbooks/lancedb-vector-search.md) · [LanceDB deployment](cookbooks/lancedb-deploy-runbook.md) |
+| Hosted captioning, generation, and reasoning | [Token Factory](token-factory.md) · [cloud composition](composing-cloud-and-token-factory.md) |
+| Evaluate rollouts with a VLM | [VLM evaluation loop](cookbooks/vlm-eval-loop-runbook.md) |
+| View and share artifacts | [Rerun](rerun-sharing.md) · [Foxglove / MCAP](foxglove-export.md) · [browser workbench](../agent.md) |
+| Autonomous-driving inference | [Alpamayo 2 Super](alpamayo2-super.md) |
+| Native Ray jobs, training, and serving | [Ray](ray.md) |
+
+## Access, images, and operations
+
+| Task | Guide |
+| --- | --- |
+| Configure credentials | [Project configuration](../configuration.md) · [Hugging Face](huggingface-token.md) · [NGC](ngc-api-key.md) · [Token Factory key](token-factory-key.md) |
+| Select images | [Public catalog](container-image-catalog.md) · [GPU compatibility](image-gpu-compatibility-matrix.md) · [SONIC variants](sonic-image-catalog.md) |
+| Use Blackwell | [B200 / B300](blackwell-datacenter-image-compatibility.md) · [RTX PRO 6000](sm120-image-catalog.md) |
+| Configure nodes and caches | [GPU driver strategy](mk8s-gpu-driver-strategy.md) · [model-weight cache](model-weight-cache.md) · [preemptible VMs](preemptible-vms.md) |
+| Reproduce benchmarks and demos | [Cookbooks](cookbooks/README.md) · [validation scope](solutions-validation.md) |
+| Add or package a solution | [Contributing](../../CONTRIBUTING.md) · [containerized solutions](contributing-a-containerized-solution.md) · [OSS catalog](oss-solution-catalog.md) · [packaging contract](container-packaging.md) |
+
+Inspect the selected guide's actual output artifacts after the run reaches a
+terminal state. A plan, successful status response, or historical benchmark
+alone does not establish a new run's result.

--- a/docs/workbench/agent-first-run.md
+++ b/docs/workbench/agent-first-run.md
@@ -1,5 +1,7 @@
 # Use Workbench with a coding agent
 
+[Workbench docs](README.md)
+
 Use your existing coding agent with terminal access to this checkout. Install
 `npa` and the Nebius CLI using the [quickstart](../quickstart.md). Describe the
 task you want to complete, then select individual tools or compose a workflow.

--- a/docs/workbench/agent-workflow-operations.md
+++ b/docs/workbench/agent-workflow-operations.md
@@ -1,5 +1,7 @@
 # Agent-operated Workbench workflows
 
+[Workbench docs](README.md)
+
 An automation agent can operate any Workbench workflow through NPA without
 knowing how NPA schedules or executes it. The caller owns its reasoning system
 and provider configuration. Workflow operations do not select, configure, or

--- a/docs/workbench/alpamayo2-super.md
+++ b/docs/workbench/alpamayo2-super.md
@@ -1,5 +1,7 @@
 # Alpamayo 2 Super
 
+[Workbench docs](README.md)
+
 NPA runs NVIDIA Alpamayo 2 Super through the upstream VLM-plus-diffusion-expert
 inference entrypoint. The redistributable `npa-alpamayo2-super` image contains the pinned
 Apache-2.0 source and CUDA runtime, but no model weights, dataset bytes,

--- a/docs/workbench/blackwell-datacenter-image-compatibility.md
+++ b/docs/workbench/blackwell-datacenter-image-compatibility.md
@@ -1,5 +1,7 @@
 # Blackwell datacenter image compatibility (B200 `sm_100` / B300 `sm_103`)
 
+[Workbench docs](README.md)
+
 How to make a Workbench container image deployable on datacenter Blackwell, and how to prove it.
 
 The per-image verdicts are machine-readable in `npa/docker/workbench/blackwell-dc-images.json` and gated by `npa/tests/docker/test_blackwell_dc_manifest.py`. This page is the human companion: the compatibility model, the build conventions, and the validation bar.

--- a/docs/workbench/blocked-image-gpu-feasibility.md
+++ b/docs/workbench/blocked-image-gpu-feasibility.md
@@ -1,5 +1,7 @@
 # Can the blocked images support every Nebius GPU?
 
+[Workbench docs](README.md)
+
 This analysis began on 2026-08-22 with eight published images carrying a
 `blocked` cell in the
 [image ↔ Nebius GPU compatibility matrix](image-gpu-compatibility-matrix.md):

--- a/docs/workbench/cli-sdk-yaml-walkthrough.md
+++ b/docs/workbench/cli-sdk-yaml-walkthrough.md
@@ -1,5 +1,7 @@
 # Workbench CLI / SDK / YAML Walkthrough
 
+[Workbench docs](README.md)
+
 > Audience: anyone calling an existing Workbench tool.
 > Prerequisites: complete [getting-started.md](getting-started.md) first.
 

--- a/docs/workbench/cli-sdk-yaml-walkthrough.md
+++ b/docs/workbench/cli-sdk-yaml-walkthrough.md
@@ -133,7 +133,7 @@ exact URI, media type, schema, size, and SHA-256.
 If you submitted without waiting, monitor it with:
 
 ```bash
-npa workbench detection-training status --service --run-id <run-id-from-train>
+npa workbench detection-training status --service --run-id "<run-id-from-train>"
 ```
 
 After completion, discover the actual checkpoint from the service's run

--- a/docs/workbench/composing-cloud-and-token-factory.md
+++ b/docs/workbench/composing-cloud-and-token-factory.md
@@ -1,5 +1,7 @@
 # Compose Nebius GPU workloads with Token Factory
 
+[Workbench docs](README.md)
+
 Run training or simulation on Nebius GPUs, write the results to S3, then use
 Token Factory to caption frames, propose a scene plan, or interpret a run's
 reports. The hosted stage runs on a CPU worker and calls the Token Factory API.

--- a/docs/workbench/container-image-catalog.md
+++ b/docs/workbench/container-image-catalog.md
@@ -1,5 +1,7 @@
 # Public Workbench Container Image Catalog
 
+[Workbench docs](README.md)
+
 Repository-selected runtime images use the public mirror by default:
 
 ```text

--- a/docs/workbench/container-packaging.md
+++ b/docs/workbench/container-packaging.md
@@ -1,5 +1,7 @@
 # Workbench Container Packaging
 
+[Workbench docs](README.md)
+
 Canonical contract for packaging workbench containers correctly, securely, and
 with the right runtime features exposed. Machine-readable rules live in
 `npa/docker/workbench/packaging-contract.yaml` (enforced by unit tests).

--- a/docs/workbench/container-packaging.md
+++ b/docs/workbench/container-packaging.md
@@ -243,7 +243,7 @@ reading the Dockerfile:
 
 ```bash
 npa/.venv/bin/python npa/scripts/scan_image_omniverse_payload.py \
-    <your-registry>/<namespace>/npa-isaac-lab:3.0.0b2.post1
+    "<your-registry>/<namespace>/npa-isaac-lab:3.0.0b2.post1"
 ```
 
 The scanner streams the image's flattened filesystem and its layer history, matching Kit
@@ -264,9 +264,9 @@ reports must finish with `VERDICT: clean`.
 is nothing credentialed left to pull:
 
 ```bash
-npa/docker/workbench/isaac-lab/build.sh --registry <your-registry>/<namespace> --push
-npa/docker/workbench/sonic/build.sh    --registry <your-registry>/<namespace> --push --variant k8s
-npa/docker/workbench/groot/build.sh    --registry <your-registry>/<namespace> --push
+npa/docker/workbench/isaac-lab/build.sh --registry "<your-registry>/<namespace>" --push
+npa/docker/workbench/sonic/build.sh    --registry "<your-registry>/<namespace>" --push --variant k8s
+npa/docker/workbench/groot/build.sh    --registry "<your-registry>/<namespace>" --push
 ```
 
 ### Public development and release — mind the order
@@ -289,10 +289,10 @@ Promote only the validated digest to its supported release tag:
 ```bash
 npa/.venv/bin/python -m npa.deploy.publish_public \
   --target ghcr.io/nebius/nebius-physical-ai \
-  --development-sha <full-git-sha> --dry-run
+  --development-sha "<full-git-sha>" --dry-run
 npa/.venv/bin/python -m npa.deploy.publish_public \
   --target ghcr.io/nebius/nebius-physical-ai \
-  --development-sha <full-git-sha>
+  --development-sha "<full-git-sha>"
 ```
 
 The publisher resolves each development tag once and copies only by immutable
@@ -334,7 +334,7 @@ Prove the development image anonymously with an empty Docker config:
 
 ```bash
 export DOCKER_CONFIG="$(mktemp -d)"
-crane manifest ghcr.io/nebius/nebius-physical-ai/npa-lerobot:dev-<full-git-sha> >/dev/null
+crane manifest "ghcr.io/nebius/nebius-physical-ai/npa-lerobot:dev-<full-git-sha>" >/dev/null
 ```
 
 ### Publication intent and registry state

--- a/docs/workbench/content-agents.md
+++ b/docs/workbench/content-agents.md
@@ -1,5 +1,7 @@
 # NVIDIA Content Agents rigid-object workflow
 
+[Workbench docs](README.md)
+
 NPA packages NVIDIA Content Agents as a Tier 1 declarative workflow for one
 self-contained, non-articulated USD object. It runs the upstream Material Agent,
 Physics Agent, OVRTX renderer, and Validation Agent, then publishes a rigid-ready

--- a/docs/workbench/content-agents.md
+++ b/docs/workbench/content-agents.md
@@ -77,7 +77,7 @@ exact built digest passes the byte/layer scan and real RTX workflow:
 ```bash
 npa/docker/workbench/content-agents/build.sh --push
 npa/.venv/bin/python npa/scripts/scan_content_agents_image.py \
-  <candidate-image>@sha256:<digest> --expected-npa-source-sha "$(git rev-parse HEAD)"
+  "<candidate-image>@sha256:<digest>" --expected-npa-source-sha "$(git rev-parse HEAD)"
 ```
 
 The accepted public image is
@@ -150,10 +150,10 @@ npa cluster up ... --gpu-driver-mode operator
 npa workbench health preflight --checks s3,token_factory --json
 npa workbench workflow validate-spec "$SPEC"
 npa workbench workflow plan-spec "$SPEC" --run-id content-agents-check \
-  --var bucket=<private-bucket>
+  --var bucket="<private-bucket>"
 npa workbench workflow submit "$SPEC" --runtime \
   --run-id content-agents-check \
-  --var bucket=<private-bucket> \
+  --var bucket="<private-bucket>" \
   --secret-env NEBIUS_TOKEN_FACTORY_KEY \
   --secret-env AWS_ACCESS_KEY_ID \
   --secret-env AWS_SECRET_ACCESS_KEY

--- a/docs/workbench/contributing-a-containerized-solution.md
+++ b/docs/workbench/contributing-a-containerized-solution.md
@@ -1,5 +1,7 @@
 # Contributing a Containerized Solution
 
+[Workbench docs](README.md)
+
 Use this checklist to add an open-source solution to NPA. The contributor
 supplies reproducible code and real test evidence. The Nebius Physical AI team
 builds, scans, pushes, and, when approved, publishes the official image.

--- a/docs/workbench/contributing-a-containerized-solution.md
+++ b/docs/workbench/contributing-a-containerized-solution.md
@@ -52,15 +52,15 @@ For a BYOF candidate:
 
 ```bash
 npa/.venv/bin/npa workbench byof run \
-  --repo-url <public-repository-url> \
-  --repo-ref <immutable-ref> \
+  --repo-url "<public-repository-url>" \
+  --repo-ref "<immutable-ref>" \
   --base-profile ubuntu \
   --workload solution-smoke \
   --build-command '<pinned-install-command>' \
   --smoke-command '<real-capability-command>' \
-  --solution-name <solution> \
-  --capability-name <capability> \
-  --smoke-artifact-name <solution>_<capability>.json \
+  --solution-name "<solution>" \
+  --capability-name "<capability>" \
+  --smoke-artifact-name "<solution>_<capability>.json" \
   --skip-push --skip-run --dry-run --output json
 ```
 

--- a/docs/workbench/cookbooks/README.md
+++ b/docs/workbench/cookbooks/README.md
@@ -1,44 +1,34 @@
-# Cookbooks
+# Workbench cookbooks
 
-Technical recipes for reproducing benchmark, demo, and customer evaluation
-workflows with Nebius Physical AI Workbench.
+[Workbench docs](../README.md) · [Workload guides](../guides/README.md) · [Workflow catalog](../../../workflows/README.md)
 
-> Looking for the SkyPilot YAML behind a cookbook? The
-> [workflow catalog](../../../workflows/README.md) maps
-> every workflow YAML to its command and guide.
+Recipes for specific workloads, benchmarks, and integrations. Start with
+[Workbench setup](../getting-started.md); each recipe states its own inputs and
+validation scope. Dated measurements apply to the versions and hardware recorded.
 
-## Available Cookbooks
+## Policy training and simulation
 
-- [GR00T N1.7 Training](groot-1-7-training.md): validate, plan, and submit
-  reproducible single- or multi-GPU fine-tuning, then recover the run ID and
-  inspect the checkpoint provenance manifest.
-- [BDD100K SkyPilot Pipeline](bdd100k-pipeline.md): provision the object store,
-  Kubernetes cluster, GPU node groups, and in-cluster LanceDB/detection-training
-  services, then run the BDD100K ingest, UDF backfill, CLIP embedding,
-  materialized-view, training, and evaluation pipeline.
-- [PushT sim-to-real guide](../guides/pusht-sim-to-real.md): train and evaluate
-  a policy for the PushT task. For the canonical 14-stage workflow, see the
-  [Sim2Real guide](../guides/sim2real-workflow.md).
-- [VLM-Eval Loop Runbook](vlm-eval-loop-runbook.md): serve a VLM with vLLM,
-  score rollout directories with `vlm-eval`, and write a task-success report.
-- [Token Factory + Nebius compute combos](tokenfactory-compute-combos.md): two
-  workflows that pair real Nebius GPU compute with hosted Token Factory
-  inference — a serverless GPU train run triaged by a text model, and a
-  Kubernetes GPU rollout judged by a hosted VLM.
-- [LeRobot GPU Benchmarks](lerobot-gpu-benchmarks.md): reproduce the May 2026
-  LeRobot GPU benchmark research across L40S, H200, B300, and RTX PRO 6000.
-- [LeRobot GPU Benchmarks Runbook](lerobot-gpu-benchmarks-runbook.md): exact
-  terminal steps for serverless Jobs, seconds/step measurements, artifact
-  checks, validation, and cleanup.
-- [Isaac Lab BYOF](byof-isaac-lab/README.md): layer a custom Isaac Lab image
-  over the digest-pinned Workbench base and run it through the SkyPilot image
-  override surface.
-- [SONIC Locomotion Fine-Tuning](sonic-locomotion-finetuning.md): retarget
-  motion data, run SONIC fine-tuning, and evaluate with MJLab through SkyPilot
-  YAML.
-- [SONIC G1 Fine-Tune to MuJoCo MVP](sonic-mvp-g1-mujoco.md): first milestone
-  G1 warm-start fine-tune from the released SONIC checkpoint and headless
-  MuJoCo checkpoint evaluation.
-- [SONIC Export and Eval Runbook](sonic-eval-runbook.md): export a trained
-  SONIC checkpoint to ONNX, run reference locomotion eval, and swap in a
-  config-driven external eval container.
+| Recipe | Purpose |
+| --- | --- |
+| [GR00T N1.7](groot-1-7-training.md) | Fine-tune, recover the run ID, and inspect checkpoint provenance |
+| [Isaac Lab BYOF](byof-isaac-lab/README.md) | Run a custom Isaac Lab fork in a container |
+| [SONIC training](sonic-train-runbook.md) | Prepare a single training stage and its runtime |
+| [SONIC locomotion](sonic-locomotion-finetuning.md) | Prepare retarget → train → MJLab resource and artifact contracts |
+| [SONIC export and eval](sonic-eval-runbook.md) | Export ONNX and inspect evaluation results |
+| [G1 MuJoCo image status](sonic-mvp-g1-mujoco.md) | Active evaluation capability and retired combined-image limitations |
+| [SONIC whole-body control](sonic-whole-body-control.md) | Training, export, serving, and data contracts |
+| [LeRobot benchmarks](lerobot-gpu-benchmarks.md) · [runbook](lerobot-gpu-benchmarks-runbook.md) | Reproduce recorded training measurements |
+| [SONIC B300 evidence](sonic-b300-routing-evidence.md) | Scope of the recorded datacenter-GPU checks |
+
+## Data and evaluation
+
+| Recipe | Purpose |
+| --- | --- |
+| [BDD100K pipeline](bdd100k-pipeline.md) | Ingest, curate, train, and evaluate detectors |
+| [LanceDB deployment](lancedb-deploy-runbook.md) | Deploy the service and load data |
+| [LanceDB vector search](lancedb-vector-search.md) | Build and query embeddings |
+| [VLM evaluation loop](vlm-eval-loop-runbook.md) | Score rollouts and inspect task-success reports |
+| [Token Factory with compute](tokenfactory-compute-combos.md) | Pair GPU jobs with hosted inference |
+| [Physical reasoning challenge](physical-reasoning-challenge.md) | Recorded reasoning recipe; use current Token Factory model guidance |
+| [Serverless coverage](serverless-tools-coverage.md) | Tool-specific modes and recorded checks |
+| [CLI / SDK / YAML parity](workbench-parity-tools.md) | Compare supported access paths |

--- a/docs/workbench/cookbooks/bdd100k-pipeline.md
+++ b/docs/workbench/cookbooks/bdd100k-pipeline.md
@@ -12,9 +12,9 @@ Two in-cluster services must be reachable before a live run, because three stage
 
 ```bash
 npa workbench lancedb deploy --runtime kubernetes --namespace workbench \
-  --storage-path s3://<your-bucket>/lancedb/
-npa workbench detection-training deploy --namespace workbench --gpu-type <h100|l40s|rtxpro6000> \
-  --output-path s3://<your-bucket>/detection-training/
+  --storage-path "s3://<your-bucket>/lancedb/"
+npa workbench detection-training deploy --namespace workbench --gpu-type "<h100|l40s|rtxpro6000>" \
+  --output-path "s3://<your-bucket>/detection-training/"
 ```
 
 > This pipeline reproduces LanceDB's autonomous-vehicle perception walkthrough on
@@ -62,7 +62,7 @@ Terraform/AWS-CLI tooling, and the SkyPilot runtime bootstrap.
 Export the non-secret identifiers used throughout this cookbook:
 
 ```bash
-export NPA_S3_BUCKET=<your-bucket>            # bucket name only, no s3:// prefix
+export NPA_S3_BUCKET="<your-bucket>"            # bucket name only, no s3:// prefix
 export AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud
 export NPA_STORAGE_ENDPOINT=storage.eu-north1.nebius.cloud
 ```
@@ -126,7 +126,7 @@ secret exists in the namespace SkyPilot uses (normally `default`):
 export KUBECONFIG=~/.npa/clusters/npa-cluster/kubeconfig
 kubectl auth can-i create pods -n default
 # Private images only: verify the operator-managed secret named by your workload.
-kubectl get secret <your-ghcr-pull-secret> -n default
+kubectl get secret "<your-ghcr-pull-secret>" -n default
 ```
 
 ### 3. In-cluster workbench services
@@ -159,8 +159,8 @@ submission time:
 python npa/scripts/run_bdd100k_pipeline.py \
   --spec workflows/testing/bdd100k-pipeline.yaml \
   --synthetic 5000 \
-  --lancedb-endpoint http://<your-lancedb-endpoint>:8686 \
-  --run-id <your-run-id>
+  --lancedb-endpoint "http://<your-lancedb-endpoint>:8686" \
+  --run-id "<your-run-id>"
 ```
 
 See [lancedb-deploy-runbook.md](lancedb-deploy-runbook.md) for deploy runtimes,
@@ -172,7 +172,7 @@ table, query, and import usage.
 After the demo, remove the GPU node group and the cluster to stop GPU spend:
 
 ```bash
-npa cluster node-group remove --cluster-name npa-cluster --name <node-group-name>
+npa cluster node-group remove --cluster-name npa-cluster --name "<node-group-name>"
 npa cluster down --terraform-dir deploy/cluster
 ```
 

--- a/docs/workbench/cookbooks/bdd100k-pipeline.md
+++ b/docs/workbench/cookbooks/bdd100k-pipeline.md
@@ -1,5 +1,7 @@
 # BDD100K SkyPilot Pipeline
 
+[Cookbooks](README.md)
+
 **Workflow:** [bdd100k-pipeline.yaml](../../../workflows/testing/bdd100k-pipeline.yaml)
 (`npa.workflow/v0.0.1`) — a readable stage graph of `toolRef`s. See
 [npa-workflow-guide.md](../npa-workflow-guide.md). `run_bdd100k_pipeline.py` renders that

--- a/docs/workbench/cookbooks/byof-isaac-lab/README.md
+++ b/docs/workbench/cookbooks/byof-isaac-lab/README.md
@@ -1,372 +1,159 @@
-# Isaac Lab Bring Your Own Fork Cookbook
+# Run a custom Isaac Lab image or training entrypoint
 
-[Cookbooks](../README.md)
+[Cookbooks](../README.md) · [Workbench setup](../../getting-started.md)
 
-This cookbook shows how to run a custom Isaac Lab fork, custom RSL-RL fork, or
-custom training wrapper on Workbench without changing the checked-in platform
-workflow. The worked example in this directory uses a synthetic image layer and
-`custom_train.py` to prove the BYOF mechanism.
+This example adds a small training wrapper to the NPA Isaac Lab image, runs
+Cartpole training, and checks that the wrapper and checkpoint actually reached
+S3. Use it to learn the two customization surfaces before packaging your own
+fork: `--image` selects container bytes; `--yaml` selects the task's `run:` block.
 
-The W10 validation exercised both override surfaces:
+| Input | Output |
+| --- | --- |
+| Compatible RT-core GPU, project storage, and candidate image | Training log, checkpoint, and checkpoint manifest |
+| Optional `custom_train.py` entrypoint | `byof_sentinel.json` proving the wrapper ran |
 
-- image override through `resources.image_id`, exposed by
-  `npa/scripts/run_isaac_lab_rl.py --image`;
-- command override through the SkyPilot YAML `run:` block, passed to the same
-  runner with `--yaml`.
+The current base is Isaac Lab 3 beta / Isaac Sim 6. The
+[historical W10 measurements](historical-validation.md) used generation 2 and
+are retained separately; they are not new validation of the current base.
 
-The reference workflow remains `npa/src/npa/workflows/byof/profiles/isaac-lab-rl-train.yaml`;
-the reference runner remains `npa/scripts/run_isaac_lab_rl.py`.
+## 1. Prepare the environment
 
-The current base is Isaac Lab 3 beta / Isaac Sim 6 and uses `--visualizer none`.
-The W10 transcripts retained below are generation 2 historical evidence; their
-`--headless` field is not the generation 3 invocation contract.
+Complete [Workbench setup](../../getting-started.md) for an **L40S or RTX PRO
+6000** cluster. Isaac requires RT cores. Use the
+[contributor Python environment](../../../../npa/README.md#developing-and-testing-npa)
+for the scripts below, and run from the repository root.
 
-## What This Cookbook Covers
-
-Use this guide when you want to:
-
-- keep Workbench's Isaac Lab S3 artifact layout;
-- run a non-default Isaac Lab container image;
-- layer a forked Isaac Lab checkout or forked `rsl_rl` package into that image;
-- invoke a custom entrypoint while preserving the output contract;
-- verify that the custom image ran and training still produced a checkpoint.
-
-The example image does not contain customer code. It only adds:
-
-- a marker label;
-- `/opt/byof/custom_train.py`;
-- a digest-pinned Workbench Isaac Lab base image.
-
-That keeps the validation focused on the mechanism, not on a particular fork.
-
-## Prerequisites
-
-Before using this cookbook, complete
-[../../getting-started.md](../../getting-started.md). That guide is the
-canonical setup path for the local NPA install, Nebius credentials, AWS profile,
-S3 endpoint, workbench environment variables, Kubernetes context, registry pull
-secret, and isolated SkyPilot runtime.
-
-Isaac Lab requires RT cores. Use L40S or RTX PRO 6000. Do not route its
-graphics/PhysX workloads to B200, H100, or H200.
-
-Before you start, verify the three live dependencies:
+You also need Docker Buildx, a registry you control, and S3 write access.
+Configure exact-host authentication for a private registry. Export S3 credentials
+privately; the runner forwards `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+when present. An AWS profile used only by your local CLI is not enough to
+supply the remote task.
 
 ```bash
-aws s3 ls "s3://${NPA_S3_BUCKET}/" --endpoint-url "${AWS_ENDPOINT_URL}"
-"${NPA_SKYPILOT_BIN}" check
-npa skypilot status
+export PROJECT_ALIAS='<your-project-alias>'
+export KUBE_CONTEXT='<verified-kubernetes-context>'
+export NPA_S3_BUCKET='<your-bucket>'
+export AWS_ENDPOINT_URL='<your-bucket-endpoint>'
+export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+
+npa workbench health preflight --checks nebius,s3 --json
+npa skypilot verify --cluster "$KUBE_CONTEXT" --output-format json
 ```
 
-The SkyPilot version must be `0.12.2` for this validation lineage.
-
-SkyPilot 0.12.2 does not interpolate environment variables inside YAML `envs`
-blocks at submission time. Use the runner script
-(`npa/scripts/run_isaac_lab_rl.py`), which materializes endpoint values before
-submission, or substitute the literal endpoint value in your YAML.
-
-## Files In This Example
-
-This directory contains `Dockerfile.example`, `custom_train.py`, and this
-README. The Dockerfile starts from the digest-pinned Workbench Isaac Lab image
-and copies `custom_train.py` to `/opt/byof/custom_train.py`.
-
-`custom_train.py` accepts the same argument shape used by the upstream RSL-RL
-training command:
+Select the profile matching your GPU. The first example below uses L40S;
+for RTX PRO 6000 select `isaac-lab-rl-train-rtxpro.yaml` instead:
 
 ```bash
---task Isaac-Cartpole-v0 \
---num_envs 64 \
---max_iterations 1 \
---visualizer none \
---experiment_name npa_byof \
---run_name "${RUN_ID}" \
-agent.save_interval=1
+export BYOF_PROFILE=npa/src/npa/workflows/byof/profiles/isaac-lab-rl-train.yaml
 ```
 
-At startup it writes `/workspace/output/byof_sentinel.json`. When
-`NPA_ISAAC_LAB_OUTPUT_DIR` is set, it also writes
-`${NPA_ISAAC_LAB_OUTPUT_DIR}/byof_sentinel.json`; the second path is uploaded by
-the existing workflow artifact uploader.
+## 2. Build and publish your candidate
 
-## Building Your Image
-
-Export the registry namespace and choose an image tag:
+[Dockerfile.example](Dockerfile.example) adds only labels and
+[`custom_train.py`](custom_train.py) to a digest-pinned NPA base. The wrapper
+writes a sentinel, then delegates to the upstream RSL-RL training script with
+the original arguments.
 
 ```bash
-export BYOF_BUILD_ID="w10-byof-image-$(date -u +%Y%m%dT%H%M%SZ)"
-export BYOF_REGISTRY=<your-registry>/<namespace>
-export BYOF_IMAGE="${BYOF_REGISTRY}/isaac-lab-byof-test:${BYOF_BUILD_ID}"
-```
+export BYOF_BUILD_ID="byof-$(date -u +%Y%m%dT%H%M%SZ)"
+export BYOF_REGISTRY='<your-registry>/<namespace>'
+export BYOF_IMAGE="$BYOF_REGISTRY/isaac-lab-byof-test:$BYOF_BUILD_ID"
 
-Build from the repo root:
-
-```bash
-docker build \
-  --platform linux/amd64 \
-  --build-arg BYOF_RUN_ID="${BYOF_BUILD_ID}" \
+docker build --platform linux/amd64 \
+  --build-arg "BYOF_RUN_ID=$BYOF_BUILD_ID" \
   -f docs/workbench/cookbooks/byof-isaac-lab/Dockerfile.example \
-  -t "${BYOF_IMAGE}" \
-  docs/workbench/cookbooks/byof-isaac-lab
+  -t "$BYOF_IMAGE" docs/workbench/cookbooks/byof-isaac-lab
+docker push "$BYOF_IMAGE"
+docker buildx imagetools inspect "$BYOF_IMAGE"
 ```
 
-The example base image digest is
-`sha256:bb735577809f9b427493fda78efebc543dcf02e3deac2ec8a36ac019bff8ee46`,
-the validated `npa-isaac-lab:3.0.0b2.post1` Workbench image. W10 used the
-historical generation 2 base; the digest above is the current generation 3
-contract. Refresh it only after a new platform base passes exact-digest GPU
-validation and guarded publication.
+Record the pushed digest and use that immutable reference for validation.
+The base fetches Isaac at runtime under the operator's accepted terms. Do not
+invoke `/isaac-sim/python.sh` during an image build: that would fetch and bake
+the runtime. Follow [BYOF onboarding](../../../../skills/workflows/byof-onboard/SKILL.md)
+and [packaging](../../container-packaging.md) when adding your own fork,
+dependencies, or assets. Public publication requires separate image acceptance.
 
-Common customizations:
-
-- copy a forked Isaac Lab tree into `/workspace/isaaclab`;
-- install a forked RSL-RL package with `/isaac-sim/python.sh -m pip install -e`;
-- add task config defaults under your fork;
-- copy private assets into a known path;
-- add internal provenance labels;
-- keep `/isaac-sim/python.sh` and the artifact upload contract available.
-
-## Pushing To The Registry
-
-Push the image:
+## 3. Preview an image-only run
 
 ```bash
-docker push "${BYOF_IMAGE}"
-```
-
-Inspect the pushed digest:
-
-```bash
-docker buildx imagetools inspect "${BYOF_IMAGE}"
-```
-
-W10 pushed
-`ghcr.io/nebius/nebius-physical-ai/isaac-lab-byof-test:w10-byof-image-20260520T223706Z`.
-The pushed manifest-list digest was
-`sha256:c3e104601e31afaa833e3e73558ec9f0c6478f1dce59261fa45073a4d03518bf`;
-the linux/amd64 platform digest was
-`sha256:d9abdad36137a2f7cb38a6dbd85313ab0c5594582c248e174c9c4a13883d399c`.
-Both differ from the vanilla base digest above.
-
-## Running With Image Override Only
-
-This path proves that `--image` replaces the default `image_id` while the
-upstream training command still runs.
-
-```bash
-export RUN_ID_A="w10-byof-image-only-$(date -u +%Y%m%dT%H%M%SZ)"
-export NPA_S3_BUCKET=<your-bucket>
-export AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud
-
-NPA_SKYPILOT_BIN="${NPA_SKYPILOT_BIN}" \
+export RUN_ID_A="byof-image-$(date -u +%Y%m%dT%H%M%SZ)"
 npa/.venv/bin/python npa/scripts/run_isaac_lab_rl.py \
-  --project <project-alias> \
-  --context <kubernetes-context> \
-  --yaml npa/src/npa/workflows/byof/profiles/isaac-lab-rl-train.yaml \
-  --image "${BYOF_IMAGE}" \
-  --task Isaac-Cartpole-v0 \
-  --iterations 1 \
-  --run-id "${RUN_ID_A}" \
-  --output-root "s3://${NPA_S3_BUCKET}/checkpoints/isaac-lab-byof" \
-  --cleanup
+  --project "$PROJECT_ALIAS" --context "$KUBE_CONTEXT" \
+  --yaml "$BYOF_PROFILE" --image "$BYOF_IMAGE" \
+  --task Isaac-Cartpole-v0 --iterations 1 --run-id "$RUN_ID_A" \
+  --output-root "s3://$NPA_S3_BUCKET/checkpoints/isaac-lab-byof" \
+  --cleanup --render-only
 ```
 
-W10 validated this surface with:
+The JSON reports the rendered YAML path and output locations. Inspect its
+image, accelerator, command, endpoint, and run prefix. `--render-only` creates
+no cloud job. Remove only `--render-only` to submit this training smoke.
+A completed one-iteration run proves checkpoint production, not convergence.
 
-```text
-Run ID: w10-byof-image-only-20260520T232650Z
-GPU: L40S
-Output: s3://${NPA_S3_BUCKET}/checkpoints/isaac-lab-byof/w10-byof-image-only-20260520T232650Z/
-Manifest train_script: /workspace/isaaclab/scripts/reinforcement_learning/rsl_rl/train.py
-```
+## 4. Override the training entrypoint
 
-Expected artifacts are `npa_isaac_lab_checkpoint.pt`,
-`npa_isaac_lab_checkpoint_manifest.json`, `npa_isaac_lab_train_summary.json`,
-`isaac_lab_train.log`, and RSL-RL run logs under `logs/rsl_rl/`.
-
-## Running With Image Plus Command Override
-
-The runner does not have a `--run-cmd` flag. The command override surface is the
-SkyPilot YAML `run:` block, selected through `--yaml`.
-
-Create a customer YAML variant outside the platform workflow:
+Keep the original profile intact. Make a private copy:
 
 ```bash
-cp npa/src/npa/workflows/byof/profiles/isaac-lab-rl-train.yaml /tmp/isaac-lab-byof-command.yaml
+export BYOF_PRIVATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/npa-byof.XXXXXX")"
+cp "$BYOF_PROFILE" "$BYOF_PRIVATE_DIR/task.yaml"
 ```
 
-In that temporary YAML, replace only the training script assignment in `run:`:
+In the copy's `run:` block, change only the `TRAIN_SCRIPT` assignment to:
 
 ```bash
 TRAIN_SCRIPT="/opt/byof/custom_train.py"
 ```
 
-Keep the rest of the run block intact so checkpoint discovery, manifest
-creation, and S3 upload still use the platform contract. The command should
-still resolve to this shape:
+Keep checkpoint discovery, manifest creation, and S3 upload unchanged. The
+wrapper must preserve task, environment count, iteration count, experiment/run
+names, visualization flags, and Hydra argument passthrough. Generation 3 uses
+`--visualizer none`; `--headless` is only for generation 2 compatibility images.
+The runner has no `--run-cmd` option.
+
+Preview with the new YAML and a fresh run ID:
 
 ```bash
-"${PYTHON_BIN}" \
-  /opt/byof/custom_train.py \
-  --task "${ISAAC_LAB_TASK}" \
-  --num_envs "${ISAAC_LAB_NUM_ENVS}" \
-  --max_iterations "${ISAAC_LAB_ITERATIONS}" \
-  --visualizer none \
-  --experiment_name "${ISAAC_LAB_EXPERIMENT_NAME}" \
-  --run_name "${ISAAC_LAB_RUN_NAME}" \
-  agent.save_interval=1
-```
-
-Launch with the custom YAML and image:
-
-```bash
-export RUN_ID_B="w10-byof-image-and-cmd-$(date -u +%Y%m%dT%H%M%SZ)"
-
-NPA_SKYPILOT_BIN="${NPA_SKYPILOT_BIN}" \
+export RUN_ID_B="byof-entrypoint-$(date -u +%Y%m%dT%H%M%SZ)"
 npa/.venv/bin/python npa/scripts/run_isaac_lab_rl.py \
-  --project <project-alias> \
-  --context <kubernetes-context> \
-  --yaml /tmp/isaac-lab-byof-command.yaml \
-  --image "${BYOF_IMAGE}" \
-  --task Isaac-Cartpole-v0 \
-  --iterations 1 \
-  --run-id "${RUN_ID_B}" \
-  --output-root "s3://${NPA_S3_BUCKET}/checkpoints/isaac-lab-byof" \
-  --cleanup
+  --project "$PROJECT_ALIAS" --context "$KUBE_CONTEXT" \
+  --yaml "$BYOF_PRIVATE_DIR/task.yaml" --image "$BYOF_IMAGE" \
+  --task Isaac-Cartpole-v0 --iterations 1 --run-id "$RUN_ID_B" \
+  --output-root "s3://$NPA_S3_BUCKET/checkpoints/isaac-lab-byof" \
+  --cleanup --render-only
 ```
 
-W10 validated this surface with:
+Verify the custom script in the rendered command, then remove `--render-only`
+to execute. Keep the private YAML until the run and any recovery are complete.
 
-```text
-Run ID: w10-byof-image-and-cmd-20260520T233113Z
-GPU: L40S
-Output: s3://${NPA_S3_BUCKET}/checkpoints/isaac-lab-byof/w10-byof-image-and-cmd-20260520T233113Z/
-Manifest train_script: /opt/byof/custom_train.py
-Sentinel: byof_sentinel.json
-```
+## 5. Verify the result and cleanup
 
-The validation sentinel included:
-
-```json
-{
-  "byof": true,
-  "script": "custom_train.py",
-  "run_id": "w10-byof-image-and-cmd-20260520T233113Z",
-  "task": "Isaac-Cartpole-v0",
-  "num_envs": "64",
-  "max_iterations": "1",
-  "headless": true,
-  "hydra_args": ["agent.save_interval=1"]
-}
-```
-
-This proves that a non-default image and a non-default entrypoint can run while
-still producing a normal Isaac Lab checkpoint.
-
-## Platform Guarantees And Image Responsibilities
-
-The platform guarantees:
-
-- a SkyPilot Kubernetes task;
-- L40S accelerator routing in the reference YAML;
-- image replacement through `resources.image_id`;
-- run id injection through `NPA_ISAAC_LAB_RUN_ID`;
-- task and iteration injection through `ISAAC_LAB_TASK` and `ISAAC_LAB_ITERATIONS`;
-- output prefix injection through `S3_OUTPUT_PREFIX`;
-- log capture to `isaac_lab_train.log`;
-- checkpoint discovery under `logs/rsl_rl/`;
-- stable checkpoint upload as `npa_isaac_lab_checkpoint.pt`;
-- manifest upload as `npa_isaac_lab_checkpoint_manifest.json`;
-- cleanup through the runner's existing SkyPilot cleanup path.
-
-Your image must provide:
-
-- `/isaac-sim/python.sh`, or a compatible Python fallback;
-- Isaac Lab and RSL-RL dependencies for the requested task;
-- the upstream training script if your wrapper delegates to it;
-- `boto3` availability or installability during setup;
-- write access to `/workspace/isaaclab/npa-runs`;
-- non-rendering Isaac Lab behavior (`--visualizer none` for generation 3);
-- any custom assets or packages your fork requires.
-
-Your custom command must preserve `--task`, `--num_envs`, `--max_iterations`,
-`--visualizer`, `--experiment_name`, `--run_name`, and Hydra override
-passthrough. The wrapper retains `--headless` only for generation 2 custom
-images.
-
-## Verifying Your Run
-
-List the output prefix:
+After success, inspect the run prefix with AWS CLI using the same endpoint and
+credentials. For the custom-entrypoint run:
 
 ```bash
-aws s3 ls \
-  "s3://${NPA_S3_BUCKET}/checkpoints/isaac-lab-byof/${RUN_ID_B}/" \
-  --recursive \
-  --endpoint-url https://storage.eu-north1.nebius.cloud
+export BYOF_RUN_URI="s3://$NPA_S3_BUCKET/checkpoints/isaac-lab-byof/$RUN_ID_B"
+aws s3 ls "$BYOF_RUN_URI/" --recursive --endpoint-url "$AWS_ENDPOINT_URL"
+aws s3 cp "$BYOF_RUN_URI/npa_isaac_lab_checkpoint_manifest.json" - \
+  --endpoint-url "$AWS_ENDPOINT_URL"
+aws s3 cp "$BYOF_RUN_URI/byof_sentinel.json" - \
+  --endpoint-url "$AWS_ENDPOINT_URL"
 ```
 
-Fetch the manifest:
+| Evidence | Required result |
+| --- | --- |
+| Checkpoint manifest | `status: success`, at least one checkpoint, matching run ID and task, expected `train_script` |
+| Checkpoint and logs | `npa_isaac_lab_checkpoint.pt`, `npa_isaac_lab_train_summary.json`, `isaac_lab_train.log`, and `logs/rsl_rl/` |
+| Custom sentinel | `byof: true`, `script: custom_train.py`, matching run ID, expected arguments |
+| Runner summary | Terminal job status and successful cleanup for this run |
 
-```bash
-aws s3 cp \
-  "s3://${NPA_S3_BUCKET}/checkpoints/isaac-lab-byof/${RUN_ID_B}/npa_isaac_lab_checkpoint_manifest.json" \
-  - \
-  --endpoint-url https://storage.eu-north1.nebius.cloud
-```
+The image-only run uses the upstream script and does not need a custom sentinel.
+`--cleanup` removes the run's compute; the shared jobs controller may remain.
+Use [teardown](../../../teardown.md) for separately owned infrastructure.
 
-Check:
-
-- `status` is `success`;
-- `checkpoint_count` is at least `1`;
-- `run_id` matches the submitted run;
-- `task` matches the requested task;
-- `train_script` is the expected upstream or custom path.
-
-For command override runs, fetch the sentinel:
-
-```bash
-aws s3 cp \
-  "s3://${NPA_S3_BUCKET}/checkpoints/isaac-lab-byof/${RUN_ID_B}/byof_sentinel.json" \
-  - \
-  --endpoint-url https://storage.eu-north1.nebius.cloud
-```
-
-Check:
-
-- `byof` is `true`;
-- `script` is `custom_train.py`;
-- `run_id` matches the submitted run;
-- `argv` contains the task, environment count, iteration count, and Hydra args.
-
-Confirm SkyPilot cleanup:
-
-```bash
-"${NPA_SKYPILOT_BIN}" status --refresh
-"${NPA_SKYPILOT_BIN}" jobs queue --refresh
-```
-
-There should be no live run cluster and no in-progress managed job after a
-successful `--cleanup` run. The shared jobs controller may remain up.
-
-## Known Constraints
-
-- Isaac Lab requires RT-core GPUs.
-- Batch jobs must disable visualization (`--visualizer none` for generation 3;
-  `--headless` only for generation 2 compatibility images).
-- The current path does not run Omniverse interactive rendering.
-- Omniverse rendering support is roadmap work, not part of this BYOF smoke.
-- The runner exposes image override directly but command override through YAML.
-- Private-registry credentials can expire; rotate only the explicitly configured
-  operator-managed secret. Public GHCR releases need no pull secret.
-- S3 access must be configured for the target bucket and endpoint.
-- The example uses a synthetic image, not a real customer image.
-- Multi-GPU and multi-iteration validation are separate prompts.
-
-## Where To Get Help
-
-Open an issue in this repository with the run id, image tag and digest,
-SkyPilot job id, manifest JSON, sentinel JSON for command override runs, and
-the relevant `sky jobs logs <job-id>` excerpt.
-
-For managed Nebius environments, include the same artifacts when contacting the
-support or account team.
+If setup fails, check image pull access, GPU spelling, the runtime's Isaac
+bootstrap, and the exact S3 endpoint. If training completes without the sentinel,
+verify the rendered `TRAIN_SCRIPT` and uploaded output directory. When reporting
+an issue, include sanitized versions, image digest, status, and log excerpts;
+keep credentials and live infrastructure identifiers private.

--- a/docs/workbench/cookbooks/byof-isaac-lab/README.md
+++ b/docs/workbench/cookbooks/byof-isaac-lab/README.md
@@ -1,5 +1,7 @@
 # Isaac Lab Bring Your Own Fork Cookbook
 
+[Cookbooks](../README.md)
+
 This cookbook shows how to run a custom Isaac Lab fork, custom RSL-RL fork, or
 custom training wrapper on Workbench without changing the checked-in platform
 workflow. The worked example in this directory uses a synthetic image layer and

--- a/docs/workbench/cookbooks/byof-isaac-lab/historical-validation.md
+++ b/docs/workbench/cookbooks/byof-isaac-lab/historical-validation.md
@@ -1,0 +1,59 @@
+# Historical Isaac Lab BYOF validation
+
+[Current cookbook](README.md)
+
+These W10 records used the generation 2 base in May 2026. They establish image
+and entrypoint overrides for that tested runtime. The current example uses
+Isaac Lab 3 beta / Isaac Sim 6 and `--visualizer none`; these older results do
+not validate that replacement runtime. `--headless` below is historical.
+
+## Published test image
+
+W10 pushed
+`ghcr.io/nebius/nebius-physical-ai/isaac-lab-byof-test:w10-byof-image-20260520T223706Z`.
+The pushed manifest-list digest was
+`sha256:c3e104601e31afaa833e3e73558ec9f0c6478f1dce59261fa45073a4d03518bf`;
+the linux/amd64 platform digest was
+`sha256:d9abdad36137a2f7cb38a6dbd85313ab0c5594582c248e174c9c4a13883d399c`.
+Both differ from the vanilla base digest above.
+
+## Image-only run
+
+W10 validated this surface with:
+
+```text
+Run ID: w10-byof-image-only-20260520T232650Z
+GPU: L40S
+Output: s3://${NPA_S3_BUCKET}/checkpoints/isaac-lab-byof/w10-byof-image-only-20260520T232650Z/
+Manifest train_script: /workspace/isaaclab/scripts/reinforcement_learning/rsl_rl/train.py
+```
+
+## Image and command override run
+
+W10 validated this surface with:
+
+```text
+Run ID: w10-byof-image-and-cmd-20260520T233113Z
+GPU: L40S
+Output: s3://${NPA_S3_BUCKET}/checkpoints/isaac-lab-byof/w10-byof-image-and-cmd-20260520T233113Z/
+Manifest train_script: /opt/byof/custom_train.py
+Sentinel: byof_sentinel.json
+```
+
+The validation sentinel included:
+
+```json
+{
+  "byof": true,
+  "script": "custom_train.py",
+  "run_id": "w10-byof-image-and-cmd-20260520T233113Z",
+  "task": "Isaac-Cartpole-v0",
+  "num_envs": "64",
+  "max_iterations": "1",
+  "headless": true,
+  "hydra_args": ["agent.save_interval=1"]
+}
+```
+
+This proves that a non-default image and a non-default entrypoint can run while
+still producing a normal Isaac Lab checkpoint.

--- a/docs/workbench/cookbooks/groot-1-7-training.md
+++ b/docs/workbench/cookbooks/groot-1-7-training.md
@@ -1,5 +1,7 @@
 # GR00T N1.7 operational training pipeline
 
+[Cookbooks](README.md)
+
 Use `groot-1-7-finetune.yaml` to validate the complete real-data path from a
 GR00T-format LeRobot dataset through distributed optimizer work, an immutable
 checkpoint, aligned offline inference, synchronized RRD/MCAP diagnostics, S3

--- a/docs/workbench/cookbooks/groot-1-7-training.md
+++ b/docs/workbench/cookbooks/groot-1-7-training.md
@@ -63,15 +63,15 @@ runtime secrets at submission time; do not commit tenant or customer values.
 ```bash
 npa/.venv/bin/npa workbench workflow submit "$SPEC" \
   --run-id "$RUN_ID" \
-  --var bucket=<bucket> \
-  --var source_data_uri=s3://<bucket>/datasets/my-groot-dataset/ \
-  --var agent_url=https://<agent-host> \
+  --var bucket="<bucket>" \
+  --var source_data_uri="s3://<bucket>/datasets/my-groot-dataset/" \
+  --var agent_url="https://<agent-host>" \
   --var gpu_type=B200 \
   --var gpu_count=2 \
   --var per_device_batch_size=1 \
   --var gradient_accumulation_steps=1 \
   --var global_batch_size=2 \
-  --registry <registry>/npa-groot:<validated-tag> \
+  --registry "<registry>/npa-groot:<validated-tag>" \
   --secret-env HF_TOKEN \
   --secret-env NPA_AGENT_BASIC_AUTH
 ```

--- a/docs/workbench/cookbooks/lancedb-deploy-runbook.md
+++ b/docs/workbench/cookbooks/lancedb-deploy-runbook.md
@@ -1,5 +1,7 @@
 # LanceDB Deploy Runbook
 
+[Cookbooks](README.md)
+
 This runbook covers the OSS LanceDB Workbench path. The persistent service is
 CPU-only, but the optional CLIP embedding UDF is GPU-accelerated.
 

--- a/docs/workbench/cookbooks/lancedb-deploy-runbook.md
+++ b/docs/workbench/cookbooks/lancedb-deploy-runbook.md
@@ -37,7 +37,7 @@ npa workbench lancedb deploy \
   --port 8686 \
   --auth-mode none \
   --replace \
-  --image <your-registry>/<namespace>/npa-lancedb:cuda13-b300-0.30.3-sm80-sm90-sm100-sm103-sm120-20260803T031514Z
+  --image "<your-registry>/<namespace>/npa-lancedb:cuda13-b300-0.30.3-sm80-sm90-sm100-sm103-sm120-20260803T031514Z"
 ```
 
 Check status:
@@ -86,7 +86,7 @@ npa workbench lancedb deploy \
 
 ```bash
 npa workbench lancedb status \
-  --endpoint http://<vm-ip>:8686 \
+  --endpoint "http://<vm-ip>:8686" \
   --token-env LANCEDB_TOKEN
 ```
 

--- a/docs/workbench/cookbooks/lancedb-vector-search.md
+++ b/docs/workbench/cookbooks/lancedb-vector-search.md
@@ -1,5 +1,7 @@
 # LanceDB Vector Search
 
+[Cookbooks](README.md)
+
 LanceDB gives the Workbench a CPU-only vector-search and data-lake layer for
 robotics datasets. The v1 integration wraps the OSS Python package in a small
 NPA service that stores Lance data in a local path or an S3-compatible object

--- a/docs/workbench/cookbooks/lancedb-vector-search.md
+++ b/docs/workbench/cookbooks/lancedb-vector-search.md
@@ -26,7 +26,7 @@ npa workbench lancedb deploy \
   --storage-path /tmp/npa-lancedb \
   --port 8686 \
   --auth-mode none \
-  --image <your-registry>/<namespace>/npa-lancedb:cuda13-b300-0.30.3-sm80-sm90-sm100-sm103-sm120-20260803T031514Z
+  --image "<your-registry>/<namespace>/npa-lancedb:cuda13-b300-0.30.3-sm80-sm90-sm100-sm103-sm120-20260803T031514Z"
 ```
 
 Create a table from local JSON, JSONL, parquet, or a directory of parquet

--- a/docs/workbench/cookbooks/lerobot-gpu-benchmarks-runbook.md
+++ b/docs/workbench/cookbooks/lerobot-gpu-benchmarks-runbook.md
@@ -1,5 +1,7 @@
 # LeRobot Benchmark on Workbench Serverless
 
+[Cookbooks](README.md)
+
 This runbook shows how to run LeRobot training benchmarks on Nebius Physical AI
 Workbench with Serverless Jobs.
 

--- a/docs/workbench/cookbooks/lerobot-gpu-benchmarks-runbook.md
+++ b/docs/workbench/cookbooks/lerobot-gpu-benchmarks-runbook.md
@@ -346,7 +346,7 @@ aws s3 rm \
 Cancel a still-running job by ID if needed:
 
 ```bash
-nebius ai job cancel --id <JOB_ID>
+nebius ai job cancel --id "<JOB_ID>"
 ```
 
 ## Related Docs

--- a/docs/workbench/cookbooks/lerobot-gpu-benchmarks.md
+++ b/docs/workbench/cookbooks/lerobot-gpu-benchmarks.md
@@ -18,16 +18,16 @@ power draw, or energy efficiency.
 For the headline result, reproduce Diffusion Policy on H200 first:
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-h200 deploy \
-  --project-id <NEBIUS_PROJECT_ID> \
-  --tenant-id <NEBIUS_TENANT_ID> \
-  --region <NEBIUS_REGION> \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-h200 deploy \
+  --project-id "<NEBIUS_PROJECT_ID>" \
+  --tenant-id "<NEBIUS_TENANT_ID>" \
+  --region "<NEBIUS_REGION>" \
   --runtime container \
   --gpu-type gpu-h200-sxm \
   --gpu-preset 1gpu-16vcpu-200gb \
   --disk-size 500
 
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-h200 profile-train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-h200 profile-train \
   --run diffusion:lerobot/pusht:100 \
   --mode wallclock \
   --batch-size 8 \
@@ -127,10 +127,10 @@ platform and preset with the Nebius shape available in your project for B300,
 L40S, or RTX PRO 6000.
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-h200 deploy \
-  --project-id <NEBIUS_PROJECT_ID> \
-  --tenant-id <NEBIUS_TENANT_ID> \
-  --region <NEBIUS_REGION> \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-h200 deploy \
+  --project-id "<NEBIUS_PROJECT_ID>" \
+  --tenant-id "<NEBIUS_TENANT_ID>" \
+  --region "<NEBIUS_REGION>" \
   --runtime container \
   --gpu-type gpu-h200-sxm \
   --gpu-preset 1gpu-16vcpu-200gb \
@@ -141,10 +141,10 @@ For B300 and RTX PRO 6000 VM deploys, use a CUDA 13 image family when your
 project requires it:
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-b300 deploy \
-  --project-id <NEBIUS_PROJECT_ID> \
-  --tenant-id <NEBIUS_TENANT_ID> \
-  --region <NEBIUS_REGION> \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-b300 deploy \
+  --project-id "<NEBIUS_PROJECT_ID>" \
+  --tenant-id "<NEBIUS_TENANT_ID>" \
+  --region "<NEBIUS_REGION>" \
   --runtime container \
   --gpu-type gpu-b300-sxm \
   --gpu-preset 1gpu-24vcpu-346gb \
@@ -155,7 +155,7 @@ npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-b300 deploy \
 Run the benchmark-style profiler:
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-h200 profile-train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-h200 profile-train \
   --run vqbet:lerobot/pusht:100 \
   --run act:lerobot/pusht:100 \
   --run diffusion:lerobot/pusht:100 \
@@ -176,9 +176,9 @@ stage-level profiler path, but it is the forward-compatible reproduction path
 for LeRobot training on Nebius Serverless Jobs.
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-jobs train \
   --runtime serverless \
-  --project-id <NEBIUS_PROJECT_ID> \
+  --project-id "<NEBIUS_PROJECT_ID>" \
   --policy-type diffusion \
   --dataset lerobot/pusht \
   --job-name diffusion-h200-100 \
@@ -186,15 +186,15 @@ npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
   --batch-size 8 \
   --gpu-type h200 \
   --gpu-count 1 \
-  --output-path s3://<YOUR_BUCKET>/lerobot-benchmarks/diffusion-h200-100/
+  --output-path "s3://<YOUR_BUCKET>/lerobot-benchmarks/diffusion-h200-100/"
 ```
 
 For B300:
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-jobs train \
   --runtime serverless \
-  --project-id <NEBIUS_PROJECT_ID> \
+  --project-id "<NEBIUS_PROJECT_ID>" \
   --policy-type diffusion \
   --dataset lerobot/pusht \
   --job-name diffusion-b300-100 \
@@ -202,7 +202,7 @@ npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
   --batch-size 8 \
   --gpu-type b300 \
   --gpu-count 1 \
-  --output-path s3://<YOUR_BUCKET>/lerobot-benchmarks/diffusion-b300-100/
+  --output-path "s3://<YOUR_BUCKET>/lerobot-benchmarks/diffusion-b300-100/"
 ```
 
 The CLI warns when you run Diffusion Policy on B300 because of the PTX JIT issue.
@@ -226,7 +226,7 @@ single-sample inference latency, faster than H200's 11.58 ms.
 **Benchmark-style profile:**
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n "<WORKBENCH_NAME>" profile-train \
   --run vqbet:lerobot/pusht:100 \
   --mode wallclock \
   --batch-size 8 \
@@ -236,16 +236,16 @@ npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
 **Serverless training:**
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-jobs train \
   --runtime serverless \
-  --project-id <NEBIUS_PROJECT_ID> \
+  --project-id "<NEBIUS_PROJECT_ID>" \
   --policy-type vqbet \
   --dataset lerobot/pusht \
   --job-name vqbet-h200-100 \
   --steps 100 \
   --batch-size 8 \
   --gpu-type h200 \
-  --output-path s3://<YOUR_BUCKET>/lerobot-benchmarks/vqbet-h200-100/
+  --output-path "s3://<YOUR_BUCKET>/lerobot-benchmarks/vqbet-h200-100/"
 ```
 
 **Validation:** Compare `throughput_steps_per_sec` against the research values:
@@ -267,7 +267,7 @@ run.
 **Benchmark-style profile:**
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n "<WORKBENCH_NAME>" profile-train \
   --run act:lerobot/pusht:100 \
   --mode wallclock \
   --batch-size 8 \
@@ -277,16 +277,16 @@ npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
 **Serverless training:**
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-jobs train \
   --runtime serverless \
-  --project-id <NEBIUS_PROJECT_ID> \
+  --project-id "<NEBIUS_PROJECT_ID>" \
   --policy-type act \
   --dataset lerobot/pusht \
   --job-name act-h200-100 \
   --steps 100 \
   --batch-size 8 \
   --gpu-type h200 \
-  --output-path s3://<YOUR_BUCKET>/lerobot-benchmarks/act-h200-100/
+  --output-path "s3://<YOUR_BUCKET>/lerobot-benchmarks/act-h200-100/"
 ```
 
 **Validation:** Expected research throughput is H200 35.5, B300 37.0,
@@ -310,7 +310,7 @@ inference also measured 36.48 ms versus H200 at 10.06 ms.
 **Benchmark-style profile:**
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n "<WORKBENCH_NAME>" profile-train \
   --run diffusion:lerobot/pusht:100 \
   --mode wallclock \
   --batch-size 8 \
@@ -320,7 +320,7 @@ npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
 **With torch.compile on H200:**
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n "<WORKBENCH_NAME>" profile-train \
   --run diffusion:lerobot/pusht:100 \
   --mode wallclock \
   --batch-size 8 \
@@ -331,16 +331,16 @@ npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
 **Serverless training:**
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-jobs train \
   --runtime serverless \
-  --project-id <NEBIUS_PROJECT_ID> \
+  --project-id "<NEBIUS_PROJECT_ID>" \
   --policy-type diffusion \
   --dataset lerobot/pusht \
   --job-name diffusion-h200-100 \
   --steps 100 \
   --batch-size 8 \
   --gpu-type h200 \
-  --output-path s3://<YOUR_BUCKET>/lerobot-benchmarks/diffusion-h200-100/
+  --output-path "s3://<YOUR_BUCKET>/lerobot-benchmarks/diffusion-h200-100/"
 ```
 
 **Validation:** This is the headline reproduction. H200 should be around
@@ -364,7 +364,7 @@ benchmark.
 **Benchmark-style profile:**
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n "<WORKBENCH_NAME>" profile-train \
   --run smolvla:lerobot/aloha_sim_insertion_human:100 \
   --mode wallclock \
   --batch-size 8 \
@@ -374,16 +374,16 @@ npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
 **Serverless training:**
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-jobs train \
   --runtime serverless \
-  --project-id <NEBIUS_PROJECT_ID> \
+  --project-id "<NEBIUS_PROJECT_ID>" \
   --policy-type smolvla \
   --dataset lerobot/aloha_sim_insertion_human \
   --job-name smolvla-b300-100 \
   --steps 100 \
   --batch-size 8 \
   --gpu-type b300 \
-  --output-path s3://<YOUR_BUCKET>/lerobot-benchmarks/smolvla-b300-100/
+  --output-path "s3://<YOUR_BUCKET>/lerobot-benchmarks/smolvla-b300-100/"
 ```
 
 **Validation:** Expected research throughput is H200 10.5, B300 11.8,
@@ -401,7 +401,7 @@ the loop. Warmup steps are excluded. The metric to compare is
 Use `profile-train --mode profiler` when you need per-stage diagnostics:
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n "<WORKBENCH_NAME>" profile-train \
   --run diffusion:lerobot/pusht:100 \
   --mode profiler \
   --batch-size 8 \
@@ -416,7 +416,7 @@ GPU architectures benefit differently from kernel pipelining.
 For inference latency, use:
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n <WORKBENCH_NAME> profile-train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n "<WORKBENCH_NAME>" profile-train \
   --run diffusion:lerobot/pusht:100 \
   --mode inference
 ```
@@ -447,18 +447,18 @@ Check quota, regional capacity, and GPU type. Serverless Jobs may need an
 explicit subnet if the project has multiple VPC subnets:
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-jobs train \
   --runtime serverless \
-  --project-id <NEBIUS_PROJECT_ID> \
+  --project-id "<NEBIUS_PROJECT_ID>" \
   --policy-type act \
   --dataset lerobot/pusht \
   --job-name act-h200-queued-debug \
   --steps 100 \
   --batch-size 8 \
   --gpu-type h200 \
-  --subnet-id <VPC_SUBNET_ID> \
+  --subnet-id "<VPC_SUBNET_ID>" \
   --submit-only \
-  --output-path s3://<YOUR_BUCKET>/lerobot-benchmarks/act-h200-queued-debug/
+  --output-path "s3://<YOUR_BUCKET>/lerobot-benchmarks/act-h200-queued-debug/"
 ```
 
 ### Training Reaches `failed`
@@ -468,16 +468,16 @@ Common causes are a missing Hugging Face token, an output path that is not an
 text output and inspect the Job in Nebius:
 
 ```bash
-npa workbench lerobot -p <PROJECT_ALIAS> -n lerobot-jobs train \
+npa workbench lerobot -p "<PROJECT_ALIAS>" -n lerobot-jobs train \
   --runtime serverless \
-  --project-id <NEBIUS_PROJECT_ID> \
+  --project-id "<NEBIUS_PROJECT_ID>" \
   --policy-type diffusion \
   --dataset lerobot/pusht \
   --job-name diffusion-h200-debug \
   --steps 100 \
   --batch-size 8 \
   --gpu-type h200 \
-  --output-path s3://<YOUR_BUCKET>/lerobot-benchmarks/diffusion-h200-debug/
+  --output-path "s3://<YOUR_BUCKET>/lerobot-benchmarks/diffusion-h200-debug/"
 ```
 
 If the command returns a Job ID, fetch logs with the Nebius CLI available in

--- a/docs/workbench/cookbooks/lerobot-gpu-benchmarks.md
+++ b/docs/workbench/cookbooks/lerobot-gpu-benchmarks.md
@@ -1,5 +1,7 @@
 # LeRobot GPU Benchmarks: Reproducing the Research via Nebius Workbench
 
+[Cookbooks](README.md)
+
 This cookbook documents how to reproduce the May 2026 LeRobot GPU benchmark
 research by @tle and @mnrozhkov with Nebius Physical AI Workbench. It is written
 for robotics teams evaluating Nebius GPU options, partners coordinating case

--- a/docs/workbench/cookbooks/physical-reasoning-challenge.md
+++ b/docs/workbench/cookbooks/physical-reasoning-challenge.md
@@ -1,9 +1,11 @@
 # Physical Reasoning Challenge (Token Factory + Cosmos3-Super-Reasoner)
 
+[Cookbooks](README.md)
+
 > Historical Cosmos3 recipe: its public hosted model was retired under the
 > [August 2026 notice](https://docs.tokenfactory.nebius.com/august-2026-deprecation-notice).
-> Use the current [Token Factory guide](/docs/workbench/token-factory.md) and
-> [migration verification](/docs/workbench/token-factory-deprecation-verification.md)
+> Use the current [Token Factory guide](../token-factory.md) and
+> [migration verification](../token-factory-deprecation-verification.md)
 > for current defaults. Explicit legacy model IDs require a serving endpoint;
 > this page does not establish their current availability.
 

--- a/docs/workbench/cookbooks/serverless-tools-coverage.md
+++ b/docs/workbench/cookbooks/serverless-tools-coverage.md
@@ -1,5 +1,7 @@
 # Workbench Tools - Serverless Coverage
 
+[Cookbooks](README.md)
+
 ## Overview
 
 The Workbench supports `--runtime serverless` on these non-LeRobot tools, each backed by Nebius Serverless Jobs:

--- a/docs/workbench/cookbooks/serverless-tools-coverage.md
+++ b/docs/workbench/cookbooks/serverless-tools-coverage.md
@@ -46,13 +46,13 @@ The serverless Job commands use the same option shape:
 ```bash
 npa workbench cosmos -p eu-north1 -n w13-cosmos train \
   --runtime serverless \
-  --project-id <YOUR_PROJECT_ID> \
+  --project-id "<YOUR_PROJECT_ID>" \
   --image ghcr.io/nebius/nebius-physical-ai/npa-cosmos:cu128-torch27-sm100-1.0.9-20260803T002017Z \
   --gpu-type h100 \
   --gpu-count 1 \
   --gpu-preset 1gpu-16vcpu-200gb \
-  --output-path s3://${NPA_S3_BUCKET}/w13-cosmos-e2e/<run-id>/ \
-  --job-name <run-id> \
+  --output-path "s3://${NPA_S3_BUCKET}/w13-cosmos-e2e/<run-id>/" \
+  --job-name "<run-id>" \
   --smoke \
   --smoke-seconds 5 \
   --timeout 3600 \
@@ -64,14 +64,14 @@ npa workbench cosmos -p eu-north1 -n w13-cosmos train \
 ```bash
 npa workbench isaac-lab -p uk-south1 -n w7p-isaac train \
   --runtime serverless \
-  --project-id <YOUR_PROJECT_ID> \
+  --project-id "<YOUR_PROJECT_ID>" \
   --task Isaac-Reach-Franka-v0 \
   --num-envs 1 \
   --steps 1 \
   --gpu-type l40s \
   --gpu-count 1 \
-  --output-path s3://${NPA_S3_BUCKET}/<run-prefix>/isaac-lab-smoke/ \
-  --job-name isaac-lab-smoke3-<run-id> \
+  --output-path "s3://${NPA_S3_BUCKET}/<run-prefix>/isaac-lab-smoke/" \
+  --job-name "isaac-lab-smoke3-<run-id>" \
   --timeout 3600 \
   --poll-interval 15
 ```
@@ -81,13 +81,13 @@ npa workbench isaac-lab -p uk-south1 -n w7p-isaac train \
 ```bash
 npa workbench fiftyone -p uk-south1 -n w7p-fiftyone load-dataset \
   --runtime serverless \
-  --project-id <YOUR_PROJECT_ID> \
+  --project-id "<YOUR_PROJECT_ID>" \
   --name w7p-curated \
   --input-path Voxel51/VisDrone2019-DET \
   --gpu-type l40s \
   --gpu-count 1 \
-  --output-path s3://${NPA_S3_BUCKET}/<run-prefix>/fiftyone-smoke/ \
-  --job-name fiftyone-smoke-<run-id> \
+  --output-path "s3://${NPA_S3_BUCKET}/<run-prefix>/fiftyone-smoke/" \
+  --job-name "fiftyone-smoke-<run-id>" \
   --timeout 3600 \
   --poll-interval 15
 ```
@@ -97,13 +97,13 @@ npa workbench fiftyone -p uk-south1 -n w7p-fiftyone load-dataset \
 ```bash
 npa workbench genesis -p uk-south1 -n w7p-genesis train-teacher \
   --runtime serverless \
-  --project-id <YOUR_PROJECT_ID> \
+  --project-id "<YOUR_PROJECT_ID>" \
   --n-envs 1 \
   --max-iterations 1 \
   --gpu-type l40s \
   --gpu-count 1 \
-  --output-path s3://${NPA_S3_BUCKET}/<run-prefix>/genesis-smoke/ \
-  --job-name genesis-smoke-<run-id> \
+  --output-path "s3://${NPA_S3_BUCKET}/<run-prefix>/genesis-smoke/" \
+  --job-name "genesis-smoke-<run-id>" \
   --timeout 3600 \
   --poll-interval 15
 ```
@@ -113,16 +113,16 @@ npa workbench genesis -p uk-south1 -n w7p-genesis train-teacher \
 ```bash
 npa workbench groot -p uk-south1 -n w7p-groot infer \
   --runtime serverless \
-  --project-id <YOUR_PROJECT_ID> \
-  --input-path s3://${NPA_S3_BUCKET}/<run-prefix>/groot-input/checkpoint/ \
-  --dataset-path s3://${NPA_S3_BUCKET}/<run-prefix>/groot-input/dataset/ \
-  --output-path s3://${NPA_S3_BUCKET}/<run-prefix>/groot-smoke/ \
+  --project-id "<YOUR_PROJECT_ID>" \
+  --input-path "s3://${NPA_S3_BUCKET}/<run-prefix>/groot-input/checkpoint/" \
+  --dataset-path "s3://${NPA_S3_BUCKET}/<run-prefix>/groot-input/dataset/" \
+  --output-path "s3://${NPA_S3_BUCKET}/<run-prefix>/groot-smoke/" \
   --gpu-type h200 \
   --gpu-count 1 \
   --model-variant nvidia/GR00T-N1.7-3B \
   --steps 1 \
   --action-horizon 1 \
-  --job-name groot-smoke-<run-id> \
+  --job-name "groot-smoke-<run-id>" \
   --timeout 3600 \
   --poll-interval 15
 ```

--- a/docs/workbench/cookbooks/sonic-b300-routing-evidence.md
+++ b/docs/workbench/cookbooks/sonic-b300-routing-evidence.md
@@ -15,8 +15,8 @@ npa workbench workflow plan-spec \
   --run-id sonic-b300-routing-preview --json
 npa workbench workflow submit \
   workflows/testing/sonic-b300-routing-evidence.yaml \
-  --run-id <new-run-id> --var bucket=<configured-bucket> \
-  --var tested_commit_sha=<git-sha>
+  --run-id "<new-run-id>" --var bucket="<configured-bucket>" \
+  --var tested_commit_sha="<git-sha>"
 ```
 
 The run-scoped prefix contains `manifest.json`, `test-report.json`, and

--- a/docs/workbench/cookbooks/sonic-b300-routing-evidence.md
+++ b/docs/workbench/cookbooks/sonic-b300-routing-evidence.md
@@ -1,5 +1,7 @@
 # SONIC B300 routing evidence workflow
 
+[Cookbooks](README.md)
+
 `sonic-b300-routing-evidence.yaml` is a released, CPU-only workflow that executes
 the installed SONIC accelerator resolver. It fails closed unless both `b300` and
 `gpu-b300-sxm` resolve to `B300:1`, while retaining L40S, H100, and B200

--- a/docs/workbench/cookbooks/sonic-eval-runbook.md
+++ b/docs/workbench/cookbooks/sonic-eval-runbook.md
@@ -19,7 +19,7 @@ template is retired).
   ```bash
   npa skypilot bootstrap
   export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
-  npa skypilot verify --cluster <npa-cluster-name>
+  npa skypilot verify --cluster "<npa-cluster-name>"
   ```
 
 - The policy checkpoint is readable from the SkyPilot task. Use an `s3://`
@@ -49,8 +49,8 @@ checkpoint and select its URI explicitly:
 npa workbench workflow submit \
   workflows/testing/sonic-export-eval.yaml \
   --run-id sonic-export-eval-$(date -u +%Y%m%dT%H%M%SZ) \
-  --project <alias> --infra k8s/<cluster> --runtime \
-  --var bucket=<bucket> --var checkpoint_uri=s3://<bucket>/<checkpoint-path> \
+  --project "<alias>" --infra "k8s/<cluster>" --runtime \
+  --var bucket="<bucket>" --var checkpoint_uri="s3://<bucket>/<checkpoint-path>" \
   --secret-env AWS_ACCESS_KEY_ID \
   --secret-env AWS_SECRET_ACCESS_KEY
 ```

--- a/docs/workbench/cookbooks/sonic-eval-runbook.md
+++ b/docs/workbench/cookbooks/sonic-eval-runbook.md
@@ -1,5 +1,7 @@
 # SONIC Export and Eval Runbook
 
+[Cookbooks](README.md)
+
 This runbook covers the end-to-end SONIC locomotion path:
 
 ```text
@@ -17,7 +19,7 @@ template is retired).
   ```bash
   npa skypilot bootstrap
   export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
-  "$NPA_SKYPILOT_BIN" check
+  npa skypilot verify --cluster <npa-cluster-name>
   ```
 
 - The policy checkpoint is readable from the SkyPilot task. Use an `s3://`
@@ -39,15 +41,16 @@ template is retired).
 
 ## One Command
 
-Submit through the generic workflow command. The SONIC materializer fills the
-first-party image and S3 endpoint as literal YAML values before SkyPilot sees
-the workflow:
+Submit through the generic workflow command. NPA resolves its toolRefs, config,
+and images before handing rendered tasks to SkyPilot. Stage a compatible
+checkpoint and select its URI explicitly:
 
 ```bash
 npa workbench workflow submit \
   workflows/testing/sonic-export-eval.yaml \
   --run-id sonic-export-eval-$(date -u +%Y%m%dT%H%M%SZ) \
-  --var bucket=<bucket> \
+  --project <alias> --infra k8s/<cluster> --runtime \
+  --var bucket=<bucket> --var checkpoint_uri=s3://<bucket>/<checkpoint-path> \
   --secret-env AWS_ACCESS_KEY_ID \
   --secret-env AWS_SECRET_ACCESS_KEY
 ```

--- a/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
+++ b/docs/workbench/cookbooks/sonic-locomotion-finetuning.md
@@ -1,224 +1,77 @@
-# SONIC Locomotion Fine-Tuning
+# SONIC locomotion workflow
 
-This cookbook describes the SkyPilot workflow at
-`workflows/testing/sonic-locomotion-finetuning.yaml`.
+[Cookbooks](README.md) · [G1 guide](../guides/g1-humanoid-walk-sonic.md)
 
-The workflow composes three Workbench stages:
+[`sonic-locomotion-finetuning.yaml`](../../../workflows/testing/sonic-locomotion-finetuning.yaml)
+is an `npa.workflow/v0.0.1` reference for **retarget → train → MJLab**.
+Prepare its resource and artifact contracts before execution. It is not raw
+SkyPilot YAML and must be submitted through `npa workbench workflow submit`.
 
-1. Retarget source motion artifacts into the SONIC embodiment schema with
-   `npa workbench sonic retargeting run`.
-2. Fine-tune or smoke-validate the SONIC locomotion checkpoint on RTX PRO 6000
-   Kubernetes with the active host-mounted runtime-fetch image.
-3. Evaluate the resulting checkpoint with MJLab metrics through
-   `npa workbench mjlab eval`.
-
-The workflow logic is in YAML. There is no Python runner script for this path.
-The same YAML can be used three ways:
-
-- raw SkyPilot, after editing the YAML literals yourself;
-- SDK submission through `npa.sdk.workbench.sonic.submit_workflow`;
-- CLI submission through `npa workbench workflow submit`.
-
-## Required Inputs
-
-Prepare these S3 prefixes before submission:
-
-- Source motions: `s3://<your-bucket-name>/motions/source/`
-- Per-run output root: `s3://<your-bucket-name>/sonic-locomotion/<run-id>/`
-
-SkyPilot 0.12.2 does not expand same-block environment variables inside `envs`.
-For raw `sky` runs, replace `<your-bucket-name>`, `<run-id>`,
-`<your-registry>`, and image tags with literal values before launch. For CLI
-or SDK submission, pass the values to the SONIC materializer and it writes the
-literal YAML before calling SkyPilot.
-
-Retargeting uses `NPA_RETARGETING_IMAGE`, which defaults to the CPU
-`npa-retargeting:0.1.1` preprocess image. That image includes the `npa` CLI,
-CPU Python dependencies, and the pinned upstream
-`NVlabs/GR00T-WholeBodyControl` data-process scripts. MJLab still uses
-`NPA_WORKBENCH_IMAGE`, which defaults to the pushed generic Workbench image
-`<your-registry>/<namespace>/npa-genesis:0.4.6`.
-
-## Tool Templates
-
-The individual tool templates are available when you want to validate stages
-separately:
+## Inspect the reference
 
 ```bash
-npa workbench sonic retargeting workflow
-npa workbench mjlab workflow
+npa workbench workflow validate-spec workflows/testing/sonic-locomotion-finetuning.yaml
+npa workbench workflow plan-spec workflows/testing/sonic-locomotion-finetuning.yaml \
+  --run-id sonic-preview --json
 ```
 
-Those commands point to:
+Validation and planning do not launch a workload. The reference contains an
+example bucket and an H100 GPU profile, which does not match the active
+first-party SONIC training image.
 
-- `workflows/testing/retargeting.yaml`
-- `workflows/testing/mjlab-eval.yaml`
+## Prepare resources and inputs
 
-## Raw SkyPilot
+Copy the spec to an operator-owned path and complete
+[Workbench setup](../getting-started.md). For first-party training, use the
+[active RTX PRO 6000 Kubernetes image](../sonic-image-catalog.md) with its required
+host driver and cache mounts. Give training and MJLab separate resource profiles
+if they require different GPU/image combinations. Changing `--gpu-target` alone
+does not rewrite the spec's resource profiles.
 
-Copy the YAML, edit literals, then run it directly with SkyPilot:
+Check these config values against the actual planned commands:
 
-```bash
-cp workflows/testing/sonic-locomotion-finetuning.yaml /tmp/sonic.yaml
-# Edit /tmp/sonic.yaml so image_id, AWS_ENDPOINT_URL, and all s3:// prefixes
-# contain concrete values. Do not leave ${VAR} in envs or image_id fields.
-sky jobs launch \
-  --name sonic-locomotion-<run-id> \
-  --secret AWS_ACCESS_KEY_ID \
-  --secret AWS_SECRET_ACCESS_KEY \
-  --yes \
-  /tmp/sonic.yaml
-```
+| Key | Consumer / purpose |
+| --- | --- |
+| `bucket`, `prefix` | Writable project storage and a unique run prefix |
+| `motion_uri` | Source motions for retargeting and MJLab |
+| `retargeted_uri` | Retargeting output |
+| `data_uri` | SONIC trainer input; not automatically replaced by `retargeted_uri` |
+| `checkpoint_uri` | Shared by training and MJLab in the reference |
+| `training_uri` | Training output prefix |
+| `mjlab_uri` | Evaluation output prefix |
+| `train_iterations`, `episodes` | Training and evaluation settings |
 
-The `sonic-finetune` stage uses the first-party SONIC image. The retargeting
-stage uses the CPU preprocess image and does not request accelerators. MJLab
-uses the generic helper image that contains the `npa` CLI and this repository's
-Workbench package.
+The reference's `checkpoint_uri` points inside the training output. A real
+fine-tune needs a valid starting checkpoint, and MJLab must consume the resulting
+compatible checkpoint. Set those inputs per stage in the prepared spec, for
+example with state `params` overlays. Verify the trainer's real output path;
+`checkpoint.json` is a manifest, not policy weights.
 
-## CLI Submission
+Retargeting writes `retargeting_result.json` and motion artifacts. Raw BVH
+conversion produces SOMA skeleton PKLs; upstream SONIC does not bundle the
+external SOMA/GMR step needed to convert those into G1 motion-library data.
+A successful conversion does not establish trainer compatibility.
 
-Bootstrap the pinned SkyPilot environment, then submit the YAML. The SONIC
-materializer resolves the first-party SONIC image from the manifest and fills
-literal S3 values before SkyPilot sees the YAML:
+## Submit the prepared workflow
 
-```bash
-npa skypilot bootstrap
-export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+Validate and plan the final copy with your actual overrides, then follow the
+[workflow submission sequence](../npa-workflow-guide.md#quick-start), including
+model access, GPU discovery, and exact-image checks. Use the same project,
+cluster, bucket, and run ID throughout. Public images need no custom registry.
 
-npa workbench workflow submit \
-  workflows/testing/sonic-locomotion-finetuning.yaml \
-  --run-id sonic-locomotion-<run-id> \
-  --registry <your-registry>/<namespace> \
-  --npa-image <your-registry>/<namespace>/npa:<tag> \
-  --gpu-target l40s \
-  --s3-endpoint https://storage.eu-north1.nebius.cloud \
-  --s3-bucket <bucket> \
-  --s3-prefix sonic-locomotion/<run-id> \
-  --secret-env AWS_ACCESS_KEY_ID \
-  --secret-env AWS_SECRET_ACCESS_KEY
-```
+Use the generic workflow command for this spec. SONIC's legacy raw-YAML
+materializer, uppercase `SONIC_*` environment overrides, and direct
+`sky jobs launch` examples belong to a different format.
 
-Use the Kubernetes controller backend unless you explicitly need the Nebius VM
-fallback:
+## Verify outputs
 
-```bash
-npa workbench workflow submit \
-  workflows/testing/sonic-locomotion-finetuning.yaml \
-  --run-id sonic-locomotion-<run-id> \
-  --controller-backend kubernetes
-```
+Inspect each stage's artifacts and the actual checkpoint consumed by MJLab:
 
-For RTX PRO 6000 Kubernetes targets, use:
+- Retargeting: `retargeting_result.json` and compatible motion files.
+- Training: weights plus the summary and checkpoint manifest.
+- MJLab: `mjlab_eval.json`, including the backend and measured metrics.
 
-```bash
---gpu-target gpu-rtx6000 \
---accelerators RTXPRO-6000-BLACKWELL-SERVER-EDITION:1
-```
-
-This resolves the SONIC stage to the active CUDA 13 runtime-fetch tag recorded
-in `sonic_image_manifest.json`. The old baked L40S and inherited MuJoCo images
-are quarantined and rejected; an EULA flag cannot make their baked bytes redistributable.
-
-For Kubernetes targets that pull private images, pass a SkyPilot config with the
-namespace's registry pull secret:
-
-```yaml
-kubernetes:
-  pod_config:
-    spec:
-      imagePullSecrets:
-        - name: <registry-pull-secret>
-```
-
-Use that file with `--config-path`. Only add `serviceAccountName` when the
-service account has the Kubernetes node and pod discovery permissions required
-by SkyPilot.
-
-## SDK Submission
-
-```python
-from pathlib import Path
-from npa.sdk.workbench import sonic
-
-sonic.submit_workflow(
-    Path("workflows/testing/sonic-locomotion-finetuning.yaml"),
-    run_id="sonic-locomotion-run",
-    registry="<your-registry>/<namespace>",
-    npa_image="<your-registry>/<namespace>/npa:<tag>",
-    gpu_target="l40s",
-    s3_endpoint="https://storage.eu-north1.nebius.cloud",
-    s3_bucket="<bucket>",
-    s3_prefix="sonic-locomotion/sonic-locomotion-run",
-    secret_envs=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
-)
-```
-
-## Stage Contract
-
-The retargeting stage writes:
-
-```text
-s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/**/*.pkl
-s3://<your-bucket-name>/sonic-locomotion/<run-id>/retargeted/retargeting_result.json
-```
-
-The `.pkl` files are real SONIC motion-lib artifacts with fields such as
-`root_trans_offset`, `pose_aa`, `dof`, `root_rot`, and `fps`. The metadata JSON
-is only a sidecar. For raw `bvh` inputs, the stage writes SOMA skeleton PKLs;
-upstream SONIC does not bundle the external SOMA Retargeter/GMR step required
-to turn raw BVH into G1 robot motion-lib data.
-
-The SONIC stage writes training artifacts under:
-
-```text
-s3://<your-bucket-name>/sonic-locomotion/<run-id>/training/
-```
-
-Expected SONIC smoke artifacts are:
-
-- `sonic_smoke_result.json`
-- `sonic_train_summary.json`
-- `checkpoint_smoke.json`
-
-The MJLab stage writes:
-
-```text
-s3://<your-bucket-name>/sonic-locomotion/<run-id>/mjlab/mjlab_eval.json
-```
-
-## Resources
-
-Retargeting is CPU-only. The first-party SONIC stage must use RTX PRO 6000
-Kubernetes with the active host-mounted image from the SONIC image manifest.
-The old L40S baked image and the combined H100/H200 MuJoCo image are quarantined;
-MJLab evaluation remains a separate H100 stage.
-
-```yaml
-resources:
-  cloud: kubernetes
-  accelerators: RTXPRO-6000-BLACKWELL-SERVER-EDITION:1
-```
-
-Keep the accelerator and image tag together using `sonic-k8s-host-mounted` from
-`docs/workbench/sonic-image-catalog.md`.
-
-## Dry Validation
-
-The tool CLIs support `NPA_DRY_RUN=1`, which validates inputs and returns the
-artifact schema without writing outputs:
-
-```bash
-NPA_DRY_RUN=1 npa workbench sonic retargeting run \
-  --input-path s3://bucket/motions/source/ \
-  --output-path s3://bucket/sonic-locomotion/run-1/retargeted/ \
-  --source-format bones-seed-csv \
-  --frame-rate 30 \
-  --source-frame-rate 120 \
-  --output json
-
-NPA_DRY_RUN=1 npa workbench mjlab eval \
-  --input-path s3://bucket/sonic-locomotion/run-1/retargeted/ \
-  --checkpoint s3://bucket/sonic-locomotion/run-1/training/checkpoint_smoke.json \
-  --output-path s3://bucket/sonic-locomotion/run-1/mjlab/ \
-  --output json
-```
+Import checks or smoke manifests alone do not establish policy learning.
+For a single training stage, use the [training runbook](sonic-train-runbook.md).
+For ONNX export/evaluation, use the [export runbook](sonic-eval-runbook.md).
+Finish with [teardown](../../teardown.md) for owned resources.

--- a/docs/workbench/cookbooks/sonic-mvp-g1-mujoco.md
+++ b/docs/workbench/cookbooks/sonic-mvp-g1-mujoco.md
@@ -1,140 +1,44 @@
-# SONIC G1 MuJoCo Image Status
+# SONIC G1 MuJoCo image status
 
-The historical `sonic-mujoco-h100-mvp` / `npa-sonic-mujoco:0.1.3-mvp`
-variant is quarantined. It inherits `npa-sonic:0.1.2`, whose built bytes include
-an old `nvcr.io/nvidia/isaac-lab` base and baked NVIDIA driver libraries.
+[Cookbooks](README.md) · [SONIC images](../sonic-image-catalog.md) · [G1 guide](../guides/g1-humanoid-walk-sonic.md)
 
-Do not submit, mirror, or publish that variant. The resolver intentionally
-rejects `h100`, `h200`, `mujoco`, and the explicit legacy variant ID. Supplying
-credentials or EULA acceptance at runtime cannot change the licensing of bytes
-already baked into the image.
+The active public `sonic-mujoco-runtime-fetch` image evaluates a Unitree G1
+checkpoint in headless MuJoCo. The old combined
+`sonic-mujoco-h100-mvp` / `npa-sonic-mujoco:0.1.3-mvp` image is quarantined;
+its historical H100 fine-tune-and-evaluate instructions no longer apply.
 
-A replacement candidate now exists. It:
+## Supported capability
 
-1. Builds independently from pinned Apache-2.0 SONIC source on a digest-pinned
-   official Python base, without NVIDIA Isaac or driver payloads.
-2. Adds a hash-locked MuJoCo/PyTorch closure and only redistributable EGL/GL
-   libraries. CUDA Toolkit runtime objects retain their upstream SDK terms.
-3. Enforces the built-byte Omniverse payload scan, source/lock verification,
-   no-weight, no-baked-consent, and Isaac runtime-fetch refusal checks.
-4. Remains a rejected candidate until an immutable public development digest is
-   recorded with real GPU rollout evidence; only then may its status become
-   `active`.
+The [image manifest](../../../npa/src/npa/deploy/sonic_image_manifest.json)
+records the active tag, immutable digest, supported GPUs, and `mujoco-eval`
+workload. The replacement is built independently from the quarantined image
+and advertises evaluation only. It is not a training image.
 
-The actor policy observation terms are state/proprioceptive:
+The evaluator reads a checkpoint through `SONIC_EVAL_CHECKPOINT_PATH` using
+the container's `mujoco-eval` entrypoint. The released warm-start checkpoint is
+`nvidia/GEAR-SONIC:sonic_release/last.pt`. ONNX evaluation through
+`npa workbench sonic eval --backend container` has a different ONNX/metadata
+contract and requests the Isaac-render workload; changing its container argument
+to `mujoco-eval` does not convert those inputs.
 
-- `gravity_dir`
-- `base_ang_vel`
-- `joint_pos`
-- `joint_vel`
-- `actions`
+## Recorded validation
 
-Camera and render paths are optional. The base env has `render_results: false`,
-and `train_agent_trl.py` only enables cameras when `enable_cameras`,
-`render_results`, `render_ego`, or `overview_camera` is true. The H100 proof
-therefore uses headless state-based training; RT-core rendering is not required.
-The public evaluator does not bake upstream Git-LFS mesh objects. If those paths
-are pointers, it substitutes primitive collision proxies while retaining the G1
-joint, actuator, mass, and inertia model, and reports that geometry mode in the
-metrics. This validates the checkpoint-to-dynamics path, not mesh fidelity.
+The manifest records real B200 acceptance: **64 finite simulation steps, zero
+falls, and verified metrics**. The public checkout omits Git-LFS assets. When
+mesh paths are pointers, the evaluator uses primitive collision proxies while
+retaining the G1 joints, actuators, masses, and inertias. Metrics record
+`geometry_mode=primitive-proxy-no-lfs-payload`.
 
-Combined-image feasibility is positive because `gear_sonic` pins
-`numpy==1.26.4` and `gear_sonic[sim]` depends on `mujoco` without forcing
-NumPy 2.x. Do not install `decoupled_wbc/sim2mujoco/requirements.txt` for this
-image; that file pins `numpy==2.2.6`.
+This establishes the measured checkpoint-to-dynamics path. It does not prove
+mesh fidelity, long-horizon walking, or fine-tuning convergence.
 
-The warm-start checkpoint is `nvidia/GEAR-SONIC:sonic_release/last.pt`, which
-the upstream downloader saves as `sonic_release/last.pt`.
+## Training and workflow composition
 
-## Images
+[`sonic-locomotion-finetuning.yaml`](../../../workflows/testing/sonic-locomotion-finetuning.yaml)
+is an `npa.workflow/v0.0.1` spec with **retarget → train → MJLab** stages.
+It is not the old raw SkyPilot fine-tune/MuJoCo template. Follow the
+[locomotion runbook](sonic-locomotion-finetuning.md) for its input and resource
+preparation, or the [training runbook](sonic-train-runbook.md) for a single stage.
 
-The quarantined historical runtime is:
-
-```text
-npa-sonic-mujoco:0.1.3-mvp
-```
-
-The replacement is `sonic-mujoco-runtime-fetch`, built independently by
-`Dockerfile.mujoco` on the digest-pinned public Python base. Release resolution
-is bound to the exact digest that passed payload gates and real B200 MuJoCo
-GPU acceptance; it never falls back to the quarantined historical digest.
-
-Build locally for inspection; official pushes use only the guarded immutable
-public development workflow:
-
-```bash
-npa/docker/workbench/sonic/build.sh \
-  --variant mujoco \
-  --tag local-audit
-```
-
-## Raw YAML
-
-The raw SkyPilot workflow is:
-
-```text
-workflows/testing/sonic-locomotion-finetuning.yaml
-```
-
-It has two stages:
-
-- `sonic-g1-finetune`: real SONIC training with `SONIC_RUN_REAL_TRAIN=1`,
-  `SONIC_TRAIN_MODE=finetune`, `+checkpoint=sonic_release/last.pt`, and tiny
-  configurable proof defaults.
-- `sonic-mujoco-eval`: downloads
-  `training/checkpoints/last.pt`, runs a real MuJoCo rollout, and writes
-  `mujoco_eval_metrics.json`, `gpu_device.json`, and `image_pull_proof.json`.
-
-## CLI Submit
-
-Use H100 spot in `eu-north1`; `me-west1` is rejected by the materializer.
-For the proven VM path, use docker-payload mode plus registry auth:
-
-```bash
-npa workbench workflow submit \
-  workflows/testing/sonic-locomotion-finetuning.yaml \
-  --tool sonic \
-  --run-id sonic-mvp-$(date -u +%Y%m%dT%H%M%SZ) \
-  --registry <your-registry>/<namespace> \
-  --gpu-target h100 \
-  --region eu-north1 \
-  --use-spot \
-  --require-controller-up \
-  --s3-endpoint https://storage.eu-north1.nebius.cloud \
-  --s3-bucket <bucket> \
-  --s3-prefix sonic-mvp-proof/<run-id> \
-  --var SONIC_PAYLOAD_MODE=docker \
-  --secret-env AWS_ACCESS_KEY_ID \
-  --secret-env AWS_SECRET_ACCESS_KEY
-```
-
-Set `--gpu-target h200` only as a capacity fallback for the same headless
-workload.
-
-## SDK
-
-```python
-from pathlib import Path
-
-from npa.sdk.workbench import sonic
-
-plan = sonic.materialize_workflow(
-    Path("workflows/testing/sonic-locomotion-finetuning.yaml"),
-    run_id="sonic-mvp-proof",
-    registry="<your-registry>/<namespace>",
-    gpu_target="h100",
-    region="eu-north1",
-    use_spot=True,
-    s3_endpoint="https://storage.eu-north1.nebius.cloud",
-    s3_bucket="<bucket>",
-    s3_prefix="sonic-mvp-proof/sonic-mvp-proof",
-    env_overrides={
-        "SONIC_PAYLOAD_MODE": "docker",
-        "SONIC_MAX_ITERATIONS": "1",
-        "SONIC_MUJOCO_STEPS": "64",
-    },
-)
-```
-
-`sonic.submit_workflow(...)` accepts the same parameters plus
-`require_controller_up=True`.
+For packaging and publication, use the [SONIC image catalog](../sonic-image-catalog.md#build-and-publication-commands).
+A runtime EULA flag does not change the redistribution status of existing bytes.

--- a/docs/workbench/cookbooks/sonic-train-runbook.md
+++ b/docs/workbench/cookbooks/sonic-train-runbook.md
@@ -1,199 +1,70 @@
-# SONIC Train Runbook
+# SONIC training runbook
 
-This runbook covers the `npa workbench sonic train --runtime serverless` path
-for Isaac Lab-based SONIC training and smoke validation.
+[Cookbooks](README.md) · [SONIC images](../sonic-image-catalog.md)
 
-## Purpose
+Run Isaac-backed SONIC training on RTX PRO 6000 Kubernetes using the active
+`sonic-k8s-host-mounted` image. It requires NVIDIA GPU Operator driver mounts
+and acquires Isaac dependencies at runtime. Complete
+[Workbench setup](../getting-started.md) and the
+[runtime cache setup](../model-weight-cache.md) first.
 
-The serverless train command submits a Nebius Serverless Job using the active
-runtime-fetch SONIC image. The job validates that Isaac Lab and SONIC are
-available in the same container, writes `sonic_smoke_result.json`, and uploads
-artifacts to the requested S3 prefix.
+## Prepare the spec
 
-The image contains no Isaac or NVIDIA driver userspace. It defaults the run-scoped
-Isaac route to `ACCEPT_EULA=Y` (with `--no-accept-eula` as an explicit opt-out),
-then acquires pinned Isaac dependencies and uses
-`gear_sonic` from `NVlabs/GR00T-WholeBodyControl`. The default build
-skips optional C++ deploy compilation; use `BUILD_SONIC_DEPLOY=1` only when
-validating the TensorRT/ONNX Runtime deploy path.
-
-Full SONIC training on BONES-SEED is a large multi-GPU workload. The Workbench
-smoke target is intentionally minimal: it validates environment integration and
-the training entry path, not convergence.
-
-## Minimal Smoke
-
-```bash
-SMOKE_TS=$(date -u +%Y%m%dT%H%M%SZ)
-npa workbench sonic -p eu-north1 -n w7sonic train \
-  --runtime serverless \
-  --project-id <YOUR_PROJECT_ID> \
-  --gpu-type rtx6000 \
-  --gpu-count 1 \
-  --embodiment unitree-g1 \
-  --steps 10 \
-  --output-path s3://${NPA_S3_BUCKET}/w7sonic-smoke/$SMOKE_TS/ \
-  --job-name sonic-smoke-$SMOKE_TS \
-  --timeout 3600 \
-  --poll-interval 15
-```
-
-When validating an unpromoted operator build, pass the pushed image explicitly:
-
-```bash
---image "<your-registry>/<namespace>/npa-sonic:cuda13-b300-0.1.2-k8s-runtime-sm80-sm90-sm100-sm103-sm120-20260803T034152Z"
-```
-
-## Standalone SkyPilot YAML
-
-The raw SkyPilot training smoke is
-`workflows/testing/sonic-train.yaml`. It has literal
-editable defaults because SkyPilot 0.12.2 does not interpolate `${VAR}` inside
-`envs` or `resources.image_id`.
-
-For a zero-NPA raw SkyPilot run, copy the YAML, replace these literals, and
-launch it directly:
-
-| YAML field | L40S value | RTX PRO 6000 Kubernetes value |
-| --- | --- | --- |
-| `resources.image_id` and `POLICY_IMAGE` | `<your-registry>/<namespace>/npa-sonic:0.1.2` | `<your-registry>/<namespace>/npa-sonic:0.1.2-k8s-runtime` |
-| `SONIC_GPU_TYPE` | `l40s` | `gpu-rtx6000` |
-| `SONIC_IMAGE_VARIANT` | `sonic-l40s-baked` | `sonic-k8s-host-mounted` |
-| `S3_ENDPOINT_URL` | your S3-compatible endpoint | your S3-compatible endpoint |
-| `S3_BUCKET` / `SONIC_OUTPUT_PREFIX` | your artifact destination | your artifact destination |
+The checked-in training spec uses `sonic_runtime: local`: the trainer runs inside
+the GPU task's container. Its H100 resource default does **not** match the active
+first-party training image. Make an operator copy:
 
 ```bash
 cp workflows/testing/sonic-train.yaml /tmp/sonic-train.yaml
-# Edit /tmp/sonic-train.yaml with concrete image and S3 values.
-sky jobs launch \
-  --name sonic-train-smoke \
-  --secret AWS_ACCESS_KEY_ID \
-  --secret AWS_SECRET_ACCESS_KEY \
-  --yes \
-  /tmp/sonic-train.yaml
 ```
 
-The same YAML can be submitted through the CLI, which materializes the image and
-S3 values before SkyPilot submission:
+In that copy, set `resources.gpu.accelerators` to the compatible RTX PRO 6000
+name reported by `npa workbench workflow gpus`. Retain the CPU and memory
+requirements and configure the required host driver/cache mounts. Use the
+[image catalog](../sonic-image-catalog.md) and [GPU driver guide](../mk8s-gpu-driver-strategy.md)
+for the exact runtime contract.
+
+Set these `config` values for your run, either in the copy or through `--var`:
+
+| Key | Meaning |
+| --- | --- |
+| `bucket` | Your writable project bucket |
+| `data_uri` | Compatible SONIC motion data in S3 |
+| `checkpoint_uri` | The selected starting checkpoint |
+| `training_uri` | A new output prefix for this run |
+| `train_iterations` | Training iterations requested by this spec |
+
+Then validate and plan:
 
 ```bash
-npa workbench workflow submit \
-  workflows/testing/sonic-train.yaml \
-  --run-id sonic-train-smoke \
-  --gpu-target l40s \
-  --s3-endpoint https://storage.eu-north1.nebius.cloud \
-  --s3-bucket <bucket> \
-  --s3-prefix sonic-train/sonic-train-smoke \
-  --secret-env AWS_ACCESS_KEY_ID \
-  --secret-env AWS_SECRET_ACCESS_KEY
+npa workbench workflow validate-spec /tmp/sonic-train.yaml
+npa workbench workflow plan-spec /tmp/sonic-train.yaml --run-id <run-id> --json
 ```
 
-For Kubernetes targets that pull from a private registry, pass a SkyPilot config
-with the namespace's registry pull secret:
+Inspect the resolved data, checkpoint, output, and GPU profile. The plan is not
+proof that the training runtime or inputs are usable.
 
-```yaml
-kubernetes:
-  pod_config:
-    spec:
-      imagePullSecrets:
-        - name: <registry-pull-secret>
-```
+## Submit and inspect
 
-Then add `--config-path /path/to/skypilot-kubernetes.yaml` to the submit command.
-Do not set `serviceAccountName` unless that account can also list Kubernetes
-nodes and pods for SkyPilot prechecks.
+Follow the [workflow submission sequence](../npa-workflow-guide.md#quick-start)
+with your prepared spec and the same project, cluster, and run ID. Run the
+SONIC-specific model-access and image checks before submission. Public images
+need no private registry override. Isaac execution defaults to acceptance;
+`--no-accept-eula` refuses the runtime fetch.
 
-When `SONIC_PAYLOAD_MODE=docker`, the default `SONIC_DOCKER_GPU_REQUEST=all`
-uses Docker's legacy `--gpus all` path. On Kubernetes sidecars where the NVIDIA
-runtime is configured for CDI, set
-`SONIC_DOCKER_GPU_REQUEST: nvidia.com/gpu=all` and ensure the SkyPilot runtime
-has `nvidia-ctk` from `nvidia-container-toolkit`. The workflow generates
-`/etc/cdi/nvidia.yaml` immediately before `docker run`, then starts the payload
-with `--runtime=nvidia`, `NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all`, and
-`NVIDIA_DRIVER_CAPABILITIES=all`. If the sidecar is unprivileged or lacks Docker
-and `nvidia-ctk`, use the direct Kubernetes host-mounted SONIC image path rather
-than the nested Docker payload.
+Inspect checkpoint weights and the training summary after completion.
+`checkpoint.json`, `checkpoint_smoke.json`, or a successful import alone does
+not establish a learned policy. Evaluate the checkpoint against the intended
+task; runtime success and policy quality are separate outcomes.
 
-SDK equivalent:
+## Serverless limitation
 
-```python
-from pathlib import Path
-from npa.sdk.workbench import sonic
+There is no built-in compute-only training image for the default serverless
+L40S/H100/H200 path. The historical baked variants are quarantined. Serverless
+training requires an independently validated compute-only `--image`; the active
+Kubernetes image cannot substitute because it requires host driver mounts.
+The public MuJoCo image serves evaluation only.
 
-sonic.submit_workflow(
-    Path("workflows/testing/sonic-train.yaml"),
-    run_id="sonic-train-smoke",
-    gpu_target="l40s",
-    s3_endpoint="https://storage.eu-north1.nebius.cloud",
-    s3_bucket="<bucket>",
-    s3_prefix="sonic-train/sonic-train-smoke",
-    secret_envs=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
-)
-```
-
-Use the exact supported host-mounted image from the manifest for RTX PRO 6000
-Blackwell on Kubernetes with the NVIDIA GPU Operator:
-
-```bash
-docker manifest inspect \
-  "ghcr.io/nebius/nebius-physical-ai/npa-sonic:cuda13-b300-0.1.2-k8s-runtime-sm80-sm90-sm100-sm103-sm120-20260803T034152Z"
-```
-
-The L40S baked variant is quarantined and must not be rebuilt or pushed as an
-NPA-owned public image. Compute-only deployments require an independently
-licensed, operator-built and validated BYOF image.
-
-Expected output artifacts:
-
-- `sonic_smoke_result.json`
-- `sonic_train_summary.json`
-- `checkpoint_smoke.json`
-
-## GPU Selection
-
-Prefer RT-core GPUs because Isaac Lab simulation workloads use rendering and
-physics paths that are best validated on RT-capable hardware:
-
-- `l40s`
-- `gpu-rtx-pro-6000`
-
-H100/H200/B200/B300 may be useful for model training throughput, but they are not
-the preferred smoke target for Isaac Lab simulation validation.
-
-The image compatibility catalog is `docs/workbench/sonic-image-catalog.md`; the
-runtime resolver reads `npa/src/npa/deploy/sonic_image_manifest.json`.
-
-## Parameters
-
-- `--embodiment`: defaults to `unitree-g1`, mapped to `UNITREE_G1_SONIC`.
-- `--checkpoint`: defaults to `nvidia/GEAR-SONIC:sonic_release/last.pt`.
-- `--data-path`: optional path or URI for training data.
-- `--sample-data`: explicitly uses the SONIC sample data path.
-- `--steps` / `--max-iterations`: minimal smoke iteration count.
-- `--output-path`: required S3 prefix for serverless artifacts.
-- `--submit-only`: submit and return without polling.
-
-If `--data-path` is omitted, the command treats the run as a sample-data smoke.
-
-## Failure Classification
-
-- `PASS`: serverless Job succeeds and S3 artifacts are present.
-- `FAIL_TRAINING`: the job starts but SONIC or Isaac Lab fails.
-- `FAIL_PLATFORM`: image pull, subnet, auth, or scheduler failure before SONIC
-  code runs.
-- `FAIL_NER`: capacity or quota blocks scheduling.
-
-Do not fall back to `npa-sonic:0.1.2`: it is quarantined because its built bytes
-inherit restricted NVIDIA content and baked driver libraries.
-
-## Known Limitations
-
-- GR00T+SONIC orchestration is not part of this runbook.
-- Additional embodiments beyond Unitree G1 are exposed as tags but not
-  qualified by Workbench smoke.
-- NIM distribution was not confirmed in discovery; the supported path is
-  Hugging Face plus the upstream SONIC repository.
-- W7 build-fix local validation passed for build, imports, and entrypoint smoke.
-  The first pushed-image L40S smoke reached Nebius Job `ERROR` before
-  `started_at` and produced no container logs, so that result is classified as
-  `FAIL_PLATFORM`, not a SONIC runtime failure.
+For retargeting and downstream evaluation, see the
+[locomotion workflow](sonic-locomotion-finetuning.md). Finish with
+[owned-resource teardown](../../teardown.md).

--- a/docs/workbench/cookbooks/sonic-train-runbook.md
+++ b/docs/workbench/cookbooks/sonic-train-runbook.md
@@ -38,7 +38,7 @@ Then validate and plan:
 
 ```bash
 npa workbench workflow validate-spec /tmp/sonic-train.yaml
-npa workbench workflow plan-spec /tmp/sonic-train.yaml --run-id <run-id> --json
+npa workbench workflow plan-spec /tmp/sonic-train.yaml --run-id "<run-id>" --json
 ```
 
 Inspect the resolved data, checkpoint, output, and GPU profile. The plan is not

--- a/docs/workbench/cookbooks/sonic-whole-body-control.md
+++ b/docs/workbench/cookbooks/sonic-whole-body-control.md
@@ -1,5 +1,7 @@
 # SONIC Whole-Body Control
 
+[Cookbooks](README.md)
+
 SONIC / GEAR-SONIC is NVIDIA GEAR's humanoid whole-body-control stack. It is a
 standalone Workbench tool for low-level motor control, motion tracking,
 teleoperation, sim2sim validation, and deployment of full-body humanoid

--- a/docs/workbench/cookbooks/sonic-whole-body-control.md
+++ b/docs/workbench/cookbooks/sonic-whole-body-control.md
@@ -51,7 +51,7 @@ Kubernetes with GPU Operator driver mounts:
 
 ```bash
 npa workbench sonic train --runtime serverless --embodiment unitree-g1 \
-  --image <validated-compute-only-image>
+  --image "<validated-compute-only-image>"
 ```
 
 Internally this maps to the SONIC embodiment tag `UNITREE_G1_SONIC`.

--- a/docs/workbench/cookbooks/tokenfactory-compute-combos.md
+++ b/docs/workbench/cookbooks/tokenfactory-compute-combos.md
@@ -1,5 +1,7 @@
 # Token Factory with Nebius GPU workloads
 
+[Cookbooks](README.md)
+
 These workflows train or roll out a policy on Nebius GPUs, then use hosted
 Token Factory inference to interpret the resulting artifacts. Start with the
 [composition guide](../composing-cloud-and-token-factory.md) for credentials,

--- a/docs/workbench/cookbooks/vlm-eval-loop-runbook.md
+++ b/docs/workbench/cookbooks/vlm-eval-loop-runbook.md
@@ -1,5 +1,7 @@
 # VLM-Eval Loop Runbook
 
+[Cookbooks](README.md)
+
 This runbook runs the sim-to-real VLM-eval loop on the self-hosted serving path:
 serve a VLM with vLLM, score rollout directories with `vlm-eval`, and write a
 task-success report.

--- a/docs/workbench/cookbooks/workbench-parity-tools.md
+++ b/docs/workbench/cookbooks/workbench-parity-tools.md
@@ -1,5 +1,7 @@
 # Cookbook: scenario-gen and dataset-of-record live smokes
 
+[Cookbooks](README.md)
+
 Two CPU-only smoke workflows that exercise the `scenario_gen` and `dataset`
 workbench tools end-to-end against real S3, with no GPU and no LanceDB/FiftyOne
 dependency. Use them to validate the tools on a configured environment before

--- a/docs/workbench/cookbooks/workbench-parity-tools.md
+++ b/docs/workbench/cookbooks/workbench-parity-tools.md
@@ -38,7 +38,7 @@ Artifacts pass over S3.
 default backend synthesizes deterministic adversarial scenarios.
 
 ```bash
-BUCKET=<your-bucket>
+BUCKET="<your-bucket>"
 RUN_ID="scenario-gen-smoke-$(date +%Y%m%d%H%M%S)"
 SPEC=/tmp/${RUN_ID}.yaml
 sed "s/example-bucket/${BUCKET}/g" \
@@ -65,7 +65,7 @@ writes a decision to S3 that the interpreter branches on (`config.quality_gate`
 >= 0.5 promotes). Requires a small raw fixture on S3.
 
 ```bash
-BUCKET=<your-bucket>
+BUCKET="<your-bucket>"
 RUN_ID="dataset-smoke-$(date +%Y%m%d%H%M%S)"
 
 cat > /tmp/records.json <<'JSON'
@@ -162,7 +162,7 @@ timeline, severity bar chart, severity-vs-diversity scatter, perturbation
 heatmap). View it with npa:
 
 ```bash
-npa rerun host s3://<bucket>/scenario-gen-smoke/<run-id>/adversarial/scenarios.rrd
+npa rerun host "s3://<bucket>/scenario-gen-smoke/<run-id>/adversarial/scenarios.rrd"
 # -> prints an app.rerun.io URL; or open the .rrd in the Rerun viewer
 ```
 
@@ -178,7 +178,7 @@ which gives every run its own **git worktree + venv + tmux session**:
 
 ```bash
 # create an isolated workspace for a branch
-npa/scripts/dev_vm_isolated_session.sh start cursor/<branch>-02d7 gpu-run-1
+npa/scripts/dev_vm_isolated_session.sh start "cursor/<branch>-02d7" gpu-run-1
 # run npa inside it (never touches the shared checkout)
 npa/scripts/dev_vm_isolated_session.sh exec gpu-run-1 \
   'npa workbench workflow submit <spec>.yaml --run-id gpu-run-1 --deploy-if-absent ...'

--- a/docs/workbench/cosmos2-transfer-20260803-release-audit.md
+++ b/docs/workbench/cosmos2-transfer-20260803-release-audit.md
@@ -1,5 +1,7 @@
 # Cosmos Transfer 2.5 release audit — 2026-08-03
 
+[Workbench docs](README.md)
+
 > **Historical release only — not a current SkyPilot bootstrap attestation.**
 > The exact index below predates `skypilot-0.12.2-v1`; its linux/amd64 OCI
 > config does not carry

--- a/docs/workbench/cosmos3-access-preflight.md
+++ b/docs/workbench/cosmos3-access-preflight.md
@@ -1,5 +1,7 @@
 # Cosmos 3 access preflight: accounts, tokens, and gated-repo diagnostics
 
+[Workbench docs](README.md)
+
 Clearing gated Hugging Face access is the most common reason a Cosmos 3
 generation run fails before it produces anything. This page is the full
 checklist: create the account, scope the token, accept the right license for

--- a/docs/workbench/cosmos3-b200-checkpoint-evaluation-20260814.md
+++ b/docs/workbench/cosmos3-b200-checkpoint-evaluation-20260814.md
@@ -198,7 +198,7 @@ npa workbench workflow validate-spec \
   workflows/testing/cosmos3-checkpoint-eval.yaml
 npa workbench workflow plan-spec \
   workflows/testing/cosmos3-checkpoint-eval.yaml \
-  --run-id <run-id>
+  --run-id "<run-id>"
 npa workbench workflow submit \
   workflows/testing/cosmos3-checkpoint-eval.yaml \
   --image "${NPA_COSMOS3_DIGEST_REF}" \

--- a/docs/workbench/cosmos3-b200-checkpoint-evaluation-20260814.md
+++ b/docs/workbench/cosmos3-b200-checkpoint-evaluation-20260814.md
@@ -1,5 +1,7 @@
 # Cosmos3 B200 checkpoint evaluation — 2026-08-14
 
+[Workbench docs](README.md)
+
 Status: **complete**. The campaign generated and reviewed 72 still images on one
 reserved-capacity NVIDIA B200 in Nebius: 40 images in the five
 checkpoint primary matrix and 32 new images for the two-checkpoint consistency

--- a/docs/workbench/cosmos3-generate.md
+++ b/docs/workbench/cosmos3-generate.md
@@ -1,5 +1,7 @@
 # Cosmos 3 generation on the workbench (`npa-cosmos3`)
 
+[Workbench docs](README.md)
+
 Cosmos 3 is NVIDIA's omni model: one checkpoint that both reasons and generates.
 This guide covers the **generation** half as a containerized workbench tool —
 image and video synthesis for Physical AI data — through the CLI, the SDK, and a

--- a/docs/workbench/cosmos3-generate.md
+++ b/docs/workbench/cosmos3-generate.md
@@ -86,13 +86,13 @@ and published only from the reviewed trusted commit.
 
 ```bash
 # Defaults to the pinned framework commit and the supported-tools tag.
-bash npa/docker/workbench/cosmos3/build.sh --registry <your-registry>
+bash npa/docker/workbench/cosmos3/build.sh --registry "<your-registry>"
 
 # Push it so the workflow's NPA_COSMOS3_IMAGE can resolve.
-bash npa/docker/workbench/cosmos3/build.sh --registry <your-registry> --push
+bash npa/docker/workbench/cosmos3/build.sh --registry "<your-registry>" --push
 
 # Pin a different upstream commit (re-validates at build time).
-bash npa/docker/workbench/cosmos3/build.sh --ref <40-char-sha>
+bash npa/docker/workbench/cosmos3/build.sh --ref "<40-char-sha>"
 ```
 
 The build runs `verify_env.py`, which walks the inference graph for every mode
@@ -123,7 +123,7 @@ model). It breaks down as:
 npa workbench cosmos3 generate \
   --mode text2image \
   --prompt "a robot arm sorting colored blocks on a white workbench" \
-  --output-path s3://<bucket>/cosmos3/<run-id>/ \
+  --output-path "s3://<bucket>/cosmos3/<run-id>/" \
   --checkpoint Cosmos3-Nano \
   --seed 0
 ```
@@ -200,7 +200,7 @@ script renders the same embedded backend + UI the VM bootstrap ships:
 ```bash
 sudo mkdir -p /opt/npa-agent && sudo chown "$(id -u)":"$(id -g)" /opt/npa-agent
 export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_ENDPOINT_URL=...
-export NPA_AGENT_S3_BUCKET=<bucket-holding-the-run>
+export NPA_AGENT_S3_BUCKET="<bucket-holding-the-run>"
 npa/.venv/bin/python npa/scripts/run_agent_local.py     # http://127.0.0.1:8088/
 ```
 

--- a/docs/workbench/cosmos3-ray-serve.md
+++ b/docs/workbench/cosmos3-ray-serve.md
@@ -86,9 +86,9 @@ Run the updated client from an editable installation of this checkout:
 
 ```bash
 npa/.venv/bin/python -m npa workbench cosmos3 ray-batch \
-  --input-path s3://<bucket>/<prefix>/batch.json \
-  --output-path s3://<bucket>/<prefix>/outputs/ \
-  --endpoint http://<service>:8000
+  --input-path "s3://<bucket>/<prefix>/batch.json" \
+  --output-path "s3://<bucket>/<prefix>/outputs/" \
+  --endpoint "http://<service>:8000"
 ```
 
 The submitted samples become concurrent deployment-handle calls; upstream Ray
@@ -145,7 +145,7 @@ with an operator-owned S3 output prefix. Configure the service's
 
 ```bash
 NPA_INTEGRATION_E2E=1 \
-NPA_COSMOS3_RAY_LIVE_OUTPUT_URI=s3://<bucket>/<prefix>/ \
+NPA_COSMOS3_RAY_LIVE_OUTPUT_URI="s3://<bucket>/<prefix>/" \
   npa/.venv/bin/python -m pytest \
   npa/tests/e2e/test_cosmos3_ray_batch_live_e2e.py -q
 ```

--- a/docs/workbench/cosmos3-ray-serve.md
+++ b/docs/workbench/cosmos3-ray-serve.md
@@ -1,5 +1,7 @@
 # Cosmos3-Nano native Ray Serve
 
+[Workbench docs](README.md)
+
 `npa-cosmos3-ray-serve` is the persistent, batch-capable counterpart to the
 single-run `npa workbench cosmos3 generate` path. It loads Cosmos3-Nano once and
 uses NVIDIA cosmos-framework 1.2.2's native `OmniModelDeployment`, including its

--- a/docs/workbench/cosmos3-super-serving.md
+++ b/docs/workbench/cosmos3-super-serving.md
@@ -1,5 +1,7 @@
 # Cosmos3-Super serving on the workbench (`npa-cosmos3-serving`)
 
+[Workbench docs](README.md)
+
 `npa workbench cosmos3 generate` runs Cosmos 3 generation as a batch job: one
 invocation, one artifact, and a full model load every time. For the 64B
 `Cosmos3-Super` checkpoint that load costs minutes, so a synthetic-data

--- a/docs/workbench/cosmos3-super-serving.md
+++ b/docs/workbench/cosmos3-super-serving.md
@@ -114,12 +114,12 @@ release promotion.
 ```bash
 docker run -d --name cosmos3-serving --gpus all --ipc=host --shm-size 32g \
   --ulimit nofile=1048576:1048576 \
-  -v <runtime-dir>:/opt/npa-cosmos3-serving/runtime \
-  -v <hf-cache-dir>:/opt/npa-cosmos3-serving/hf-cache \
+  -v "<runtime-dir>:/opt/npa-cosmos3-serving/runtime" \
+  -v "<hf-cache-dir>:/opt/npa-cosmos3-serving/hf-cache" \
   -e NPA_COSMOS3_ACCEPT_NVIDIA_SOFTWARE_LICENSE=YES \
-  -e HF_TOKEN=<your-token> \
+  -e HF_TOKEN="<your-token>" \
   -p 8000:8000 \
-  ghcr.io/nebius/nebius-physical-ai/npa-cosmos3-serving@sha256:<validated-digest>
+  "ghcr.io/nebius/nebius-physical-ai/npa-cosmos3-serving@sha256:<validated-digest>"
 ```
 
 Both mounted directories must be writable by uid 1000: the image runs as a non-root

--- a/docs/workbench/curobo.md
+++ b/docs/workbench/curobo.md
@@ -18,7 +18,7 @@ S3 destination. The default evaluates both kinematic and 3 kg dynamics
 configurations. B200 and RTX PRO 6000 require separate GPU qualification.
 
 ```bash
-npa workbench workflow submit workflows/testing/curobo-benchmark.yaml --var bucket=<your-bucket>
+npa workbench workflow submit workflows/testing/curobo-benchmark.yaml --var bucket="<your-bucket>"
 ```
 
 All input problems remain in the success denominator, including invalid queries

--- a/docs/workbench/curobo.md
+++ b/docs/workbench/curobo.md
@@ -1,5 +1,7 @@
 # cuRobo V2 motion planning
 
+[Workbench docs](README.md)
+
 The image candidate remains `0.8.0-cuda13-b300-unbuilt` and publication-quarantined
 until built-image checks and real GPU validation pass. Build from committed inputs;
 `build.sh` checks scoped source cleanliness and archives the exact commit for Docker.

--- a/docs/workbench/foxglove-export.md
+++ b/docs/workbench/foxglove-export.md
@@ -124,7 +124,7 @@ CLI callers can convert/export locally with `npa workbench foxglove export-run`
 and build a web-only link for an already indexed recording with:
 
 ```bash
-npa workbench foxglove open --recording-id <recording-id>
+npa workbench foxglove open --recording-id "<recording-id>"
 ```
 
 ## Real Isaac motion qualification

--- a/docs/workbench/foxglove-export.md
+++ b/docs/workbench/foxglove-export.md
@@ -1,5 +1,7 @@
 # Export MCAP and open it in Foxglove Web
 
+[Workbench docs](README.md)
+
 The NPA agent preserves two distinct operations over one canonical artifact:
 
 - **Download MCAP** resolves the active run's canonical S3 recording and downloads

--- a/docs/workbench/getting-started.md
+++ b/docs/workbench/getting-started.md
@@ -92,6 +92,10 @@ npa provision-if-absent --project "$project_alias" \
   --cluster-name "$cluster_name" --dry-run --output-format json
 ```
 
+Inspect `status` and `preflight.decision` in the JSON. A dry run can exit zero
+while reporting `blocked`; resolve its `preflight.reasons` before applying.
+Reserved GPU availability does not provide boot-disk quota.
+
 When its GPU/CPU topology matches the workload, run the same command without
 `--dry-run`. See [Kubernetes setup](kubernetes.md) for operational details.
 

--- a/docs/workbench/getting-started.md
+++ b/docs/workbench/getting-started.md
@@ -1,5 +1,7 @@
 # Workbench Getting Started
 
+[Workbench docs](README.md)
+
 Complete the [platform quickstart](../quickstart.md) through credential setup,
 then use this page to prepare a GPU workflow on Nebius Kubernetes. Run commands
 from the repository root with your environment activated. Keep project settings
@@ -16,7 +18,7 @@ CLI/SDK calls do not require the Kubernetes setup below.
 | [Compositional Sim2Real](guides/sim2real-workflow.md) | The canonical 14-stage spec requests RTX PRO 6000 GPUs, CPU capacity, and an Isaac runtime cache. Follow its full runbook. |
 | [Isaac Lab BYOF](cookbooks/byof-isaac-lab/README.md) | A custom container and RT-core GPU capacity, such as L40S or RTX PRO 6000, as specified by the cookbook. |
 
-H100/H200 do not provide the RT cores needed for Isaac rendering. Read the
+H100/H200 and B200/B300 do not provide the RT cores needed for Isaac rendering. Read the
 chosen workflow's resource profiles before provisioning: model memory, CPU,
 driver, and GPU requirements differ between tools.
 
@@ -142,7 +144,8 @@ npa workbench workflow preflight-images "$workflow_spec" \
   --var "bucket=$bucket_name" --json
 ```
 
-Gate: every selected image passes. Supported NPA images pull anonymously from
+Gate: every selected image passes. This check may create and delete a temporary
+probe pod in the selected cluster. Supported NPA images pull anonymously from
 `ghcr.io/nebius/nebius-physical-ai`. `NPA_REGISTRY` and saved registry settings
 do not repoint those defaults. Use a complete image reference or explicit
 workflow `--registry` only for intentional custom images, with exact-host

--- a/docs/workbench/guides/README.md
+++ b/docs/workbench/guides/README.md
@@ -1,123 +1,74 @@
-# Workbench Guides
+# Choose a Workbench workload
 
-[Workbench docs](../README.md)
+[Workbench docs](../README.md) · [Cookbooks](../cookbooks/README.md) · [Workflow catalog](../../../workflows/README.md)
 
-Choose a robot, generation, reconstruction, or data workflow to run on Nebius.
-Complete the [npa quickstart](../../quickstart.md) first, then follow the chosen
-guide's input, access, and GPU requirements through to its output artifacts.
-
-## Choose a workflow
-
-| I want to… | Guide |
-| --- | --- |
-| Train or evaluate a robot policy | Pick a [robot guide](#robot-and-reconstruction-guides) below |
-| Generate images with Cosmos 3 | [Cosmos 3 generation](../cosmos3-generate.md) |
-| Augment a source video with Cosmos 3 | [PAIDF + Cosmos 3](paidf-cosmos3.md) |
-| Set up and run PAIDF with Cosmos 3 | [PAIDF Cosmos 3 setup and run guide](../../../workflows/guides/paidf-cosmos3.md) |
-| Build a labeled and curated dataset with Cosmos Transfer | [Physical AI Data Factory](physical-ai-data-factory-deploy.md) |
-| Run the compositional simulation-to-policy loop | [Sim2Real workflow](sim2real-workflow.md) |
-
-For an existing YAML spec, browse the
-[workflow catalog](../../../workflows/README.md).
-For hosted captioning, generation, and reasoning stages, see
-[Token Factory](../token-factory.md).
+Choose the result you want, then follow that guide from inputs to inspected
+artifacts. Complete the [quickstart](../../quickstart.md) and
+[GPU runtime setup](../getting-started.md) before a cloud run. A local preview
+checks the declaration; each guide states what its live validation actually proves.
 
 ## Robot and reconstruction guides
 
-Pick a guide for the robot or scene you want to work with. Check its runtime and
-validation scope before running; the recorded backend checks below distinguish
-local checks, smoke runs, and live outcomes.
-
-| Guide | Robot | Sim / engine | Public dataset | GPU |
-| --- | --- | --- | --- | --- |
-| [Pick-and-place with a Franka arm](franka-pick-and-place-genesis.md) | Franka Emika Panda | Genesis | DROID (Franka) | H200 for headless training; see rendering caveat |
-| [Inspect the PushT SDK](pusht-sim-to-real.md) | sim pusher | Structural smoke; training guide linked separately | `lerobot/pusht` | See chosen training path |
-| [Train a Reachy 2 humanoid policy](reachy2-lerobot-policy.md) | Reachy 2 | LeRobot | Pollen Robotics / LeRobot Hub | yes |
-| [Unitree G1 with SONIC](g1-humanoid-walk-sonic.md) | Unitree G1 | SONIC / MuJoCo | NVIDIA GEAR-SONIC checkpoint | RTX PRO 6000 training; B200 MuJoCo evaluation |
-| [Train a quadruped to run](quadruped-isaac-lab.md) | ANYmal / quadruped | Isaac Lab | Isaac Lab built-in tasks | RT-core: L40S / RTX PRO 6000 |
-| [Turn a photo capture into a 3D scene](neural-reconstruction.md) | n/a (scene capture) | NVIDIA NuRec / NRE | `nvidia/PhysicalAI-NuRec-PPISP` | RT-core: RTX PRO 6000 / L40S |
-| [Build a parameterized living-lab digital twin](living-lab-nurec-fanout.md) (default 16-GPU) | n/a (multi-zone scene capture) | NVIDIA NuRec / NRE (16-way default fan-out, parameterizable) | `nvidia/PhysicalAI-NuRec-PPISP` | 16 x RTX PRO 6000 default (8 x 2) |
-
-## Before you start
-
-Complete [installation and project setup](../../quickstart.md), then
-[Workbench setup](../getting-started.md) for GPU workflows. Run commands from
-the clone root with its environment active. Replace placeholders with your
-actual project, inputs, and output prefix; examples that only plan or smoke-test
-are labeled as such.
-
-## Recorded backend checks
-
-These entries record earlier checks against local and live backends. Each result
-applies to the stated runtime and scope; the table does not establish that every
-guide has completed end to end. Consult the selected tool's current guide and
-skill for implementation changes since these checks.
-
-| Path | Backend | Result |
+| Goal | Guide and required input | Compute and result scope |
 | --- | --- | --- |
-| `vlm-eval benchmark/run` (stub) | local, offline | works (`accuracy: 1.0`) |
-| `lerobot train --runtime serverless --smoke` | Nebius AI Job (H200) | works — produced a real ACT checkpoint (`model.safetensors`) in S3 |
-| `genesis train-teacher --runtime serverless` | Nebius AI Job (H100) | works, but is a **smoke** (import check + placeholder checkpoint); real Genesis training is local/VM |
-| `sim_to_real.local_smoke` | local, no cluster | runs the spine; reports `blocked` unless `lerobot` is installed locally |
-| `isaac-lab train --runtime serverless` | Nebius AI Job (`gpu-l40s-a`) | **capacity-blocked** — `NotEnoughResources` / VM schedule timeout |
-| `isaac-lab train --runtime serverless` | Nebius AI Job (`gpu-l40s-d`) | job schedules and completes; minimal run produced no artifact yet (small step budget / `W9-isaac-lab-e2e-fix`) |
-| `lerobot` / `fiftyone` deploy `--preemptible --dry-run` | Nebius Terraform VM path | CLI + dry-run OK; full apply needs IAM bootstrap on your project |
-| Preemptible VM flags and resume | — | [preemptible-vms.md](../preemptible-vms.md) |
+| Train a Franka pick-and-place teacher | [Franka / Genesis](franka-pick-and-place-genesis.md); generated simulation tasks | H200 headless training was exercised; recorded held-out success was 0%. Read the rendering caveat. |
+| Inspect the PushT SDK structure | [PushT smoke](pusht-sim-to-real.md); `lerobot/pusht` reference | Local structural smoke; follow the linked training path for learned weights. |
+| Train a Reachy 2 policy | [Reachy 2 / LeRobot](reachy2-lerobot-policy.md); a dataset with matching observation/action schemas | GPU policy training; validate compatibility before substituting a dataset. |
+| Train or evaluate Unitree G1 locomotion | [G1 / SONIC](g1-humanoid-walk-sonic.md); compatible motion/checkpoint inputs | RTX PRO 6000 training; B200 MuJoCo evaluation is a separate capability. |
+| Train an ANYmal quadruped | [Quadruped / Isaac Lab](quadruped-isaac-lab.md); built-in simulator task | L40S or RTX PRO 6000; Isaac requires RT cores. |
+| Reconstruct a scene capture | [NuRec / NRE](neural-reconstruction.md); compatible NCore capture | RTX PRO 6000 or L40S; inspect USDZ, renders, and Rerun outputs. |
+| Reconstruct several living-lab zones | [Living-lab fan-out](living-lab-nurec-fanout.md); capture inputs per zone | Advanced parameterized workflow; default is 16 RTX PRO 6000 GPUs. |
 
-Isaac Lab needs RT cores, and serverless RT-core capacity varies by SKU: the
-default `gpu-l40s-a` pool failed to schedule, while `gpu-l40s-d` had capacity and
-ran to completion. `gpu-rtx6000` is **not** a serverless platform (use the
-managed-Kubernetes path). For real Isaac Lab training prefer an RT-core VM /
-managed-K8s + BYOF; for a serverless capacity retry use `--gpu-type gpu-l40s-d`.
+For the candidate COLMAP ingestion path, see [NCore conversion](nurec-colmap-reconstruct.md);
+it remains unvalidated end to end. For browser teleoperation measurements, see
+[LeIsaac transport latency](leisaac-transport-latency.md).
 
-These are historical records, not current capacity recommendations. Newer
-[Genesis training evidence](franka-pick-and-place-genesis.md#go-bigger) records
-real serverless PPO training and a held-out quality result. Current SONIC
-capabilities and B200 MuJoCo evidence are in the [image catalog](../sonic-image-catalog.md).
+## Generation and dataset production
+
+| Goal | Start with |
+| --- | --- |
+| Generate images with Cosmos 3 | [Generation guide](../cosmos3-generate.md) and [access preflight](../cosmos3-access-preflight.md) |
+| Augment your source video with Cosmos 3 | [PAIDF + Cosmos 3](paidf-cosmos3.md) and [setup/run procedure](../../../workflows/guides/paidf-cosmos3.md) |
+| Produce a labeled dataset with Cosmos Transfer | [Data Factory deployment](physical-ai-data-factory-deploy.md); its [quickstart](physical-ai-data-factory-deploy.md#quick-start-copy-paste) can seed generated frames |
+| Understand Data Factory stages and artifacts | [Component and S3 mapping](physical-ai-data-factory.md) |
+| Reuse a verified dataset campaign | [Campaign reuse](paidf-campaign-reuse.md) |
+| Caption or reason about existing artifacts | [Token Factory](../token-factory.md) |
+
+<a id="physical-ai-data-factory-video-data-augmentation"></a>
+
+Data Factory composes annotation, Cosmos augmentation, evaluation, curation, and
+Rerun visualization on Nebius + SkyPilot. Select the actual workflow's inputs
+and model access requirements; generation and input-conditioned augmentation
+have different contracts.
+
+## Sim-to-real: the full 14-stage loop
+
+This path needs robot assets, compatible source data, prepared compute, immutable
+images, and storage. Start with the operator runbook, then use the contract pages
+when adapting it:
+
+| Task | Guide |
+| --- | --- |
+| Configure, preflight, submit, and recover | [Sim2Real operator runbook](sim2real-workflow.md) |
+| Prepare formats, schemas, and S3 layout | [Data contracts](sim2real-data-contracts.md) |
+| Supply customer data and robot assets | [Customer assets](sim2real-customer-assets.md) · [RobotSpec](sim2real-robot-spec.md) |
+| Understand stages, loops, and parallel execution | [Architecture](sim2real-architecture.md) |
+| Recover after interruption | [Durable runtime behavior](sim2real-durable-controller.md) |
+| Present a prepared result | [Demonstration script](sim2real-demo-script-10min.md) |
 
 <a id="bring-your-own-everything"></a>
 
 ## Use your own data, policy, or robot
 
-Check the selected tool's contract before substituting inputs:
+Match the selected tool's dataset format, observation/action schema, runtime,
+and output contract. A new robot may also need simulator assets and action
+mappings. Use [BYOF](../cookbooks/byof-isaac-lab/README.md) for an Isaac image or
+training-entrypoint customization, and the [cookbooks](../cookbooks/README.md)
+for other tool-specific recipes.
 
-- Datasets must match the required format and observation/action schemas.
-  LeRobotDataset is supported by the LeRobot paths; other guides use video,
-  motion, scene, or tool-specific inputs.
-- A custom policy image must implement the selected tool's input, output,
-  and runtime contract.
-- A different robot may need assets, simulator support, observation and action
-  mappings, and training configuration. Available commands vary by tool.
+<a id="recorded-backend-checks"></a>
 
-See the [cookbooks](../cookbooks/README.md) for detailed recipes.
-
-## Physical AI Data Factory (video data augmentation)
-
-Turn a handful of frames into a labeled, curated, multiplied dataset: annotate →
-Cosmos Transfer augment → evaluate/validate → re-label → FiftyOne curate → Rerun
-visualize. Runs on Nebius + SkyPilot (no OSMO); pure composition of workbench
-tools.
-
-| Doc | Use when |
-| --- | --- |
-| [physical-ai-data-factory-deploy.md](physical-ai-data-factory-deploy.md) | **Copy-paste runbook** — from zero to a running blueprint (includes a one-block Quick start that stages input frames and submits) |
-| [physical-ai-data-factory.md](physical-ai-data-factory.md) | Conceptual guide — blueprint→stage mapping, S3 layout, viewing results |
-| [paidf-campaign-reuse.md](paidf-campaign-reuse.md) | Reuse one immutable source, generation, and evaluation campaign across provider workshops |
-
-> **Fastest start:** the deploy runbook's [Quick start](physical-ai-data-factory-deploy.md#quick-start-copy-paste)
-> seeds captionable frames (no dataset needed) and submits an input-conditioned
-> Cosmos run in a single block. The GPU runner turns those same frames into a
-> temporary clip; no upstream example media is packaged or required.
-
-## Sim-to-real (14-stage production loop)
-
-These guides are separate from the easy PushT walkthrough above. They document the
-full VLM→RL loop, data contracts, and cluster operations:
-
-| Doc | Use when |
-| --- | --- |
-| [sim2real-workflow.md](sim2real-workflow.md) | Run the loop (quickstart, CLI) |
-| [sim2real-data-contracts.md](sim2real-data-contracts.md) | **Canonical** formats, schemas, S3 layout |
-| [sim2real-customer-assets.md](sim2real-customer-assets.md) | Customer uploads, scorecard |
-| [sim2real-architecture.md](sim2real-architecture.md) | Standard-runtime graph, loops, parallel waves, resume |
-| [sim2real-demo-script-10min.md](sim2real-demo-script-10min.md) | Presentation walkthrough |
+Earlier local, serverless, and capacity checks are retained in the
+[historical backend record](../../archive/workbench-backend-checks.md).
+For a new run, use the [current image/GPU matrix](../image-gpu-compatibility-matrix.md)
+and inspect that run's actual artifacts.

--- a/docs/workbench/guides/README.md
+++ b/docs/workbench/guides/README.md
@@ -1,5 +1,7 @@
 # Workbench Guides
 
+[Workbench docs](../README.md)
+
 Choose a robot, generation, reconstruction, or data workflow to run on Nebius.
 Complete the [npa quickstart](../../quickstart.md) first, then follow the chosen
 guide's input, access, and GPU requirements through to its output artifacts.
@@ -29,44 +31,20 @@ local checks, smoke runs, and live outcomes.
 | Guide | Robot | Sim / engine | Public dataset | GPU |
 | --- | --- | --- | --- | --- |
 | [Pick-and-place with a Franka arm](franka-pick-and-place-genesis.md) | Franka Emika Panda | Genesis | DROID (Franka) | H200 for headless training; see rendering caveat |
-| [Teach a robot to push a T](pusht-sim-to-real.md) | sim pusher | sim-to-real loop | `lerobot/pusht` | H100 |
+| [Inspect the PushT SDK](pusht-sim-to-real.md) | sim pusher | Structural smoke; training guide linked separately | `lerobot/pusht` | See chosen training path |
 | [Train a Reachy 2 humanoid policy](reachy2-lerobot-policy.md) | Reachy 2 | LeRobot | Pollen Robotics / LeRobot Hub | yes |
-| [Make a Unitree G1 walk](g1-humanoid-walk-sonic.md) | Unitree G1 | MuJoCo | NVIDIA GEAR-SONIC checkpoint | H100 |
+| [Unitree G1 with SONIC](g1-humanoid-walk-sonic.md) | Unitree G1 | SONIC / MuJoCo | NVIDIA GEAR-SONIC checkpoint | RTX PRO 6000 training; B200 MuJoCo evaluation |
 | [Train a quadruped to run](quadruped-isaac-lab.md) | ANYmal / quadruped | Isaac Lab | Isaac Lab built-in tasks | RT-core: L40S / RTX PRO 6000 |
 | [Turn a photo capture into a 3D scene](neural-reconstruction.md) | n/a (scene capture) | NVIDIA NuRec / NRE | `nvidia/PhysicalAI-NuRec-PPISP` | RT-core: RTX PRO 6000 / L40S |
 | [Build a parameterized living-lab digital twin](living-lab-nurec-fanout.md) (default 16-GPU) | n/a (multi-zone scene capture) | NVIDIA NuRec / NRE (16-way default fan-out, parameterizable) | `nvidia/PhysicalAI-NuRec-PPISP` | 16 x RTX PRO 6000 default (8 x 2) |
 
-## How these guides work
-
-Every guide follows the same shape so you always know where you are:
-
-- **The hook** — what you'll build and why it's fun.
-- **Ingredients** — robot, sim, dataset, and what you need installed.
-- **Fast path** — the shortest command that produces a result.
-- **Go bigger** — scale the fast path into a larger GPU run.
-- **Look at it** — visualize the result (Rerun, FiftyOne, reports).
-- **Dig deeper** — links to the full cookbook and the skill behind it.
-
 ## Before you start
 
-Install `npa` once (Python 3.10+). The virtual environment can live anywhere:
-
-```bash
-git clone https://github.com/nebius/nebius-physical-ai.git
-cd nebius-physical-ai
-
-python3 -m venv .venv
-source .venv/bin/activate
-pip install --upgrade pip
-pip install -e npa
-
-npa --version
-```
-
-The guides assume you have completed
-[../../quickstart.md](../../quickstart.md) and
-[../getting-started.md](../getting-started.md) (Nebius auth, an S3 bucket, and
-`npa configure`). Each guide calls out exactly when credentials are required.
+Complete [installation and project setup](../../quickstart.md), then
+[Workbench setup](../getting-started.md) for GPU workflows. Run commands from
+the clone root with its environment active. Replace placeholders with your
+actual project, inputs, and output prefix; examples that only plan or smoke-test
+are labeled as such.
 
 ## Recorded backend checks
 
@@ -92,7 +70,10 @@ ran to completion. `gpu-rtx6000` is **not** a serverless platform (use the
 managed-Kubernetes path). For real Isaac Lab training prefer an RT-core VM /
 managed-K8s + BYOF; for a serverless capacity retry use `--gpu-type gpu-l40s-d`.
 
-SONIC G1 (MuJoCo) is documented from its cookbook and not yet re-run here.
+These are historical records, not current capacity recommendations. Newer
+[Genesis training evidence](franka-pick-and-place-genesis.md#go-bigger) records
+real serverless PPO training and a held-out quality result. Current SONIC
+capabilities and B200 MuJoCo evidence are in the [image catalog](../sonic-image-catalog.md).
 
 <a id="bring-your-own-everything"></a>
 

--- a/docs/workbench/guides/franka-pick-and-place-genesis.md
+++ b/docs/workbench/guides/franka-pick-and-place-genesis.md
@@ -100,11 +100,11 @@ A serverless H200 training example:
 
 ```bash
 npa workbench genesis train-teacher \
-  --runtime serverless --project-id <your-project-id> \
+  --runtime serverless --project-id "<your-project-id>" \
   --gpu-type h200 --gpu-count 1 \
-  --job-name <your-training-job-name> \
+  --job-name "<your-training-job-name>" \
   --n-envs 1024 --max-iterations 500 --action-space cartesian \
-  --output-path s3://<your-bucket>/<new-training-prefix>/
+  --output-path "s3://<your-bucket>/<new-training-prefix>/"
 ```
 
 Inspect `model.pt`, `arch_config.json`, `train_teacher_summary.json`, and

--- a/docs/workbench/guides/franka-pick-and-place-genesis.md
+++ b/docs/workbench/guides/franka-pick-and-place-genesis.md
@@ -1,11 +1,11 @@
 # Pick-and-Place with a Franka Arm in Genesis
 
-**The hook:** spin up thousands of Franka Emika Panda arms in parallel inside
-the Genesis physics engine, train one of them to pick up a cube and drop it in a
-target zone, then record demonstrations you can turn into a LeRobot dataset —
-the same format the famous DROID Franka dataset uses.
+[Guides](README.md)
 
-This is the classic "hello robot" of manipulation, done at GPU scale.
+Train and evaluate a PPO teacher for Franka cube pick-and-place in Genesis,
+then record demonstrations for LeRobot. The recorded H200 run produced real
+checkpoint weights but zero successful held-out episodes; use evaluation to
+determine whether a checkpoint is suitable for demonstrations.
 
 ## Ingredients
 

--- a/docs/workbench/guides/g1-humanoid-walk-sonic.md
+++ b/docs/workbench/guides/g1-humanoid-walk-sonic.md
@@ -1,116 +1,47 @@
-# Make a Unitree G1 Humanoid Walk (SONIC + MuJoCo)
+# Unitree G1 with SONIC
 
-**The hook:** take NVIDIA's released **GEAR-SONIC** locomotion checkpoint, warm-
-start a fine-tune for the **Unitree G1** humanoid, then watch it walk in a
-headless **MuJoCo** rollout — all as one SkyPilot workflow on an H100. This is
-whole-body humanoid control, and you don't have to train from scratch.
+[Guides](README.md) · [SONIC image catalog](../sonic-image-catalog.md)
 
-## Ingredients
+Use NVIDIA GEAR-SONIC checkpoints for Unitree G1 locomotion. Choose training,
+ONNX evaluation, or MuJoCo checkpoint evaluation first: they require different
+inputs and image capabilities.
 
-- **Robot:** [Unitree G1](https://www.unitree.com/g1) humanoid (legs + whole
-  body).
-- **Sim / engine:** [MuJoCo](https://mujoco.org/) for the headless eval rollout;
-  SONIC's training stack for fine-tuning.
-- **Public checkpoint:** NVIDIA
-  [`nvidia/GEAR-SONIC`](https://huggingface.co/nvidia/GEAR-SONIC) —
-  `sonic_release/last.pt` is the warm-start.
-- **You need:** Nebius creds, a container registry, an S3 bucket, and **H100**
-  capacity (`eu-north1`). SONIC training is state-based and headless, so no RT
-  cores are required for this path.
+## Choose the path
 
-## The shape of the workflow
+| Goal | Path | Requirements |
+| --- | --- | --- |
+| Train or fine-tune | [SONIC training](../cookbooks/sonic-train-runbook.md) | Compatible motion data; active RTX PRO 6000 Kubernetes image and host driver mounts |
+| Retarget, train, and score | [Locomotion workflow](../cookbooks/sonic-locomotion-finetuning.md) | Source motions, prepared GPU profiles, and MJLab-compatible checkpoint |
+| Export and evaluate ONNX | [Export/eval runbook](../cookbooks/sonic-eval-runbook.md) | Checkpoint, ONNX metadata, and the selected evaluator's runtime |
+| Evaluate a checkpoint in MuJoCo | [MuJoCo image status](../cookbooks/sonic-mvp-g1-mujoco.md) | Active `sonic-mujoco-runtime-fetch` image and its checkpoint input contract |
 
-```text
-GEAR-SONIC checkpoint ──finetune (G1, headless)──▶ trained checkpoint
-                                                          │
-                                                  MuJoCo rollout eval
-                                                          │
-                                              mujoco_eval_metrics.json
-```
+The old combined H100 fine-tune/MuJoCo image is quarantined. The active public
+MuJoCo replacement advertises **evaluation only**; it cannot satisfy a training
+stage. Check the [image catalog](../sonic-image-catalog.md) before choosing a GPU.
 
-One SkyPilot YAML runs both stages: `sonic-g1-finetune` then
-`sonic-mujoco-eval`. The fine-tune uses tiny proof defaults so you can prove the
-path before scaling iterations.
+## Inspect the workflow
 
-## Fast path
-
-Meet the tool and check routing first:
+From an installed checkout, these commands validate and plan without launching:
 
 ```bash
-npa workbench sonic list
-npa workbench sonic status
+npa workbench sonic --help
+npa workbench workflow validate-spec workflows/testing/sonic-locomotion-finetuning.yaml
+npa workbench workflow plan-spec workflows/testing/sonic-locomotion-finetuning.yaml \
+  --run-id g1-preview --json
 ```
 
-Submit the fine-tune + MuJoCo-eval workflow on H100 spot (docker-payload mode):
+The current spec contains **retarget → train → MJLab**, with an example bucket
+and H100 resource profile. That profile does not satisfy the active first-party
+SONIC training image. Follow the [locomotion runbook](../cookbooks/sonic-locomotion-finetuning.md)
+to prepare the spec before submission. It is not the retired two-stage
+fine-tune/MuJoCo template.
 
-```bash
-npa workbench workflow submit \
-  workflows/testing/sonic-locomotion-finetuning.yaml \
-  --tool sonic \
-  --run-id sonic-g1-$(date -u +%Y%m%dT%H%M%SZ) \
-  --registry <your-registry>/<namespace> \
-  --gpu-target h100 \
-  --region eu-north1 \
-  --use-spot \
-  --require-controller-up \
-  --s3-endpoint https://storage.eu-north1.nebius.cloud \
-  --s3-bucket <bucket> \
-  --s3-prefix sonic-g1/<run-id> \
-  --var SONIC_PAYLOAD_MODE=docker \
-  --var SONIC_MAX_ITERATIONS=1 \
-  --var SONIC_MUJOCO_STEPS=64 \
-  --secret-env AWS_ACCESS_KEY_ID \
-  --secret-env AWS_SECRET_ACCESS_KEY
-```
+## Verify the result
 
-When it finishes you'll have `mujoco_eval_metrics.json`, `gpu_device.json`, and
-`image_pull_proof.json` in S3 — proof the G1 checkpoint ran a real MuJoCo
-rollout.
+Inspect the actual checkpoint and evaluation report. A smoke manifest proves
+only the checks it records. The public MuJoCo release records a B200 acceptance
+run of 64 finite simulation steps and zero falls; this does not establish
+long-horizon walking, training convergence, or mesh fidelity.
 
-Prefer Python? The SDK runs the same materialize/submit path:
-
-```python
-from pathlib import Path
-from npa.sdk.workbench import sonic
-
-plan = sonic.materialize_workflow(
-    Path("workflows/testing/sonic-locomotion-finetuning.yaml"),
-    run_id="sonic-g1-proof",
-    registry="<your-registry>/<namespace>",
-    gpu_target="h100",
-    region="eu-north1",
-    use_spot=True,
-    s3_endpoint="https://storage.eu-north1.nebius.cloud",
-    s3_bucket="<bucket>",
-    s3_prefix="sonic-g1/sonic-g1-proof",
-    env_overrides={
-        "SONIC_PAYLOAD_MODE": "docker",
-        "SONIC_MAX_ITERATIONS": "1",
-        "SONIC_MUJOCO_STEPS": "64",
-    },
-)
-```
-
-## Go bigger
-
-- **Train longer:** raise `SONIC_MAX_ITERATIONS` and `SONIC_MUJOCO_STEPS` once
-  the proof run is green.
-- **Export to ONNX and re-evaluate:** `npa workbench sonic export` produces a
-  deterministic-action ONNX graph, and `npa workbench sonic eval` scores it. See
-  the [SONIC Export and Eval Runbook](../cookbooks/sonic-eval-runbook.md).
-- **Score with MJLab:** the
-  [SONIC Locomotion Fine-Tuning cookbook](../cookbooks/sonic-locomotion-finetuning.md)
-  adds motion retargeting and MJLab evaluation.
-
-## Heads up
-
-- Use `--gpu-target h200` only as a capacity fallback for the same headless
-  workload. `me-west1` is rejected; use `eu-north1`.
-- SONIC **render** validation (the Isaac render path) needs RT cores; the walk-
-  in-MuJoCo path in this guide does not.
-
-## Dig deeper
-
-- Cookbook: [SONIC G1 Fine-Tune to MuJoCo MVP](../cookbooks/sonic-mvp-g1-mujoco.md)
-- Workflow YAML: `workflows/testing/sonic-locomotion-finetuning.yaml`
-- Skill: `skills/tools/sonic/SKILL.md`
+For results you can share, use [Rerun](../rerun-sharing.md) or
+[Foxglove / MCAP](../foxglove-export.md) when the run produces those artifacts.

--- a/docs/workbench/guides/leisaac-transport-latency.md
+++ b/docs/workbench/guides/leisaac-transport-latency.md
@@ -1,5 +1,7 @@
 # LeIsaac low-latency browser transport
 
+[Guides](README.md)
+
 This runbook describes the measured transport behind the public agent's LeIsaac
 keyboard teleoperation. It is deliberately separate from the recorder state
 machine: video congestion must not delay controls, and transport changes must

--- a/docs/workbench/guides/living-lab-nurec-fanout.md
+++ b/docs/workbench/guides/living-lab-nurec-fanout.md
@@ -122,13 +122,13 @@ npa workbench workflow plan-spec \
 Stage the npa source the pods install (the NRE image has no `npa`), then submit:
 
 ```bash
-export NPA_SRC_S3_URI=s3://<your-bucket>/npa-src/<tag>
+export NPA_SRC_S3_URI="s3://<your-bucket>/npa-src/<tag>"
 RUN_ID="living-lab-$(date -u +%Y%m%dt%H%M%S)z"
 npa workbench workflow submit \
   workflows/testing/living-lab-nurec-fanout.yaml \
   --run-id "$RUN_ID" --runtime \
-  --infra k8s/<your-rtx-16gpu-context> \
-  --var bucket=<your-bucket> \
+  --infra "k8s/<your-rtx-16gpu-context>" \
+  --var bucket="<your-bucket>" \
   --var prefix="checkpoints/living-lab/$RUN_ID" \
   --secret-env AWS_ACCESS_KEY_ID --secret-env AWS_SECRET_ACCESS_KEY \
   --secret-env NGC_API_KEY

--- a/docs/workbench/guides/living-lab-nurec-fanout.md
+++ b/docs/workbench/guides/living-lab-nurec-fanout.md
@@ -1,5 +1,7 @@
 # Living-lab digital twin: parameterized neural reconstruction (16-GPU default)
 
+[Guides](README.md)
+
 A "living lab" is a research space observed by many cameras. This workflow turns
 real multi-view captures of such a space into a **multi-zone digital twin**:
 independent NVIDIA NuRec / NRE neural reconstructions, one per RTX PRO 6000

--- a/docs/workbench/guides/neural-reconstruction.md
+++ b/docs/workbench/guides/neural-reconstruction.md
@@ -86,9 +86,9 @@ RUN_ID="nurec-$(date -u +%Y%m%dt%H%M%S)z"
 
 npa workbench workflow submit \
   workflows/main/nurec-reconstruct.yaml \
-  --run-id "$RUN_ID" --project <project-alias> --runtime \
-  --infra k8s/<your-rt-core-context> \
-  --var bucket=<your-bucket> \
+  --run-id "$RUN_ID" --project "<project-alias>" --runtime \
+  --infra "k8s/<your-rt-core-context>" \
+  --var bucket="<your-bucket>" \
   --var prefix="checkpoints/neural-reconstruction/$RUN_ID" \
   --secret-env AWS_ACCESS_KEY_ID --secret-env AWS_SECRET_ACCESS_KEY \
   --secret-env NGC_API_KEY
@@ -97,7 +97,7 @@ npa workbench workflow submit \
 Watch it:
 
 ```bash
-npa workbench workflow status "$RUN_ID" --project <project-alias> --watch
+npa workbench workflow status "$RUN_ID" --project "<project-alias>" --watch
 ```
 
 A healthy run looks like this — `reconstruct` is the long pole:

--- a/docs/workbench/guides/neural-reconstruction.md
+++ b/docs/workbench/guides/neural-reconstruction.md
@@ -1,5 +1,7 @@
 # Turn a real photo capture into a 3D scene you can fly through
 
+[Guides](README.md)
+
 Point a camera at a thing. Get back a 3D scene you can re-render from angles the
 camera never visited.
 
@@ -54,36 +56,28 @@ check ──▶ fetch ──▶ reconstruct ──▶ render ──▶ visualize
 
 ## Fast path
 
-Free, no GPU, no credentials — see the shape of the pipeline before committing to
-it:
+Inspect the workflow locally before preparing its GPU runtime:
 
 ```bash
 npa workbench workflow plan-spec \
   workflows/main/nurec-reconstruct.yaml
 ```
 
-Then the cheap real preflight (seconds, no image pull):
+With your NGC key in the private environment or credential store, check access:
 
 ```bash
-export NGC_API_KEY=...
-npa workbench nurec check --json
+npa workbench nurec check --output json
 ```
 
 This probes actual **download authorization**, not just visibility — a gated
 Hugging Face repo still answers `200` on its metadata endpoint, so "I can see it"
 is not "I can fetch it".
 
-> **Never** test a token with `echo "${HF_TOKEN:+yes}${HF_TOKEN:-no}"`. That
-> prints the token: `${VAR:-no}` only falls back when the variable is *empty*.
-> Use `hf auth whoami` or `echo ${#HF_TOKEN}`.
-
 ## Go bigger: the real GPU run
 
-The NRE container has no `npa` inside it, so stage the source the pods install:
-
-```bash
-export NPA_SRC_S3_URI=s3://<your-bucket>/npa-src/<tag>
-```
+Complete [Workbench setup](../getting-started.md) for your RT-core cluster.
+Source staging is automatic when the task needs NPA; an explicit
+`NPA_SRC_S3_URI` is an override. Use the same project and target throughout.
 
 Submit:
 
@@ -92,7 +86,7 @@ RUN_ID="nurec-$(date -u +%Y%m%dt%H%M%S)z"
 
 npa workbench workflow submit \
   workflows/main/nurec-reconstruct.yaml \
-  --run-id "$RUN_ID" \
+  --run-id "$RUN_ID" --project <project-alias> --runtime \
   --infra k8s/<your-rt-core-context> \
   --var bucket=<your-bucket> \
   --var prefix="checkpoints/neural-reconstruction/$RUN_ID" \
@@ -103,7 +97,7 @@ npa workbench workflow submit \
 Watch it:
 
 ```bash
-sky jobs queue
+npa workbench workflow status "$RUN_ID" --project <project-alias> --watch
 ```
 
 A healthy run looks like this — `reconstruct` is the long pole:

--- a/docs/workbench/guides/nurec-colmap-reconstruct.md
+++ b/docs/workbench/guides/nurec-colmap-reconstruct.md
@@ -1,5 +1,7 @@
 # Reconstruct a COLMAP source capture with NCore and NRE
 
+[Guides](README.md)
+
 The new COLMAP ingestion path is **not yet live validated**. It extends the
 existing NuRec capability with NVIDIA's Apache-2.0 NCore converter. The full
 workflow runs conversion on CPU, then uses the existing, separately licensed

--- a/docs/workbench/guides/paidf-campaign-reuse.md
+++ b/docs/workbench/guides/paidf-campaign-reuse.md
@@ -1,6 +1,8 @@
 <!-- register: operator runbook | reader: PAIDF workshop authors and provider-integration contributors | consumed: workshop preparation and derivative-run execution -->
 # Reuse one PAIDF campaign across provider workshops
 
+[Guides](README.md)
+
 Build the expensive source, Cosmos generation, and evaluation stages once. Freeze their exact manifests as a base campaign. Each Encord, FiftyOne, Foxglove, Rerun, or simulation-provider workshop then becomes a derivative run that reads the base and writes to its own prefix.
 
 This is a small contract layer, not a provider plugin system. Provider execution remains in the relevant SDK, CLI, or workflow code.

--- a/docs/workbench/guides/paidf-cosmos3.md
+++ b/docs/workbench/guides/paidf-cosmos3.md
@@ -1,5 +1,7 @@
 # PAIDF with Cosmos 3 video conditioning
 
+[Guides](README.md)
+
 For a complete manual setup and run, start with the
 [PAIDF Cosmos 3 setup and run guide](../../../workflows/guides/paidf-cosmos3.md). It covers
 project setup, new or existing Kubernetes clusters, credential-file formats,

--- a/docs/workbench/guides/physical-ai-data-factory-deploy.md
+++ b/docs/workbench/guides/physical-ai-data-factory-deploy.md
@@ -472,11 +472,11 @@ Explicit environment variables are optional overrides when scripting. They take
 precedence over configured values, but are not required for the quick start:
 
 ```bash
-export AWS_ACCESS_KEY_ID=<...>
-export AWS_SECRET_ACCESS_KEY=<...>
-export AWS_ENDPOINT_URL=https://storage.<region>.nebius.cloud
-export NEBIUS_TOKEN_FACTORY_KEY=<...>
-export HF_TOKEN=<...>                # optional
+export AWS_ACCESS_KEY_ID="<...>"
+export AWS_SECRET_ACCESS_KEY="<...>"
+export AWS_ENDPOINT_URL="https://storage.<region>.nebius.cloud"
+export NEBIUS_TOKEN_FACTORY_KEY="<...>"
+export HF_TOKEN="<...>"                # optional
 ```
 
 ### 2b. `~/.npa/config.yaml` (machine-managed project config)
@@ -512,8 +512,8 @@ If the bucket / cluster do not exist yet, `provision-if-absent` creates only wha
 is missing (dry-run first):
 
 ```bash
-npa provision-if-absent --project <alias> --dry-run --output-format json
-npa provision-if-absent --project <alias> \
+npa provision-if-absent --project "<alias>" --dry-run --output-format json
+npa provision-if-absent --project "<alias>" \
   --cpu-nodes 1 --cpu-platform cpu-d3 --cpu-preset 8vcpu-32gb \
   --gpu-nodes 1 --gpu-platform gpu-rtx6000 \
   --gpu-preset 1gpu-24vcpu-218gb --on-demand          # real
@@ -555,16 +555,16 @@ project:
 
 ```bash
 # Interactive: pick one of the projects `npa configure` saved, then deploy.
-npa agent setup --name <agent-name>
+npa agent setup --name "<agent-name>"
 ```
 
 For scripted / non-interactive deploys, pass the ids explicitly instead:
 
 ```bash
 npa agent fresh-setup \
-  --project <alias> --name <agent-name> \
-  --project-id <nebius-project-id> --tenant-id <nebius-tenant-id> \
-  --region <region>
+  --project "<alias>" --name "<agent-name>" \
+  --project-id "<nebius-project-id>" --tenant-id "<nebius-tenant-id>" \
+  --region "<region>"
 ```
 
 Both provision the VM and bake the UI/backend. To re-bake later (e.g. after an
@@ -572,7 +572,7 @@ agent code change) without reprovisioning:
 
 ```bash
 # Bake/refresh the UI + backend + nginx on the VM (~1 min; reuses auth/creds).
-npa agent bootstrap --project <alias> --name <agent-name>
+npa agent bootstrap --project "<alias>" --name "<agent-name>"
 ```
 
 Before IAM or VM creation, agent deploy probes the exact Terraform backend
@@ -612,7 +612,7 @@ agent config exists.
 Verify the deploy:
 
 ```bash
-NPA_AGENT_CHAT_LIVE=1 npa agent verify-live --project <alias> --name <agent-name>
+NPA_AGENT_CHAT_LIVE=1 npa agent verify-live --project "<alias>" --name "<agent-name>"
 ```
 
 ### 3a. Auth and first connection
@@ -723,7 +723,7 @@ and stages `source.mp4`, the exact 93-frame `conditioning.mp4`, eight derived
 caption frames, and `provenance.json` under the canonical input prefix.
 
 ```bash
-BUCKET=<your-artifact-bucket>
+BUCKET="<your-artifact-bucket>"
 RUN_ID="$(npa workbench workflow prepare-run "$SPEC" --project "$PROJECT")"
 INPUT="s3://$BUCKET/physical-ai-data-factory/$RUN_ID/input"
 ```
@@ -795,7 +795,7 @@ back the `image_id` lines to confirm the three images are pinned:
 ```bash
 npa workbench workflow submit "$SPEC" --run-id preflight --plan-only \
   --assume-decision promote_checkpoint --registry "$REGISTRY" \
-  --var bucket=<your-artifact-bucket> | grep -E 'image_id|accelerators'
+  --var bucket="<your-artifact-bucket>" | grep -E 'image_id|accelerators'
 ```
 
 > **Do not submit with cleared workbench images.** The submit CLI no longer treats
@@ -837,7 +837,7 @@ NPA_WORKFLOW_GPU_ACCELERATOR=RTXPRO6000:4 \
 NPA_WORKFLOW_GPU_MEMORY=384Gi \
 npa workbench workflow submit "$SPEC" \
   --run-id "$(date -u +paidf-4gpu-%Y%m%dt%H%M%sz)" \
-  --var bucket=<your-artifact-bucket> \
+  --var bucket="<your-artifact-bucket>" \
   --var n_augmentations=4 \
   --assume-decision promote_checkpoint \
   --secret-env NEBIUS_TOKEN_FACTORY_KEY \
@@ -888,7 +888,7 @@ is an instantaneous preflight snapshot, not a reservation.
 NPA_WORKFLOW_GPU_ACCELERATOR=RTXPRO6000:4 \
 npa workbench workflow submit "$SPEC" \
   --run-id "$(date -u +paidf-4x4-%Y%m%dt%H%M%sz)" \
-  --var bucket=<your-artifact-bucket> \
+  --var bucket="<your-artifact-bucket>" \
   --var n_augmentations=16 \
   --var augment_nodes=4 \
   --assume-decision promote_checkpoint \
@@ -963,7 +963,7 @@ letting the prompt change what it is *made of*:
 ```bash
 npa workbench workflow submit "$SPEC" \
   --run-id "$(date -u +paidf-seg-%Y%m%dt%H%M%sz)" \
-  --var bucket=<your-artifact-bucket> \
+  --var bucket="<your-artifact-bucket>" \
   --var augment_control=seg \
   --var augment_control_prompt="robot arm, conveyor, bin" \
   --var augment_mask_prompt="robot arm" \
@@ -1030,9 +1030,9 @@ Run real curation standalone against a completed run's augmented output:
 
 ```bash
 npa workbench fiftyone curate-augmented \
-  --augment-uri s3://<your-artifact-bucket>/physical-ai-data-factory/<run-id>/cosmos_augmented/ \
-  --report-uri  s3://<your-artifact-bucket>/physical-ai-data-factory/<run-id>/curation/report.json \
-  --curator-report-uri s3://<your-artifact-bucket>/physical-ai-data-factory/<run-id>/curation/cosmos_curator.json \
+  --augment-uri "s3://<your-artifact-bucket>/physical-ai-data-factory/<run-id>/cosmos_augmented/" \
+  --report-uri  "s3://<your-artifact-bucket>/physical-ai-data-factory/<run-id>/curation/report.json" \
+  --curator-report-uri "s3://<your-artifact-bucket>/physical-ai-data-factory/<run-id>/curation/cosmos_curator.json" \
   --require-fiftyone \
   --dedup-threshold 0.10
 ```
@@ -1070,7 +1070,7 @@ sign in, then:
 
 Useful authenticated JSON endpoints for scripted verification:
 
-```bash
+```text
 GET  /api/artifacts/runs?prefix=physical-ai-data-factory
 GET  /api/artifacts/run/<run-id>?prefix=physical-ai-data-factory
 GET  /api/artifacts/provenance/<run-id>
@@ -1116,13 +1116,13 @@ Then remove them:
 ```bash
 # 1. Cancel the workflow. Planned/staged runs that never launched are a
 #    successful repeat-safe no-op.
-npa workflow cancel <run-id> --project "$PROJECT" --json
+npa workflow cancel "<run-id>" --project "$PROJECT" --json
 
 # 2. Agent VM, its network, local record, and the IAM the deploy created for it.
-npa agent destroy --project "$PROJECT" --name <agent-name> --yes
+npa agent destroy --project "$PROJECT" --name "<agent-name>" --yes
 
 # 3. Remove the shared jobs controller only after every NPA workflow is terminal.
-npa skypilot cleanup-controller --project "$PROJECT" --context <context> --yes
+npa skypilot cleanup-controller --project "$PROJECT" --context "<context>" --yes
 
 # 4. Cluster. `down` owns everything the Terraform path created — cluster, VPC,
 #    subnet — and clears ~/.npa/clusters/<context>/. It reads
@@ -1136,8 +1136,8 @@ npa storage bucket delete --project "$PROJECT" --yes --wait
 # 6. Storage IAM. Inspect first. If legacy state lacks ownership provenance,
 #    reconcile the exact immutable ID before returning to the guarded delete.
 npa storage service-account delete --project "$PROJECT" --dry-run
-npa storage service-account reconcile --project "$PROJECT" --id <exact-id> --dry-run
-npa storage service-account reconcile --project "$PROJECT" --id <exact-id> \
+npa storage service-account reconcile --project "$PROJECT" --id "<exact-id>" --dry-run
+npa storage service-account reconcile --project "$PROJECT" --id "<exact-id>" \
   --reason '<legacy NPA setup evidence>' --attest-npa-created --yes
 npa storage service-account delete --project "$PROJECT" --dry-run
 npa storage service-account delete --project "$PROJECT" --yes
@@ -1145,8 +1145,8 @@ npa storage service-account delete --project "$PROJECT" --yes
 # 7. Retire any separately created private registry through its provider.
 #    NPA has no top-level registry command. For an NPA-created disposable
 #    project, remove only its unique provider default topology.
-npa network delete-project-default --project "$PROJECT" --project-id <project-id> \
-  --tenant-id <tenant-id> --yes
+npa network delete-project-default --project "$PROJECT" --project-id "<project-id>" \
+  --tenant-id "<tenant-id>" --yes
 
 # 8. Optional: delete only a proven NPA-created, provider-empty project.
 npa destroy --project "$PROJECT" --all --delete-project --yes --json
@@ -1164,13 +1164,13 @@ If project configuration was already removed, take the opaque receipt ID printed
 before that rewrite and use the same NPA-only recovery surfaces:
 
 ```bash
-npa agent destroy --receipt <receipt-id> --name <agent-name> --yes
-npa skypilot cleanup-controller --receipt <receipt-id> --context <context> --yes
-npa cluster down --receipt <receipt-id> --context <context> --force
-npa storage service-account delete --receipt <receipt-id> --id <exact-id> --dry-run
-npa workflow cancel <run-id> --receipt <receipt-id> --json
+npa agent destroy --receipt "<receipt-id>" --name "<agent-name>" --yes
+npa skypilot cleanup-controller --receipt "<receipt-id>" --context "<context>" --yes
+npa cluster down --receipt "<receipt-id>" --context "<context>" --force
+npa storage service-account delete --receipt "<receipt-id>" --id "<exact-id>" --dry-run
+npa workflow cancel "<run-id>" --receipt "<receipt-id>" --json
 # Optional, after the provider proves every managed child absent:
-npa destroy --receipt <receipt-id> --all --delete-project --yes --json
+npa destroy --receipt "<receipt-id>" --all --delete-project --yes --json
 ```
 
 Exact flags override receipt fields, and receipt fields override live config;

--- a/docs/workbench/guides/physical-ai-data-factory-deploy.md
+++ b/docs/workbench/guides/physical-ai-data-factory-deploy.md
@@ -1,5 +1,10 @@
 # Deploy the Physical AI Data Factory (from zero)
 
+[Guides](README.md) · [Quick start](#quick-start-copy-paste) · [Failure recovery](#if-submit-fails) · [View outputs](#8-view-results-in-the-npa-agent)
+
+Follow the quick start once. The numbered sections below explain its individual
+steps and optional variants; they are not a second setup sequence.
+
 A step-by-step, copy-paste runbook that takes you from an empty machine to a
 running **NVIDIA Physical AI Data Factory** blueprint on Nebius + SkyPilot, with
 results viewable in the NPA agent (Main stages, embedded Rerun, and an explicitly
@@ -1076,7 +1081,9 @@ POST /api/sim-viz/load-artifact   # {"run_id":"<run-id>","key":"reports/sim2real
 
 ---
 
-## 8. Tear everything down
+<a id="8-tear-everything-down"></a>
+
+## 9. Tear everything down
 
 Cleanup has three owners — the agent VM, the cluster, and the storage/IAM that
 `npa configure` provisioned. Preview the unified, project-scoped teardown first;
@@ -1135,14 +1142,11 @@ npa storage service-account reconcile --project "$PROJECT" --id <exact-id> \
 npa storage service-account delete --project "$PROJECT" --dry-run
 npa storage service-account delete --project "$PROJECT" --yes
 
-# 7. If this validation created a private image registry, delete its exact
-#    immutable artifact DAG and registry. For an NPA-created disposable project,
-#    remove only its unique provider default topology; either command refuses
-#    mixed/shared evidence.
-npa registry delete --project "$PROJECT" --project-id <project-id> \
-  --tenant-id <tenant-id> --id <registry-id> --name <registry-name> --yes
-npa network delete-project-default --project "$PROJECT" \
-  --project-id <project-id> --tenant-id <tenant-id> --yes
+# 7. Retire any separately created private registry through its provider.
+#    NPA has no top-level registry command. For an NPA-created disposable
+#    project, remove only its unique provider default topology.
+npa network delete-project-default --project "$PROJECT" --project-id <project-id> \
+  --tenant-id <tenant-id> --yes
 
 # 8. Optional: delete only a proven NPA-created, provider-empty project.
 npa destroy --project "$PROJECT" --all --delete-project --yes --json
@@ -1244,7 +1248,9 @@ Notes:
   actual deferred removal requires `--remove-environment --yes` and never
   includes source, `.git`, credentials, or unrelated caches.
 
-## 9. Where to go next
+<a id="9-where-to-go-next"></a>
+
+## 10. Where to go next
 
 - Conceptual blueprint, stage-by-stage mapping, and S3 layout:
   [physical-ai-data-factory.md](physical-ai-data-factory.md).

--- a/docs/workbench/guides/physical-ai-data-factory.md
+++ b/docs/workbench/guides/physical-ai-data-factory.md
@@ -1,5 +1,7 @@
 # NVIDIA Physical AI Data Factory on NPA (no OSMO)
 
+[Guides](README.md)
+
 This guide runs the **NVIDIA Physical AI Data Factory** blueprint natively on
 Nebius + SkyPilot. It is delivered as a single npa.workflow spec
 (`workflows/testing/physical-ai-data-factory.yaml`) that

--- a/docs/workbench/guides/physical-ai-data-factory.md
+++ b/docs/workbench/guides/physical-ai-data-factory.md
@@ -360,9 +360,9 @@ so Git-LFS payloads never enter a layer.
 
 ```bash
 docker run --rm -e HF_TOKEN=... -v curator-weights:/config/models \
-  <registry>/npa-cosmos-curate:0.1.0 fetch-models --models split-annotate
+  "<registry>/npa-cosmos-curate:0.1.0" fetch-models --models split-annotate
 docker run --rm -v curator-weights:/config/models \
-  <registry>/npa-cosmos-curate:0.1.0 models --output text
+  "<registry>/npa-cosmos-curate:0.1.0" models --output text
 ```
 
 `--models` takes a capability set (`split-transnetv2`, `embed-internvideo2`,
@@ -384,11 +384,11 @@ npa workbench workflow validate-spec "$SPEC" --json
 # --var bucket= is what ties the plan to your storage; without it the spec's
 # `example-bucket` placeholder is planned (plan-spec warns when that happens).
 npa workbench workflow plan-spec "$SPEC" --run-id demo \
-  --assume-decision promote_checkpoint --var bucket=<your-bucket> --json
+  --assume-decision promote_checkpoint --var bucket="<your-bucket>" --json
 # Render the serial SkyPilot YAML without launching (needs NPA_SRC_S3_URI or --image
 # for the CPU tool steps, same as the other Token Factory specs):
-NPA_SRC_S3_URI=s3://<your-bucket>/npa-src/npa/ \
-  npa workbench workflow submit "$SPEC" --run-id demo --var bucket=<your-bucket> \
+NPA_SRC_S3_URI="s3://<your-bucket>/npa-src/npa/" \
+  npa workbench workflow submit "$SPEC" --run-id demo --var bucket="<your-bucket>" \
     --assume-decision promote_checkpoint --plan-only
 ```
 
@@ -398,14 +398,14 @@ NPA_SRC_S3_URI=s3://<your-bucket>/npa-src/npa/ \
 SPEC=workflows/testing/physical-ai-data-factory.yaml
 npa workbench health access --capability paidf
 npa workbench workflow preflight-images "$SPEC" \
-  --project <alias> --registry <registry>
-RUN_ID="$(npa workbench workflow prepare-run "$SPEC" --project <alias>)"
+  --project "<alias>" --registry "<registry>"
+RUN_ID="$(npa workbench workflow prepare-run "$SPEC" --project "<alias>")"
 npa workbench workflow submit "$SPEC" \
-  --project <alias> --run-id "$RUN_ID" \
-  --var bucket=<your-bucket> \
+  --project "<alias>" --run-id "$RUN_ID" \
+  --var bucket="<your-bucket>" \
   --runtime --auto-load \
   --assume-decision promote_checkpoint \
-  --infra k8s/<your-kube-context> \
+  --infra "k8s/<your-kube-context>" \
   --secret-env NEBIUS_TOKEN_FACTORY_KEY \
   --secret-env AWS_ACCESS_KEY_ID \
   --secret-env AWS_SECRET_ACCESS_KEY \
@@ -434,18 +434,18 @@ and reuses the generic image-pull check/secret refresh.
 Monitor an exact run using NPA alone:
 
 ```bash
-npa workbench workflow status <run-id> --project <alias>
+npa workbench workflow status "<run-id>" --project "<alias>"
 # Explicit fallback; the final manifest itself may still be pending:
-npa workbench workflow status <run-id> --project <alias> \
-  --workflow-s3-uri s3://<bucket>/physical-ai-data-factory/<run-id>/npa-workflow
+npa workbench workflow status "<run-id>" --project "<alias>" \
+  --workflow-s3-uri "s3://<bucket>/physical-ai-data-factory/<run-id>/npa-workflow"
 
 # Intentional offline inspection (exit 0 but never live-verified):
-npa workbench workflow status <run-id> --project <alias> --cached
+npa workbench workflow status "<run-id>" --project "<alias>" --cached
 
 # After DNS/controller recovery, explicitly resume the same run:
-npa workbench workflow submit "$SPEC" --project <alias> \
-  --resume-run <run-id> --var bucket=<your-bucket> --runtime \
-  --assume-decision promote_checkpoint --infra k8s/<your-kube-context>
+npa workbench workflow submit "$SPEC" --project "<alias>" \
+  --resume-run "<run-id>" --var bucket="<your-bucket>" --runtime \
+  --assume-decision promote_checkpoint --infra "k8s/<your-kube-context>"
 ```
 
 The launch path does not treat the earlier cluster/GPU snapshot as controller
@@ -574,7 +574,7 @@ or remove the canonical prefix. If the agent's base prefix is
 `checkpoints`, place the run under `checkpoints/physical-ai-data-factory/<run-id>/`
 (or pass the matching discovery prefix). Then:
 
-```bash
+```text
 # discover runs
 GET /api/artifacts/runs?prefix=physical-ai-data-factory
 # list a run's artifacts (render hints: video / image / json / text)

--- a/docs/workbench/guides/pusht-sim-to-real.md
+++ b/docs/workbench/guides/pusht-sim-to-real.md
@@ -1,42 +1,32 @@
-# Teach a Robot to Push a T (PushT, Sim-to-Real)
+# PushT: inspect the sim-to-real SDK
 
-**The hook:** PushT is the beloved toy benchmark of robot learning — shove a
-T-shaped block onto a target. In this guide you run the **whole sim-to-real
-loop** end to end with one command: stage a public dataset, train a policy,
-evaluate it, collect feedback, and record a Rerun visualization you can scrub
-frame by frame.
+[Guides](README.md) · [LeRobot training](reachy2-lerobot-policy.md) · [Sim2Real workflow](sim2real-workflow.md)
 
-The best part: you can dry-run the entire spine locally before spending a
-single GPU-minute.
+PushT uses a planar pusher to move a T-shaped block onto a target. This guide
+shows the SDK's **structural smoke**: dataset inspection, splitting, feedback,
+and report wiring. For GPU policy training, use the [LeRobot guide](reachy2-lerobot-policy.md)
+with a compatible PushT dataset and policy configuration.
 
 ## Ingredients
 
-- **Robot:** a simulated planar pusher (the PushT task).
-- **Sim / engine:** the workbench **sim-to-real loop** — imitation training plus
-  a pluggable evaluator and feedback source.
-- **Public dataset:**
-  [`lerobot/pusht`](https://huggingface.co/lerobot/pusht) — MIT-licensed, with
-  vision, state, action, episode, and timestamp fields. Pinned revision
+- Install [npa](../../install.md) and allow access to the public Hugging Face dataset.
+- The helper defaults to `lerobot/pusht` at revision
   `7628202a2180972f291ba1bc6723834921e72c19`.
-- **You need:** `npa` installed for the local smoke; Nebius creds + an H100 for
-  the live run.
+- The base NPA install does not include the upstream `lerobot` package.
+  Dataset checks can report partial or blocked when that package is unavailable.
 
 ## Fast path (local smoke, no cluster)
 
-Run the same structural spine the live pipeline uses, entirely on your machine,
-with typed return objects:
+Run this Python example in the environment where NPA is installed:
 
 ```python
 from npa.sdk.workbench import sim_to_real
 
 report = sim_to_real.local_smoke(
     run_id="pusht-hello",
-    s3_bucket="your-bucket-name",
-    s3_endpoint="https://storage.eu-north1.nebius.cloud",
-    s3_prefix="sim-to-real/pusht-hello",
-    input_data_uri="s3://your-bucket-name/datasets/lerobot-pusht/",
-    policy_image="npa-lerobot-policy:0.1.1",
-    gpu="H100:1",
+    output_dir="./outputs/pusht-hello",
+    input_data_uri="hf://datasets/lerobot/pusht",
+    s3_bucket="example-bucket",  # artifact layout only; no S3 round trip
     eval_backend="state-success",
     feedback_source="sim-env",
     feedback_type="scalar",
@@ -44,78 +34,35 @@ report = sim_to_real.local_smoke(
     attempt_s3_roundtrip=False,
 )
 print(report.status)
+for component in report.components:
+    print(component.name, component.tier, component.evidence)
+print(report.artifacts["local_report_dir"])
 ```
 
-This validates the data split, the eval backend, the feedback object, and the
-Rerun recording wiring without provisioning anything. It downloads and inspects
-the public `lerobot/pusht` metadata (≈206 episodes, ≈25k frames) on the fly.
-
-The report is **tiered**, so read `report.status` and the per-component tiers
-literally. In a plain `pip install -e npa` environment the `LeRobotDataset`
-import isn't present, so the dataset component reports `PARTIAL`/`BLOCKED` and
-`report.status` is `blocked` — that's expected. Install the LeRobot extra (so
-`import lerobot` works) for a fully green local smoke; the live H100 run below
-uses the policy image and doesn't need LeRobot on your laptop.
-
-## The one-command live run
-
-When you're ready to do it for real on an H100:
-
-```bash
-npa workbench workflow submit \
-  workflows/main/sim2real.yaml \
-  --run-id <run-id> \
-  --var NPA_SIM2REAL_BUCKET=<your-bucket> \
-  --var NPA_SIM2REAL_TRIGGER_DATASET_URI=s3://<your-bucket>/<trigger-prefix>/
-```
-
-That wrapper renders `sim-to-real-pipeline.yaml`, submits it on `H100:1`, runs
-the real training/eval loop, prints the **task-success score** plus the
-checkpoint / report / Rerun S3 URIs, and tears down the run-scoped cluster.
-Warm runs target about 5-6 minutes for the small proof config.
-
-## What's happening under the hood
-
-```text
-lerobot/pusht ─▶ split (train / heldout) ─▶ imitation train ─▶ eval ─▶ feedback
-                                                   │                      │
-                                                   └──── checkpoint ◀──────┘
-                                                          + Rerun .rrd
-```
-
-Both the **evaluator** and the **feedback source** are swappable:
-
-- `--eval-backend`: `state-success` (pose predicate), `vlm-frames` (VLM judges
-  rendered frames), or `heldout-metrics`.
-- `--feedback-source`: `none`, `sim-env`, `vlm`, or `byo-container`.
-
-The `vlm-eval` judge is documented in its own
-[skill](../../../skills/tools/vlm-eval/SKILL.md).
+This downloads dataset content. It uses fixture rollouts and stub VLM feedback;
+it produces no trained policy weights and does not test cloud execution.
+`attempt_s3_roundtrip=False` skips the explicit storage round-trip probe; the
+explicit `hf://datasets/` input also avoids selecting an S3 dataset source.
+Read each component's evidence instead of treating the overall status as a
+training result. Installing another dependency does not turn this smoke into
+real policy training.
 
 ## Look at it
 
-Download the Rerun recording and scrub through demonstrations, the policy
-rollout, and per-episode feedback:
+Inspect the local report directory. The `rerun` component records the generated
+recording and its `view_command`, or explains why only a partial recording was
+possible. Open that recording to inspect the documented data and feedback;
+fixture rollout data is not a learned policy evaluation.
 
-```bash
-rerun /tmp/npa-sim-to-real-<run-id>/<run-id>.rrd
-```
+## Continue with a real workflow
 
-## Bring your own dataset
+The maintained 14-stage workflow is
+[`workflows/main/sim2real.yaml`](../../../workflows/main/sim2real.yaml).
+Follow its [runbook](sim2real-workflow.md) and
+[data contracts](sim2real-data-contracts.md) for inputs, GPU resources, images,
+submission, and quality gates. It has different requirements from this SDK smoke.
+The retired `sim-to-real-pipeline.yaml` is not a runnable next step.
 
-Point the loop at any `LeRobotDataset` in S3 and keep the same visualization:
-
-```bash
---input-data-uri "s3://your-bucket-name/datasets/my-lerobot-dataset/"
-```
-
-This is exactly how you'd plug in the [Franka demos](franka-pick-and-place-genesis.md)
-you recorded in Genesis, or a [Reachy 2](reachy2-lerobot-policy.md) dataset.
-
-## Dig deeper
-
-- **14-stage production loop:** [Sim-to-real workflow](sim2real-workflow.md) · [Data contracts](sim2real-data-contracts.md)
-- Canonical 14-stage YAML: `workflows/main/sim2real.yaml`
-- Generic loop semantics remain covered by a test-only fixture under
-  `npa/tests/fixtures/npa-workflows/`; it is not an operator workflow.
-- Skill: `skills/workflows/sim-to-real/SKILL.md`
+A custom dataset must match the selected trainer's observation, action, and
+robot schemas. See [customer assets](sim2real-customer-assets.md) before
+substituting a different robot or dataset.

--- a/docs/workbench/guides/quadruped-isaac-lab.md
+++ b/docs/workbench/guides/quadruped-isaac-lab.md
@@ -1,9 +1,10 @@
 # Train a Quadruped to Run in Isaac Lab
 
-**The hook:** drop a four-legged robot into NVIDIA **Isaac Lab**, run massively
-parallel reinforcement learning, and watch it learn to trot across flat and
-rough terrain. Isaac Lab ships dozens of ready-made tasks, so you get a real
-locomotion policy without writing an environment from scratch.
+[Guides](README.md)
+
+Train an ANYmal velocity policy with Isaac Lab on an RT-core GPU, then
+evaluate its checkpoint on held-out episodes. The evaluation report distinguishes
+successful execution from meeting the requested survival-rate threshold.
 
 ## Ingredients
 

--- a/docs/workbench/guides/reachy2-lerobot-policy.md
+++ b/docs/workbench/guides/reachy2-lerobot-policy.md
@@ -52,7 +52,7 @@ Reachy dataset you want (a Pollen Robotics / LeRobot Hub repo ID):
 ```bash
 npa workbench lerobot train \
   --policy-type act \
-  --dataset pollen-robotics/<reachy-dataset> \
+  --dataset "pollen-robotics/<reachy-dataset>" \
   --job-name reachy-act-hello \
   --steps 2000 \
   --batch-size 8 \

--- a/docs/workbench/guides/reachy2-lerobot-policy.md
+++ b/docs/workbench/guides/reachy2-lerobot-policy.md
@@ -1,23 +1,21 @@
 # Train a Reachy 2 Humanoid Policy from a Public Dataset
 
-**The hook:** Reachy 2 is the open-source humanoid from Pollen Robotics (now
-part of Hugging Face) — a friendly upper-body robot with two arms, a head, and
-a mobile base. In this guide you take a **public Reachy dataset off the Hugging
-Face Hub** and train an imitation policy on it with LeRobot, no robot hardware
-required.
+[Guides](README.md)
 
-It's the fastest way to feel what teaching a humanoid to manipulate is like.
+Train a LeRobot imitation policy from a Reachy 2 dataset on Nebius, then
+inspect its checkpoint. Choose a real Hub dataset with observation and action
+schemas supported by your policy; the dataset ID below is a placeholder.
 
 ## Ingredients
 
 - **Robot:** [Reachy 2](https://huggingface.co/docs/lerobot/main/en/reachy2)
   (Pollen Robotics). Fully supported by LeRobot for teleop, training, and eval.
-- **Sim / engine:** LeRobot training + evaluation; pair it with the
-  [sim-to-real loop](pusht-sim-to-real.md) for closed-loop rollouts.
+- **Sim / engine:** LeRobot training and task-compatible evaluation. The
+  [Sim2Real workflow](sim2real-workflow.md) has additional simulator and data requirements.
 - **Public dataset:** Reachy datasets published on the Hub under
   [`pollen-robotics`](https://huggingface.co/pollen-robotics) and
-  [`lerobot`](https://huggingface.co/lerobot). Any `LeRobotDataset` works — the
-  examples below show the swap.
+  [`lerobot`](https://huggingface.co/lerobot). Use a `LeRobotDataset` whose
+  robot, camera, and action schemas match your training configuration.
 - **You need:** Nebius creds + a GPU (see [getting-started](../getting-started.md)).
 
 ## The shape of the workflow
@@ -37,6 +35,10 @@ Diffusion Policy, and SmolVLA — start with `act` for a quick single-task
 baseline.
 
 ## Fast path
+
+These examples assume a configured LeRobot workbench. Use the
+[runtime guide](../runtime-modes.md) to deploy one; select an existing workbench
+with `-p <project-alias> -n <workbench-name>` before `train`.
 
 **1. See the tool:**
 
@@ -85,9 +87,8 @@ npa workbench lerobot list-checkpoints
   `~/.npa/config.yaml`.)
 - **Try a stronger policy:** `--policy-type smolvla` for a language-conditioned
   VLA baseline, or `diffusion` for smooth continuous actions.
-- **Close the loop:** feed your checkpoint into the
-  [sim-to-real loop](pusht-sim-to-real.md) to evaluate rollouts and collect
-  feedback, then visualize with Rerun.
+- **Build a full pipeline:** adapt the [Sim2Real workflow](sim2real-workflow.md)
+  after checking its [customer input contracts](sim2real-customer-assets.md).
 - **Benchmark the GPUs:** see the
   [LeRobot GPU benchmarks](../cookbooks/lerobot-gpu-benchmarks.md) across L40S,
   H200, B300, and RTX PRO 6000.
@@ -96,8 +97,9 @@ npa workbench lerobot list-checkpoints
 
 Got a real Reachy 2? LeRobot records directly to the same format with
 `lerobot-record --robot.type=reachy2 ...`, then you push to the Hub or stage to
-S3 and train with the exact commands above. The workbench never cares whether
-the data came from a real robot, a teleop session, or a simulator.
+S3 and train with the commands above. Training still requires matching
+observation, action, camera, and robot schemas, regardless of how the data was
+collected.
 
 ## Dig deeper
 

--- a/docs/workbench/guides/sim2real-architecture.md
+++ b/docs/workbench/guides/sim2real-architecture.md
@@ -1,5 +1,7 @@
 # Sim2Real compositional architecture
 
+[Guides](README.md)
+
 The canonical operator surface is
 `workflows/main/sim2real.yaml`. It is an ordinary
 `npa.workflow/v0.0.1` graph executed through the standard planner, SkyPilot

--- a/docs/workbench/guides/sim2real-customer-assets.md
+++ b/docs/workbench/guides/sim2real-customer-assets.md
@@ -52,7 +52,7 @@ Customer trigger URI and train-env URI definitions: [data contracts § Customer 
 export CUSTOMER_ASSET_PROFILE=industrial
 export CUSTOMER_TASK_ID=my-batch-20260614       # substitutes YOUR-TASK-ID in profile URIs
 export CUSTOMER_ROBOT_PRESET=flexiv             # optional; default ur5e in industrial profile
-<private-operator-pack>/sim2real-rtxpro/trigger-pipeline.sh
+"<private-operator-pack>/sim2real-rtxpro/trigger-pipeline.sh"
 ```
 
 Profiles: `<private-operator-pack>/sim2real-rtxpro/customer-asset-profiles/*.profile.example`.
@@ -66,7 +66,7 @@ Copy to `~/.npa/customer-asset.profile` and set `CUSTOMER_ASSET_PROFILE` to that
 Dry-run:
 
 ```bash
-CUSTOMER_ASSET_PROFILE=industrial <private-operator-pack>/sim2real-rtxpro/apply-customer-asset-profile.sh
+CUSTOMER_ASSET_PROFILE=industrial "<private-operator-pack>/sim2real-rtxpro/apply-customer-asset-profile.sh"
 ```
 
 Customer JSON templates (`YOUR-BUCKET` / `YOUR-TASK-ID` placeholders):
@@ -289,7 +289,7 @@ Run prefix: `s3://<bucket>/sim2real-b/<run-id>/`
 Fetch and inspect (replace bucket/run id):
 
 ```bash
-PREFIX=s3://<bucket>/sim2real-b/<run-id>
+PREFIX="s3://<bucket>/sim2real-b/<run-id>"
 aws s3 cp "${PREFIX}/outer_loop/decision.json" - --endpoint-url "${AWS_ENDPOINT_URL}" \
   | jq '{decision, success_rate, threshold, checkpoint_uri}'
 aws s3 cp "${PREFIX}/checkpoints/candidate/candidate.json" - --endpoint-url "${AWS_ENDPOINT_URL}" \

--- a/docs/workbench/guides/sim2real-customer-assets.md
+++ b/docs/workbench/guides/sim2real-customer-assets.md
@@ -1,5 +1,7 @@
 # Sim2Real — Customer asset handoff
 
+[Guides](README.md)
+
 **Audience:** What the customer **uploads** (trigger, scene, robot) vs NPA stock smoke paths.
 
 **Data types (schemas, LeRobot vs NPA JSON):** [sim2real-data-contracts.md](./sim2real-data-contracts.md) — read that first if URIs are confusing.
@@ -132,7 +134,7 @@ evaluation, and final reports enforce the same embodiment and dimensions without
 silent Franka fallback. See [the RobotSpec guide](./sim2real-robot-spec.md).
 
 Wire all customer asset seams at submit (CLI flag, SDK kwarg, and YAML env are 1:1 —
-see [runbook README](../../../npa/workflows/workbench/sim2real/README.md#one-byo-seam-one-value)):
+see [runbook README](sim2real-data-contracts.md)):
 
 ```bash
 # Trigger only (Monday stock run)

--- a/docs/workbench/guides/sim2real-data-contracts.md
+++ b/docs/workbench/guides/sim2real-data-contracts.md
@@ -1,5 +1,7 @@
 # Sim-to-Real — Data types & artifact contracts
 
+[Guides](README.md)
+
 **Canonical reference** for formats, schemas, and S3 layout in the 14-stage sim-to-real
 loop. Other guides link here instead of duplicating tables.
 

--- a/docs/workbench/guides/sim2real-demo-script-10min.md
+++ b/docs/workbench/guides/sim2real-demo-script-10min.md
@@ -38,19 +38,19 @@ s3://<bucket>/<prefix>/<run-id>/
 1. **Pre-stage a golden run** — Sync the validated run tree for offline walkthrough:
 
    ```bash
-   <private-operator-pack>/sim2real-rtxpro/prestage-offline-run.sh <pre-staged-run-id>
+   "<private-operator-pack>/sim2real-rtxpro/prestage-offline-run.sh" "<pre-staged-run-id>"
    # -> /tmp/sim2real-prestage/<run-id>/
-   rerun /tmp/sim2real-prestage/<pre-staged-run-id>/reports/sim2real.rrd
+   rerun "/tmp/sim2real-prestage/<pre-staged-run-id>/reports/sim2real.rrd"
    ```
 
    S3 canonical path: `s3://<bucket>/<prefix>/<pre-staged-run-id>/reports/sim2real.rrd`
 2. **Start a live job early** — 15–30 min before showtime:
 
-   ```bash
-   export KUBECONFIG=~/.npa/clusters/<cluster>/kubeconfig
+   ```text
+   export KUBECONFIG="$HOME/.npa/clusters/<cluster>/kubeconfig"
    npa workbench workflow submit \
      workflows/main/sim2real.yaml \
-     --runtime --resume --run-id <live-run-id> <operator-vars-and-secrets>
+     --runtime --resume --run-id "<live-run-id>" <operator-vars-and-secrets>
    ```
 
 3. **Optional: pre-stage a loop-back run** — Second run where `eval/gold-heldout/outer-XX/report.json` has `success_rate` below threshold and `outer_loop/loopback.json` exists (for held-out failure narrative).
@@ -111,10 +111,10 @@ Show one slide or browser tab: the 14-state graph from [sim2real-architecture.md
 > "One standard workflow owns every state, parallel lane, loop decision, retry,
 > and durable S3 checkpoint."
 
-```bash
+```text
 # What runs on cluster (abbreviated)
 npa workbench workflow submit workflows/main/sim2real.yaml \
-  --runtime --resume --run-id <run-id> <operator-vars-and-secrets>
+  --runtime --resume --run-id "<run-id>" <operator-vars-and-secrets>
 ```
 
 Mention: RTX PRO/L40S placement, queue admission, and retries remain visible to
@@ -189,7 +189,7 @@ Command to narrate loop-back:
 
 ```bash
 # canonical proof uses OUTER_ITERATIONS=3 and keeps gold held out until the final pass
-grep -E 'outer=|decision=' /tmp/sim2real-cluster/<live-run-id>.log
+grep -E 'outer=|decision=' "/tmp/sim2real-cluster/<live-run-id>.log"
 ```
 
 ### 8:00–8:45 — Stages 12–13 (external seam and retrigger record)
@@ -239,13 +239,13 @@ jq '.components[] | select(.name=="stage_14_rerun_viz") | {tier, message}' \
 npa workbench health preflight
 
 # Submit live run
-export KUBECONFIG=~/.npa/clusters/<cluster>/kubeconfig
+export KUBECONFIG="$HOME/.npa/clusters/<cluster>/kubeconfig"
 INNER_ITERATIONS=3 OUTER_ITERATIONS=3 ROLLOUT_COUNT=64 STEPS_PER_ROLLOUT=32 \
   VALIDATION_ENV_COUNT=64 HELDOUT_ENV_COUNT=64 SUCCESS_THRESHOLD=0.50 \
-  <private-operator-pack>/sim2real-rtxpro/submit-k8s-staged-job.sh
+  "<private-operator-pack>/sim2real-rtxpro/submit-k8s-staged-job.sh"
 
 # Monitor
-<private-operator-pack>/sim2real-rtxpro/monitor-k8s-job.sh sim2real-<live-run-id>
+"<private-operator-pack>/sim2real-rtxpro/monitor-k8s-job.sh" "sim2real-<live-run-id>"
 
 # Canonical URIs from code (optional)
 npa/.venv/bin/python -c "

--- a/docs/workbench/guides/sim2real-demo-script-10min.md
+++ b/docs/workbench/guides/sim2real-demo-script-10min.md
@@ -1,5 +1,7 @@
 # Sim-to-Real Pipeline — 10-Minute Demo Script
 
+[Guides](README.md)
+
 > **Presentation-only legacy script.** Do not use the private operator-pack
 > commands below to launch a qualification run. The sole production entrypoint
 > is `npa workbench workflow submit workflows/main/sim2real.yaml --runtime`; follow

--- a/docs/workbench/guides/sim2real-durable-controller.md
+++ b/docs/workbench/guides/sim2real-durable-controller.md
@@ -1,5 +1,7 @@
 # Sim2Real durability: standard workflow runtime
 
+[Guides](README.md)
+
 The former Sim2Real-specific controller is retired from the canonical path.
 Durability now belongs to the standard `npa.workflow` runtime, not to a driver
 pod that creates and watches child Jobs.

--- a/docs/workbench/guides/sim2real-robot-spec.md
+++ b/docs/workbench/guides/sim2real-robot-spec.md
@@ -1,5 +1,7 @@
 # Canonical Sim2Real RobotSpec input
 
+[Guides](README.md)
+
 The canonical 14-stage workflow accepts one optional `config.robot_spec_uri`.
 Leave it empty for the unchanged stock Franka path. Set it to an exact `s3://`
 object containing `npa.sim2real.robot_spec.v1` to run a custom articulated robot.

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -1,5 +1,7 @@
 # Compositional Sim2Real operator runbook
 
+[Guides](README.md)
+
 This is the onboarding source of truth for the canonical 14-stage workflow:
 [`sim2real.yaml`](../../../workflows/main/sim2real.yaml).
 Complete the gates in order. A production submit repeats the decisive S3,
@@ -170,7 +172,7 @@ kubectl get pvc npa-isaac-cache -o custom-columns=NAME:.metadata.name,PHASE:.sta
 Expected: the Job completes, its log ends with a successful bootstrap, and the
 PVC is `Bound` with `RWX`. Exit 78 means acceptance was explicitly disabled;
 image pull failures are handled in the next gate. See
-[runtime-fetch packaging](../container-packaging.md#nvidia-isaac--omniverse-runtime-fetch-images).
+[runtime-fetch packaging](../container-packaging.md#runtime-fetched-isaac-sim-why-the-isaac-images-are-publishable).
 
 ## 5. Build/push once and prove the exact image pulls
 

--- a/docs/workbench/guides/sim2real-workflow.md
+++ b/docs/workbench/guides/sim2real-workflow.md
@@ -455,7 +455,7 @@ wave that reached a genuine terminal `FAILED` status is preserved as-is and
 gated-model license, for example). Add `--retries 1` to authorize one new
 attempt at that specific wave:
 
-```bash
+```text
 npa/.venv/bin/npa workbench workflow submit "${SPEC}" \
   --project "${NPA_PROJECT}" --infra "k8s/${NPA_CLUSTER}" \
   --runtime --resume-run "${RUN_ID}" --retries 1 --max-wait-seconds 0 \

--- a/docs/workbench/huggingface-token.md
+++ b/docs/workbench/huggingface-token.md
@@ -1,5 +1,7 @@
 # Set up a Hugging Face token
 
+[Workbench docs](README.md)
+
 Many workbench models and datasets are hosted on [Hugging Face](https://huggingface.co).
 A Hugging Face access token lets `npa` download private or **gated** assets and
 raises rate limits. Public assets work anonymously. Tokens inherit the owning

--- a/docs/workbench/image-byte-scanning.md
+++ b/docs/workbench/image-byte-scanning.md
@@ -1,5 +1,7 @@
 # Complete-byte checks for cuRobo images
 
+[Workbench docs](README.md)
+
 The trusted cuRobo publication workflow adds an archive byte scan before pushing
 an image and after pulling its exact digest. It retains the existing Trivy,
 license, runtime, provenance, SBOM, and payload checks. Other workbench images

--- a/docs/workbench/image-gpu-compatibility-matrix.md
+++ b/docs/workbench/image-gpu-compatibility-matrix.md
@@ -1,5 +1,7 @@
 # Image ↔ Nebius GPU compatibility matrix
 
+[Workbench docs](README.md)
+
 Every Workbench container image against every Nebius GPU platform, and — separately — which of those cells has actually been run on real hardware.
 
 **Last measured:** see the dated runs and exact-digest records below.

--- a/docs/workbench/isaac-lab-3.md
+++ b/docs/workbench/isaac-lab-3.md
@@ -28,8 +28,8 @@ path. Managed deployments default to the reproducible container:
 ```bash
 npa workbench isaac-lab deploy \
   --runtime container \
-  --gpu-type <discovered-rtx-platform> \
-  --gpu-preset <matching-preset>
+  --gpu-type "<discovered-rtx-platform>" \
+  --gpu-preset "<matching-preset>"
 ```
 
 Native `--runtime vm` installation is intentionally unsupported for generation
@@ -45,9 +45,9 @@ barrier:
 ```bash
 npa workbench workflow submit \
   workflows/testing/isaac-lab-rl-sweep.yaml \
-  --run-id <unique-run-id> \
+  --run-id "<unique-run-id>" \
   --runtime \
-  --var bucket=<configured-bucket> \
+  --var bucket="<configured-bucket>" \
   --image ghcr.io/nebius/nebius-physical-ai/npa-isaac-lab:3.0.0b2.post1 \
   --secret-env AWS_ACCESS_KEY_ID \
   --secret-env AWS_SECRET_ACCESS_KEY
@@ -59,7 +59,7 @@ export. RGB capture is enabled by default for that post-training rollout:
 ```bash
 npa workbench isaac-lab train \
   --task Isaac-Cartpole-v0 \
-  --output-dir <output-directory> \
+  --output-dir "<output-directory>" \
   --export-trajectories
 ```
 

--- a/docs/workbench/isaac-lab-3.md
+++ b/docs/workbench/isaac-lab-3.md
@@ -1,5 +1,7 @@
 # Isaac Lab 3 workbench
 
+[Workbench docs](README.md)
+
 NPA pins the newest released point in the Isaac Lab 3 beta line:
 `v3.0.0-beta2.patch1` (`isaaclab==3.0.0b2.post1`) at commit
 `ffff603eafc6b74264a5261cc0183d6a65390d78`, paired with Isaac Sim

--- a/docs/workbench/kubernetes.md
+++ b/docs/workbench/kubernetes.md
@@ -26,9 +26,9 @@ Complete the platform quickstart first, then collect these values from your
 operator:
 
 ```bash
-export NEBIUS_PROJECT_ID=<your-project-id>
-export NEBIUS_TENANT_ID=<your-tenant-id>
-export NPA_S3_BUCKET=<your-bucket>
+export NEBIUS_PROJECT_ID="<your-project-id>"
+export NEBIUS_TENANT_ID="<your-tenant-id>"
+export NPA_S3_BUCKET="<your-bucket>"
 export AWS_ENDPOINT_URL=https://storage.eu-north1.nebius.cloud
 export NPA_STORAGE_ENDPOINT=storage.eu-north1.nebius.cloud
 ```
@@ -60,7 +60,7 @@ Select the managed Kubernetes context provided by your operator:
 
 ```bash
 kubectl config get-contexts
-kubectl config use-context <your-nebius-mk8s-context>
+kubectl config use-context "<your-nebius-mk8s-context>"
 kubectl config current-context
 ```
 
@@ -94,7 +94,7 @@ Use the NPA-managed SkyPilot virtualenv. Do not rely on an unrelated `sky` from
 npa skypilot bootstrap
 export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
 npa skypilot status
-npa skypilot verify --cluster <npa-cluster-name> --output-format json
+npa skypilot verify --cluster "<npa-cluster-name>" --output-format json
 ```
 
 The validated SkyPilot version is `0.12.2`. NPA defaults managed jobs to a
@@ -109,7 +109,7 @@ or workflow stages to call the same service endpoint:
 
 ```bash
 npa workbench detection-training deploy \
-  --project <project-alias> --cluster-name <npa-cluster-name> \
+  --project "<project-alias>" --cluster-name "<npa-cluster-name>" \
   --output-path "s3://${NPA_S3_BUCKET}/detection-training/" \
   --namespace workbench \
   --gpu-type h100
@@ -152,7 +152,7 @@ Monitor from S3-backed workflow state:
 
 ```bash
 npa workbench workflow status "s3://${NPA_S3_BUCKET}/workflows/${RUN_ID}/" --watch
-npa workbench workflow logs "s3://${NPA_S3_BUCKET}/workflows/${RUN_ID}/" --stage <stage>
+npa workbench workflow logs "s3://${NPA_S3_BUCKET}/workflows/${RUN_ID}/" --stage "<stage>"
 npa workbench workflow artifacts "s3://${NPA_S3_BUCKET}/workflows/${RUN_ID}/"
 ```
 

--- a/docs/workbench/kubernetes.md
+++ b/docs/workbench/kubernetes.md
@@ -1,5 +1,7 @@
 # Workbench On Kubernetes
 
+[Workbench docs](README.md)
+
 This guide is the Kubernetes-specific path after
 [Workbench Getting Started](getting-started.md). Use it when a Workbench
 workflow or service should run on a Nebius Managed Kubernetes cluster through
@@ -92,7 +94,7 @@ Use the NPA-managed SkyPilot virtualenv. Do not rely on an unrelated `sky` from
 npa skypilot bootstrap
 export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
 npa skypilot status
-"${NPA_SKYPILOT_BIN}" check
+npa skypilot verify --cluster <npa-cluster-name> --output-format json
 ```
 
 The validated SkyPilot version is `0.12.2`. NPA defaults managed jobs to a
@@ -107,11 +109,15 @@ or workflow stages to call the same service endpoint:
 
 ```bash
 npa workbench detection-training deploy \
+  --project <project-alias> --cluster-name <npa-cluster-name> \
   --output-path "s3://${NPA_S3_BUCKET}/detection-training/" \
-  --storage-endpoint storage.eu-north1.nebius.cloud \
   --namespace workbench \
   --gpu-type h100
 ```
+
+Storage credentials and endpoint resolve from the selected project. Configure
+`DETECTION_TRAINING_TOKEN` in the private environment for the default token
+authentication.
 
 Inside Kubernetes, use the cluster-local service endpoint printed by the deploy
 command, for example:

--- a/docs/workbench/leisaac-teleoperation.md
+++ b/docs/workbench/leisaac-teleoperation.md
@@ -1,5 +1,7 @@
 # LeIsaac browser teleoperation
 
+[Workbench docs](README.md)
+
 For the measured split control/video transport, fallback behavior, latency
 instrumentation, and security model, see
 [LeIsaac low-latency browser transport](guides/leisaac-transport-latency.md).

--- a/docs/workbench/lerobot-version-support-audit-20260813.md
+++ b/docs/workbench/lerobot-version-support-audit-20260813.md
@@ -1,5 +1,7 @@
 # LeRobot version support audit and proposal — 2026-08-13
 
+[Workbench docs](README.md)
+
 Upstream LeRobot is at **0.6.1** (released 2026-08-03). This workbench defaults
 to **0.5.1** (2026-04-07) and offers **0.6.0** (2026-07-06) as a selectable
 alternative. This audit answers whether the workbench should support 0.6.1, what

--- a/docs/workbench/ltx2.md
+++ b/docs/workbench/ltx2.md
@@ -1,5 +1,7 @@
 # LTX-2.5 Workbench support
 
+[Workbench docs](README.md)
+
 NPA packages Lightricks' LTX-2.5 video/audio model as a BYOF solution whose
 image contains **no LTX-2.5 bytes at all** — no `ltx-core`, no `ltx-pipelines`,
 no weights, no CUDA wheels. On first use the container fetches upstream's pinned

--- a/docs/workbench/ltx2.md
+++ b/docs/workbench/ltx2.md
@@ -157,7 +157,7 @@ proves the refusal works and that proving it downloaded nothing; it fails if any
 LTX, weight, or CUDA payload appears in any layer.
 
 ```bash
-npa/docker/workbench/ltx2/build.sh --registry <your-registry> --push
+npa/docker/workbench/ltx2/build.sh --registry "<your-registry>" --push
 ```
 
 **2. Scan the pushed bytes, not the Dockerfile.** The claim is about bytes in
@@ -166,7 +166,7 @@ directions by `npa/tests/docker/test_ltx_image_payload_scan.py`.
 
 ```bash
 npa/.venv/bin/python npa/scripts/scan_image_ltx_payload.py \
-  <your-registry>/npa-ltx2:dev-<full-git-sha>
+  "<your-registry>/npa-ltx2:dev-<full-git-sha>"
 ```
 
 Only the immutable public development tag is tested before release promotion.
@@ -175,7 +175,7 @@ Only the immutable public development tag is tested before release promotion.
 build ran, now against the artifact anyone would pull.
 
 ```bash
-docker run --rm <your-registry>/npa-ltx2@sha256:<digest> ltx-runtime assert-refusal
+docker run --rm "<your-registry>/npa-ltx2@sha256:<digest>" ltx-runtime assert-refusal
 ```
 
 It must print `NPA_LTX_BOOTSTRAP_REFUSES_WITHOUT_ENTITLEMENT_OK`. Confirm the
@@ -183,7 +183,7 @@ unentitled refusal separately, and that it names the token rather than one of
 the gates behind it:
 
 ```bash
-docker run --rm <your-registry>/npa-ltx2@sha256:<digest> ltx-runtime ensure
+docker run --rm "<your-registry>/npa-ltx2@sha256:<digest>" ltx-runtime ensure
 # exits 78, names HF_TOKEN and the gated repository, downloads nothing
 ```
 
@@ -200,7 +200,7 @@ the generation, which is a much less obvious failure).
 
 ```bash
 export NPA_INTEGRATION_E2E=1 NPA_LTX2_LIVE_GPU=1
-export NPA_LTX2_REUSE_IMAGE=<your-registry>/npa-ltx2@sha256:<digest>
+export NPA_LTX2_REUSE_IMAGE="<your-registry>/npa-ltx2@sha256:<digest>"
 npa/.venv/bin/python -m pytest npa/tests/e2e/test_ltx2_live_e2e.py -q
 ```
 

--- a/docs/workbench/mk8s-gpu-driver-strategy.md
+++ b/docs/workbench/mk8s-gpu-driver-strategy.md
@@ -1,5 +1,7 @@
 # Managed Kubernetes GPU driver strategy
 
+[Workbench docs](README.md)
+
 NPA uses one GPU driver policy for both direct `npa cluster` provisioning and
 `npa fleet`: GPU node groups use a Nebius managed-driver image by default, while
 CPU-only node groups and clusters receive no GPU driver settings. The policy is

--- a/docs/workbench/model-weight-cache.md
+++ b/docs/workbench/model-weight-cache.md
@@ -1,5 +1,7 @@
 # Caching runtime-downloaded model weights and reviewed SDKs
 
+[Workbench docs](README.md)
+
 The workbench images bake **no model weights**. Every NVIDIA Cosmos checkpoint and
 guardrail, GR00T, the Cosmos-Curate towers, the Qwen VLMs, Wan 2.2 and LTX are
 license-gated or too large to redistribute, so

--- a/docs/workbench/model-weight-cache.md
+++ b/docs/workbench/model-weight-cache.md
@@ -40,7 +40,7 @@ On by default wherever the answer is not "invent storage nobody asked for":
   default to; name a Nebius filesystem and every job attaches it:
 
   ```bash
-  export NPA_MODEL_CACHE_FILESYSTEM=<filesystem>   # not an s3:// bucket
+  export NPA_MODEL_CACHE_FILESYSTEM="<filesystem>"   # not an s3:// bucket
   ```
 
 Nothing here provisions storage. NPA will not create a claim, guess a class, or bill

--- a/docs/workbench/ncore-component-scanning.md
+++ b/docs/workbench/ncore-component-scanning.md
@@ -1,5 +1,7 @@
 # NCore non-Debian component coverage
 
+[Workbench docs](README.md)
+
 NCore's supplemental component gate is required **in addition to** the selected
 Debian SPDX scan and ordinary Trivy vulnerability, secret and license scans.
 It is specific to the selected NCore scratch image. It neither fabricates an

--- a/docs/workbench/ncore-oci-publication.md
+++ b/docs/workbench/ncore-oci-publication.md
@@ -1,5 +1,7 @@
 # NCore OCI development publication
 
+[Workbench docs](README.md)
+
 NCore remains quarantined from supported releases pending complete conversion,
 RTX NRE training/rendering and readback acceptance. This command publishes only
 `ghcr.io/nebius/nebius-physical-ai/npa-ncore:dev-<full-source-sha>`. It does not

--- a/docs/workbench/ngc-api-key.md
+++ b/docs/workbench/ngc-api-key.md
@@ -1,5 +1,7 @@
 # Set up an NVIDIA NGC API key
 
+[Workbench docs](README.md)
+
 NVIDIA distributes some workbench assets through [NGC](https://ngc.nvidia.com)
 and `nvcr.io`. An NGC API key authenticates the pull; the owning account must
 also have repository entitlement. NPA does not add an independent manual EULA

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -68,7 +68,7 @@ mode or as `run_id` with `--output-format json`. Find durable runs with:
 
 ```bash
 npa workbench workflow list \
-  --s3-bucket <bucket> --workflow-s3-prefix <parent-prefix> --json
+  --s3-bucket "<bucket>" --workflow-s3-prefix "<parent-prefix>" --json
 ```
 
 When tasks need source, submission automatically stages a content-addressed
@@ -218,8 +218,8 @@ and launches it. Runtime-required workflows select the driver automatically.
 `--runtime` adds a driver that executes the graph wave by wave:
 
 ```bash
-npa workbench workflow submit <spec.yaml> --run-id <id> --runtime \
-  --project <alias> --infra k8s/<cluster> --var bucket=<bucket>
+npa workbench workflow submit "<spec.yaml>" --run-id "<id>" --runtime \
+  --project "<alias>" --infra "k8s/<cluster>" --var bucket="<bucket>"
 ```
 
 | Capability | Behaviour |

--- a/docs/workbench/npa-workflow-guide.md
+++ b/docs/workbench/npa-workflow-guide.md
@@ -1,59 +1,95 @@
 # NPA workflow guide (`apiVersion: npa.workflow/v0.0.1`)
 
-Declarative state-machine specs for workbench tool pipelines. One format is consumed
-three ways: YAML file, CLI, and Python SDK.
+[Workbench docs](README.md) · [Workflow catalog](../../workflows/README.md)
+
+A workflow is a graph of tool calls, S3 artifacts, and transitions. NPA validates
+and plans the YAML, then uses SkyPilot to execute it. This page covers the command
+sequence and format; each workload guide supplies its inputs and resource needs.
 
 ## Quick start
 
+From the clone root, inspect a generation workflow locally:
+
 ```bash
-# Validate structure and closed toolRef / predicate registries
-npa workbench workflow validate-spec workflows/testing/vlm-eval-single.yaml
-
-# Expand loops/branches in the demo-only Sim2Real DSL fixture (dry-run)
-npa workbench workflow plan-spec workflows/main/sim2real.yaml \
-  --run-id demo --assume-decision loop_back
-
-# Plan + optional scheduler hints + S3 run manifest
-npa workbench workflow run-spec workflows/testing/vlm-eval-single.yaml \
-  --plan-only --scheduler-plan --persist-state --json
-
-# Submit an npa.workflow spec
-npa workbench workflow submit workflows/testing/vlm-eval-single.yaml \
-  --run-id demo --registry <your-registry>/<namespace>
-
-# Plan only (no submit) — inspect planned steps
-# Token Factory (and other no-image tools) need NPA_SRC_S3_URI or --image
-NPA_SRC_S3_URI=s3://<bucket>/npa-src/npa \
-  npa workbench workflow submit workflows/testing/token-factory-caption.yaml \
-  --plan-only --run-id demo
+workflow_spec=workflows/testing/cosmos3-generate.yaml
+npa workbench workflow validate-spec "$workflow_spec"
+npa workbench workflow plan-spec "$workflow_spec" --run-id preview --json
 ```
 
-A successful submit prints the resolved run ID in text mode and returns it as
-the top-level `run_id` in `--output-format json`. If the spec configures an S3
-`bucket`, NPA also writes a run manifest under its resolved prefix. List those
-runs later with the established durable-run command:
+These commands launch no workload. The plan still contains the example bucket.
+For execution, complete [Workbench setup](getting-started.md) and the
+[Cosmos 3 prerequisites](cosmos3-generate.md#workflow), then set your actual target:
+
+```bash
+project_alias='<your-project-alias>'
+cluster_name='<your-npa-cluster-name>'
+bucket_name='<your-bucket>'
+run_id="$(npa workbench workflow prepare-run "$workflow_spec" --project "$project_alias")"
+
+npa workbench workflow plan-spec "$workflow_spec" \
+  --run-id "$run_id" --var "bucket=$bucket_name"
+npa workbench workflow preflight-images "$workflow_spec" \
+  --project "$project_alias" --infra "k8s/$cluster_name" \
+  --var "bucket=$bucket_name" --json
+```
+
+Review the resolved GPU shape, image, and output prefix. Image preflight may
+create and delete a temporary probe pod. Then run the workload:
+
+```bash
+npa workbench workflow submit "$workflow_spec" \
+  --project "$project_alias" --infra "k8s/$cluster_name" \
+  --run-id "$run_id" --var "bucket=$bucket_name" --runtime \
+  --secret-env HF_TOKEN \
+  --secret-env AWS_ACCESS_KEY_ID --secret-env AWS_SECRET_ACCESS_KEY
+```
+
+`--runtime` supervises execution to a terminal state. The default generation
+requires gated guardrail access through `HF_TOKEN`. Secrets resolve from the
+private environment or selected project's credential store; pass names only.
+Public images need no registry login. Use `--registry` only for custom images.
+
+Inspect the same run from another shell or after submission returns:
+
+```bash
+npa workbench workflow status "$run_id" --project "$project_alias"
+npa workbench workflow logs "$run_id" --project "$project_alias"
+npa workbench workflow artifacts "$run_id" --project "$project_alias" --json
+```
+
+Open the generated media and `generate.json`; a successful job alone does not
+prove output quality. Keep the run ID for [recovery](../run-lifecycle.md#restart-safety)
+and follow [teardown](../teardown.md) when finished with owned resources.
+
+### Source staging and run IDs
+
+`prepare-run` reserves a new identity. `submit` prints the resolved ID in text
+mode or as `run_id` with `--output-format json`. Find durable runs with:
 
 ```bash
 npa workbench workflow list \
   --s3-bucket <bucket> --workflow-s3-prefix <parent-prefix> --json
 ```
 
-Author and submit `npa.workflow/v0.0.1` specs from the
-[`workflow catalog`](../../workflows/README.md). `workflows/main/` contains only
-`sim2real.yaml`, `paidf-cosmos3.yaml`, and `nurec-reconstruct.yaml`; other specs, including new
-workflows, belong in `workflows/testing/`.
+When tasks need source, submission automatically stages a content-addressed
+archive and persists its identity. A manually staged `NPA_SRC_S3_URI` or explicit
+image remains an override; it is not a prerequisite for the ordinary path.
+Resume the exact run using the command NPA prints, or `--resume-run <id>` with
+the original specification and target. See [run identity](../run-lifecycle.md#run-identity).
 
-**No-image tools** (Token Factory specs): set
-`NPA_SRC_S3_URI=s3://bucket/prefix/npa` so the job can sync and install `npa`,
-or pass `--image` to a workbench image that already includes it. `--plan-only`
-does not mint or print live registry tokens.
+### Choose another spec
+
+Browse the [workflow catalog](../../workflows/README.md). `workflows/main/`
+contains `sim2real.yaml`, `paidf-cosmos3.yaml`, and `nurec-reconstruct.yaml`;
+other catalog workflows live in `workflows/testing/`. A directory name does not
+establish a workflow's validation scope; read its guide.
 
 Reference specs (all pytest-guarded):
 
 | File | Shows |
 | --- | --- |
 | `vlm-eval-single.yaml` | Single `toolRef`, terminal state |
-| `token-factory-caption.yaml` | Zero-GPU Token Factory caption |
+| `token-factory-caption.yaml` | Hosted Token Factory captioning |
 | `tokenfactory-rollout-judge.yaml` | Serial two-tool chain with `inputs`/`outputs` |
 | `sim2real.yaml` | Canonical compositional 14-stage Sim2Real runtime; requires immutable component images and task-aligned S3 inputs for execution |
 | `bdd100k-pipeline.yaml` | AV failure-mode pipeline — ingest → backfill → train → eval |
@@ -65,6 +101,9 @@ Reference specs (all pytest-guarded):
 | `mjlab-eval.yaml` / `retargeting.yaml` / `sonic-*.yaml` / `cosmos3-reason.yaml` | Single-tool workbench specs |
 
 ## Document shape
+
+This excerpt illustrates the schema. Use a complete spec from the catalog for
+execution; each `toolRef` also requires its own configuration and inputs.
 
 ```yaml
 apiVersion: npa.workflow/v0.0.1
@@ -151,8 +190,8 @@ for execution; use it only for offline planning previews.
 
 ## Tool catalog
 
-See `docs/workbench/npa-workflow-tool-catalog.md` and
-`npa/src/npa/orchestration/npa_workflow/catalog.py`. Add new tools in Python, not by
+See the [toolRef catalog](npa-workflow-tool-catalog.md) and its
+[source](../../npa/src/npa/orchestration/npa_workflow/catalog.py). Add new tools in Python, not by
 inventing YAML fields.
 
 ## Runtime features (v0.0.1+)
@@ -180,8 +219,7 @@ and launches it. Runtime-required workflows select the driver automatically.
 
 ```bash
 npa workbench workflow submit <spec.yaml> --run-id <id> --runtime \
-  [--resume] [--poll-seconds 30] [--max-wait-seconds 3600] \
-  [--retries 1] [--max-concurrency 2] [--no-cancel-on-timeout]
+  --project <alias> --infra k8s/<cluster> --var bucket=<bucket>
 ```
 
 | Capability | Behaviour |

--- a/docs/workbench/npa-workflow-tool-catalog.md
+++ b/docs/workbench/npa-workflow-tool-catalog.md
@@ -1,5 +1,7 @@
 # NPA workflow tool catalog (v0.0.1)
 
+[Workbench docs](README.md)
+
 Workbench tools referenced by `toolRef` in NPA workflow specs. Each tool is
 invoked as a container command; artifacts pass via S3 URIs in `config`.
 

--- a/docs/workbench/openpi-pi05-polaris.md
+++ b/docs/workbench/openpi-pi05-polaris.md
@@ -256,8 +256,8 @@ npa/.venv/bin/npa workbench workflow validate-spec \
 npa/.venv/bin/npa workbench workflow plan-spec \
   workflows/testing/openpi-pi05-full-droid-finetune.yaml \
   --run-id openpi-full-droid-plan \
-  --var runtime_image=registry.example.invalid/operator/openpi@sha256:<digest> \
-  --var durable_pvc=<run-owned-claim>
+  --var runtime_image="registry.example.invalid/operator/openpi@sha256:<digest>" \
+  --var durable_pvc="<run-owned-claim>"
 ```
 
 Before live submission, prove the selected project/tenant/region, eight reserved
@@ -281,7 +281,7 @@ npa/.venv/bin/npa workbench workflow validate-spec \
 npa/.venv/bin/npa workbench workflow plan-spec \
   workflows/testing/openpi-pi05-four-mode.yaml \
   --run-id openpi-four-mode-plan \
-  --var runtime_image=registry.example.invalid/operator/openpi@sha256:<digest>
+  --var runtime_image="registry.example.invalid/operator/openpi@sha256:<digest>"
 ```
 
 On a fresh isolated B200 MK8s context, the canonical E2E builds the source,
@@ -293,10 +293,10 @@ and inference regression, and submits the connected graph through
 ```bash
 NPA_INTEGRATION_E2E=1 \
 NPA_BYOF_OPENPI_LIVE_B200=1 \
-NPA_E2E_PROJECT=<project-alias> \
-NPA_E2E_S3_BUCKET=<existing-project-bucket> \
-NPA_BYOF_S3_ENDPOINT=https://storage.<bucket-region>.nebius.cloud \
-NPA_BYOF_OPENPI_REGISTRY=<operator-registry>/<namespace> \
+NPA_E2E_PROJECT="<project-alias>" \
+NPA_E2E_S3_BUCKET="<existing-project-bucket>" \
+NPA_BYOF_S3_ENDPOINT="https://storage.<bucket-region>.nebius.cloud" \
+NPA_BYOF_OPENPI_REGISTRY="<operator-registry>/<namespace>" \
 NPA_OPENPI_ACCEPT_GEMMA_TERMS=YES \
 npa/.venv/bin/python -m pytest -q -s \
   npa/tests/e2e/test_byof_openpi_polaris_live_e2e.py

--- a/docs/workbench/openpi-pi05-polaris.md
+++ b/docs/workbench/openpi-pi05-polaris.md
@@ -1,5 +1,7 @@
 # OpenPI pi0.5 Polaris: direct, serve, train, and evaluate
 
+[Workbench docs](README.md)
+
 The connected OpenPI workflow family has two deliberately separate surfaces:
 
 - `byof-openpi.yaml` packages and byte-scans the immutable upstream

--- a/docs/workbench/oss-solution-catalog.md
+++ b/docs/workbench/oss-solution-catalog.md
@@ -1,5 +1,7 @@
 # OSS Physical AI Solution Candidates
 
+[Workbench docs](README.md)
+
 This catalog tracks open-source Physical AI projects that are being onboarded as
 Workbench registry candidates through BYOF, including entries subsequently
 promoted to native tools or public images as noted below. Promotion requires the pushed registry image

--- a/docs/workbench/preemptible-vms.md
+++ b/docs/workbench/preemptible-vms.md
@@ -1,5 +1,7 @@
 # Workbench preemptible VMs
 
+[Workbench docs](README.md)
+
 **Short answer:** yes — Workbench GPU VM deploys support Nebius **preemptible**
 (spot-style) instances. They are **on by default** for most tools. Use
 `--no-preemptible` when you need a VM that stays up until you tear it down.

--- a/docs/workbench/preemptible-vms.md
+++ b/docs/workbench/preemptible-vms.md
@@ -31,7 +31,7 @@ Under the hood, Terraform sets `enable_preemptible=true`, which maps to
 Deploy a preemptible LeRobot VM (default — no extra flag needed):
 
 ```bash
-npa workbench lerobot -p <project> -n cheap-h200 deploy \
+npa workbench lerobot -p "<project>" -n cheap-h200 deploy \
   --gpu-type gpu-h200-sxm \
   --gpu-preset 1gpu-16vcpu-200gb
 ```
@@ -39,7 +39,7 @@ npa workbench lerobot -p <project> -n cheap-h200 deploy \
 Force a **non-preemptible** VM for a long training block:
 
 ```bash
-npa workbench lerobot -p <project> -n stable-h200 deploy \
+npa workbench lerobot -p "<project>" -n stable-h200 deploy \
   --gpu-type gpu-h200-sxm \
   --gpu-preset 1gpu-16vcpu-200gb \
   --no-preemptible
@@ -50,7 +50,7 @@ Same pattern works on `genesis`, `groot`, `isaac-lab`, and `cosmos` VM deploys.
 Preview without provisioning:
 
 ```bash
-npa workbench lerobot -p <project> -n preview deploy \
+npa workbench lerobot -p "<project>" -n preview deploy \
   --gpu-type gpu-h200-sxm --gpu-preset 1gpu-16vcpu-200gb \
   --preemptible --dry-run
 ```
@@ -81,7 +81,7 @@ runtime.
    left orphaned:
 
    ```bash
-   npa workbench lerobot -p <project> -n cheap-h200 deploy --destroy
+   npa workbench lerobot -p "<project>" -n cheap-h200 deploy --destroy
    ```
 
 See also the preemptible H200 research flow in
@@ -95,7 +95,7 @@ with yours):
 
 ```bash
 # From ~/.npa/config.yaml workbench entry or terraform output
-nebius compute instance get --id <instance-id> --format json \
+nebius compute instance get --id "<instance-id>" --format json \
   | jq '.spec.preemptible // .preemptible'
 ```
 

--- a/docs/workbench/ray.md
+++ b/docs/workbench/ray.md
@@ -120,9 +120,9 @@ Then submit a durable batch from a CPU client:
 
 ```bash
 npa workbench cosmos3 ray-batch \
-  --input-path s3://<bucket>/<prefix>/batch.json \
-  --output-path s3://<bucket>/<prefix>/outputs/ \
-  --endpoint http://<private-service>:8000
+  --input-path "s3://<bucket>/<prefix>/batch.json" \
+  --output-path "s3://<bucket>/<prefix>/outputs/" \
+  --endpoint "http://<private-service>:8000"
 ```
 
 The bearer token comes from `NPA_COSMOS3_RAY_TOKEN`, not the command line. The

--- a/docs/workbench/ray.md
+++ b/docs/workbench/ray.md
@@ -1,5 +1,7 @@
 # Use Workbench with Ray
 
+[Workbench docs](README.md)
+
 Workbench uses Ray through a small set of explicit paths. There is no `npa ray`
 command and no NPA wrapper around Ray Jobs. Use the native `ray` CLI for
 application submission and control; use `npa` only for the infrastructure,

--- a/docs/workbench/rerun-sharing.md
+++ b/docs/workbench/rerun-sharing.md
@@ -1,5 +1,7 @@
 # Share Rerun recordings safely
 
+[Workbench docs](README.md)
+
 `npa rerun host` and `npa rerun share` create time-boxed `app.rerun.io` links
 for `.rrd` recordings in object storage. Browser loading requires a one-time
 bucket CORS rule because the viewer fetches the recording from a different

--- a/docs/workbench/rerun-sharing.md
+++ b/docs/workbench/rerun-sharing.md
@@ -13,8 +13,8 @@ First inspect the additive plan, then apply it with a Nebius profile that can
 administer the bucket:
 
 ```bash
-npa storage bucket cors --project <alias>
-npa storage bucket cors --project <alias> --apply
+npa storage bucket cors --project "<alias>"
+npa storage bucket cors --project "<alias>" --apply
 ```
 
 Use `--name <bucket>` when sharing from a bucket other than the project's
@@ -43,11 +43,11 @@ if plan.changed:
 ## Create and verify a share
 
 ```bash
-npa rerun host recording.rrd --target-project <alias> --ttl-hours 1
+npa rerun host recording.rrd --target-project "<alias>" --ttl-hours 1
 npa rerun share recording.rrd \
-  --target-project <alias> \
-  --workspace <workspace> \
-  --label <label> \
+  --target-project "<alias>" \
+  --workspace "<workspace>" \
+  --label "<label>" \
   --ttl-hours 24
 ```
 
@@ -60,8 +60,8 @@ The URL is itself a temporary credential. Give it the shortest useful lifetime
 and revoke durable shares when the review ends:
 
 ```bash
-npa rerun list-shares --target-project <alias> --output json
-npa rerun revoke <sha256-or-label> --target-project <alias>
+npa rerun list-shares --target-project "<alias>" --output json
+npa rerun revoke "<sha256-or-label>" --target-project "<alias>"
 ```
 
 ## Native local fallback
@@ -70,7 +70,7 @@ When a bucket administrator cannot update CORS, download the recording and open
 it in the native viewer:
 
 ```bash
-rerun <recording.rrd>
+rerun "<recording.rrd>"
 ```
 
 This fallback does not require a browser origin, a presigned URL, or bucket

--- a/docs/workbench/runtime-modes.md
+++ b/docs/workbench/runtime-modes.md
@@ -25,11 +25,11 @@ For a LeRobot workbench, supply your configured project alias and choose a
 workbench name. These parent selectors precede the subcommand:
 
 ```bash
-npa workbench lerobot -p <project-alias> -n <workbench-name> deploy \
+npa workbench lerobot -p "<project-alias>" -n "<workbench-name>" deploy \
   --runtime container \
-  --project-id <project-id> --tenant-id <tenant-id> --region <region>
-npa workbench lerobot -p <project-alias> -n <workbench-name> status
-npa workbench lerobot -p <project-alias> -n <workbench-name> system-info
+  --project-id "<project-id>" --tenant-id "<tenant-id>" --region "<region>"
+npa workbench lerobot -p "<project-alias>" -n "<workbench-name>" status
+npa workbench lerobot -p "<project-alias>" -n "<workbench-name>" system-info
 ```
 
 Use the tool's deploy help to select GPU sizing and the matching image. A
@@ -41,10 +41,10 @@ separate commands with their own dataset and checkpoint requirements.
 Deploy to a VM you already operate:
 
 ```bash
-npa workbench lerobot -p <project-alias> -n <workbench-name> deploy \
-  --runtime byovm --host <ssh-host> \
+npa workbench lerobot -p "<project-alias>" -n "<workbench-name>" deploy \
+  --runtime byovm --host "<ssh-host>" \
   --ssh-user ubuntu --ssh-key ~/.ssh/id_ed25519
-npa workbench lerobot -p <project-alias> -n <workbench-name> system-info
+npa workbench lerobot -p "<project-alias>" -n "<workbench-name>" system-info
 ```
 
 NPA probes `nvidia-smi` and saves the detected GPU names and count. If needed,

--- a/docs/workbench/runtime-modes.md
+++ b/docs/workbench/runtime-modes.md
@@ -1,0 +1,77 @@
+# Choose a Workbench runtime
+
+[Workbench docs](README.md) · [CLI reference](../cli/workbench.md)
+
+For pipelines, start with [Workbench setup](getting-started.md) and submit a
+[workflow spec](npa-workflow-guide.md). Use direct tool deployment when you need
+a persistent workbench or an existing VM. Check `npa workbench <tool> deploy --help`;
+runtime support varies by tool.
+
+| Runtime | What NPA manages | Prerequisites |
+| --- | --- | --- |
+| `vm` | Terraform VM and tool installation over SSH | Nebius project, Terraform, SSH key |
+| `container` | Terraform VM and tool container over SSH | Same, plus the selected container's access requirements |
+| `byovm` | Tool deployment on an existing VM | Reachable host, SSH key, compatible GPU and driver |
+| `serverless` | AI Job or Endpoint, depending on the command | Nebius project permissions, subnet, supported image/platform |
+
+Complete [configuration](../configuration.md) and the tool's credential and
+model-access checks before deploying. Public NPA images resolve from GHCR;
+[image compatibility](image-gpu-compatibility-matrix.md) depends on the exact tool
+and GPU. Local engine extras are unnecessary when the engine runs remotely.
+
+## Managed VM or container
+
+For a LeRobot workbench, supply your configured project alias and choose a
+workbench name. These parent selectors precede the subcommand:
+
+```bash
+npa workbench lerobot -p <project-alias> -n <workbench-name> deploy \
+  --runtime container \
+  --project-id <project-id> --tenant-id <tenant-id> --region <region>
+npa workbench lerobot -p <project-alias> -n <workbench-name> status
+npa workbench lerobot -p <project-alias> -n <workbench-name> system-info
+```
+
+Use the tool's deploy help to select GPU sizing and the matching image. A
+successful deploy establishes the workbench; training and evaluation are
+separate commands with their own dataset and checkpoint requirements.
+
+## Bring your own VM (BYOVM)
+
+Deploy to a VM you already operate:
+
+```bash
+npa workbench lerobot -p <project-alias> -n <workbench-name> deploy \
+  --runtime byovm --host <ssh-host> \
+  --ssh-user ubuntu --ssh-key ~/.ssh/id_ed25519
+npa workbench lerobot -p <project-alias> -n <workbench-name> system-info
+```
+
+NPA probes `nvidia-smi` and saves the detected GPU names and count. If needed,
+`--gpu-count <N>` restricts visible devices. Host defaults can also come from
+`ssh.host`, `ssh.user`, and `ssh.key_path` in the credential store.
+
+BYOVM does not create, resize, stop, or destroy the VM. A BYOVM `--destroy`
+removes the local workbench entry; retire the actual VM through its owner.
+
+## Serverless
+
+The command determines whether serverless means a batch job or a serving
+endpoint. For Cosmos, `deploy --runtime serverless` creates an endpoint;
+`serve` checks or prewarms it. Changing its image or model requires redeployment.
+See the [Cosmos serverless SDK](../sdk/cosmos-serverless.md).
+
+Use `--subnet-id` explicitly when the project has multiple subnets. Pass secrets
+through the private environment or credential store. Authentication success
+does not establish permission to create AI Jobs or Endpoints in that project.
+
+The older Cosmos serverless endpoint has no supported generated-media export
+to S3. For an image or video artifact, use the
+[Cosmos 3 generation workflow](cosmos3-generate.md). A serverless training smoke
+that writes a status manifest does not prove model training.
+
+## After a run
+
+Inspect the workload's checkpoint, media, or report as well as its status.
+Use the [teardown guide](../teardown.md) to remove owned resources in order;
+local cleanup does not stop cloud compute.

--- a/docs/workbench/sim2real-live-findings-evaluation-20260902.md
+++ b/docs/workbench/sim2real-live-findings-evaluation-20260902.md
@@ -1,5 +1,7 @@
 # Sim2Real live findings: evaluation and RTX remediation (2026-09-02)
 
+[Workbench docs](README.md)
+
 This document began as an evaluation of five findings reported after the Living
 Lab run against `origin/main` at `e5ddb7d25ef2af5485bb43409579657497220a77`.
 The follow-up on the same branch now implements the repository and provisioning

--- a/docs/workbench/sim2real-pr387-update.md
+++ b/docs/workbench/sim2real-pr387-update.md
@@ -1,5 +1,7 @@
 # PR #387: unique scope after the current-main audit
 
+[Workbench docs](README.md)
+
 The rebased PR retains the Sim2Real submit check that rejects rollout,
 validation, or gold requests exceeding their deterministic sealed splits before
 GPU work. Focused regression tests cover all three consumers and the supported

--- a/docs/workbench/sm120-image-catalog.md
+++ b/docs/workbench/sm120-image-catalog.md
@@ -28,7 +28,7 @@ Build the base image:
 ```bash
 npa/docker/workbench/base/cuda13-b300/build.sh \
   --registry "${NPA_REGISTRY}" \
-  --tag sm80-sm90-sm100-sm103-sm120-<timestamp> \
+  --tag "sm80-sm90-sm100-sm103-sm120-<timestamp>" \
   --push
 ```
 
@@ -38,7 +38,7 @@ Build the Genesis sm_120 image:
 npa/docker/workbench/genesis/build_sm120.sh \
   --base-image "${NPA_REGISTRY}/npa-base:cuda13-b300-sm80-sm90-sm100-sm103-sm120-v2-latest" \
   --registry "${NPA_REGISTRY}" \
-  --tag 0.4.6-sm80-sm90-sm100-sm103-sm120-<timestamp> \
+  --tag "0.4.6-sm80-sm90-sm100-sm103-sm120-<timestamp>" \
   --push
 ```
 

--- a/docs/workbench/sm120-image-catalog.md
+++ b/docs/workbench/sm120-image-catalog.md
@@ -1,5 +1,7 @@
 # sm_120 Image Catalog
 
+[Workbench docs](README.md)
+
 This catalog records the first-party images used for RTX PRO 6000 Blackwell
 (`sm_120`) validation. Published redistributable releases use the public GHCR
 channel; rebuilds may target an operator-controlled registry via `NPA_REGISTRY`.

--- a/docs/workbench/solutions-validation.md
+++ b/docs/workbench/solutions-validation.md
@@ -23,7 +23,7 @@ CLI namespace and the `npa.sdk.workbench` SDK namespace.
 Workbench currently covers tools such as Isaac Lab, FiftyOne, LeRobot, LanceDB,
 Cosmos, GR00T, Genesis, and SONIC. These tools follow a consistent CLI pattern:
 
-```bash
+```text
 npa workbench <tool> <verb> [options]
 ```
 

--- a/docs/workbench/solutions-validation.md
+++ b/docs/workbench/solutions-validation.md
@@ -1,5 +1,7 @@
 # Solutions Framework Validation
 
+[Workbench docs](README.md)
+
 ## Overview
 
 The solutions framework is the Nebius Physical AI organization model for

--- a/docs/workbench/sonic-image-catalog.md
+++ b/docs/workbench/sonic-image-catalog.md
@@ -1,5 +1,7 @@
 # SONIC Image Catalog
 
+[Workbench docs](README.md)
+
 The machine-readable source of truth is
 `npa/src/npa/deploy/sonic_image_manifest.json`. Resolvers, workflow
 materializers, and publishers all consume that manifest.
@@ -34,16 +36,10 @@ docker manifest inspect \
   ghcr.io/nebius/nebius-physical-ai/npa-sonic:<tag>
 ```
 
-It is the default only for supported RTX PRO Kubernetes routing. Select it
-explicitly when useful:
-
-```bash
-npa workbench workflow submit \
-  workflows/testing/sonic-train.yaml \
-  --gpu-target gpu-rtx6000 \
-  --image-variant sonic-k8s-host-mounted \
-  --accelerators RTXPRO-6000-BLACKWELL-SERVER-EDITION:1
-```
+It is the default only for supported RTX PRO Kubernetes routing. Prepare the
+spec's actual GPU resource profile and required host mounts using the
+[training runbook](cookbooks/sonic-train-runbook.md). `--gpu-target` selects image
+routing; it does not rewrite `npa.workflow` resource profiles.
 
 ## Quarantined images
 
@@ -76,18 +72,6 @@ proxies and records `geometry_mode=primitive-proxy-no-lfs-payload`. This prevent
 unclassified robot assets from silently entering the image; it is not a visual
 or mesh-fidelity validation claim.
 
-```python
-sonic.submit_workflow(
-    Path("workflows/testing/sonic-train.yaml"),
-    run_id="sonic-smoke",
-    registry="<your-registry>/<namespace>",
-    gpu_target="gpu-rtx6000",
-    s3_endpoint="https://storage.eu-north1.nebius.cloud",
-    s3_bucket="<bucket>",
-    secret_envs=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
-)
-```
-
 There is therefore no built-in compute-only image for the default serverless
 L40S path, nor for H100/H200. `npa workbench sonic train --runtime serverless`
 fails before provisioning unless the operator passes an independently built and
@@ -96,13 +80,13 @@ as that substitute: it depends on Kubernetes GPU Operator driver mounts.
 
 ## Build and publication
 
-The retargeting workflow uses `NPA_RETARGETING_IMAGE` for the CPU preprocess
+Legacy raw SkyPilot materializers use `NPA_RETARGETING_IMAGE` for the CPU preprocess
 image. The committed default is
 `ghcr.io/nebius/nebius-physical-ai/npa-retargeting:0.1.1`, a pushed
 image that installs this repository's `npa` package, CPU preprocess
 dependencies, and pinned upstream SONIC data-process scripts.
 
-MJLab workflows use `NPA_WORKBENCH_IMAGE` for the generic Workbench CLI image.
+Those materializers use `NPA_WORKBENCH_IMAGE` for MJLab's generic Workbench CLI image.
 The committed default remains
 `ghcr.io/nebius/nebius-physical-ai/npa-genesis:0.4.6`.
 

--- a/docs/workbench/sonic-image-catalog.md
+++ b/docs/workbench/sonic-image-catalog.md
@@ -33,7 +33,7 @@ variable or pull secret is required:
 
 ```bash
 docker manifest inspect \
-  ghcr.io/nebius/nebius-physical-ai/npa-sonic:<tag>
+  "ghcr.io/nebius/nebius-physical-ai/npa-sonic:<tag>"
 ```
 
 It is the default only for supported RTX PRO Kubernetes routing. Prepare the
@@ -98,8 +98,8 @@ publication runs only through the guarded workflow, which creates an immutable
 
 ```bash
 gh workflow run publish-public-images.yml \
-  --ref <prepared-branch> \
-  -f development_sha=<full-git-sha> \
+  --ref "<prepared-branch>" \
+  -f development_sha="<full-git-sha>" \
   -f build_development_tools=sonic-mujoco \
   -f dry_run=true
 ```

--- a/docs/workbench/token-factory-deprecation-verification.md
+++ b/docs/workbench/token-factory-deprecation-verification.md
@@ -1,5 +1,7 @@
 # Token Factory default migration verification
 
+[Workbench docs](README.md)
+
 Verified on 2026-09-04/05 UTC against the public Token Factory API with one
 configured account and synthetic inputs. The deprecation claim is true, with
 an observed exception for Llama 3.3.

--- a/docs/workbench/token-factory-deprecation-verification.md
+++ b/docs/workbench/token-factory-deprecation-verification.md
@@ -123,7 +123,7 @@ npa/.venv/bin/python -m pytest \
   npa/tests/e2e/test_token_factory_e2e.py \
   npa/tests/e2e/test_hosted_rollout_e2e.py \
   npa/tests/e2e/test_agent_token_factory_e2e.py -q \
-  --basetemp=<private-artifact-directory>
+  --basetemp="<private-artifact-directory>"
 ```
 
 Authentication preflight and `models` are useful prerequisites, not proof of

--- a/docs/workbench/token-factory-key.md
+++ b/docs/workbench/token-factory-key.md
@@ -1,5 +1,7 @@
 # Set up a Nebius Token Factory key
 
+[Workbench docs](README.md)
+
 [Nebius Token Factory](https://tokenfactory.nebius.com/) is an OpenAI-compatible
 hosted-inference API for open text and vision models. It is the cheapest way to
 get a real result on Nebius — **zero GPU, no cluster** — so it's a great way to

--- a/docs/workbench/token-factory.md
+++ b/docs/workbench/token-factory.md
@@ -1,5 +1,7 @@
 # Nebius Token Factory integration
 
+[Workbench docs](README.md)
+
 Token Factory provides hosted text generation, image captioning, and scene
 reasoning. Use these capabilities to annotate inputs or interpret results from
 your Nebius GPU workloads. Direct CLI calls run from your machine; the

--- a/docs/workbench/troubleshooting/known-footguns.md
+++ b/docs/workbench/troubleshooting/known-footguns.md
@@ -1,8 +1,27 @@
 # Known Operational Footguns
 
-These are known operational failure modes surfaced during W10 Isaac Lab BYOF
-validation. They are documented here so partners can request the right operator
-action before discovering each issue through a failed run.
+[Workbench docs](../README.md) · [Run lifecycle](../../run-lifecycle.md) · [Teardown](../../teardown.md)
+
+Start with the failed run's exact ID and project:
+
+```bash
+npa workbench workflow status <run-id> --project <alias>
+npa workbench workflow logs <run-id> --project <alias>
+npa workbench workflow artifacts <run-id> --project <alias> --json
+```
+
+| Symptom | Check |
+| --- | --- |
+| Pending GPU task | [Per-node GPU count](#requesting-name2-on-a-fleet-of-1-gpu-nodes), [GPU names](#kubernetes-gpu-names-do-not-match-workflow-specs), and [CPU sizing](#default-l40s-preset-has-insufficient-cpu) |
+| Image pull failure | [Registry pull permissions](#registry-pull-returns-403-even-though-the-tag-exists) |
+| Submit stalls at the controller | [SkyPilot runtime](#submit-hangs-with-no-output-skypilot-controller-pod_config-loop) |
+| S3 works but Terraform fails | [Exact state-prefix permissions](#writable-s3-but-terraform-state-returns-403) |
+| Kubernetes reports anonymous `403` | [Kubeconfig authentication](#sky-check-reports-http-403-anonymous) |
+| Teardown stops partway | [Cancel verification](#controller-teardown-refuses-right-after-workflow-cancel) and [cleanup recovery](#teardown-is-seven-ordered-steps-with-no-single-entry-point) |
+| Gated model download fails | [Cosmos access preflight](../cosmos3-access-preflight.md) |
+
+The cases below include earlier validation incidents. Capacity and permissions
+must be checked on your selected project and cluster.
 
 ## L40S Capacity Is On-Demand-Zero
 
@@ -15,8 +34,6 @@ Current workaround: ask your Nebius support or operations contact to provision
 an L40S node group before the run. If your workflow can use another RT-core GPU
 and your region has it available, use RTX Pro 6000 in US Central.
 
-Category for follow-up: capacity.
-
 ## Default L40S Preset Has Insufficient CPU
 
 Symptom: Kubernetes pod scheduling fails with a CPU resource error even though
@@ -27,8 +44,6 @@ SkyPilot workflow request, such as a 16-CPU request.
 
 Current workaround: ask for a larger L40S preset, or reduce the SkyPilot CPU
 request in the workflow YAML when that is acceptable for the workload.
-
-Category for follow-up: platform.
 
 ## Writable S3 But Terraform State Returns 403
 
@@ -46,8 +61,6 @@ state, output, rollback, and destroy. It fails before resource creation when the
 contract is missing or forbidden. Do not broaden IAM merely to compensate for a
 dropped subprocess environment.
 
-Category for follow-up: platform.
-
 ## Private Registry Credentials Expire
 
 Symptom: the task pod fails to pull the Workbench image with a registry
@@ -60,8 +73,6 @@ Mitigation: public GHCR releases require no credentials. For a private image,
 rotate the exact-host credential through the operator's secret-management
 process and update the explicitly referenced standard Docker config secret.
 NPA does not mint tokens or refresh Kubernetes registry secrets.
-
-Category for follow-up: security.
 
 ## Registry Pull Returns 403 Even Though The Tag Exists
 
@@ -84,10 +95,8 @@ private image comes back `403`. Run it standalone with:
 npa workbench workflow preflight-images <spec.yaml>
 ```
 
-The fix is to grant the run's identity pull access to that repository. Pass
-`--no-preflight-images` to skip the gate.
-
-Category for follow-up: security.
+Grant the run's identity pull access to that exact repository, then rerun image
+preflight. Skipping the check does not repair a pull failure.
 
 ## Submit Hangs With No Output (SkyPilot Controller pod_config Loop)
 
@@ -106,8 +115,6 @@ repairs an already-bootstrapped venv in place; `npa skypilot status` reports the
 installed client and fails when it is out of range. Submit also streams SkyPilot's
 output live and names this failure when it appears, instead of buffering silently.
 
-Category for follow-up: platform.
-
 ## Requesting `NAME:2` On A Fleet Of 1-GPU Nodes
 
 Symptom: a job fails `FAILED_PRECHECKS`, or never schedules, on a cluster that
@@ -121,8 +128,6 @@ cluster shape than "N single-GPU node presets".
 Mitigation: `npa workbench workflow gpus --cluster <name>` prints each
 accelerator's *requestable quantity per node*. Submit rejects a request above that
 maximum with a one-line fix rather than letting it fail later.
-
-Category for follow-up: platform.
 
 ## Kubernetes GPU Names Do Not Match Workflow Specs
 
@@ -162,8 +167,6 @@ matching local metadata. An ambient current context, first/stale profile, or
 auth/RBAC/connectivity uncertainty is never treated as proof. Planned/staged runs that never launched report
 `already_absent` and remain repeat-safe without calling SkyPilot.
 
-Category for follow-up: platform.
-
 ## A Managed Job Sits In PENDING Forever
 
 Symptom: a managed job stays `PENDING` for hours and never becomes `FAILED`,
@@ -179,8 +182,6 @@ job (via SkyPilot's own `skypilot-cluster-name` label) and reports the container
 waiting reason — `ImagePullBackOff`, `Unschedulable`, `CreateContainerConfigError`
 — with a remedy. `npa cleanup` also lists non-terminal managed jobs, since one of
 them will block controller teardown.
-
-Category for follow-up: platform.
 
 ## Cluster Teardown Goes Quiet For Several Minutes
 
@@ -216,8 +217,6 @@ detail confirms `NotFound` means the instance is already absent; NPA reports tha
 race as idempotent progress. The same event with PermissionDenied or any other
 real deletion failure remains visible verbatim.
 
-Category for follow-up: platform.
-
 ## No-Cluster Teardown Downloads Terraform Providers Into The Checkout
 
 Symptom: `npa cluster down --force` runs authentication and `terraform init` even
@@ -249,17 +248,19 @@ git diff -- deploy/cluster/.terraform.lock.hcl
 Do not delete the lock file or use an unverified provider package merely to make
 teardown proceed.
 
-Category for follow-up: platform.
+<a id="teardown-is-seven-ordered-steps-with-no-single-entry-point"></a>
 
-## Teardown Is Seven Ordered Steps With No Single Entry Point
+## Teardown leaves resources or local state behind
 
 Symptom: an environment looks torn down but still has a hung managed job, a local
 SkyPilot venv, empty `~/.npa/agents` / `~/.npa/clusters` directories, or an IAM
 service account nothing removed.
 
-Root cause: teardown spans cancel → agent destroy → cluster down → bucket delete →
-owned storage-IAM delete → forget project → remove local state, and nothing checks
-the order or reports what is left.
+Teardown spans cloud resources and local state. Use
+`npa destroy --project <alias> --all` to preview the ordered project plan; it
+executes only with `--yes`. If a phase fails, retain its recovery receipt and
+follow [the teardown guide](../../teardown.md). Local cleanup alone cannot stop
+cloud resources.
 
 Mitigation: `npa cleanup` reports residual local state (with sizes), empty per-alias
 state directories, and any managed job still non-terminal — the step most often
@@ -324,8 +325,6 @@ required by scope verification, `--tenant-id`/`--profile` or a receipt. Exact
 NotFound is verified absence; auth, RBAC, network, and parse failures remain
 unresolved. NPA never recreates a project stanza merely to record the result.
 
-Category for follow-up: platform.
-
 ## Raw Access-Key List JSON Can Disclose The Secret
 
 Symptom: ordinary `nebius iam v2 access-key list --format json` output contains
@@ -376,8 +375,6 @@ network and explains that only the network owner may remove the parent network;
 unrelated permission, dependency, and non-default security-group failures remain
 ordinary failures. See Nebius'
 [security-group deletion rules](https://docs.nebius.com/vpc/security-groups/manage#deleting-security-groups).
-
-Category for follow-up: platform.
 
 ## Literal AWS Endpoint In SkyPilot YAML
 

--- a/docs/workbench/troubleshooting/known-footguns.md
+++ b/docs/workbench/troubleshooting/known-footguns.md
@@ -5,9 +5,9 @@
 Start with the failed run's exact ID and project:
 
 ```bash
-npa workbench workflow status <run-id> --project <alias>
-npa workbench workflow logs <run-id> --project <alias>
-npa workbench workflow artifacts <run-id> --project <alias> --json
+npa workbench workflow status "<run-id>" --project "<alias>"
+npa workbench workflow logs "<run-id>" --project "<alias>"
+npa workbench workflow artifacts "<run-id>" --project "<alias>" --json
 ```
 
 | Symptom | Check |
@@ -19,20 +19,42 @@ npa workbench workflow artifacts <run-id> --project <alias> --json
 | Kubernetes reports anonymous `403` | [Kubeconfig authentication](#sky-check-reports-http-403-anonymous) |
 | Teardown stops partway | [Cancel verification](#controller-teardown-refuses-right-after-workflow-cancel) and [cleanup recovery](#teardown-is-seven-ordered-steps-with-no-single-entry-point) |
 | Gated model download fails | [Cosmos access preflight](../cosmos3-access-preflight.md) |
+| Provisioning preview reports `blocked` | [Quota and preview status](#provisioning-preview-exits-zero-but-reports-blocked) |
 
 The cases below include earlier validation incidents. Capacity and permissions
 must be checked on your selected project and cluster.
 
-## L40S Capacity Is On-Demand-Zero
+## Provisioning preview exits zero but reports blocked
+
+`npa provision-if-absent --dry-run --output-format json` can exit zero while
+its JSON reports `status: blocked` and `preflight.decision: blocked`. Exit zero
+means the preview completed; inspect the decision and reasons before provisioning:
+
+```bash
+npa provision-if-absent --project "<alias>" --dry-run --output-format json \
+  | jq '{status, decision: .preflight.decision, reasons: .preflight.reasons}'
+```
+
+Reserved GPU capacity does not supply missing block-storage or CPU quota.
+Check the selected project's requested disks and node shapes against the reported
+quota. Resolve the named shortage or choose a workload that fits; an `unknown`
+decision also needs investigation. Keep the actual provisioning command's
+resource selections consistent with the preview.
+
+<a id="l40s-capacity-is-on-demand-zero"></a>
+
+## An L40S job waits for capacity
 
 Symptom: SkyPilot keeps backing off while trying to schedule an L40S job.
 
 Root cause: the workbench cluster may have no provisioned L40S capacity, and
 on-demand L40S availability can be zero for the target region.
 
-Current workaround: ask your Nebius support or operations contact to provision
-an L40S node group before the run. If your workflow can use another RT-core GPU
-and your region has it available, use RTX Pro 6000 in US Central.
+Check the selected project's quota, available capacity, and actual node pools.
+Prepare a compatible node group through [Workbench setup](../getting-started.md).
+If capacity is unavailable, consult your platform operator or Nebius support.
+An RTX PRO 6000 is an alternative only when the workload, image, region, and
+available node shape support it.
 
 ## Default L40S Preset Has Insufficient CPU
 
@@ -92,7 +114,7 @@ pull with the selected exact-host credentials and refuses to submit when a
 private image comes back `403`. Run it standalone with:
 
 ```bash
-npa workbench workflow preflight-images <spec.yaml>
+npa workbench workflow preflight-images "<spec.yaml>"
 ```
 
 Grant the run's identity pull access to that exact repository, then rerun image
@@ -120,10 +142,10 @@ output live and names this failure when it appears, instead of buffering silentl
 Symptom: a job fails `FAILED_PRECHECKS`, or never schedules, on a cluster that
 clearly has enough GPUs in total.
 
-Root cause: SkyPilot places all GPUs of one task on a **single node**. A cluster
-of 2 nodes × 1 GPU can never satisfy `NAME:2`, and adding nodes does not help.
-Multi-GPU fan-out documentation assumes N GPUs on one pod, which is a different
-cluster shape than "N single-GPU node presets".
+Root cause: `accelerators: NAME:2` requests two GPUs **per node**. Two nodes with
+one GPU each cannot satisfy that request. Use a node with two GPUs, or a supported
+multi-node workload that explicitly requests one GPU per node. Extra nodes do
+not automatically turn a single-node application into distributed execution.
 
 Mitigation: `npa workbench workflow gpus --cluster <name>` prints each
 accelerator's *requestable quantity per node*. Submit rejects a request above that
@@ -315,9 +337,9 @@ operator-actionable partial cleanup and exit 2. Use the project ID if the alias
 was already forgotten:
 
 ```bash
-npa storage service-account delete --project-id <project-id> --dry-run
-npa storage service-account delete --project-id <project-id> --yes
-npa cleanup --full --yes --project <alias>
+npa storage service-account delete --project-id "<project-id>" --dry-run
+npa storage service-account delete --project-id "<project-id>" --yes
+npa cleanup --full --yes --project "<alias>"
 ```
 
 For alias-free journaling, also pass `--id <exact-service-account-id>` and, when
@@ -344,7 +366,7 @@ For a human-readable inventory, use the CLI's supported output field selection
 and do not enable debug output:
 
 ```bash
-nebius iam v2 access-key list --parent-id <project-id> --all \
+nebius iam v2 access-key list --parent-id "<project-id>" --all \
   --format 'jsonpath={range .items[*]}{.metadata.id}{"\t"}{.metadata.name}{"\t"}{.status.state}{"\n"}{end}'
 ```
 

--- a/docs/workbench/wan2.2.md
+++ b/docs/workbench/wan2.2.md
@@ -1,5 +1,7 @@
 # Wan 2.2 TI2V-5B Workbench support
 
+[Workbench docs](README.md)
+
 NPA packages the official Alibaba Wan 2.2 source as a BYOF solution and runs
 real TI2V-5B generation on Nebius GPUs. The single-GPU workflow targets one RTX
 PRO 6000 Blackwell; the distributed workflow runs one shared generation across

--- a/npa/README.md
+++ b/npa/README.md
@@ -65,117 +65,20 @@ chosen specification, prepare its data and resources, submit it, then inspect
 [recovery guide](../docs/workbench/troubleshooting/known-footguns.md) covers
 setup and runtime failures.
 
-The following are individual LeRobot/Genesis commands, including the older
-five-stage distillation helper. Their setup and inputs are tool-specific; they
-are not the canonical 14-stage Sim2Real workflow:
-
-```bash
-# Provision or update a Nebius LeRobot workbench
-npa workbench lerobot -p eu-north1 -n h200 deploy \
-  --project-id project-... \
-  --tenant-id tenant-... \
-  --region eu-north1
-
-# Train/eval/serve a LeRobot policy on the remote workbench
-npa workbench lerobot train --policy-type act --dataset lerobot/aloha_sim_transfer_cube_human --job-name act-demo --output-path s3://my-bucket/checkpoints/act-demo/
-npa workbench lerobot eval --input-path s3://my-bucket/checkpoints/act-demo/ --env aloha
-npa workbench lerobot serve --input-path s3://my-bucket/checkpoints/act-demo/
-npa workbench lerobot infer --observation /tmp/obs.json --output json
-
-# Genesis-side local stages
-npa workbench genesis train-teacher --n-envs 4096
-npa workbench genesis generate-demos --checkpoint ./checkpoints/teacher/model.pt
-npa workbench genesis eval-student --checkpoint ./checkpoints/student/checkpoints/last/pretrained_model
-
-# Convert demos to LeRobotDataset v3
-npa adapter convert --input ./runs/demos --output ./runs/dataset
-
-# Run the full distillation workflow
-npa workbench workflow run distill --local
-npa workbench workflow run distill --remote --project eu-north1 --s3-bucket s3://my-bucket/checkpoints/
-```
-
 ## Workbench Runtimes
 
-Deploy commands support these runtime modes where implemented:
+Choose a runtime supported by the selected tool:
 
-- `vm`: provisions and manages a Nebius VM with Terraform and installs the tool over SSH.
-- `container`: provisions and manages a Nebius VM with Terraform, then starts the tool container over SSH.
-- `byovm`: skips Terraform entirely and deploys the app to an existing SSH-accessible VM.
-- `serverless`: creates a Nebius Serverless AI Endpoint for a containerized serving backend. Cosmos supports this runtime first.
+| Mode | Runs on |
+| --- | --- |
+| Workflow | SkyPilot jobs on the configured cluster; see [Workbench setup](../docs/workbench/getting-started.md) |
+| `vm` / `container` | A Nebius VM managed through Terraform and SSH |
+| `byovm` | An existing SSH-accessible VM supplied by you |
+| `serverless` | Nebius AI Jobs or Endpoints, where the tool supports them |
 
-For Cosmos, `deploy --runtime serverless` creates the Endpoint resource with
-the image, platform, preset, environment, and volumes baked into the resource.
-`serve` is only a pre-warm/health operation; changing the served model or image
-requires redeploying the endpoint.
-
-```bash
-npa workbench cosmos -p eu-north1 -n cosmos-sl deploy \
-  --runtime serverless \
-  --project-id project-... \
-  --image ghcr.io/nebius/nebius-physical-ai/npa-cosmos:cu128-torch27-sm100-1.0.9-20260803T002017Z \
-  --platform gpu-h200-sxm \
-  --preset 1gpu-16vcpu-200gb \
-  --server-port 8080 \
-  --subnet-id vpcsubnet-... \
-  --wait
-
-npa workbench cosmos -p eu-north1 -n cosmos-sl status
-npa workbench cosmos -p eu-north1 -n cosmos-sl serve
-npa workbench cosmos -p eu-north1 -n cosmos-sl infer --prompt "A robot arm stacks colored cubes"
-npa workbench cosmos -p eu-north1 -n cosmos-sl teardown --yes
-```
-
-When a Nebius project has multiple subnets, pass `--subnet-id` on serverless
-deploy. Secrets should come from `~/.npa/credentials.yaml` or environment
-variables; do not pass tokens as command-line arguments.
-
-Use `byovm` when the VM already exists, for example for pre-provisioned
-multi-GPU machines. BYOVM does not create, stop, start, resize, or destroy the
-VM. A BYOVM `--destroy` only removes the local workbench entry from
-`~/.npa/config.yaml`.
-
-BYOVM requires a host and SSH key, either from flags:
-
-```bash
-npa workbench lerobot -p eu-north1 -n my-multi-gpu deploy \
-  --runtime byovm \
-  --host 203.0.113.10 \
-  --ssh-user ubuntu \
-  --ssh-key ~/.ssh/id_ed25519 \
-  --gpu-count 4
-```
-
-or from `~/.npa/credentials.yaml`:
-
-```yaml
-ssh:
-  host: 203.0.113.10
-  user: ubuntu
-  key_path: ~/.ssh/id_ed25519
-```
-
-During BYOVM deploy, `npa` probes the target with `nvidia-smi`, stores the
-detected GPU count and names in `~/.npa/config.yaml`, and writes
-`CUDA_VISIBLE_DEVICES` plus `NPA_GPU_COUNT` into the remote environment. Use
-`--gpu-count <N>` to limit the visible devices on a larger VM.
-
-Status and system information commands use the same saved SSH metadata:
-
-```bash
-npa workbench lerobot -p eu-north1 -n my-multi-gpu status
-npa workbench lerobot -p eu-north1 -n my-multi-gpu system-info
-```
-
-The multi-GPU BYOVM pytest suite is opt-in and expects a live target:
-
-```bash
-export NPA_TEST_BYOVM_HOST=203.0.113.10
-export NPA_TEST_BYOVM_SSH_KEY=~/.ssh/id_ed25519
-export NPA_TEST_BYOVM_GPU_COUNT=4
-export NPA_TEST_BYOVM_S3_PREFIX=s3://my-bucket/test-artifacts/
-pytest tests/test_multi_gpu -m multi_gpu
-```
+See [runtime modes](../docs/workbench/runtime-modes.md) for direct deploy,
+BYOVM, and serverless examples. A mode supported by one tool does not imply
+support in every other tool.
 
 <a id="config"></a>
 
@@ -224,32 +127,10 @@ output or raise CLI exits and do not guarantee typed response objects.
 The [walkthrough](../docs/workbench/cli-sdk-yaml-walkthrough.md) explains these
 differences with a detection-training service example.
 
-Artifact utilities also have Python entry points:
-
-```python
-from npa import convert, demo, rerun
-
-# Convert a LeRobot dataset to MP4.
-convert.lerobot_to_mp4(
-    input_path="s3://my-bucket/dataset/",
-    output_path="trajectory.mp4",
-    renderer="matplotlib",
-)
-
-# Stage demo artifacts.
-demo.stage(target_bucket="customer-bucket", target_project="eu-north1")
-
-# Share a Rerun recording.
-result = rerun.host("recording.rrd")
-print(f"View at: {result.share_url}")
-```
-
-Lower-level access for advanced workflows:
-
-```python
-from npa.adapter.lerobot.render import render_lerobot_to_mp4_result
-from npa.clients.http import HTTPClient
-```
+For artifact conversion and sharing, see the
+[CLI / SDK walkthrough](../docs/workbench/cli-sdk-yaml-walkthrough.md),
+[Foxglove export](../docs/workbench/foxglove-export.md), and
+[Rerun sharing](../docs/workbench/rerun-sharing.md).
 
 ## Package map
 

--- a/npa/README.md
+++ b/npa/README.md
@@ -46,7 +46,7 @@ Extra tools required by specific commands:
 
 ## CLI layout
 
-```bash
+```text
 npa workbench lerobot ...
 npa workbench genesis ...
 npa workbench cosmos ...
@@ -88,30 +88,36 @@ See [configuration](../docs/configuration.md) for project setup, credential
 precedence, the credential-file layout, token access, and cross-project storage.
 Use the [first-run prompts](../docs/workbench/agent-first-run.md) with a coding agent.
 
-Terraform remote state for managed workbenches is stored in the Nebius S3
-bucket under:
-
-```text
-npa/terraform-state/<project-alias>/<workbench-name>/terraform.tfstate
-```
-
-Deploy saves the S3 backend bucket, endpoint, and access key under
-`projects.<alias>.terraform_state` in `~/.npa/config.yaml` and writes that file
-with `0600` permissions. Destroy reuses those exact backend credentials. If
-Terraform still fails with `AccessDenied` while saving state after destroy, the
-service account/access key used for `terraform_state` needs S3 `PutObject` on
-`arn:aws:s3:::<bucket>/npa/terraform-state/<project-alias>/<workbench-name>/terraform.tfstate`
-plus `GetObject` on that object and `ListBucket` on the bucket/prefix.
+Managed workbench teardown reuses the saved Terraform backend. See
+[Terraform state](../docs/configuration.md#terraform-state-for-managed-workbenches)
+for its storage path and permissions.
 
 ## SDK examples
 
-For Workbench integration, start with the documented module for your tool:
+Plan a workflow from Python without credentials or cloud resources. Run this
+from the repository root in the environment where you installed `npa`:
+
+```python
+from npa.orchestration.npa_workflow import build_plan, load_spec, validate_spec
+
+spec = load_spec("workflows/testing/cosmos3-generate.yaml")
+validate_spec(spec)
+plan = build_plan(spec, run_id="demo")
+for step in plan.steps:
+    print(step.state, step.tool_ref)
+```
+
+Expect `generate workbench.cosmos3.generate`. The plan resolves the checked-in
+example; execution still requires real input, storage, credentials, and GPUs.
+
+After submitting a real run, read its artifacts through the monitoring SDK.
+Set `NPA_RUN_ID` and `NPA_WORKFLOW_S3_URI` to the values returned by submission,
+and configure the project's S3 credentials first:
 
 ```python
 import os
 from npa.sdk.workbench import workflow
 
-# Read an existing run's durable artifacts after workflow submission.
 artifacts = workflow.artifacts(
     os.environ["NPA_RUN_ID"],
     workflow_s3_uri=os.environ["NPA_WORKFLOW_S3_URI"],
@@ -157,10 +163,28 @@ targets from the repo root:
 python3 -m venv npa/.venv
 npa/.venv/bin/python -m pip install -e "npa[dev,adapter]"
 
-make test PYTHON="$(pwd)/npa/.venv/bin/python"        # unit suite
 make test-smoke PYTHON="$(pwd)/npa/.venv/bin/python"  # onboarding CLI checks
 make lint PYTHON="$(pwd)/npa/.venv/bin/python"        # ruff
+npa/.venv/bin/python -m pytest npa/tests/guardrails/test_documentation_examples.py -q
 ```
+
+For the **full unit suite**, use CPython 3.12 on Linux with `ffmpeg` and `ffprobe` available.
+Some runtime tests exercise Linux `/proc` and filesystem semantics, so macOS
+can run the focused checks above but does not reproduce the full Linux gate.
+The interpreter must provide `os.memfd_create`; some Conda builds omit it.
+Install CI's CPU checkpoint/export dependencies in this same environment:
+
+```bash
+npa/.venv/bin/python -m pip install --index-url https://download.pytorch.org/whl/cpu torch==2.13.0
+npa/.venv/bin/python -m pip install -e "npa[sonic]"
+umask 077  # Private files are required by publication handoff tests.
+PATH="$PWD/npa/.venv/bin:$PATH" NPA_REQUIRE_FFMPEG=1 \
+  make test PYTHON="$PWD/npa/.venv/bin/python" PYTEST_ADDOPTS='-n auto'
+```
+
+The CPU wheel exercises real checkpoint loading without a GPU. See
+[the CI environment](../.github/workflows/test.yml) for the complete coverage
+gate; some optional checks also use Node, tmux, or Docker.
 
 Use an **absolute** interpreter path: the recipes change into `npa/` before
 running. Without an override, Make prefers the contributor environment

--- a/npa/deploy/cosmos3-nano-video/README.md
+++ b/npa/deploy/cosmos3-nano-video/README.md
@@ -1,90 +1,116 @@
-# Cosmos3-Nano: 30-second diffusion video on NPA mk8s
+# Cosmos3-Nano: 30-second video service
 
-This deployment runs 16 Ray Serve replicas on 16 B200 GPUs, with one GPU and
-tensor parallelism 1 per replica. It supports 30-second text-to-video
-continuation and source-conditioned visual augmentation through `vllm serve
---omni` and `Cosmos3OmniDiffusersPipeline`.
-Guardrails are **off**, explicitly selected with `--no-guardrails`. Audio is
-disabled. This is the diffusion generation route.
+[Workbench docs](../../../docs/workbench/README.md) · [Runtime details](runtime-details.md) · [Recorded measurements](measurements.md)
 
-## Model and frame contract
+This operator recipe serves diffusion video generation through vLLM-Omni and
+Ray Serve. It runs **16 replicas on 16 B200 GPUs**, with one GPU and TP=1 per
+replica. Use it for 30-second continuation or source-conditioned appearance
+augmentation. Audio is disabled and this recipe explicitly runs with
+**guardrails off** (`--no-guardrails`).
 
-The [official Nano model card](https://huggingface.co/nvidia/Cosmos3-Nano/blob/7a312c868bcce8e40b3eb40861300a9d0ba3fde1/README.md)
-was checked before generation. It currently specifies **5–400 output frames**,
-up to **five conditioning input frames**, and output at the requested fps. The
-often-quoted 4 fps recommendation applies to reasoner inputs. Only BF16 is
-officially tested. This recipe deliberately retains a stricter **300-frame
-per-request ceiling**.
+For the guarded Cosmos Framework generation path, start with
+[Cosmos 3 generation](../../../docs/workbench/cosmos3-generate.md) or
+[native Cosmos Ray Serve](../../../docs/workbench/cosmos3-ray-serve.md).
+They use different images and APIs.
 
-The [baked diffusion pipeline](https://github.com/vllm-project/vllm-omni/blob/9c1b7504b178afcf541867c1a2d30db48c69cda8/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py)
-rounds non-transfer frame counts upward to `4k+1`; 300 would become 301. At 24 fps
-and 832×480, the rollout requests **297, 297, and 137 frames**. The first request
-is text-to-video. Subsequent requests upload the previous segment as MP4 and
-set `condition_frame_indexes_vision: [0, 1]` and `condition_video_keep: last` in
-`extra_params`. These are latent indices: two latent positions represent five
-pixel frames, which remain clean conditioning through denoising.
+## Before provisioning
 
-Stitching discards the duplicated five-frame prefix from each continuation,
-then trims one final frame: `297 + 292 + 132 - 1 = 720`, exactly 30 seconds.
-There is no blending or interpolation to hide discontinuities. The client
-retains the chunks and eight-frame contact sheets around joins at 12.375 and
-24.5417 seconds. Generation uses 35 steps, guidance 6, flow shift 10, and a
-4096-token sequence setting inside `extra_params` (the image's HTTP handler
-does not parse a top-level `max_sequence_length` form field).
+| Requirement | What to verify |
+| --- | --- |
+| Compute | Task-owned Nebius Kubernetes cluster with 16 B200 GPUs, a CPU pool, and validated managed CUDA 13 drivers |
+| Shared storage | A verified RWX filesystem and `csi-mounted-fs-path-sc`; the example PVC requests 512 GiB |
+| Image | Validated immutable digest of your **operator-private** image; this image is excluded from the public NPA publisher |
+| Model | Anonymous payload access to the pinned Cosmos3-Nano checkpoint; see the [payload probe](runtime-details.md#deploy-and-operate) |
+| Control plane | KubeRay operator 1.7.0 watching `workbench`; its managed Ray credentials remain separate from the inference token |
+| Client | Installed NPA, project-scoped S3 credentials, a private service route, and a writable private recovery directory |
 
-## Source-conditioned visual augmentation
+Run `npa workbench health preflight --checks nebius --json` before provisioning.
+Follow the [GPU driver procedure](../../../docs/workbench/mk8s-gpu-driver-strategy.md)
+and [runtime infrastructure requirements](runtime-details.md#infrastructure-and-image).
+Keep reservation identifiers and registry coordinates in private configuration.
 
-Continuation preserves a generated tail and extends time. Visual augmentation
-instead transforms an existing video's appearance while conditioning every
-output interval on the corresponding original frames. The earlier continuation
-benchmark is evidence for continuation and concurrency, not augmentation quality.
+## Deploy in order
 
-`nano-video-augment` accepts a real S3 source MP4 at **832×480, 24 fps**, with at
-least six frames. It rejects invalid hashes, incomplete decoding, changing
-dimensions, incorrect timestamps and unsupported controls before GPU work. Output
-duration matches the complete source; no silent resampling or truncation occurs.
-The CLI and SDK share one client and the server's request/report contract.
+The manifests are templates. `kubectl apply` does **not** expand their `${...}`
+placeholders. Render private copies with these exact values before applying:
 
-The installed upstream `make_edge_control` computes Canny edges from each
-original source interval. Controls are stored as lossless FFV1 videos and must
-round-trip pixel-exactly through the actual transfer loader. No extra learned
-preprocessor checkpoint is needed. The first interval uses zero RGB conditioning
-frames. Later intervals upload the preceding **augmented five-frame tail** for
-continuity while using edges from the matching **original** interval for motion.
-This is the image's structural transfer path, not continuation prefix conditioning.
+| Variable or Secret | Use |
+| --- | --- |
+| `NPA_COSMOS3_VIDEO_IMAGE` | Operator-private `registry/image@sha256:...` |
+| `NPA_COSMOS3_SHARED_PVC` | Bound RWX claim; the supplied manifest names it `cosmos3-nano-video-shared` |
+| `NPA_B200_GPU_PRODUCT` | Exact `nvidia.com/gpu.product` label on validated B200 workers |
+| `cosmos3-nano-video-registry` | Registry pull Secret in `workbench` |
+| `cosmos3-nano-video-auth`, key `token` | Separate inference API token in `workbench` |
 
-With the default 121-frame windows, a 720-frame source uses intervals starting
-at frames **0, 116, 232, 348, 464, 580 and 696**. Their lengths are six windows
-of 121 frames and one of 24. The final model window is 25 frames; native padding
-is trimmed back to 24. Removing the repeated five-frame prefixes yields
-`121 + 5×116 + 19 = 720` frames, without blending or interpolation. All seven
-requests run sequentially on one selected replica. The service retains the
-original 16-replica least-outstanding plus FIFO policy and holds its GPU lock
-until accepted generation finishes, including repeated client cancellations.
+1. Provision and validate compute, shared filesystem, and KubeRay. Confirm the
+   CPU head can select nodes without `nvidia.com/gpu.count`.
+2. Create the two Secrets and apply [shared-pvc.yaml](shared-pvc.yaml). Confirm
+   the claim is `Bound` before starting the staging Job.
+3. Apply your rendered [weights-job.yaml](weights-job.yaml). Require completion
+   and its verified `READY.json`; this Job is the only model-cache writer.
+4. Apply your rendered [rayservice.yaml](rayservice.yaml). Require all **16**
+   model replicas healthy and correctly placed on B200 GPUs.
+5. Verify authenticated inference readiness, then connect through a private
+   route or the loopback forwarding command below.
 
-`--chunk-frames 297` uses three source intervals starting at **0, 292 and 584**,
-with lengths **297, 297 and 136**. The last model window is 137 frames and is
-trimmed to the source length. Dropping the two five-frame prefixes gives
-`297 + 292 + 131 = 720` frames, with joins at frames 297 and 589. Longer windows
-reduce the number of independently sampled boundaries; they do not remove the
-need to inspect each join or guarantee better motion.
+Inspect the selected context's resources:
 
-The default transfer parameters are 35 steps, text guidance **3**, control
-guidance **1.5**, flow shift **10**, medium Canny thresholds **100/200**, BF16,
-TP=1, shared control/target temporal positions, and a 4096-token limit. These
-start from the installed single-edge transfer defaults; increasing guidance or
-steps is not inherently a quality improvement. Steps and text guidance also
-respect the actual video API's upper bounds of 200 and 20. There is no generic
-`strength`, `control_weight`, arbitrary server-side file path, or unchecked
-extra-parameter bag.
+```bash
+kubectl -n workbench get pvc cosmos3-nano-video-shared
+kubectl -n workbench get job cosmos3-nano-video-weights
+kubectl -n workbench logs job/cosmos3-nano-video-weights
+kubectl -n workbench get rayservice cosmos3-nano-video
+```
 
-Use a detailed scene description, preferably a structured JSON object covering
-subjects, setting, lighting, materials, camera motion and temporal continuity,
-following [NVIDIA's transfer guidance](https://github.com/NVIDIA/Cosmos/tree/main/cookbooks/cosmos3/generator/transfer).
-The exact submitted and effective positive, negative and system prompts are
-retained per interval. The installed formatter rewrites JSON duration to the
-integer local model-window duration even when metadata templates are disabled;
-the retained source-frame map supplies the exact global timestamps.
+Use the stable **head** Service: this recipe sets `proxy_location: HeadOnly`,
+so worker endpoints in the generated Serve Service do not host the HTTP proxy.
+Keep this terminal open:
+
+```bash
+kubectl -n workbench port-forward service/cosmos3-nano-video-head-svc 8000:8000
+```
+
+The [deployment details](runtime-details.md#deploy-and-operate) cover Ray
+management authentication, model staging, service routing, and readiness.
+A running pod or live HTTP process does not establish that all models are ready.
+
+## Configure the client
+
+Set these variables in your private shell or secret store:
+
+| Variable | Value |
+| --- | --- |
+| `NPA_COSMOS3_VIDEO_ENDPOINT` | `http://127.0.0.1:8000` when using the tunnel above |
+| `NPA_COSMOS3_VIDEO_TOKEN` | Token from the inference Secret |
+| `NPA_COSMOS3_VIDEO_RECOVERY_DIR` | Private local directory outside the checkout |
+| `NPA_COSMOS3_SINGLE_OUTPUT_URI` | Fresh run-scoped S3 destination for continuation |
+
+Also configure NPA's S3 endpoint and credentials. Use a new output prefix for
+each generation; existing immutable artifacts must not be overwritten.
+
+## Generate a continuation video
+
+```bash
+npa workbench cosmos3 nano-video-batch --concurrency 1 \
+  --output-path "$NPA_COSMOS3_SINGLE_OUTPUT_URI"
+```
+
+Expect three generated chunks and a stitched MP4 with **720 frames, 24 fps,
+832×480, and 30 seconds**, plus hashes and join contact sheets. The client fully
+decodes the media and verifies publication by reading S3 objects back.
+Inspect both joins; successful decoding does not prove seamless visual motion.
+See [frame arithmetic](runtime-details.md#model-and-frame-contract).
+
+The SDK entry is `npa.sdk.workbench.cosmos3.nano_video_batch`. For concurrent
+requests, use a fresh batch destination and the desired `--concurrency`; the
+[recorded eight-request run](measurements.md#measured-b200-acceptance) reports
+its specific timing and overlap, not sustained saturation throughput.
+
+## Augment an existing video
+
+Provide an S3 MP4 at **832×480 and 24 fps**, with at least six frames. This route
+preserves the complete source duration and does not silently resample or trim
+it. Set the input/output URIs and your positive/negative scene descriptions:
 
 ```bash
 npa workbench cosmos3 nano-video-augment \
@@ -95,313 +121,46 @@ npa workbench cosmos3 nano-video-augment \
   --seed 42 --num-inference-steps 35 --guidance-scale 3 \
   --control-guidance 1.5 --flow-shift 10 --edge-threshold medium \
   --chunk-frames 121 --output-format json
+```
 
-# Retrieve completed work or retry artifact downloads/publication; never generates again.
+Inspect `input.mp4`, `augmented.mp4`, and `comparison.mp4`. The comparison shows
+**source on the left, augmentation on the right**. Review source motion,
+identity, lighting, materials, and every join; changed bytes alone do not prove
+a useful augmentation. See the [control and chunk contract](runtime-details.md#source-conditioned-visual-augmentation)
+and [recorded augmentation assessment](measurements.md#measured-full-source-augmentation).
+
+## Recover and finish
+
+After an interrupted augmentation download or publication, recover the same
+request instead of generating again:
+
+```bash
 npa workbench cosmos3 nano-video-augment-recover \
   --output-path "$NPA_COSMOS3_AUGMENT_OUTPUT_URI" --output-format json
 ```
 
-SDK entries are `npa.sdk.workbench.cosmos3.nano_video_augment` and
-`nano_video_augment_recover`. The authenticated API accepts multipart `/run`
-with exactly `request` (JSON) and `input_reference` (the complete MP4). Existing
-JSON continuation requests remain supported. `GET /result?request_id=...`
-retrieves durable state through any replica on the shared output filesystem.
-A missing result after an interrupted POST is ambiguous and never authorizes an
-automatic generation retry.
+Recovery verifies existing bytes and retrieves completed artifacts through the
+authenticated API when needed. Missing state after an interrupted POST is
+ambiguous; preserve the recovery directory and inspect it before any new request.
 
-Artifacts keep **`input.mp4`**, **`augmented.mp4`** and the synchronized, labeled
-**`comparison.mp4`** separate, alongside source controls, augmented RGB tails,
-chunk outputs, exact requests, hashes and measurements. The comparison places
-the actual source on the left. S3 reservation and publication use conditional
-immutable writes with hash-verified readback. Recovery accepts existing objects
-only when their bytes match and can finish publication without a serving token
-when the completed local result is already verified.
-If artifact retrieval fails after generation, recovery uses authenticated GETs
-to retrieve the same completed request before validating and publishing it;
-the original submission marker remains unchanged.
+Save and verify S3 outputs before removing the serving deployment. Stop new
+requests, let accepted work finish, close the port-forward, and remove only the
+RayService, staging Job, Secrets, storage, and infrastructure you own. Shared
+filesystem and cluster deletion are separate lifecycle steps; see
+[teardown](../../../docs/teardown.md).
 
-Technical validity is separate from visual quality. A changed hash does not
-prove meaningful augmentation. Evaluate requested appearance change, lighting,
-materials/reflections, identity, source motion, wheel contact and every actual join
-against a rubric fixed before candidate scoring. Record agent/VLM judgments and
-their sampling limitations separately; do not present them as a standardized
-quality score or claim eight-way augmentation from the continuation benchmark.
+<a id="model-and-frame-contract"></a>
+<a id="source-conditioned-visual-augmentation"></a>
+<a id="infrastructure-and-image"></a>
 
-## Infrastructure and image
+## Detailed contracts and evidence
 
-Use NPA `cluster up` or the NPA fleet mk8s backend with a task-owned project in
-`us-central1`, 16 `gpu-b200-sxm` GPUs, managed CUDA 13 drivers,
-a CPU pool, and shared filesystem storage. Ray uses 16 one-GPU worker pods,
-so the cluster may provide two eight-GPU nodes or a validated mix of B200 node
-sizes. Keep NPA's quota, fabric,
-stabilization and per-node CUDA validation enabled. If using reserved capacity,
-supply its exact group through owner-only runtime configuration and require
-`STRICT` reservation placement. Follow the [fleet instructions](../../../skills/tools/fleet/SKILL.md)
-and [driver strategy](../../../docs/workbench/mk8s-gpu-driver-strategy.md).
+The former detailed sections are preserved in [runtime-details.md](runtime-details.md).
 
-The head explicitly advertises zero Ray GPUs and hides NVIDIA/CUDA devices.
-Its required affinity selects nodes without `nvidia.com/gpu.count`; verify that
-the NPA CPU pool has no such label and every validated GPU node has a positive
-count before applying the manifest. Worker device visibility stays under the
-Kubernetes device plugin and Ray's one-GPU assignment.
+<a id="measured-b200-acceptance"></a>
+<a id="measured-full-source-augmentation"></a>
 
-For a mixed cluster, declare the planned per-node GPU counts through
-`GpuHealthConfig.expected_gpu_counts`. Its optional `nvswitch_gpu_counts` subset
-identifies node sizes that require fabric checks. Every multi-GPU SXM/NVL size
-must be included. An explicitly unattached one-GPU guest can report fabric as
-not applicable while still passing driver, device-plugin and CUDA checks.
-The mixed live health test verifies the declared total, node-count distribution,
-stability and CUDA on every GPU ordinal before serving begins.
-
-The Dockerfile extends `vllm/vllm-omni:cosmos3`, pinned to manifest digest
-`sha256:6d2630c7d637b699557573f2c3fee8df5d4d0cd718977aa22549ed6a6ef30587`.
-The Dockerfile pins that index's Linux AMD64 manifest,
-`sha256:970dee6658ea223f615b2438ce41e47f1d5322225482546e6e6bc5d8134f757c`.
-The extension supplies Ray Serve, FFmpeg and the NPA adapters. It preserves the
-diffusion engine and adds no model weights, task or customer data, credentials
-or acceptance state. The inherited image contains public vendor test fixtures
-and example media. Its vendor runtime makes this an **operator-private** image;
-the NPA public publisher excludes it. Build and push only to the operator's own
-registry, then deploy the verified immutable image digest.
-
-The staging Job is the single writer of the shared model cache. It downloads
-the pinned Nano revision once, verifies all diffusion and VAE tensor dtypes as
-BF16, hashes the staged files, and atomically publishes `READY.json`. Replicas
-mount the cache read-only and run with Hugging Face offline mode. Their vLLM
-processes preserve `--init-timeout 1800`. The synchronous HTTP generation route
-has no additional workload deadline. Each replica runs one complete rollout
-at a time; Ray's custom router considers all replicas at one rank and chooses
-the least outstanding queue, with capacity rejection protecting concurrent
-admission.
-
-The router uses Ray's public FIFO fulfillment mixin to keep pending requests
-reachable when another scheduler has already consumed their routing metadata.
-FIFO selects the pending request; fresh queue snapshots across all replicas
-select the least outstanding replica. The router follows Ray's normal retry backoff.
-It disables Ray 2.56's queue-length cache because the cached-success path can
-spin after out-of-order assignments and accumulate background probes in the
-head proxy. Every selection still compares the complete replica rank; strict
-admission prevents two requests from occupying the same replica.
-
-The adapter writes an explicit single diffusion stage configuration with
-`model_config.sound_gen: false`, BF16 and TP=1, then passes it through
-`--stage-configs-path`. This supported legacy flag is needed for the pinned
-engine: its single-stage diffusion fallback drops `--stage-overrides`, and the
-checkpoint's sound dimensions would otherwise enable an unstaged audio
-tokenizer. The image's CPU validation resolves the actual engine configuration
-and checks that sound remains disabled; CLI parsing alone is insufficient.
-
-## Deploy and operate
-
-1. Verify provider credentials with `npa workbench health preflight --checks
-   nebius --json`, and anonymously probe the pinned checkpoint payload using
-   the command below before provisioning. Verify the selected image and storage
-   before starting generation. The broader `health access --capability cosmos3`
-   also checks gated guardrail weights; this recipe disables guardrails and does
-   not fetch those weights. Check their actual upstream access separately if
-   enabling a guardrail-dependent route.
-2. Provision the NPA mk8s cluster and shared filesystem. Install KubeRay operator
-   **1.7.0** with its namespace watch restricted to `workbench`. Resolve all
-   manifest placeholders from owner-only configuration. Keep the operator's
-   standard namespace-scoped Secret permissions: `rayClusterConfig.authOptions`
-   enables token authentication, and KubeRay creates a separate management Secret,
-   injects it into the head and workers, and authenticates its dashboard requests.
-   Do not override `RAY_AUTH_*` in the pod templates or reuse the inference token.
-3. Apply [shared-pvc.yaml](shared-pvc.yaml) after NPA installs its shared-filesystem
-   CSI driver. Create the API token Secret and operator-private registry pull
-   Secret, then run the weight staging
-   Job to completion. Run the RayService only after the immutable cache is ready.
-4. Require all 16 model replicas to be healthy, confirm B200 placement, and
-   verify both the API and Ray dashboard reject unauthenticated requests. Expose access through an
-   authenticated private route or a local port-forward.
-5. Set `NPA_COSMOS3_VIDEO_ENDPOINT`, `NPA_COSMOS3_VIDEO_TOKEN` and
-   `NPA_COSMOS3_VIDEO_RECOVERY_DIR` outside Git. Configure the normal NPA S3
-   endpoint and credentials in the client process. Use distinct artifact
-   prefixes for each batch, separate from any agent trajectory dataset.
-
-Ray management credentials grant code execution and are for administrators only.
-KubeRay's [token authentication integration](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kuberay-auth.html)
-uses its existing namespace-scoped RBAC; inference clients need only the separate
-API token. Management authentication does not encrypt cluster traffic. Keep Ray
-ports on the trusted private cluster network and use an authenticated encrypted
-administrative tunnel when accessing the dashboard remotely. The application
-builder refuses a cluster without explicit token authentication. For standalone
-containers, the default `--serve` launcher creates a fresh owner-only management
-credential before starting local Ray, disables the dashboard and removes the
-credential on shutdown. Docker health checks use the authenticated inference
-endpoint and do not need access to the management credential.
-
-The payload preflight reads one byte from a diffusion shard at the exact model
-revision. It uses no Hugging Face token and does not stage the checkpoint:
-
-```bash
-npa/.venv/bin/python - <<'PY'
-from urllib.request import Request, urlopen
-
-revision = "7a312c868bcce8e40b3eb40861300a9d0ba3fde1"
-shard = "transformer/diffusion_pytorch_model-00001-of-00007.safetensors"
-url = f"https://huggingface.co/nvidia/Cosmos3-Nano/resolve/{revision}/{shard}"
-with urlopen(Request(url, headers={"Range": "bytes=0-0"})) as response:
-    if response.status != 206 or len(response.read(1)) != 1:
-        raise RuntimeError("Exact-revision Nano payload access was not verified")
-print("Anonymous pinned Nano payload access: PASS")
-PY
-```
-
-For `proxy_location: HeadOnly`, route port 8000 through KubeRay's stable
-`cosmos3-nano-video-head-svc`, for example
-`http://cosmos3-nano-video-head-svc.workbench.svc.cluster.local:8000` inside the
-cluster, or a local port-forward to that Service. KubeRay updates this Service's
-head-only selector when the active cluster changes. The generated
-`cosmos3-nano-video-serve-svc` is unused: KubeRay 1.7 always labels worker pods
-as serving endpoints, while these workers have no HTTP proxy. The explicit
-worker readiness probe checks Ray's native health endpoint on port 52365;
-all 16 model replicas must separately pass application readiness. Custom
-`serveService.spec.selector` values are
-[overwritten by KubeRay](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/controllers/ray/common/service.go#L216).
-
-```bash
-npa workbench cosmos3 nano-video-batch --concurrency 1 \
-  --output-path "$NPA_COSMOS3_SINGLE_OUTPUT_URI"
-npa workbench cosmos3 nano-video-batch --concurrency 8 \
-  --output-path "$NPA_COSMOS3_FANOUT_OUTPUT_URI"
-```
-
-The SDK entry is `npa.sdk.workbench.cosmos3.nano_video_batch`. The authenticated
-service accepts `/run`; `/artifacts/<request_id>/<filename>` serves the retained
-files. CLI and SDK verify returned hashes, fully decode all three chunks and the
-stitched MP4, and
-publish immutable S3 objects with read-after-write verification. Publication
-failure retains the local recovery copy; **do not repeat GPU generation to
-retry an upload**.
-
-## Measured B200 acceptance
-
-The measurements below are retained evidence from the September 6 deployment.
-Subsequent PR maintenance reconciled current main and hardened failed-start
-cleanup and loopback readiness against ambient proxies. Those lifecycle changes
-have CPU regression coverage; they have not been rebuilt into a newly validated
-GPU image. These measurements apply to the previously tested artifacts.
-
-After adding augmentation and shared-server cancellation handling, acceptance was rerun on the updated image: one full 30-second continuation video through the SDK, then eight complete continuation requests concurrently through the CLI. All nine clips passed full decoding at 832×480, 24 fps and 720 frames. The two batches published 13 and 97 immutable objects respectively, with read-after-write hash verification. Models were already initialized and BF16 weights prestaged before timing.
-
-The updated-image single-request batch took **155.85 s**; the eight-request batch took **161.23 s**. These batch times include generation, downloads and local validation, and exclude S3 publication. The complete sequential acceptance test case, including both batches and their S3 publication/readback, took **323.87 s**; pytest reported **324.88 s** for the full invocation. Deployment, model initialization and prestaging are excluded.
-
-| Request | Chunk 1 (s) | Chunk 2 (s) | Chunk 3 (s) | Server total (s) | Client total (s) | Peak allocator reserved (MiB) | Peak device used (MiB) |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| S1 | 59.89 | 60.04 | 22.46 | 149.99 | 155.82 | 37408.00 | 38316.00 |
-| C1 | 59.60 | 60.45 | 22.74 | 150.82 | 155.66 | 38220.00 | 39130.00 |
-| C2 | 60.74 | 61.29 | 23.07 | 154.47 | 161.14 | 37408.00 | 38316.00 |
-| C3 | 60.12 | 60.68 | 22.98 | 152.85 | 160.05 | 37408.00 | 38316.00 |
-| C4 | 59.18 | 59.83 | 22.40 | 150.07 | 154.55 | 37408.00 | 38316.00 |
-| C5 | 60.91 | 61.07 | 22.79 | 153.94 | 161.08 | 37408.00 | 38316.00 |
-| C6 | 60.00 | 60.62 | 23.01 | 152.24 | 158.89 | 37408.00 | 38316.00 |
-| C7 | 60.48 | 60.95 | 22.89 | 153.46 | 161.01 | 37408.00 | 38316.00 |
-| C8 | 59.64 | 60.59 | 22.95 | 152.18 | 159.24 | 37408.00 | 38316.00 |
-
-S1 is the single request; C1–C8 belong to the concurrent batch. Chunk time is the synchronous diffusion HTTP round trip inside the replica. Server total includes generation, full decode, stitching, seam extraction and GPU sampler teardown. Client total additionally includes routing, artifact downloads and client validation; it excludes S3 publication.
-
-Both memory columns use MiB. Despite its name, the engine’s `X-Peak-Memory-MB` header divides bytes by `1024**2` and reports the peak CUDA allocator reserved pool. Device usage comes from the assigned B200’s `nvidia-smi memory.used` sampled every 0.5 seconds; this includes total device residency and can miss shorter spikes. These are separate measurements.
-
-The eight-request batch completed **8/8** videos on **eight distinct replicas**, with **eight overlapping rollout intervals** and **eight overlapping diffusion chunk requests**. These results cover one eight-request batch on the 16-replica deployment; sustained saturation throughput was not measured.
-
-After the timed acceptance, the exact deployed image separately passed the repository B200 checker with Torch 2.11.0+cu130 and native `sm_100` support. Its shipped golden-evaluation command also generated a complete three-chunk rollout, and all four MP4s independently decoded successfully. All 16 serving replicas and their pods remained unchanged. This separate check ran alongside the serving model; its timing and memory are excluded from the production measurements above.
-
-The original pre-augmentation acceptance also remains valid: its single and eight-request batches took **153.61 s** and **163.04 s**, respectively, and all nine videos and 110 published objects passed validation. Those measurements use the earlier image.
-
-During that original run, across 75 successful CPU-head samples taken every 5 seconds, proxy RSS peaked at **214.68 MiB** (private USS **111.47 MiB**) and whole-head cgroup usage peaked at **1639.55 MiB**. The same proxy process and head pod remained present, with zero sampled OOM events. This observation window includes baseline and completion handoff; it is separate from generation latency, and five-second samples can miss brief spikes.
-
-Separate independent reviews of the original nine clips and all 18 joins in the updated-image nine-clip acceptance found no obvious hard cuts or scene/vehicle identity resets in the eight-frame contact sheets. Small wheel, reflection and edge changes remain visible around some joins. Static contact sheets do not establish imperceptible motion continuity; the stitch uses direct concatenation without blending.
-
-The private image scan retained 218 HIGH and six unfixed CRITICAL findings, with zero fixable CRITICAL findings and zero detected secrets. The targeted dependency updates remove the base image’s fixable CRITICAL findings. One inherited package metadata mismatch remains: `nixl` requires `nixl-cu13==1.3.0`, while the vendor image installs 1.3.1; the selected TP=1 single-stage diffusion route does not configure NIXL transfer. No new dependency conflicts were introduced.
-
-Exact resource identities, private endpoints, registry coordinates and generated artifacts remain in access-controlled runtime storage. This README includes measurements and generic configuration only.
-
-## Measured full-source augmentation
-
-Eleven complete variants were generated from the same task-generated warehouse
-robot video. The selected 30-second result changes the bright clean scene into
-a dimmer warehouse with warm overhead illumination, rough dark damp concrete,
-localized shallow puddles and restrained reflections. The original orange robot,
-aisle geometry, camera travel and scene timing remain recognizable. The retained
-comparison labels the **actual source on the left** and **augmentation on the
-right**, correcting the earlier source/output labeling confusion.
-
-The selected run used **35 steps, text guidance 5, control guidance 1, flow shift
-10, high Canny thresholds 200/300, 297-frame windows, seed 480240 and 4096 tokens**.
-BF16, TP=1, shared control/target temporal positions, audio off and guardrails off
-remain as described above. Its structured positive prompt specifies matte orange
-paint, transparent shallow water over rough concrete, warm-white practical lamps,
-restrained haze and source-matched travel. The structured negative prompt targets
-glowing orange floor smears, trench-like lane markings, plastic materials and
-motion/contact defects. Exact submitted and effective prompts are retained with
-the private artifacts. Increasing steps to 50 or guidance did not consistently
-improve realism; lower Canny thresholds did not improve wet-floor realism in
-the same 297-frame configuration.
-
-| Source interval, zero-based inclusive | Preparation (s) | Diffusion HTTP (s) | Peak allocator reserved (MiB) | Peak device used (MiB) |
-| --- | ---: | ---: | ---: | ---: |
-| 0–296 | 24.84 | 167.09 | 38012 | 38918 |
-| 292–588 | 6.85 | 165.86 | 38012 | 38918 |
-| 584–719 | 6.51 | 53.08 | 38012 | 38920 |
-
-Server wall time was **440.21 s**, including control preparation, generation,
-validation and stitching. The client submission/download/validation interval was
-**450.51 s**, excluding source S3 setup and output publication. The complete live
-test case, including source setup, immutable publication/readback and recovery
-verification, took **455.38 s**; JUnit reports **456.05 s** for the pytest suite. The
-selected request overlapped two other augmentation requests on distinct existing
-replicas for part of its execution; this is not an isolated throughput benchmark.
-The memory sampling limits above apply. Input and output each fully decoded to
-**720 frames, 24 fps, 832×480 and 30.000 s**; the synchronized comparison is
-1664×480 with the same frame/timestamp contract.
-
-The rubric was frozen before generation. Independent agent review produced the
-following task-specific ordinal judgments; the hosted VLM results use a separate
-0–1 scale and are retained without forcing agreement.
-
-| Component | Agent (0–4) | Hosted VLM (0–1) |
-| --- | ---: | ---: |
-| Requested environmental change | 3 | 0.75 |
-| Lighting realism | 3 | 0.50 |
-| Materials and reflections | 3 | 0.50 |
-| Robot identity | 3 | 0.75 |
-| Source geometry, camera and timing | 4 | 0.75 |
-| Motion and floor contact | 3 | 0.50–0.75 |
-| Temporal continuity | 3 | 0.50 |
-
-The motion rating initially was 2. A separately retained review of unmodified
-native tire/contact crops supported qualitative source-following travel and
-stable floor contact, yielding 3 with moderate confidence under the unchanged
-anchors. The original review remains preserved. Exact tire angle, speed and
-no-slip physics remain unverified: repetitive dark tread and hub covers provide
-weak angular cues in both source and output. Automated CPU estimates did not
-establish rolling fidelity. Complete browser playback decoded all 720 frames
-without dropped frames; agent review also inspected dense sequences across both
-joins. These observations are not a human rating or a standardized aggregate
-quality score. The actual hosted VLM was MiniMax-M3; its 17 sampled-frame calls
-sometimes inferred freezing from weak motion cues, reversed front/rear wheel
-descriptions or used inconsistent verbal anchors, so its scores cannot certify
-physical motion.
-
-Remaining imperfections include weaker puddles and robot reflections late in the
-clip, small hub/tire-detail changes and occasional rectangular floor sheen. The
-result is a noticeable, plausible augmentation with these limits. It does not
-establish an eight-way augmentation batch; the separate single-plus-eight test
-above measures continuation.
-
-To reuse the selected settings, provide a new immutable destination and the
-desired structured positive, negative and system prompts through the environment:
-
-```bash
-npa workbench cosmos3 nano-video-augment \
-  --input-path "$NPA_COSMOS3_AUGMENT_INPUT_URI" \
-  --output-path "$NPA_COSMOS3_AUGMENT_OUTPUT_URI" \
-  --prompt "$NPA_COSMOS3_AUGMENT_PROMPT" \
-  --negative-prompt "$NPA_COSMOS3_AUGMENT_NEGATIVE_PROMPT" \
-  --system-prompt "$NPA_COSMOS3_AUGMENT_SYSTEM_PROMPT" \
-  --seed "${NPA_COSMOS3_AUGMENT_SEED:-480240}" \
-  --num-inference-steps 35 --guidance-scale 5 --control-guidance 1 \
-  --flow-shift 10 --edge-threshold high --chunk-frames 297 \
-  --max-sequence-length 4096 --output-format json
-```
+Historical latency, memory, concurrency, visual review, and image-scan results
+are preserved in [measurements.md](measurements.md). They apply to the recorded
+image and deployment; later source changes have not received a new GPU validation
+through this documentation update.

--- a/npa/deploy/cosmos3-nano-video/measurements.md
+++ b/npa/deploy/cosmos3-nano-video/measurements.md
@@ -1,0 +1,134 @@
+# Cosmos3-Nano video measurements
+
+[Deployment and client guide](README.md) · [Runtime contract](runtime-details.md)
+
+## Measured B200 acceptance
+
+The measurements below are retained evidence from the September 6 deployment.
+Subsequent PR maintenance reconciled current main and hardened failed-start
+cleanup and loopback readiness against ambient proxies. Those lifecycle changes
+have CPU regression coverage; they have not been rebuilt into a newly validated
+GPU image. These measurements apply to the previously tested artifacts.
+
+After adding augmentation and shared-server cancellation handling, acceptance was rerun on the updated image: one full 30-second continuation video through the SDK, then eight complete continuation requests concurrently through the CLI. All nine clips passed full decoding at 832×480, 24 fps and 720 frames. The two batches published 13 and 97 immutable objects respectively, with read-after-write hash verification. Models were already initialized and BF16 weights prestaged before timing.
+
+The updated-image single-request batch took **155.85 s**; the eight-request batch took **161.23 s**. These batch times include generation, downloads and local validation, and exclude S3 publication. The complete sequential acceptance test case, including both batches and their S3 publication/readback, took **323.87 s**; pytest reported **324.88 s** for the full invocation. Deployment, model initialization and prestaging are excluded.
+
+| Request | Chunk 1 (s) | Chunk 2 (s) | Chunk 3 (s) | Server total (s) | Client total (s) | Peak allocator reserved (MiB) | Peak device used (MiB) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| S1 | 59.89 | 60.04 | 22.46 | 149.99 | 155.82 | 37408.00 | 38316.00 |
+| C1 | 59.60 | 60.45 | 22.74 | 150.82 | 155.66 | 38220.00 | 39130.00 |
+| C2 | 60.74 | 61.29 | 23.07 | 154.47 | 161.14 | 37408.00 | 38316.00 |
+| C3 | 60.12 | 60.68 | 22.98 | 152.85 | 160.05 | 37408.00 | 38316.00 |
+| C4 | 59.18 | 59.83 | 22.40 | 150.07 | 154.55 | 37408.00 | 38316.00 |
+| C5 | 60.91 | 61.07 | 22.79 | 153.94 | 161.08 | 37408.00 | 38316.00 |
+| C6 | 60.00 | 60.62 | 23.01 | 152.24 | 158.89 | 37408.00 | 38316.00 |
+| C7 | 60.48 | 60.95 | 22.89 | 153.46 | 161.01 | 37408.00 | 38316.00 |
+| C8 | 59.64 | 60.59 | 22.95 | 152.18 | 159.24 | 37408.00 | 38316.00 |
+
+S1 is the single request; C1–C8 belong to the concurrent batch. Chunk time is the synchronous diffusion HTTP round trip inside the replica. Server total includes generation, full decode, stitching, seam extraction and GPU sampler teardown. Client total additionally includes routing, artifact downloads and client validation; it excludes S3 publication.
+
+Both memory columns use MiB. Despite its name, the engine’s `X-Peak-Memory-MB` header divides bytes by `1024**2` and reports the peak CUDA allocator reserved pool. Device usage comes from the assigned B200’s `nvidia-smi memory.used` sampled every 0.5 seconds; this includes total device residency and can miss shorter spikes. These are separate measurements.
+
+The eight-request batch completed **8/8** videos on **eight distinct replicas**, with **eight overlapping rollout intervals** and **eight overlapping diffusion chunk requests**. These results cover one eight-request batch on the 16-replica deployment; sustained saturation throughput was not measured.
+
+After the timed acceptance, the exact deployed image separately passed the repository B200 checker with Torch 2.11.0+cu130 and native `sm_100` support. Its shipped golden-evaluation command also generated a complete three-chunk rollout, and all four MP4s independently decoded successfully. All 16 serving replicas and their pods remained unchanged. This separate check ran alongside the serving model; its timing and memory are excluded from the production measurements above.
+
+The original pre-augmentation acceptance also remains valid: its single and eight-request batches took **153.61 s** and **163.04 s**, respectively, and all nine videos and 110 published objects passed validation. Those measurements use the earlier image.
+
+During that original run, across 75 successful CPU-head samples taken every 5 seconds, proxy RSS peaked at **214.68 MiB** (private USS **111.47 MiB**) and whole-head cgroup usage peaked at **1639.55 MiB**. The same proxy process and head pod remained present, with zero sampled OOM events. This observation window includes baseline and completion handoff; it is separate from generation latency, and five-second samples can miss brief spikes.
+
+Separate independent reviews of the original nine clips and all 18 joins in the updated-image nine-clip acceptance found no obvious hard cuts or scene/vehicle identity resets in the eight-frame contact sheets. Small wheel, reflection and edge changes remain visible around some joins. Static contact sheets do not establish imperceptible motion continuity; the stitch uses direct concatenation without blending.
+
+The private image scan retained 218 HIGH and six unfixed CRITICAL findings, with zero fixable CRITICAL findings and zero detected secrets. The targeted dependency updates remove the base image’s fixable CRITICAL findings. One inherited package metadata mismatch remains: `nixl` requires `nixl-cu13==1.3.0`, while the vendor image installs 1.3.1; the selected TP=1 single-stage diffusion route does not configure NIXL transfer. No new dependency conflicts were introduced.
+
+Exact resource identities, private endpoints, registry coordinates and generated artifacts remain in access-controlled runtime storage. This page includes measurements and generic configuration only.
+
+## Measured full-source augmentation
+
+Eleven complete variants were generated from the same task-generated warehouse
+robot video. The selected 30-second result changes the bright clean scene into
+a dimmer warehouse with warm overhead illumination, rough dark damp concrete,
+localized shallow puddles and restrained reflections. The original orange robot,
+aisle geometry, camera travel and scene timing remain recognizable. The retained
+comparison labels the **actual source on the left** and **augmentation on the
+right**, correcting the earlier source/output labeling confusion.
+
+The selected run used **35 steps, text guidance 5, control guidance 1, flow shift
+10, high Canny thresholds 200/300, 297-frame windows, seed 480240 and 4096 tokens**.
+BF16, TP=1, shared control/target temporal positions, audio off and guardrails off
+remain as described in the [runtime contract](runtime-details.md). Its structured positive prompt specifies matte orange
+paint, transparent shallow water over rough concrete, warm-white practical lamps,
+restrained haze and source-matched travel. The structured negative prompt targets
+glowing orange floor smears, trench-like lane markings, plastic materials and
+motion/contact defects. Exact submitted and effective prompts are retained with
+the private artifacts. Increasing steps to 50 or guidance did not consistently
+improve realism; lower Canny thresholds did not improve wet-floor realism in
+the same 297-frame configuration.
+
+| Source interval, zero-based inclusive | Preparation (s) | Diffusion HTTP (s) | Peak allocator reserved (MiB) | Peak device used (MiB) |
+| --- | ---: | ---: | ---: | ---: |
+| 0–296 | 24.84 | 167.09 | 38012 | 38918 |
+| 292–588 | 6.85 | 165.86 | 38012 | 38918 |
+| 584–719 | 6.51 | 53.08 | 38012 | 38920 |
+
+Server wall time was **440.21 s**, including control preparation, generation,
+validation and stitching. The client submission/download/validation interval was
+**450.51 s**, excluding source S3 setup and output publication. The complete live
+test case, including source setup, immutable publication/readback and recovery
+verification, took **455.38 s**; JUnit reports **456.05 s** for the pytest suite. The
+selected request overlapped two other augmentation requests on distinct existing
+replicas for part of its execution; this is not an isolated throughput benchmark.
+The memory sampling limits above apply. Input and output each fully decoded to
+**720 frames, 24 fps, 832×480 and 30.000 s**; the synchronized comparison is
+1664×480 with the same frame/timestamp contract.
+
+The rubric was frozen before generation. Independent agent review produced the
+following task-specific ordinal judgments; the hosted VLM results use a separate
+0–1 scale and are retained without forcing agreement.
+
+| Component | Agent (0–4) | Hosted VLM (0–1) |
+| --- | ---: | ---: |
+| Requested environmental change | 3 | 0.75 |
+| Lighting realism | 3 | 0.50 |
+| Materials and reflections | 3 | 0.50 |
+| Robot identity | 3 | 0.75 |
+| Source geometry, camera and timing | 4 | 0.75 |
+| Motion and floor contact | 3 | 0.50–0.75 |
+| Temporal continuity | 3 | 0.50 |
+
+The motion rating initially was 2. A separately retained review of unmodified
+native tire/contact crops supported qualitative source-following travel and
+stable floor contact, yielding 3 with moderate confidence under the unchanged
+anchors. The original review remains preserved. Exact tire angle, speed and
+no-slip physics remain unverified: repetitive dark tread and hub covers provide
+weak angular cues in both source and output. Automated CPU estimates did not
+establish rolling fidelity. Complete browser playback decoded all 720 frames
+without dropped frames; agent review also inspected dense sequences across both
+joins. These observations are not a human rating or a standardized aggregate
+quality score. The actual hosted VLM was MiniMax-M3; its 17 sampled-frame calls
+sometimes inferred freezing from weak motion cues, reversed front/rear wheel
+descriptions or used inconsistent verbal anchors, so its scores cannot certify
+physical motion.
+
+Remaining imperfections include weaker puddles and robot reflections late in the
+clip, small hub/tire-detail changes and occasional rectangular floor sheen. The
+result is a noticeable, plausible augmentation with these limits. It does not
+establish an eight-way augmentation batch; the separate single-plus-eight test
+above measures continuation.
+
+To reuse the selected settings, provide a new immutable destination and the
+desired structured positive, negative and system prompts through the environment:
+
+```bash
+npa workbench cosmos3 nano-video-augment \
+  --input-path "$NPA_COSMOS3_AUGMENT_INPUT_URI" \
+  --output-path "$NPA_COSMOS3_AUGMENT_OUTPUT_URI" \
+  --prompt "$NPA_COSMOS3_AUGMENT_PROMPT" \
+  --negative-prompt "$NPA_COSMOS3_AUGMENT_NEGATIVE_PROMPT" \
+  --system-prompt "$NPA_COSMOS3_AUGMENT_SYSTEM_PROMPT" \
+  --seed "${NPA_COSMOS3_AUGMENT_SEED:-480240}" \
+  --num-inference-steps 35 --guidance-scale 5 --control-guidance 1 \
+  --flow-shift 10 --edge-threshold high --chunk-frames 297 \
+  --max-sequence-length 4096 --output-format json
+```

--- a/npa/deploy/cosmos3-nano-video/runtime-details.md
+++ b/npa/deploy/cosmos3-nano-video/runtime-details.md
@@ -1,0 +1,271 @@
+# Cosmos3-Nano video runtime details
+
+[Deployment and client guide](README.md) · [Recorded measurements](measurements.md)
+
+## Model and frame contract
+
+The [official Nano model card](https://huggingface.co/nvidia/Cosmos3-Nano/blob/7a312c868bcce8e40b3eb40861300a9d0ba3fde1/README.md)
+was checked before generation. It currently specifies **5–400 output frames**,
+up to **five conditioning input frames**, and output at the requested fps. The
+often-quoted 4 fps recommendation applies to reasoner inputs. Only BF16 is
+officially tested. This recipe deliberately retains a stricter **300-frame
+per-request ceiling**.
+
+The [baked diffusion pipeline](https://github.com/vllm-project/vllm-omni/blob/9c1b7504b178afcf541867c1a2d30db48c69cda8/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py)
+rounds non-transfer frame counts upward to `4k+1`; 300 would become 301. At 24 fps
+and 832×480, the rollout requests **297, 297, and 137 frames**. The first request
+is text-to-video. Subsequent requests upload the previous segment as MP4 and
+set `condition_frame_indexes_vision: [0, 1]` and `condition_video_keep: last` in
+`extra_params`. These are latent indices: two latent positions represent five
+pixel frames, which remain clean conditioning through denoising.
+
+Stitching discards the duplicated five-frame prefix from each continuation,
+then trims one final frame: `297 + 292 + 132 - 1 = 720`, exactly 30 seconds.
+There is no blending or interpolation to hide discontinuities. The client
+retains the chunks and eight-frame contact sheets around joins at 12.375 and
+24.5417 seconds. Generation uses 35 steps, guidance 6, flow shift 10, and a
+4096-token sequence setting inside `extra_params` (the image's HTTP handler
+does not parse a top-level `max_sequence_length` form field).
+
+## Source-conditioned visual augmentation
+
+Continuation preserves a generated tail and extends time. Visual augmentation
+instead transforms an existing video's appearance while conditioning every
+output interval on the corresponding original frames. The earlier continuation
+benchmark is evidence for continuation and concurrency, not augmentation quality.
+
+`nano-video-augment` accepts a real S3 source MP4 at **832×480, 24 fps**, with at
+least six frames. It rejects invalid hashes, incomplete decoding, changing
+dimensions, incorrect timestamps and unsupported controls before GPU work. Output
+duration matches the complete source; no silent resampling or truncation occurs.
+The CLI and SDK share one client and the server's request/report contract.
+
+The installed upstream `make_edge_control` computes Canny edges from each
+original source interval. Controls are stored as lossless FFV1 videos and must
+round-trip pixel-exactly through the actual transfer loader. No extra learned
+preprocessor checkpoint is needed. The first interval uses zero RGB conditioning
+frames. Later intervals upload the preceding **augmented five-frame tail** for
+continuity while using edges from the matching **original** interval for motion.
+This is the image's structural transfer path, not continuation prefix conditioning.
+
+With the default 121-frame windows, a 720-frame source uses intervals starting
+at frames **0, 116, 232, 348, 464, 580 and 696**. Their lengths are six windows
+of 121 frames and one of 24. The final model window is 25 frames; native padding
+is trimmed back to 24. Removing the repeated five-frame prefixes yields
+`121 + 5×116 + 19 = 720` frames, without blending or interpolation. All seven
+requests run sequentially on one selected replica. The service retains the
+original 16-replica least-outstanding plus FIFO policy and holds its GPU lock
+until accepted generation finishes, including repeated client cancellations.
+
+`--chunk-frames 297` uses three source intervals starting at **0, 292 and 584**,
+with lengths **297, 297 and 136**. The last model window is 137 frames and is
+trimmed to the source length. Dropping the two five-frame prefixes gives
+`297 + 292 + 131 = 720` frames, with joins at frames 297 and 589. Longer windows
+reduce the number of independently sampled boundaries; they do not remove the
+need to inspect each join or guarantee better motion.
+
+The default transfer parameters are 35 steps, text guidance **3**, control
+guidance **1.5**, flow shift **10**, medium Canny thresholds **100/200**, BF16,
+TP=1, shared control/target temporal positions, and a 4096-token limit. These
+start from the installed single-edge transfer defaults; increasing guidance or
+steps is not inherently a quality improvement. Steps and text guidance also
+respect the actual video API's upper bounds of 200 and 20. There is no generic
+`strength`, `control_weight`, arbitrary server-side file path, or unchecked
+extra-parameter bag.
+
+Use a detailed scene description, preferably a structured JSON object covering
+subjects, setting, lighting, materials, camera motion and temporal continuity,
+following [NVIDIA's transfer guidance](https://github.com/NVIDIA/Cosmos/tree/main/cookbooks/cosmos3/generator/transfer).
+The exact submitted and effective positive, negative and system prompts are
+retained per interval. The installed formatter rewrites JSON duration to the
+integer local model-window duration even when metadata templates are disabled;
+the retained source-frame map supplies the exact global timestamps.
+
+```bash
+npa workbench cosmos3 nano-video-augment \
+  --input-path "$NPA_COSMOS3_AUGMENT_INPUT_URI" \
+  --output-path "$NPA_COSMOS3_AUGMENT_OUTPUT_URI" \
+  --prompt "$NPA_COSMOS3_AUGMENT_PROMPT" \
+  --negative-prompt "$NPA_COSMOS3_AUGMENT_NEGATIVE_PROMPT" \
+  --seed 42 --num-inference-steps 35 --guidance-scale 3 \
+  --control-guidance 1.5 --flow-shift 10 --edge-threshold medium \
+  --chunk-frames 121 --output-format json
+
+# Retrieve completed work or retry artifact downloads/publication; never generates again.
+npa workbench cosmos3 nano-video-augment-recover \
+  --output-path "$NPA_COSMOS3_AUGMENT_OUTPUT_URI" --output-format json
+```
+
+SDK entries are `npa.sdk.workbench.cosmos3.nano_video_augment` and
+`nano_video_augment_recover`. The authenticated API accepts multipart `/run`
+with exactly `request` (JSON) and `input_reference` (the complete MP4). Existing
+JSON continuation requests remain supported. `GET /result?request_id=...`
+retrieves durable state through any replica on the shared output filesystem.
+A missing result after an interrupted POST is ambiguous and never authorizes an
+automatic generation retry.
+
+Artifacts keep **`input.mp4`**, **`augmented.mp4`** and the synchronized, labeled
+**`comparison.mp4`** separate, alongside source controls, augmented RGB tails,
+chunk outputs, exact requests, hashes and measurements. The comparison places
+the actual source on the left. S3 reservation and publication use conditional
+immutable writes with hash-verified readback. Recovery accepts existing objects
+only when their bytes match and can finish publication without a serving token
+when the completed local result is already verified.
+If artifact retrieval fails after generation, recovery uses authenticated GETs
+to retrieve the same completed request before validating and publishing it;
+the original submission marker remains unchanged.
+
+Technical validity is separate from visual quality. A changed hash does not
+prove meaningful augmentation. Evaluate requested appearance change, lighting,
+materials/reflections, identity, source motion, wheel contact and every actual join
+against a rubric fixed before candidate scoring. Record agent/VLM judgments and
+their sampling limitations separately; do not present them as a standardized
+quality score or claim eight-way augmentation from the continuation benchmark.
+
+## Infrastructure and image
+
+Use NPA `cluster up` or the NPA fleet mk8s backend with a task-owned project in
+`us-central1`, 16 `gpu-b200-sxm` GPUs, managed CUDA 13 drivers,
+a CPU pool, and shared filesystem storage. Ray uses 16 one-GPU worker pods,
+so the cluster may provide two eight-GPU nodes or a validated mix of B200 node
+sizes. Keep NPA's quota, fabric,
+stabilization and per-node CUDA validation enabled. If using reserved capacity,
+supply its exact group through owner-only runtime configuration and require
+`STRICT` reservation placement. Follow the [fleet instructions](../../../skills/tools/fleet/SKILL.md)
+and [driver strategy](../../../docs/workbench/mk8s-gpu-driver-strategy.md).
+
+The head explicitly advertises zero Ray GPUs and hides NVIDIA/CUDA devices.
+Its required affinity selects nodes without `nvidia.com/gpu.count`; verify that
+the NPA CPU pool has no such label and every validated GPU node has a positive
+count before applying the manifest. Worker device visibility stays under the
+Kubernetes device plugin and Ray's one-GPU assignment.
+
+For a mixed cluster, declare the planned per-node GPU counts through
+`GpuHealthConfig.expected_gpu_counts`. Its optional `nvswitch_gpu_counts` subset
+identifies node sizes that require fabric checks. Every multi-GPU SXM/NVL size
+must be included. An explicitly unattached one-GPU guest can report fabric as
+not applicable while still passing driver, device-plugin and CUDA checks.
+The mixed live health test verifies the declared total, node-count distribution,
+stability and CUDA on every GPU ordinal before serving begins.
+
+The Dockerfile extends `vllm/vllm-omni:cosmos3`, pinned to manifest digest
+`sha256:6d2630c7d637b699557573f2c3fee8df5d4d0cd718977aa22549ed6a6ef30587`.
+The Dockerfile pins that index's Linux AMD64 manifest,
+`sha256:970dee6658ea223f615b2438ce41e47f1d5322225482546e6e6bc5d8134f757c`.
+The extension supplies Ray Serve, FFmpeg and the NPA adapters. It preserves the
+diffusion engine and adds no model weights, task or customer data, credentials
+or acceptance state. The inherited image contains public vendor test fixtures
+and example media. Its vendor runtime makes this an **operator-private** image;
+the NPA public publisher excludes it. Build and push only to the operator's own
+registry, then deploy the verified immutable image digest.
+
+The staging Job is the single writer of the shared model cache. It downloads
+the pinned Nano revision once, verifies all diffusion and VAE tensor dtypes as
+BF16, hashes the staged files, and atomically publishes `READY.json`. Replicas
+mount the cache read-only and run with Hugging Face offline mode. Their vLLM
+processes preserve `--init-timeout 1800`. The synchronous HTTP generation route
+has no additional workload deadline. Each replica runs one complete rollout
+at a time; Ray's custom router considers all replicas at one rank and chooses
+the least outstanding queue, with capacity rejection protecting concurrent
+admission.
+
+The router uses Ray's public FIFO fulfillment mixin to keep pending requests
+reachable when another scheduler has already consumed their routing metadata.
+FIFO selects the pending request; fresh queue snapshots across all replicas
+select the least outstanding replica. The router follows Ray's normal retry backoff.
+It disables Ray 2.56's queue-length cache because the cached-success path can
+spin after out-of-order assignments and accumulate background probes in the
+head proxy. Every selection still compares the complete replica rank; strict
+admission prevents two requests from occupying the same replica.
+
+The adapter writes an explicit single diffusion stage configuration with
+`model_config.sound_gen: false`, BF16 and TP=1, then passes it through
+`--stage-configs-path`. This supported legacy flag is needed for the pinned
+engine: its single-stage diffusion fallback drops `--stage-overrides`, and the
+checkpoint's sound dimensions would otherwise enable an unstaged audio
+tokenizer. The image's CPU validation resolves the actual engine configuration
+and checks that sound remains disabled; CLI parsing alone is insufficient.
+
+## Deploy and operate
+
+1. Verify provider credentials with `npa workbench health preflight --checks
+   nebius --json`, and anonymously probe the pinned checkpoint payload using
+   the command below before provisioning. Verify the selected image and storage
+   before starting generation. The broader `health access --capability cosmos3`
+   also checks gated guardrail weights; this recipe disables guardrails and does
+   not fetch those weights. Check their actual upstream access separately if
+   enabling a guardrail-dependent route.
+2. Provision the NPA mk8s cluster and shared filesystem. Install KubeRay operator
+   **1.7.0** with its namespace watch restricted to `workbench`. Resolve all
+   manifest placeholders from owner-only configuration. Keep the operator's
+   standard namespace-scoped Secret permissions: `rayClusterConfig.authOptions`
+   enables token authentication, and KubeRay creates a separate management Secret,
+   injects it into the head and workers, and authenticates its dashboard requests.
+   Do not override `RAY_AUTH_*` in the pod templates or reuse the inference token.
+3. Apply [shared-pvc.yaml](shared-pvc.yaml) after NPA installs its shared-filesystem
+   CSI driver. Create the API token Secret and operator-private registry pull
+   Secret, then run the weight staging
+   Job to completion. Run the RayService only after the immutable cache is ready.
+4. Require all 16 model replicas to be healthy, confirm B200 placement, and
+   verify both the API and Ray dashboard reject unauthenticated requests. Expose access through an
+   authenticated private route or a local port-forward.
+5. Set `NPA_COSMOS3_VIDEO_ENDPOINT`, `NPA_COSMOS3_VIDEO_TOKEN` and
+   `NPA_COSMOS3_VIDEO_RECOVERY_DIR` outside Git. Configure the normal NPA S3
+   endpoint and credentials in the client process. Use distinct artifact
+   prefixes for each batch, separate from any agent trajectory dataset.
+
+Ray management credentials grant code execution and are for administrators only.
+KubeRay's [token authentication integration](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kuberay-auth.html)
+uses its existing namespace-scoped RBAC; inference clients need only the separate
+API token. Management authentication does not encrypt cluster traffic. Keep Ray
+ports on the trusted private cluster network and use an authenticated encrypted
+administrative tunnel when accessing the dashboard remotely. The application
+builder refuses a cluster without explicit token authentication. For standalone
+containers, the default `--serve` launcher creates a fresh owner-only management
+credential before starting local Ray, disables the dashboard and removes the
+credential on shutdown. Docker health checks use the authenticated inference
+endpoint and do not need access to the management credential.
+
+The payload preflight reads one byte from a diffusion shard at the exact model
+revision. It uses no Hugging Face token and does not stage the checkpoint:
+
+```bash
+npa/.venv/bin/python - <<'PY'
+from urllib.request import Request, urlopen
+
+revision = "7a312c868bcce8e40b3eb40861300a9d0ba3fde1"
+shard = "transformer/diffusion_pytorch_model-00001-of-00007.safetensors"
+url = f"https://huggingface.co/nvidia/Cosmos3-Nano/resolve/{revision}/{shard}"
+with urlopen(Request(url, headers={"Range": "bytes=0-0"})) as response:
+    if response.status != 206 or len(response.read(1)) != 1:
+        raise RuntimeError("Exact-revision Nano payload access was not verified")
+print("Anonymous pinned Nano payload access: PASS")
+PY
+```
+
+For `proxy_location: HeadOnly`, route port 8000 through KubeRay's stable
+`cosmos3-nano-video-head-svc`, for example
+`http://cosmos3-nano-video-head-svc.workbench.svc.cluster.local:8000` inside the
+cluster, or a local port-forward to that Service. KubeRay updates this Service's
+head-only selector when the active cluster changes. The generated
+`cosmos3-nano-video-serve-svc` is unused: KubeRay 1.7 always labels worker pods
+as serving endpoints, while these workers have no HTTP proxy. The explicit
+worker readiness probe checks Ray's native health endpoint on port 52365;
+all 16 model replicas must separately pass application readiness. Custom
+`serveService.spec.selector` values are
+[overwritten by KubeRay](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/controllers/ray/common/service.go#L216).
+
+```bash
+npa workbench cosmos3 nano-video-batch --concurrency 1 \
+  --output-path "$NPA_COSMOS3_SINGLE_OUTPUT_URI"
+npa workbench cosmos3 nano-video-batch --concurrency 8 \
+  --output-path "$NPA_COSMOS3_FANOUT_OUTPUT_URI"
+```
+
+The SDK entry is `npa.sdk.workbench.cosmos3.nano_video_batch`. The authenticated
+service accepts `/run`; `/artifacts/<request_id>/<filename>` serves the retained
+files. CLI and SDK verify returned hashes, fully decode all three chunks and the
+stitched MP4, and
+publish immutable S3 objects with read-after-write verification. Publication
+failure retains the local recovery copy; **do not repeat GPU generation to
+retry an upload**.

--- a/npa/docker/workbench/foxglove-embed/README.md
+++ b/npa/docker/workbench/foxglove-embed/README.md
@@ -1,5 +1,7 @@
 # npa-foxglove-embed
 
+[Foxglove guide](../../../../docs/workbench/foxglove-export.md) · [Workbench docs](../../../../docs/workbench/README.md)
+
 Static host for the [Foxglove embedding SDK](https://docs.foxglove.dev/docs/embed/typescript-sdk)
 (`@foxglove/embed`), the shared NPA glue module, and MCAP/bag recordings.
 
@@ -11,10 +13,10 @@ Static host for the [Foxglove embedding SDK](https://docs.foxglove.dev/docs/embe
 | `/data/` | Operator-mounted recordings, served with CORS + byte ranges (no directory listing; `FOXGLOVE_DATA_BROWSE=browse` opts in) |
 | `/healthz` | `{"ok":true,...}` liveness/readiness probe |
 
-## What this image is *not*
+## Prerequisites
 
-It does not contain the Foxglove application. The SDK creates an iframe pointing at
-a Foxglove deployment you control:
+The SDK embeds a separately hosted Foxglove application. Before starting the
+container, choose a deployment that your users can access:
 
 - `https://embed.foxglove.dev/` — Foxglove-hosted; requires a Foxglove organization
   on a plan that allows embedding (Pro / Enterprise / Academic), and users sign in there.
@@ -25,6 +27,8 @@ it is not configured instead of rendering an empty viewer.
 
 ## Build
 
+From the repository root with Docker installed:
+
 ```bash
 docker build -t npa-foxglove-embed:0.58.0 \
   -f npa/docker/workbench/foxglove-embed/Dockerfile npa
@@ -34,16 +38,25 @@ Build args: `FOXGLOVE_EMBED_VERSION`, `FOXGLOVE_EMBED_INTEGRITY` (npm `dist.inte
 `FOXGLOVE_EMBED_REGISTRY` (mirror / air-gapped cache). Version and integrity defaults are
 kept in sync with `npa.workbench.foxglove` by `npa/tests/docker/test_foxglove_image.py`.
 
-## Run
+## Run locally
+
+Replace `/path/to/recordings` with a directory containing your MCAP recording.
+Keep the terminal open while viewing; Ctrl-C stops and removes the container.
 
 ```bash
-docker run --rm -p 8099:8099 \
+docker run --rm -p 127.0.0.1:8099:8099 \
   -v /path/to/recordings:/srv/data:ro \
   npa-foxglove-embed:0.58.0
 
 # then open, e.g.
 # http://localhost:8099/?src=https://embed.foxglove.dev/&org=my-org&mcap=/data/run.mcap
 ```
+
+Check `http://localhost:8099/healthz` for `ok: true`, then open the example
+viewer URL with your organization and recording filename. A healthy static host
+does not establish that Foxglove sign-in or recording access works. If the host
+reports an unconfigured viewer, supply `src`; if playback fails, verify that
+`/data/run.mcap` resolves and the selected Foxglove deployment can reach it.
 
 Foxglove requires a [secure context](https://developer.mozilla.org/docs/Web/Security/Secure_Contexts):
 `localhost` works for local runs; serve it over HTTPS (or behind an HTTPS ingress) anywhere else.

--- a/npa/docker/workbench/groot/README.md
+++ b/npa/docker/workbench/groot/README.md
@@ -1,26 +1,52 @@
-# GR00T Container Image
+# GR00T runtime image
 
-Build locally for the Linux x86_64 Nebius runtime:
+[Workbench docs](../../../../docs/workbench/README.md) · [Training cookbook](../../../../docs/workbench/cookbooks/groot-1-7-training.md)
+
+This image runs NVIDIA Isaac-GR00T N1.7 inference and fine-tuning on Linux
+x86_64. For a first workload, follow the training cookbook and use an accepted
+image from the [public catalog](../../../../docs/workbench/container-image-catalog.md).
+Build a candidate when changing the runtime or adding your own code.
+
+## Build a candidate
+
+Run from the **repository root** with Docker Buildx available:
 
 ```bash
-docker/workbench/groot/build.sh
+npa/docker/workbench/groot/build.sh --help
+npa/docker/workbench/groot/build.sh --tag my-groot-candidate
 ```
 
-Build and push to an operator-controlled registry:
+The local build produces `npa-groot:my-groot-candidate`. To build and push to a
+registry you control, authenticate to that registry first, then run:
 
 ```bash
-docker/workbench/groot/build.sh --registry <your-registry>/<namespace> --push
+npa/docker/workbench/groot/build.sh \
+  --registry '<your-registry>/<namespace>' --tag my-groot-candidate --push
 ```
 
-The image bakes Isaac-GR00T N1.7 at commit
-`3df8b3825d67f755e69141446f4315f281b9b7e6`, GR00T package version `0.1.0`,
-Isaac Lab `2.3.2.post1`, and the Cosmos
-Reason2 model revision patch used by the VM deploy path. Model weights,
-datasets, HuggingFace cache, checkpoints, and outputs stay outside the image
-under `/opt/groot-data`.
+Use a distinct candidate tag and validate its immutable digest before selecting
+it for workloads. Publishing to the official public channel follows the
+[contribution and image-validation procedure](../../../../docs/workbench/container-packaging.md).
 
-The same environment supports real single-node training. The reference
-`npa.workflow` spec at
-`workflows/testing/groot-1-7-finetune.yaml` runs the pinned
-vendor launcher locally in the allocated image and uses `torchrun` when more
-than one GPU is selected.
+## What is installed and what is fetched
+
+| Component | Contract |
+| --- | --- |
+| Isaac-GR00T | Source pinned to `3df8b3825d67f755e69141446f4315f281b9b7e6`; package version `0.1.0` |
+| Cosmos Reason2 dependency | Model revision configured by the Dockerfile; weights fetched at runtime |
+| Isaac Sim / Isaac Lab | Fetched only when `/isaac-sim/python.sh` is first used for simulation; **not baked into this image** |
+| Models, datasets, checkpoints, and caches | Kept under the mounted `/opt/groot-data` and Isaac cache paths |
+
+Standard inference and fine-tuning need Hugging Face access to the selected
+GR00T and Cosmos Reason2 weights. They do not need Isaac simulation or its
+runtime download. Isaac simulation additionally needs an RT-core GPU and the
+operator's accepted NVIDIA terms; see the
+[GR00T operating guidance](../../../../skills/tools/groot/SKILL.md).
+
+## Run and verify
+
+Use [`groot-1-7-finetune.yaml`](../../../../workflows/testing/groot-1-7-finetune.yaml)
+with the cookbook's dataset, checkpoint, and image settings. Its `gpu_count`
+controls a single-node allocation and the real trainer; counts above one use
+`torchrun`. Inspect the training report and emitted checkpoint. Image build
+success alone does not prove GPU execution or learned policy quality.

--- a/npa/docker/workbench/ncore/README.md
+++ b/npa/docker/workbench/ncore/README.md
@@ -1,9 +1,25 @@
 # NCore CPU ingestion image
 
+[Container catalog](../../../../docs/workbench/container-image-catalog.md) · [Neural reconstruction guide](../../../../docs/workbench/guides/neural-reconstruction.md)
+
 This image packages the official pinned NCore COLMAP converter and V4 reader.
 It remains a quarantined development candidate; no image acceptance or GPU
 readiness is implied. See [REDISTRIBUTION.md](REDISTRIBUTION.md) for the source,
 application dependency and acceptance boundaries.
+
+Use the [neural reconstruction guide](../../../../docs/workbench/guides/neural-reconstruction.md)
+for capture-to-scene workflows. This directory is the packaging reference for
+maintainers preparing a candidate image.
+
+| Need | Read |
+| --- | --- |
+| Source and runtime redistribution boundaries | [REDISTRIBUTION.md](REDISTRIBUTION.md) |
+| Exact base, native-library selection, and notices | [BASE-SOURCES.md](BASE-SOURCES.md) |
+| Build, scan, and publication sequence | [OCI publication procedure](../../../../docs/workbench/ncore-oci-publication.md) |
+| Startup cache requirements | [Runtime setup](#runtime-setup) below |
+| Supplemental selected-file scan | [Publication evidence](#selected-base-publication-evidence) below |
+
+## Candidate status
 
 The selected base now pins CPython 3.12.14 to address CVE-2026-6100. Its 665
 interpreter/stdlib paths and 61 ELF hashes come from the official linux/amd64
@@ -18,6 +34,8 @@ building. Its `--keyring` option defaults to
 `<analysis-root>/keyring/debian-archive-keyring.gpg`; CI supplies the prepared
 path explicitly. Packaging guards execute the complete committed snapshot and
 require successful test execution, including setup and teardown.
+
+## Runtime setup
 
 At container startup, the unprivileged user fetches two exact Debian native
 libraries needed by real APT/curl. The fixed isolated root installer verifies
@@ -60,7 +78,9 @@ purls. Partial-package scope is explicit; no installed dpkg state or package
 license conclusion is invented.
 
 After independently verifying the final OCI index, sole linux/amd64 child and
-config, derive a merged filesystem tar from that exact platform and run:
+config, derive a merged filesystem tar from that exact platform. Set the five
+variables below to those verified inputs and a fresh evidence directory, then
+run from the repository root:
 
 ```bash
 npa/.venv/bin/python -m npa.deploy.ncore_selected_sbom \

--- a/npa/examples/fleet/kuberay/README.md
+++ b/npa/examples/fleet/kuberay/README.md
@@ -1,50 +1,103 @@
-# Fixed CPU RayCluster example
+# Run native Ray work on a fixed CPU cluster
 
-This example opts a Fleet Managed Kubernetes cluster into KubeRay. Fleet owns
-the infrastructure; native Ray Jobs and Core APIs execute application code on a
-fixed CPU worker group. KubeRay is disabled when its configuration is omitted.
+[Fleet guide](../../../../docs/fleet-kuberay.md) · [Repository](../../../../README.md)
 
-Copy [cpu-raycluster.yaml](cpu-raycluster.yaml) outside the repository and set
-your authorized tenant, project, region and profile. Choose a nonempty CPU pool
-large enough for the head, workers and Kubernetes system pods.
+Deploy a CPU RayCluster on Nebius Managed Kubernetes, then verify work on every
+Ray worker. Fleet owns the infrastructure; native Ray Jobs runs the application.
+The example needs no GPU, model, or dataset.
+
+## Before you start
+
+- Install NPA, Terraform, `kubectl`, and the authenticated Nebius CLI; follow
+  [first-run setup](../../../../docs/workbench/getting-started.md).
+- Select an authorized existing project with quota for Kubernetes, one CPU node,
+  and its boot disk. The template uses one `16vcpu-64gb` CPU node and two Ray
+  worker pods. These are two Ray workers on one host, not two physical hosts.
+- Keep your fleet YAML, kubeconfig, and validation evidence outside the checkout.
+
+## Deploy and check readiness
+
+From the repository root, copy [cpu-raycluster.yaml](cpu-raycluster.yaml) to a
+private path. Set its `tenant_id`, `region`, `profile`, and existing project's
+`name` and `project_id`; leave `profile` empty to use the authenticated default.
+Use that same path throughout the lifecycle:
+
+```bash
+export FLEET_SPEC="/absolute/private/cpu-raycluster.yaml"
+npa workbench health preflight --checks nebius --json
+npa fleet plan --spec "$FLEET_SPEC"
+npa fleet deploy --spec "$FLEET_SPEC" --no-create-projects --yes
+npa fleet status --spec "$FLEET_SPEC"
+```
+
+Select this cluster's exact Fleet-generated kubeconfig, then require the head
+and both workers to be ready:
+
+```bash
+export KUBECONFIG="/absolute/private/fleet-generated-kubeconfig"
+kubectl -n ray-cluster get rayclusters,pods,services
+```
+
+A successful deploy is followed by **three ready Ray pods**, a fixed two-worker
+RayCluster, and a ClusterIP head service. Use the
+[native submit guide](../../../../docs/fleet-kuberay.md#execute-and-inspect-worker-work)
+for authenticated loopback access and `ray job submit/status/logs/stop`.
+
+## Verify actual worker execution
+
+[verify_workers.py](verify_workers.py) computes 10,000 square values per worker
+and verifies distinct Ray worker placement, sums, and SHA-256 digests. Successful
+logs include `KUBERAY_RESULT=` with `worker_count: 2`. The output is a text
+verification record; data inside the cluster remains ephemeral.
+
+The committed live test also verifies deployed image digests, pod resources,
+network settings, native job status, and removal of its own staged source. It
+uses an already deployed cluster. Create a mode-0600 JSON file outside the
+checkout with these keys (the evidence directory must be mode 0700):
+
+```json
+{
+  "spec": "/absolute/private/cpu-raycluster.yaml",
+  "kubeconfig": "/absolute/private/fleet-generated-kubeconfig",
+  "evidence_dir": "/absolute/private/cpu-ray-evidence"
+}
+```
+
+From the repository root:
+
+```bash
+export NPA_FLEET_KUBERAY_LIVE_CONFIG="/absolute/private/cpu-ray-live.json"
+NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest \
+  npa/tests/e2e/test_fleet_kuberay_live.py -q
+```
+
+Expected: `1 passed`. Without the private configuration and live-test gate,
+ordinary test runs skip this cloud access.
+
+## Change worker capacity
 
 | Configuration key | Default | Meaning |
 | --- | --- | --- |
 | `kuberay.enabled` | `false` | Explicitly enable the CPU RayCluster. |
 | `kuberay.worker_replicas` | `1` | Fixed positive number of worker pods. |
-| `kuberay.worker_cpus` | `2` | Positive integer CPU request and limit per worker. |
-| `kuberay.worker_memory_gib` | `4` | Positive integer memory request and limit in GiB. |
+| `kuberay.worker_cpus` | `2` | CPU request and limit per worker. |
+| `kuberay.worker_memory_gib` | `4` | Memory request and limit per worker, in GiB. |
 
-Worker settings require `enabled: true`. The example selects two workers;
-`kuberay: {enabled: false}` fully disables an inherited default policy.
+Worker settings require `enabled: true`. Size the CPU pool for the head, workers,
+and Kubernetes system pods. `kuberay: {enabled: false}` fully disables an inherited
+policy. This path uses the pinned public upstream Ray CPU image and supports
+neither autoscaling nor GPU Ray workers.
 
-```bash
-npa workbench health preflight --checks nebius --json
-npa fleet plan --spec /path/to/private-fleet.yaml
-npa fleet deploy --spec /path/to/private-fleet.yaml --no-create-projects --yes
-```
+## Finish
 
-Use the exact Fleet-generated kubeconfig and authenticated loopback forwarding
-to access Ray Jobs. [The fleet KubeRay guide](../../../../docs/fleet-kuberay.md)
-describes access, native submit/status/log/stop commands and teardown.
-[verify_workers.py](verify_workers.py) computes and verifies 10,000 square values
-per worker, with distinct worker placement, sums and SHA-256 digests. Its output
-is a text verification record; application data in the cluster is ephemeral.
-
-The optional live regression reads `NPA_FLEET_KUBERAY_LIVE_CONFIG`. It is unset by
-default, so ordinary test runs skip live access. To run it, set the variable to
-an owner-private JSON file containing `spec` (the one-target fleet YAML path),
-`kubeconfig` (the exact cluster credential path), and `evidence_dir` (a private
-directory with mode 0700). Live tests also require `NPA_INTEGRATION_E2E=1`; this
-shared gate is unset by default. After deploying the cluster and observing all
-Ray pods ready, run from the repository root:
+Save needed logs and outputs, stop remaining exact Ray submission IDs, and close
+any port-forward process. Then destroy the same owned fleet target:
 
 ```bash
-NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest \
-  npa/tests/e2e/test_fleet_kuberay_live.py -q
+npa fleet destroy --spec "$FLEET_SPEC" --yes
 ```
 
-Stop remaining jobs and save needed output before `npa fleet destroy`. Verify
-the exact owned resources are absent and retain the project and unrelated
-infrastructure. This example uses the pinned public upstream Ray CPU image;
-it does not build an NPA image or exercise GPU training.
+Verify that its cluster, node groups, and instances are absent. Fleet retains the
+project; preserve unrelated infrastructure and private ownership receipts. See
+[the teardown contract](../../../../docs/fleet-kuberay.md#execute-and-inspect-worker-work)
+if cleanup refuses changed Terraform inputs or incomplete state.

--- a/npa/pyproject.toml
+++ b/npa/pyproject.toml
@@ -132,6 +132,7 @@ dev = [
     "pytest-mock>=3.14",
     "pytest-cov>=5.0",
     "pytest-timeout>=2.3",
+    "markdown-it-py>=3,<5",
     "jsonschema>=4.23,<5",
     # The suite is parallel-safe; `-n auto` takes it from ~6 min to ~2 min on 8
     # cores, which is the difference between running it every iteration and not.
@@ -150,6 +151,7 @@ dev = [
     "pytest-mock>=3.14",
     "pytest-cov>=5.0",
     "pytest-timeout>=2.3",
+    "markdown-it-py>=3,<5",
     "jsonschema>=4.23,<5",
     # The suite is parallel-safe; `-n auto` takes it from ~6 min to ~2 min on 8
     # cores, which is the difference between running it every iteration and not.

--- a/npa/scripts/image_byte_scan/go_helper/README.md
+++ b/npa/scripts/image_byte_scan/go_helper/README.md
@@ -1,12 +1,22 @@
 # Whole-file Gitleaks helper
 
+[Image scanning](../../../../docs/workbench/ncore-oci-publication.md) · [Repository](../../../../README.md)
+
 This analysis tool is built outside container contexts. It calls the pinned
 Gitleaks 8.28.0 `Detector.Detect` API on each complete raw record, including binary
 and empty records. It does not use Gitleaks file discovery, MIME filtering,
 stdin chunking, a baseline, or image-authored ignore files.
 
-An explicit Linux amd64 bootstrap runs native regression tests before writing a
-terminal dependency receipt:
+## Prepare the helper
+
+Run on **Linux amd64**, from an NPA checkout with its development environment
+installed. The bootstrap downloads its pinned Go toolchain and modules; a local
+Go installation is not required. macOS and ARM hosts are not supported by this
+native preparation path.
+
+Choose a private analysis directory outside the checkout. Replace the three
+absolute paths below before running. The bootstrap runs native regression tests
+before writing a terminal dependency receipt:
 
 ```bash
 npa/.venv/bin/python npa/scripts/image_byte_scan/go_helper/build.py \
@@ -26,6 +36,8 @@ canaries. Hermetic bootstrap tests are collected by normal repository CI and can
 ```bash
 npa/.venv/bin/python -m pytest npa/tests/docker/test_image_byte_go_build.py -q
 ```
+
+## What successful preparation produces
 
 The bootstrap pins [Go 1.27.1](https://go.dev/dl/) Linux amd64 to SHA-256
 `63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445`.
@@ -54,8 +66,13 @@ big-endian byte length followed by exactly that many bytes, repeatedly. It emits
 one JSON result per record, retaining every finding but returning only rule and
 line information, record ordinal, byte count and SHA-256. Clean EOF between
 records produces a final summary. A truncated header or payload is an error.
-Exit 0 means no findings, 1 means findings after processing all complete records,
-and 2 means a protocol, configuration or IO failure. Failures never establish a
+The scanner process uses these exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | All records processed; no findings. |
+| `1` | All complete records processed; findings retained. |
+| `2` | Protocol, configuration, or I/O failure. | Failures never establish a
 clean scan. The caller separately records exact coverage and handles resource
 exhaustion as failure.
 

--- a/npa/src/npa/burst/examples/README.md
+++ b/npa/src/npa/burst/examples/README.md
@@ -1,38 +1,56 @@
 # Burst task examples
 
-Single-task SkyPilot YAMLs that are inputs to **`npa burst submit-yaml`**, not workflow
-templates.
+[Workflow catalog](../../../../../workflows/README.md) · [Burst operating guide](../../../../../skills/tools/burst/SKILL.md)
 
-`npa.burst.core.submit_yaml()` is deliberately scoped to *one* executable SkyPilot task: it
-loads the document, substitutes `${VAR}` placeholders from `--var`, refuses to submit while any
-placeholder is unresolved, and forwards explicit exact-host registry credentials when
-the operator supplies them. That is a different capability from the workflow surface — there is no plan, no
-stage graph, no decision artifact, and nothing for a `toolRef` to describe.
+These are single-task inputs to `npa burst submit-yaml`, **not workflow templates**.
+The current example runs a small Isaac Lab Cartpole training exercise on one
+L40S VM, then writes a **local Cosmos SDG contract manifest**. It does not run
+Cosmos generation or upload that manifest to S3.
 
-These files live here rather than in the retired raw SkyPilot workflow catalog so that burst
-can keep its single-task path without reopening a workflow authoring surface. The same reasoning
-relocated the BYOF resource profiles to `npa/src/npa/workflows/byof/profiles/` (see
-`DESIGN.md` §R10).
+## Before submitting
 
-| File | What it exercises |
-| --- | --- |
-| `isaac-lab-cosmos-sdg-burst-smoke.yaml` | Isaac Lab headless Cartpole training on a burst GPU, then a Cosmos SDG transfer-contract manifest. One task on purpose. |
+Install NPA and [bootstrap SkyPilot](../../../../../docs/orchestration/skypilot-setup.md).
+Configure an authorized Nebius project, verify credentials, and check L40S
+capacity and the selected Isaac image. This YAML uses `cloud: nebius`; it does
+not consume an existing Kubernetes GPU pool. Isaac runtime use requires the
+operator's accepted NVIDIA terms and an RT-core GPU.
 
-## Rules
+Public GHCR images need no registry credentials. For a private image, configure
+exact-host SkyPilot Docker credentials as described in the Burst guide.
 
-- **One task per file.** `submit_yaml` rejects anything else, and a multi-stage pipeline is a
-  workflow: author an `npa.workflow/v0.0.1` spec under
-  `workflows/` instead.
-- **Keep `${VAR}` placeholders.** They are the burst substitution surface; concrete registry
-  ids, bucket names and run ids must never be committed here.
-- `npa/tests/guardrails/test_burst_examples.py` pins both rules.
+## Submit and inspect
 
-## Submitting
+Run from the repository root with your own run label and destination contract:
 
 ```bash
 npa burst submit-yaml npa/src/npa/burst/examples/isaac-lab-cosmos-sdg-burst-smoke.yaml \
-  --name <run-id> \
-  --var NPA_RUN_ID=<run-id> \
-  --var ISAAC_LAB_IMAGE=<registry>/npa-isaac-lab:3.0.0b2.post1 \
-  --var NPA_OUTPUT_URI=s3://<your-bucket>/<prefix>/<run-id>/
+  --name '<run-id>' \
+  --var 'NPA_RUN_ID=<run-id>' \
+  --var 'ISAAC_LAB_IMAGE=ghcr.io/nebius/nebius-physical-ai/npa-isaac-lab:3.0.0b2.post1' \
+  --var 'NPA_OUTPUT_URI=s3://<your-bucket>/<prefix>/<run-id>/' \
+  --json
 ```
+
+Save the returned job ID and handle. Use the same runtime configuration to
+inspect it:
+
+```bash
+npa burst status '<job-id-or-handle-json>'
+npa burst logs '<job-id-or-handle-json>' --follow
+```
+
+Expect completed Isaac training and `cosmos_sdg_manifest.json` in the task's
+local output directory, with the manifest printed in logs. `NPA_OUTPUT_URI`
+populates URI fields; it is not an uploader. Preserve needed logs and files
+before deleting compute. Burst has no durable workflow artifact ledger or
+resume command. Follow [teardown](../../../../../docs/teardown.md) for the exact
+managed job and its owned resources.
+
+## Rules for changes
+
+- **One task per file.** Multi-stage pipelines belong in `workflows/` as
+  `npa.workflow/v0.0.1` specs.
+- Keep `${VAR}` placeholders; submission refuses unresolved values. Never commit
+  live resource IDs, bucket names, or credentials.
+- The example set is pinned by
+  [`test_burst_examples.py`](../../../../tests/guardrails/test_burst_examples.py).

--- a/npa/src/npa/solutions/README.md
+++ b/npa/src/npa/solutions/README.md
@@ -1,25 +1,26 @@
-# NPA Solutions
+# NPA solutions
 
-Validation context: [docs/workbench/solutions-validation.md](../../../../docs/workbench/solutions-validation.md)
-documents the current solutions framework validation state.
+[Contributor guide](../../../../CONTRIBUTING.md) · [Solutions architecture](../../../../docs/architecture/solutions-model.md)
 
-A solution is a top-level product namespace on the NPA platform. It groups a
-related CLI surface, optional SDK namespace, workflows, containers, manifests,
-and agent skills around one implementation domain.
+A solution is a top-level NPA product namespace. It groups commands, optional
+Python clients, workflows, images, and agent skills for one domain. **Workbench**
+is the current reference: its commands start with `npa workbench`.
 
-Workbench is the reference implementation. It owns robotics and physical AI
-workflow tooling under `npa workbench`, with SDK clients under
-`npa.sdk.workbench`, workbench-specific CLI internals under
-`npa.cli.workbench`, and tool skills under `skills/tools/`.
+To add a robotics tool to Workbench, use
+[add a Workbench tool](../../../../skills/workflows/add-workbench-tool/SKILL.md).
+Create a new solution only when it needs its own top-level namespace.
 
-## Adding A Second Solution
+## Files to change for a new solution
 
-1. Add `npa/src/npa/cli/<solution>/__init__.py`.
-2. Register the solution CLI namespace in `npa/src/npa/cli/main.py`.
-3. Add a `[[solutions]]` entry in `npa/src/npa/solutions/solutions.toml`.
-4. Add an SDK namespace if applicable.
-5. Add `skills/tools/<solution>/` or `skills/workflows/<solution>/` skill files
-   and register them in `skills/index.yaml`.
+1. Implement `npa/src/npa/cli/<solution>/__init__.py` and register it in
+   [`npa.cli.main`](../cli/main.py).
+2. Add a `[[solutions]]` entry to [`solutions.toml`](solutions.toml).
+3. Add a Python namespace if the solution supports programmatic access.
+4. Add its root skill under `skills/tools/` or `skills/workflows/`, then register
+   it in [`skills/index.yaml`](../../../../skills/index.yaml).
+5. Document and test the supported commands and integration paths using the
+   [contribution checks](../../../../CONTRIBUTING.md).
 
-Future solution examples include `datalake` for dataset and storage workflows
-and `simfarm` for simulation fleet workflows.
+See [solutions validation](../../../../docs/workbench/solutions-validation.md)
+for what the framework has exercised. Names such as `datalake` and `simfarm`
+are design examples, not installed solutions.

--- a/npa/src/npa/viz/adapters/README.md
+++ b/npa/src/npa/viz/adapters/README.md
@@ -1,4 +1,6 @@
-# Rerun Adapters
+# Rerun adapters
+
+[Viewer and sharing guide](../../../../../docs/workbench/rerun-sharing.md) · [Workbench docs](../../../../../docs/workbench/README.md)
 
 This package contains standalone Rerun `.rrd` exporters for Unitree G1
 LeRobotDataset artifacts and GR00T prediction artifacts.
@@ -6,6 +8,15 @@ LeRobotDataset artifacts and GR00T prediction artifacts.
 The adapters are intentionally separate from `npa convert lerobot-to-mp4 --renderer rerun`.
 The MP4 renderer creates quick-review videos; these adapters create reusable
 Rerun recordings for customer artifacts, handoff, and post-demo inspection.
+
+## Before you start
+
+Install NPA using the [installation guide](../../../../../docs/install.md).
+Run the Python examples in that environment. Provide a Unitree G1 dataset with
+its canonical 43D state layout; these skeleton adapters do not infer arbitrary
+robot kinematics. GR00T overlays also need predictions aligned with that input.
+For local-only conversion, replace the S3 URI with your dataset directory.
+For S3 inputs or outputs, configure credentials for the exact bucket first.
 
 ## LeRobotDataset to Rerun
 
@@ -56,12 +67,14 @@ state layout before logging.
 Local outputs are written directly. For `s3://...` outputs, the adapter first
 writes a local temporary `.rrd`, then uploads it to the requested object path.
 
-Both adapters apply a default 5 second duration cap and evenly subsample longer
-sources. Pass `duration_s` to request a shorter cap.
+Both skeleton adapters default to at most five seconds and evenly subsample
+longer sources. `duration_s` can shorten that preview; it cannot extend the
+built-in five-second maximum. The recording is a sampled trajectory preview,
+not a full-length replay. Both functions return `None`; inspect the written file.
 
 ## Viewer
 
-Open a recording locally with:
+Open the file created by the corresponding example:
 
 ```bash
 rerun /tmp/isaac-lab-trajectory.rrd

--- a/npa/src/npa/workbench/nurec/examples/README.md
+++ b/npa/src/npa/workbench/nurec/examples/README.md
@@ -1,5 +1,7 @@
 # NuRec single-pod SkyPilot example
 
+[Reconstruction guide](../../../../../../docs/workbench/guides/neural-reconstruction.md) · [Workflow catalog](../../../../../../workflows/README.md)
+
 This directory holds the intentionally retained **single-pod** NuRec/NRE SkyPilot
 task from #234. It is an example for running the NuRec tool end to end inside one
 pod, not a workflow authoring catalog.
@@ -28,14 +30,33 @@ behavior #234 validated and documented.
 - This file must never move back under the retired raw SkyPilot workflow catalog.
 - `npa/tests/guardrails/test_nurec_examples.py` pins these rules.
 
+## Before submitting
+
+Complete the reconstruction guide's project, storage, model/container access,
+and RT-core GPU setup. The example selects RTX PRO 6000 and needs a matching
+Kubernetes context with enough CPU, memory, and scratch storage for NRE.
+Prepare the NGC image-pull Secret in the task namespace and export required
+runtime credentials privately. The template's `NPA_SRC_S3_URI` must name a
+verified staged source tree; replace every other placeholder consistently too.
+
+For a first reconstruction, use the guide's canonical declarative workflow.
+This retained example is for the specific shared-scratch, single-pod behavior
+validated in #234; it is not a self-contained fresh-account quickstart.
+
 ## Submitting
 
 ```bash
 npa workbench workflow submit npa/src/npa/workbench/nurec/examples/nurec-reconstruct.yaml \
-  --run-id neural-reconstruction-<scene>-<yyyymmdd>t<hhmmss>z \
+  --run-id "neural-reconstruction-<scene>-<yyyymmdd>t<hhmmss>z" \
   --var NPA_NUREC_IMAGE=nvcr.io/nvidia/nre/nre-ga:26.04 \
-  --var NPA_NUREC_RUN_ID=<run-id> \
-  --var NPA_NUREC_RUN_URI=s3://<bucket>/<prefix>/neural-reconstruction/<run-id> \
-  --var NPA_SRC_S3_URI=s3://<bucket>/npa-src/<tag> \
-  --infra k8s/<rt-core-context>
+  --var NPA_NUREC_RUN_ID="<run-id>" \
+  --var NPA_NUREC_RUN_URI="s3://<bucket>/<prefix>/neural-reconstruction/<run-id>" \
+  --var NPA_SRC_S3_URI="s3://<bucket>/npa-src/<tag>" \
+  --infra "k8s/<rt-core-context>"
 ```
+
+Use the same run ID for `--run-id`, `NPA_NUREC_RUN_ID`, and the output prefix.
+Inspect all six stages and the final S3 outputs: reconstruction USDZ, novel-view
+renders, `reports/sim2real.rrd`, and `reports/final.json`. The pod's `/tmp` data
+is temporary; preserve outputs before following the
+[cleanup procedure](../../../../../../docs/teardown.md).

--- a/npa/src/npa/workflows/byof/profiles/README.md
+++ b/npa/src/npa/workflows/byof/profiles/README.md
@@ -1,5 +1,7 @@
 # BYOF SkyPilot resource profiles
 
+[BYOF cookbook](../../../../../../docs/workbench/cookbooks/byof-isaac-lab/README.md) · [Workflow catalog](../../../../../../workflows/README.md)
+
 These are **resource profiles**, not workflow templates. Each one describes the pod a
 BYOF workload runs in — accelerator, CPU/memory floors, the image placeholder the runner
 substitutes, and the smoke command for that workload — and nothing else.
@@ -17,11 +19,25 @@ means editing the spec; picking a *pod shape* means picking a profile here.
 | `isaac-lab-rl-train-rtxpro-smoke.yaml` | `rl-train` smoke | RTX PRO, `num_envs=4`, `iterations=1` |
 | `byof-datagen-rtxpro-smoke.yaml` | `datagen` smoke | RTX PRO, scripted LeIsaac datagen |
 | `byof-container-smoke-rtxpro.yaml` | `container-verify` / `solution-smoke` | CPU only |
+| `byof-solution-smoke-ltx2-rtxpro-gpu.yaml` | LTX-2.5 candidate shape with CPU offload; not hardware validated | One RTX PRO, 192 GiB host memory |
+| `byof-solution-smoke-rtxpro-2gpu.yaml` | Capability smoke requiring two GPUs in one pod | `RTXPRO-6000-BLACKWELL-SERVER-EDITION:2` |
 | `byof-solution-smoke-rtxpro-gpu.yaml` | `solution-smoke` needing CUDA/EGL/Vulkan | RTX PRO |
 | `byof-solution-smoke-openpi-b200-gpu.yaml` | OpenPI pi0.5 Polaris immutable-image builder regression: direct + same-pod served inference, runtime-only checkpoint; the digest then feeds `openpi-pi05-four-mode.yaml` | `B200:1` (`sm_100`) |
 | `byof-solution-smoke-wan22-rtxpro-gpu.yaml` | Wan TI2V-5B tensor-only `solution-smoke` with SM120-tested PyTorch SDPA | `RTXPRO-6000-BLACKWELL-SERVER-EDITION:1` |
 | `byof-solution-smoke-wan22-b200-4gpu.yaml` | Wan TI2V-5B distributed `solution-smoke` with FSDP + Ulysses | one Kubernetes pod, `B200:4` |
-| `skypilot-kubernetes-rtxpro.yaml` | *not a task* — SkyPilot **global config** (`--config`) setting `imagePullSecrets` | — |
+| `skypilot-kubernetes-rtxpro.yaml` | *not a task* — SkyPilot **global config** (`--config`) Kubernetes options (the committed file is empty) | — |
+
+## Select a profile
+
+Choose by the workload and the exact accelerator label reported by your cluster.
+A two-GPU profile requires two available GPUs on **one node**. Filenames do not
+establish hardware validation; read the solution guide and any candidate status.
+
+Pass the profile to `npa workbench byof run --yaml <profile-path>`, or to the
+Isaac runner as shown in the cookbook. Use a private copy when changing CPU,
+memory, GPU, image, or command requirements. Supply credentials privately;
+the runner materializes placeholders and preserves the S3 output contract.
+The global `skypilot-kubernetes-rtxpro.yaml` is supplied as `--config`, not `--yaml`.
 
 ## Why they are here and not in the SkyPilot catalog
 

--- a/npa/tests/fixtures/skypilot/README.md
+++ b/npa/tests/fixtures/skypilot/README.md
@@ -1,13 +1,18 @@
-# Raw SkyPilot task fixtures
+# Raw SkyPilot test fixtures
 
-These are **not** shipped workflows. They are frozen copies of two retired catalog templates,
-kept only as fixtures for `tests/cli/test_workflow_cli.py`.
+[Contributor guide](../../../../CONTRIBUTING.md)
 
-`npa workbench workflow submit <a raw SkyPilot YAML>` remains a supported path — a customer can
-bring their own task and have the wrapper resolve images, registry auth, S3 wiring and
-`${PLACEHOLDER}` substitution for it. That contract needs a raw task to exercise, and it should
-**not** be exercised against a shipped template: doing so is what made these tests block the
-templates' retirement even though nothing in the product referenced them.
+These frozen tasks exercise raw-YAML handling in
+[`test_workflow_cli.py`](../../cli/test_workflow_cli.py). They are test inputs,
+not examples to deploy. For current runnable workflows, use the
+[workflow catalog](../../../../workflows/README.md).
 
-Keeping the fixtures here says the wrapper's contract is independent of the catalog, which is
-the point of retiring the catalog in the first place. See EVIDENCE.md §R51.
+The fixtures keep coverage of image resolution, registry authentication, S3
+wiring, and `${PLACEHOLDER}` substitution independent of the shipped catalog.
+That allows production templates to change or retire without removing coverage
+of customer-owned raw SkyPilot tasks.
+
+When editing a fixture, run its CLI tests and explain which input contract the
+change exercises. Keep private infrastructure values and credentials out of
+fixture content. See the historical R51 record in
+[EVIDENCE.md](../../../../EVIDENCE.md) for the catalog retirement.

--- a/npa/tests/guardrails/documentation_examples.py
+++ b/npa/tests/guardrails/documentation_examples.py
@@ -1,0 +1,255 @@
+"""Parse repository documentation links and literal NPA command examples offline."""
+
+from __future__ import annotations
+
+import os
+import ast
+import re
+import shlex
+import subprocess
+from collections import Counter
+from functools import lru_cache
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+from markdown_it import MarkdownIt
+from typer.core import TyperGroup, TyperOption
+import yaml
+
+_MARKDOWN = MarkdownIt().enable("table")
+_SHELL_LANGUAGES = {"bash", "sh", "shell", "console"}
+_SHELL_BOUNDARIES = {"|", "||", "&&", ";", ">", ">>", "2>&1"}
+_NON_USER_DOCS = {"archive", "architecture", "cli", "security", "testing"}
+
+
+def _documentation_paths(root: Path) -> list[Path]:
+    paths = {root / "README.md", root / "CONTRIBUTING.md"}
+    for directory in ("docs", "workflows"):
+        paths.update((root / directory).rglob("*.md"))
+    for directory in ("npa", "deploy", "workbench", "research"):
+        for parent, directories, files in os.walk(root / directory):
+            directories[:] = [
+                name for name in directories
+                if not name.startswith(".") and name not in {"vendor", "node_modules"}
+            ]
+            if "README.md" in files:
+                paths.add(Path(parent) / "README.md")
+                paths.update(Path(parent).glob("*.md"))
+    return sorted(paths)
+
+
+def _has_current_commands(path: Path, root: Path) -> bool:
+    relative = path.relative_to(root)
+    if relative.parts[0] == "research" or path.name == "CONTRIBUTING.md":
+        return False
+    return not (
+        relative.parts[0] == "docs"
+        and len(relative.parts) > 2
+        and relative.parts[1] in _NON_USER_DOCS
+    )
+
+
+class _HtmlReferences(HTMLParser):
+    def __init__(self, content: str):
+        super().__init__()
+        self.links: list[str] = []
+        self.anchors: set[str] = set()
+        self.feed(content)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if values.get("id"):
+            self.anchors.add(values["id"])
+        if tag == "a" and values.get("name"):
+            self.anchors.add(values["name"])
+        destination = values.get("href") if tag == "a" else values.get("src")
+        if tag in {"a", "img", "source", "video"} and destination:
+            self.links.append(destination)
+
+
+def _inline_text(token) -> str:
+    return "".join(
+        child.content for child in token.children or []
+        if child.type in {"text", "code_inline", "image"}
+    )
+
+
+@lru_cache(maxsize=None)
+def _anchors(path: Path) -> set[str]:
+    tokens = _MARKDOWN.parse(path.read_text(encoding="utf-8"))
+    anchors: set[str] = set()
+    counts: Counter[str] = Counter()
+    for index, token in enumerate(tokens):
+        if token.type == "heading_open":
+            label = _inline_text(tokens[index + 1]).lower()
+            slug = "".join(char for char in label if char.isalnum() or char in "-_ ")
+            slug = slug.replace(" ", "-")
+            unique = slug + (f"-{counts[slug]}" if counts[slug] else "")
+            while unique in anchors:
+                counts[slug] += 1
+                unique = f"{slug}-{counts[slug]}"
+            counts[slug] += 1
+            anchors.add(unique)
+        for child in [token, *(token.children or [])]:
+            if child.type in {"html_block", "html_inline"}:
+                anchors.update(_HtmlReferences(child.content).anchors)
+    return anchors
+
+
+def _links(content: str) -> list[tuple[int, str]]:
+    found: list[tuple[int, str]] = []
+    for token in _MARKDOWN.parse(content):
+        line = (token.map or [0])[0] + 1
+        for child in [token, *(token.children or [])]:
+            if child.type in {"link_open", "image"}:
+                found.append((line, child.attrGet("href") or child.attrGet("src")))
+            elif child.type in {"html_block", "html_inline"}:
+                found.extend((line, href) for href in _HtmlReferences(child.content).links)
+    return found
+
+
+def _link_errors(path: Path) -> list[str]:
+    errors = []
+    for line, href in _links(path.read_text(encoding="utf-8")):
+        uri = urlsplit(href)
+        if uri.scheme or uri.netloc or "$" in href:
+            continue
+        target = (path.parent / unquote(uri.path)).resolve() if uri.path else path
+        if not target.exists():
+            errors.append(f"line {line}: missing file: {href}")
+        elif (
+            uri.fragment and target.suffix.lower() == ".md"
+            and unquote(uri.fragment) not in _anchors(target)
+        ):
+            errors.append(f"line {line}: missing anchor: {href}")
+    return errors
+
+
+def _shell_commands(content: str) -> list[tuple[int, list[str]]]:
+    commands = []
+    for token in _MARKDOWN.parse(content):
+        if token.type != "fence" or token.info.strip() not in _SHELL_LANGUAGES:
+            continue
+        lines = token.content.splitlines(keepends=True)
+        pending = ""
+        start = 0
+        for offset, line in enumerate(lines):
+            if not pending:
+                start = (token.map or [0])[0] + offset + 2
+            pending += line.rstrip("\n").removesuffix("\\")
+            if line.rstrip("\n").endswith("\\"):
+                pending += " "
+                continue
+            command = pending.strip().removeprefix("$ ")
+            argv = _npa_argv(command)
+            if argv:
+                commands.append((start, argv))
+            pending = ""
+    return commands
+
+
+def _npa_argv(command: str) -> list[str]:
+    command = re.sub(r"\$\([^)]*\)", "command-output", command)
+    try:
+        argv = shlex.split(command, comments=True)
+    except ValueError:
+        # Heredoc bodies may span quoted lines; Bash validates the whole block.
+        return []
+    if argv and argv[0] == "env":
+        argv = argv[1:]
+    while argv and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", argv[0]):
+        argv = argv[1:]
+    if argv and Path(argv[0]).name == "npa":
+        return ["npa", *argv[1:]]
+    return []
+
+
+def _python_syntax_errors(path: Path) -> list[str]:
+    errors = []
+    for token in _MARKDOWN.parse(path.read_text(encoding="utf-8")):
+        if token.type != "fence" or token.info.strip() not in {"python", "py"}:
+            continue
+        try:
+            ast.parse(token.content)
+        except SyntaxError as exc:
+            line = (token.map or [0])[0] + (exc.lineno or 1) + 1
+            errors.append(f"line {line}: {exc.msg}")
+    return errors
+
+
+def _shell_syntax_errors(path: Path, bash: str) -> list[str]:
+    errors = []
+    for token in _MARKDOWN.parse(path.read_text(encoding="utf-8")):
+        if token.type != "fence" or token.info.strip() not in {"bash", "sh", "shell"}:
+            continue
+        result = subprocess.run(
+            [bash, "-n"], input=token.content, text=True, capture_output=True,
+        )
+        if result.returncode:
+            line = (token.map or [0])[0] + 2
+            errors.append(f"line {line}: {result.stderr.strip()}")
+    return errors
+
+
+def _option_parameters(command) -> dict:
+    return {
+        spelling: parameter
+        for parameter in command.params if isinstance(parameter, TyperOption)
+        for spelling in [*parameter.opts, *parameter.secondary_opts]
+    }
+
+
+def _command_error(root, argv: list[str]) -> str:
+    command = root
+    names = ["npa"]
+    index = 1
+    while index < len(argv):
+        argument = argv[index]
+        if argument in _SHELL_BOUNDARIES or argument == "--" or argument.startswith("..."):
+            break
+        if argument.startswith("-"):
+            option = argument.split("=", 1)[0]
+            if option == "--help":
+                break
+            parameter = _option_parameters(command).get(option)
+            if parameter is None:
+                return f"{' '.join(names)}: unknown option {option}"
+            index += 1 if parameter.is_flag or "=" in argument else 1 + parameter.nargs
+            continue
+        if isinstance(command, TyperGroup):
+            if argument.startswith(("$", "<", "[")):
+                break
+            context = command.context_class(command, info_name=names[-1])
+            child = command.get_command(context, argument)
+            if child is None:
+                return f"{' '.join(names)}: unknown command {argument}"
+            command = child
+            names.append(argument)
+        index += 1
+    return ""
+
+
+def _workflow_variable_errors(root: Path, argv: list[str]) -> list[str]:
+    if argv[1:3] != ["workbench", "workflow"]:
+        return []
+    paths = [
+        root / value for value in argv
+        if value.startswith("workflows/") and value.endswith(".yaml")
+    ]
+    variables = [
+        argv[index + 1].split("=", 1)[0]
+        for index, value in enumerate(argv[:-1]) if value == "--var"
+    ]
+    errors = []
+    for path in paths:
+        if not path.is_file():
+            errors.append(f"missing workflow specification: {path.relative_to(root)}")
+            continue
+        spec = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(spec, dict) or spec.get("apiVersion") != "npa.workflow/v0.0.1":
+            continue
+        for variable in variables:
+            if variable not in spec.get("config", {}):
+                errors.append(f"{path.name}: undeclared configuration variable {variable}")
+    return errors

--- a/npa/tests/guardrails/test_documentation_examples.py
+++ b/npa/tests/guardrails/test_documentation_examples.py
@@ -1,0 +1,207 @@
+"""Keep user documentation navigable and its literal CLI names aligned with NPA."""
+
+from pathlib import Path
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+from typer.main import get_command
+
+from npa.cli.main import app
+
+from documentation_examples import (
+    _anchors,
+    _command_error,
+    _documentation_paths,
+    _has_current_commands,
+    _link_errors,
+    _python_syntax_errors,
+    _shell_commands,
+    _shell_syntax_errors,
+    _workflow_variable_errors,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOCUMENTS = _documentation_paths(REPO_ROOT)
+COMMAND_DOCUMENTS = [path for path in DOCUMENTS if _has_current_commands(path, REPO_ROOT)]
+
+
+@pytest.fixture(scope="module")
+def cli_tree():
+    """Build command metadata without invoking callbacks or cloud operations."""
+    return get_command(app)
+
+
+@pytest.mark.parametrize("path", DOCUMENTS, ids=lambda path: str(path.relative_to(REPO_ROOT)))
+def test_documented_relative_links_resolve(path: Path) -> None:
+    errors = _link_errors(path)
+    assert not errors, "\n".join(errors)
+
+
+@pytest.mark.parametrize(
+    "path", COMMAND_DOCUMENTS, ids=lambda path: str(path.relative_to(REPO_ROOT))
+)
+def test_documented_literal_commands_and_options_exist(path: Path, cli_tree) -> None:
+    errors = []
+    for line, argv in _shell_commands(path.read_text(encoding="utf-8")):
+        error = _command_error(cli_tree, argv)
+        if error:
+            errors.append(f"line {line}: {error}")
+        errors.extend(
+            f"line {line}: {error}" for error in _workflow_variable_errors(REPO_ROOT, argv)
+        )
+    assert not errors, "\n".join(errors)
+
+
+@pytest.mark.parametrize(
+    "path", COMMAND_DOCUMENTS, ids=lambda path: str(path.relative_to(REPO_ROOT))
+)
+def test_documented_shell_and_python_examples_parse_without_execution(path: Path) -> None:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("Bash is required to parse the documented shell examples")
+    errors = _shell_syntax_errors(path, bash) + _python_syntax_errors(path)
+    assert not errors, "\n".join(errors)
+
+
+def test_shell_syntax_check_rejects_redirection_placeholders_without_running_code(
+    tmp_path: Path,
+) -> None:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("Bash is required for shell syntax validation")
+    source = tmp_path / "README.md"
+    marker = tmp_path / "must-not-exist"
+    source.write_text(
+        f"```bash\ntouch '{marker}'\nnpa configure --project-id <project-id>\n```\n",
+        encoding="utf-8",
+    )
+    assert len(_shell_syntax_errors(source, bash)) == 1
+    source.write_text(f"```bash\ntouch '{marker}'\n```\n", encoding="utf-8")
+    assert _shell_syntax_errors(source, bash) == []
+    assert not marker.exists()
+
+
+def test_documentation_inventory_excludes_vendor_and_virtualenv(tmp_path: Path) -> None:
+    for relative in (
+        "npa/.venv/README.md", "deploy/cluster/vendor/tool/README.md",
+        "npa/src/npa/new-tool/README.md", "docs/new-guide.md",
+    ):
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    paths = _documentation_paths(tmp_path)
+    assert tmp_path / "npa/src/npa/new-tool/README.md" in paths
+    assert tmp_path / "docs/new-guide.md" in paths
+    assert not any(".venv" in path.parts or "vendor" in path.parts for path in paths)
+
+
+def test_link_check_covers_references_images_html_and_anchors(tmp_path: Path) -> None:
+    target = tmp_path / "next page.md"
+    target.write_text("# Setup\n\n## Setup\n\n<a id='manual'></a>\n", encoding="utf-8")
+    source = tmp_path / "README.md"
+    source.write_text(
+        "[next][guide]\n\n[guide]: next%20page.md#setup-1\n"
+        "[manual](next%20page.md#manual)\n"
+        "[broken](next%20page.md#gone)\n"
+        "![missing image](image.png)\n"
+        "<a href='gone.md'>missing HTML link</a>\n"
+        "<img src='gone.svg' alt='missing HTML image'>\n"
+        "```md\n[example](ignore.md)\n```\n"
+        "[external](https://example.com)\n",
+        encoding="utf-8",
+    )
+    errors = _link_errors(source)
+    assert len(errors) == 4
+    for destination in ("#gone", "image.png", "gone.md", "gone.svg"):
+        assert any(destination in error for error in errors)
+
+
+def test_heading_anchors_handle_formatting_and_duplicate_collisions(tmp_path: Path) -> None:
+    source = tmp_path / "headings.md"
+    source.write_text(
+        "# Run `npa` & **inspect**\n# Setup\n# Setup-1\n# Setup\n"
+        "```html\n<a id='example-only'></a>\n```\n",
+        encoding="utf-8",
+    )
+    assert _anchors(source) == {"run-npa--inspect", "setup", "setup-1", "setup-2"}
+
+
+@pytest.mark.parametrize(
+    ("command", "message"),
+    [
+        ("npa registry delete", "unknown command registry"),
+        ("npa workbench nurec check --json", "unknown option --json"),
+        ("npa workbench workflow submit '$SPEC' --invented", "unknown option --invented"),
+        ("npa workbench workflow submit demo.yaml --var 'prompt=--literal' --runtime", ""),
+        ("npa --help", ""),
+        ("npa workbench nurec check --output json | jq .", ""),
+    ],
+)
+def test_command_check_detects_retired_names_without_running_them(
+    command: str, message: str, cli_tree,
+) -> None:
+    _, argv = _shell_commands(f"```bash\n{command}\n```\n")[0]
+    assert message in _command_error(cli_tree, argv)
+    if not message:
+        assert _command_error(cli_tree, argv) == ""
+
+
+def test_shell_parser_preserves_line_numbers_and_continuations() -> None:
+    content = "# Example\n\n```bash\n# comment\nnpa workbench workflow submit \\\n  '$SPEC' --runtime\n$ npa --version\n```\n"
+    assert _shell_commands(content) == [
+        (5, ["npa", "workbench", "workflow", "submit", "$SPEC", "--runtime"]),
+        (7, ["npa", "--version"]),
+    ]
+
+
+@pytest.mark.parametrize("prefix", ["NPA_DEBUG=1 ", "env NPA_DEBUG=1 ", "npa/.venv/bin/"])
+def test_command_check_also_covers_environment_and_interpreter_prefixes(
+    prefix: str, cli_tree,
+) -> None:
+    _, argv = _shell_commands(f"```bash\n{prefix}npa registry delete\n```\n")[0]
+    assert _command_error(cli_tree, argv) == "npa: unknown command registry"
+
+
+def test_workflow_examples_cannot_silently_override_an_unused_variable(tmp_path: Path) -> None:
+    path = tmp_path / "workflows/main/example.yaml"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "apiVersion: npa.workflow/v0.0.1\nconfig:\n  bucket: example-bucket\n",
+        encoding="utf-8",
+    )
+    command = ["npa", "workbench", "workflow", "submit", "workflows/main/example.yaml"]
+    assert _workflow_variable_errors(tmp_path, [*command, "--var", "bucket=example-bucket"]) == []
+    assert _workflow_variable_errors(
+        tmp_path, [*command, "--var", "NPA_SIM2REAL_BUCKET=example-bucket"]
+    ) == ["example.yaml: undeclared configuration variable NPA_SIM2REAL_BUCKET"]
+
+
+def test_package_readme_python_preview_runs_without_cloud_credentials(
+    tmp_path: Path,
+) -> None:
+    from markdown_it import MarkdownIt
+
+    blocks = MarkdownIt().parse((REPO_ROOT / "npa/README.md").read_text())
+    examples = [
+        block.content for block in blocks
+        if block.type == "fence" and block.info == "python" and "build_plan" in block.content
+    ]
+    assert len(examples) == 1
+    example = tmp_path / "readme_preview.py"
+    example.write_text(
+        "import socket\n"
+        "def refuse_network(*args, **kwargs):\n"
+        "    raise RuntimeError('The README planning example must not contact a service')\n"
+        "socket.socket.connect = refuse_network\n\n" + examples[0],
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, "-I", str(example)], cwd=REPO_ROOT,
+        env={"PATH": os.defpath, "NPA_CONFIG_DIR": str(tmp_path / "empty-config")},
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "generate workbench.cosmos3.generate"

--- a/npa/tests/workbench/test_nurec_access.py
+++ b/npa/tests/workbench/test_nurec_access.py
@@ -837,7 +837,8 @@ def test_guide_only_documents_commands_that_exist() -> None:
         for part in parts:
             get_sub = getattr(cmd, "get_command", None)
             if get_sub is None:
-                return False
+                # A leaf command may take positional values, including a run ID.
+                return True
             cmd = get_sub(None, part)  # type: ignore[arg-type]
             if cmd is None:
                 return False

--- a/npa/tests/workflows/test_ray_tune_synthetic.py
+++ b/npa/tests/workflows/test_ray_tune_synthetic.py
@@ -40,7 +40,8 @@ def test_reference_files_and_runtime_contract_exist() -> None:
     requirements = (EXAMPLE / "cluster/requirements.txt").read_text().splitlines()
     assert requirements == ["ray[default,tune]==2.58.0"]
     readme = (EXAMPLE / "README.md").read_text()
-    assert 'TUNE_RUNTIME="$HOME/.npa-ray-tune"' in readme
+    assert 'ssh "$TUNE_CLUSTER"' in readme
+    assert 'printf "%s/.npa-ray-tune\\n" "$HOME"' in readme
     assert "TUNE_RUNTIME=/root" not in readme
 
 

--- a/npa/workflows/workbench/README.md
+++ b/npa/workflows/workbench/README.md
@@ -1,81 +1,57 @@
-# NPA Workbench reference assets
+# Workbench reference assets
 
-This directory retains workflow configuration, conventions, operator notes, and
-finite legacy compatibility assets. The supported declarative workflow catalog
-lives at the repository root in `workflows/main/` and `workflows/testing/`.
-SkyPilot remains the workflow execution engine.
+[Workflow catalog](../../../workflows/README.md) · [Workbench docs](../../../docs/workbench/README.md)
 
-## ➡️ Start here: the workflow catalog
+This directory contains configuration assets, native Ray development examples,
+and Sim2Real operator notes. Start in the root [workflow catalog](../../../workflows/README.md)
+when you want to compose and run a pipeline with `npa workbench workflow`.
 
-**[Workflow catalog](../../../workflows/README.md)** is the catalog of every
-supported workflow spec (`apiVersion: npa.workflow/v0.0.1`). Author and submit
-these with:
+## Choose an example
 
-```bash
-npa workbench workflow validate-spec <spec.yaml>
-npa workbench workflow plan-spec <spec.yaml> --run-id demo
-npa workbench workflow submit <spec.yaml> --run-id demo
-```
+| Goal | Start here | Result |
+| --- | --- | --- |
+| Compose Workbench tools | [Declarative workflows](../../../workflows/README.md) | A planned state graph and run-scoped artifacts |
+| Run the 14-stage robot pipeline | [Sim2Real runbook](../../../docs/workbench/guides/sim2real-workflow.md) | Per-stage evidence, evaluation, and Rerun/MCAP outputs |
+| Edit a GPU application and resubmit Python | [Ray CLIP](ray-clip-development/README.md) | Image embeddings, retrieval results, and source-change evidence |
+| Train a small distributed model | [Ray Train](ray-train-synthetic/README.md) | Synthetic-regression checkpoints and rank metrics on two B200 hosts |
+| Try hyperparameter search and checkpoint recovery | [Ray Tune](ray-tune-synthetic/README.md) | Three CPU trials, the selected optimum, and verified JSON results |
 
-Authoring skills: `skills/workflows/author-npa-workflow/SKILL.md` (edit) and
-`skills/workflows/generate-npa-workflow/SKILL.md` (design new pipelines).
+## Preview a workflow locally
 
-## Layout
-
-- `configs/`: component and benchmark configuration assets.
-- `sim2real/`: operator notes and the finite legacy compatibility DAG. The only
-  supported Sim2Real submission spec is `workflows/main/sim2real.yaml`; it uses
-  the ordinary standard runtime and never routes to direct Kubernetes.
-- `schemas/`: conventions for parameters, artifacts, naming, and runtime
-  constraints.
-- `steps/` and `templates/`: legacy placeholders kept for compatibility with
-  older examples.
-
-### Raw SkyPilot YAML
-
-The retired raw SkyPilot workflow catalog is gone. The `npa.workflow` engine
-still renders specs to SkyPilot at submit time, and `npa workbench workflow
-submit` still accepts customer-owned raw SkyPilot YAML, but shipped raw YAMLs
-must live only in guarded, tool-specific homes such as burst examples, BYOF
-resource profiles, or the NuRec single-pod example.
-
-## Sim-To-Real
-
-Submit the staged VLM-to-RL loop:
+From the repository root, after [installing NPA](../../../docs/install.md):
 
 ```bash
-npa workbench workflow submit \
-  workflows/main/sim2real.yaml \
-  --run-id <run-id> \
-  --var NPA_SIM2REAL_BUCKET=<your-bucket> \
-  --var NPA_SIM2REAL_TRIGGER_DATASET_URI=s3://<your-bucket>/<trigger-prefix>/
+npa workbench workflow validate-spec workflows/testing/cosmos3-generate.yaml
+npa workbench workflow plan-spec workflows/testing/cosmos3-generate.yaml --run-id demo
 ```
 
-The legacy `sim_to_real` H100 quickstart and its template are retired: that path ran
-`npa.workflows.sim_to_real real-loop`, which raises a `DeprecationWarning` pointing at the
-compositional standard runtime. The single canonical YAML is
-[`workflows/main/sim2real.yaml`](../../../workflows/main/sim2real.yaml); the deeper reference is
-[`docs/workbench/guides/sim2real-workflow.md`](../../../docs/workbench/guides/sim2real-workflow.md).
+Expect a valid spec and one `generate` stage. These commands require no cloud
+resources. To execute, complete the selected workload's input, credential,
+image, and resource setup, then follow its submission and cleanup commands.
+The [workflow guide](../../../docs/workbench/npa-workflow-guide.md) explains
+`prepare-run`, `submit --runtime`, monitoring, and resume.
 
-## Submission Pattern
+## Directory map
 
-Use the thin Python wrappers under `npa/scripts/` when a workflow needs runtime
-substitution, S3 paths, secret-env injection, GPU validation, or cleanup:
+| Directory | Purpose |
+| --- | --- |
+| `configs/` | Component and benchmark configuration |
+| [`sim2real/`](sim2real/README.md) | Operator notes and finite legacy compatibility assets |
+| `schemas/` | Parameter, artifact, naming, and runtime conventions |
+| `steps/`, `templates/` | Legacy compatibility placeholders |
+| `ray-*/` | Standalone native Ray application examples and platform setup |
 
-```bash
-npa/.venv/bin/python npa/scripts/run_isaac_lab_rl.py --help
-npa/.venv/bin/python npa/scripts/run_bdd100k_pipeline.py --help
-```
+## Raw SkyPilot YAML
 
-Invoke SkyPilot through `NPA_SKYPILOT_BIN`, normally resolved by:
+NPA renders declarative workflows to SkyPilot when submitting. The workflow
+command also accepts customer-owned raw SkyPilot tasks. Shipped raw tasks live
+in specific example directories: [burst](../../src/npa/burst/examples/README.md),
+[BYOF profiles](../../src/npa/workflows/byof/profiles/README.md), and
+[NuRec single-pod execution](../../src/npa/workbench/nurec/examples/README.md).
+The retired raw workflow catalog must not be restored.
 
-```bash
-npa skypilot bootstrap
-export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
-```
-
-## Cleanup
-
-Wrappers that create live GPU resources must use explicit SkyPilot cleanup and
-must poll for absence when they own the user-facing lifecycle. Do not rely on a
-detached terminal or manual cleanup as the only teardown path.
+Use the [authoring skill](../../../skills/workflows/author-npa-workflow/SKILL.md)
+for specification edits and the
+[pipeline design skill](../../../skills/workflows/generate-npa-workflow/SKILL.md)
+for new compositions. Stop active jobs and preserve outputs before removing
+owned infrastructure; see [teardown](../../../docs/teardown.md).

--- a/npa/workflows/workbench/ray-clip-development/README.md
+++ b/npa/workflows/workbench/ray-clip-development/README.md
@@ -1,224 +1,81 @@
-# CLIP image retrieval with Ray Jobs
+# Build an image-retrieval dataset with Ray Jobs
 
-[Start with the complete GPU guide](../../../../docs/testing/fast-source-iteration.md).
-It covers the tools, private backend setup, first image embeddings, a one-line
-Python edit, result download and cleanup. The customer interface is ordinary
-`ray job submit/status/logs/stop`; there is no NPA submission or finish wrapper.
+[Ray guide](../../../../docs/workbench/ray.md) · [Reference examples](../README.md)
 
-The source is split by purpose:
+Embed generated RGB images with Workbench's real CLIP model on an RTX PRO 6000,
+search the resulting vectors, then edit one line of Python and submit it again.
+Ray Jobs transfers your source to the prepared workers; no image rebuild is
+needed for a source edit.
 
-- `fast_sync.py`: CPU-only endpoint qualification that submits two synthetic
-  source revisions through Ray 2.58 `runtime_env.working_dir`, verifies the
-  exact imported bytes and changed remote result, and records exact Job cleanup
-  privately.
-- `embed.py`: the normal Ray Core application—CPU preprocessing, CUDA CLIP actor,
-  Parquet vectors, Lance table, retrieval and RGB preview.
-- `report.py`: CPU-only conversion of downloaded results to a validated Rerun recording.
-- `worker.py`: deterministic RGB inputs and the editable `CROP_POLICY`.
-- `cluster.yaml` and `cluster/`: SkyPilot worker request, pinned environment
-  preparation and an independent application Ray service.
-- `application.py` and `validation.py`: optional distributed/checkpoint checks.
-- `network-policy.yaml`: the network boundary described in the guide.
+## Start here
 
-The guide's visible `cp` supplies the canonical Workbench
-`bdd100k_udfs.py` as `npa_lancedb_bdd100k_udfs.py`. Ray working-directory upload
-transfers those exact bytes. Keep credentials, models, output directories and
-unreviewed files out of this source directory.
+Follow the [complete GPU walkthrough](../../../../docs/testing/fast-source-iteration.md)
+for setup through cleanup. It includes the source copy, launch, authenticated
+connection, baseline, changed result, and download commands in runnable order.
 
-In `report.json`, `ray_nodes` counts distinct Ray node IDs used by the actors;
-the basic report records those IDs in `actors[].node_id`. The advanced report
-uses `model_initializations[].node_id` and `final_actors`. These count Ray nodes,
-not physical hosts.
-On Kubernetes, proving distinct physical workers additionally requires mapping
-Ray node addresses to pod IPs and the pods' assigned Kubernetes nodes. The audit
-uses that separate platform evidence for its one-worker and two-worker claims.
+| Prepare | Expected result |
+| --- | --- |
+| Linux development host, NPA, Ray 2.58 client, OpenSSH, and rsync | Native `ray job submit/status/logs/stop` access |
+| Authorized Kubernetes context and [private SkyPilot API](platform/README.md) | One reusable RTX PRO 6000 worker for the basic run |
+| Access to pinned public CLIP weights and Python packages | RGB preview, 512-dimensional vectors, and a searchable Lance table |
+| A durable local output directory | Downloaded reports and hashes that survive compute teardown |
 
-For optional private S3 retention after downloading a completed result, see
-[Archive completed Ray CLIP results](../../../../docs/testing/ray-clip-archive.md).
-The companion verifies immutable publication and restore on CPU; the local
-rsync workflow remains usable on its own.
+The basic example generates its own input images; it needs no customer dataset,
+Hugging Face token, or S3 credential. Procedural-image results verify execution
+and retrieval consistency, not model semantic accuracy.
 
-The pod preparation receipt separates dependency installation, model download
-and weight hashing, and `cuda_environment_inspection_seconds`. That last phase
-includes the CUDA/version probe and `pip freeze`; it is not model-download time.
-Its recorded start, dependency-ready, model-ready and finish timestamps define
-those boundaries. Actor `model_load_seconds` measures the later GPU model load.
+## Inspect the result
 
-## Optional: two GPU workers and actor recovery
+| Artifact | Check |
+| --- | --- |
+| `preview.png` | Original image and the exact crop embedded by CLIP |
+| Parquet vectors and Lance table | Complete row count and successful retrieval checks |
+| `report.json` | Actual actor placement, source hashes, model identity, and timings |
+| `SHA256SUMS` | Downloaded bytes match the completed output |
 
-Use the main guide's setup and connection sequence, adding `--num-nodes 2` to
-its **new cluster** `sky launch` command (and its dry run). Each worker requests
-one RTX PRO 6000 GPU. Do not resize a cluster that is running someone else's
-work. The following commands run from this application directory with the
-same Ray client and authenticated tunnel used by the main guide. If you already
-ran its Finish step, repeat its setup and UDF copy: Finish removes the generated
-UDF snapshot.
+Ray node counts describe Ray runtimes. To claim separate physical hosts, also
+map Ray node addresses to pods and the pods' assigned Kubernetes nodes.
+Source resubmission creates new actors and reloads weights; a running actor
+reuses its loaded model between batches.
 
-Set `CROP_POLICY = "left"` in `worker.py`. Submit the baseline:
+<a id="optional-two-gpu-workers-and-actor-recovery"></a>
+<a id="optional-stop-a-real-running-gpu-job"></a>
+<a id="preserve-the-outputs-and-finish"></a>
+<a id="review-a-downloaded-result-in-rerun"></a>
 
-```bash
-ray job submit --address http://127.0.0.1:8265 \
-  --submission-id complex-baseline --working-dir . -- \
-  python application.py --actors 2 --records 16384 --recovery-check \
-  --output-path /tmp/ray-clip-results/complex-baseline
-```
+## Continue with a specific check
 
-This runs CPU preprocessing partitions, inference batches in two GPU actors,
-and driver aggregation into Parquet and Lance. It records actual node/GPU
-placement and overlapping inference intervals. `SPREAD` alone is not proof of
-two physical nodes; inspect `report.json` together with platform placement.
+| Goal | Procedure |
+| --- | --- |
+| Review original images, crops, vectors, and timing in Rerun | [Convert a completed result](view-results.md) |
+| Use two GPUs, replace an actor, or stop active inference | [Distributed and recovery checks](distributed-checks.md) |
+| Resume an interrupted driver from verified shards | [Checkpoint resume](../../../../docs/testing/ray-clip-checkpoint-resume.md) |
+| Preserve results in private S3 and restore them | [Archive and restore](../../../../docs/testing/ray-clip-archive.md) |
+| Review measured validation and its limits | [Recorded audit](../../../../docs/architecture/ray-fast-development-audit.md) |
 
-After the first shard is committed, the application calls `ray.kill` on **one
-owned actor**, creates its replacement and replays that shard. Its checkpoint
-identity includes source, input, weights and dependency provenance. Replay
-verifies the committed Parquet hash and skips a second inference/write. Other
-shards continue normally. `recovery.json` reports a new actor instance, model
-reload and zero inference calls for the reused checkpoint. This is explicit
-application checkpointing; Ray does not promise exactly-once external writes.
+Save and verify outputs before cleanup. Follow the main guide's exact finish
+sequence: stop owned Ray Jobs, cancel the SkyPilot service task, remove its
+workers, and close the tunnel. The platform API and shared Kubernetes cluster
+have a separate lifecycle.
 
-For an interrupted driver Job, see [resume a partial checkpoint tree](../../../../docs/testing/ray-clip-checkpoint-resume.md).
-The manual live gate requires `NPA_RAY_CLIP_CHECKPOINT_LIVE_CONFIG` to name an
-owner-only JSON configuration for a preflighted native Ray Jobs cluster, as
-described in that guide. Without this variable the live gate is skipped.
-It covers validated reuse of later shards and current versus retained timings.
+## Find the source to edit
 
-Change the visible line to `CROP_POLICY = "right"` and rerun:
+| File | Purpose |
+| --- | --- |
+| [worker.py](worker.py) | Generated RGB inputs and editable `CROP_POLICY` |
+| [embed.py](embed.py) | Basic preprocessing, CUDA actor, vector export, and retrieval |
+| [report.py](report.py) | CPU-only conversion of downloaded results to Rerun |
+| [cluster.yaml](cluster.yaml) · [cluster/](cluster/) | Worker request and separate application Ray service |
+| [application.py](application.py) · [validation.py](validation.py) | Distributed and checkpoint checks |
+| [fast_sync.py](fast_sync.py) | CPU-only qualification of source transfer and exact job cleanup |
+| [network-policy.yaml](network-policy.yaml) | Namespace ingress boundary used by the platform guide |
 
-```bash
-ray job submit --address http://127.0.0.1:8265 \
-  --submission-id complex-changed --working-dir . -- \
-  python application.py --actors 2 --records 16384 --recovery-check \
-  --output-path /tmp/ray-clip-results/complex-changed \
-  --compare-baseline-path /tmp/ray-clip-results/complex-baseline
-```
+The walkthrough copies the canonical `bdd100k_udfs.py` into this directory as
+`npa_lancedb_bdd100k_udfs.py`. Repeat that copy after editing the original UDF.
+Keep credentials, model caches, results, and unrelated files outside the source
+uploaded by `--working-dir`.
 
-Restore `CROP_POLICY = "left"` and submit again:
-
-```bash
-ray job submit --address http://127.0.0.1:8265 \
-  --submission-id complex-restored --working-dir . -- \
-  python application.py --actors 2 --records 16384 --recovery-check \
-  --output-path /tmp/ray-clip-results/complex-restored \
-  --compare-baseline-path /tmp/ray-clip-results/complex-baseline
-```
-
-The changed run requires at least 99% of vectors to differ by L2 distance
-above 0.01; restoration requires absolute error at most `1e-5`. All rows and
-retrieval checks must pass. Source redeployment creates new actors and reloads
-weights; model residency is reused only between batches in the same actor.
-Procedural images test execution/retrieval consistency, not semantic accuracy.
-
-## Optional: stop a real running GPU job
-
-This separate job commits a real shard, then continues CUDA inference until
-you stop it. It has no implicit runtime limit:
-
-```bash
-ray job submit --address http://127.0.0.1:8265 --no-wait \
-  --submission-id clip-cancel --working-dir . -- \
-  python application.py --actors 2 --records 4096 --cancellation-probe \
-  --output-path /tmp/ray-clip-results/cancellation
-ray job logs --follow --address http://127.0.0.1:8265 clip-cancel
-```
-
-Wait for `RAY_CLIP_FIRST_CHECKPOINT` in the logs, then press Ctrl-C to stop
-following logs. The GPU job continues. Cancel precisely that submission:
-
-```bash
-ray job stop --address http://127.0.0.1:8265 clip-cancel
-ray job status --address http://127.0.0.1:8265 clip-cancel
-```
-
-Require `STOPPED`; a stop request alone is not terminal evidence. A cancelled
-job has partial checkpoints, not a completed dataset or successful report.
-
-## Preserve the outputs and finish
-
-Use the `CLUSTER` and `RESULTS` values established by the main guide:
-
-```bash
-mkdir -p "$RESULTS"
-rsync -az "$CLUSTER:/tmp/ray-clip-results/" "$RESULTS/"
-for run in complex-baseline complex-changed complex-restored; do
-  (cd "$RESULTS/$run" && sha256sum -c SHA256SUMS)
-done
-cat "$RESULTS/complex-changed/recovery.json"
-cat "$RESULTS/complex-restored/retrieval.json"
-```
-
-Open `preview.png` and inspect each `report.json` for actual placement,
-source hashes, model loads, timing boundaries and full-vector comparison.
-The main guide's exact cleanup sequence closes the tunnel, cancels the one
-SkyPilot service task and removes the owned development resources. Preserve
-these local artifacts before deleting worker storage. No uploader Job,
-finish marker, object-store credential or NPA workflow completion signal is
-required.
-
-The [audit](../../../../docs/architecture/ray-fast-development-audit.md) records
-execution of these commands on two physical GPU workers, their measured timing
-boundaries, source/recovery checks and limitations. Earlier session-workflow
-results are retained separately as historical evidence.
-
-## Review a downloaded result in Rerun
-
-After the existing rsync and checksum step, convert either a basic `embed.py`
-result or a completed advanced `application.py` result. From the repository root,
-use the NPA environment (it already includes `rerun-sdk==0.31.4`, NumPy, PyArrow
-and Pillow):
-
-```bash
-npa/.venv/bin/python npa/workflows/workbench/ray-clip-development/report.py \
-  --input-path "$RESULTS/baseline" \
-  --output-path "$RESULTS/baseline.rrd" \
-  --run-id clip-baseline
-npa/.venv/bin/rerun rrd verify "$RESULTS/baseline.rrd"
-npa/.venv/bin/rerun rrd print -vv "$RESULTS/baseline.rrd"
-npa/.venv/bin/rerun "$RESULTS/baseline.rrd"
-```
-
-Use your public-safe native Jobs submission label for `--run-id`; the producer
-has no persisted submission ID, so this label is supplied by the reader and is
-not independent Jobs status evidence. Keep recordings private if their images
-are private. The converter requires a new `.rrd` outside the downloaded input
-tree, preserves its checksum manifests, and emits one JSON receipt with source
-and recording hashes plus independently decoded entity row counts. It never
-loads CLIP or connects to Ray. Import `convert(input_path, output_path, run_id=...)`
-from the same module for Python use.
-
-The first view shows original RGB images beside the exact crops embedded by the
-GPU. Move the `record_id` timeline through the first eight records to inspect
-images; vectors and their norms cover every record. The Dataframe/Tensor views
-can inspect `vectors/embedding`, and `retrieval/top_ids` contains the persisted
-query and hit IDs. No spatial projection or semantic accuracy is implied.
-
-Advanced results additionally expose `shard_index` checkpoint counts, verified
-checkpoint hashes, per-shard preprocessing/inference durations, and a
-`coordinator_elapsed` concurrency trace. This last timeline starts at the first
-recorded coordinator observation and covers only its observed inference wave,
-including RPC edges. Worker clocks are never combined. Model loads and aggregate
-timings are static measurements; their intervals overlap and must not be added.
-Recovery lineage is static because the source records no recovery timestamp.
-Rerun's built-in `log_time` and `log_tick` describe converter logging; select the
-custom timelines above to inspect persisted workload facts.
-Application/converter source hashes and model byte identities are retained; host, node, process,
-allocation and imported-file identifiers are omitted.
-
-Missing final reports, partial/cancelled results, checksum gaps or corruption,
-unsafe paths/symlinks, invalid vectors, mismatched preview bytes, inconsistent
-retrievals and corrupt advanced checkpoints fail conversion before publication.
-An advanced report also requires a successful actor cleanup receipt. A failed
-writer or decoded-content check leaves no final RRD. The original Parquet,
-Lance and model artifacts remain the authoritative result; the RRD is a derived
-review artifact. Creating the file does not upload or share it.
-
-To qualify a real downloaded result through the committed live test, run once
-for each producer you used:
-
-```bash
-NPA_INTEGRATION_E2E=1 NPA_RAY_CLIP_RESULTS="$RESULTS/baseline" \
-  npa/.venv/bin/python -m pytest npa/tests/e2e/test_ray_clip_report_live.py -q
-```
-
-The test requires actual CUDA actor and completed inference receipts, invokes
-the converter CLI, runs Rerun's independent verifier and decodes every record
-index. Unit fixtures use explicit synthetic vectors and are not GPU evidence.
+The preparation receipt separates dependency installation, model download and
+hashing, and `cuda_environment_inspection_seconds` (the CUDA/version probe plus
+`pip freeze`). Actor `model_load_seconds` measures the later GPU model load;
+these timing boundaries describe different phases.

--- a/npa/workflows/workbench/ray-clip-development/distributed-checks.md
+++ b/npa/workflows/workbench/ray-clip-development/distributed-checks.md
@@ -1,0 +1,121 @@
+# Ray CLIP: distributed execution and recovery
+
+[Example overview](README.md) · [First GPU run](../../../../docs/testing/fast-source-iteration.md)
+
+Complete the first GPU run and retain its client environment, authenticated
+tunnel, `CLUSTER`, and `RESULTS` variables before using these optional checks.
+
+## Optional: two GPU workers and actor recovery
+
+Use the main guide's setup and connection sequence, adding `--num-nodes 2` to
+its **new cluster** `sky launch` command (and its dry run). Each worker requests
+one RTX PRO 6000 GPU. Do not resize a cluster that is running someone else's
+work. The following commands run from this application directory with the
+same Ray client and authenticated tunnel used by the main guide. If you already
+ran its Finish step, repeat its setup and UDF copy: Finish removes the generated
+UDF snapshot.
+
+Set `CROP_POLICY = "left"` in `worker.py`. Submit the baseline:
+
+```bash
+ray job submit --address http://127.0.0.1:8265 \
+  --submission-id complex-baseline --working-dir . -- \
+  python application.py --actors 2 --records 16384 --recovery-check \
+  --output-path /tmp/ray-clip-results/complex-baseline
+```
+
+This runs CPU preprocessing partitions, inference batches in two GPU actors,
+and driver aggregation into Parquet and Lance. It records actual node/GPU
+placement and overlapping inference intervals. `SPREAD` alone is not proof of
+two physical nodes; inspect `report.json` together with platform placement.
+
+After the first shard is committed, the application calls `ray.kill` on **one
+owned actor**, creates its replacement and replays that shard. Its checkpoint
+identity includes source, input, weights and dependency provenance. Replay
+verifies the committed Parquet hash and skips a second inference/write. Other
+shards continue normally. `recovery.json` reports a new actor instance, model
+reload and zero inference calls for the reused checkpoint. This is explicit
+application checkpointing; Ray does not promise exactly-once external writes.
+
+For an interrupted driver Job, see [resume a partial checkpoint tree](../../../../docs/testing/ray-clip-checkpoint-resume.md).
+The manual live gate requires `NPA_RAY_CLIP_CHECKPOINT_LIVE_CONFIG` to name an
+owner-only JSON configuration for a preflighted native Ray Jobs cluster, as
+described in that guide. Without this variable the live gate is skipped.
+It covers validated reuse of later shards and current versus retained timings.
+
+Change the visible line to `CROP_POLICY = "right"` and rerun:
+
+```bash
+ray job submit --address http://127.0.0.1:8265 \
+  --submission-id complex-changed --working-dir . -- \
+  python application.py --actors 2 --records 16384 --recovery-check \
+  --output-path /tmp/ray-clip-results/complex-changed \
+  --compare-baseline-path /tmp/ray-clip-results/complex-baseline
+```
+
+Restore `CROP_POLICY = "left"` and submit again:
+
+```bash
+ray job submit --address http://127.0.0.1:8265 \
+  --submission-id complex-restored --working-dir . -- \
+  python application.py --actors 2 --records 16384 --recovery-check \
+  --output-path /tmp/ray-clip-results/complex-restored \
+  --compare-baseline-path /tmp/ray-clip-results/complex-baseline
+```
+
+The changed run requires at least 99% of vectors to differ by L2 distance
+above 0.01; restoration requires absolute error at most `1e-5`. All rows and
+retrieval checks must pass. Source redeployment creates new actors and reloads
+weights; model residency is reused only between batches in the same actor.
+Procedural images test execution/retrieval consistency, not semantic accuracy.
+
+## Optional: stop a real running GPU job
+
+This separate job commits a real shard, then continues CUDA inference until
+you stop it. It has no implicit runtime limit:
+
+```bash
+ray job submit --address http://127.0.0.1:8265 --no-wait \
+  --submission-id clip-cancel --working-dir . -- \
+  python application.py --actors 2 --records 4096 --cancellation-probe \
+  --output-path /tmp/ray-clip-results/cancellation
+ray job logs --follow --address http://127.0.0.1:8265 clip-cancel
+```
+
+Wait for `RAY_CLIP_FIRST_CHECKPOINT` in the logs, then press Ctrl-C to stop
+following logs. The GPU job continues. Cancel precisely that submission:
+
+```bash
+ray job stop --address http://127.0.0.1:8265 clip-cancel
+ray job status --address http://127.0.0.1:8265 clip-cancel
+```
+
+Require `STOPPED`; a stop request alone is not terminal evidence. A cancelled
+job has partial checkpoints, not a completed dataset or successful report.
+
+## Preserve the outputs and finish
+
+Use the `CLUSTER` and `RESULTS` values established by the main guide:
+
+```bash
+mkdir -p "$RESULTS"
+rsync -az "$CLUSTER:/tmp/ray-clip-results/" "$RESULTS/"
+for run in complex-baseline complex-changed complex-restored; do
+  (cd "$RESULTS/$run" && sha256sum -c SHA256SUMS)
+done
+cat "$RESULTS/complex-changed/recovery.json"
+cat "$RESULTS/complex-restored/retrieval.json"
+```
+
+Open `preview.png` and inspect each `report.json` for actual placement,
+source hashes, model loads, timing boundaries and full-vector comparison.
+The main guide's exact cleanup sequence closes the tunnel, cancels the one
+SkyPilot service task and removes the owned development resources. Preserve
+these local artifacts before deleting worker storage. No uploader Job,
+finish marker, object-store credential or NPA workflow completion signal is
+required.
+
+The [audit](../../../../docs/architecture/ray-fast-development-audit.md) records
+execution of these commands on two physical GPU workers, their measured timing
+boundaries, source/recovery checks and limitations. Earlier session-workflow
+results are retained separately as historical evidence.

--- a/npa/workflows/workbench/ray-clip-development/platform/README.md
+++ b/npa/workflows/workbench/ray-clip-development/platform/README.md
@@ -1,9 +1,11 @@
-# Set up the SkyPilot API once
+# Set up a private SkyPilot API for Ray development
 
-This page is for the operator who owns a Nebius GPU Kubernetes context. It
+[CLIP example](../README.md) · [Ray Train](../../ray-train-synthetic/README.md) · [Ray Tune](../../ray-tune-synthetic/README.md)
+
+This page is for the operator who owns a Nebius Kubernetes context. It
 creates one private SkyPilot API and one namespace for a trusted development
-team. Developers can then follow the [CLIP guide](../../../../../docs/testing/fast-source-iteration.md)
-using Ray Jobs. They do not set up an API for every source edit or GPU Job.
+team. Developers reuse it for CLIP, Ray Train, or Ray Tune through native Ray Jobs.
+Prepare GPU nodes only for the GPU examples; Ray Tune needs CPU capacity.
 
 The service is the upstream SkyPilot API, managed by Docker Compose. Its named
 volume retains cluster identities and SSH keys across API restarts. Keep that
@@ -14,13 +16,14 @@ volume until every development cluster it owns has been removed.
 - A Linux operator host with Docker Engine and the
   [Docker Compose plugin](https://docs.docker.com/compose/install/linux/).
   `docker compose version` must work. The tested plugin is **5.5.0**.
-- `kubectl` configured for the authorized Nebius GPU cluster, and an installed,
+- `kubectl` configured for the authorized Nebius cluster, and an installed,
   authenticated `nebius` CLI. `kubectl get nodes` must succeed before continuing.
   The kubeconfig must use `nebius` or `/usr/local/bin/nebius` for its exec-auth
   command; its selected profile must exist in the operator's Nebius CLI config.
 - This repository with NPA installed in `npa/.venv`. From the repository root:
 
   ```bash
+  export NPA_REPO="$PWD"
   npa/.venv/bin/npa skypilot bootstrap
   export NPA_SKYPILOT_BIN="$(npa/.venv/bin/npa skypilot status --bin-path)"
   export SKYPILOT_DISABLE_USAGE_COLLECTION=1
@@ -29,6 +32,25 @@ volume until every development cluster it owns has been removed.
 The API image is pinned by digest in [compose.yaml](compose.yaml) and reports
 SkyPilot **0.12.2**. It runs on the operator host without a GPU. No image build,
 object-storage account or managed-jobs controller is part of this setup.
+
+## Choose the application to verify
+
+Set `SKY_EXAMPLE` to the absolute example directory. Keep this variable through
+setup; it selects the final dry-run and resolves the example's relative mounts.
+
+```bash
+export SKY_EXAMPLE="$NPA_REPO/npa/workflows/workbench/ray-clip-development"
+```
+
+| Example directory under `npa/workflows/workbench/` | Capacity needed for its eventual launch |
+| --- | --- |
+| `ray-clip-development` | One RTX PRO 6000; two for distributed checks |
+| `ray-train-synthetic` | Two B200 hosts, one GPU rank per host |
+| `ray-tune-synthetic` | One CPU pod, 6 CPUs and 12 GiB memory |
+
+For Train or Tune, change only the last directory in `SKY_EXAMPLE` above.
+This setup verifies access and rendering; it does not provision the underlying
+Kubernetes cluster or guarantee capacity for the subsequent workload.
 
 ## Give this platform a namespace and private configuration
 
@@ -79,7 +101,7 @@ namespace while it owns development clusters.
 ## Start and prove the API
 
 ```bash
-cd npa/workflows/workbench/ray-clip-development/platform
+cd "$NPA_REPO/npa/workflows/workbench/ray-clip-development/platform"
 docker compose --env-file "$PLATFORM_DIR/platform.env" up -d --wait
 docker compose --env-file "$PLATFORM_DIR/platform.env" exec -T api \
   kubectl auth can-i create pods
@@ -92,7 +114,7 @@ export KUBE_CONTEXT="$(kubectl config current-context)"
   --config "kubernetes.allowed_contexts=[\"$KUBE_CONTEXT\"]" -o json
 "$NPA_SKYPILOT_BIN" gpus list --infra "k8s/$KUBE_CONTEXT" \
   --config "kubernetes.allowed_contexts=[\"$KUBE_CONTEXT\"]"
-cd ..
+cd "$SKY_EXAMPLE"
 "$NPA_SKYPILOT_BIN" launch --dryrun --yes -c "$PLATFORM_NAME-check" \
   --infra "k8s/$KUBE_CONTEXT" \
   --config "kubernetes.allowed_contexts=[\"$KUBE_CONTEXT\"]" cluster.yaml
@@ -100,12 +122,13 @@ cd ..
 
 Require both permission probes to say `yes`, the check's JSON to contain
 `"Kubernetes": ["compute"]`, and the dry-run to finish successfully with the
-intended context. The accelerator name in `cluster.yaml` must appear in the GPU
+intended context. For GPU examples, the accelerator name in `cluster.yaml` must appear in the GPU
 listing; use SkyPilot's displayed spelling without changing shared node labels.
 SkyPilot can return exit zero when its credential check enables
 no infrastructure. An HTTP health response alone also does not prove that the
 API's execution queue works. This dry-run allocates no GPU; the first real launch
-in the CLIP guide proves the remaining bootstrap and CUDA boundary.
+in the chosen application guide proves runtime startup and, for GPU examples,
+CUDA execution. An empty GPU listing is expected on a CPU-only Tune platform.
 
 The service binds only the operator host's loopback port. It has no Docker socket,
 host network or privileged mode. Root inside the container has only
@@ -120,9 +143,10 @@ this HTTP port on a public interface. Ray's separate Jobs endpoint is reached
 through the authenticated tunnel in the CLIP guide.
 
 Give developers these values: the API endpoint, the fixed namespace's kubeconfig
-and context, and the pinned `NPA_SKYPILOT_BIN` path. Then return to the
-[first GPU run](../../../../../docs/testing/fast-source-iteration.md). Keep the
-API running across source edits and across the medium and distributed examples.
+and context, and the pinned `NPA_SKYPILOT_BIN` path. Then return to the selected
+[CLIP](../../../../../docs/testing/fast-source-iteration.md),
+[Train](../../ray-train-synthetic/README.md), or [Tune](../../ray-tune-synthetic/README.md)
+procedure. Keep the API running across source edits and development clusters.
 
 ## Finish the platform
 

--- a/npa/workflows/workbench/ray-clip-development/view-results.md
+++ b/npa/workflows/workbench/ray-clip-development/view-results.md
@@ -1,0 +1,71 @@
+# View completed Ray CLIP results
+
+[Example overview](README.md) · [First GPU run](../../../../docs/testing/fast-source-iteration.md)
+
+Start with a completed, downloaded result and its checksum manifest. Set
+`RESULTS` to the local result parent directory used by the main guide. This
+conversion uses CPU only and does not start Ray or download a model.
+
+## Review a downloaded result in Rerun
+
+After the existing rsync and checksum step, convert either a basic `embed.py`
+result or a completed advanced `application.py` result. From the repository root,
+use the NPA environment (it already includes `rerun-sdk==0.31.4`, NumPy, PyArrow
+and Pillow):
+
+```bash
+npa/.venv/bin/python npa/workflows/workbench/ray-clip-development/report.py \
+  --input-path "$RESULTS/baseline" \
+  --output-path "$RESULTS/baseline.rrd" \
+  --run-id clip-baseline
+npa/.venv/bin/rerun rrd verify "$RESULTS/baseline.rrd"
+npa/.venv/bin/rerun rrd print -vv "$RESULTS/baseline.rrd"
+npa/.venv/bin/rerun "$RESULTS/baseline.rrd"
+```
+
+Use your public-safe native Jobs submission label for `--run-id`; the producer
+has no persisted submission ID, so this label is supplied by the reader and is
+not independent Jobs status evidence. Keep recordings private if their images
+are private. The converter requires a new `.rrd` outside the downloaded input
+tree, preserves its checksum manifests, and emits one JSON receipt with source
+and recording hashes plus independently decoded entity row counts. It never
+loads CLIP or connects to Ray. Import `convert(input_path, output_path, run_id=...)`
+from the same module for Python use.
+
+The first view shows original RGB images beside the exact crops embedded by the
+GPU. Move the `record_id` timeline through the first eight records to inspect
+images; vectors and their norms cover every record. The Dataframe/Tensor views
+can inspect `vectors/embedding`, and `retrieval/top_ids` contains the persisted
+query and hit IDs. No spatial projection or semantic accuracy is implied.
+
+Advanced results additionally expose `shard_index` checkpoint counts, verified
+checkpoint hashes, per-shard preprocessing/inference durations, and a
+`coordinator_elapsed` concurrency trace. This last timeline starts at the first
+recorded coordinator observation and covers only its observed inference wave,
+including RPC edges. Worker clocks are never combined. Model loads and aggregate
+timings are static measurements; their intervals overlap and must not be added.
+Recovery lineage is static because the source records no recovery timestamp.
+Rerun's built-in `log_time` and `log_tick` describe converter logging; select the
+custom timelines above to inspect persisted workload facts.
+Application/converter source hashes and model byte identities are retained; host, node, process,
+allocation and imported-file identifiers are omitted.
+
+Missing final reports, partial/cancelled results, checksum gaps or corruption,
+unsafe paths/symlinks, invalid vectors, mismatched preview bytes, inconsistent
+retrievals and corrupt advanced checkpoints fail conversion before publication.
+An advanced report also requires a successful actor cleanup receipt. A failed
+writer or decoded-content check leaves no final RRD. The original Parquet,
+Lance and model artifacts remain the authoritative result; the RRD is a derived
+review artifact. Creating the file does not upload or share it.
+
+To qualify a real downloaded result through the committed live test, run once
+for each producer you used:
+
+```bash
+NPA_INTEGRATION_E2E=1 NPA_RAY_CLIP_RESULTS="$RESULTS/baseline" \
+  npa/.venv/bin/python -m pytest npa/tests/e2e/test_ray_clip_report_live.py -q
+```
+
+The test requires actual CUDA actor and completed inference receipts, invokes
+the converter CLI, runs Rerun's independent verifier and decodes every record
+index. Unit fixtures use explicit synthetic vectors and are not GPU evidence.

--- a/npa/workflows/workbench/ray-train-synthetic/README.md
+++ b/npa/workflows/workbench/ray-train-synthetic/README.md
@@ -1,35 +1,38 @@
 # Train on two GPUs with native Ray Train
 
-This reference learns a synthetic linear regression with PyTorch DDP on two
-B200 hosts, one CUDA rank per host. It saves native Ray Train checkpoints to
-S3 and exports the final model, optimizer momentum, rank evidence, metrics and
-a factual Rerun recording. Ray Jobs handles source delivery and application
-control; SkyPilot owns the hosts and the Ray service task.
+[Ray guide](../../../../docs/workbench/ray.md) · [Reference examples](../README.md)
 
-This is a tool-specific development example, outside the `npa.workflow`
-catalog. It introduces no NPA CLI, service, container or job controller.
-Production pipelines composed of several capabilities belong in `npa.workflow`.
+Train synthetic linear regression with PyTorch DDP on **two B200 hosts**, one
+CUDA rank per host. Native Ray Train saves recoverable checkpoints to S3 and
+exports the trained model, metrics, and a Rerun recording. Ray Jobs handles
+source delivery and job control; SkyPilot owns the hosts and service task.
 
-## Prepare the platform and storage
+This example verifies distributed optimization and checkpoint recovery. It is
+not a robotics-policy benchmark. Use the [`npa.workflow` catalog](../../../../workflows/README.md)
+for production pipelines composed of multiple Workbench capabilities.
 
-Use the existing [private SkyPilot platform setup](../ray-clip-development/platform/README.md).
-It supplies an isolated Kubernetes namespace, private kubeconfig, SkyPilot
-0.12.2 API and `NPA_SKYPILOT_BIN`. Keep its authenticated SSH and NetworkPolicy
-boundary. The Ray Jobs dashboard binds to loopback; never expose it publicly.
+## 1. Prepare clients, compute, and storage
 
-The selected Nebius Kubernetes cluster must have two compatible B200 GPU nodes.
-Use `npa workbench health preflight --checks nebius --json` before provisioning,
-then the [GPU provisioning procedure](../../../../skills/tools/gpu-cluster-provisioning/SKILL.md).
-Confirm the actual accelerator spelling with `"$NPA_SKYPILOT_BIN" gpus list`.
-Change `resources.accelerators` in a private copy of `cluster.yaml` if the
-verified cluster uses another spelling. Two ranks on one host prove distributed
-training, but do not prove the two-host claim made by this profile.
+Complete the [private SkyPilot platform setup](../ray-clip-development/platform/README.md).
+Retain its private `KUBECONFIG`, verified context, API endpoint, and
+`NPA_SKYPILOT_BIN`. Select two compatible B200 GPU nodes and verify their
+accelerator spelling with `"$NPA_SKYPILOT_BIN" gpus list`. Each hosting pod requests
+12 CPUs and at least 48 GiB memory in addition to its GPU.
+
+From the repository root, use the [contributor environment](../../../../npa/README.md#developing-and-testing-npa)
+and install the separate application Jobs client:
+
+```bash
+export NPA_REPO="$PWD"
+export TRAIN_EXAMPLE="$NPA_REPO/npa/workflows/workbench/ray-train-synthetic"
+export RAY_BIN="$NPA_REPO/npa/.venv/bin/ray"
+npa/.venv/bin/python -m pip install 'ray[default,train]==2.58.0'
+export TRAIN_RESULTS="$HOME/ray-train-results"
+```
 
 Select a workload bucket owned by the authorized project and a fresh run prefix.
-Verify provider ownership, then write/read/delete a probe in that exact prefix
-using the executing credentials and endpoint. A generic S3 list or authentication
-check does not prove write permission. Keep storage credentials outside this
-source directory. Provide the following variables in the private operator shell:
+Verify ownership and write/read/delete permission at that exact prefix. Export
+these variables privately before launch:
 
 ```text
 AWS_ACCESS_KEY_ID
@@ -39,19 +42,18 @@ AWS_DEFAULT_REGION     # bucket signing region
 TRAIN_STORAGE_URI      # s3://<your-bucket>/<fresh-training-prefix>
 ```
 
-The SkyPilot launch forwards the named variables without putting their values
-on the command line. Both Ray hosts inherit them before service startup.
-Do not put keys in a Jobs runtime-env file or pass them explicitly to
-`pyarrow.fs.S3FileSystem`, which serializes explicit keys with the filesystem.
-Only trusted code may share this Ray cluster and its storage identity.
+Only trusted code may share this runtime's storage identity. Launch forwards
+credential variable names; keep their values outside source files, Jobs runtime
+environment files, and explicit `pyarrow.fs.S3FileSystem` arguments.
 
-## Start the application Ray service
+## 2. Start and connect to the Ray service
 
-From this directory, select a unique development-cluster name:
+Launch **from the example directory** so its relative `./cluster` mount resolves:
 
 ```bash
-export TRAIN_CLUSTER=synthetic-train
-export KUBE_CONTEXT="$(kubectl config current-context)"
+cd "$TRAIN_EXAMPLE"
+export TRAIN_CLUSTER='<unique-development-cluster-name>'
+export KUBE_CONTEXT='<verified-kubernetes-context>'
 "$NPA_SKYPILOT_BIN" launch --yes --detach-run -c "$TRAIN_CLUSTER" \
   --infra "k8s/$KUBE_CONTEXT" \
   --config "kubernetes.allowed_contexts=[\"$KUBE_CONTEXT\"]" \
@@ -60,27 +62,12 @@ export KUBE_CONTEXT="$(kubectl config current-context)"
 "$NPA_SKYPILOT_BIN" queue "$TRAIN_CLUSTER"
 ```
 
-Record the exact service-task ID from the queue. Preparation installs application
-Ray **2.58.0** with Train V2, Arrow **23.0.1**, NumPy **2.4.6** and Rerun
-**0.31.4** and Pillow **12.3.0**, retaining Torch **2.13.0+cu130** from the
-immutable upstream PyTorch 2.13.0 CUDA 13.0 runtime image.
-The image digest and the separately recorded dependency freeze identify different
-parts of the runtime; this is not a fully hash-locked transitive installation.
-There is no model download or external training dataset.
-The Jobs driver and every new or restarted training worker also check the exact
-Torch version before training, so environment drift after preparation fails closed.
-Every rank records its imported Torch, CUDA and Ray versions alongside its metrics.
+Record the exact service-task ID. Preparation installs the pinned application
+environment in a fresh private `/opt/npa-ray-train` on each host. It refuses an
+existing runtime directory; preserve failed-attempt evidence and use fresh pods.
+See [runtime versions and checks](runtime-validation.md#application-environment).
 
-The pinned image runs preparation as root. Preparation requires an owned `/opt`
-without shared write access and creates a fresh mode-0700 `/opt/npa-ray-train`.
-Its `env`, `exports`, and Ray temporary directories stay inside that private
-application directory; `preparation.json` records the verified versions and
-dependency freeze. An existing directory fails preparation without changing its
-contents. Preserve a failed attempt's evidence and use fresh hosting pods for a
-new attempt. The service checks the directory's owner and permissions before
-starting, and sets `RAY_TMPDIR` to this directory for its application processes.
-
-Use the SkyPilot-generated SSH alias to reach Jobs through one owned tunnel:
+Use the generated SSH alias for an authenticated loopback tunnel:
 
 ```bash
 export TRAIN_SOCKET="$HOME/.ssh/${TRAIN_CLUSTER}-jobs.sock"
@@ -88,156 +75,112 @@ ssh -M -S "$TRAIN_SOCKET" -fNT -o ExitOnForwardFailure=yes \
   -L 18265:127.0.0.1:8265 "$TRAIN_CLUSTER"
 unset RAY_ADDRESS RAY_API_SERVER_ADDRESS
 export RAY_API=http://127.0.0.1:18265
-# Install ray[default,train]==2.58.0 in your own client environment.
-ray job list --address "$RAY_API"
+"$RAY_BIN" job list --address "$RAY_API"
 ```
 
-Wait for Jobs readiness; SkyPilot launch completion alone does not establish it.
-Ray's native Jobs client gives those two environment variables precedence over
-an explicit address. Keep them unset in the operator shell; the live suite
-rejects them before client contact. Each submitted driver receives its separate
-application GCS address from the native Jobs service.
-Check both hosts joined the application GCS on port 6381, with two total GPUs.
-Application ports are separate from SkyPilot's management Ray; never use
-ambient discovery or a broad `ray stop`.
-The driver propagates its selected GCS address through the native runtime
-environment to Train's actors. This also keeps the head-pinned placement cleanup
-actor's State API on the application service when management Ray is present.
+Require Jobs readiness and both hosts joined to application GCS port 6381, with
+two GPUs total. The separate SkyPilot management runtime must remain intact.
+Keep the two ambient Ray address variables unset: the Jobs client can prioritize
+them over `--address`. Do not expose Jobs publicly or use a broad `ray stop`.
 
-## Train, inspect, recover
+## 3. Train and inspect completion
+
+Still in `$TRAIN_EXAMPLE`:
 
 ```bash
-ray job submit --address "$RAY_API" --submission-id train-baseline \
+"$RAY_BIN" job submit --address "$RAY_API" --submission-id train-baseline \
   --working-dir . -- /opt/npa-ray-train/env/bin/python train.py \
   --storage-path "$TRAIN_STORAGE_URI" --run-name baseline \
   --output-dir /opt/npa-ray-train/exports/train-baseline
-ray job status --address "$RAY_API" train-baseline
-ray job logs --address "$RAY_API" train-baseline
+"$RAY_BIN" job status --address "$RAY_API" train-baseline
+"$RAY_BIN" job logs --address "$RAY_API" train-baseline
 ```
 
-The default 32 steps train distinct deterministic shards with SGD momentum.
-Every step records globally reduced loss, gradient norm, parameter change,
-applied learning rate, synchronized samples/second and actual CUDA rank evidence.
-An exact-zero gradient is valid when SGD momentum still produces a measured
-parameter update; every recorded step must retain that update evidence.
-Every fourth step, plus the last, saves the full journal and model/optimizer.
-Export reloads the checkpoint, checks held-out improvement and matches its
-parameters against the final CUDA-rank hashes. These measurements demonstrate
-execution and optimizer progress, not a robotics-policy benchmark.
+Require `SUCCEEDED`. The default 32 optimizer steps use deterministic rank shards
+and SGD momentum. Every fourth step and the final step save the journal,
+model, and optimizer. Export verifies held-out loss improvement and matching
+final parameters across CUDA ranks.
 
-Each new training run needs a fresh `--run-name`. A retry of the same run uses
-the same native `RunConfig(name, storage_path)` pair. The saved recipe must
-match exactly. Run the worker-failure exercise under a separate name:
+Each new experiment needs a fresh `--run-name`. Do not run concurrent drivers
+with the same storage path and run name.
+
+## 4. Download and view the durable result
+
+Exports appear under `$TRAIN_STORAGE_URI/baseline/exports/`. Each upload is
+read back and verified; conflicting existing bytes are refused.
+
+| File | What it proves |
+| --- | --- |
+| `state.pt` | Final model and SGD momentum checkpoint |
+| `metrics.json` | Every optimizer step, loss, gradient, parameter update, and CUDA rank |
+| `metrics.rrd` | Derived visualization of the recorded measurements |
+| `result.json` | Recipe, validation, runtime, and artifact bindings |
+| `SHA256SUMS` | Exact exported file hashes |
+
+Use a fresh destination directory:
 
 ```bash
-ray job submit --address "$RAY_API" --submission-id train-recovery \
+"$NPA_REPO/npa/.venv/bin/python" "$TRAIN_EXAMPLE/inspect_results.py" \
+  "$TRAIN_RESULTS/baseline" --download "$TRAIN_STORAGE_URI/baseline/exports"
+"$NPA_REPO/npa/.venv/bin/rerun" rrd verify "$TRAIN_RESULTS/baseline/metrics.rrd"
+"$NPA_REPO/npa/.venv/bin/rerun" "$TRAIN_RESULTS/baseline/metrics.rrd"
+```
+
+The inspector requires four verified artifacts, 32 decoded optimizer steps,
+five metric entities, and eight checkpoint events for the default recipe.
+The RRD values must match the full journal. The local inspector uses NPA's
+Rerun dependencies; the deeper live suite additionally installs matching Torch.
+Download again into another fresh directory after compute teardown to verify
+that the S3 result outlives its hosts.
+
+## Optional: prove checkpoint recovery
+
+Use a separate native run name:
+
+```bash
+"$RAY_BIN" job submit --address "$RAY_API" --submission-id train-recovery \
   --working-dir . -- /opt/npa-ray-train/env/bin/python train.py \
   --storage-path "$TRAIN_STORAGE_URI" --run-name recovery \
   --output-dir /opt/npa-ray-train/exports/train-recovery --fail-after-step 8
 ```
 
-Rank one raises after native Train confirms checkpoint 8 is committed. Native
-Train restarts the worker group; both ranks load its model and optimizer and
-continue at step 9. The final journal must contain each step exactly once and
-prove both restored ranks. Do not use V1 `TorchTrainer.restore()` or
-`resume_from_checkpoint`: Ray 2.58 defaults to Train V2.
+Rank one raises only after checkpoint 8 is committed. Train restarts both ranks,
+restores model and optimizer, and continues at step 9. The final journal must
+contain every step exactly once and prove restoration on both ranks. This uses
+Train V2; do not substitute V1 `TorchTrainer.restore()` or `resume_from_checkpoint`.
+For driver retries, retain the same native `RunConfig(name, storage_path)` pair
+and exact saved recipe. `ray.train.Result.from_path()` reopens checkpoint state
+through the same S3 filesystem but does not restore Jobs terminal status.
 
-## Preserve and view the outputs
-
-Exports live under `<storage-prefix>/<run-name>/exports/`. The application uploads
-`state.pt`, `metrics.json`, `metrics.rrd`, `result.json`, then `SHA256SUMS`, checking
-each object with read-after-write. Conflicting existing exports are refused.
-Do not launch two drivers concurrently with the same native run name.
-
-If S3 export delivery fails after training, preserve the host's export directory.
-Retry those exact bytes without retraining or regenerating the RRD:
+If export delivery fails after training, preserve the host's export and retry
+its exact bytes without retraining:
 
 ```bash
-ray job submit --address "$RAY_API" --submission-id train-export-retry \
+"$RAY_BIN" job submit --address "$RAY_API" --submission-id train-export-retry \
   --working-dir . -- /opt/npa-ray-train/env/bin/python inspect_results.py \
   /opt/npa-ray-train/exports/train-baseline --publish "$TRAIN_STORAGE_URI/baseline/exports"
 ```
 
-An interrupted upload is safe to retry with the same export; differing bytes
-are refused. If the host and its export were lost before publication finished,
-recover the native checkpoint and write a fresh export destination, preserving
-the partial earlier attempt. Rerun recordings carry event timestamps, so a
-regenerated recording is a new artifact even when its metric values agree.
+If those host files were lost, recover the checkpoint into a fresh export
+destination. A regenerated RRD carries new event timestamps and is a new artifact.
+The [live validation procedure](runtime-validation.md#committed-live-suite) tests
+baseline training, recovery, independent checkpoint decoding, and active cancellation.
 
-From an installed NPA checkout, use its interpreter and a fresh durable directory:
+## 5. Stop the application and its hosts
 
-```bash
-npa/.venv/bin/python npa/workflows/workbench/ray-train-synthetic/inspect_results.py \
-  "$HOME/ray-train-results/baseline" \
-  --download "$TRAIN_STORAGE_URI/baseline/exports"
-npa/.venv/bin/rerun rrd verify "$HOME/ray-train-results/baseline/metrics.rrd"
-npa/.venv/bin/rerun rrd print -vv "$HOME/ray-train-results/baseline/metrics.rrd"
-npa/.venv/bin/rerun "$HOME/ray-train-results/baseline/metrics.rrd"
-```
-
-The inspector compares every decoded optimizer step and scalar value with the
-journal, including CUDA rank counts and checkpoint events. The recording uses
-the application run name as its recording ID and logs no infrastructure IDs.
-Repeat the download into another fresh directory after compute teardown to
-prove the artifacts outlive their hosts. Native checkpoint recovery can also
-reopen `ray.train.Result.from_path` with the same custom S3 filesystem; its
-`checkpoint.as_directory()` downloads through that filesystem. Preserve Jobs
-terminal status separately: `Result.from_path()` does not restore failure status.
-
-The committed live suite runs baseline training, checkpoint recovery and active
-cancellation against this prepared runtime. In an owner-only file outside the
-checkout, set `address` to the loopback Jobs URL, `storage_uri` to the verified
-fresh S3 prefix, and `evidence_dir` to an owner-only local directory. Keep the
-same verified AWS variables in the test process. From the repository root:
+Stop each remaining exact Ray submission ID and confirm a terminal state before
+removing its hosting task. A stop request alone does not prove cancellation:
 
 ```bash
-export NPA_RAY_TRAIN_LIVE_CONFIG="$HOME/.config/ray-train/live.json"
-NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest \
-  npa/tests/e2e/test_ray_train_synthetic_live.py -v
-```
-
-Install the pinned Ray client and matching Torch in this checkout's own venv
-first; they are optional reference dependencies. The suite independently loads
-the downloaded model and SGD momentum, recomputes held-out loss, verifies two
-distinct B200 hosts, decodes every RRD step and checks that recovered parameters
-match uninterrupted training. It records intent before each native submission
-and attempts cleanup for every owned ID even after a transport or assertion
-failure. The hosting task, platform and provider teardown remain operator-owned.
-Cancellation also verifies that the captured placement groups are removed and
-the detached Train cleanup actor exits; terminal Jobs status alone is insufficient.
-
-## Stop only this application
-
-For an active run, `ray job stop --address "$RAY_API" <exact-submission-id>`
-must reach `STOPPED`; confirm using native status and logs. Download useful
-evidence first when possible. The committed live suite exercises a real active
-training cancellation after checkpoint progress, in addition to success and
-worker recovery.
-
-```bash
-# Stop any remaining exact Ray submission IDs before the hosting task.
-"$NPA_SKYPILOT_BIN" cancel "$TRAIN_CLUSTER" <service-task-id> --yes
+"$RAY_BIN" job stop --address "$RAY_API" '<exact-submission-id>'
+"$RAY_BIN" job status --address "$RAY_API" '<exact-submission-id>'
+# After all owned application jobs stop and outputs are saved:
+"$NPA_SKYPILOT_BIN" cancel "$TRAIN_CLUSTER" '<service-task-id>' --yes
 "$NPA_SKYPILOT_BIN" down "$TRAIN_CLUSTER" --yes
 ssh -S "$TRAIN_SOCKET" -O exit "$TRAIN_CLUSTER"
 ```
 
-Verify the owned pods are absent independently. Retain the shared Kubernetes
-cluster/platform unless you also own their lifecycle. Destroy separately owned
-validation infrastructure only after workloads stop; retain verified S3 outputs.
-
-## Compatibility and licenses
-
-The [Ray 2.58 Train storage contract](https://github.com/ray-project/ray/blob/ray-2.58.0/doc/source/train/user-guides/persistent-storage.rst),
-[V2 report API](https://github.com/ray-project/ray/blob/ray-2.58.0/python/ray/train/v2/api/train_fn_utils.py)
-and [Torch 2.13.0 serialization](https://github.com/pytorch/pytorch/blob/v2.13.0/torch/serialization.py)
-govern this implementation. The committed live test is
-`npa/tests/e2e/test_ray_train_synthetic_live.py`; it requires an explicitly
-selected private runtime configuration and performs real GPU work.
-
-This repository ships application source only. Ray and Arrow are Apache-2.0,
-PyTorch uses its [BSD-style license](https://github.com/pytorch/pytorch/blob/v2.13.0/LICENSE),
-and Rerun is Apache-2.0/MIT. The upstream image supplies CUDA/cuDNN under their
-respective [NVIDIA terms](https://docs.nvidia.com/cuda/eula/index.html).
-Runtime use requires the operator's acceptance; no new image is built or
-redistributed here, and the NPA public image catalog is unchanged. Inputs are
-generated tensors and outputs are this run's trained parameters and measurements.
+Verify the owned pods are absent. Retain the shared platform and Kubernetes
+cluster unless you own their lifecycle. Keep S3 results and private ownership
+receipts. [Compatibility and licenses](runtime-validation.md#compatibility-and-licenses)
+describe the pinned upstream runtime and its NVIDIA CUDA terms.

--- a/npa/workflows/workbench/ray-train-synthetic/runtime-validation.md
+++ b/npa/workflows/workbench/ray-train-synthetic/runtime-validation.md
@@ -1,0 +1,69 @@
+# Ray Train runtime and live validation
+
+[Run the example](README.md)
+
+This reference pins a specific two-host B200 runtime. These details support
+reproduction and review; follow the README for the ordered operator commands.
+
+## Application environment
+
+Record the exact service-task ID from the queue. Preparation installs application
+Ray **2.58.0** with Train V2, Arrow **23.0.1**, NumPy **2.4.6** and Rerun
+**0.31.4** and Pillow **12.3.0**, retaining Torch **2.13.0+cu130** from the
+immutable upstream PyTorch 2.13.0 CUDA 13.0 runtime image.
+The image digest and the separately recorded dependency freeze identify different
+parts of the runtime; this is not a fully hash-locked transitive installation.
+There is no model download or external training dataset.
+The Jobs driver and every new or restarted training worker also check the exact
+Torch version before training, so environment drift after preparation fails closed.
+Every rank records its imported Torch, CUDA and Ray versions alongside its metrics.
+
+The pinned image runs preparation as root. Preparation requires an owned `/opt`
+without shared write access and creates a fresh mode-0700 `/opt/npa-ray-train`.
+Its `env`, `exports`, and Ray temporary directories stay inside that private
+application directory; `preparation.json` records the verified versions and
+dependency freeze. An existing directory fails preparation without changing its
+contents. Preserve a failed attempt's evidence and use fresh hosting pods for a
+new attempt. The service checks the directory's owner and permissions before
+starting, and sets `RAY_TMPDIR` to this directory for its application processes.
+
+## Committed live suite
+
+The committed live suite runs baseline training, checkpoint recovery and active
+cancellation against this prepared runtime. In an owner-only file outside the
+checkout, set `address` to the loopback Jobs URL, `storage_uri` to the verified
+fresh S3 prefix, and `evidence_dir` to an owner-only local directory. Keep the
+same verified AWS variables in the test process. From the repository root:
+
+```bash
+export NPA_RAY_TRAIN_LIVE_CONFIG="$HOME/.config/ray-train/live.json"
+NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest \
+  npa/tests/e2e/test_ray_train_synthetic_live.py -v
+```
+
+Install the pinned Ray client and matching Torch in this checkout's own venv
+first; they are optional reference dependencies. The suite independently loads
+the downloaded model and SGD momentum, recomputes held-out loss, verifies two
+distinct B200 hosts, decodes every RRD step and checks that recovered parameters
+match uninterrupted training. It records intent before each native submission
+and attempts cleanup for every owned ID even after a transport or assertion
+failure. The hosting task, platform and provider teardown remain operator-owned.
+Cancellation also verifies that the captured placement groups are removed and
+the detached Train cleanup actor exits; terminal Jobs status alone is insufficient.
+
+## Compatibility and licenses
+
+The [Ray 2.58 Train storage contract](https://github.com/ray-project/ray/blob/ray-2.58.0/doc/source/train/user-guides/persistent-storage.rst),
+[V2 report API](https://github.com/ray-project/ray/blob/ray-2.58.0/python/ray/train/v2/api/train_fn_utils.py)
+and [Torch 2.13.0 serialization](https://github.com/pytorch/pytorch/blob/v2.13.0/torch/serialization.py)
+govern this implementation. The committed live test is
+`npa/tests/e2e/test_ray_train_synthetic_live.py`; it requires an explicitly
+selected private runtime configuration and performs real GPU work.
+
+This repository ships application source only. Ray and Arrow are Apache-2.0,
+PyTorch uses its [BSD-style license](https://github.com/pytorch/pytorch/blob/v2.13.0/LICENSE),
+and Rerun is Apache-2.0/MIT. The upstream image supplies CUDA/cuDNN under their
+respective [NVIDIA terms](https://docs.nvidia.com/cuda/eula/index.html).
+Runtime use requires the operator's acceptance; no new image is built or
+redistributed here, and the NPA public image catalog is unchanged. Inputs are
+generated tensors and outputs are this run's trained parameters and measurements.

--- a/npa/workflows/workbench/ray-tune-synthetic/README.md
+++ b/npa/workflows/workbench/ray-tune-synthetic/README.md
@@ -1,67 +1,104 @@
-# Tune a synthetic objective with native Ray Tune
+# Native Ray Tune: search, checkpoint, and recover
 
-This guarded reference runs a real three-trial Ray Tune search on public,
-generated numeric inputs. It demonstrates the supported boundary without adding
-an NPA Tune wrapper: SkyPilot owns one reusable CPU host and its Ray service
-task; native Ray Jobs owns source delivery, submission, logs, status, and stop;
-the application owns its Tune recipe and exported result contract.
+[Ray guide](../../../../docs/workbench/ray.md) · [Reference examples](../README.md)
 
-This example is outside the `npa.workflow` catalog. Use `npa.workflow` for a
-production graph that composes several Workbench capabilities. This reference
-adds no CLI group, service, container, controller, or GPU claim.
+Run a three-trial CPU search on generated numeric inputs. Ray Tune selects the
+best step size and retries one deliberately interrupted trial from its checkpoint.
+The result is a set of JSON reports that an independent inspector verifies.
+Start locally; the optional cloud path runs the same source through Ray Jobs.
 
-## What it proves
+| You provide | You get |
+| --- | --- |
+| Python environment with Ray 2.58.0; no model or dataset | Three completed trials, best step size `0.2`, and zero best loss |
+| Fresh storage and export directories | Native Tune checkpoints plus checksum-verified result reports |
+| Optional cloud platform | A reusable CPU service with native Jobs submit, logs, status, and stop |
 
-The search evaluates step sizes `0.1`, `0.2`, and `0.3` against a deterministic
-target of `0.2`. Every trial reports three iterations and a native Tune
-checkpoint. The optional failure probe raises once after the `0.3` trial's first
-checkpoint; `FailureConfig(max_failures=1)` reschedules that trial, which resumes
-at iteration two. The final result must select `0.2` with zero loss.
-
-`search.py` writes a fresh owner-only export containing:
-
-- `result.json`: completion, Ray version, experiment path, and selected optimum;
-- `trials.json`: every search value, final loss, completion, checkpoint, and
-  observed retry state;
-- `runtime.json`: Python and Ray versions;
-- `SHA256SUMS`: complete-byte hashes for the three JSON artifacts.
-
-`inspect_results.py` checks the complete file set, every digest, all trials,
-checkpoint availability, and the known optimum. The export is independent
-review evidence; Tune's experiment directory remains the recovery source.
+This is a native Ray application example. Use the
+[`npa.workflow` catalog](../../../../workflows/README.md) for pipelines that
+compose several Workbench capabilities.
 
 ## Run locally first
 
-Use the repository interpreter after installing the application dependency:
+From the repository root, use the
+[contributor environment](../../../../npa/README.md#developing-and-testing-npa)
+and install the application's additional dependency:
 
 ```bash
-cd <npa-checkout>
-export TUNE_EXAMPLE=npa/workflows/workbench/ray-tune-synthetic
-npa/.venv/bin/pip install 'ray[default,tune]==2.58.0'
+export NPA_REPO="$PWD"
+export TUNE_EXAMPLE="$NPA_REPO/npa/workflows/workbench/ray-tune-synthetic"
+export RAY_BIN="$NPA_REPO/npa/.venv/bin/ray"
+npa/.venv/bin/python -m pip install 'ray[default,tune]==2.58.0'
+
+unset RAY_ADDRESS RAY_API_SERVER_ADDRESS
+export TUNE_RESULTS="$(mktemp -d "${TMPDIR:-/tmp}/npa-tune.XXXXXX")"
 npa/.venv/bin/python "$TUNE_EXAMPLE/search.py" \
   --local \
-  --storage-path "$PWD/local-storage" \
+  --storage-path "$TUNE_RESULTS/local-storage" \
   --run-name local-search \
-  --output-dir "$PWD/local-result" \
+  --output-dir "$TUNE_RESULTS/local-result" \
   --fail-step-size 0.3
-npa/.venv/bin/python "$TUNE_EXAMPLE/inspect_results.py" "$PWD/local-result"
+npa/.venv/bin/python "$TUNE_EXAMPLE/inspect_results.py" "$TUNE_RESULTS/local-result"
 ```
 
-Use fresh paths. Existing output directories are refused so a retry cannot
-overwrite earlier evidence. This CPU run proves Tune scheduling, checkpointed
-trial retry, result selection, and artifact validation; it proves no GPU or
-multi-node behavior.
+Expected inspector output:
+
+```json
+{"artifacts_verified": 3, "resumed_trials": 1, "trials_verified": 3}
+```
+
+The `0.3` trial deliberately fails after its first checkpoint, then resumes at
+iteration two. An error from that injected failure is expected; the final search
+and inspection must still succeed. This exact local path was verified on macOS
+with Ray 2.58.0. It establishes CPU search and checkpoint recovery.
+
+Use fresh paths for another run: existing export directories are refused.
+Copy results somewhere durable before deleting temporary files. The application
+shuts down its locally started Ray runtime when it finishes.
+
+## What to inspect
+
+| File | Contents |
+| --- | --- |
+| `result.json` | Completion, selected optimum, and experiment path |
+| `trials.json` | Every trial's loss, iterations, checkpoint, and retry state |
+| `runtime.json` | Python/Ray versions and exact source hash |
+| `SHA256SUMS` | Hashes of the three JSON files |
+
+`inspect_results.py` checks the complete file set, source and artifact hashes,
+trial completion, checkpoint evidence, and the known optimum. The export is a
+reviewable summary. Tune's experiment directory holds the state needed for
+restoration; preserve both when recovery matters.
+
+## Optional: prepare the cloud platform
+
+Complete the [private SkyPilot platform setup](../ray-clip-development/platform/README.md)
+first. It supplies the pinned SkyPilot 0.12.2 executable, authenticated access,
+and an explicitly selected Kubernetes context. The example requests one CPU
+pod with 6 CPUs and 12 GiB memory; leave room for platform/system pods.
+
+Keep the local variables above, then select the exact context supplied by setup:
+
+```bash
+export TUNE_CLUSTER='<unique-development-cluster-name>'
+export KUBE_CONTEXT='<verified-kubernetes-context>'
+export NPA_SKYPILOT_BIN="$(npa skypilot status --bin-path)"
+npa workbench health preflight --checks nebius --json
+```
+
+For S3 checkpoints, also verify the selected bucket's ownership and
+write/read/delete access to your run prefix. Export `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, and `AWS_DEFAULT_REGION` privately.
+Append name-only `--env` forwards for those four variables to the launch below.
+Keep credential values out of YAML and Jobs runtime-environment files.
+The default example below stores experiment state on the service host.
 
 ## Start the reusable Ray service
 
-Use the private SkyPilot platform setup documented beside the native Ray CLIP
-reference. Bootstrap SkyPilot 0.12.2 through NPA and invoke only the returned
-`NPA_SKYPILOT_BIN`; do not use an ambient `sky` executable. Select the exact
-Kubernetes context and a unique cluster name:
+Launch **from the example directory** so `cluster.yaml` and its relative
+`./cluster` file mount resolve correctly:
 
 ```bash
-export TUNE_CLUSTER=tune-synthetic
-export KUBE_CONTEXT="$(kubectl config current-context)"
+cd "$TUNE_EXAMPLE"
 "$NPA_SKYPILOT_BIN" launch --yes --detach-run -c "$TUNE_CLUSTER" \
   --infra "k8s/$KUBE_CONTEXT" \
   --config "kubernetes.allowed_contexts=[\"$KUBE_CONTEXT\"]" \
@@ -69,122 +106,102 @@ export KUBE_CONTEXT="$(kubectl config current-context)"
 "$NPA_SKYPILOT_BIN" queue "$TUNE_CLUSTER"
 ```
 
-The digest-pinned upstream Ray image and the separately prepared environment
-both use Ray 2.58.0. Preparation fails if its private runtime already exists;
-retain that attempt and use a fresh host rather than adopting unknown bytes.
-The dashboard binds to loopback. Reach it through an authenticated SSH tunnel,
-keep GCS and Jobs private, and allow only trusted application code on the
-service.
+Record the exact service-task ID. Preparation creates a fresh private
+`~/.npa-ray-tune` on the **remote host** using the pinned Ray image and Ray 2.58.0
+application environment. If preparation finds an existing runtime, preserve
+that attempt and use fresh hosting pods.
+
+Connect through the SkyPilot-generated SSH alias. Read the remote runtime path
+instead of expanding your local `$HOME` into a remote command:
 
 ```bash
+export TUNE_RUNTIME="$(ssh "$TUNE_CLUSTER" 'printf "%s/.npa-ray-tune\n" "$HOME"')"
 export TUNE_SOCKET="$HOME/.ssh/${TUNE_CLUSTER}-jobs.sock"
 ssh -M -S "$TUNE_SOCKET" -fNT -o ExitOnForwardFailure=yes \
   -L 18265:127.0.0.1:8265 "$TUNE_CLUSTER"
 unset RAY_ADDRESS RAY_API_SERVER_ADDRESS
 export RAY_API=http://127.0.0.1:18265
-ray job list --address "$RAY_API"
+"$RAY_BIN" job list --address "$RAY_API"
 ```
 
-Wait for the native Jobs endpoint before submitting. Application Ray uses
-ports separate from SkyPilot's management Ray; never use `ray stop` or ambient
-Ray discovery.
+Wait until Jobs responds. The dashboard and GCS remain private; application
+ports are separate from SkyPilot's management Ray. Submit only trusted code and
+use the explicit Jobs address throughout.
 
 ## Submit and inspect through Ray Jobs
 
-From this example directory, choose one exact submission ID and fresh host
-paths. For a durable experiment, use a run-scoped S3 `--storage-path` whose
-bucket ownership and exact prefix were verified privately before launch. Pass
-the matching S3 credential variables to the SkyPilot launch environment; never
-put values in source or Jobs runtime-environment JSON.
-
-For S3, add these name-only forwards to the earlier `launch` command after the
-exact bucket and prefix pass ownership and write/read/delete checks:
-
-```bash
---env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY \
---env AWS_ENDPOINT_URL_S3 --env AWS_DEFAULT_REGION
-```
+Still in `$TUNE_EXAMPLE`, choose a fresh submission ID and output paths:
 
 ```bash
 export TUNE_JOB=tune-reference
-export TUNE_RUNTIME="$HOME/.npa-ray-tune"
-ray job submit --address "$RAY_API" --submission-id "$TUNE_JOB" \
+"$RAY_BIN" job submit --address "$RAY_API" --submission-id "$TUNE_JOB" \
   --working-dir . -- \
   "$TUNE_RUNTIME/env/bin/python" search.py \
   --storage-path "$TUNE_RUNTIME/experiments" \
   --run-name reference \
   --output-dir "$TUNE_RUNTIME/exports/$TUNE_JOB" \
   --fail-step-size 0.3
-ray job status --address "$RAY_API" "$TUNE_JOB"
-ray job logs --address "$RAY_API" "$TUNE_JOB"
+"$RAY_BIN" job status --address "$RAY_API" "$TUNE_JOB"
+"$RAY_BIN" job logs --address "$RAY_API" "$TUNE_JOB"
 ```
 
-Require `SUCCEEDED`; a submission banner is not completion evidence. Preserve
-both the export and, for local storage, the Tune experiment directory before
-teardown:
+Require `SUCCEEDED`, then download the export and local experiment state:
 
 ```bash
-mkdir -p "$RESULTS"
-rsync -az "$TUNE_CLUSTER:$TUNE_RUNTIME/exports/$TUNE_JOB/" "$RESULTS/export/"
-rsync -az "$TUNE_CLUSTER:$TUNE_RUNTIME/experiments/reference/" "$RESULTS/experiment/"
-# After returning to the repository root:
-npa/.venv/bin/python "$TUNE_EXAMPLE/inspect_results.py" "$RESULTS/export"
-(cd "$RESULTS/export" && sha256sum -c SHA256SUMS)
+mkdir -p "$TUNE_RESULTS/cloud"
+rsync -az "$TUNE_CLUSTER:$TUNE_RUNTIME/exports/$TUNE_JOB/" "$TUNE_RESULTS/cloud/export/"
+rsync -az "$TUNE_CLUSTER:$TUNE_RUNTIME/experiments/reference/" "$TUNE_RESULTS/cloud/experiment/"
+"$NPA_REPO/npa/.venv/bin/python" "$TUNE_EXAMPLE/inspect_results.py" "$TUNE_RESULTS/cloud/export"
 ```
 
-An S3 experiment path makes Tune's checkpoints and experiment state survive
-host teardown, but the checksum-bound summary still must be copied to durable
-storage. A local experiment path is not durable after `sky down`.
+Expect the same three-artifact, three-trial, one-resumed-trial receipt. For
+S3-backed experiments, use the verified run-scoped S3 URI as `--storage-path`
+instead; preserve the export separately. Host-local checkpoints disappear when
+the hosting pod is deleted.
 
 ## Failure and recovery boundaries
 
-The injected trial failure is recovered automatically from its last checkpoint.
-That validates one application exception, not node loss, head loss, or exactly-once
-external side effects. A second failure exceeds the declared budget and the
-application refuses to export a successful result.
+The injected exception exercises native Tune checkpointed retry with
+`FailureConfig(max_failures=1)`. It does not simulate node or head loss. A second
+failure exceeds the recipe's retry allowance and cannot produce a successful
+export.
 
-If the Jobs driver, head, or service is interrupted after Tune has persisted
-experiment state, rerun the exact recipe with `--restore`, the same
-`--storage-path` and `--run-name`, and a fresh output directory. The application
+After a driver interruption, keep the same source, `--storage-path`, and
+`--run-name`, add `--restore`, and select a fresh output directory. The example
 uses `Tuner.can_restore` and `Tuner.restore(..., resume_errored=True)`. Restore
-does not accept a changed search space and cannot fix deterministic application
-bugs. Treat Tune experiment state as trusted executable state; never restore a
-path writable by an untrusted party.
+cannot repair an incompatible search space or deterministic application bug.
+Only restore experiment state written by trusted code.
 
-Stopping the Ray Job is separate from Tune restoration:
+To stop an active job:
 
 ```bash
-ray job stop --address "$RAY_API" "$TUNE_JOB"
-ray job status --address "$RAY_API" "$TUNE_JOB"
+"$RAY_BIN" job stop --address "$RAY_API" "$TUNE_JOB"
+"$RAY_BIN" job status --address "$RAY_API" "$TUNE_JOB"
 ```
 
-Poll the exact ID to `STOPPED`; a stop request is not terminal evidence. An
-interrupted export is not a completed result. Preserve any partial evidence and
-use a fresh output directory after restoration.
+Wait for `STOPPED`. Preserve partial evidence; an interrupted export is not a
+completed result.
 
 ## Cleanup
 
-Cancel exact Ray Jobs before their hosting service. Then cancel only the
-recorded SkyPilot service task and remove only the named development cluster:
+After all owned Ray Jobs are terminal and needed outputs are saved, cancel the
+recorded SkyPilot service task and remove its development cluster:
 
 ```bash
-"$NPA_SKYPILOT_BIN" cancel "$TUNE_CLUSTER" <service-task-id> --yes
+"$NPA_SKYPILOT_BIN" cancel "$TUNE_CLUSTER" '<service-task-id>' --yes
 "$NPA_SKYPILOT_BIN" down "$TUNE_CLUSTER" --yes
 ssh -S "$TUNE_SOCKET" -O exit "$TUNE_CLUSTER"
 ```
 
-Verify the owned pod and tunnel are absent. Retain shared Kubernetes and the
-SkyPilot API unless their separate owner explicitly authorized teardown.
+Verify the owned pod and tunnel are gone. Keep shared Kubernetes and the
+SkyPilot API running; a separately owned platform has its own cleanup procedure.
+Do not use `ray stop`, which can affect other Ray processes on the host.
 
 ## Agent guidance and compatibility
 
-When operating this reference, keep the native ownership split visible. Start
-with the local CPU run; before cloud work, run `npa workbench health preflight
---checks nebius --json` and verify the exact target context. If S3 is selected,
-verify bucket ownership plus write/read/delete access to the exact run prefix.
-Track the submission ID, service-task ID, cluster name, tunnel socket, storage
-path, and result destination privately. Never infer GPU, multi-node, or workload
-quality evidence from this numeric CPU search.
+Keep the cluster name, service-task ID, Jobs ID, tunnel, storage prefix, and
+result destination in private run notes. A successful CPU search establishes
+no GPU or multi-node behavior.
 
 The implementation follows the Ray 2.58 primary sources for
 [`Tuner`](https://github.com/ray-project/ray/blob/ray-2.58.0/python/ray/tune/tuner.py),

--- a/npa/workflows/workbench/sim2real/README.md
+++ b/npa/workflows/workbench/sim2real/README.md
@@ -7,25 +7,26 @@ Use the single canonical spec and complete the operator runbook before submit:
 - [canonical RobotSpec and URDF example](../../../../docs/workbench/guides/sim2real-robot-spec.md)
 - [architecture and durable resume](../../../../docs/architecture/sim2real-compositional-workflow.md)
 
-Configured operators submit through the standard durable runtime:
+## Start with your inputs
+
+| Prepare | Contract |
+| --- | --- |
+| Robot embodiment and capture assets | [Customer assets](../../../../docs/workbench/guides/sim2real-customer-assets.md) and [RobotSpec](../../../../docs/workbench/guides/sim2real-robot-spec.md) |
+| Project, cluster, bucket, immutable images, and Isaac cache | [Operator runbook](../../../../docs/workbench/guides/sim2real-workflow.md) |
+| Expected 14-stage graph and recovery behavior | [Architecture](../../../../docs/architecture/sim2real-compositional-workflow.md) |
+
+From the repository root, validate the canonical spec locally:
 
 ```bash
-npa workbench workflow submit \
-  workflows/main/sim2real.yaml \
-  --runtime --run-id <run-id> \
-  --var bucket=<bucket> \
-  --var robot_spec_uri=<exact-s3-object-or-empty> \
-  --var controller_image=<immutable-ref> \
-  --var transfer_image=<immutable-ref> \
-  --var envgen_image=<immutable-ref> \
-  --var isaac_image=<immutable-ref> \
-  --var viewer_image=<immutable-ref> \
-  --var isaac_cache_pvc=<bound-rwx-pvc> \
-  --secret-env AWS_ACCESS_KEY_ID \
-  --secret-env AWS_SECRET_ACCESS_KEY \
-  --secret-env HF_TOKEN \
-  --secret-env NEBIUS_TOKEN_FACTORY_KEY
+npa workbench workflow validate-spec workflows/main/sim2real.yaml
 ```
+
+This checks the declaration; it does not prove image access, model access, GPU
+placement, or customer-data compatibility. Continue with the operator runbook's
+preflight and complete `submit --runtime` command using your verified inputs.
+Keep the returned run ID for status, logs, artifacts, and durable resume.
+
+## Runtime and outputs
 
 The YAML exposes all 14 stages and runs through the standard workflow runtime.
 Each real solution has its own image/resource state, S3 inputs and outputs, and
@@ -38,7 +39,7 @@ Runtime values are operator inputs; this directory contains no
 tenant, project, registry, bucket, cluster, credential, or run identifier.
 
 `controller_image` must be the small CPU-only image built from
-`docker/workbench/sim2real-control/Dockerfile`. It contains the exact source and
+[npa/docker/workbench/sim2real-control/Dockerfile](../../../docker/workbench/sim2real-control/Dockerfile). It contains the exact source and
 pinned S3 dependencies but no Genesis, Isaac, CUDA, trainer, or injected source
 bootstrap. GPU solution images remain attached only to their corresponding
 workflow states.

--- a/research/lerobot-deploy/README.md
+++ b/research/lerobot-deploy/README.md
@@ -1,5 +1,10 @@
 # LeRobot on Nebius
 
+**Historical standalone deployment reference.** For new LeRobot work, use the
+[current Workbench guide](../../docs/workbench/guides/reachy2-lerobot-policy.md). The commands below belong to the older
+Terraform/VM setup and have not been revalidated by this documentation update.
+
+
 Deploy a preemptible H200 GPU instance on Nebius Cloud for LeRobot training.
 LeRobot is treated as an **installed dependency** (pinned PyPI version) — this
 repo owns only infrastructure and orchestration.

--- a/research/lerobot-deploy/training/README.md
+++ b/research/lerobot-deploy/training/README.md
@@ -1,5 +1,10 @@
 # Training Scripts
 
+**Historical standalone deployment reference.** For new LeRobot work, use the
+[current Workbench guide](../../../docs/workbench/guides/reachy2-lerobot-policy.md). The commands below belong to the older
+Terraform/VM setup and have not been revalidated by this documentation update.
+
+
 This directory contains the local source-of-truth for the LeRobot wrapper
 scripts used by this repo.
 
@@ -14,10 +19,10 @@ Files:
 
 ## Local Vs VM Paths
 
-On your Mac, the scripts live here:
+In this checkout, the scripts live here:
 
 ```bash
-/Users/timothyle/repos/lerobot-deploy/training
+<checkout>/research/lerobot-deploy/training
 ```
 
 On the deployed VM, cloud-init writes runnable copies here:
@@ -39,7 +44,7 @@ repo onto the instance.
 Get the current IP from Terraform:
 
 ```bash
-cd /Users/timothyle/repos/lerobot-deploy
+cd '<checkout>/research/lerobot-deploy'
 terraform -chdir=terraform output -raw ssh_command
 ```
 

--- a/skills/atomic/guardrail-failures/SKILL.md
+++ b/skills/atomic/guardrail-failures/SKILL.md
@@ -5,8 +5,8 @@ description: Use when a guardrail test or CI gate in npa fails and you need to m
 
 # Decoding A Guardrail Failure
 
-The guardrail suite is ~2000 assertions over 43 files and runs in under a
-minute. It is static: it reads the repo and checks that surfaces which must
+The guardrail suite checks thousands of repository contracts. It reads the
+repo and checks that surfaces which must
 agree still agree. A failure almost always means one of two things — you changed
 one side of a contract and not the other, or you added something the contract
 requires you to register.
@@ -62,6 +62,7 @@ change hits most.
 | `test_develop_skills` | A development skill names a repo path or guardrail that does not exist, or a new guardrail file is undocumented. Update the skill. |
 | `test_no_dangling_workflow_references` | A doc, skill, or script names a workflow YAML that does not exist. Repoint or remove the reference. |
 | `test_docs_green_path` | The documented path from README to a real submit is no longer runnable end to end. Update the quickstart with the new step. |
+| `test_documentation_examples` | Fix the reported Markdown link/heading, shell/Python syntax, CLI command/option, or undeclared workflow variable. Quote shell placeholders; label HTTP routes and abbreviated grammar as `text`. Keep the package README's planning example executable offline. Generated CLI references and historical command records retain separate validation scope. |
 | `test_agent_workflow_operations` | The agent operations guide omitted a lifecycle stage, exposed a non-NPA subprocess, or coupled workflow operation to a model/provider flag. Restore the fixed, provider-neutral NPA command journey. |
 | `test_audit_container_docs_skill` | The public container catalog disagrees with the publish inventory. Update `docs/workbench/container-image-catalog.md`. |
 | `test_solution_licensing_skill` | The licensing skill no longer covers an artifact boundary. Update the skill, not the test. |

--- a/workbench/mlflow/README.md
+++ b/workbench/mlflow/README.md
@@ -1,29 +1,93 @@
-# MLflow + Postgres Workbench Stack
+# MLflow and Postgres on a Linux workbench VM
 
-This VM-scoped stack uses Docker Compose because the dev VM already has Docker and the requested service is local workbench infrastructure, not a multi-node Workbench/Kubernetes workload. Postgres metadata stays on a host bind mount (`./postgres-data`) backed by the VM block disk; artifacts go to an isolated Nebius Object Storage bucket through the MLflow server artifact proxy when the installed MLflow version supports `--serve-artifacts`.
+[Workbench docs](../../docs/workbench/README.md)
 
-MLflow is published only on `127.0.0.1:5000`; Postgres is on an internal Docker network only and has no host-published port. If MLflow is exposed beyond localhost, place it behind TLS and authentication (for example an HTTPS reverse proxy with Basic/OIDC auth) before changing the bind address.
+Run a local MLflow tracking server with Postgres metadata and an S3 artifact
+proxy. Docker Compose owns the two containers; Nebius holds the artifact bucket.
+This stack is separate from NPA's Kubernetes workflow runtime.
 
-Postgres migration note: this Compose service is intentionally containerized for the dev workbench. To migrate to Nebius Managed PostgreSQL, create a managed instance/database/role, restore a `pg_dump` from `./postgres-data`, and replace `MLFLOW_PG_HOST`/credentials in `.env` and `secrets/postgres_password`; no MLflow schema changes are required.
+## Before you start
 
-## Commands
+Use a **Linux VM you own**, Docker Engine, Bash, `jq`, OpenSSL, an authenticated
+Nebius CLI profile, and permission to manage the selected project's storage and
+IAM. The deploy script installs the Compose plugin if needed. It also creates or
+reuses a dedicated bucket, service account, IAM group, and access key.
+
+Use a dedicated bucket: bootstrap updates its `mlflow/*` bucket policy.
+Keep `.env`, `secrets/`, `evidence/`, and `postgres-data/` private and out of Git.
+Set the region and endpoint explicitly; the legacy discovery fallback assumes
+a particular operator checkout path.
+
+## Deploy and verify
+
+From the repository root:
 
 ```bash
-cd ~/nebius-physical-ai-mlflow/workbench/mlflow
-export NPA_PROJECT_ID="<project-id>"
-export NPA_TENANT_ID="<tenant-id>"
+cd workbench/mlflow
+export NPA_PROJECT_ID='<your-project-id>'
+export NPA_TENANT_ID='<your-tenant-id>'
+export NPA_NEBIUS_PROFILE='<your-authenticated-profile>'
+export NPA_REGION=us-central1
+export NPA_STORAGE_ENDPOINT=https://storage.us-central1.nebius.cloud
+
 ./scripts/deploy.sh
 ./scripts/verify.sh
+```
+
+Use the region and HTTPS endpoint for your actual project. Deployment builds the
+local image and waits for service health. Verification exercises the tracking,
+model, and S3 artifact path and writes `evidence/verify-summary.json`; require
+`status: passed`. Open `http://127.0.0.1:5000` on the VM, or access that loopback
+port through an authenticated SSH tunnel.
+
+| Location | Data and lifetime |
+| --- | --- |
+| `postgres-data/` | Database on the VM's block disk; survives container restart |
+| Dedicated S3 bucket, `mlflow/*` | Artifacts through the server proxy where the installed MLflow supports it |
+| `secrets/` | Runtime-mounted Postgres and S3 credentials |
+| `evidence/resource-summary.json` | Exact cloud resources selected or created by bootstrap |
+
+MLflow binds only to `127.0.0.1:5000`; Postgres has no host-published port. A
+remote/public service needs an authenticating HTTPS proxy before its bind
+address changes.
+
+## Optional checks and image reuse
+
+To test restart persistence, run:
+
+```bash
 ./scripts/verify-twice-clean.sh
+```
 
-# Publish the MLflow and pinned Postgres images to the configured operator registry.
+This stops and redeploys the stack twice, verifies each pass, and keeps the
+existing database and S3 data. Use it only when those restarts are acceptable.
+
+To publish the MLflow and pinned Postgres images to your configured operator
+registry, follow the repository's [image packaging procedure](../../docs/workbench/container-packaging.md),
+then use the existing scripts:
+
+```bash
 ./scripts/push-image.sh
-
-# Redeploy from the pushed images instead of rebuilding/pulling from public registries.
 set -a
 . evidence/pushed-images.env
 set +a
 MLFLOW_USE_PUBLISHED_IMAGE=1 ./scripts/deploy.sh
 ```
 
-`bootstrap-nebius.sh` discovers the project region and storage endpoint from `~/.npa/config.yaml` for the `NPA_PROJECT_ID` supplied at runtime, creates/reuses a dedicated bucket, service account, bucket policy scoped to the mlflow/* prefix, and runtime-mounted S3 key files under `secrets/`.
+The environment file selects the pushed images for redeployment. Keep it private.
+
+## Stop and remove resources
+
+```bash
+docker compose down --remove-orphans
+```
+
+This stops the containers and retains the database, secrets, and cloud resources.
+Back up needed metadata with Postgres tools and preserve artifacts before
+removing storage. Review `evidence/resource-summary.json`, then retire only the
+bucket, access key, service account, and IAM group owned by this stack through
+Nebius administration. Do not delete the VM disk until its database is saved.
+
+For Managed PostgreSQL migration, create the destination database and role,
+restore a `pg_dump`, and update `MLFLOW_PG_HOST` and credentials. The Compose
+stack's containerized database is not automatically migrated by NPA.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,76 +1,205 @@
-# NPA workflow specs (`apiVersion: npa.workflow/v0.0.1`)
+# NPA workflow catalog
 
-YAML specifications for composing Workbench tools. Each `toolRef` names a
-catalog operation. Author, validate, and submit these specs; NPA renders the
-scheduler YAML.
+[Docs](../docs/README.md) · [Authoring guide](../docs/workbench/npa-workflow-guide.md)
 
-Start with the [workflow guides](guides/README.md) for setup and execution.
-For PAIDF with Cosmos 3 on Nebius, follow the
-[PAIDF Cosmos 3 setup and run guide](guides/paidf-cosmos3.md). It includes
-credentials, current CLI installation, runtime submission, monitoring recovery,
-and output inspection, including full-video structural conditioning, aligned
-evaluation, configurable quality acceptance and per-variant caption coverage.
-Its [local MP4 instructions](guides/paidf-cosmos3.md#r3b-run-the-full-pipeline-from-a-local-mp4)
-include a fresh public download, portable checksum and decode checks, and the
-full runtime command with a new run ID.
-Its [LeRobot instructions](guides/paidf-cosmos3.md#r3a-augment-one-lerobot-episode-and-camera)
-include a pinned public v3 example, S3 staging, explicit episode/camera selection,
-and the full submission command. One run augments one selected video; it does
-not produce a reconstructed LeRobot action/state dataset.
+These `npa.workflow/v0.0.1` YAML files compose Workbench operations into a state
+graph. NPA validates the graph, renders SkyPilot tasks, and manages run-scoped
+artifacts. Start with a runbook that matches the result you want.
 
-Agent skills: [author a workflow](../skills/workflows/author-npa-workflow/SKILL.md)
-and [design a new pipeline](../skills/workflows/generate-npa-workflow/SKILL.md).
+## Choose a starting point
+
+| Goal | Spec and runbook |
+| --- | --- |
+| Augment a video or LeRobot episode | [PAIDF + Cosmos 3](guides/paidf-cosmos3.md) — public starter, local MP4, and episode/camera inputs |
+| Generate an image or video | [Cosmos 3](../docs/workbench/cosmos3-generate.md) |
+| Reconstruct a captured scene | [NuRec](../docs/workbench/guides/neural-reconstruction.md) |
+| Compose the 14-stage robot loop | [Sim2Real](../docs/workbench/guides/sim2real-workflow.md) |
+| Train a GR00T policy | [GR00T N1.7](../docs/workbench/cookbooks/groot-1-7-training.md) |
+| Package your own repository | [BYOF](../docs/workbench/cookbooks/byof-isaac-lab/README.md) |
+
+A catalog entry describes a contract, not a guarantee that every configuration
+has run successfully. The `testing/` directory includes executable examples,
+integration tests, and explicitly labeled fixtures. Read each guide's required
+input, image/GPU compatibility, and validation scope before allocating compute.
 
 ## Commands
 
-Run commands from the repository root after completing the selected guide's
-setup. Replace `<spec.yaml>` with a catalog path such as
-`workflows/main/paidf-cosmos3.yaml`; live submission also needs the guide's
-project, storage, secret, and runtime options.
+From the repository root with [NPA installed](../docs/install.md), inspect a
+checked-in example locally:
 
 ```bash
-npa workbench workflow validate-spec '<spec.yaml>'
-npa workbench workflow plan-spec '<spec.yaml>' --run-id demo
-npa workbench workflow submit '<spec.yaml>' --run-id demo --runtime
-npa workbench workflow submit '<spec.yaml>' --plan-only     # plan + render only
+npa workbench workflow validate-spec workflows/testing/cosmos3-generate.yaml
+npa workbench workflow plan-spec workflows/testing/cosmos3-generate.yaml --run-id demo
 ```
 
-`npa workbench workflow submit` plans the state graph and launches the run.
-Use `--plan-only` to inspect the planned steps without launching. Successful
-submit output always includes `run_id`; JSON callers receive it as the top-level
-`run_id` field. Runs whose specs configure `bucket` can also be rediscovered:
+Expect a valid spec and one `generate` stage. Its bucket is a placeholder;
+validation and planning do not verify model access, stage data, or reserve GPUs.
+
+For execution, follow the selected runbook in order:
+
+1. Configure the project and prepare its input, storage, credentials, and compute.
+2. Validate and plan with the configuration overrides you will submit.
+3. Use `prepare-run` to persist a run ID, then check image pullability.
+4. Submit through `submit --runtime` using the same project, context, and values.
+5. Inspect the exact run's `status`, `logs`, and `artifacts`; verify the outputs.
+
+Successful submission reports `run_id`, including at the top level of JSON
+output. Keep it with your private run notes. Runs with durable bucket-backed
+state can also be rediscovered:
 
 ```bash
 npa workbench workflow list \
-  --s3-bucket '<bucket>' --workflow-s3-prefix '<parent-prefix>' --json
+  --s3-bucket '<your-bucket>' --workflow-s3-prefix '<parent-prefix>' --json
 ```
 
-Specs with a `parallel:` fan-out group or a loop that must **early-exit on the
-real decision artifact** are submitted with the runtime orchestrator:
+See [run lifecycle](../docs/run-lifecycle.md) for launch, monitoring, interrupted
+submissions, and safe resume, and [teardown](../docs/teardown.md) for cleanup.
 
-```bash
-npa workbench workflow submit '<spec.yaml>' --run-id demo --runtime
-npa workbench workflow plan-spec '<spec.yaml>' --waves    # offline wave preview
-```
+### Runtime choices
 
-See the [workflow guide](../docs/workbench/npa-workflow-guide.md)
-(Runtime orchestrator) and [design reference](../DESIGN.md).
+Use the runtime orchestrator for parallel groups and decisions evaluated during
+the run. `metadata.executionMode: runtime` selects it automatically and rejects
+`--no-runtime`. Runtime-required workflows reject `--assume-decision` during
+execution; use assumed decisions only to inspect alternate paths offline.
+`plan-spec --waves` previews scheduling waves. `submit --plan-only` previews the
+static render and launches no workload.
 
-`metadata.executionMode: runtime` automatically selects the runtime orchestrator
-and rejects `--no-runtime`. Runtime-required workflows also reject
-`--assume-decision` for execution before staging or provisioning. Offline plans
-may use assumed decisions to inspect each route. PAIDF Cosmos 3 declares this
-mode so actual evaluator reports control refinement and downstream work.
-Runtime submission checks free GPU capacity against each stage as it launches.
-CPU stages can continue after generation finishes even when other workloads
-occupy the GPUs. GPU stages retain their gang-size and placement checks.
+`config.source_overlay: true` uses the automatically staged checkout's NPA code
+with the selected images' installed dependencies. Other workflows default to
+false; `NPA_SRC_OVERLAY=1` is an operator override. Keep the checkout available
+during submission. The [authoring guide](../docs/workbench/npa-workflow-guide.md)
+explains the full source and image contract.
 
-`config.source_overlay: true` selects the automatically staged checkout's NPA
-code in pinned workbench images while keeping their installed dependencies.
-The default is false for other workflows; `NPA_SRC_OVERLAY=1` remains available
-as an operator override. Keep the source checkout available during submission.
-PAIDF's additional CLI flags and YAML defaults are described in its
-[generation and evaluation settings](guides/paidf-cosmos3.md#r5-find-and-change-generation-and-evaluation-settings).
+## Layout
+
+| Directory | Contents |
+| --- | --- |
+| `main/` | The three principal pipelines listed below |
+| `testing/` | All other catalog specs, including component tests and fixtures |
+| [`guides/`](guides/README.md) | Setup and operation runbooks |
+
+The CLI, agent, and live-submit matrix discover both YAML directories. Raw
+SkyPilot tasks are separate tool-specific examples; see the
+[reference-assets index](../npa/workflows/workbench/README.md).
+
+## Spec catalog
+
+### Main workflows
+
+| Spec | Notes |
+| --- | --- |
+| [`nurec-reconstruct.yaml`](main/nurec-reconstruct.yaml) | Real NCore V4 capture → 3DGUT training on an RT-core GPU → USDZ → rig-offset novel views → Rerun; [guide and measured evidence](../docs/workbench/guides/neural-reconstruction.md#promotion-evidence), [readiness record](main/nurec-reconstruct.readiness.json) |
+| [`paidf-cosmos3.yaml`](main/paidf-cosmos3.yaml) | Generic LeRobot/video input → prepared timeline → guarded Cosmos 3 full-video edge transfer → aligned evaluator gate/refinement → captions for every accepted variant → real Curator + FiftyOne Brain + Rerun ([guide](guides/paidf-cosmos3.md)) |
+| [`sim2real.yaml`](main/sim2real.yaml) | Canonical 14-stage Sim2Real workflow through the standard SkyPilot runtime ([guide](../docs/workbench/guides/sim2real-workflow.md)) |
+
+### Testing and reference workflows
+
+Jump to: [Generation and reconstruction](#generation-and-reconstruction) · [Robot learning and simulation](#robot-learning-and-simulation) · [Data, perception, and scenario analysis](#data-perception-and-scenario-analysis) · [Bring your own framework](#bring-your-own-framework) · [Hosted inference and VLM evaluation](#hosted-inference-and-vlm-evaluation) · [Infrastructure and runtime examples](#infrastructure-and-runtime-examples)
+
+#### Generation and reconstruction
+
+| Spec | Notes |
+| --- | --- |
+| [`content-agents-rigid-object.yaml`](testing/content-agents-rigid-object.yaml) | NVIDIA Content Agents with a public image and runtime-fetched OVRTX: source USD → real Material/Physics Agents + OVRTX → upstream validation → rigid Isaac object USDZ/adapter ([guide](../docs/workbench/content-agents.md)) |
+| [`cosmos-fetch.yaml`](testing/cosmos-fetch.yaml) | Check Cosmos source/checkpoint access and materialize a local cache |
+| [`cosmos-synth-fanout-curation.yaml`](testing/cosmos-synth-fanout-curation.yaml) | Cosmos synth fan-out + curation |
+| [`cosmos2-transfer.yaml`](testing/cosmos2-transfer.yaml) | Standalone Cosmos Transfer 2.5 GPU augmentation → video and frames |
+| [`cosmos3-checkpoint-eval.yaml`](testing/cosmos3-checkpoint-eval.yaml) | B200-only guarded Cosmos3 still-image checkpoint evaluation |
+| [`cosmos3-generate.yaml`](testing/cosmos3-generate.yaml) | Cosmos3-Nano image generation with default guardrails; gated guardrail assets require HF access |
+| [`cosmos3-ray-batch.yaml`](testing/cosmos3-ray-batch.yaml) | Prepared SDG batch through an existing Cosmos3-Nano Ray Serve deployment → media and provenance |
+| [`cosmos3-reason.yaml`](testing/cosmos3-reason.yaml) | Cosmos3 reason |
+| [`cosmos3-super-b200-benchmark.yaml`](testing/cosmos3-super-b200-benchmark.yaml) | Cosmos3-Super serving benchmark on one eight-GPU B200 node |
+| [`cosmos3-super-h200-benchmark.yaml`](testing/cosmos3-super-h200-benchmark.yaml) | Cosmos3-Super serving benchmark on one eight-GPU H200 node |
+| [`cosmos3-super-h200-single-gpu.yaml`](testing/cosmos3-super-h200-single-gpu.yaml) | Isolated Cosmos3-Super TP-1 validation on one H200; distinct from node-throughput benchmarks |
+| [`cosmos3-text-to-image.yaml`](testing/cosmos3-text-to-image.yaml) | Public Cosmos3-Nano image generation with guardrails disabled → verified image and manifest |
+| [`nurec-colmap-reconstruct.yaml`](testing/nurec-colmap-reconstruct.yaml) | Full COLMAP source -> Apache-2.0 NCore CPU conversion -> separately licensed NRE full-default reconstruction/render on RTX PRO 6000 -> Rerun -> final report; not yet live validated ([guide](../docs/workbench/guides/nurec-colmap-reconstruct.md)) |
+| [`physical-ai-data-factory.yaml`](testing/physical-ai-data-factory.yaml) | Cosmos Transfer 2.5 PAIDF blueprint ([deploy guide](../docs/workbench/guides/physical-ai-data-factory-deploy.md)) |
+
+#### Robot learning and simulation
+
+| Spec | Notes |
+| --- | --- |
+| [`curobo-benchmark.yaml`](testing/curobo-benchmark.yaml) | Complete pinned MotionBenchMaker and MPiNets benchmark in cuRobo V2 kinematic and payload-dynamics modes; image remains publication-quarantined pending image checks and real GPU validation ([guide](../docs/workbench/curobo.md)) |
+| [`groot-1-7-finetune.yaml`](testing/groot-1-7-finetune.yaml) | Real GR00T data → parameterized 1-to-many-GPU optimizer smoke → immutable checkpoint → aligned offline evaluation → outcome classification → RRD/MCAP → inspected S3 publication → NPA agent viewer handoff; no rollout or statistical-learning claim |
+| [`isaac-franka-capture-reason.yaml`](testing/isaac-franka-capture-reason.yaml) | Headless Isaac Lab Franka RGB capture on GPU → hosted manipulation reasoning |
+| [`isaac-lab-rl-sweep.yaml`](testing/isaac-lab-rl-sweep.yaml) | **Parallel** GPU sweep (port of the `execution: parallel` SkyPilot template) + ranking barrier; submit with `--runtime` |
+| [`mjlab-eval.yaml`](testing/mjlab-eval.yaml) | MJLab locomotion eval |
+| [`openpi-pi05-four-mode.yaml`](testing/openpi-pi05-four-mode.yaml) | Connected OpenPI runtime graph: live negative gate, direct inference, private cross-pod ClusterIP serving, real pi0.5 LoRA optimizer/checkpoint smoke, and disjoint held-out evaluation; consumes the immutable digest built by `byof-openpi.yaml` ([guide](../docs/workbench/openpi-pi05-polaris.md)) |
+| [`openpi-pi05-full-droid-finetune.yaml`](testing/openpi-pi05-full-droid-finetune.yaml) | Complete upstream pi0.5 full-DROID recipe: checksum-synced RLDS 1.0.1 and preparation RRD, ten-million-frame normalization, fixed 100-update distributed qualification RRD, global batch 256, 100,000 updates on eight one-RTX-PRO-6000 nodes, durable resume, immutable checkpoint lineage, and verified progress RRD snapshots at 1k/10k/25k/50k/75k/100k ([guide](../docs/workbench/openpi-pi05-polaris.md)) |
+| [`retargeting.yaml`](testing/retargeting.yaml) | Motion retargeting |
+| [`rl-policy-training-sim-success.yaml`](testing/rl-policy-training-sim-success.yaml) | Isaac Lab RL train (partial) |
+| [`robocasa-data-policy.yaml`](testing/robocasa-data-policy.yaml) | Native multi-task PandaOmron trajectories → LeRobotDataset v3 → real ACT training → exact-checkpoint evaluation on disjoint RoboCasa tasks → insights |
+| [`robocasa-smoke.yaml`](testing/robocasa-smoke.yaml) | Native RoboCasa workbench: task registration, asset availability, headless EGL reset, and a real random rollout with video through the npa-robocasa service |
+| [`sonic-eval.yaml`](testing/sonic-eval.yaml) | SONIC eval |
+| [`sonic-export-eval.yaml`](testing/sonic-export-eval.yaml) | Export → eval |
+| [`sonic-export.yaml`](testing/sonic-export.yaml) | SONIC export |
+| [`sonic-locomotion-finetuning.yaml`](testing/sonic-locomotion-finetuning.yaml) | Retarget → train → mjlab |
+| [`sonic-train.yaml`](testing/sonic-train.yaml) | SONIC train |
+
+#### Data, perception, and scenario analysis
+
+| Spec | Notes |
+| --- | --- |
+| [`alpamayo2-super-inference.yaml`](testing/alpamayo2-super-inference.yaml) | Real Alpamayo 2 Super 34B trajectory inference on `B200:1`; runtime-only OpenMDW weights and separately gated PhysicalAI-AV sample data ([guide](../docs/workbench/alpamayo2-super.md)) |
+| [`adversarial-scenario-hardening.yaml`](testing/adversarial-scenario-hardening.yaml) | Adversarial scenario generation and ranking → policy hardening loop → promotion gate |
+| [`av-night-scene-hardening.yaml`](testing/av-night-scene-hardening.yaml) | AV night-scene hardening from diagram |
+| [`bdd100k-pipeline.yaml`](testing/bdd100k-pipeline.yaml) | 11-stage AV pipeline |
+| [`dataset-ingest-curate.yaml`](testing/dataset-ingest-curate.yaml) | Sensor-data ingest → validation gate → slice curation → queryable version registration |
+| [`dataset-of-record-smoke.yaml`](testing/dataset-of-record-smoke.yaml) | CPU dataset-of-record smoke using the manifest-backed query fallback |
+| [`hardening-with-insights.yaml`](testing/hardening-with-insights.yaml) | Adversarial hardening loop → policy publication → insights metrics, lineage, and dashboard |
+| [`insights-aggregate.yaml`](testing/insights-aggregate.yaml) | CPU aggregation of an existing run prefix → dashboard and static HTML |
+| [`insights-smoke.yaml`](testing/insights-smoke.yaml) | CPU fixture-run ingestion → comparison and dashboard artifacts |
+| [`scenario-gen-smoke.yaml`](testing/scenario-gen-smoke.yaml) | CPU adversarial scenario generation and ranking smoke |
+
+#### Bring your own framework
+
+| Spec | Notes |
+| --- | --- |
+| [`byof-droid-policy-learning.yaml`](testing/byof-droid-policy-learning.yaml) | OSS registry: DROID policy learning pinned image + RLDS config smoke |
+| [`byof-ltx2.yaml`](testing/byof-ltx2.yaml) | LTX-2.5 video generation and FiftyOne curation; source and gated weights fetched at runtime |
+| [`byof-maniskill.yaml`](testing/byof-maniskill.yaml) | OSS registry: ManiSkill pinned image + PickCube smoke |
+| [`byof-mujoco-playground.yaml`](testing/byof-mujoco-playground.yaml) | OSS registry: MuJoCo Playground pinned image + Cartpole smoke |
+| [`byof-open-dreamer.yaml`](testing/byof-open-dreamer.yaml) | Open Dreamer multi-GPU tokenizer and dynamics training on Minecraft/VPT data → action-conditioned dream rollout and Rerun evidence |
+| [`byof-openpi.yaml`](testing/byof-openpi.yaml) | OSS registry: OpenPI pi0.5 Polaris direct + WebSocket-served Franka joint-position inference on `B200:1`; runtime-only checkpoint and scoped Gemma gate ([guide](../docs/workbench/openpi-pi05-polaris.md)) |
+| [`byof-robocasa.yaml`](testing/byof-robocasa.yaml) | OSS registry: RoboCasa pinned image + headless kitchen-task smoke |
+| [`byof-wan2.2-multigpu.yaml`](testing/byof-wan2.2-multigpu.yaml) | Wan 2.2 generation across four participating GPU ranks; MP4, topology, and Rerun evidence |
+| [`byof-wan2.2.yaml`](testing/byof-wan2.2.yaml) | Wan 2.2 TI2V-5B on one RTX PRO 6000; decoded MP4 and verified Rerun evidence |
+| [`byof.yaml`](testing/byof.yaml) | BYOF via `run_byof_repo.py` |
+
+#### Hosted inference and VLM evaluation
+
+| Spec | Notes |
+| --- | --- |
+| [`token-factory-batch-generate.yaml`](testing/token-factory-batch-generate.yaml) | Hosted asynchronous batch text generation → generations JSONL |
+| [`token-factory-caption.yaml`](testing/token-factory-caption.yaml) | Hosted vision captioning; pass `--secret-env NEBIUS_TOKEN_FACTORY_KEY` |
+| [`token-factory-cosmos-reason.yaml`](testing/token-factory-cosmos-reason.yaml) | Hosted inference; pass `--secret-env NEBIUS_TOKEN_FACTORY_KEY` |
+| [`token-factory-gate-loop.yaml`](testing/token-factory-gate-loop.yaml) | Zero-GPU **runtime** gate loop: real early-exit + `goto` branch; submit with `--runtime` |
+| [`token-factory-generate.yaml`](testing/token-factory-generate.yaml) | Hosted inference; pass `--secret-env NEBIUS_TOKEN_FACTORY_KEY` |
+| [`token-factory-parallel-fanout.yaml`](testing/token-factory-parallel-fanout.yaml) | Zero-GPU **parallel** fan-out (JobGroup) + join barrier; submit with `--runtime` |
+| [`token-factory-trigger-watch.yaml`](testing/token-factory-trigger-watch.yaml) | Wait for frames in an inbox prefix → hosted vision captioning |
+| [`tokenfactory-cosmos-gate.yaml`](testing/tokenfactory-cosmos-gate.yaml) | Gate loop |
+| [`tokenfactory-rollout-judge-combo.yaml`](testing/tokenfactory-rollout-judge-combo.yaml) | LeRobot GPU rollout → hosted VLM evaluation |
+| [`tokenfactory-rollout-judge.yaml`](testing/tokenfactory-rollout-judge.yaml) | Reason → VLM chain |
+| [`tokenfactory-scene-to-rollout-judge.yaml`](testing/tokenfactory-scene-to-rollout-judge.yaml) | Hosted scene reasoning → GPU policy rollout → hosted VLM evaluation against the plan |
+| [`tokenfactory-train-triage.yaml`](testing/tokenfactory-train-triage.yaml) | LeRobot GPU policy training → hosted text triage of run artifacts |
+| [`vlm-eval-benchmark.yaml`](testing/vlm-eval-benchmark.yaml) | VLM benchmark |
+| [`vlm-eval-loop.yaml`](testing/vlm-eval-loop.yaml) | Self-hosted VLM rollout-set evaluation → aggregate task-success report |
+| [`vlm-eval-single.yaml`](testing/vlm-eval-single.yaml) | Self-hosted VLM eval |
+| [`vlm-eval-token-factory.yaml`](testing/vlm-eval-token-factory.yaml) | Hosted Token Factory VLM evaluation over a rollout prefix |
+
+#### Infrastructure and runtime examples
+
+| Spec | Notes |
+| --- | --- |
+| [`multi-node-probe.yaml`](testing/multi-node-probe.yaml) | Gang-scheduled multi-node stage with evidence from every rank |
+| [`sim2real-envgen-shards.yaml`](testing/sim2real-envgen-shards.yaml) | **DEMO ONLY** isolated envgen fan-out fixture |
+| [`sim2real-two-step-agent.yaml`](testing/sim2real-two-step-agent.yaml) | **DEMO ONLY** agent-generated two-state DSL fixture |
+| [`sim2real-two-step.yaml`](testing/sim2real-two-step.yaml) | **DEMO ONLY** two-state DSL fixture |
+| [`sonic-b300-routing-evidence.yaml`](testing/sonic-b300-routing-evidence.yaml) | CPU-only, fail-closed explicit B300 routing evidence with a time-structured RRD ([cookbook](../docs/workbench/cookbooks/sonic-b300-routing-evidence.md)) |
+
+The canonical Sim2Real spec is `workflows/main/sim2real.yaml`; it uses the same
+standard runtime as the other workflows. Its small `sim2real-*` fixtures do not
+substitute for a complete robot-learning run.
 
 ## Live GPU / CPU submit E2E
 
@@ -101,125 +230,8 @@ one-shot test verifies that assumed promotion is refused. Runtime validation
 downloads and fully decodes the source and generated videos, verifies their
 timelines and control hashes, and checks every downstream component report.
 
-## Layout
-
-- `main/` contains [sim2real.yaml](main/sim2real.yaml),
-  [paidf-cosmos3.yaml](main/paidf-cosmos3.yaml), and
-  [nurec-reconstruct.yaml](main/nurec-reconstruct.yaml).
-- `testing/` contains all other supported declarative workflow YAMLs, including
-  examples, integration workflows, and component validation pipelines.
-- [`guides/`](guides/README.md) contains setup and operating guides alongside
-  the catalog. It contains documentation, not executable workflow specs.
-- This README documents the catalog. The non-YAML robot specification example
-  lives with its [guide](../docs/workbench/guides/sim2real-robot-spec.md).
-
-Both workflow directories are discovered by the CLI, agent, and live-submit
-matrix. Raw SkyPilot examples and resource profiles remain in their guarded
-BYOF, burst, and NuRec homes; they are not part of this catalog.
-
-The Cosmos Transfer 2.5 Physical AI Data Factory blueprint remains available as
-[physical-ai-data-factory.yaml](testing/physical-ai-data-factory.yaml). Its
-[deploy guide](../docs/workbench/guides/physical-ai-data-factory-deploy.md)
-describes the real component and artifact contracts.
-
-## Spec catalog
-
-The tables list every checked-in spec in `main/` and `testing/`. A catalog
-entry describes the workflow contract; it does not establish live validation
-of every stage. Consult each guide and spec for prerequisites and evidence.
-
-### Main workflows
-
-| Spec | Notes |
-| --- | --- |
-| [`nurec-reconstruct.yaml`](main/nurec-reconstruct.yaml) | Real NCore V4 capture → 3DGUT training on an RT-core GPU → USDZ → rig-offset novel views → Rerun; [guide and measured evidence](../docs/workbench/guides/neural-reconstruction.md#promotion-evidence), [readiness record](main/nurec-reconstruct.readiness.json) |
-| [`paidf-cosmos3.yaml`](main/paidf-cosmos3.yaml) | Generic LeRobot/video input → prepared timeline → guarded Cosmos 3 full-video edge transfer → aligned evaluator gate/refinement → captions for every accepted variant → real Curator + FiftyOne Brain + Rerun ([guide](guides/paidf-cosmos3.md)) |
-| [`sim2real.yaml`](main/sim2real.yaml) | Canonical 14-stage Sim2Real workflow through the standard SkyPilot runtime ([guide](../docs/workbench/guides/sim2real-workflow.md)) |
-
-### Testing and reference workflows
-
-| Spec | Notes |
-| --- | --- |
-| [`adversarial-scenario-hardening.yaml`](testing/adversarial-scenario-hardening.yaml) | Adversarial scenario generation and ranking → policy hardening loop → promotion gate |
-| [`alpamayo2-super-inference.yaml`](testing/alpamayo2-super-inference.yaml) | Real Alpamayo 2 Super 34B trajectory inference on `B200:1`; runtime-only OpenMDW weights and separately gated PhysicalAI-AV sample data ([guide](../docs/workbench/alpamayo2-super.md)) |
-| [`av-night-scene-hardening.yaml`](testing/av-night-scene-hardening.yaml) | AV night-scene hardening from diagram |
-| [`bdd100k-pipeline.yaml`](testing/bdd100k-pipeline.yaml) | 11-stage AV pipeline |
-| [`byof-droid-policy-learning.yaml`](testing/byof-droid-policy-learning.yaml) | OSS registry: DROID policy learning pinned image + RLDS config smoke |
-| [`byof-ltx2.yaml`](testing/byof-ltx2.yaml) | LTX-2.5 video generation and FiftyOne curation; source and gated weights fetched at runtime |
-| [`byof-maniskill.yaml`](testing/byof-maniskill.yaml) | OSS registry: ManiSkill pinned image + PickCube smoke |
-| [`byof-mujoco-playground.yaml`](testing/byof-mujoco-playground.yaml) | OSS registry: MuJoCo Playground pinned image + Cartpole smoke |
-| [`byof-open-dreamer.yaml`](testing/byof-open-dreamer.yaml) | Open Dreamer multi-GPU tokenizer and dynamics training on Minecraft/VPT data → action-conditioned dream rollout and Rerun evidence |
-| [`byof-openpi.yaml`](testing/byof-openpi.yaml) | OSS registry: OpenPI pi0.5 Polaris direct + WebSocket-served Franka joint-position inference on `B200:1`; runtime-only checkpoint and scoped Gemma gate ([guide](../docs/workbench/openpi-pi05-polaris.md)) |
-| [`byof-robocasa.yaml`](testing/byof-robocasa.yaml) | OSS registry: RoboCasa pinned image + headless kitchen-task smoke |
-| [`byof-wan2.2-multigpu.yaml`](testing/byof-wan2.2-multigpu.yaml) | Wan 2.2 generation across four participating GPU ranks; MP4, topology, and Rerun evidence |
-| [`byof-wan2.2.yaml`](testing/byof-wan2.2.yaml) | Wan 2.2 TI2V-5B on one RTX PRO 6000; decoded MP4 and verified Rerun evidence |
-| [`byof.yaml`](testing/byof.yaml) | BYOF via `run_byof_repo.py` |
-| [`content-agents-rigid-object.yaml`](testing/content-agents-rigid-object.yaml) | NVIDIA Content Agents with a public image and runtime-fetched OVRTX: source USD → real Material/Physics Agents + OVRTX → upstream validation → rigid Isaac object USDZ/adapter ([guide](../docs/workbench/content-agents.md)) |
-| [`cosmos-fetch.yaml`](testing/cosmos-fetch.yaml) | Check Cosmos source/checkpoint access and materialize a local cache |
-| [`cosmos-synth-fanout-curation.yaml`](testing/cosmos-synth-fanout-curation.yaml) | Cosmos synth fan-out + curation |
-| [`cosmos2-transfer.yaml`](testing/cosmos2-transfer.yaml) | Standalone Cosmos Transfer 2.5 GPU augmentation → video and frames |
-| [`cosmos3-checkpoint-eval.yaml`](testing/cosmos3-checkpoint-eval.yaml) | B200-only guarded Cosmos3 still-image checkpoint evaluation |
-| [`cosmos3-generate.yaml`](testing/cosmos3-generate.yaml) | Cosmos3-Nano image generation with default guardrails; gated guardrail assets require HF access |
-| [`cosmos3-ray-batch.yaml`](testing/cosmos3-ray-batch.yaml) | Prepared SDG batch through an existing Cosmos3-Nano Ray Serve deployment → media and provenance |
-| [`cosmos3-reason.yaml`](testing/cosmos3-reason.yaml) | Cosmos3 reason |
-| [`cosmos3-super-b200-benchmark.yaml`](testing/cosmos3-super-b200-benchmark.yaml) | Cosmos3-Super serving benchmark on one eight-GPU B200 node |
-| [`cosmos3-super-h200-benchmark.yaml`](testing/cosmos3-super-h200-benchmark.yaml) | Cosmos3-Super serving benchmark on one eight-GPU H200 node |
-| [`cosmos3-super-h200-single-gpu.yaml`](testing/cosmos3-super-h200-single-gpu.yaml) | Isolated Cosmos3-Super TP-1 validation on one H200; distinct from node-throughput benchmarks |
-| [`cosmos3-text-to-image.yaml`](testing/cosmos3-text-to-image.yaml) | Public Cosmos3-Nano image generation with guardrails disabled → verified image and manifest |
-| [`curobo-benchmark.yaml`](testing/curobo-benchmark.yaml) | Complete pinned MotionBenchMaker and MPiNets benchmark in cuRobo V2 kinematic and payload-dynamics modes; image remains publication-quarantined pending image checks and real GPU validation ([guide](../docs/workbench/curobo.md)) |
-| [`dataset-ingest-curate.yaml`](testing/dataset-ingest-curate.yaml) | Sensor-data ingest → validation gate → slice curation → queryable version registration |
-| [`dataset-of-record-smoke.yaml`](testing/dataset-of-record-smoke.yaml) | CPU dataset-of-record smoke using the manifest-backed query fallback |
-| [`groot-1-7-finetune.yaml`](testing/groot-1-7-finetune.yaml) | Real GR00T data → parameterized 1-to-many-GPU optimizer smoke → immutable checkpoint → aligned offline evaluation → outcome classification → RRD/MCAP → inspected S3 publication → NPA agent viewer handoff; no rollout or statistical-learning claim |
-| [`hardening-with-insights.yaml`](testing/hardening-with-insights.yaml) | Adversarial hardening loop → policy publication → insights metrics, lineage, and dashboard |
-| [`insights-aggregate.yaml`](testing/insights-aggregate.yaml) | CPU aggregation of an existing run prefix → dashboard and static HTML |
-| [`insights-smoke.yaml`](testing/insights-smoke.yaml) | CPU fixture-run ingestion → comparison and dashboard artifacts |
-| [`isaac-franka-capture-reason.yaml`](testing/isaac-franka-capture-reason.yaml) | Headless Isaac Lab Franka RGB capture on GPU → hosted manipulation reasoning |
-| [`isaac-lab-rl-sweep.yaml`](testing/isaac-lab-rl-sweep.yaml) | **Parallel** GPU sweep (port of the `execution: parallel` SkyPilot template) + ranking barrier; submit with `--runtime` |
-| [`mjlab-eval.yaml`](testing/mjlab-eval.yaml) | MJLab locomotion eval |
-| [`multi-node-probe.yaml`](testing/multi-node-probe.yaml) | Gang-scheduled multi-node stage with evidence from every rank |
-| [`nurec-colmap-reconstruct.yaml`](testing/nurec-colmap-reconstruct.yaml) | Full COLMAP source -> Apache-2.0 NCore CPU conversion -> separately licensed NRE full-default reconstruction/render on RTX PRO 6000 -> Rerun -> final report; not yet live validated ([guide](../docs/workbench/guides/nurec-colmap-reconstruct.md)) |
-| [`openpi-pi05-four-mode.yaml`](testing/openpi-pi05-four-mode.yaml) | Connected OpenPI runtime graph: live negative gate, direct inference, private cross-pod ClusterIP serving, real pi0.5 LoRA optimizer/checkpoint smoke, and disjoint held-out evaluation; consumes the immutable digest built by `byof-openpi.yaml` ([guide](../docs/workbench/openpi-pi05-polaris.md)) |
-| [`openpi-pi05-full-droid-finetune.yaml`](testing/openpi-pi05-full-droid-finetune.yaml) | Complete upstream pi0.5 full-DROID recipe: checksum-synced RLDS 1.0.1 and preparation RRD, ten-million-frame normalization, fixed 100-update distributed qualification RRD, global batch 256, 100,000 updates on eight one-RTX-PRO-6000 nodes, durable resume, immutable checkpoint lineage, and verified progress RRD snapshots at 1k/10k/25k/50k/75k/100k ([guide](../docs/workbench/openpi-pi05-polaris.md)) |
-| [`physical-ai-data-factory.yaml`](testing/physical-ai-data-factory.yaml) | Cosmos Transfer 2.5 PAIDF blueprint ([deploy guide](../docs/workbench/guides/physical-ai-data-factory-deploy.md)) |
-| [`retargeting.yaml`](testing/retargeting.yaml) | Motion retargeting |
-| [`rl-policy-training-sim-success.yaml`](testing/rl-policy-training-sim-success.yaml) | Isaac Lab RL train (partial) |
-| [`robocasa-data-policy.yaml`](testing/robocasa-data-policy.yaml) | Native multi-task PandaOmron trajectories → LeRobotDataset v3 → real ACT training → exact-checkpoint evaluation on disjoint RoboCasa tasks → insights |
-| [`robocasa-smoke.yaml`](testing/robocasa-smoke.yaml) | Native RoboCasa workbench: task registration, asset availability, headless EGL reset, and a real random rollout with video through the npa-robocasa service |
-| [`scenario-gen-smoke.yaml`](testing/scenario-gen-smoke.yaml) | CPU adversarial scenario generation and ranking smoke |
-| [`sim2real-envgen-shards.yaml`](testing/sim2real-envgen-shards.yaml) | **DEMO ONLY** isolated envgen fan-out fixture |
-| [`sim2real-two-step-agent.yaml`](testing/sim2real-two-step-agent.yaml) | **DEMO ONLY** agent-generated two-state DSL fixture |
-| [`sim2real-two-step.yaml`](testing/sim2real-two-step.yaml) | **DEMO ONLY** two-state DSL fixture |
-| [`sonic-b300-routing-evidence.yaml`](testing/sonic-b300-routing-evidence.yaml) | CPU-only, fail-closed explicit B300 routing evidence with a time-structured RRD ([cookbook](../docs/workbench/cookbooks/sonic-b300-routing-evidence.md)) |
-| [`sonic-eval.yaml`](testing/sonic-eval.yaml) | SONIC eval |
-| [`sonic-export-eval.yaml`](testing/sonic-export-eval.yaml) | Export → eval |
-| [`sonic-export.yaml`](testing/sonic-export.yaml) | SONIC export |
-| [`sonic-locomotion-finetuning.yaml`](testing/sonic-locomotion-finetuning.yaml) | Retarget → train → mjlab |
-| [`sonic-train.yaml`](testing/sonic-train.yaml) | SONIC train |
-| [`token-factory-batch-generate.yaml`](testing/token-factory-batch-generate.yaml) | Hosted asynchronous batch text generation → generations JSONL |
-| [`token-factory-caption.yaml`](testing/token-factory-caption.yaml) | Hosted vision captioning; pass `--secret-env NEBIUS_TOKEN_FACTORY_KEY` |
-| [`token-factory-cosmos-reason.yaml`](testing/token-factory-cosmos-reason.yaml) | Hosted inference; pass `--secret-env NEBIUS_TOKEN_FACTORY_KEY` |
-| [`token-factory-gate-loop.yaml`](testing/token-factory-gate-loop.yaml) | Zero-GPU **runtime** gate loop: real early-exit + `goto` branch; submit with `--runtime` |
-| [`token-factory-generate.yaml`](testing/token-factory-generate.yaml) | Hosted inference; pass `--secret-env NEBIUS_TOKEN_FACTORY_KEY` |
-| [`token-factory-parallel-fanout.yaml`](testing/token-factory-parallel-fanout.yaml) | Zero-GPU **parallel** fan-out (JobGroup) + join barrier; submit with `--runtime` |
-| [`token-factory-trigger-watch.yaml`](testing/token-factory-trigger-watch.yaml) | Wait for frames in an inbox prefix → hosted vision captioning |
-| [`tokenfactory-cosmos-gate.yaml`](testing/tokenfactory-cosmos-gate.yaml) | Gate loop |
-| [`tokenfactory-rollout-judge-combo.yaml`](testing/tokenfactory-rollout-judge-combo.yaml) | LeRobot GPU rollout → hosted VLM evaluation |
-| [`tokenfactory-rollout-judge.yaml`](testing/tokenfactory-rollout-judge.yaml) | Reason → VLM chain |
-| [`tokenfactory-scene-to-rollout-judge.yaml`](testing/tokenfactory-scene-to-rollout-judge.yaml) | Hosted scene reasoning → GPU policy rollout → hosted VLM evaluation against the plan |
-| [`tokenfactory-train-triage.yaml`](testing/tokenfactory-train-triage.yaml) | LeRobot GPU policy training → hosted text triage of run artifacts |
-| [`vlm-eval-benchmark.yaml`](testing/vlm-eval-benchmark.yaml) | VLM benchmark |
-| [`vlm-eval-loop.yaml`](testing/vlm-eval-loop.yaml) | Self-hosted VLM rollout-set evaluation → aggregate task-success report |
-| [`vlm-eval-single.yaml`](testing/vlm-eval-single.yaml) | Self-hosted VLM eval |
-| [`vlm-eval-token-factory.yaml`](testing/vlm-eval-token-factory.yaml) | Hosted Token Factory VLM evaluation over a rollout prefix |
-
-The single canonical Sim2Real YAML is
-`workflows/main/sim2real.yaml`. It is planned, rendered,
-submitted, and resumed by the same standard `npa.workflow` + SkyPilot runtime as
-every other spec; there is no filename detector or direct-Kubernetes bypass.
-
 ## Further reading
 
-- [Workflow guides](guides/README.md): setup and operating instructions.
-- [Workflow authoring and runtime](../docs/workbench/npa-workflow-guide.md).
-- [Tool catalog](../docs/workbench/npa-workflow-tool-catalog.md).
-- [GR00T training cookbook](../docs/workbench/cookbooks/groot-1-7-training.md).
+- [Workflow runbooks](guides/README.md) and [robot guides](../docs/workbench/guides/README.md).
+- [Tool catalog](../docs/workbench/npa-workflow-tool-catalog.md) and [authoring reference](../docs/workbench/npa-workflow-guide.md).
+- Agent skills: [author a workflow](../skills/workflows/author-npa-workflow/SKILL.md) or [design a pipeline](../skills/workflows/generate-npa-workflow/SKILL.md).

--- a/workflows/guides/README.md
+++ b/workflows/guides/README.md
@@ -1,14 +1,26 @@
-# Workflow guides
+# Workflow runbooks
 
-Follow these guides from setup through submission, monitoring, and output
-inspection. Run their commands from the repository root; workflow specifications
-live in [`../main/`](../main/) and [`../testing/`](../testing/).
+[Workflow catalog](../README.md) · [Workbench guides](../../docs/workbench/guides/README.md)
 
-| Workflow | Guide |
-| --- | --- |
-| [PAIDF with Cosmos 3](../main/paidf-cosmos3.yaml) | [PAIDF Cosmos 3 setup and run guide](paidf-cosmos3.md): project and cluster setup, credentials, runtime submission, troubleshooting, and Rerun evidence |
+Use a runbook to prepare inputs, provision the right compute, submit a workflow,
+and inspect its outputs. YAML files alone contain placeholder storage and may
+require images or model access that you must prepare first.
 
-See the [workflow catalog](../README.md) for all specifications and the
-[Workbench guide index](../../docs/workbench/guides/README.md) for other tool and
-workflow references. Each guide records the scope and limitations of its live
-validation.
+| Result | Runbook | Input and output |
+| --- | --- | --- |
+| Source-conditioned video augmentation | [PAIDF + Cosmos 3](paidf-cosmos3.md) | Public starter, local MP4, or one LeRobot episode/camera → generated variants, evaluation, curation, and Rerun |
+| A labeled dataset | [Physical AI Data Factory](../../docs/workbench/guides/physical-ai-data-factory-deploy.md) | Source video → Cosmos Transfer augmentation, labels, curation, and recording |
+| 3D reconstruction | [NuRec](../../docs/workbench/guides/neural-reconstruction.md) | Sensor capture → scene USDZ, novel views, and Rerun |
+| Robot-learning pipeline | [Sim2Real](../../docs/workbench/guides/sim2real-workflow.md) | Task-aligned trigger and prepared images → training/evaluation and review artifacts |
+
+For PAIDF + Cosmos 3, jump directly to
+[local MP4 input](paidf-cosmos3.md#r3b-run-the-full-pipeline-from-a-local-mp4),
+[LeRobot input](paidf-cosmos3.md#r3a-augment-one-lerobot-episode-and-camera), or
+[generation and acceptance settings](paidf-cosmos3.md#r5-find-and-change-generation-and-evaluation-settings)
+after completing its shared setup.
+
+To create a new workflow, use the
+[authoring guide](../../docs/workbench/npa-workflow-guide.md) and
+[tool catalog](../../docs/workbench/npa-workflow-tool-catalog.md). Validate and
+plan locally before attempting cloud execution. After a run, preserve its ID
+and inspect the declared outputs before [cleanup](../../docs/teardown.md).

--- a/workflows/guides/paidf-cosmos3.md
+++ b/workflows/guides/paidf-cosmos3.md
@@ -275,6 +275,10 @@ npa provision-if-absent --project "$PROJECT_ALIAS" --cluster-name "$CLUSTER_NAME
   --dry-run --output-format json
 ```
 
+Check `status` and `preflight.decision`: a dry run can exit zero while reporting
+`blocked`. Resolve the listed `preflight.reasons` first; reserved GPU capacity
+does not replace the boot-disk quota required by the cluster.
+
 Check the project, region, node types, and disk sizes in the plan. When they
 match your intended setup and quota, run the same `provision-if-absent` command
 without `--dry-run --output-format json`. Wait for provisioning and node health


### PR DESCRIPTION
New users were following incomplete command snippets, conflicting runtime guidance, and long operator notes before reaching a usable result. This rewrites all 32 maintained READMEs around prerequisites, the first run, expected artifacts, recovery, and cleanup. The READMEs are 777 lines shorter; detailed contracts and historical measurements remain in linked references.

- Reorganize setup, workload selection, workflow catalogs, Ray examples, BYOF, container READMEs, and operational guides. Explain structural smokes, training checkpoints, and measured task quality separately.
- Correct stale commands, flags, workflow variables, working directories, remote-home expansion, GPU requirements, and shell-placeholder quoting. Document blocked provisioning previews and full-suite Linux prerequisites.
- Add offline checks for local Markdown links/anchors, shell and Python syntax, CLI commands/options, workflow variables, and the actual package README planning example. Register the checks in the contributor failure index and update the existing NuRec/Ray Tune documentation assertions.

Validation completed:

- 3,396 repository guardrails passed; 772 focused documentation/tool tests passed; Ruff and test collection passed.
- All 32 accepted public image digests verified anonymously; all 16 external README links resolved.
- Isaac BYOF README commands rendered successfully for L40S and RTX PRO 6000, both image-only and custom-entrypoint variants.
- Local native Ray Tune completed three trials, recovered one interrupted trial, and verified all three report artifacts.
- A fresh task-owned Nebius CPU fleet passed the existing KubeRay live test. The guide's native Ray CLI commands also succeeded through authenticated loopback forwarding, verifying distinct worker placement and both deterministic results.

The full Linux `make test` run passed: 20,633 passed, 122 skipped, and one xpassed. It used standard CPython 3.12, the CPU checkpoint/export dependencies, and the documented private umask; no tests were excluded beyond the normal Makefile marker filter. After the final small README/test-isolation edits, the cloud focused run passed 648 tests with one skip. Cloud cleanup is complete: the task-owned cluster, VM, disk, bucket, storage IAM, network, and project were deleted and verified absent. Final GitHub CI passed: 20,662 passed, 532 skipped, and one xpassed; coverage 75.99%. All 21 applicable checks succeeded. The built-image job was conditionally skipped because no image was built. GPU provisioning was blocked by block-storage quota, so this update makes no new GPU-training or generation-validation claim. Exact infrastructure and credential evidence remains outside the repository and PR.
