### PR TITLE
Fix NCore CI failures across supported Python versions

### DIFF
--- a/npa/docker/workbench/ncore/base_sources.py
+++ b/npa/docker/workbench/ncore/base_sources.py
@@ -50,9 +50,25 @@ def digest(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
+def _stream_digest(stream) -> str:
+    digest = hashlib.sha256()
+    while chunk := stream.read(1024 * 1024):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
 def file_digest(path: Path) -> str:
+    """Hash all file bytes with bounded memory on supported Python versions.
+
+    Args:
+        path: File to hash.
+    Returns:
+        SHA256 hex digest.
+    Raises:
+        OSError: The file cannot be read.
+    """
     with path.open("rb") as stream:
-        return hashlib.file_digest(stream, "sha256").hexdigest()
+        return _stream_digest(stream)
 
 
 def safe_path(name: str) -> str:
@@ -547,7 +563,7 @@ def inventory(archive_path: Path) -> dict:
         for ordinal, name in enumerate(manifest["Layers"]):
             name = safe_path(name)
             with outer.extractfile(name) as blob:
-                compressed_sha = hashlib.file_digest(blob, "sha256").hexdigest()
+                compressed_sha = _stream_digest(blob)
             if (
                 name.startswith("blobs/sha256/")
                 and name.split("/")[-1] != compressed_sha
@@ -557,7 +573,7 @@ def inventory(archive_path: Path) -> dict:
                 magic = blob.read(2)
                 blob.seek(0)
                 stream = gzip.GzipFile(fileobj=blob) if magic == b"\x1f\x8b" else blob
-                diff_sha = hashlib.file_digest(stream, "sha256").hexdigest()
+                diff_sha = _stream_digest(stream)
             if diff_ids[ordinal] != "sha256:" + diff_sha:
                 raise ValueError("layer diff_id mismatch")
             row = {

--- a/npa/scripts/ncore_publication/artifact.py
+++ b/npa/scripts/ncore_publication/artifact.py
@@ -1,7 +1,6 @@
 """Derive inspection archives from the verified, unchanged NCore OCI graph."""
 
 import gzip
-import hashlib
 import io
 import json
 from pathlib import Path
@@ -9,7 +8,7 @@ import shutil
 import tarfile
 
 from image_byte_scan import core as W, ncore_verification as N, prepare as P
-from .process import file_sha, write_json
+from .process import file_sha, stream_sha, write_json
 
 _EMPTY_DIFF_ID = "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
 _EMPTY_BLOB = "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
@@ -228,7 +227,7 @@ def _saved_layer(archive, members, name, expected, classic):
     W.require(name in members and members[name].isfile(), "loaded_export_missing_layer")
     member = members[name]
     with archive.extractfile(member) as stream:
-        stored = "sha256:" + hashlib.file_digest(stream, "sha256").hexdigest()
+        stored = "sha256:" + stream_sha(stream)
     exact = stored == expected["digest"] and member.size == expected["size"]
     # Classic Docker may re-export the exact decoded tar. Bind all its bytes to
     # the original diff ID; recompression or merely equal extracted files fails.
@@ -236,7 +235,7 @@ def _saved_layer(archive, members, name, expected, classic):
     with archive.extractfile(member) as stream:
         compressed = exact and expected["mediaType"].endswith("+gzip")
         decoded = gzip.GzipFile(fileobj=stream) if compressed else stream
-        diff_id = "sha256:" + hashlib.file_digest(decoded, "sha256").hexdigest()
+        diff_id = "sha256:" + stream_sha(decoded)
     W.require(diff_id == expected["diff_id"], "loaded_layer_diff_id")
     return dict(original_digest=expected["digest"], exported_digest=stored, diff_id=diff_id,
                 byte_relation="stored" if exact else "decoded")
@@ -274,7 +273,7 @@ def _saved_manifest(archive, members, inspected, expected, config_size):
         W.require(blob in members and members[blob].isfile() and members[blob].size == entry["size"],
                   "loaded_manifest_missing_blob")
         with archive.extractfile(members[blob]) as stream:
-            W.require("sha256:" + hashlib.file_digest(stream, "sha256").hexdigest() == entry["digest"],
+            W.require("sha256:" + stream_sha(stream) == entry["digest"],
                       "loaded_manifest_blob_digest")
         names.add(blob)
     return names

--- a/npa/scripts/ncore_publication/process.py
+++ b/npa/scripts/ncore_publication/process.py
@@ -97,6 +97,22 @@ def run_byte_scanner(argv, output):
     return result.returncode
 
 
+def stream_sha(stream):
+    """Hash a binary stream from its current position through EOF.
+
+    Args:
+        stream: Open binary stream positioned at the first byte to hash.
+    Returns:
+        SHA256 hex digest.
+    Raises:
+        OSError: The stream cannot be read.
+    """
+    digest = hashlib.sha256()
+    while chunk := stream.read(1024 * 1024):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
 def file_sha(path):
     """Hash a file without retaining its contents.
 
@@ -108,7 +124,7 @@ def file_sha(path):
         OSError: The file cannot be read.
     """
     with path.open("rb") as stream:
-        return hashlib.file_digest(stream, "sha256").hexdigest()
+        return stream_sha(stream)
 
 
 def write_json(path, value):

--- a/npa/scripts/ncore_publication/provenance.py
+++ b/npa/scripts/ncore_publication/provenance.py
@@ -150,7 +150,7 @@ def _sbom_generator():
 
 def _material_reference(dependency):
     uri = urlsplit(dependency["uri"])
-    pairs = parse_qsl(uri.query, strict_parsing=True)
+    pairs = parse_qsl(uri.query, strict_parsing=True) if uri.query else []
     qualifiers = dict(pairs)
     digest = dependency["digest"]
     W.require(uri.scheme == "pkg" and not uri.netloc and not uri.fragment

--- a/npa/src/npa/deploy/ncore_component_advisories.py
+++ b/npa/src/npa/deploy/ncore_component_advisories.py
@@ -30,8 +30,11 @@ def _write(path, value):
 
 
 def _file_hash(path):
+    digest = hashlib.sha256()
     with path.open("rb") as stream:
-        return hashlib.file_digest(stream, "sha256").hexdigest()
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _environment(directory):

--- a/npa/src/npa/workflows/ncore_runtime.py
+++ b/npa/src/npa/workflows/ncore_runtime.py
@@ -44,8 +44,20 @@ class NcoreRuntimeError(RuntimeError):
 
 
 def sha256(path: Path) -> str:
+    """Hash a runtime artifact without loading it entirely into memory.
+
+    Args:
+        path: Runtime artifact or lock file to hash.
+    Returns:
+        SHA256 hex digest.
+    Raises:
+        OSError: The file cannot be read.
+    """
+    digest = hashlib.sha256()
     with path.open("rb") as stream:
-        return hashlib.file_digest(stream, "sha256").hexdigest()
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def read_lock(path: Path) -> dict:

--- a/npa/tests/docker/test_ncore_hashing.py
+++ b/npa/tests/docker/test_ncore_hashing.py
@@ -1,0 +1,60 @@
+"""Verify NCore artifact hashing without Python 3.11's file_digest API."""
+
+import hashlib
+import importlib.util
+import io
+from pathlib import Path
+import sys
+
+import pytest
+
+from npa.deploy import ncore_component_advisories
+from npa.workflows import ncore_runtime
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "npa/scripts"))
+
+from ncore_publication import process  # noqa: E402
+
+
+@pytest.fixture
+def sources():
+    path = ROOT / "npa/docker/workbench/ncore/base_sources.py"
+    spec = importlib.util.spec_from_file_location("ncore_hashing_sources", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("component", ["runtime", "source", "publication", "advisories"])
+@pytest.mark.parametrize("payload", [b"", b"artifact bytes", bytes(range(256)) * 8193],
+                         ids=["empty", "small", "multiple-chunks"])
+def test_file_hashes_all_bytes_without_file_digest(monkeypatch, tmp_path, sources, component, payload):
+    monkeypatch.delattr(hashlib, "file_digest", raising=False)
+    path = tmp_path / "artifact"
+    path.write_bytes(payload)
+    hash_file = {
+        "runtime": ncore_runtime.sha256,
+        "source": sources.file_digest,
+        "publication": process.file_sha,
+        "advisories": ncore_component_advisories._file_hash,
+    }[component]
+
+    assert hash_file(path) == hashlib.sha256(payload).hexdigest()
+
+
+@pytest.mark.parametrize("component", ["source", "publication"])
+def test_stream_hash_consumes_short_reads_from_current_position(sources, component):
+    class ShortReads(io.BytesIO):
+        def read(self, size=-1):
+            assert size > 0
+            return super().read(min(size, 7))
+
+    payload = b"the complete remaining stream contents"
+    stream = ShortReads(b"prefix" + payload)
+    stream.seek(len(b"prefix"))
+    hash_stream = sources._stream_digest if component == "source" else process.stream_sha
+
+    assert hash_stream(stream) == hashlib.sha256(payload).hexdigest()
+    assert stream.tell() == len(b"prefix" + payload)
+    assert not stream.closed

--- a/npa/tests/docker/test_ncore_oci_publication.py
+++ b/npa/tests/docker/test_ncore_oci_publication.py
@@ -174,26 +174,37 @@ def test_source_revision_and_mode_max_statement_binding(private):
         provenance.verify(index, config, blobs, graph, SHA)
 
 
-@pytest.mark.parametrize("change", ["root", "revision", "subject", "duplicate-sbom", "no-packages", "no-materials"])
-def test_local_provenance_refuses_release_incompatible_evidence(private, change):
+@pytest.mark.parametrize("change,reason", [
+    ("root", "nonroot_required"),
+    ("revision", "config_source_revision"),
+    ("subject", "statement_subject"),
+    ("duplicate-sbom", "unknown_or_duplicate_predicate"),
+    ("no-packages", "embedded_sbom_required"),
+    ("no-materials", "provenance_dependencies_required"),
+])
+@pytest.mark.parametrize("reverse_documents", [False, True])
+def test_local_provenance_refuses_release_incompatible_evidence(private, change, reason, reverse_documents):
     path, digest, _ = _archive(private)
     graph, _ = artifact.inspect(path, digest)
     index, config, blobs = artifact.documents(path, digest, graph)
-    statements = [row for row in blobs.values() if "predicateType" in row]
+    if reverse_documents:
+        blobs = dict(reversed(list(blobs.items())))
+    # Blob order follows content digests, not the attestation's predicate type.
+    statements = {row["predicateType"]: row for row in blobs.values() if "predicateType" in row}
     if change == "root":
         config["config"]["User"] = "000:0"
     elif change == "revision":
         config["config"]["Labels"]["org.opencontainers.image.revision"] = "b" * 40
     elif change == "subject":
-        statements[0]["subject"][0]["digest"]["sha256"] = "e" * 64
+        statements[provenance.SPDX]["subject"][0]["digest"]["sha256"] = "e" * 64
     elif change == "duplicate-sbom":
         att = blobs[index["manifests"][1]["digest"]]
         att["layers"].append(copy.deepcopy(att["layers"][0]))
     elif change == "no-packages":
-        statements[0]["predicate"]["packages"] = []
+        statements[provenance.SPDX]["predicate"]["packages"] = []
     else:
-        statements[1]["predicate"]["materials"] = []
-    with pytest.raises(ValueError):
+        statements["https://slsa.dev/provenance/v0.2"]["predicate"]["materials"] = []
+    with pytest.raises(ValueError, match=reason):
         provenance.verify(index, config, blobs, graph, SHA)
 
 

--- a/npa/tests/docker/test_ncore_publication_closure.py
+++ b/npa/tests/docker/test_ncore_publication_closure.py
@@ -150,7 +150,7 @@ def test_actual_imported_source_closure_rejects_changed_bytes(tmp_path, monkeypa
     path.write_bytes(b"reviewed")
     module = SimpleNamespace(__file__=str(path))
     monkeypatch.setattr(process, "ROOT", tmp_path)
-    monkeypatch.setattr(process.sys, "modules", {"npa.imported": module})
+    monkeypatch.setattr(process, "sys", SimpleNamespace(modules={"npa.imported": module}))
     monkeypatch.setattr(process.subprocess, "run", lambda *_, **__: subprocess.CompletedProcess([], 0, b"reviewed"))
     process._verify_imported_sources(SHA)
     (tmp_path / "unrelated.py").write_bytes(b"dirty unrelated source")
@@ -162,7 +162,8 @@ def test_actual_imported_source_closure_rejects_changed_bytes(tmp_path, monkeypa
 
 def test_host_npa_import_cannot_resolve_to_another_checkout(tmp_path, monkeypatch):
     monkeypatch.setattr(process, "ROOT", tmp_path / "checkout")
-    monkeypatch.setattr(process.sys, "modules", {"npa": SimpleNamespace(__file__=str(tmp_path / "elsewhere.py"))})
+    module = SimpleNamespace(__file__=str(tmp_path / "elsewhere.py"))
+    monkeypatch.setattr(process, "sys", SimpleNamespace(modules={"npa": module}))
     with pytest.raises(ValueError, match="host_npa_import_outside_checkout"):
         process._verify_imported_sources(SHA)
 
@@ -192,7 +193,7 @@ def test_repository_loader_compiles_compared_commit_without_reading_cached_bytec
 
 def test_npa_cannot_be_preloaded_before_import_authorization(monkeypatch):
     monkeypatch.setattr(process, "committed_source", lambda sha: None)
-    monkeypatch.setattr(process.sys, "modules", {"npa": SimpleNamespace()})
+    monkeypatch.setattr(process, "sys", SimpleNamespace(modules={"npa": SimpleNamespace()}))
     with pytest.raises(ValueError, match="host_npa_import_before_source_authorization"):
         with process.committed_npa_imports(SHA):
             pytest.fail("preloaded package accepted")
@@ -397,6 +398,21 @@ def _base_material():
     reference, digest = base.split("@")
     return {"uri": "pkg:docker/" + reference.replace(":", "@") + "?platform=linux%2Famd64&digest=" + digest,
             "digest": {"sha256": digest[7:]}}
+
+
+@pytest.mark.parametrize("query", ["", "?platform=linux%2Famd64"])
+def test_material_reference_accepts_optional_qualifiers(query):
+    dependency = {"uri": "pkg:docker/fixture@1" + query, "digest": {"sha256": "b" * 64}}
+    expected = {"platform": "linux/amd64"} if query else {}
+    assert provenance._material_reference(dependency) == ("docker/fixture@1", expected)
+
+
+@pytest.mark.parametrize("query", ["?platform", "?&platform=linux%2Famd64",
+                                   "?platform=linux%2Famd64&"])
+def test_material_reference_still_rejects_malformed_qualifiers(query):
+    dependency = {"uri": "pkg:docker/fixture@1" + query, "digest": {"sha256": "b" * 64}}
+    with pytest.raises(ValueError):
+        provenance._material_reference(dependency)
 
 
 @pytest.mark.parametrize("change", [None, "unrelated", "digest", "uri-digest", "platform", "duplicate", "query", "builder", "missing-generator"])


### PR DESCRIPTION
Fix the NCore failures in [Test run 34696207329](https://github.com/nebius/nebius-physical-ai/actions/runs/34696207329/job/103560018012).

Python 3.10 failed on `hashlib.file_digest`, then pytest crashed while reporting a failure because a test replaced the process-wide `sys.modules`. Once those were fixed, strict parsing of empty provenance queries exposed another Python 3.10 incompatibility. The Python 3.14 failures came from tests selecting SPDX and SLSA statements by their position in a digest-keyed map.

Use streaming SHA-256 on all supported Python versions, handle absent query qualifiers while retaining strict validation of present qualifiers, and isolate the import-registry mock to the publication module. Select test statements by predicate type and verify the expected rejection reason with both document orders. Add regression coverage for hashing without `file_digest`, multiple chunks, short reads, and optional/malformed qualifiers.

Validation:

- 325 focused tests passed on Python 3.10 and 3.14.
- Linux NCore suite: 1,219 passed, one skipped on both Python 3.10 and 3.12.
- 3,396 guardrails and 114 onboarding tests passed; Ruff passed.
- Linux security-regression suite: 648 passed.
- Full Linux coverage run (`pytest tests/ -q -n auto --tb=short --cov=npa --cov-report=term --cov-fail-under=60` from `npa/`): 75.91% coverage, 20,689 passed, 521 skipped, one xpassed. Nine Fleet tests rejected their evidence paths because the validation host has `/tmp/.git`. Rerunning both affected Fleet modules with a Git-free `--basetemp` passed all 52 tests without code changes.
- Secret and confidentiality scans passed.
