### PR TITLE
Document fresh PAIDF Cosmos3 media audits

### DIFF
--- a/npa/tests/workflows/test_paidf_cosmos3.py
+++ b/npa/tests/workflows/test_paidf_cosmos3.py
@@ -14,9 +14,22 @@ import pytest
 from npa.workflows import paidf_cosmos3 as c3
 
 FFMPEG = shutil.which("ffmpeg")
+REPO_ROOT = Path(__file__).resolve().parents[3]
 requires_ffmpeg = pytest.mark.skipif(
     FFMPEG is None, reason="ffmpeg is required for video fixture tests"
 )
+
+
+def test_mp4_guide_preserves_the_fresh_run_audit_contract() -> None:
+    guide = (REPO_ROOT / "workflows/guides/paidf-cosmos3.md").read_text()
+    section = guide.split("### R3b.", 1)[1].split("### R4.", 1)[0]
+
+    timestamp = 'NPA_E2E_PAIDF_MP4_FRESH_AFTER="$(date -u'
+    submit = 'npa workbench workflow submit "$SPEC"'
+    audit = "test_paidf_cosmos3_mp4_live.py -q"
+    assert timestamp in section
+    assert section.index(timestamp) < section.index(submit) < section.index(audit)
+    assert 'NPA_E2E_PAIDF_MP4_RUN_URI="s3://$BUCKET/paidf-cosmos3/$RUN_ID/"' in section
 
 
 def _quality_disposition(*, accepted: bool) -> dict[str, object]:

--- a/workflows/guides/paidf-cosmos3.md
+++ b/workflows/guides/paidf-cosmos3.md
@@ -708,10 +708,17 @@ if actual != expected:
     raise SystemExit("MP4 checksum mismatch; stop before submission")
 print("Verified fresh public MP4:", actual)
 PY
+NPA_E2E_PAIDF_MP4_FRESH_AFTER="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" || exit 1
+export NPA_E2E_PAIDF_MP4_FRESH_AFTER
+printf 'Save the freshness timestamp for the next run: %s\n' \
+  "$NPA_E2E_PAIDF_MP4_FRESH_AFTER"
 ```
 
 Stop if either download or verification fails. This sample is 3.38 seconds at
 50 fps, with 169 frames. Run the two media checks above against it as well.
+Save the printed pre-submission timestamp with the new run ID you reserve next.
+Restore that same value if you audit from another terminal; generating a later
+timestamp after submission makes the freshness check invalid.
 
 Run R2 now to reserve a **new** `RUN_ID`, select its separate SkyPilot directory,
 and validate the workflow and images. Use this full command in place of R3:
@@ -745,6 +752,31 @@ the reference and both generated variants should each contain 81 frames at
 24 fps (3.375 seconds); the original retains its 169 frames at 50 fps. Compare
 generated media against the **prepared reference**, and inspect the actual
 action and appearance before using accepted data for training.
+
+#### Audit the fresh local-MP4 run
+
+After all 15 stages succeed, run this optional read-only audit from the
+repository root with the same `RUN_ID`, `BUCKET`, `PROJECT_ALIAS`, and saved
+pre-submission `NPA_E2E_PAIDF_MP4_FRESH_AFTER`. The test verifies the pinned
+source hash, fresh object timestamps, lack of replay/adoption, prepared and
+generated timelines, curation, and both recording identities. It does not
+submit jobs. A reused run ID or timestamp recorded after submission cannot
+satisfy the freshness contract.
+
+Install the test dependencies in the separate contributor environment once,
+as shown in the R3a audit, then require **one passed test**, not a skip:
+
+```bash
+(
+  set -e
+  : "${NPA_E2E_PAIDF_MP4_FRESH_AFTER:?Restore the saved pre-submission UTC timestamp for this run}"
+  export NPA_E2E_PAIDF_MP4_FRESH_AFTER
+  export NPA_INTEGRATION_E2E=1
+  export NPA_E2E_PROJECT="$PROJECT_ALIAS"
+  export NPA_E2E_PAIDF_MP4_RUN_URI="s3://$BUCKET/paidf-cosmos3/$RUN_ID/"
+  npa/.venv/bin/python -m pytest npa/tests/e2e/test_paidf_cosmos3_mp4_live.py -q
+)
+```
 
 ### R4. Monitor and recover
 


### PR DESCRIPTION
## Summary

- capture the local-MP4 freshness timestamp before submission
- document the exact read-only completed-run audit for source identity, freshness, timelines, curation, and recordings
- add a regression test that keeps timestamp, submit, and audit commands in the required order
- leave the canonical workflow YAML, runtime implementation, dependencies, and platform-specific behavior unchanged

## Validation

- canonical PAIDF Cosmos3 workflow validates with 17 states
- 41 PAIDF Cosmos3 workflow tests passed
- 3,441 guardrail tests passed
- lint and generated-doc drift checks passed
- staged confidentiality and gitleaks scans passed
- a fresh public-MP4 run and a fresh LeRobot v3 run each completed all 15 stages
- the exact original, normalized conditioning, and both generated videos from each run decoded fully and were opened for beginning/middle/end visual review

The visual review confirmed frame-aligned motion and scene structure in all four generated clips. One generated variant in each run applied a conspicuous warm/orange treatment with peripheral texture or halo artifacts; that is run-quality evidence for human review, not a host-platform issue or a workflow-code change.