### PR TITLE
security: remediate NLTK model path traversal alerts

### DIFF
--- a/npa/docker/workbench/common/install_hardened_nltk.sh
+++ b/npa/docker/workbench/common/install_hardened_nltk.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install NLTK from the upstream commit that fixes GHSA-8mgp-746c-j5xp.
+
+set -euo pipefail
+
+readonly NLTK_SOURCE_COMMIT="cbc98458b43de5f792f0382583c16df39e5c5117"
+readonly NLTK_SOURCE_SHA256="3c4a9e92b53e34074ae5b7bbf21109868b5ef620b40c68b8542a2db37f7d9d0c"
+readonly NLTK_SOURCE_VERSION="3.10.3"
+readonly NLTK_HARDENED_VERSION="3.10.3.post1+npa.cbc98458"
+readonly NLTK_SOURCE_URL="https://codeload.github.com/nltk/nltk/tar.gz/${NLTK_SOURCE_COMMIT}"
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 SYSTEM|PYTHON" >&2
+  exit 64
+fi
+
+target="$1"
+if [ "$target" = SYSTEM ]; then
+  python_path="$(command -v python)"
+  uv_target=(--system)
+elif [ -x "$target" ]; then
+  python_path="$target"
+  uv_target=(--python "$target")
+else
+  echo "target Python is not executable: $target" >&2
+  exit 66
+fi
+
+work="$(mktemp -d)"
+cleanup() {
+  rm -rf -- "$work"
+}
+trap cleanup EXIT
+
+archive="$work/nltk.tar.gz"
+source_dir="$work/source"
+curl --fail --location "$NLTK_SOURCE_URL" --output "$archive"
+printf '%s  %s\n' "$NLTK_SOURCE_SHA256" "$archive" | sha256sum --check --strict
+mkdir "$source_dir"
+tar --extract --gzip --file "$archive" --strip-components=1 --directory "$source_dir"
+test "$(cat "$source_dir/nltk/VERSION")" = "$NLTK_SOURCE_VERSION"
+printf '%s\n' "$NLTK_HARDENED_VERSION" > "$source_dir/nltk/VERSION"
+
+# The overlays install an exact setuptools version first. Avoid an unpinned
+# isolated build environment, and install only this verified source.
+UV_CACHE_DIR="${UV_CACHE_DIR:-$work/uv-cache}" \
+  uv pip install "${uv_target[@]}" --no-deps --no-build-isolation "$source_dir"
+test "$("$python_path" -c 'import importlib.metadata; print(importlib.metadata.version("nltk"))')" = \
+  "$NLTK_HARDENED_VERSION"

--- a/npa/docker/workbench/common/verify_hardened_nltk.py
+++ b/npa/docker/workbench/common/verify_hardened_nltk.py
@@ -1,0 +1,98 @@
+"""Exercise NLTK's fixes for GHSA-8mgp-746c-j5xp at image-build time."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import inspect
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Callable
+
+import nltk.data
+from nltk.classify.maxent import save_maxent_params
+from nltk.parse.transitionparser import TransitionParser
+from nltk.tag.perceptron import AveragedPerceptron, PerceptronTagger
+
+HARDENED_VERSION = "3.10.3.post1+npa.cbc98458"
+
+
+class _Weights:
+    def tolist(self) -> list[float]:
+        return []
+
+
+def _expect_denied(label: str, operation: Callable[[], object]) -> None:
+    try:
+        operation()
+    except (PermissionError, ValueError):
+        return
+    raise RuntimeError(f"{label} accepted a path outside the NLTK data sandbox")
+
+
+def _verify_transition_train_guard() -> None:
+    source = inspect.getsource(TransitionParser.train)
+    expected = 'pathsec_open(modelfile, "wb", context="TransitionParser.train")'
+    if expected not in source:
+        raise RuntimeError(
+            "TransitionParser.train does not use the pathsec write guard"
+        )
+
+
+def main() -> None:
+    version = importlib.metadata.version("nltk")
+    if version != HARDENED_VERSION:
+        raise RuntimeError(f"nltk={version}; expected {HARDENED_VERSION}")
+
+    root = Path(tempfile.mkdtemp(prefix="npa-nltk-security-"))
+    allowed = root / "allowed"
+    outside = root / "outside"
+    allowed.mkdir(mode=0o700)
+    outside.mkdir(mode=0o700)
+    nltk.data.path[:] = [str(allowed)]
+
+    try:
+        model = AveragedPerceptron(weights={"feature": {"TAG": 1.0}})
+        safe_model = allowed / "perceptron.json"
+        model.save(safe_model)
+        AveragedPerceptron().load(safe_model)
+
+        denied_model = outside / "perceptron.json"
+        _expect_denied("AveragedPerceptron.save", lambda: model.save(denied_model))
+        denied_model.write_text("{}", encoding="utf-8")
+        before = hashlib.sha256(denied_model.read_bytes()).digest()
+        _expect_denied(
+            "AveragedPerceptron.load", lambda: AveragedPerceptron().load(denied_model)
+        )
+
+        denied_tagger = outside / "tagger"
+        _expect_denied(
+            "PerceptronTagger.save_to_json",
+            lambda: PerceptronTagger(load=False).save_to_json(loc=denied_tagger),
+        )
+        denied_maxent = outside / "maxent"
+        _expect_denied(
+            "save_maxent_params",
+            lambda: save_maxent_params(_Weights(), {}, [], {}, str(denied_maxent)),
+        )
+        _expect_denied(
+            "TransitionParser.parse",
+            lambda: TransitionParser(TransitionParser.ARC_STANDARD).parse(
+                [], str(denied_model)
+            ),
+        )
+        _verify_transition_train_guard()
+
+        if hashlib.sha256(denied_model.read_bytes()).digest() != before:
+            raise RuntimeError("a denied NLTK operation modified an outside file")
+        if denied_tagger.exists() or denied_maxent.exists():
+            raise RuntimeError("a denied NLTK operation created an outside directory")
+    finally:
+        shutil.rmtree(root)
+
+    print(f"[PASS] NLTK path sandbox verified ({HARDENED_VERSION})")
+
+
+if __name__ == "__main__":
+    main()

--- a/npa/docker/workbench/cosmos3-nano-video/Dockerfile
+++ b/npa/docker/workbench/cosmos3-nano-video/Dockerfile
@@ -5,10 +5,14 @@ FROM ${BASE_IMAGE}
 
 USER root
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ffmpeg linux-libc-dev \
+    && apt-get install -y --no-install-recommends ca-certificates curl ffmpeg linux-libc-dev \
     && rm -rf /var/lib/apt/lists/*
 COPY docker/workbench/cosmos3-nano-video/requirements.txt /opt/npa/requirements.txt
+COPY --chmod=755 docker/workbench/common/install_hardened_nltk.sh /opt/npa/install_hardened_nltk.sh
+COPY docker/workbench/common/verify_hardened_nltk.py /opt/npa/verify_hardened_nltk.py
 RUN uv pip install --system --no-cache -r /opt/npa/requirements.txt \
+    && /opt/npa/install_hardened_nltk.sh SYSTEM \
+    && python /opt/npa/verify_hardened_nltk.py \
     && useradd --create-home --uid 10001 --shell /bin/bash npa-video \
     && mkdir -p /opt/npa/npa/workbench/cosmos /models /outputs /tmp/ray \
     && chown -R 10001:10001 /models /outputs /tmp/ray

--- a/npa/docker/workbench/cosmos3-nano-video/requirements.txt
+++ b/npa/docker/workbench/cosmos3-nano-video/requirements.txt
@@ -4,4 +4,10 @@ httpx==0.28.1
 # Security updates for dependencies inherited from the pinned vendor runtime.
 aiohttp==3.14.3
 cryptography==50.0.0
-nltk==3.10.3
+# NLTK is installed by common/install_hardened_nltk.sh from the pinned fix commit.
+click==8.3.3
+defusedxml==0.7.1
+joblib==1.6.0
+regex==2026.9.3
+setuptools==84.0.0
+tqdm==4.70.0

--- a/npa/docker/workbench/cosmos3-ray-serve/Dockerfile
+++ b/npa/docker/workbench/cosmos3-ray-serve/Dockerfile
@@ -59,9 +59,9 @@ USER ubuntu
 # The group's NATTEN wheel matches Torch 2.13; the inherited Flash Attention
 # wheels target Torch 2.10 and must be removed. Inexact sync preserves the
 # parent's required qwen-vl-utils and boto3 inference additions. After syncing,
-# replace the complete Ray Serve dependency closure and NLTK via
-# hash-verified packages. uv-managed environments
-# intentionally omit pip — use `uv pip install --python` instead of the
+# replace the complete Ray Serve dependency closure with hash-verified packages,
+# then install NLTK from the hash-verified upstream security commit. uv-managed
+# environments intentionally omit pip — use `uv pip install --python` instead of the
 # nonexistent `.venv/bin/pip`. The image serves Python deployments and has no JVM;
 # remove Ray's unused Java worker bundle instead of distributing its old libraries.
 # Do NOT use --frozen for the serve extra alone
@@ -73,6 +73,8 @@ COPY --chown=ubuntu:ubuntu docker/workbench/cosmos3-ray-serve/verify_env.py /opt
 COPY --chown=ubuntu:ubuntu --chmod=755 docker/workbench/cosmos3-ray-serve/entrypoint.sh /usr/local/bin/cosmos3-ray-serve-entrypoint
 COPY --chown=ubuntu:ubuntu --chmod=755 docker/workbench/cosmos3-ray-serve/smoke_functional.sh /opt/cosmos3-ray-serve/smoke_functional.sh
 COPY --chown=ubuntu:ubuntu docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.txt /tmp/cosmos3-ray-security-upgrades-requirements.txt
+COPY --chown=ubuntu:ubuntu --chmod=755 docker/workbench/common/install_hardened_nltk.sh /opt/npa/install_hardened_nltk.sh
+COPY --chown=ubuntu:ubuntu docker/workbench/common/verify_hardened_nltk.py /opt/npa/verify_hardened_nltk.py
 COPY --chown=ubuntu:ubuntu docker/workbench/sonic/packaging-requirements.txt /tmp/cosmos3-packaging-requirements.txt
 
 RUN export UV_CACHE_DIR=/tmp/uv-cache \
@@ -82,12 +84,13 @@ RUN export UV_CACHE_DIR=/tmp/uv-cache \
     && uv pip uninstall --python .venv/bin/python flash-attn flash-attn-3-nv \
     && uv pip install --python .venv/bin/python --no-deps --require-hashes \
        --requirement /tmp/cosmos3-ray-security-upgrades-requirements.txt \
+    && /opt/npa/install_hardened_nltk.sh .venv/bin/python \
     && .venv/bin/python -c 'from pathlib import Path; import ray; p=Path(ray.__file__).parent / "jars" / "ray_dist.jar"; p.unlink(missing_ok=True)' \
     && uv pip check --python .venv/bin/python \
     && .venv/bin/python -c 'from pathlib import Path; import subprocess; interpreters=sorted({p.resolve() for p in Path("/opt/uv/python").glob("*/bin/python3")}); assert interpreters; [subprocess.run(["uv","pip","install","--break-system-packages","--python",str(p),"--no-deps","--require-hashes","-r","/tmp/cosmos3-packaging-requirements.txt"],check=True) for p in interpreters]' \
     && rm -f /tmp/cosmos3-packaging-requirements.txt \
     && test "$(.venv/bin/python -c 'import ray; print(ray.__version__)')" = "${COSMOS3_RAY_VERSION}" \
-    && .venv/bin/python -c 'import importlib.metadata; assert importlib.metadata.version("nltk") == "3.10.3"' \
+    && .venv/bin/python /opt/npa/verify_hardened_nltk.py \
     && uv pip install --python /opt/npa/.venv/bin/python --no-deps -e /opt/npa \
     && rm -rf /tmp/uv-cache /home/ubuntu/.cache/uv \
     && test ! -e /tmp/uv-cache && test ! -e /home/ubuntu/.cache/uv \

--- a/npa/docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.in
+++ b/npa/docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.in
@@ -1,7 +1,13 @@
 # Replace the serving dependency closure above the immutable framework lock.
 # GPU/model dependencies are not part of this overlay.
+# Regenerate with `uv pip compile --python-version 3.12 --exclude-newer
+# 2026-09-08T20:00:00Z --generate-hashes --no-header` from the repository root.
 ray[serve]==2.58.0
-nltk==3.10.3
+# NLTK is installed by common/install_hardened_nltk.sh from the pinned fix commit.
+# Preserve its runtime dependencies in this hash-verified closure.
+defusedxml==0.7.1
+joblib==1.6.0
+regex==2026.9.3
 # The framework's serve extra includes Gradio. Its old Starlette upper bound
 # conflicts with patched Ray; upgrade both sides of that interface together.
 gradio==6.16.0

--- a/npa/docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.txt
+++ b/npa/docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.txt
@@ -554,7 +554,6 @@ click==8.3.3 \
     --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
     # via
     #   -r npa/docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.in
-    #   nltk
     #   ray
     #   uvicorn
 cloudpickle==3.1.2 \
@@ -618,7 +617,7 @@ cryptography==50.0.1 \
 defusedxml==0.7.1 \
     --hash=sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69 \
     --hash=sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
-    # via nltk
+    # via -r npa/docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.in
 distlib==0.4.3 \
     --hash=sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b \
     --hash=sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed
@@ -979,7 +978,7 @@ jinja2==3.1.6 \
 joblib==1.6.0 \
     --hash=sha256:2ccc96785b12046c08fd6d55839c12857831b54a3c1673ffadd2f04bfc4eda03 \
     --hash=sha256:3dbbf9f6e4b592a2357b854608e980fe6390d131d7a82f011a377ef2ebef7aba
-    # via nltk
+    # via -r npa/docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.in
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -1455,10 +1454,6 @@ multidict==6.7.1 \
     # via
     #   aiohttp
     #   yarl
-nltk==3.10.3 \
-    --hash=sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4 \
-    --hash=sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c
-    # via -r npa/docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.in
 numpy==2.2.6 \
     --hash=sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff \
     --hash=sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47 \
@@ -2368,7 +2363,7 @@ regex==2026.9.3 \
     --hash=sha256:f5e8a0ce681ddabf6a35d7b817d74a94ab237ae7233a5b97118db0b4e524473f \
     --hash=sha256:f93c60d8c522b4ecea35dd6c58cc42f251ecb12882a5d67d4bd8d12137fbd05b \
     --hash=sha256:fbaf76379bf2a72e534bbb1276d45e63a80d8cade17953ed79a350d6426262fb
-    # via nltk
+    # via -r npa/docker/workbench/cosmos3-ray-serve/security-upgrades-requirements.in
 requests==2.34.2 \
     --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0 \
     --hash=sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed
@@ -2541,9 +2536,7 @@ tomlkit==0.14.0 \
 tqdm==4.70.0 \
     --hash=sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220 \
     --hash=sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
-    # via
-    #   huggingface-hub
-    #   nltk
+    # via huggingface-hub
 typer==0.27.2 \
     --hash=sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945 \
     --hash=sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d

--- a/npa/docker/workbench/cosmos3/Dockerfile
+++ b/npa/docker/workbench/cosmos3/Dockerfile
@@ -109,6 +109,8 @@ RUN git clone --filter=blob:none "${COSMOS3_SOURCE_REPO}" "${COSMOS3_REPO}" \
 # build time rather than assumed.
 COPY --chown=ubuntu:ubuntu docker/workbench/cosmos3/verify_env.py /opt/cosmos3/verify_env.py
 COPY --chown=ubuntu:ubuntu docker/workbench/cosmos3/security-upgrades-requirements.txt /tmp/cosmos3-security-upgrades.txt
+COPY --chown=ubuntu:ubuntu --chmod=755 docker/workbench/common/install_hardened_nltk.sh /opt/npa/install_hardened_nltk.sh
+COPY --chown=ubuntu:ubuntu docker/workbench/common/verify_hardened_nltk.py /opt/npa/verify_hardened_nltk.py
 COPY --chown=ubuntu:ubuntu docker/workbench/sonic/packaging-requirements.txt /tmp/cosmos3-packaging-requirements.txt
 RUN cd "${COSMOS3_REPO}" \
     && UV_CACHE_DIR=/tmp/uv-cache uv python install \
@@ -120,11 +122,13 @@ RUN cd "${COSMOS3_REPO}" \
        ${COSMOS3_INFERENCE_DEPS} \
     && UV_CACHE_DIR=/tmp/uv-cache uv pip install --python .venv/bin/python \
        --no-deps --require-hashes -r /tmp/cosmos3-security-upgrades.txt \
+    && /opt/npa/install_hardened_nltk.sh .venv/bin/python \
     && uv pip check --python .venv/bin/python \
     && rm -f /tmp/cosmos3-security-upgrades.txt \
     && find .venv -type f -path '*/imageio_ffmpeg/binaries/ffmpeg*' -delete \
     && test "$(.venv/bin/python -c 'import imageio_ffmpeg; print(imageio_ffmpeg.get_ffmpeg_exe())')" = /usr/bin/ffmpeg \
     && test -z "$(find .venv -type f -path '*/imageio_ffmpeg/binaries/ffmpeg*' -print -quit)" \
+    && .venv/bin/python /opt/npa/verify_hardened_nltk.py \
     && COSMOS_DEVICE=cpu .venv/bin/python /opt/cosmos3/verify_env.py \
     && rm -rf /tmp/uv-cache
 

--- a/npa/docker/workbench/cosmos3/security-upgrades-requirements.in
+++ b/npa/docker/workbench/cosmos3/security-upgrades-requirements.in
@@ -11,5 +11,5 @@ pytest==9.0.3
 requests==2.34.2
 setuptools==84.0.0
 urllib3==2.7.0
-nltk==3.10.3
+# NLTK is installed by common/install_hardened_nltk.sh from the pinned fix commit.
 defusedxml==0.7.1

--- a/npa/docker/workbench/cosmos3/security-upgrades-requirements.txt
+++ b/npa/docker/workbench/cosmos3/security-upgrades-requirements.txt
@@ -1,5 +1,5 @@
 # Hash-verified portable dependencies; regenerate from the adjacent .in with
-# uv pip compile --no-deps --generate-hashes --no-header --no-annotate.
+# uv pip compile --python-version 3.12 --no-deps --generate-hashes --no-header --no-annotate.
 click==8.3.3 \
     --hash=sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2 \
     --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
@@ -126,9 +126,6 @@ msgpack==1.2.1 \
     --hash=sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2 \
     --hash=sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc \
     --hash=sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c
-nltk==3.10.3 \
-    --hash=sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4 \
-    --hash=sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c
 pillow==12.3.0 \
     --hash=sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756 \
     --hash=sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a \

--- a/npa/tests/docker/test_cosmos3_ray_serve_image_contract.py
+++ b/npa/tests/docker/test_cosmos3_ray_serve_image_contract.py
@@ -141,7 +141,9 @@ def test_dockerfile_uses_uv_not_pip_in_run_directives() -> None:
     text = DOCKERFILE.read_text(encoding="utf-8")
     # Remove comment lines so we don't flag the documentation that mentions
     # .venv/bin/pip in the intentionally explanatory comment.
-    non_comment_lines = [line for line in text.split("\n") if not line.strip().startswith("#")]
+    non_comment_lines = [
+        line for line in text.split("\n") if not line.strip().startswith("#")
+    ]
     non_comment = "\n".join(non_comment_lines)
     assert "uv pip install --python .venv/bin/python --no-deps" in non_comment
     # The executable instruction must not use the nonexistent pip binary
@@ -156,7 +158,7 @@ def test_security_upgrades_requirements_file_has_hash_pinned_cves() -> None:
     content = req_file.read_text(encoding="utf-8")
     assert "ray==2.58.0" in content
     assert "ray[serve]==2.58.0" in req_file.with_suffix(".in").read_text()
-    assert "nltk==3.10.3" in content
+    assert not re.search(r"^nltk==", content, re.M)
     assert "ray-haproxy==2.8.25" in content
     # Every dependency is exact and hash-bound, including the new serve extra.
     requirements = re.split(r"\n(?=[a-zA-Z])", content)
@@ -172,15 +174,14 @@ def test_dockerfile_copies_security_requirements_and_verifies_versions() -> None
         "security-upgrades-requirements.txt"
         " /tmp/cosmos3-ray-security-upgrades-requirements.txt"
     ) in text
-    assert (
-        "--requirement /tmp/cosmos3-ray-security-upgrades-requirements.txt"
-    ) in text
-    assert 'assert importlib.metadata.version("nltk") == "3.10.3"' in text
+    assert ("--requirement /tmp/cosmos3-ray-security-upgrades-requirements.txt") in text
+    assert "/opt/npa/install_hardened_nltk.sh .venv/bin/python" in text
+    assert ".venv/bin/python /opt/npa/verify_hardened_nltk.py" in text
     assert "${COSMOS3_RAY_VERSION}" in text
     assert "--no-deps --require-hashes" in text
     # Must verify the Ray version matches the ARG value post-install
     assert (
-        'test "$(.venv/bin/python -c \'import ray; print(ray.__version__)\')"'
+        "test \"$(.venv/bin/python -c 'import ray; print(ray.__version__)')\""
         ' = "${COSMOS3_RAY_VERSION}"'
     ) in text
 

--- a/npa/tests/docker/test_portable_security_overlays.py
+++ b/npa/tests/docker/test_portable_security_overlays.py
@@ -12,6 +12,7 @@ import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2] / "docker" / "workbench"
+HARDENED_NLTK_VERSION = "3.10.3.post1+npa.cbc98458"
 
 
 @pytest.mark.parametrize(
@@ -34,6 +35,41 @@ def test_portable_overlay_hashes_and_application_order(image: str) -> None:
     assert sync < overlay < check
     assert "pillow==12.3.0" in lock
     assert "setuptools==84.0.0" in lock
+
+
+def test_hardened_nltk_source_install_contract() -> None:
+    installer = (ROOT / "common" / "install_hardened_nltk.sh").read_text()
+    verifier = (ROOT / "common" / "verify_hardened_nltk.py").read_text()
+    commit = "cbc98458b43de5f792f0382583c16df39e5c5117"
+    archive_sha = "3c4a9e92b53e34074ae5b7bbf21109868b5ef620b40c68b8542a2db37f7d9d0c"
+
+    assert f'NLTK_SOURCE_COMMIT="{commit}"' in installer
+    assert f'NLTK_SOURCE_SHA256="{archive_sha}"' in installer
+    assert f'NLTK_HARDENED_VERSION="{HARDENED_NLTK_VERSION}"' in installer
+    assert "codeload.github.com/nltk/nltk/tar.gz/${NLTK_SOURCE_COMMIT}" in installer
+    assert "sha256sum --check --strict" in installer
+    assert "--no-deps --no-build-isolation" in installer
+    assert f'HARDENED_VERSION = "{HARDENED_NLTK_VERSION}"' in verifier
+
+    affected = {
+        "cosmos3": ROOT / "cosmos3" / "security-upgrades-requirements.in",
+        "cosmos3-nano-video": ROOT / "cosmos3-nano-video" / "requirements.txt",
+        "cosmos3-ray-serve": (
+            ROOT / "cosmos3-ray-serve" / "security-upgrades-requirements.in"
+        ),
+    }
+    for image, manifest in affected.items():
+        requirements = manifest.read_text()
+        docker = (ROOT / image / "Dockerfile").read_text()
+        assert not re.search(r"^nltk(?:\[[^]]+\])?\s*[=<>~!]", requirements, re.M)
+        assert "docker/workbench/common/install_hardened_nltk.sh" in docker
+        assert "docker/workbench/common/verify_hardened_nltk.py" in docker
+        assert "/opt/npa/install_hardened_nltk.sh" in docker
+        assert "/opt/npa/verify_hardened_nltk.py" in docker
+
+    nano_requirements = affected["cosmos3-nano-video"].read_text()
+    for dependency in ("click", "defusedxml", "joblib", "regex", "tqdm"):
+        assert re.search(rf"^{dependency}==", nano_requirements, re.M)
 
 
 def test_transfer_overlay_retains_exact_verified_wheel_urls() -> None:


### PR DESCRIPTION
## Summary

- replace the three vulnerable `nltk==3.10.3` workbench pins reported by Dependabot alerts #86, #117, and #118
- install NLTK from advisory-listed cumulative upstream fix commit `cbc98458b43de5f792f0382583c16df39e5c5117`, with its codeload archive locked to SHA-256 `3c4a9e92b53e34074ae5b7bbf21109868b5ef620b40c68b8542a2db37f7d9d0c`
- assign an explicit post-release build version and verify the fixed model path sandbox behavior during each affected image build
- retain hash-pinned runtime dependencies and add regression contracts for the source pin, archive integrity, Docker wiring, and denied out-of-sandbox operations

## Finding and remediation evidence

GitHub's advisory for GHSA-8mgp-746c-j5xp / CVE-2026-81726 marks `nltk <= 3.10.3` vulnerable and lists no released patched version. The pinned commit is one of the advisory's fix references and is a descendant of its other two fix commits. The local version `3.10.3.post1+npa.cbc98458` is therefore outside the advisory range while preserving the upstream 3.10.3 source identity.

The affected tooling is pip requirements metadata used by the Cosmos 3, Cosmos 3 Nano video, and Cosmos 3 Ray Serve image builds. No source-level scanner suppression or configuration change is part of the remediation.

Default-branch Dependabot alerts are expected to remain open until this change merges; this PR proves the branch resolution rather than claiming pre-merge closure.

## Validation

- `pip-audit --no-deps --disable-pip`: 0 findings across the three affected branch manifests (12, 10, and 113 locked dependencies)
- clean Python 3.12 Nano-style environment: 78 installed packages compatible; hardened NLTK sandbox verifier passes
- focused NLTK/image contracts: 30 passed
- Docker tests: 2,602 passed, 1 skipped
- required security regression workload: 648 passed
- onboarding smoke: 114 passed
- harness guardrails: 2,817 passed
- container catalog/index audit: 8 passed
- native complete-byte scanner integration: passed
- mocked browser coverage: 146 passed; CI production-wrapper invocation: passed
- CLI install integration: 12 passed
- docs drift, repository lint, tag consistency, source drift, diff confidentiality, and gitleaks range scan: passed
- GitHub PR validation: 21 checks passed, 1 expected conditional image job skipped, 0 failed. This includes the Python 3.12 coverage gate, browser suite, security regression, confidentiality and secret scans, docs/lint/guardrails, Trivy configuration and base-image scans, packaging classifier, and native complete-byte scanner.
- Local Python 3.12 coverage reached 75.99%. Every host-environment failure from the over-isolated invocation was rerun under corrected CI-grade Node/temp-path settings (91 passed, 1 expected skip), and a separate empty-home probe confirmed all 10 live Token Factory cases skip without operator configuration.

No GPU, model, cloud job, deployment, or application-image build was needed for this dependency-only remediation. The PR image-security workflow supplies the authoritative Trivy configuration and base-image scan results.
