### PR TITLE
Make workbench health preflight project-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ A few highlights:
 - **`health preflight`** — validates HF / NGC / S3 / Token Factory before a
   deploy or a GPU job. Use `npa workbench health preflight --project <alias>
   --checks s3,nebius` to check the selected project's storage and your current
-  Nebius CLI authentication. Without `--project`, S3 uses the existing host
+  Nebius CLI authentication. Missing project storage fails without borrowing
+  shell or host credentials. Without `--project`, S3 uses the existing host
   credential selection. The S3 check makes one listing request; it does not
   enumerate your dataset or verify write access.
 - **`foxglove`** — packs run frames, metrics, and logs into MCAP for the

--- a/README.md
+++ b/README.md
@@ -225,7 +225,11 @@ A few highlights:
 - **`vlm-eval`** — scores rollouts with API or self-hosted vLLM backends; see
   [`vlm-eval-single.yaml`](workflows/testing/vlm-eval-single.yaml).
 - **`health preflight`** — validates HF / NGC / S3 / Token Factory before a
-  deploy or a GPU job.
+  deploy or a GPU job. Use `npa workbench health preflight --project <alias>
+  --checks s3,nebius` to check the selected project's storage and your current
+  Nebius CLI authentication. Without `--project`, S3 uses the existing host
+  credential selection. The S3 check makes one listing request; it does not
+  enumerate your dataset or verify write access.
 - **`foxglove`** — packs run frames, metrics, and logs into MCAP for the
   embedded viewer ([CLI](docs/cli/foxglove.md) ·
   [export contract](docs/workbench/foxglove-export.md)).

--- a/npa/src/npa/cli/workbench/health.py
+++ b/npa/src/npa/cli/workbench/health.py
@@ -11,18 +11,20 @@ import os
 import shutil
 import sys
 import webbrowser
+from dataclasses import replace
 from pathlib import Path
 from typing import Optional
 
 import typer
 
-from npa.clients.credentials import load_credentials
+from npa.clients.config import ConfigError, list_projects, resolve_project_storage
+from npa.clients.credentials import CredentialsConfig, load_credentials
 from npa.clients.huggingface import validate_hf_access, validate_hf_identity
 from npa.clients.kube import run_kubectl
 from npa.clients.nebius_auth import ProfileVerification, nebius_profile, verify_profile
 from npa.clients.storage import StorageClient
 from npa.guardrails.skypilot import inspect_image_exists
-from npa.lifecycle_intent import json_stdout_contract
+from npa.lifecycle_intent import OperationIntent, intent_boundary, json_stdout_contract
 from npa.workflows.credential_preflight import (
     DEFAULT_CREDENTIAL_CHECKS,
     SUPPORTED_CREDENTIAL_CHECKS,
@@ -31,6 +33,7 @@ from npa.workflows.credential_preflight import (
 )
 from npa.workflows.sim2real_health import (
     ALL_CHECKS,
+    CheckResult,
     DoctorProbes,
     FAIL,
     KubeResult,
@@ -54,6 +57,14 @@ app = typer.Typer(
 )
 
 _STATUS_ICON = {PASS: "PASS", WARN: "WARN", FAIL: "FAIL", SKIP: "SKIP"}
+_PREFLIGHT_CHECKS_HELP = (
+    "Comma-separated checks to run, or 'all'. "
+    f"Choices: all, {', '.join(SUPPORTED_CREDENTIAL_CHECKS)}."
+)
+_PREFLIGHT_OFFLINE_HELP = (
+    "Skip live provider probes; credential checks use presence only and "
+    "Nebius CLI authentication is skipped."
+)
 
 
 def _repo_root() -> Path:
@@ -121,37 +132,7 @@ def _nebius_profile_verifier() -> ProfileVerification:
     return verify_profile(nebius_profile())
 
 
-@app.command("preflight")
-@json_stdout_contract
-def preflight_command(
-    checks: str = typer.Option(
-        ",".join(DEFAULT_CREDENTIAL_CHECKS),
-        "--checks",
-        help=(
-            "Comma-separated checks to run, or 'all'. "
-            f"Choices: all, {', '.join(SUPPORTED_CREDENTIAL_CHECKS)}."
-        ),
-    ),
-    offline: bool = typer.Option(
-        False,
-        "--offline",
-        help=(
-            "Skip live provider probes; credential checks use presence only and "
-            "Nebius CLI authentication is skipped."
-        ),
-    ),
-    warn_only: bool = typer.Option(
-        False, "--warn-only", help="Exit 0 even when a check fails."
-    ),
-    output_json: bool = typer.Option(False, "--json", help="Print the report as JSON."),
-) -> None:
-    """Validate service credentials and optional Nebius CLI authentication.
-
-    A single PASS/WARN/FAIL/SKIP report over the credentials nearly every
-    workbench tool needs, so cold-start credential gaps surface here instead of
-    mid-run. Exits non-zero on any FAIL unless ``--warn-only`` is passed.
-    """
-
+def _selected_checks(checks: str) -> list[str]:
     selected = list(dict.fromkeys(item.strip() for item in checks.split(",") if item.strip()))
     if not selected:
         raise typer.BadParameter("select at least one check or 'all'.", param_hint="--checks")
@@ -164,28 +145,107 @@ def preflight_command(
             f"{', '.join(unknown)}. Choices: all, {', '.join(SUPPORTED_CREDENTIAL_CHECKS)}.",
             param_hint="--checks",
         )
-    if "all" in selected:
-        selected = list(SUPPORTED_CREDENTIAL_CHECKS)
+    return list(SUPPORTED_CREDENTIAL_CHECKS) if "all" in selected else selected
 
-    credentials = load_credentials()
+
+def _project_credentials(project: str, credentials: CredentialsConfig) -> CredentialsConfig:
+    if project not in list_projects():
+        raise ConfigError("Unknown project alias. Pass an alias saved by `npa configure`.")
+    storage = resolve_project_storage(project, include_shared_credentials=False)
+    if not all((
+        storage.checkpoint_bucket, storage.endpoint_url,
+        storage.aws_access_key_id, storage.aws_secret_access_key,
+    )):
+        raise ConfigError("Configure a bucket, endpoint, and S3 key pair for this project.")
+    bucket = storage.checkpoint_bucket
+    if "://" not in bucket:
+        bucket = f"s3://{bucket}"
+    return replace(
+        credentials,
+        s3_bucket=bucket,
+        s3_endpoint=storage.endpoint_url,
+        s3_access_key_id=storage.aws_access_key_id,
+        s3_secret_access_key=storage.aws_secret_access_key,
+    )
+
+
+def _credential_probes(credentials: CredentialsConfig, *, offline: bool) -> CredentialProbes:
     if offline:
-        probes = CredentialProbes()
-    else:
-        probes = CredentialProbes(
-            hf_validator=validate_hf_identity,
-            ngc_validator=_ngc_auth_verifier,
-            # Probe with the resolved credentials (endpoint/keys often live in
-            # ~/.npa rather than the process env), not env-only defaults.
-            s3_client_factory=lambda: StorageClient.from_environment(
-                endpoint_url=credentials.s3_endpoint,
-                aws_access_key_id=credentials.s3_access_key_id,
-                aws_secret_access_key=credentials.s3_secret_access_key,
-            ),
-            token_factory_verifier=_token_factory_verifier,
-            nebius_profile_verifier=_nebius_profile_verifier,
-        )
+        return CredentialProbes()
+    return CredentialProbes(
+        hf_validator=validate_hf_identity,
+        ngc_validator=_ngc_auth_verifier,
+        s3_client_factory=lambda: StorageClient.from_environment(
+            endpoint_url=credentials.s3_endpoint,
+            aws_access_key_id=credentials.s3_access_key_id,
+            aws_secret_access_key=credentials.s3_secret_access_key,
+        ),
+        token_factory_verifier=_token_factory_verifier,
+        nebius_profile_verifier=_nebius_profile_verifier,
+    )
 
-    results = run_credential_preflight(credentials, probes=probes, checks=selected)
+
+def _credential_results(checks: list[str], *, project: str, offline: bool) -> list[CheckResult]:
+    credentials = load_credentials()
+    storage_failure = None
+    if project and "s3" in checks:
+        try:
+            credentials = _project_credentials(project, credentials)
+        except ConfigError as exc:
+            storage_failure = CheckResult(
+                name="s3", status=FAIL,
+                summary="Selected project storage is not configured.", remedy=str(exc),
+            )
+    probe_checks = [name for name in checks if not (storage_failure and name == "s3")]
+    results = run_credential_preflight(
+        credentials, probes=_credential_probes(credentials, offline=offline), checks=probe_checks,
+    )
+    by_name = {result.name: result for result in results}
+    if storage_failure:
+        by_name["s3"] = storage_failure
+    return [by_name[name] for name in checks]
+
+
+@app.command(
+    "preflight", help="Validate service credentials and optional Nebius CLI authentication.",
+)
+@intent_boundary(OperationIntent.OBSERVE)
+@json_stdout_contract
+def preflight_command(
+    project: str = typer.Option(
+        "", "--project", "-p",
+        help="Configured project alias for the S3 check; other checks keep their credential selection.",
+    ),
+    checks: str = typer.Option(
+        ",".join(DEFAULT_CREDENTIAL_CHECKS), "--checks", help=_PREFLIGHT_CHECKS_HELP,
+    ),
+    offline: bool = typer.Option(
+        False, "--offline", help=_PREFLIGHT_OFFLINE_HELP,
+    ),
+    warn_only: bool = typer.Option(
+        False, "--warn-only", help="Exit 0 even when a check fails."
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Print the report as JSON."),
+) -> None:
+    """Validate service credentials and optional Nebius CLI authentication.
+
+    Args:
+        project: Optional configured project alias for the S3 check.
+        checks: Comma-separated checks or all.
+        offline: Report presence without provider requests.
+        warn_only: Return success even when a check fails.
+        output_json: Emit one JSON report instead of text.
+
+    Returns:
+        None.
+
+    Raises:
+        typer.BadParameter: The check selection is invalid.
+        typer.Exit: A check failed and warn_only is false.
+    """
+    results = _credential_results(
+        _selected_checks(checks), project=project.strip(), offline=offline,
+    )
     _emit_results(results, output_json=output_json)
 
     if has_failure(results) and not warn_only:

--- a/npa/src/npa/cli/workbench/health.py
+++ b/npa/src/npa/cli/workbench/health.py
@@ -22,6 +22,7 @@ from npa.clients.credentials import CredentialsConfig, load_credentials
 from npa.clients.huggingface import validate_hf_access, validate_hf_identity
 from npa.clients.kube import run_kubectl
 from npa.clients.nebius_auth import ProfileVerification, nebius_profile, verify_profile
+from npa.clients.project_credential_store import ProjectCredentialStoreError
 from npa.clients.storage import StorageClient
 from npa.guardrails.skypilot import inspect_image_exists
 from npa.lifecycle_intent import OperationIntent, intent_boundary, json_stdout_contract
@@ -151,7 +152,9 @@ def _selected_checks(checks: str) -> list[str]:
 def _project_credentials(project: str, credentials: CredentialsConfig) -> CredentialsConfig:
     if project not in list_projects():
         raise ConfigError("Unknown project alias. Pass an alias saved by `npa configure`.")
-    storage = resolve_project_storage(project, include_shared_credentials=False)
+    storage = resolve_project_storage(
+        project, include_shared_credentials=False, include_environment=False,
+    )
     if not all((
         storage.checkpoint_bucket, storage.endpoint_url,
         storage.aws_access_key_id, storage.aws_secret_access_key,
@@ -191,7 +194,7 @@ def _credential_results(checks: list[str], *, project: str, offline: bool) -> li
     if project and "s3" in checks:
         try:
             credentials = _project_credentials(project, credentials)
-        except ConfigError as exc:
+        except (ConfigError, ProjectCredentialStoreError) as exc:
             storage_failure = CheckResult(
                 name="s3", status=FAIL,
                 summary="Selected project storage is not configured.", remedy=str(exc),

--- a/npa/src/npa/clients/config.py
+++ b/npa/src/npa/clients/config.py
@@ -1456,6 +1456,7 @@ def resolve_project_storage(
     project: str | None = None,
     *,
     include_shared_credentials: bool = True,
+    include_environment: bool = True,
 ) -> StorageConfig:
     """Resolve project-level object storage settings.
 
@@ -1466,6 +1467,19 @@ def resolve_project_storage(
     workflows that only need a writable default bucket. Exact-project
     credential-store records are selected atomically: a partial record is
     ignored rather than mixed with routing or key fields from another source.
+
+    Args:
+        project: Configured project alias, or the saved default when omitted.
+        include_shared_credentials: Allow fallback to host credential files.
+        include_environment: Allow fallback to process S3 settings. Disable with
+            include_shared_credentials for readiness of saved project storage.
+
+    Returns:
+        Storage settings resolved from the permitted sources.
+
+    Raises:
+        ConfigError: The saved configuration cannot be read.
+        ProjectCredentialStoreError: The project credential store is invalid.
     """
     yml = _load_yaml()
     try:
@@ -1572,16 +1586,17 @@ def resolve_project_storage(
             return value
         return default
 
-    env_bucket = os.environ.get("NPA_CHECKPOINT_BUCKET", "") or os.environ.get(
+    environment = os.environ if include_environment else {}
+    env_bucket = environment.get("NPA_CHECKPOINT_BUCKET", "") or environment.get(
         "NEBIUS_S3_BUCKET", ""
     )
     env_endpoint = (
-        os.environ.get("AWS_ENDPOINT_URL", "")
-        or os.environ.get("NEBIUS_S3_ENDPOINT", "")
-        or os.environ.get("NPA_STORAGE_ENDPOINT", "")
+        environment.get("AWS_ENDPOINT_URL", "")
+        or environment.get("NEBIUS_S3_ENDPOINT", "")
+        or environment.get("NPA_STORAGE_ENDPOINT", "")
     )
-    env_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
-    env_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+    env_access_key = environment.get("AWS_ACCESS_KEY_ID", "")
+    env_secret_key = environment.get("AWS_SECRET_ACCESS_KEY", "")
 
     # Shared credentials are host-scoped. The scoped config stanza remains
     # primary; shared values are only a fallback for projects without an exact

--- a/npa/src/npa/clients/storage.py
+++ b/npa/src/npa/clients/storage.py
@@ -145,6 +145,25 @@ class StorageClient:
             or os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
         )
 
+    def probe_list_access(self, bucket_uri: str) -> None:
+        """Verify listing permission with one request, including for empty buckets.
+
+        Args:
+            bucket_uri: S3 bucket or directory URI whose listing permission to test.
+
+        Returns:
+            None. Object names and continuation tokens are discarded.
+
+        Raises:
+            StorageError: The destination is not an S3 URI.
+            botocore.exceptions.BotoCoreError: The request could not complete.
+            ClientError: The service rejected the listing request.
+        """
+        bucket, prefix = _parse_bucket_uri(bucket_uri)
+        if prefix and not prefix.endswith("/"):
+            prefix += "/"
+        self._s3.list_objects_v2(Bucket=bucket, Prefix=prefix, Delimiter="/", MaxKeys=1)
+
     def list_checkpoints(self, bucket_uri: str) -> list[dict[str, str]]:
         """List checkpoint directories under the given S3 URI."""
         bucket, prefix = _parse_bucket_uri(bucket_uri)

--- a/npa/src/npa/workflows/credential_preflight.py
+++ b/npa/src/npa/workflows/credential_preflight.py
@@ -204,7 +204,7 @@ def check_s3(credentials: Any, probes: CredentialProbes) -> CheckResult:
         )
     try:
         client = probes.s3_client_factory()
-        client.list_checkpoints(bucket)
+        client.probe_list_access(bucket)
     except Exception as exc:  # noqa: BLE001 - surface any reachability/auth error
         text = str(exc)
         remedy = (

--- a/npa/tests/cli/test_health_project_preflight.py
+++ b/npa/tests/cli/test_health_project_preflight.py
@@ -1,0 +1,180 @@
+"""Exercise project-selected health checks with real configuration parsing."""
+
+import json
+from dataclasses import replace
+from unittest.mock import Mock
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from npa.cli.main import app
+from npa.cli.workbench import health
+from npa.clients import config, credentials
+
+
+@pytest.fixture
+def project_files():
+    config.CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    config.CONFIG_PATH.write_text(
+        yaml.safe_dump(
+            {
+                "default_project": "other",
+                "projects": {
+                    "target": {"project_id": "project-target"},
+                    "other": {"project_id": "project-other"},
+                },
+            }
+        )
+    )
+    data = {
+        "storage": {
+            "bucket": "s3://host-bucket",
+            "endpoint": "https://host.invalid",
+            "access_key_id": "host-access",
+            "secret_access_key": "host-secret",
+        },
+        "project_credentials": {
+            "schema_version": "npa.project-credentials.v2",
+            "projects": {
+                "project-target": {
+                    "storage": {
+                        "bucket": "target-bucket/results",
+                        "endpoint_url": "https://target.invalid",
+                        "aws_access_key_id": "target-access",
+                        "aws_secret_access_key": "target-secret",
+                    }
+                }
+            },
+        },
+    }
+    credentials.CREDENTIALS_PATH.write_text(yaml.safe_dump(data))
+    credentials.CREDENTIALS_PATH.chmod(0o600)
+    return data
+
+
+def _invoke(*options):
+    return CliRunner().invoke(
+        app,
+        [
+            "workbench",
+            "health",
+            "preflight",
+            "--checks",
+            "s3",
+            "--json",
+            *options,
+        ],
+    )
+
+
+def test_project_probe_uses_exact_record_and_preserves_files(
+    project_files, monkeypatch
+):
+    before = [
+        path.read_bytes() for path in (config.CONFIG_PATH, credentials.CREDENTIALS_PATH)
+    ]
+    client = Mock()
+    factory = Mock(return_value=client)
+    monkeypatch.setattr(health.StorageClient, "from_environment", factory)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "unrelated-access")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "unrelated-secret")
+    monkeypatch.setenv("NEBIUS_S3_BUCKET", "s3://unrelated-bucket")
+    result = _invoke("--project", "target")
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["ok"] is True
+    factory.assert_called_once_with(
+        endpoint_url="https://target.invalid",
+        aws_access_key_id="target-access",
+        aws_secret_access_key="target-secret",
+    )
+    client.probe_list_access.assert_called_once_with("s3://target-bucket/results")
+    client.list_checkpoints.assert_not_called()
+    assert before == [
+        path.read_bytes() for path in (config.CONFIG_PATH, credentials.CREDENTIALS_PATH)
+    ]
+    assert "target-secret" not in result.output
+
+
+@pytest.mark.parametrize(
+    "missing", ["bucket", "endpoint_url", "aws_access_key_id", "aws_secret_access_key"]
+)
+def test_partial_project_storage_does_not_use_host_credentials(
+    project_files, monkeypatch, missing
+):
+    project_files["project_credentials"]["projects"]["project-target"]["storage"].pop(
+        missing
+    )
+    credentials.CREDENTIALS_PATH.write_text(yaml.safe_dump(project_files))
+    factory = Mock(side_effect=AssertionError("must not reach storage"))
+    monkeypatch.setattr(health.StorageClient, "from_environment", factory)
+    result = _invoke("-p", "target")
+    assert result.exit_code == 1, result.output
+    assert json.loads(result.stdout)["checks"][0]["status"] == "FAIL"
+    factory.assert_not_called()
+
+
+def test_unknown_project_returns_json_failure_without_a_probe(
+    project_files, monkeypatch
+):
+    factory = Mock(side_effect=AssertionError("must not reach storage"))
+    monkeypatch.setattr(health.StorageClient, "from_environment", factory)
+    result = _invoke("--project", "missing")
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "Unknown project alias" in payload["checks"][0]["remedy"]
+    factory.assert_not_called()
+
+
+def test_explicitly_deselected_storage_fails(project_files):
+    project_files["project_credentials"]["projects"]["project-target"][
+        "storage_selected"
+    ] = False
+    credentials.CREDENTIALS_PATH.write_text(yaml.safe_dump(project_files))
+    result = _invoke("--project", "target", "--offline")
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["ok"] is False
+
+
+def test_project_offline_never_constructs_storage_client(project_files, monkeypatch):
+    factory = Mock(side_effect=AssertionError("offline must not reach storage"))
+    monkeypatch.setattr(health.StorageClient, "from_environment", factory)
+    result = _invoke("--project", "target", "--offline")
+    assert result.exit_code == 0
+    assert "not probed" in json.loads(result.stdout)["checks"][0]["summary"]
+    factory.assert_not_called()
+
+
+def test_warn_only_retains_failure_in_json(project_files):
+    result = _invoke("--project", "missing", "--warn-only")
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["ok"] is False
+
+
+def test_project_storage_failure_preserves_other_requested_checks(project_files):
+    result = _invoke("--project", "missing", "--checks", "hf,s3,nebius", "--offline")
+    assert result.exit_code == 1
+    checks = json.loads(result.stdout)["checks"]
+    assert [(check["name"], check["status"]) for check in checks] == [
+        ("hf", "WARN"), ("s3", "FAIL"), ("nebius", "SKIP"),
+    ]
+
+
+def test_no_project_retains_host_storage_selection(project_files, monkeypatch):
+    client = Mock()
+    monkeypatch.setattr(
+        health.StorageClient, "from_environment", Mock(return_value=client)
+    )
+    result = _invoke()
+    assert result.exit_code == 0, result.output
+    client.probe_list_access.assert_called_once_with("s3://host-bucket")
+
+
+def test_project_preserves_non_storage_credentials(project_files):
+    original = replace(
+        credentials.load_credentials(), tokens={"HF_TOKEN": "synthetic-hf"}
+    )
+    resolved = health._project_credentials("target", original)
+    assert resolved.hf_token == original.hf_token
+    assert resolved.s3_bucket != original.s3_bucket

--- a/npa/tests/cli/test_health_project_preflight.py
+++ b/npa/tests/cli/test_health_project_preflight.py
@@ -68,6 +68,17 @@ def _invoke(*options):
     )
 
 
+@pytest.fixture
+def host_storage_environment(monkeypatch):
+    for name, value in {
+        "AWS_ACCESS_KEY_ID": "unrelated-access",
+        "AWS_SECRET_ACCESS_KEY": "unrelated-secret",
+        "AWS_ENDPOINT_URL": "https://unrelated.invalid",
+        "NPA_CHECKPOINT_BUCKET": "s3://unrelated-bucket",
+    }.items():
+        monkeypatch.setenv(name, value)
+
+
 def test_project_probe_uses_exact_record_and_preserves_files(
     project_files, monkeypatch
 ):
@@ -100,7 +111,7 @@ def test_project_probe_uses_exact_record_and_preserves_files(
     "missing", ["bucket", "endpoint_url", "aws_access_key_id", "aws_secret_access_key"]
 )
 def test_partial_project_storage_does_not_use_host_credentials(
-    project_files, monkeypatch, missing
+    project_files, monkeypatch, missing, host_storage_environment
 ):
     project_files["project_credentials"]["projects"]["project-target"]["storage"].pop(
         missing
@@ -112,6 +123,29 @@ def test_partial_project_storage_does_not_use_host_credentials(
     assert result.exit_code == 1, result.output
     assert json.loads(result.stdout)["checks"][0]["status"] == "FAIL"
     factory.assert_not_called()
+
+
+def test_missing_project_record_does_not_use_environment_credentials(
+    project_files, monkeypatch, host_storage_environment
+):
+    factory = Mock()
+    monkeypatch.setattr(health.StorageClient, "from_environment", factory)
+    result = _invoke("--project", "other")
+    assert result.exit_code == 1, result.output
+    assert json.loads(result.stdout)["checks"][0]["status"] == "FAIL"
+    factory.assert_not_called()
+
+
+def test_invalid_project_store_preserves_json_and_other_checks(project_files):
+    project_files["project_credentials"]["schema_version"] = "unsupported-schema"
+    credentials.CREDENTIALS_PATH.write_text(yaml.safe_dump(project_files))
+    before = credentials.CREDENTIALS_PATH.read_bytes()
+    result = _invoke("--project", "target", "--checks", "s3,nebius", "--offline")
+    assert result.exit_code == 1
+    assert [(item["name"], item["status"]) for item in json.loads(result.stdout)["checks"]] == [
+        ("s3", "FAIL"), ("nebius", "SKIP"),
+    ]
+    assert credentials.CREDENTIALS_PATH.read_bytes() == before
 
 
 def test_unknown_project_returns_json_failure_without_a_probe(
@@ -178,3 +212,33 @@ def test_project_preserves_non_storage_credentials(project_files):
     resolved = health._project_credentials("target", original)
     assert resolved.hf_token == original.hf_token
     assert resolved.s3_bucket != original.s3_bucket
+
+
+@pytest.mark.parametrize("section", ["storage", "object_storage", "object-storage", "terraform_state"])
+def test_inline_project_storage_stays_read_only_without_legacy_migration(
+    project_files, monkeypatch, host_storage_environment, section
+):
+    del project_files["project_credentials"]
+    credentials.CREDENTIALS_PATH.write_text(yaml.safe_dump(project_files))
+    document = yaml.safe_load(config.CONFIG_PATH.read_text())
+    document["projects"]["target"][section] = {
+        "bucket": "inline-bucket/prefix",
+        "endpoint": "https://inline.invalid",
+        "access_key": "inline-access",
+        "secret_key": "inline-secret",
+    }
+    config.CONFIG_PATH.write_text(yaml.safe_dump(document))
+    paths = (config.CONFIG_PATH, credentials.CREDENTIALS_PATH)
+    before = [path.read_bytes() for path in paths]
+    client = Mock()
+    factory = Mock(return_value=client)
+    monkeypatch.setattr(health.StorageClient, "from_environment", factory)
+    result = _invoke("--project", "target")
+    assert result.exit_code == 0, result.output
+    factory.assert_called_once_with(
+        endpoint_url="https://inline.invalid",
+        aws_access_key_id="inline-access",
+        aws_secret_access_key="inline-secret",
+    )
+    client.probe_list_access.assert_called_once_with("s3://inline-bucket/prefix")
+    assert [path.read_bytes() for path in paths] == before

--- a/npa/tests/cli/test_workbench_health_cli.py
+++ b/npa/tests/cli/test_workbench_health_cli.py
@@ -529,7 +529,7 @@ def test_preflight_fails_on_bad_s3(monkeypatch) -> None:
         s3_bucket = "s3://bkt/"
 
     class _Client:
-        def list_checkpoints(self, uri):
+        def probe_list_access(self, uri):
             raise RuntimeError("403 Forbidden")
 
     captured_kwargs: dict = {}
@@ -562,7 +562,7 @@ def test_preflight_warn_only_suppresses_exit(monkeypatch) -> None:
         s3_bucket = "s3://bkt/"
 
     class _Client:
-        def list_checkpoints(self, uri):
+        def probe_list_access(self, uri):
             raise RuntimeError("403 Forbidden")
 
     monkeypatch.setattr(health_module, "load_credentials", lambda *a, **k: _Creds())

--- a/npa/tests/clients/test_storage_list_probe.py
+++ b/npa/tests/clients/test_storage_list_probe.py
@@ -4,7 +4,7 @@ import pytest
 from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 
-from npa.clients.storage import StorageClient
+from npa.clients.storage import StorageClient, StorageError
 
 
 @pytest.fixture
@@ -40,10 +40,20 @@ def test_probe_checks_empty_or_populated_prefix_without_paginating(
         stubber.assert_no_pending_responses()
 
 
-def test_probe_preserves_service_denial(storage):
+@pytest.mark.parametrize("code,status", [
+    ("AccessDenied", 403), ("SignatureDoesNotMatch", 403),
+    ("NoSuchBucket", 404), ("ServiceUnavailable", 503),
+])
+def test_probe_preserves_service_denial(storage, code, status):
     with Stubber(storage.s3) as stubber:
         stubber.add_client_error(
-            "list_objects_v2", service_error_code="AccessDenied", http_status_code=403
+            "list_objects_v2", service_error_code=code, http_status_code=status
         )
-        with pytest.raises(ClientError, match="AccessDenied"):
+        with pytest.raises(ClientError, match=code):
             storage.probe_list_access("s3://test-bucket")
+
+
+@pytest.mark.parametrize("uri", ["test-bucket/prefix", "https://storage.invalid/bucket"])
+def test_probe_rejects_non_s3_destinations_before_request(storage, uri):
+    with Stubber(storage.s3), pytest.raises(StorageError, match="Expected s3://"):
+        storage.probe_list_access(uri)

--- a/npa/tests/clients/test_storage_list_probe.py
+++ b/npa/tests/clients/test_storage_list_probe.py
@@ -1,0 +1,49 @@
+"""Check the S3 wire contract for constant-size credential probes."""
+
+import pytest
+from botocore.exceptions import ClientError
+from botocore.stub import Stubber
+
+from npa.clients.storage import StorageClient
+
+
+@pytest.fixture
+def storage():
+    return StorageClient(
+        endpoint_url="https://storage.invalid",
+        aws_access_key_id="synthetic-access",
+        aws_secret_access_key="synthetic-secret",
+    )
+
+
+@pytest.mark.parametrize("prefix", ["", "run", "run/"])
+@pytest.mark.parametrize("truncated", [False, True])
+def test_probe_checks_empty_or_populated_prefix_without_paginating(
+    storage, prefix, truncated
+):
+    expected_prefix = prefix.rstrip("/") + "/" if prefix else ""
+    response = {"IsTruncated": truncated, "KeyCount": int(truncated)}
+    if truncated:
+        response["NextContinuationToken"] = "must-not-be-followed"
+    with Stubber(storage.s3) as stubber:
+        stubber.add_response(
+            "list_objects_v2",
+            response,
+            {
+                "Bucket": "test-bucket",
+                "Prefix": expected_prefix,
+                "Delimiter": "/",
+                "MaxKeys": 1,
+            },
+        )
+        assert storage.probe_list_access(f"s3://test-bucket/{prefix}") is None
+        stubber.assert_no_pending_responses()
+
+
+def test_probe_preserves_service_denial(storage):
+    with Stubber(storage.s3) as stubber:
+        stubber.add_client_error(
+            "list_objects_v2", service_error_code="AccessDenied", http_status_code=403
+        )
+        with pytest.raises(ClientError, match="AccessDenied"):
+            storage.probe_list_access("s3://test-bucket")

--- a/npa/tests/e2e/test_health_project_preflight_live.py
+++ b/npa/tests/e2e/test_health_project_preflight_live.py
@@ -30,7 +30,9 @@ def live_project(tmp_path):
     if not project:
         pytest.skip("Set NPA_E2E_PROJECT to an explicitly configured test project")
     with operation_intent(OperationIntent.OBSERVE):
-        storage = resolve_project_storage(project, include_shared_credentials=False)
+        storage = resolve_project_storage(
+            project, include_shared_credentials=False, include_environment=False,
+        )
     if not all(
         (
             storage.checkpoint_bucket,
@@ -109,6 +111,38 @@ def test_live_bad_project_signature_is_a_failure(live_project):
     record["aws_secret_access_key"] = "synthetic-invalid-signing-key"
     path.write_text(yaml.safe_dump(document))
     assert _preflight(project, directory) == (1, False, ["FAIL"])
+
+
+@pytest.mark.parametrize("missing", [
+    "bucket", "endpoint_url", "aws_access_key_id", "aws_secret_access_key", "record",
+])
+def test_live_incomplete_project_does_not_borrow_valid_host_credentials(live_project, missing):
+    project, storage, directory = live_project
+    overrides = {
+        "AWS_ACCESS_KEY_ID": storage.aws_access_key_id,
+        "AWS_SECRET_ACCESS_KEY": storage.aws_secret_access_key,
+        "AWS_ENDPOINT_URL": storage.endpoint_url,
+        "NPA_CHECKPOINT_BUCKET": "s3://" + storage.checkpoint_bucket.removeprefix("s3://"),
+    }
+    config_path = directory / "config.yaml"
+    document = yaml.safe_load(config_path.read_text())
+    project_config = document["projects"][project]
+    project_id = project_config["project_id"]
+    for section in ("object-storage", "object_storage", "storage", "terraform_state"):
+        project_config.pop(section, None)
+    config_path.write_text(yaml.safe_dump(document))
+    path = directory / "credentials.yaml"
+    document = yaml.safe_load(path.read_text())
+    projects = document["project_credentials"]["projects"]
+    if missing == "record":
+        projects.pop(project_id)
+    else:
+        projects[project_id]["storage"].pop(missing)
+    path.write_text(yaml.safe_dump(document))
+    before = {item.name: item.read_bytes() for item in directory.iterdir()}
+    assert _preflight(None, directory, **overrides) == (0, True, ["PASS"])
+    assert _preflight(project, directory, **overrides) == (1, False, ["FAIL"])
+    assert before == {item.name: item.read_bytes() for item in directory.iterdir()}
 
 
 def test_live_probe_checks_empty_and_populated_prefix_with_one_request(live_project):

--- a/npa/tests/e2e/test_health_project_preflight_live.py
+++ b/npa/tests/e2e/test_health_project_preflight_live.py
@@ -1,0 +1,147 @@
+"""Validate selected-project health against real S3 with private config copies.
+
+Run with NPA_INTEGRATION_E2E=1 and NPA_E2E_PROJECT set to an explicitly
+configured test project. Only the prefix test writes objects; it removes its
+unique objects in a finally block. No cloud identity or credential is printed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import uuid
+
+import pytest
+import yaml
+
+from npa.clients.config import CONFIG_PATH, resolve_project_storage
+from npa.clients.credentials import CREDENTIALS_PATH
+from npa.clients.storage import StorageClient
+from npa.lifecycle_intent import OperationIntent, operation_intent
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture
+def live_project(tmp_path):
+    project = os.environ.get("NPA_E2E_PROJECT", "").strip()
+    if not project:
+        pytest.skip("Set NPA_E2E_PROJECT to an explicitly configured test project")
+    with operation_intent(OperationIntent.OBSERVE):
+        storage = resolve_project_storage(project, include_shared_credentials=False)
+    if not all(
+        (
+            storage.checkpoint_bucket,
+            storage.endpoint_url,
+            storage.aws_access_key_id,
+            storage.aws_secret_access_key,
+        )
+    ):
+        pytest.fail("Selected live project needs complete object storage configuration")
+    directory = tmp_path / "config"
+    directory.mkdir(mode=0o700)
+    for source in (CONFIG_PATH, CREDENTIALS_PATH):
+        destination = directory / source.name
+        destination.write_bytes(source.read_bytes())
+        destination.chmod(0o600)
+    return project, storage, directory
+
+
+def _preflight(project, directory, **overrides):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "npa",
+            "workbench",
+            "health",
+            "preflight",
+            "--checks",
+            "s3",
+            "--json",
+            *(["--project", project] if project else []),
+        ],
+        env={**os.environ, "NPA_CONFIG_DIR": str(directory), **overrides},
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except ValueError:
+        pytest.fail("Storage preflight did not return one JSON document")
+    statuses = [check["status"] for check in payload.get("checks", [])]
+    return result.returncode, payload.get("ok"), statuses
+
+
+def test_live_project_overrides_unrelated_host_storage_without_changing_config(
+    live_project,
+):
+    project, _storage, directory = live_project
+    before = {path.name: path.read_bytes() for path in directory.iterdir()}
+    overrides = {
+        "AWS_ACCESS_KEY_ID": "synthetic-invalid-access",
+        "AWS_SECRET_ACCESS_KEY": "synthetic-invalid-secret",
+        "NEBIUS_S3_BUCKET": "s3://synthetic-unrelated-bucket",
+        "NPA_CHECKPOINT_BUCKET": "s3://synthetic-unrelated-bucket",
+    }
+    assert _preflight(None, directory, **overrides) == (1, False, ["FAIL"])
+    assert _preflight(project, directory, **overrides) == (0, True, ["PASS"])
+    unchanged = before == {path.name: path.read_bytes() for path in directory.iterdir()}
+    assert unchanged, "Readiness checks changed the private configuration"
+
+
+def test_live_unknown_project_does_not_report_host_readiness(live_project):
+    _project, _storage, directory = live_project
+    assert _preflight("missing-" + uuid.uuid4().hex, directory) == (1, False, ["FAIL"])
+
+
+def test_live_bad_project_signature_is_a_failure(live_project):
+    project, _storage, directory = live_project
+    config = yaml.safe_load((directory / "config.yaml").read_text())
+    project_id = config["projects"][project]["project_id"]
+    path = directory / "credentials.yaml"
+    document = yaml.safe_load(path.read_text())
+    record = document["project_credentials"]["projects"][project_id]["storage"]
+    record["aws_secret_access_key"] = "synthetic-invalid-signing-key"
+    path.write_text(yaml.safe_dump(document))
+    assert _preflight(project, directory) == (1, False, ["FAIL"])
+
+
+def test_live_probe_checks_empty_and_populated_prefix_with_one_request(live_project):
+    _project, storage, _directory = live_project
+    client = StorageClient(
+        endpoint_url=storage.endpoint_url,
+        aws_access_key_id=storage.aws_access_key_id,
+        aws_secret_access_key=storage.aws_secret_access_key,
+    )
+    bucket = storage.checkpoint_bucket.removeprefix("s3://").split("/", 1)[0]
+    prefix = "health-preflight-test/" + uuid.uuid4().hex + "/"
+    keys = [prefix + "first", prefix + "second"]
+    requests = []
+    truncated = []
+    client.s3.meta.events.register(
+        "before-parameter-build.s3.ListObjectsV2",
+        lambda params, **_: requests.append(dict(params)),
+    )
+    client.s3.meta.events.register(
+        "after-call.s3.ListObjectsV2",
+        lambda parsed, **_: truncated.append(parsed.get("IsTruncated", False)),
+    )
+    try:
+        client.probe_list_access(f"s3://{bucket}/{prefix}")
+        for key in keys:
+            client.s3.put_object(
+                Bucket=bucket, Key=key, Body=b"health preflight fixture"
+            )
+        client.probe_list_access(f"s3://{bucket}/{prefix}")
+        assert len(requests) == 2
+        assert truncated == [False, True]
+        assert all(request.get("MaxKeys") == 1 for request in requests)
+        assert all("ContinuationToken" not in request for request in requests)
+    finally:
+        for key in keys:
+            client.s3.delete_object(Bucket=bucket, Key=key)

--- a/npa/tests/workflows/test_credential_preflight.py
+++ b/npa/tests/workflows/test_credential_preflight.py
@@ -130,7 +130,7 @@ def test_s3_present_unverified_without_probe() -> None:
 
 def test_s3_pass_when_reachable() -> None:
     class _Client:
-        def list_checkpoints(self, uri):
+        def probe_list_access(self, uri):
             return []
 
     creds = _Creds(
@@ -145,7 +145,7 @@ def test_s3_pass_when_reachable() -> None:
 
 def test_s3_fail_on_auth_error() -> None:
     class _Client:
-        def list_checkpoints(self, uri):
+        def probe_list_access(self, uri):
             raise RuntimeError("403 Forbidden AccessDenied")
 
     creds = _Creds(
@@ -276,7 +276,7 @@ def test_run_credential_preflight_rejects_unknown_check() -> None:
 
 def test_has_failure_true_when_any_fail() -> None:
     class _Client:
-        def list_checkpoints(self, uri):
+        def probe_list_access(self, uri):
             raise RuntimeError("403")
 
     creds = _Creds(

--- a/skills/atomic/health-preflight/SKILL.md
+++ b/skills/atomic/health-preflight/SKILL.md
@@ -41,7 +41,7 @@ combined with `all`. Repeated names run once.
 
 Select `--project <alias>` (or `-p`) when checking a configured project's S3
 storage. This reads the project's bucket, endpoint, and credential pair through
-the project storage resolver, without adopting the host credential file or
+the project storage resolver, without adopting host credential files or shell S3 settings, or
 changing saved configuration. A complete exact-project record wins over ambient
 S3 settings. Unknown projects and missing or deselected project storage produce
 a JSON-compatible FAIL and a nonzero exit, including offline; `--warn-only`

--- a/skills/atomic/health-preflight/SKILL.md
+++ b/skills/atomic/health-preflight/SKILL.md
@@ -29,6 +29,7 @@ Token Factory. Request the optional `nebius` check before provisioning:
 npa workbench health preflight --checks all
 npa workbench health preflight --checks nebius --json
 npa workbench health preflight --checks s3,token_factory
+npa workbench health preflight --project <alias> --checks s3,nebius
 npa workbench health preflight --checks all --offline  # presence only; Nebius is SKIP
 ```
 
@@ -37,6 +38,20 @@ Valid `--checks` values are `all`, `hf`, `ngc`, `s3`, `token_factory`,
 work does not require a Nebius Cloud profile. Explicit `all` includes `nebius`.
 Empty selections and unknown check names are errors, including unknown names
 combined with `all`. Repeated names run once.
+
+Select `--project <alias>` (or `-p`) when checking a configured project's S3
+storage. This reads the project's bucket, endpoint, and credential pair through
+the project storage resolver, without adopting the host credential file or
+changing saved configuration. A complete exact-project record wins over ambient
+S3 settings. Unknown projects and missing or deselected project storage produce
+a JSON-compatible FAIL and a nonzero exit, including offline; `--warn-only`
+preserves that FAIL while returning zero. The flag scopes only the S3 check;
+other checks and Nebius auth profile selection are unchanged.
+
+The S3 probe issues one `ListObjectsV2` request with `MaxKeys=1`. An empty bucket
+or prefix is valid. It discards object names and continuation tokens instead of
+enumerating checkpoint directories, so a large dataset does not increase the
+number of requests. Listing permission still does not prove write access.
 
 Online `nebius` runs the selected Nebius CLI profile through `iam whoami` and
 `iam get-access-token` with browser launch and update checks disabled. It
@@ -125,10 +140,11 @@ the actual spec and ledger; `--s3-endpoint` binds both probe and worker endpoint
 S3 keys are selected as a pair from one source, with non-secret provenance;
 an incomplete explicit pair cannot borrow a saved principal's other key.
 
-The credential preflight resolves its bucket from `NPA_CHECKPOINT_BUCKET`, then
+Without `--project`, credential preflight resolves its bucket from `NPA_CHECKPOINT_BUCKET`, then
 `NEBIUS_S3_BUCKET`, then saved credentials. Setting only `NPA_S3_BUCKET` changes
 the workflow destination but does not select the credential preflight bucket.
-When checking an explicitly authorized workflow destination, set
+For configured project storage, prefer `--project <alias>`. When checking an
+explicitly authorized destination through environment credentials, set
 `NPA_CHECKPOINT_BUCKET` to an unsigned `s3://` URI for that same bucket in the
 private process environment and use the matching endpoint and credentials.
 The list probe requires a URI, so a bare bucket name fails before S3 access.
@@ -198,4 +214,13 @@ missing-profile, and offline paths (including stale ambient token scrubbing):
 ```bash
 NPA_INTEGRATION_E2E=1 npa/.venv/bin/python -m pytest \
   npa/tests/e2e/test_nebius_auth_preflight.py -q
+```
+
+For selected-project S3 coverage, use an explicitly configured disposable test
+project. The live tests use private configuration copies and clean up their
+unique fixture objects:
+
+```bash
+NPA_INTEGRATION_E2E=1 NPA_E2E_PROJECT=<alias> npa/.venv/bin/python -m pytest \
+  npa/tests/e2e/test_health_project_preflight_live.py -q
 ```


### PR DESCRIPTION
Workbench readiness could report PASS using the host's S3 credentials while deployment targeted a different project. `npa workbench health preflight --project <alias>` now checks saved project storage without borrowing shell or host-file credentials or changing configuration. Missing, incomplete, deselected, or invalid project storage produces a failed S3 check while preserving the other requested checks and the JSON report. All four supported legacy project storage formats remain usable without credential migration.

S3 readiness now calls `ListObjectsV2` with `MaxKeys=1` and never follows continuation tokens. Empty buckets and prefixes are valid. Omitting `--project` preserves existing credential selection. This verifies listing permission; workflow submit remains responsible for checking actual output writes.

Validation:

- [Full CI on the final commit](https://github.com/nebius/nebius-physical-ai/actions/runs/34696701902): 20,693 passed, 541 skipped, 1 xpassed; 76.00% package coverage. All 12 CLI installation checks passed. All nine PR checks are green, including browser, security, documentation, confidentiality, and guardrails.
- 178 targeted configuration, CLI, and S3 tests passed; all 648 required security runtime tests also passed locally on Linux/Python 3.12 with PyTorch 2.13.0 CPU.
- Twelve live S3/authentication tests passed on each of macOS and Linux using real Nebius storage. They cover invalid host credentials, invalid project signing credentials, incomplete or missing project records with valid host credentials, unknown aliases, empty prefixes, truncated responses, and unchanged configuration files.
- Six new or strengthened unit regressions fail on the previous PR commit. All five new live incomplete-storage cases also reproduce its incorrect PASS, then pass with the fix.

Live validation used an isolated project. Test objects, the bucket, and the NPA-created storage service account were removed; provider checks confirmed zero buckets, VMs, and Kubernetes clusters plus exact service-account absence. The project is retained. GPU validation remains unproven: compute preflight found insufficient network-SSD quota for the supported default cluster, so no GPU workload was launched.
