### PR TITLE
Add Ray Alpamayo sweeps and paired hard-case workflows

### DIFF
--- a/docs/cli/alpamayo2-super.md
+++ b/docs/cli/alpamayo2-super.md
@@ -10,6 +10,7 @@ NVIDIA Alpamayo 2 Super trajectory-inference workbench.
 Options
 --help  Show this message and exit.
 Commands
+sweep  Sweep scenarios with Ray; optionally refine a baseline report's hard cases.
 infer  Run the real upstream expert trajectory inference and publish artifacts.
 terms  Print separately applicable source, model, and dataset terms.
 ```
@@ -24,6 +25,7 @@ terms  Print separately applicable source, model, and dataset terms.
 
 | Command | Description |
 | --- | --- |
+| `sweep` | Sweep scenarios with Ray; optionally refine a baseline report's hard cases. |
 | `infer` | Run the real upstream expert trajectory inference and publish artifacts. |
 | `terms` | Print separately applicable source, model, and dataset terms. |
 
@@ -31,7 +33,7 @@ terms  Print separately applicable source, model, and dataset terms.
 
 ```bash
 npa workbench alpamayo2-super --help
-npa workbench alpamayo2-super infer --help
+npa workbench alpamayo2-super sweep --help
 ```
 
 Regenerate this page with `bash scripts/build_docs.sh` after changing `alpamayo2-super`.

--- a/docs/workbench/alpamayo2-ray-extended-validation.md
+++ b/docs/workbench/alpamayo2-ray-extended-validation.md
@@ -153,11 +153,12 @@ the table above uses the complete telemetry files for averages.
 
 Both compute applications succeeded. Inference actors exited, both GPUs had
 zero remaining compute processes, and the telemetry application and samplers
-stopped. Owned CPU test pods were removed. At handoff, expired Nebius CLI
-authentication still prevents removing the three Ray pods, two unused cache
-PVCs and their namespace. The pods continue reserving the two GPUs until that
-cleanup completes. An ownership-checked cleanup procedure is retained in
-private evidence; the shared cluster, filesystem and bucket must be preserved.
+stopped. Owned CPU test pods were removed. After operator authentication was
+renewed, cleanup verified resource ownership and removed all three Ray pods,
+both unused cache PVCs and their namespace. Both owned persistent volumes were
+reclaimed, releasing the workload's GPU reservations. All four shared cluster
+nodes remained Ready; the shared cluster, filesystem and bucket were preserved.
+Private evidence retains the ownership checks and cleanup receipt.
 
 Exact resource identifiers, credentials, recordings and gated camera artifacts
 remain outside Git in private operator evidence.

--- a/docs/workbench/alpamayo2-ray-extended-validation.md
+++ b/docs/workbench/alpamayo2-ray-extended-validation.md
@@ -118,6 +118,9 @@ The extended work also fixed two failures found through testing:
 | Full Linux `make test` target, two pytest workers | 20,104 passed; 123 skipped; 1 XPASS |
 | Package-only coverage | 75.98%; 60% gate passed |
 | Guardrails after startup fix | 2,828 passed |
+| Guardrails after rebasing onto current main for PR review | 3,414 passed |
+| Focused Alpamayo tests after the PR review fixture fix | 64 passed |
+| Bandit 1.9.4 scan of the sweep tests at the CI severity/confidence thresholds | Reproduced B108 before replacing the fixed temporary path with `tmp_path`; zero findings after the fix |
 | Focused startup regressions | Failed before fix; 49 related tests passed after fix |
 | Dedicated Linux security regression target before PR publication | 651 passed; real CPU checkpoint runtime; tested code matches the branch |
 | Independent live artifact tests | Two passed for each of three reports |

--- a/docs/workbench/alpamayo2-ray-extended-validation.md
+++ b/docs/workbench/alpamayo2-ray-extended-validation.md
@@ -1,0 +1,163 @@
+# Extended Alpamayo Ray GPU validation
+
+On September 12, 2026, a dedicated Ray cluster completed **340 real Alpamayo 2
+Super inferences on two RTX PRO 6000 GPUs on separate physical hosts**. NVIDIA
+telemetry recorded approximately **2 hours 20 minutes between first and last
+GPU activity per worker**. All requested cases produced verified artifacts.
+
+This extends the [earlier 20-case workflow validation](alpamayo2-ray-validation.md).
+The implementation and reusable templates are described in the
+[Alpamayo Ray guide](alpamayo2-super.md#ray-experiments).
+
+## Experiment and Ray execution
+
+The experiment followed the baseline, threshold selection and paired refinement
+graph from the base templates:
+
+| Stage | Cases | Configuration |
+|---|---:|---|
+| Baseline | 100 | Five manifest samples, seeds 42–61, 10 diffusion steps |
+| Broad refinement | 200 | Same samples/seeds, 20 and 30 steps; selection threshold 0.0 m |
+| Exploratory hard-case follow-up | 40 | Sample 2, same seeds, 50 and 100 steps; selected by the baseline's default 2.0 m gate |
+
+The two compute applications completed through native Ray Jobs. Ray Core
+scheduled two GPU actors concurrently in each stage, with one inference in
+flight per actor. The final State API snapshot recorded 340 finished inference
+tasks, six actor initializations, 11 finished CPU reduction tasks and 858
+finished CPU telemetry tasks. Three Ray nodes ran on two physical GPU hosts;
+the CPU head shared a physical host with one worker.
+
+This extended run exercised the shared application SDK through native Ray Jobs.
+It did not exercise standard SkyPilot workflow submission, KubeRay, or the
+templates' default B200 allocation. The earlier run separately exercised the
+workflow executor in Kubernetes Jobs. Ray token authentication was enabled;
+an unauthenticated Jobs request returned HTTP 401.
+
+The runtime fetched the gated dataset and model after access preflight passed.
+The upstream source revision was
+`beb2977d9a7e9d66837d4a3ad5144ff59de37519`, model revision
+`00554695e729a6ff0b6281fd2c81b18d06e33dbe`, and dataset revision
+`b719eea7f0a63619ef51ec7f54178af0937ef050`. The source archive SHA-256 was
+`e29d3fdda10c6dd8c622fdd327740706e064720fb4fca583bd6a2e28910d5be6`.
+Runtime, sweep and reduction module hashes matched the local checkout on all
+three Ray nodes. Separate driver provenance also matched for the follow-up.
+
+## Actual GPU use
+
+| Measurement | Worker 1 | Worker 2 |
+|---|---:|---:|
+| First-to-last activity span | 2 h 19 m 12 s | 2 h 20 m 00 s |
+| Mean utilization during that span | 9.73% | 10.44% |
+| Peak utilization | 100% | 100% |
+| Peak memory | 71,447 MiB | 71,447 MiB |
+| Peak board power | 587.41 W | 614.47 W |
+| Retained one-second samples | 9,278 | 9,276 |
+
+These spans include idle intervals, preprocessing, weight reloads and rendering.
+They are not continuous busy GPU time. The utilization-weighted estimates were
+0.226 and 0.243 GPU-hours, respectively. Initial model downloading is excluded
+from the activity span. Sample files contain no detected sampling gaps.
+GPU process evidence matched the actual upstream inference commands.
+
+The current adapter starts an upstream subprocess for each case. Downloaded
+model files are cached, but model weights are not resident between cases.
+The repeated memory allocation pattern and low mean utilization expose this
+performance limitation; adding Ray workers alone does not remove it. A future
+resident-model adapter needs separate correctness and throughput qualification.
+
+Each worker used approximately 67 GiB of local model cache, with adequate local
+disk space remaining. Unlike the earlier run, this study required no manual
+model-blob relocation. Initial storage attempts encountered block-storage quota
+and mounted-filesystem capacity constraints; the final inference cache used
+local worker storage. No GPU worker restarted during the study.
+
+## Measured trajectory errors
+
+Values are means of the emitted minimum average displacement error (ADE), in
+meters, over 20 matched seeds per scenario. Lower values are better.
+
+| Manifest sample | 10 steps | 20 steps | 30 steps | 50 steps | 100 steps |
+|---|---:|---:|---:|---:|---:|
+| 0 | 1.2088 | 1.2333 | 1.2458 | — | — |
+| 1 | 1.5129 | 1.6214 | 1.6645 | — | — |
+| 2 | 2.1673 | 2.3257 | 2.3813 | 2.4331 | 2.4690 |
+| 3 | 1.1925 | 1.2408 | 1.2581 | — | — |
+| 4 | 1.1366 | 1.1795 | 1.1970 | — | — |
+
+More steps increased mean ADE for all five clips. Only sample 2 exceeded the
+default baseline selection threshold, and its 50/100-step follow-up also
+increased mean error. The follow-up was exploratory, selected after observing
+the baseline. These five clips do not establish general model quality or
+driving safety.
+
+Independent verification decoded all 340 case JSON/PNG outputs, checked report
+hashes, exact case coverage, clip identity, pinned revisions, projection shape,
+request settings and the executed sample/seed/step arguments. It recomputed
+17 per-setting summaries and 240 paired comparisons from downloaded
+measurements. All 12 overlapping cases from the earlier experiment reproduced
+ADE/FDE exactly. Individual metrics were checked for consistency across
+artifacts; raw trajectory coordinates were not emitted, so their geometry
+was not independently recomputed.
+
+## Bugs fixed and validation
+
+The branch adds Ray sweep/refinement templates and fixes manifest fallback,
+artifact validation, empty download results and renderer dependency formatting.
+The extended work also fixed two failures found through testing:
+
+- Agent planning truncated a complete tool catalog at the generic observation
+  size limit. Catalog observations now preserve the complete result, with a
+  regression that checks what the next planner receives.
+- SkyPilot startup could mistake a temporarily undiscoverable, still-running
+  child process for an exited server. Startup now retains the owned subprocess
+  handle and waits while that process is alive. Regression cases reproduce
+  one and three missed discovery scans and preserve failure on actual exit.
+
+| Check | Result |
+|---|---|
+| Full Linux `make test` target, two pytest workers | 20,104 passed; 123 skipped; 1 XPASS |
+| Package-only coverage | 75.98%; 60% gate passed |
+| Guardrails after startup fix | 2,828 passed |
+| Focused startup regressions | Failed before fix; 49 related tests passed after fix |
+| Independent live artifact tests | Two passed for each of three reports |
+| Ruff, generated CLI docs drift, diff confidentiality and secret scans | Passed |
+
+The Linux environment included the repository development/adapter/SONIC
+dependencies, official CPU PyTorch, and CLI prerequisites. Source hashes for
+the tested fixes matched the checkout. The full target excludes separately
+marked live/GPU/E2E tests; this is not a claim that every browser, scanner
+comparison or CI job ran. Earlier macOS failures remain recorded in the
+initial report; the complete Linux target now passes.
+
+## Recording and operational handoff
+
+Private evidence includes the actual browser viewport captured while observing
+Ray State API data, Jobs logs, measured results and NVIDIA telemetry. It is a
+recording of the monitoring browser, not the whole desktop. The startup segment
+lasts 18 m 52.6 s; the main segment lasts 2 h 00 m 37.6 s, separated by a
+31.25-second restart gap. Original-speed MP4 and a labeled 90× timelapse are
+provided alongside the original WebM files.
+
+The main capture stopped when a monitor reload failed. Its unfinalized WebM
+was recovered by remuxing recorded packets without re-encoding; the original
+bytes were retained. The recovered duration comes from packet timestamps,
+not an invented completion timestamp. It shows the 300-case completion but
+does not cover completion of the final 40 cases. A separate, explicitly
+labeled post-run recording shows the final 340-case state.
+
+Monitor refresh gaps over 30 seconds were approximately 45, 232, 627 and 46
+seconds. The largest followed expiry of the operator's Kubernetes login;
+telemetry observation resumed through CPU Ray tasks. The underlying one-second
+GPU files continued without gaps. The monitor graphs display recent peaks;
+the table above uses the complete telemetry files for averages.
+
+Both compute applications succeeded. Inference actors exited, both GPUs had
+zero remaining compute processes, and the telemetry application and samplers
+stopped. Owned CPU test pods were removed. At handoff, expired Nebius CLI
+authentication still prevents removing the three Ray pods, two unused cache
+PVCs and their namespace. The pods continue reserving the two GPUs until that
+cleanup completes. An ownership-checked cleanup procedure is retained in
+private evidence; the shared cluster, filesystem and bucket must be preserved.
+
+Exact resource identifiers, credentials, recordings and gated camera artifacts
+remain outside Git in private operator evidence.

--- a/docs/workbench/alpamayo2-ray-extended-validation.md
+++ b/docs/workbench/alpamayo2-ray-extended-validation.md
@@ -119,6 +119,7 @@ The extended work also fixed two failures found through testing:
 | Package-only coverage | 75.98%; 60% gate passed |
 | Guardrails after startup fix | 2,828 passed |
 | Focused startup regressions | Failed before fix; 49 related tests passed after fix |
+| Dedicated Linux security regression target before PR publication | 651 passed; real CPU checkpoint runtime; tested code matches the branch |
 | Independent live artifact tests | Two passed for each of three reports |
 | Ruff, generated CLI docs drift, diff confidentiality and secret scans | Passed |
 

--- a/docs/workbench/alpamayo2-ray-validation.md
+++ b/docs/workbench/alpamayo2-ray-validation.md
@@ -1,5 +1,10 @@
 # Alpamayo Ray workflow validation
 
+This is the initial 20-case report. The subsequent
+[340-case, multi-hour Ray study](alpamayo2-ray-extended-validation.md) adds
+shared-cluster execution, measured GPU utilization, recordings and a passing
+full Linux test target.
+
 The scenario sweep and baseline/refinement templates completed 20 real
 Alpamayo 2 Super inferences on two separate RTX PRO 6000 GPUs. Each workflow
 used one Ray GPU actor; CPU Ray tasks reduced the measured errors. The

--- a/docs/workbench/alpamayo2-ray-validation.md
+++ b/docs/workbench/alpamayo2-ray-validation.md
@@ -1,0 +1,89 @@
+# Alpamayo Ray workflow validation
+
+The scenario sweep and baseline/refinement templates completed 20 real
+Alpamayo 2 Super inferences on two separate RTX PRO 6000 GPUs. Each workflow
+used one Ray GPU actor; CPU Ray tasks reduced the measured errors. The
+Hugging Face model and gated dataset were fetched at runtime after the
+operator's access check passed.
+
+## Execution and evidence
+
+Two isolated Kubernetes Jobs ran `npa workbench workflow run-spec --execute
+--persist-state --require-inputs` against the new workflow YAMLs. This proves
+the workflow executor, Ray application, real model inference, and S3 stage
+handoffs on the selected RTX cluster. It does not prove the standard SkyPilot
+`submit` control plane, the templates' default B200 allocation, or a shared
+multi-node Ray cluster.
+
+- Sweep: samples `0,1` × seeds `42,43` × steps `10,20`: **8 cases**.
+- Hard-case baseline: samples `0,1` × seeds `42,43` × steps `10`: **4 cases**.
+- Refinement: both samples × the same seeds × steps `20,30`: **8 cases**.
+  The live override `minimum_ade=0.0` exercised refinement for both samples.
+  Their baseline means were below the checked-in `2.0` default; that default
+  would correctly produce an empty refinement on this small dataset.
+
+The accepted image digest was
+`sha256:2164450f8baf57d8798f64063ea27bf11611f5b695c467de0c2e319e3134ebd5`.
+The staged source archive was independently checked in each worker against
+SHA-256 `a04ec3f2ff53020ca90d0ff5873b4e7469921a37ed2ad94b048741228f14ed74`.
+The final sweep driver and CLI are byte-identical to that snapshot. Later
+changes tightened finite-metric validation, corrected renderer dependency
+probe formatting, and updated documentation/tests. The final artifact
+validator was run against all 20 downloaded real outputs; the GPU runs were
+not repeated for those later changes.
+
+Each of the three report hashes passed the independent live artifact verifier.
+All 20 case JSON/PNG artifacts decoded and matched their requested sample,
+seed, pinned model/dataset revisions, projection shape, and error measurements.
+Eight refinement comparisons and six per-setting ADE summaries were also
+independently recalculated from downloaded measurements.
+
+## Measured results
+
+ADE is average displacement error; lower is better. Values below are means
+over the two explicit seeds, in meters.
+
+| Manifest sample | 10 steps | 20 steps | 30 steps |
+|---|---:|---:|---:|
+| 0 | 1.3513 | 1.3974 | 1.4140 |
+| 1 | 1.7464 | 1.8885 | 1.9407 |
+
+Extra steps increased mean ADE for both samples. One sample/seed improved
+slightly while the other three worsened; the report preserves these paired
+differences instead of assuming refinement is an improvement. This is a
+two-scenario offline experiment, not evidence of driving safety or general
+model quality. Case elapsed time includes model loading, rendering and upload.
+
+## Local checks and remaining validation
+
+| Check | Result |
+|---|---|
+| Guardrails | 2,826 passed |
+| Renderer dependency requirements | 21 passed |
+| Final Alpamayo runtime and real local Ray scheduling tests | 36 passed |
+| Workflow/catalog/smoke checks | 227 passed |
+| Onboarding CLI smoke checks | 114 passed |
+| Independent live artifact tests | 2 passed for each of 3 reports |
+| Ruff across `npa/` | Passed |
+| Generated CLI documentation drift | Passed |
+
+The broad macOS test run was interrupted after 19,678 passes, 221 failures,
+36 errors, 203 skips and one XPASS. Two new integration failures found there
+were fixed and passed subsequent checks. A clean base checkout reproduced
+13 representative failures, including Linux `/proc` assumptions, platform
+cache paths and missing SkyPilot CLI prerequisites. The other broad-suite
+failures have not all been classified. Full Linux CI remains unverified.
+
+The GPU nodes had constrained root disks. During the initial model download,
+completed immutable model blobs were copied to pod memory storage, checked
+with SHA-256 and replaced by links to those copies. Incomplete blobs were left
+alone. This manual cache intervention preserved real model bytes but means the
+run does not establish unattended operation on a disk-constrained worker.
+Provide adequate model/data cache space for a repeat run.
+
+Both Jobs completed and were deleted before their owned namespace was removed.
+The shared cluster's four nodes remained Ready. Reports, workflow logs and
+licensed camera images remain in private operator evidence; no live
+infrastructure identifiers or gated dataset images are included here.
+
+See the [workflow usage and artifact-verification commands](alpamayo2-super.md#ray-experiments).

--- a/docs/workbench/alpamayo2-super.md
+++ b/docs/workbench/alpamayo2-super.md
@@ -148,10 +148,12 @@ case coverage, pinned revisions, sample identity, projected trajectory shape,
 and consistency of the measured errors. It requires a prior real GPU run;
 it does not submit another workload.
 
-The [RTX validation report](alpamayo2-ray-validation.md) records the measured
-20-case experiment, test results, cache intervention, and remaining platform
-coverage. The templates' B200 default and standard SkyPilot submission still
-need their own live qualification.
+The [initial RTX validation report](alpamayo2-ray-validation.md) records the
+20-case workflow experiment. The [extended Ray study](alpamayo2-ray-extended-validation.md)
+records 340 cases on two physical GPU hosts over multiple hours, measured
+utilization, paired results, recordings and the full Linux test result. The
+templates' B200 default and standard SkyPilot submission still need their own
+live qualification.
 
 ## Serve inference
 

--- a/docs/workbench/alpamayo2-super.md
+++ b/docs/workbench/alpamayo2-super.md
@@ -75,7 +75,10 @@ node. The catalog rejects multi-node replication of this single-node command.
 
 Ray GPU actors call the shared upstream inference implementation. Each actor
 keeps one case in flight and reuses the downloaded pinned model snapshot. Model
-weights load into a fresh upstream subprocess for each case. Ray CPU tasks
+weights load into a fresh upstream subprocess for each case. Actors emit
+structured progress events in the driver logs: `alpamayo.case_started`
+and `alpamayo.case_completed`. Completion events include measured ADE and elapsed
+time after artifact publication; CLI progress stays on stderr. Ray CPU tasks
 calculate per-scenario/per-setting mean ADE, mean FDE, and population standard
 deviation across seeds. `elapsed_seconds` measures the whole case, including
 model fetch/load, inference, rendering, and artifact upload. It does not isolate

--- a/docs/workbench/alpamayo2-super.md
+++ b/docs/workbench/alpamayo2-super.md
@@ -55,8 +55,100 @@ headroom. RTX PRO 6000 is an independent `sm_120` validation path, not something
 inferred from B200 success.
 
 Successful inference publishes `result.json` (pins and provenance),
-`trajectory.json` (the predicted ego trajectory), and `trajectory.png` (the
-calibrated-camera visualization).
+`trajectory.json` (upstream trajectory metadata and displacement-error metrics),
+and `trajectory.png` (the calibrated-camera visualization). The upstream JSON
+does not contain the full predicted coordinate array. NPA snapshots the selected
+manifest before downloading weights, verifies the output sample identity, seed,
+and required camera projection, and decodes the PNG before publication. Missing
+or invalid manifests fail before model fetch; they cannot fall back to upstream's
+default clip. `result.json` includes the manifest hash and validated metrics.
+
+## Ray experiments
+
+The [sweep template](../../workflows/testing/alpamayo2-ray-sweep.yaml) extends the
+single-inference template into a scenario × seed × diffusion-step experiment.
+Its default grid contains eight cases: samples `0,1`, seeds `42,43`, and step
+counts `10,20`. Change these comma-separated config values to define an experiment;
+there is no implicit truncation. `workers` defaults to one GPU actor. Increase
+both the resource allocation and actor count together for multiple GPUs on one
+node. The catalog rejects multi-node replication of this single-node command.
+
+Ray GPU actors call the shared upstream inference implementation. Each actor
+keeps one case in flight and reuses the downloaded pinned model snapshot. Model
+weights load into a fresh upstream subprocess for each case. Ray CPU tasks
+calculate per-scenario/per-setting mean ADE, mean FDE, and population standard
+deviation across seeds. `elapsed_seconds` measures the whole case, including
+model fetch/load, inference, rendering, and artifact upload. It does not isolate
+inference latency. The runtime uses an independent local Ray instance with
+a 256 MiB object store for small measurement records; it never discovers
+SkyPilot's management Ray through an ambient address.
+
+Use the current source with the accepted image: the release image predates the
+new sweep command. Source staging is required until an image containing this
+implementation is released. The renderer installs Ray 2.58.0 into the NPA stage
+interpreter, independently of the upstream model interpreter.
+
+```bash
+npa workbench health preflight --checks nebius,hf,s3 --json
+npa workbench health access --capability alpamayo2-super --json
+npa workbench workflow validate-spec workflows/testing/alpamayo2-ray-sweep.yaml --json
+npa workbench workflow submit workflows/testing/alpamayo2-ray-sweep.yaml \
+  --project YOUR_PROJECT --infra k8s/YOUR_CONTEXT --stage-src \
+  --var bucket=YOUR_BUCKET \
+  --secret-env HF_TOKEN --secret-env AWS_ACCESS_KEY_ID \
+  --secret-env AWS_SECRET_ACCESS_KEY
+```
+
+On a verified RTX PRO 6000 target, set
+`NPA_WORKFLOW_GPU_ACCELERATOR=RTXPRO6000:1` in the submitting process. The
+checked-in B200 default remains the same as the inference base template.
+
+The [hard-case template](../../workflows/testing/alpamayo2-ray-hardcases.yaml)
+first measures a baseline, then consumes its S3 `report.json` to select every
+scenario whose mean ADE exceeds `minimum_ade` (default `2.0` meters). It reruns
+those scenarios at `refinement_steps` (default `20,30`) using the baseline seeds.
+An empty selection completes with zero refinement cases. Comparisons require
+the same model revision, dataset revision, manifest hash, scenario, and seed.
+A negative `ade_change_m` means lower measured displacement error; extra steps
+are not assumed to improve a prediction. These are offline error measurements,
+not driving-safety or closed-loop policy evaluations.
+
+Both templates publish a `report.json` and `SHA256SUMS`. Each measured case links
+its independently verified `result.json`, `trajectory.json`, and `trajectory.png`
+under a fresh execution subdirectory. A missing case, duplicate, invalid metric,
+or failed actor prevents a complete report. Use a new run ID for each experiment;
+this path does not implement checkpoint recovery or automatic inference retries.
+
+For an already allocated GPU environment, `npa workbench alpamayo2-super sweep`
+exposes `--output-path`, `--run-id`, `--sample-indices`, `--seeds`,
+`--diffusion-steps`, and `--workers`. Supply `--input-path` with a baseline report
+and `--minimum-ade` to refine it. Public CLI handoffs use S3. The Python SDK's
+`sweep(AlpamayoSweepRequest(...))` uses the same implementation and can use local
+paths for development. A dedicated Ray Jobs driver can invoke
+`python -m npa.workbench.alpamayo2_super.ray_sweep` with an explicit
+`--ray-address HOST:PORT`; deliver the NPA source and dependencies to every worker.
+The module defaults to `local` and rejects `auto` to avoid management-cluster
+discovery. `ray[default]==2.58.0` is required in the application environment.
+
+Independently verify a completed live report with the read-only artifact test.
+Set `NPA_ALPAMAYO_RAY_REPORT_URI` to the exact authorized S3 `report.json` and
+provide that bucket's storage credentials in the test environment:
+
+```bash
+NPA_INTEGRATION_E2E=1 \
+NPA_ALPAMAYO_RAY_REPORT_URI=s3://YOUR_BUCKET/runs/YOUR_RUN/alpamayo2-ray-sweep/sweep/report.json \
+  npa/.venv/bin/python -m pytest npa/tests/e2e/test_alpamayo_ray_artifacts_live.py -q
+```
+
+This downloads and decodes every case's artifacts and checks report hashes,
+case coverage, pinned revisions, sample identity, projected trajectory shape,
+and consistency of the measured errors. It requires a prior real GPU run;
+it does not submit another workload.
+
+The [RTX validation report](alpamayo2-ray-validation.md) records the measured
+20-case experiment, test results, cache intervention, and remaining platform
+coverage. The templates' B200 default and standard SkyPilot submission still
+need their own live qualification.
 
 ## Serve inference
 

--- a/docs/workbench/npa-workflow-tool-catalog.md
+++ b/docs/workbench/npa-workflow-tool-catalog.md
@@ -26,6 +26,7 @@ accidental dead entries fail the guardrail. The retired monolithic
 | `workbench.curobo.validate` | `npa workbench curobo validate` | result prefix | hash and complete coverage validation | no |
 | `workbench.curobo.visualize` | `npa workbench curobo visualize` | validated result prefix | verified RRD joint/FK recording | no |
 | `workbench.alpamayo2_super.infer` | `npa workbench alpamayo2-super infer` | pinned model/dataset revisions and PhysicalAI-AV sample index | trajectory JSON, calibrated PNG, immutable provenance under `config.output_uri` | no (real upstream VLM + diffusion expert inference on GPU) |
+| `workbench.alpamayo2_super.sweep` | `npa workbench alpamayo2-super sweep` | scenario indices, seeds, diffusion settings; optional completed baseline report | per-case verified artifacts, ADE/FDE statistics, matched refinement changes, report checksums | no (Ray GPU actors invoke upstream Alpamayo inference; Ray CPU tasks reduce measured results) |
 | `infra.fleet.deploy` | `npa fleet deploy` | `config.fleet_spec` | fleet deploy JSON | no |
 | `infra.soperator.deploy` | `npa soperator deploy` | `config.soperator_spec` | cluster deploy JSON | no |
 | `workbench.nurec.check` | `npa workbench nurec check` | `config.nurec_image`, `config.dataset_id` | access-check JSON (NGC pullability, HF rights, RT-core GPU) | no |

--- a/npa/README.md
+++ b/npa/README.md
@@ -38,6 +38,11 @@ environments, and the separate SkyPilot environment.
 
 Extra tools required by specific commands:
 
+- `ray[default]==2.58.0` in the NPA application environment for
+  `npa workbench alpamayo2-super sweep`. The workflow renderer installs this
+  dependency for the [Ray experiment templates](../docs/workbench/alpamayo2-super.md#ray-experiments).
+  Use `--sample-indices`, `--seeds`, and `--diffusion-steps` for a baseline,
+  or `--input-path` and `--minimum-ade` to refine a completed S3 report.
 - `nebius` CLI for Serverless AI Endpoint deploys and managed Nebius deploy commands
 - `terraform` for VM and container workbench deploys
 - `ffmpeg` for `npa adapter convert`

--- a/npa/src/npa/agent_backend/actions.py
+++ b/npa/src/npa/agent_backend/actions.py
@@ -1224,7 +1224,9 @@ def run_action_loop(
         if terminal_empty:
             replan_reason = ""
         status = "error" if replan_reason == "tool_error" else "empty" if empty_result else "ok"
-        observed = _observe(observation)
+        # The trusted local catalog is the complete routing inventory. A text
+        # prefix hides registered capabilities from the next planning step.
+        observed = observation if tool == "tools_catalog" else _observe(observation)
         steps.append(
             {
                 "step": step_index + 1,

--- a/npa/src/npa/cli/workbench/alpamayo2_super.py
+++ b/npa/src/npa/cli/workbench/alpamayo2_super.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+from contextlib import redirect_stdout
+import sys
 
 import typer
+from npa.cli.path_contract import validate_read_path, validate_write_path
 
 from npa.workbench.alpamayo2_super.runtime import (
     DEFAULT_DATASET_REVISION,
@@ -21,6 +24,53 @@ app = typer.Typer(
     help="NVIDIA Alpamayo 2 Super trajectory-inference workbench.",
     no_args_is_help=True,
 )
+
+
+@app.command("sweep")
+def sweep_cmd(
+    output_path: str = typer.Option(..., "--output-path"),
+    run_id: str = typer.Option(..., "--run-id"),
+    sample_indices: str = typer.Option("0,1", "--sample-indices"),
+    seeds: str = typer.Option("42,43", "--seeds"),
+    diffusion_steps: str = typer.Option("10,20", "--diffusion-steps"),
+    workers: int = typer.Option(1, "--workers", min=1),
+    input_path: str = typer.Option("", "--input-path"),
+    minimum_ade: float = typer.Option(2.0, "--minimum-ade", min=0),
+) -> None:
+    """Sweep scenarios with Ray; optionally refine a baseline report's hard cases.
+
+    Args:
+        output_path: S3 report destination.
+        run_id: Experiment identity.
+        sample_indices: Comma-separated manifest indices for a baseline.
+        seeds: Comma-separated seeds; refinement inherits baseline seeds.
+        diffusion_steps: Comma-separated integration-step counts.
+        workers: GPU actor count on this allocated node.
+        input_path: Optional S3 baseline report.json.
+        minimum_ade: Refine baseline scenarios above this mean ADE in meters.
+    Returns:
+        None; writes a JSON report to stdout.
+    Raises:
+        typer.Exit: Input validation or inference fails.
+    """
+    _sweep_command(locals())
+
+
+def _sweep_command(values: dict) -> None:
+    from npa.workbench.alpamayo2_super.ray_sweep import AlpamayoSweepRequest, run_sweep
+
+    try:
+        validate_write_path(values["output_path"], tool="alpamayo2-super")
+        if values["input_path"]:
+            validate_read_path(values["input_path"], tool="alpamayo2-super")
+        for name in ("sample_indices", "seeds", "diffusion_steps"):
+            values[name] = [int(value.strip()) for value in values[name].split(",")]
+        with redirect_stdout(sys.stderr):
+            result = run_sweep(AlpamayoSweepRequest(**values))
+    except (ValueError, Alpamayo2SuperError) as exc:
+        typer.echo(f"Alpamayo sweep failed: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    typer.echo(json.dumps(result, indent=2, sort_keys=True, allow_nan=False))
 
 
 @app.command("infer")

--- a/npa/src/npa/orchestration/npa_workflow/catalog.py
+++ b/npa/src/npa/orchestration/npa_workflow/catalog.py
@@ -248,6 +248,24 @@ TOOL_CATALOG: dict[str, ToolEntry] = {
             "{{run.id}}",
         ],
     ),
+    "workbench.alpamayo2_super.sweep": ToolEntry(
+        name="workbench.alpamayo2_super.sweep",
+        description="Ray GPU actor sweep over Alpamayo scenarios, seeds, and diffusion settings, with optional matched hard-case refinement.",
+        access_capabilities=("alpamayo2-super",),
+        omit_flags_when_empty=("--input-path",),
+        config_defaults={"input_uri": "", "minimum_ade": "2.0", "workers": "1"},
+        argv_template=[
+            "npa", "workbench", "alpamayo2-super", "sweep",
+            "--output-path", "{{config.output_uri}}",
+            "--input-path", "{{config.input_uri}}",
+            "--sample-indices", "{{config.sample_indices}}",
+            "--seeds", "{{config.seeds}}",
+            "--diffusion-steps", "{{config.diffusion_steps}}",
+            "--workers", "{{config.workers}}",
+            "--minimum-ade", "{{config.minimum_ade}}",
+            "--run-id", "{{run.id}}",
+        ],
+    ),
     "infra.fleet.deploy": ToolEntry(
         name="infra.fleet.deploy",
         description=(

--- a/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
+++ b/npa/src/npa/orchestration/npa_workflow/skypilot_render.py
@@ -132,6 +132,9 @@ DECLARATIVE_PIP_EXTRAS = frozenset({"viz"})
 #: `huggingface_hub`, and the interpreter running npa in a vendor image is not the vendor's own
 #: venv, so the library is not necessarily importable there (live job 244).
 TOOL_REF_PIP_REQUIREMENTS: dict[str, tuple[tuple[str, str], ...]] = {
+    "workbench.alpamayo2_super.sweep": (
+        ('python:ray;assert(ray.__version__=="2.58.0")', "ray[default]==2.58.0"),
+    ),
     # The OpenPI BYOF environment intentionally contains only upstream's
     # pinned runtime. Four-mode stages publish/read private object-storage
     # artifacts from that same interpreter, so install the NPA storage client

--- a/npa/src/npa/orchestration/npa_workflow/submit_matrix.py
+++ b/npa/src/npa/orchestration/npa_workflow/submit_matrix.py
@@ -88,6 +88,18 @@ SUBMIT_LIVE_MATRIX: tuple[SubmitLiveCase, ...] = (
             "operator-side PhysicalAI-AV dataset acceptance."
         ),
     ),
+    SubmitLiveCase(
+        "alpamayo2-ray-sweep.yaml", "gpu",
+        secret_envs=("HF_TOKEN", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
+        image_tool="alpamayo2-super",
+        notes="Real Ray scenario/seed/diffusion sweep; requires current staged NPA source and gated PhysicalAI-AV access.",
+    ),
+    SubmitLiveCase(
+        "alpamayo2-ray-hardcases.yaml", "gpu",
+        secret_envs=("HF_TOKEN", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
+        image_tool="alpamayo2-super",
+        notes="Ray baseline followed by error-threshold selection and matched-seed refinement; requires current staged NPA source.",
+    ),
     # --- CPU / zero-GPU (Token Factory hosted) ---
     SubmitLiveCase(
         "token-factory-caption.yaml",

--- a/npa/src/npa/orchestration/skypilot/local_api.py
+++ b/npa/src/npa/orchestration/skypilot/local_api.py
@@ -417,6 +417,7 @@ def ensure_isolated_api(
                          "SKYPILOT_GLOBAL_CONFIG", "SKYPILOT_SERVER_PLUGINS_CONFIG", "PYTHONPATH", _ENDPOINT, _MARKER)
         binding = {key: hashlib.sha256(daemon_env.get(key, "").encode()).hexdigest() for key in identity_keys}
         files = _identity_files(daemon_env, config=parsed_config)
+        spawned = None
         process = _process(record) if record.get("interpreter") else None
         if process:
             if record.get("interpreter") != interpreter or record.get("config_sha256") != config_hash:
@@ -453,13 +454,18 @@ def ensure_isolated_api(
                           pid=None, start_ticks=None, state="starting")
             _write(root / "daemon.json", record)
             with open(root / "server.log", "ab", opener=lambda p, flags: os.open(p, flags, 0o600)) as log:
-                subprocess.Popen([interpreter, "-m", "sky.server.server", "--host", "127.0.0.1",
+                spawned = subprocess.Popen([interpreter, "-m", "sky.server.server", "--host", "127.0.0.1",
                                   "--port", str(record["port"]), "--metrics-port", str(record["metrics_port"])],
                                  env=daemon_env, cwd=cwd, stdin=subprocess.DEVNULL,
                                  stdout=log, stderr=log, start_new_session=True)
         while True:
             process = _process(record)
             if process is None:
+                # A fresh /proc scan can miss the child during startup. Its
+                # absence is not exit evidence while our Popen handle is alive.
+                if spawned is not None and spawned.poll() is None:
+                    time.sleep(0.2)
+                    continue
                 raise IsolatedApiError("owned SkyPilot API exited before readiness; inspect its private server log")
             record.update(process)
             _write(root / "daemon.json", record)

--- a/npa/src/npa/sdk/workbench/alpamayo2_super.py
+++ b/npa/src/npa/sdk/workbench/alpamayo2_super.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from npa.workbench.alpamayo2_super.ray_sweep import AlpamayoSweepRequest
+
 from npa.workbench.alpamayo2_super.runtime import (
     DEFAULT_DATASET_REVISION,
     DEFAULT_MANIFEST,
@@ -49,4 +51,21 @@ def infer(
     )
 
 
-__all__ = ["Alpamayo2SuperRequest", "infer"]
+def sweep(request: AlpamayoSweepRequest) -> dict[str, Any]:
+    """Run a Ray experiment through the shared Workbench implementation.
+
+    Args:
+        request: An AlpamayoSweepRequest with explicit experiment settings.
+    Returns:
+        Complete measured report and published artifact locations.
+    Raises:
+        ValueError: Experiment inputs or measurements are invalid.
+        RuntimeError: Ray or inference execution fails.
+        OSError: Artifact I/O fails.
+    """
+    from npa.workbench.alpamayo2_super.ray_sweep import run_sweep
+
+    return run_sweep(request)
+
+
+__all__ = ["Alpamayo2SuperRequest", "AlpamayoSweepRequest", "infer", "sweep"]

--- a/npa/src/npa/workbench/alpamayo2_super/ray_report.py
+++ b/npa/src/npa/workbench/alpamayo2_super/ray_report.py
@@ -1,0 +1,149 @@
+"""Validate Alpamayo sweep measurements and compare matched scenarios and seeds."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+import math
+from statistics import fmean, pstdev
+
+
+def case_grid(samples: list[int], seeds: list[int], steps: list[int]) -> list[dict]:
+    """Expand an explicit scenario, seed, and diffusion-step experiment.
+
+    Args:
+        samples: Non-negative validation-manifest indices.
+        seeds: Non-negative random seeds.
+        steps: Positive diffusion-step counts.
+    Returns:
+        Unique cases in reproducible sample/seed/step order.
+    Raises:
+        ValueError: A dimension is empty, duplicated, or invalid.
+    """
+    for name, values, minimum in (("samples", samples, 0), ("seeds", seeds, 0), ("steps", steps, 1)):
+        if not values or len(set(values)) != len(values):
+            raise ValueError(f"{name} must be non-empty and contain no duplicates")
+        if any(type(value) is not int or value < minimum for value in values):
+            raise ValueError(f"{name} must contain integers >= {minimum}")
+    return [
+        {"sample_index": sample, "seed": seed, "diffusion_steps": count}
+        for sample in sorted(samples) for seed in sorted(seeds) for count in sorted(steps)
+    ]
+
+
+def case_key(case: dict) -> tuple[int, int, int]:
+    """Identify one reproducible inference request.
+
+    Args:
+        case: Sample, seed, and diffusion settings.
+    Returns:
+        Sample index, seed, diffusion steps.
+    Raises:
+        KeyError: A required setting is absent.
+    """
+    return case["sample_index"], case["seed"], case["diffusion_steps"]
+
+
+def validate_measurements(rows: list[dict], cases: list[dict]) -> list[dict]:
+    """Reject incomplete, duplicate, or non-finite sweep results.
+
+    Args:
+        rows: Actual inference measurements.
+        cases: Exact expected experiment cases.
+    Returns:
+        Measurements sorted by sample, seed, and step count.
+    Raises:
+        ValueError: Results do not exactly cover the experiment or metrics are invalid.
+        KeyError: Required measurement fields are missing.
+    """
+    expected = {case_key(case) for case in cases}
+    observed = [case_key(row) for row in rows]
+    if len(observed) != len(expected) or set(observed) != expected:
+        raise ValueError("sweep results must cover every requested case exactly once")
+    for row in rows:
+        for name in ("min_ade_m", "min_fde_m", "elapsed_seconds"):
+            value = row[name]
+            if type(value) not in (int, float) or not math.isfinite(value) or value < 0:
+                raise ValueError(f"invalid {name} in inference measurement")
+    return sorted(rows, key=case_key)
+
+
+def summarize_sample(rows: list[dict]) -> list[dict]:
+    """Measure seed variability separately for each diffusion-step setting.
+
+    Args:
+        rows: Validated measurements for one scenario.
+    Returns:
+        Per-setting mean ADE/FDE, seed standard deviation, and case elapsed time.
+    Raises:
+        KeyError: Measurement fields are missing.
+    """
+    groups = defaultdict(list)
+    for row in rows:
+        groups[row["diffusion_steps"]].append(row)
+    summaries = []
+    for steps, members in sorted(groups.items()):
+        errors = [row["min_ade_m"] for row in members]
+        summaries.append({
+            "sample_index": members[0]["sample_index"], "diffusion_steps": steps,
+            "seed_count": len(members), "mean_ade_m": fmean(errors),
+            "seed_ade_std_m": pstdev(errors),
+            "mean_fde_m": fmean(row["min_fde_m"] for row in members),
+            "mean_elapsed_seconds": fmean(row["elapsed_seconds"] for row in members),
+        })
+    return summaries
+
+
+def select_hard_samples(report: dict, minimum_ade: float) -> list[int]:
+    """Select every scenario whose mean ADE exceeds the operator threshold.
+
+    Args:
+        report: Completed baseline sweep report.
+        minimum_ade: Non-negative mean displacement error in meters.
+    Returns:
+        Sorted unique scenario indices; an empty selection is valid.
+    Raises:
+        ValueError: Threshold or baseline report is invalid.
+        KeyError: Required baseline fields are missing.
+    """
+    if not math.isfinite(minimum_ade) or minimum_ade < 0:
+        raise ValueError("minimum_ade must be finite and non-negative")
+    if report.get("schema") != "npa.alpamayo.ray-sweep.v1" or report.get("status") != "complete":
+        raise ValueError("refinement requires a complete Alpamayo Ray sweep report")
+    rows = validate_measurements(report["measurements"], report["cases"])
+    groups = defaultdict(list)
+    for row in rows:
+        groups[row["sample_index"]].append(row["min_ade_m"])
+    return sorted(sample for sample, values in groups.items() if fmean(values) > minimum_ade)
+
+
+def matched_comparisons(baseline: list[dict], refined: list[dict]) -> list[dict]:
+    """Compare errors only between identical scenarios and random seeds.
+
+    Args:
+        baseline: Baseline measurements.
+        refined: Measurements from the refinement sweep.
+    Returns:
+        ADE and FDE changes for every matching baseline/refined setting pair.
+    Raises:
+        KeyError: Required measurement fields are missing.
+        ValueError: A refined case has no matching baseline seed or sample identity.
+    """
+    matches = defaultdict(list)
+    for row in baseline:
+        matches[(row["sample_index"], row["seed"])].append(row)
+    comparisons = []
+    for row in refined:
+        previous = matches[(row["sample_index"], row["seed"])]
+        if not previous:
+            raise ValueError("refinement has no matched baseline scenario and seed")
+        for before in previous:
+            if before["sample"] != row["sample"]:
+                raise ValueError("baseline and refinement manifest identities differ")
+            comparisons.append({
+                "sample_index": row["sample_index"], "seed": row["seed"],
+                "baseline_steps": before["diffusion_steps"],
+                "refined_steps": row["diffusion_steps"],
+                "ade_change_m": row["min_ade_m"] - before["min_ade_m"],
+                "fde_change_m": row["min_fde_m"] - before["min_fde_m"],
+            })
+    return comparisons

--- a/npa/src/npa/workbench/alpamayo2_super/ray_sweep.py
+++ b/npa/src/npa/workbench/alpamayo2_super/ray_sweep.py
@@ -78,6 +78,7 @@ class _InferenceWorker:
         import ray
 
         label = "sample-{}-seed-{}-steps-{}".format(*case_key(case))
+        print(json.dumps({"event": "alpamayo.case_started", **case}), flush=True)
         started = time.monotonic()
         result = run_inference(
             Alpamayo2SuperRequest(
@@ -86,13 +87,17 @@ class _InferenceWorker:
             ),
             model_resolver=self._resolve,
         )
-        return {
+        measurement = {
             **case, **result["metrics"], "sample": result["sample"],
             "elapsed_seconds": time.monotonic() - started,
             "artifacts": result["artifacts"],
             "ray_node_id": ray.get_runtime_context().get_node_id(),
             "ray_actor_id": str(ray.get_runtime_context().get_actor_id()),
         }
+        print(json.dumps({"event": "alpamayo.case_completed", **case,
+                          "elapsed_seconds": measurement["elapsed_seconds"],
+                          "min_ade_m": measurement["min_ade_m"]}), flush=True)
+        return measurement
 
 
 def dispatch_cases(cases: list[dict], actors: list) -> list[dict]:

--- a/npa/src/npa/workbench/alpamayo2_super/ray_sweep.py
+++ b/npa/src/npa/workbench/alpamayo2_super/ray_sweep.py
@@ -1,0 +1,282 @@
+"""Execute Alpamayo scenario sweeps with Ray GPU actors and CPU reductions."""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import time
+import uuid
+
+from npa.clients.storage import StorageClient
+from npa.workbench.alpamayo2_super.runtime import (
+    DEFAULT_MANIFEST,
+    DEFAULT_MODEL_REVISION,
+    DEFAULT_DATASET_REVISION,
+    Alpamayo2SuperRequest,
+    _publish,
+    _resolve_model_snapshot,
+    run_inference,
+)
+from npa.workbench.alpamayo2_super.ray_report import (
+    case_grid, case_key, matched_comparisons, select_hard_samples,
+    summarize_sample, validate_measurements,
+)
+
+
+@dataclass(frozen=True)
+class AlpamayoSweepRequest:
+    """Define a reproducible Ray experiment without provisioning infrastructure.
+
+    Args:
+        output_path: Report destination, with independent execution subdirectories.
+        run_id: Operator-supplied experiment identity.
+        sample_indices: Manifest indices for a new baseline.
+        seeds: Random seeds for a new baseline; refinement inherits baseline seeds.
+        diffusion_steps: Explicit integration-step settings to evaluate.
+        workers: GPU actor count within an already allocated Ray cluster.
+        manifest: Worker-readable pinned validation manifest.
+        ray_address: Explicit application Ray address, or local for an owned runtime.
+        input_path: Optional completed baseline report to refine.
+        minimum_ade: Refine scenarios whose baseline mean ADE exceeds this value.
+    Returns:
+        None.
+    Raises:
+        None.
+    """
+
+    output_path: str
+    run_id: str
+    sample_indices: list[int] = field(default_factory=lambda: [0, 1])
+    seeds: list[int] = field(default_factory=lambda: [42, 43])
+    diffusion_steps: list[int] = field(default_factory=lambda: [10, 20])
+    workers: int = 1
+    manifest: str = DEFAULT_MANIFEST
+    ray_address: str = "local"
+    input_path: str = ""
+    minimum_ade: float = 2.0
+
+
+class _InferenceWorker:
+    def __init__(self, output_path: str, manifest: str, run_id: str):
+        self.output_path = output_path
+        self.manifest = manifest
+        self.run_id = run_id
+        self.snapshot = ""
+
+    def _resolve(self, request):
+        if not self.snapshot:
+            self.snapshot = _resolve_model_snapshot(request)
+        return self.snapshot
+
+    def infer(self, case: dict) -> dict:
+        import ray
+
+        label = "sample-{}-seed-{}-steps-{}".format(*case_key(case))
+        started = time.monotonic()
+        result = run_inference(
+            Alpamayo2SuperRequest(
+                output_path=f"{self.output_path.rstrip('/')}/{label}/",
+                manifest=self.manifest, run_id=self.run_id, **case,
+            ),
+            model_resolver=self._resolve,
+        )
+        return {
+            **case, **result["metrics"], "sample": result["sample"],
+            "elapsed_seconds": time.monotonic() - started,
+            "artifacts": result["artifacts"],
+            "ray_node_id": ray.get_runtime_context().get_node_id(),
+            "ray_actor_id": str(ray.get_runtime_context().get_actor_id()),
+        }
+
+
+def dispatch_cases(cases: list[dict], actors: list) -> list[dict]:
+    """Keep one inference in flight per actor and collect every case exactly once.
+
+    Args:
+        cases: Explicit reproducible experiment cases.
+        actors: Ray actors exposing an infer method.
+    Returns:
+        Validated measurements in deterministic case order.
+    Raises:
+        ValueError: Actors are absent or returned measurements are invalid.
+        ray.exceptions.RayError: An actor or inference task fails.
+    """
+    import ray
+
+    if cases and not actors:
+        raise ValueError("at least one inference actor is required")
+    remaining = iter(cases)
+    pending = {}
+    rows = []
+    for actor in actors:
+        case = next(remaining, None)
+        if case is not None:
+            pending[actor.infer.remote(case)] = actor
+    while pending:
+        completed, _ = ray.wait(list(pending), num_returns=1)
+        reference = completed[0]
+        actor = pending.pop(reference)
+        rows.append(ray.get(reference))
+        case = next(remaining, None)
+        if case is not None:
+            pending[actor.infer.remote(case)] = actor
+    return validate_measurements(rows, cases)
+
+
+def _reduce(rows: list[dict]) -> list[dict]:
+    import ray
+
+    groups = defaultdict(list)
+    for row in rows:
+        groups[row["sample_index"]].append(row)
+    reduce_sample = ray.remote(num_cpus=1)(summarize_sample)
+    references = [reduce_sample.remote(group) for _, group in sorted(groups.items())]
+    return [row for group in ray.get(references) for row in group]
+
+
+def _read_report(path: str) -> dict:
+    with tempfile.TemporaryDirectory(prefix="npa-alpamayo-baseline-") as scratch:
+        local = Path(scratch) / "report.json"
+        if path.startswith("s3://"):
+            StorageClient.from_environment().download_file(path, str(local))
+        else:
+            local = Path(path).expanduser()
+        return json.loads(local.read_text())
+
+
+def _cases_and_baseline(args) -> tuple[list[dict], dict | None]:
+    if not args.input_path:
+        return case_grid(args.sample_indices, args.seeds, args.diffusion_steps), None
+    baseline = _read_report(args.input_path)
+    samples = select_hard_samples(baseline, args.minimum_ade)
+    expected = {"model_revision": DEFAULT_MODEL_REVISION, "dataset_revision": DEFAULT_DATASET_REVISION}
+    if baseline.get("revisions") != expected:
+        raise ValueError("baseline uses different model or dataset revisions")
+    seeds = sorted({row["seed"] for row in baseline["cases"]})
+    cases = case_grid(samples, seeds, args.diffusion_steps) if samples else []
+    return cases, baseline
+
+
+def _execute_sweep(args, cases: list[dict], execution: str) -> tuple[list[dict], list[dict]]:
+    import ray
+
+    if not cases:
+        return [], []
+    if args.workers < 1:
+        raise ValueError("workers must be positive")
+    resources = ray.cluster_resources()
+    if resources.get("GPU", 0) < args.workers or resources.get("CPU", 0) < 2 * args.workers:
+        raise ValueError("Ray cluster lacks the requested GPU/CPU actor capacity")
+    worker = ray.remote(num_gpus=1, num_cpus=2, max_restarts=0)(_InferenceWorker)
+    actors = [worker.remote(execution, args.manifest, args.run_id) for _ in range(args.workers)]
+    try:
+        rows = dispatch_cases(cases, actors)
+    finally:
+        for actor in actors:
+            ray.kill(actor, no_restart=True)
+    return rows, _reduce(rows)
+
+
+def _publish_report(report: dict, output_path: str) -> dict:
+    with tempfile.TemporaryDirectory(prefix="npa-alpamayo-report-") as scratch:
+        local = Path(scratch)
+        encoded = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+        (local / "report.json").write_text(encoded)
+        digest = hashlib.sha256(encoded.encode()).hexdigest()
+        (local / "SHA256SUMS").write_text(f"{digest}  report.json\n")
+        return _publish(local, output_path)
+
+
+@contextmanager
+def _ray_connection(address: str):
+    import ray
+
+    if ray.is_initialized():
+        raise ValueError("run a sweep in a dedicated driver process with its own Ray connection")
+    with tempfile.TemporaryDirectory(prefix="npa-alpamayo-ray-") as scratch:
+        options = {}
+        if address == "local":
+            options = {"_temp_dir": scratch, "object_store_memory": 256 * 1024 * 1024,
+                       "include_dashboard": False}
+        try:
+            ray.init(address=address, log_to_driver=True, **options)
+            yield
+        finally:
+            ray.shutdown()
+
+
+def _report(args, cases, rows, summaries, baseline):
+    comparisons = matched_comparisons(baseline["measurements"], rows) if baseline else []
+    return {
+        "schema": "npa.alpamayo.ray-sweep.v1", "status": "complete",
+        "run_id": args.run_id, "cases": cases, "measurements": rows,
+        "summaries": summaries, "comparisons": comparisons,
+        "revisions": {"model_revision": DEFAULT_MODEL_REVISION, "dataset_revision": DEFAULT_DATASET_REVISION},
+        "baseline_uri": args.input_path, "selection_minimum_ade_m": args.minimum_ade if baseline else None,
+        "model_lifetime": "one upstream subprocess per case; actor reuses downloaded snapshot",
+    }
+
+
+def run_sweep(args: AlpamayoSweepRequest) -> dict:
+    """Run a Ray sweep or refine all baseline scenarios above the error threshold.
+
+    Args:
+        args: Experiment inputs, outputs, and explicit Ray connection settings.
+    Returns:
+        Complete report with exact measurements and published report locations.
+    Raises:
+        ValueError: Experiment, baseline, capacity, or metrics are invalid.
+        RuntimeError: Inference or Ray execution fails.
+        OSError: Artifact I/O fails.
+    """
+    if not args.ray_address or args.ray_address == "auto":
+        raise ValueError("select local or an explicit application Ray address")
+    case_grid([0], [0], args.diffusion_steps)
+    cases, baseline = _cases_and_baseline(args)
+    execution = args.output_path.rstrip("/") + "/executions/" + uuid.uuid4().hex
+    with _ray_connection(args.ray_address):
+        rows, summaries = _execute_sweep(args, cases, execution)
+        report = _report(args, cases, rows, summaries, baseline)
+        artifacts = _publish_report(report, args.output_path)
+        return {**report, "artifacts": artifacts}
+
+
+def _integers(value: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in value.split(",")]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected comma-separated integers") from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the workflow module's command-line contract.
+
+    Args:
+        None.
+    Returns:
+        Parser for Ray sweep and refinement inputs.
+    Raises:
+        None.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-path", required=True)
+    parser.add_argument("--input-path", default="")
+    parser.add_argument("--sample-indices", type=_integers, default=[0, 1])
+    parser.add_argument("--seeds", type=_integers, default=[42, 43])
+    parser.add_argument("--diffusion-steps", type=_integers, default=[10, 20])
+    parser.add_argument("--minimum-ade", type=float, default=2.0)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--manifest", default=DEFAULT_MANIFEST)
+    parser.add_argument("--ray-address", default="local")
+    parser.add_argument("--run-id", required=True)
+    return parser
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_sweep(AlpamayoSweepRequest(**vars(build_parser().parse_args()))), indent=2, allow_nan=False))

--- a/npa/src/npa/workbench/alpamayo2_super/runtime.py
+++ b/npa/src/npa/workbench/alpamayo2_super/runtime.py
@@ -8,7 +8,9 @@ weights, PhysicalAI-AV data, credentials, or populated Hugging Face cache.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, replace
+import hashlib
 import json
+import math
 import os
 from pathlib import Path
 import subprocess
@@ -175,71 +177,122 @@ def _resolve_model_snapshot(request: Alpamayo2SuperRequest) -> str:
         raise Alpamayo2SuperError(
             f"failed to fetch pinned Alpamayo2-Super snapshot ({completed.returncode}):\n{tail}"
         )
-    resolved = (completed.stdout or "").splitlines()[-1].strip()
+    lines = (completed.stdout or "").splitlines()
+    resolved = lines[-1].strip() if lines else ""
     if not resolved or not Path(resolved).is_dir():
         raise Alpamayo2SuperError("Hugging Face did not return a local model snapshot")
     return resolved
 
 
+def _snapshot_manifest(request: Alpamayo2SuperRequest, local_dir: Path) -> tuple[str, dict]:
+    try:
+        contents = Path(request.manifest).expanduser().read_bytes()
+        document = json.loads(contents)
+        sample = document["samples"][request.sample_index]
+        if not isinstance(sample["clip_id"], str) or not sample["clip_id"].strip():
+            raise ValueError("clip_id must be a non-empty string")
+        timestamp = sample["t0_us"]
+        if isinstance(timestamp, bool) or not isinstance(timestamp, int) or timestamp < 0:
+            raise ValueError("t0_us must be a non-negative integer")
+    except (OSError, ValueError, KeyError, IndexError, TypeError) as exc:
+        raise Alpamayo2SuperError("invalid or unavailable validation manifest/sample") from exc
+    directory = local_dir / "inputs"
+    directory.mkdir()
+    snapshot = directory / "manifest.json"
+    snapshot.write_bytes(contents)
+    return str(snapshot), {
+        "clip_id": sample["clip_id"], "t0_us": timestamp,
+        "manifest_sha256": hashlib.sha256(contents).hexdigest(),
+    }
+
+
+def _validate_artifacts(local_dir: Path, request: Alpamayo2SuperRequest, sample: dict) -> dict:
+    from PIL import Image, UnidentifiedImageError
+
+    try:
+        metadata = json.loads((local_dir / "trajectory.json").read_text())
+        if not isinstance(metadata, dict):
+            raise ValueError("trajectory metadata must be an object")
+        for key, expected in {"clip_id": sample["clip_id"], "t0_us": sample["t0_us"], "seed": request.seed}.items():
+            if metadata.get(key) != expected:
+                raise ValueError(f"trajectory metadata does not match requested {key}")
+        if request.require_camera_projection and metadata.get("projection_available") is not True:
+            raise ValueError("required camera projection is missing")
+        for name in ("min_ade_m", "min_fde_m", "fde_at_min_ade_m"):
+            value = metadata.get(name)
+            if type(value) not in (int, float) or not math.isfinite(value) or value < 0:
+                raise ValueError(f"invalid trajectory metric {name}")
+        with Image.open(local_dir / "trajectory.png") as picture:
+            if picture.format != "PNG":
+                raise ValueError("trajectory.png is not a PNG image")
+            picture.load()
+    except (OSError, ValueError, UnidentifiedImageError) as exc:
+        raise Alpamayo2SuperError(f"invalid required inference artifacts: {exc}") from exc
+    return {key: metadata.get(key) for key in ("min_ade_m", "min_fde_m", "fde_at_min_ade_m")}
+
+
+def _provenance(request: Alpamayo2SuperRequest, argv: list[str]) -> dict[str, Any]:
+    return {
+        "schema": ARTIFACT_SCHEMA,
+        "model": {"id": request.model_id, "revision": request.model_revision},
+        "dataset": {
+            "id": DEFAULT_DATASET_REPO, "revision": request.dataset_revision,
+            "operator_runtime_fetch": True,
+        },
+        "request": asdict(request),
+        "runtime": {
+            "image": request.runtime_image or os.environ.get("NPA_TASK_IMAGE", ""),
+            "weights_baked": False, "dataset_baked": False,
+            "cache_tier": "node-local-ephemeral",
+        },
+        "argv": argv,
+    }
+
+
+def _execute(argv: list[str], request: Alpamayo2SuperRequest, runner: Callable) -> None:
+    completed = runner(
+        argv, cwd="/opt/alpamayo2", env=_runtime_env(request), text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False,
+    )
+    if completed.returncode != 0:
+        tail = "\n".join((completed.stdout or "").splitlines()[-40:])
+        raise Alpamayo2SuperError(
+            f"upstream Alpamayo2-Super inference failed ({completed.returncode}):\n{tail}"
+        )
+
+
 def run_inference(
     request: Alpamayo2SuperRequest,
-    *,
-    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    *, runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     model_resolver: Callable[[Alpamayo2SuperRequest], str] = _resolve_model_snapshot,
 ) -> dict[str, Any]:
-    """Run upstream inference and publish its JSON/PNG plus NPA provenance."""
+    """Run upstream inference and publish verified artifacts and provenance.
 
+    Args:
+        request: Reproducible sample and output settings.
+        runner: Subprocess execution boundary.
+        model_resolver: Resolve the pinned model to a local snapshot.
+    Returns:
+        Inference provenance and published artifact locations.
+    Raises:
+        Alpamayo2SuperError: Invalid inputs, upstream failure, or invalid outputs.
+        OSError: Local artifact publication fails.
+    """
     _validate(request)
     with tempfile.TemporaryDirectory(prefix="npa-alpamayo2-super-") as scratch:
         local_dir = Path(scratch)
         execution_request = request
+        sample = {}
         if not request.dry_run:
-            execution_request = replace(request, model_id=model_resolver(request))
+            manifest, sample = _snapshot_manifest(request, local_dir)
+            execution_request = replace(request, manifest=manifest, model_id=model_resolver(request))
         argv = build_inference_argv(execution_request, local_output=local_dir)
-        base = {
-            "schema": ARTIFACT_SCHEMA,
-            "model": {"id": request.model_id, "revision": request.model_revision},
-            "dataset": {
-                "id": DEFAULT_DATASET_REPO,
-                "revision": request.dataset_revision,
-                "operator_runtime_fetch": True,
-            },
-            "request": asdict(request),
-            "runtime": {
-                "image": request.runtime_image or os.environ.get("NPA_TASK_IMAGE", ""),
-                "weights_baked": False,
-                "dataset_baked": False,
-                "cache_tier": "node-local-ephemeral",
-            },
-            "argv": argv,
-        }
+        base = _provenance(request, argv)
         if request.dry_run:
             return {**base, "status": "dry_run", "artifacts": {}}
-        completed = runner(
-            argv,
-            cwd="/opt/alpamayo2",
-            env=_runtime_env(request),
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=False,
-        )
-        if completed.returncode != 0:
-            tail = "\n".join((completed.stdout or "").splitlines()[-40:])
-            raise Alpamayo2SuperError(
-                f"upstream Alpamayo2-Super inference failed ({completed.returncode}):\n{tail}"
-            )
-        expected = (local_dir / "trajectory.json", local_dir / "trajectory.png")
-        missing = [
-            path.name
-            for path in expected
-            if not path.is_file() or path.stat().st_size == 0
-        ]
-        if missing:
-            raise Alpamayo2SuperError(
-                "upstream inference returned success without required artifacts: "
-                + ", ".join(missing)
-            )
+        _execute(argv, request, runner)
+        base["metrics"] = _validate_artifacts(local_dir, request, sample)
+        base["sample"] = sample
         result_path = local_dir / "result.json"
         result_path.write_text(
             json.dumps({**base, "status": "ok"}, indent=2, sort_keys=True) + "\n",

--- a/npa/tests/cli/test_agent_backend_render.py
+++ b/npa/tests/cli/test_agent_backend_render.py
@@ -3985,6 +3985,7 @@ def test_rendered_catalog_action_reaches_factual_completion(monkeypatch, tmp_pat
         monkeypatch, tmp_path, module_name="npa_rendered_action_catalog_completion"
     )
     expected = sorted(tool_catalog_payload())
+    planner_inputs = []
     plans = iter(
         [
             {"tool": "tools_catalog", "args": {}},
@@ -3992,7 +3993,8 @@ def test_rendered_catalog_action_reaches_factual_completion(monkeypatch, tmp_pat
         ]
     )
 
-    def planner(_messages, *, tier):
+    def planner(messages, *, tier):
+        planner_inputs.append(messages)
         return {"choices": [{"message": {"content": json.dumps(next(plans))}}]}
 
     result = module.run_action_loop(
@@ -4008,3 +4010,5 @@ def test_rendered_catalog_action_reaches_factual_completion(monkeypatch, tmp_pat
     assert calls[0]["tool"] == "tools_catalog"
     assert calls[0]["status"] == "ok"
     assert calls[0]["observation"] == {"tool_refs": expected}
+    catalog_observation = {"tool": "tools_catalog", "result": {"tool_refs": expected}}
+    assert json.dumps(catalog_observation, sort_keys=True) in planner_inputs[1][-1]["content"]

--- a/npa/tests/e2e/test_alpamayo_ray_artifacts_live.py
+++ b/npa/tests/e2e/test_alpamayo_ray_artifacts_live.py
@@ -69,6 +69,10 @@ def _verify_case(client, row, directory):
     assert result["runtime"]["weights_baked"] is False
     assert result["runtime"]["dataset_baked"] is False
     assert "@sha256:" in result["runtime"]["image"]
+    for field in ("sample_index", "seed", "diffusion_steps"):
+        assert result["request"][field] == row[field]
+        flag_index = result["argv"].index("--" + field.replace("_", "-"))
+        assert result["argv"][flag_index + 1] == str(row[field])
     assert result["sample"] == row["sample"]
     assert metadata["clip_id"] == row["sample"]["clip_id"]
     assert metadata["t0_us"] == row["sample"]["t0_us"]

--- a/npa/tests/e2e/test_alpamayo_ray_artifacts_live.py
+++ b/npa/tests/e2e/test_alpamayo_ray_artifacts_live.py
@@ -1,0 +1,89 @@
+"""Independently reopen real Alpamayo Ray reports and their S3 inference artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+
+from PIL import Image
+import pytest
+
+from npa.clients.storage import StorageClient
+from npa.workbench.alpamayo2_super.runtime import DEFAULT_DATASET_REVISION, DEFAULT_MODEL_REVISION
+
+
+pytestmark = [
+    pytest.mark.e2e_pipeline,
+    pytest.mark.skipif(
+        os.environ.get("NPA_INTEGRATION_E2E") != "1"
+        or not os.environ.get("NPA_ALPAMAYO_RAY_REPORT_URI"),
+        reason="requires an explicit completed live Ray report in authorized S3 storage",
+    ),
+]
+
+
+def _read(client, uri, path):
+    client.download_file(uri, str(path))
+    return json.loads(path.read_text())
+
+
+@pytest.fixture
+def live_report(tmp_path):
+    client = StorageClient.from_environment()
+    uri = os.environ["NPA_ALPAMAYO_RAY_REPORT_URI"]
+    report = _read(client, uri, tmp_path / "report.json")
+    client.download_file(uri.rsplit("/", 1)[0] + "/SHA256SUMS", str(tmp_path / "SHA256SUMS"))
+    expected = (tmp_path / "SHA256SUMS").read_text().split()[0]
+    assert hashlib.sha256((tmp_path / "report.json").read_bytes()).hexdigest() == expected
+    assert report["status"] == "complete"
+    assert report["revisions"] == {
+        "model_revision": DEFAULT_MODEL_REVISION, "dataset_revision": DEFAULT_DATASET_REVISION,
+    }
+    return client, report
+
+
+def test_live_report_has_exact_case_coverage(live_report):
+    _, report = live_report
+    fields = ("sample_index", "seed", "diffusion_steps")
+    requested = {tuple(case[field] for field in fields) for case in report["cases"]}
+    observed = [tuple(row[field] for field in fields) for row in report["measurements"]]
+    assert len(observed) == len(requested)
+    assert set(observed) == requested
+    for row in report["measurements"]:
+        assert row["ray_actor_id"] and row["ray_node_id"]
+        assert row["elapsed_seconds"] > 0
+        assert all(math.isfinite(row[name]) and row[name] >= 0 for name in ("min_ade_m", "min_fde_m"))
+
+
+def _verify_case(client, row, directory):
+    directory.mkdir()
+    result = _read(client, row["artifacts"]["result.json"], directory / "result.json")
+    metadata = _read(client, row["artifacts"]["trajectory.json"], directory / "trajectory.json")
+    client.download_file(row["artifacts"]["trajectory.png"], str(directory / "trajectory.png"))
+    assert result["status"] == "ok"
+    assert result["model"]["revision"] == DEFAULT_MODEL_REVISION
+    assert result["dataset"]["revision"] == DEFAULT_DATASET_REVISION
+    assert result["runtime"]["weights_baked"] is False
+    assert result["runtime"]["dataset_baked"] is False
+    assert "@sha256:" in result["runtime"]["image"]
+    assert result["sample"] == row["sample"]
+    assert metadata["clip_id"] == row["sample"]["clip_id"]
+    assert metadata["t0_us"] == row["sample"]["t0_us"]
+    assert metadata["seed"] == row["seed"]
+    assert metadata["pred_xyz_shape"] == [1, 1, 1, 64, 3]
+    assert metadata["projection_available"] is True
+    for metric in ("min_ade_m", "min_fde_m"):
+        assert metadata[metric] == result["metrics"][metric] == row[metric]
+    with Image.open(directory / "trajectory.png") as picture:
+        assert picture.format == "PNG"
+        picture.load()
+        assert picture.width > 0 and picture.height > 0
+
+
+def test_live_case_artifacts_decode_and_match_the_requested_samples(live_report, tmp_path: Path):
+    client, report = live_report
+    for index, row in enumerate(report["measurements"]):
+        _verify_case(client, row, tmp_path / f"case-{index}")

--- a/npa/tests/guardrails/test_e2e_gate_reachability.py
+++ b/npa/tests/guardrails/test_e2e_gate_reachability.py
@@ -16,6 +16,9 @@ RUNNER_FILES = (
 # These specialized suites intentionally remain operator-invoked. The reason is
 # machine-reviewed here instead of letting an environment gate silently rot.
 MANUAL_GATES = {
+    "NPA_ALPAMAYO_RAY_REPORT_URI": (
+        "read-only artifact verification requires an operator-selected completed Alpamayo Ray report in private storage"
+    ),
     "NPA_RAY_FAST_SYNC_LIVE_CONFIG": (
         "native working-directory source delivery requires an operator-selected Ray Jobs endpoint and private evidence"
     ),

--- a/npa/tests/orchestration/skypilot/test_local_api.py
+++ b/npa/tests/orchestration/skypilot/test_local_api.py
@@ -60,6 +60,38 @@ def test_real_listener_owned_and_same_process_adopted_on_retry(local_runtime):
     assert (local_runtime["isolated_dir"] / "local-api" / "daemon.json").stat().st_mode & 0o777 == 0o600
 
 
+@pytest.mark.parametrize("missed_scans", [1, 3])
+def test_live_new_server_waits_for_process_discovery(local_runtime, monkeypatch, missed_scans):
+    inspect_process = api._process
+    remaining = missed_scans
+
+    def delayed_discovery(record, **kwargs):
+        nonlocal remaining
+        process = inspect_process(record, **kwargs)
+        if process and remaining:
+            remaining -= 1
+            return None
+        return process
+
+    with monkeypatch.context() as patch:
+        patch.setattr(api, "_process", delayed_discovery)
+        result = api.ensure_isolated_api(**local_runtime)
+
+    assert remaining == 0
+    assert result["outcome"] == "owned_isolated_api"
+    record = _record(local_runtime)
+    assert api._listener_owned(record, inspect_process(record))
+    assert api.ensure_isolated_api(**local_runtime) == result
+
+
+def test_new_server_exit_still_fails_readiness(local_runtime):
+    modules = Path(local_runtime["environment"]["PYTHONPATH"])
+    (modules / "sky" / "server" / "server.py").write_text("raise SystemExit(7)\n")
+
+    with pytest.raises(api.IsolatedApiError, match="exited before readiness"):
+        api.ensure_isolated_api(**local_runtime)
+
+
 @pytest.mark.parametrize("resolver", ["resolve_project_storage", "resolve_terraform_state"])
 def test_project_resolution_preserves_verified_api_but_rotation_is_rejected(
     local_runtime, tmp_path, monkeypatch, resolver,

--- a/npa/tests/workbench/test_alpamayo2_super.py
+++ b/npa/tests/workbench/test_alpamayo2_super.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import subprocess
+import pytest
+from PIL import Image
 
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
@@ -15,6 +17,8 @@ from npa.workbench.alpamayo2_super.runtime import (
     ARTIFACT_SCHEMA,
     Alpamayo2SuperRequest,
     run_inference,
+    Alpamayo2SuperError,
+    _resolve_model_snapshot,
 )
 from npa.workbench.alpamayo2_super.service import create_app
 
@@ -31,16 +35,29 @@ def test_dry_run_is_revision_pinned_and_real_upstream_argv(tmp_path: Path) -> No
     assert "--require-camera-projection" in result["argv"]
 
 
-def test_execution_requires_real_json_and_png_then_publishes(tmp_path: Path) -> None:
+@pytest.fixture
+def manifest(tmp_path: Path) -> Path:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps({"samples": [{"clip_id": "fixture-clip", "t0_us": 1}]}))
+    return path
+
+
+def _artifact_runner(argv, **kwargs):
+    Image.new("RGB", (8, 8), "blue").save(argv[argv.index("--save-viz") + 1])
+    Path(argv[argv.index("--save-json") + 1]).write_text(json.dumps({
+        "clip_id": "fixture-clip", "t0_us": 1, "seed": 42,
+        "projection_available": True, "min_ade_m": 1.0, "min_fde_m": 2.0,
+        "fde_at_min_ade_m": 2.0,
+    }))
+    return subprocess.CompletedProcess(argv, 0, stdout="minADE: 1.0")
+
+
+def test_execution_requires_real_json_and_png_then_publishes(tmp_path: Path, manifest) -> None:
     def fake_runner(argv, **kwargs):  # type: ignore[no-untyped-def]
-        Path(argv[argv.index("--save-viz") + 1]).write_bytes(b"png")
-        Path(argv[argv.index("--save-json") + 1]).write_text(
-            json.dumps({"minADE": 1.0}), encoding="utf-8"
-        )
-        return subprocess.CompletedProcess(argv, 0, stdout="minADE: 1.0")
+        return _artifact_runner(argv, **kwargs)
 
     result = run_inference(
-        Alpamayo2SuperRequest(output_path=str(tmp_path)),
+        Alpamayo2SuperRequest(output_path=str(tmp_path / "outputs"), manifest=str(manifest)),
         runner=fake_runner,
         model_resolver=lambda request: "/runtime/model/snapshot",
     )
@@ -50,10 +67,75 @@ def test_execution_requires_real_json_and_png_then_publishes(tmp_path: Path) -> 
         "trajectory.json",
         "trajectory.png",
     }
-    assert (tmp_path / "trajectory.png").read_bytes() == b"png"
-    provenance = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    with Image.open(tmp_path / "outputs/trajectory.png") as picture:
+        assert picture.size == (8, 8)
+    provenance = json.loads((tmp_path / "outputs/result.json").read_text(encoding="utf-8"))
     assert provenance["runtime"]["weights_baked"] is False
     assert provenance["runtime"]["dataset_baked"] is False
+    assert provenance["sample"]["clip_id"] == "fixture-clip"
+    assert provenance["metrics"]["min_ade_m"] == 1.0
+
+
+@pytest.mark.parametrize("document,index", [
+    (None, 0), ("not json", 0), ({"samples": []}, 0),
+    ({"samples": [{"clip_id": "fixture", "t0_us": 1}]}, 1),
+    ({"samples": [{"clip_id": "fixture", "t0_us": True}]}, 0),
+])
+def test_invalid_manifest_fails_before_model_fetch(tmp_path, document, index):
+    path = tmp_path / "missing.json"
+    if document is not None:
+        path.write_text(document if isinstance(document, str) else json.dumps(document))
+    def must_not_fetch(request):
+        pytest.fail("invalid sample triggered model download")
+    with pytest.raises(Alpamayo2SuperError, match="manifest/sample"):
+        run_inference(Alpamayo2SuperRequest(
+            output_path=str(tmp_path / "outputs"), manifest=str(path), sample_index=index,
+        ), model_resolver=must_not_fetch)
+
+
+def test_manifest_is_snapshotted_before_model_fetch(tmp_path, manifest):
+    def resolver(request):
+        manifest.unlink()
+        return "/runtime/model/snapshot"
+    def runner(argv, **kwargs):
+        snapshot = Path(argv[argv.index("--manifest") + 1])
+        assert json.loads(snapshot.read_text())["samples"][0]["clip_id"] == "fixture-clip"
+        return _artifact_runner(argv, **kwargs)
+    result = run_inference(Alpamayo2SuperRequest(
+        output_path=str(tmp_path / "outputs"), manifest=str(manifest),
+    ), runner=runner, model_resolver=resolver)
+    assert set(result["artifacts"]) == {"result.json", "trajectory.json", "trajectory.png"}
+
+
+@pytest.mark.parametrize("damage", ["png", "json", "sample", "projection", "missing_metric", "nan_metric", "negative_metric"])
+def test_invalid_artifacts_are_not_published(tmp_path, manifest, damage):
+    def runner(argv, **kwargs):
+        result = _artifact_runner(argv, **kwargs)
+        picture = Path(argv[argv.index("--save-viz") + 1])
+        metadata = Path(argv[argv.index("--save-json") + 1])
+        if damage == "png":
+            picture.write_bytes(b"nonempty invalid png")
+        elif damage == "json":
+            metadata.write_text("[]")
+        else:
+            data = json.loads(metadata.read_text())
+            if damage.endswith("_metric"):
+                data["min_ade_m"] = {"missing_metric": None, "nan_metric": float("nan"), "negative_metric": -1}[damage]
+            else:
+                data["clip_id" if damage == "sample" else "projection_available"] = False
+            metadata.write_text(json.dumps(data))
+        return result
+    output = tmp_path / "outputs"
+    with pytest.raises(Alpamayo2SuperError, match="invalid required inference artifacts"):
+        run_inference(Alpamayo2SuperRequest(output_path=str(output), manifest=str(manifest)),
+                      runner=runner, model_resolver=lambda request: "/runtime/model/snapshot")
+    assert not output.exists()
+
+
+def test_empty_snapshot_resolver_output_is_a_domain_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, stdout=""))
+    with pytest.raises(Alpamayo2SuperError, match="local model snapshot"):
+        _resolve_model_snapshot(Alpamayo2SuperRequest(output_path=str(tmp_path)))
 
 
 def test_cli_and_api_share_dry_run_contract(tmp_path: Path) -> None:

--- a/npa/tests/workbench/test_alpamayo_ray_sweep.py
+++ b/npa/tests/workbench/test_alpamayo_ray_sweep.py
@@ -45,7 +45,7 @@ def test_sweep_cli_and_sdk_use_shared_request_and_keep_stdout_json(monkeypatch):
     assert observed[0] == observed[1]
 
 
-def test_public_sweep_cli_rejects_local_handoffs_before_execution(monkeypatch):
+def test_public_sweep_cli_rejects_local_handoffs_before_execution(monkeypatch, tmp_path):
     from typer.testing import CliRunner
     from npa.cli.main import app
     from npa.workbench.alpamayo2_super import ray_sweep
@@ -54,7 +54,7 @@ def test_public_sweep_cli_rejects_local_handoffs_before_execution(monkeypatch):
         pytest.fail("invalid path reached inference")
     monkeypatch.setattr(ray_sweep, "run_sweep", forbidden)
     result = CliRunner().invoke(app, ["workbench", "alpamayo2-super", "sweep",
-        "--output-path", "/tmp/fixture", "--run-id", "fixture"])
+        "--output-path", str(tmp_path / "fixture"), "--run-id", "fixture"])
     assert result.exit_code == 1
     assert "S3 handoff contract" in result.output
 

--- a/npa/tests/workbench/test_alpamayo_ray_sweep.py
+++ b/npa/tests/workbench/test_alpamayo_ray_sweep.py
@@ -1,0 +1,176 @@
+"""Exercise sweep statistics and real Ray scheduling with explicit synthetic workers."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import pytest
+
+from npa.workbench.alpamayo2_super.ray_report import (
+    case_grid, matched_comparisons, select_hard_samples,
+    summarize_sample, validate_measurements,
+)
+from npa.workbench.alpamayo2_super.ray_sweep import (
+    AlpamayoSweepRequest, _cases_and_baseline, dispatch_cases,
+)
+from npa.workbench.alpamayo2_super.runtime import DEFAULT_DATASET_REVISION, DEFAULT_MODEL_REVISION
+
+
+def test_sweep_cli_and_sdk_use_shared_request_and_keep_stdout_json(monkeypatch):
+    from typer.testing import CliRunner
+    from npa.cli.main import app
+    from npa.sdk.workbench.alpamayo2_super import sweep
+    from npa.workbench.alpamayo2_super import ray_sweep
+
+    observed = []
+    def execute(request):
+        observed.append(request)
+        print("synthetic progress message")
+        return {"status": "complete"}
+    monkeypatch.setattr(ray_sweep, "run_sweep", execute)
+    result = CliRunner().invoke(app, [
+        "workbench", "alpamayo2-super", "sweep", "--output-path", "s3://fixture-bucket/sweep/",
+        "--run-id", "fixture", "--sample-indices", "0,2", "--seeds", "42,44",
+        "--diffusion-steps", "10,20",
+    ])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"status": "complete"}
+    assert "synthetic progress message" in result.stderr
+    assert observed[0].sample_indices == [0, 2]
+    assert observed[0].seeds == [42, 44]
+    assert sweep(observed[0]) == {"status": "complete"}
+    assert observed[0] == observed[1]
+
+
+def test_public_sweep_cli_rejects_local_handoffs_before_execution(monkeypatch):
+    from typer.testing import CliRunner
+    from npa.cli.main import app
+    from npa.workbench.alpamayo2_super import ray_sweep
+
+    def forbidden(request):
+        pytest.fail("invalid path reached inference")
+    monkeypatch.setattr(ray_sweep, "run_sweep", forbidden)
+    result = CliRunner().invoke(app, ["workbench", "alpamayo2-super", "sweep",
+        "--output-path", "/tmp/fixture", "--run-id", "fixture"])
+    assert result.exit_code == 1
+    assert "S3 handoff contract" in result.output
+
+
+def _measurement(case):
+    return {
+        **case, "min_ade_m": float(case["sample_index"] + 1), "min_fde_m": 3.0,
+        "elapsed_seconds": 0.1,
+        "sample": {"clip_id": f"fixture-{case['sample_index']}", "t0_us": 1, "manifest_sha256": "fixture"},
+    }
+
+
+@pytest.fixture
+def baseline():
+    cases = case_grid([0, 1], [42, 43], [10])
+    return {
+        "schema": "npa.alpamayo.ray-sweep.v1", "status": "complete",
+        "cases": cases, "measurements": [_measurement(case) for case in cases],
+        "revisions": {"model_revision": DEFAULT_MODEL_REVISION, "dataset_revision": DEFAULT_DATASET_REVISION},
+    }
+
+
+@pytest.mark.parametrize("samples,seeds,steps", [([], [1], [1]), ([0, 0], [1], [1]), ([0], [1], [0]), ([-1], [1], [1])])
+def test_invalid_experiment_dimensions(samples, seeds, steps):
+    with pytest.raises(ValueError):
+        case_grid(samples, seeds, steps)
+
+
+@pytest.mark.parametrize("damage", ["missing", "duplicate", "nan", "negative", "none"])
+def test_measurements_must_be_complete_and_finite(baseline, damage):
+    rows = baseline["measurements"]
+    if damage == "missing":
+        rows.pop()
+    elif damage == "duplicate":
+        rows[0] = copy.deepcopy(rows[-1])
+    else:
+        rows[0]["min_ade_m"] = {"nan": float("nan"), "negative": -1, "none": None}[damage]
+    with pytest.raises(ValueError):
+        validate_measurements(rows, baseline["cases"])
+
+
+def test_seed_variation_is_not_pooled_across_diffusion_settings():
+    rows = [_measurement(case) for case in case_grid([0], [42, 43], [10, 20])]
+    for row in rows:
+        row["min_ade_m"] = {10: {42: 1, 43: 3}, 20: {42: 8, 43: 12}}[row["diffusion_steps"]][row["seed"]]
+    summary = summarize_sample(rows)
+    assert [row["mean_ade_m"] for row in summary] == [2, 10]
+    assert [row["seed_ade_std_m"] for row in summary] == [1, 2]
+
+
+def test_hard_case_selection_uses_measured_rows_and_accepts_empty_selection(baseline):
+    baseline["summaries"] = [{"sample_index": 0, "mean_ade_m": 9999}]
+    assert select_hard_samples(baseline, 1.5) == [1]
+    assert select_hard_samples(baseline, 2) == []
+
+
+def test_refinement_inherits_baseline_seeds_and_rejects_revision_drift(baseline, tmp_path):
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(baseline))
+    request = AlpamayoSweepRequest(output_path=str(tmp_path), run_id="fixture", input_path=str(path), minimum_ade=1.5)
+    cases, _ = _cases_and_baseline(replace(request, seeds=[999], diffusion_steps=[20]))
+    assert cases == case_grid([1], [42, 43], [20])
+    baseline["revisions"]["model_revision"] = "different"
+    path.write_text(json.dumps(baseline))
+    with pytest.raises(ValueError, match="different model or dataset"):
+        _cases_and_baseline(request)
+
+
+def test_matched_comparisons_reject_unmatched_seed_and_manifest_change(baseline):
+    refined = _measurement({"sample_index": 1, "seed": 42, "diffusion_steps": 20})
+    refined["min_ade_m"] = 1.0
+    comparisons = matched_comparisons(baseline["measurements"], [refined])
+    assert comparisons[0]["ade_change_m"] == -1.0
+    with pytest.raises(ValueError, match="no matched baseline"):
+        matched_comparisons(baseline["measurements"], [{**refined, "seed": 123}])
+    refined["sample"]["manifest_sha256"] = "changed"
+    with pytest.raises(ValueError, match="manifest identities"):
+        matched_comparisons(baseline["measurements"], [refined])
+
+
+class _SyntheticWorker:
+    def infer(self, case):
+        return _measurement(case)
+
+
+class _FailingWorker:
+    def infer(self, case):
+        raise ValueError("synthetic inference boundary failure")
+
+
+@pytest.fixture(scope="module")
+def local_ray():
+    ray = pytest.importorskip("ray")
+    ray.init(address="local", num_cpus=2, include_dashboard=False, log_to_driver=False,
+             runtime_env={"env_vars": {"PYTHONPATH": str(Path(__file__).parent)}})
+    yield ray
+    ray.shutdown()
+
+
+def test_real_ray_actors_cover_every_case_once(local_ray):
+    cases = case_grid([0, 1, 2], [42, 43], [10, 20])
+    actor = local_ray.remote(num_cpus=1)(_SyntheticWorker)
+    actors = [actor.remote() for _ in range(2)]
+    try:
+        rows = dispatch_cases(cases, actors)
+        assert len(rows) == 12
+        assert [(row["sample_index"], row["seed"], row["diffusion_steps"]) for row in rows] == [tuple(case.values()) for case in cases]
+    finally:
+        for worker in actors:
+            local_ray.kill(worker)
+
+
+def test_real_ray_failure_is_not_reported_as_partial_success(local_ray):
+    actor = local_ray.remote(num_cpus=1)(_FailingWorker).remote()
+    try:
+        with pytest.raises(local_ray.exceptions.RayTaskError, match="synthetic inference boundary"):
+            dispatch_cases(case_grid([0], [42], [10]), [actor])
+    finally:
+        local_ray.kill(actor)

--- a/skills/index.yaml
+++ b/skills/index.yaml
@@ -708,6 +708,8 @@ skills:
       - type: npa_workflow_yaml
         paths:
           - workflows/testing/alpamayo2-super-inference.yaml
+          - workflows/testing/alpamayo2-ray-sweep.yaml
+          - workflows/testing/alpamayo2-ray-hardcases.yaml
       - type: file_exists
         path: npa/docker/workbench/alpamayo2-super/REDISTRIBUTION.md
   - name: retargeting

--- a/skills/tools/alpamayo2-super/SKILL.md
+++ b/skills/tools/alpamayo2-super/SKILL.md
@@ -109,11 +109,29 @@ B200 result.
 
 ## Verify changes
 
+For Ray scenario/seed/diffusion experiments, use
+`workflows/testing/alpamayo2-ray-sweep.yaml` and
+`workflows/testing/alpamayo2-ray-hardcases.yaml`, derived from the inference
+template. Submit current changes with `--stage-src`: the accepted release image
+does not yet contain `npa workbench alpamayo2-super sweep`. The catalog installs
+Ray 2.58.0 in the NPA interpreter. GPU actors reuse downloaded snapshots while
+upstream subprocesses reload weights per case; do not claim resident-model reuse.
+CPU reductions report measured errors and seed variability. Refinement inherits
+baseline seeds, verifies source manifest and revision identity, and supports an
+empty selection without fabricating inference. Keep public handoffs on S3.
+See `docs/workbench/alpamayo2-super.md#ray-experiments` for controls and outputs.
+
+Inference now snapshots and validates its manifest before fetching the model,
+verifies sidecar sample/seed/projection identity, and fully decodes the PNG before
+publication. The upstream sidecar contains metadata and metrics, not full XYZ
+coordinates; do not describe it as a coordinate recording.
+
 ```bash
 npa/.venv/bin/python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py \
   skills/tools/alpamayo2-super
 npa/.venv/bin/python -m pytest \
   npa/tests/workbench/test_alpamayo2_super.py \
+  npa/tests/workbench/test_alpamayo_ray_sweep.py \
   npa/tests/workbench/test_alpamayo2_super_service_security.py \
   npa/tests/guardrails/test_skills_index.py \
   npa/tests/orchestration/npa_workflow/test_catalog_doc_sync.py -q

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -140,6 +140,8 @@ Jump to: [Generation and reconstruction](#generation-and-reconstruction) · [Rob
 
 | Spec | Notes |
 | --- | --- |
+| [`alpamayo2-ray-sweep.yaml`](testing/alpamayo2-ray-sweep.yaml) | Ray GPU actors sweep scenario, seed, and diffusion settings; Ray CPU tasks reduce measured ADE/FDE and seed variability ([guide](../docs/workbench/alpamayo2-super.md#ray-experiments)) |
+| [`alpamayo2-ray-hardcases.yaml`](testing/alpamayo2-ray-hardcases.yaml) | Ray baseline → mean-error selection → refinement with matched scenarios and seeds; reports measured error changes ([guide](../docs/workbench/alpamayo2-super.md#ray-experiments)) |
 | [`alpamayo2-super-inference.yaml`](testing/alpamayo2-super-inference.yaml) | Real Alpamayo 2 Super 34B trajectory inference on `B200:1`; runtime-only OpenMDW weights and separately gated PhysicalAI-AV sample data ([guide](../docs/workbench/alpamayo2-super.md)) |
 | [`adversarial-scenario-hardening.yaml`](testing/adversarial-scenario-hardening.yaml) | Adversarial scenario generation and ranking → policy hardening loop → promotion gate |
 | [`av-night-scene-hardening.yaml`](testing/av-night-scene-hardening.yaml) | AV night-scene hardening from diagram |

--- a/workflows/testing/alpamayo2-ray-hardcases.readiness.json
+++ b/workflows/testing/alpamayo2-ray-hardcases.readiness.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "workflow-readiness/v1",
+  "workflow_sha256": "1f3d09976587a952afead4f149655fe21441b3117af3f232876117803afc4c49",
+  "planning": {
+    "validation": {
+      "status": "verified",
+      "reason": "validate-spec and plan-spec both completed successfully.",
+      "evidence": [
+        "npa workbench workflow validate-spec workflows/testing/alpamayo2-ray-hardcases.yaml --json",
+        "npa workbench workflow plan-spec workflows/testing/alpamayo2-ray-hardcases.yaml --json"
+      ]
+    },
+    "task_fidelity": {
+      "status": "verified",
+      "reason": "Resolved commands execute the declared scenario/seed grid and consume the baseline report for refinement.",
+      "evidence": [
+        "docs/workbench/alpamayo2-super.md#ray-experiments"
+      ]
+    }
+  },
+  "prerequisites": {
+    "output_storage": {
+      "status": "verified",
+      "reason": "Exact selected-project storage setup and live HF/S3/Nebius credential preflight passed.",
+      "evidence": [
+        "Access-controlled operational evidence; no private identifiers committed."
+      ]
+    },
+    "worker_input": {
+      "status": "verified",
+      "reason": "Pinned model and PhysicalAI-AV dataset access passed. Worker uses the image validation manifest.",
+      "evidence": [
+        "npa workbench health access --capability alpamayo2-super --json"
+      ]
+    },
+    "credentials": {
+      "status": "verified",
+      "reason": "Hugging Face authentication and exact gated dataset fetch access passed after interactive acceptance.",
+      "evidence": [
+        "npa workbench health preflight --checks nebius,hf,s3 --json"
+      ]
+    },
+    "source_image": {
+      "status": "verified",
+      "reason": "The recorded source archive was SHA-256 checked and executed in the accepted image; subsequent changes and their validation are documented.",
+      "evidence": [
+        "sha256:2164450f8baf57d8798f64063ea27bf11611f5b695c467de0c2e319e3134ebd5",
+        "source archive sha256:a04ec3f2ff53020ca90d0ff5873b4e7469921a37ed2ad94b048741228f14ed74",
+        "docs/workbench/alpamayo2-ray-validation.md"
+      ]
+    },
+    "target_runtime": {
+      "status": "unverified",
+      "reason": "12 real RTX PRO 6000 inferences completed through run-spec in Kubernetes with manual cache intervention. The default B200 allocation and standard SkyPilot submit path remain unverified.",
+      "evidence": [
+        "docs/workbench/alpamayo2-ray-validation.md"
+      ]
+    }
+  }
+}

--- a/workflows/testing/alpamayo2-ray-hardcases.yaml
+++ b/workflows/testing/alpamayo2-ray-hardcases.yaml
@@ -1,0 +1,61 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+metadata:
+  name: alpamayo2-ray-hardcases
+  description: >-
+    Measure a multi-scenario Alpamayo baseline with Ray, select all scenarios
+    above a mean displacement-error threshold, and rerun those scenarios with
+    the same random seeds and additional diffusion steps. Compare measured
+    error changes without assuming that more steps improve a trajectory.
+
+config:
+  bucket: example-bucket
+  prefix: "runs/{{run.id}}/alpamayo2-ray-hardcases"
+  sample_indices: "0,1"
+  seeds: "42,43"
+  diffusion_steps: "10"
+  refinement_steps: "20,30"
+  minimum_ade: "2.0"
+  workers: "1"
+
+  baseline_uri: "s3://{{config.bucket}}/{{config.prefix}}/baseline/"
+  refined_uri: "s3://{{config.bucket}}/{{config.prefix}}/refined/"
+  output_uri: "{{config.baseline_uri}}"
+
+resources:
+  gpu:
+    cloud: kubernetes
+    accelerators: B200:1
+    cpus: 16
+    memory: 128Gi
+
+initial: baseline
+
+states:
+  baseline:
+    description: Establish per-scenario baseline errors across explicit random seeds.
+    toolRef: workbench.alpamayo2_super.sweep
+    resources: gpu
+    outputs:
+      - uri: "{{config.baseline_uri}}report.json"
+        schema: npa.alpamayo.ray-sweep.v1
+    next: refine
+
+  refine:
+    description: Refine every selected hard scenario and compare matched seeds.
+    toolRef: workbench.alpamayo2_super.sweep
+    resources: gpu
+    params:
+      input_uri: "{{config.baseline_uri}}report.json"
+      output_uri: "{{config.refined_uri}}"
+      diffusion_steps: "{{config.refinement_steps}}"
+    inputs:
+      - uri: "{{config.baseline_uri}}report.json"
+        schema: npa.alpamayo.ray-sweep.v1
+    outputs:
+      - uri: "{{config.refined_uri}}report.json"
+        schema: npa.alpamayo.ray-sweep.v1
+      - uri: "{{config.refined_uri}}SHA256SUMS"
+        schema: npa.checksums.sha256.v1
+    terminal: true

--- a/workflows/testing/alpamayo2-ray-sweep.readiness.json
+++ b/workflows/testing/alpamayo2-ray-sweep.readiness.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "workflow-readiness/v1",
+  "workflow_sha256": "22f8e4d7b0e260f2485ccfe14a7c2e5c4646e31dadad359fd6c5e55c3f3bcc0e",
+  "planning": {
+    "validation": {
+      "status": "verified",
+      "reason": "validate-spec and plan-spec both completed successfully.",
+      "evidence": [
+        "npa workbench workflow validate-spec workflows/testing/alpamayo2-ray-sweep.yaml --json",
+        "npa workbench workflow plan-spec workflows/testing/alpamayo2-ray-sweep.yaml --json"
+      ]
+    },
+    "task_fidelity": {
+      "status": "verified",
+      "reason": "Resolved commands execute the declared scenario/seed grid.",
+      "evidence": [
+        "docs/workbench/alpamayo2-super.md#ray-experiments"
+      ]
+    }
+  },
+  "prerequisites": {
+    "output_storage": {
+      "status": "verified",
+      "reason": "Exact selected-project storage setup and live HF/S3/Nebius credential preflight passed.",
+      "evidence": [
+        "Access-controlled operational evidence; no private identifiers committed."
+      ]
+    },
+    "worker_input": {
+      "status": "verified",
+      "reason": "Pinned model and PhysicalAI-AV dataset access passed. Worker uses the image validation manifest.",
+      "evidence": [
+        "npa workbench health access --capability alpamayo2-super --json"
+      ]
+    },
+    "credentials": {
+      "status": "verified",
+      "reason": "Hugging Face authentication and exact gated dataset fetch access passed after interactive acceptance.",
+      "evidence": [
+        "npa workbench health preflight --checks nebius,hf,s3 --json"
+      ]
+    },
+    "source_image": {
+      "status": "verified",
+      "reason": "The recorded source archive was SHA-256 checked and executed in the accepted image; subsequent changes and their validation are documented.",
+      "evidence": [
+        "sha256:2164450f8baf57d8798f64063ea27bf11611f5b695c467de0c2e319e3134ebd5",
+        "source archive sha256:a04ec3f2ff53020ca90d0ff5873b4e7469921a37ed2ad94b048741228f14ed74",
+        "docs/workbench/alpamayo2-ray-validation.md"
+      ]
+    },
+    "target_runtime": {
+      "status": "unverified",
+      "reason": "8 real RTX PRO 6000 inferences completed through run-spec in Kubernetes with manual cache intervention. The default B200 allocation and standard SkyPilot submit path remain unverified.",
+      "evidence": [
+        "docs/workbench/alpamayo2-ray-validation.md"
+      ]
+    }
+  }
+}

--- a/workflows/testing/alpamayo2-ray-sweep.yaml
+++ b/workflows/testing/alpamayo2-ray-sweep.yaml
@@ -1,0 +1,41 @@
+apiVersion: npa.workflow/v0.0.1
+kind: Workflow
+
+metadata:
+  name: alpamayo2-ray-sweep
+  description: >-
+    Extend the Alpamayo inference template into a Ray GPU-actor experiment over
+    scenarios, random seeds, and diffusion settings. Publish verified per-case
+    camera figures and trajectory metadata, then reduce measured ADE/FDE and
+    seed variability with Ray CPU tasks. Requires current staged NPA source.
+
+config:
+  bucket: example-bucket
+  prefix: "runs/{{run.id}}/alpamayo2-ray-sweep"
+  sample_indices: "0,1"
+  seeds: "42,43"
+  diffusion_steps: "10,20"
+  workers: "1"
+
+  output_uri: "s3://{{config.bucket}}/{{config.prefix}}/sweep/"
+
+resources:
+  gpu:
+    cloud: kubernetes
+    accelerators: B200:1
+    cpus: 16
+    memory: 128Gi
+
+initial: sweep
+
+states:
+  sweep:
+    description: Run every experiment case once and reduce scenario/setting statistics.
+    toolRef: workbench.alpamayo2_super.sweep
+    resources: gpu
+    outputs:
+      - uri: "{{config.output_uri}}report.json"
+        schema: npa.alpamayo.ray-sweep.v1
+      - uri: "{{config.output_uri}}SHA256SUMS"
+        schema: npa.checksums.sha256.v1
+    terminal: true


### PR DESCRIPTION
Alpamayo previously exposed single-case inference, and a missing validation manifest could fall through to an upstream default sample. This adds reproducible Ray sweeps and paired hard-case refinement, with strict input/artifact checks so a successful process exit cannot publish invalid results.

- Add the `alpamayo2-super sweep` CLI/SDK, toolRef, and two base-template workflows. Ray GPU actors execute cases; CPU tasks reduce measured errors. Reports preserve exact coverage, matched seeds, model/data revisions, sample identity, checksums, and immutable case executions.
- Reject unavailable manifests, corrupt or mismatched JSON/PNG outputs, missing required projections, non-finite metrics, and empty model-download results. Emit flushed Ray progress events and fix renderer dependency formatting.
- Fix two failures exposed during validation: truncated tool catalogs in agent planning and a SkyPilot startup race that mistook delayed process discovery for child exit.

Validation:

- PR review fix: replace the fixed temporary test path with pytest's `tmp_path`; Bandit 1.9.4 reproduces B108 before the fix and reports zero findings afterward, without suppressions. Rebased onto `main` at `027e1fda`.
- Local checks after rebasing: 227 focused tests covering Alpamayo and upstream NCore changes, 3,417 guardrails, Ruff, and confidentiality/secret scans passed. All nine GitHub CI checks passed on `69a1503c`; GitHub reports `CLEAN`.
- [Full GitHub Python 3.12 suite](https://github.com/nebius/nebius-physical-ai/actions/runs/34704633875): 20,799 passed, 549 skipped, 1 XPASS; package coverage 75.97% against the 60% gate. CLI install checks also passed.
- [Security regression](https://github.com/nebius/nebius-physical-ai/actions/runs/34704633908): zero new scanner findings and 651 passing runtime security tests with the real CPU checkpoint runtime.
- Both templates passed `validate-spec` and `submit --plan-only` on this head. The rendered `B200:1` tasks passed setup/run shell syntax checks; this is local rendering validation, with no live submission.
- 340 real Alpamayo inferences on two separate RTX PRO 6000 hosts through native Ray Jobs/Core, plus an earlier 20-case workflow-executor run.
- Approximately 2 h 20 m of observed GPU activity per worker; peaks 100%, means 9.73% and 10.44%. Per-case weight reloads remain a performance limitation.
- All 340 outputs, 17 summaries, and 240 paired comparisons independently verified. Additional diffusion steps worsened mean ADE on all five clips.

See [extended validation](https://github.com/nebius/nebius-physical-ai/blob/69a1503cf54ee3b42d32b60777adaf83e86f2732/docs/workbench/alpamayo2-ray-extended-validation.md) and [workflow usage](https://github.com/nebius/nebius-physical-ai/blob/69a1503cf54ee3b42d32b60777adaf83e86f2732/docs/workbench/alpamayo2-super.md#ray-experiments). Raw recordings and operational evidence remain private; the report documents the capture interruption and separate post-run segment.

Standard SkyPilot submission and the templates' B200 default still need separate live qualification. GPU workload pods, cache volumes, and namespace were removed; all four shared nodes remained Ready. No container image is published here; the guide explains source staging for the current accepted image.
