### PR TITLE
Clarify Workbench as an agent control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,20 @@ tools also expose Python interfaces.
 ### How Workbench runs a task
 
 ```mermaid
-flowchart LR
+flowchart TB
     you["You"] <--> agent["Your coding agent<br/>Codex · Claude Code · other"]
-    agent --> npa["npa Workbench<br/>configure · preflight · plan · submit · inspect"]
+    agent <-->|"requests and results"| npa["Workbench control plane<br/>npa: configure · preflight · plan · submit · inspect"]
     spec["npa.workflow YAML"] --> npa
 
     subgraph nebius["Nebius AI Cloud"]
-        npa --> sky["SkyPilot orchestration"]
-        sky --> tools["Containerized tools<br/>simulate · train · generate · evaluate"]
+        direction LR
+        sky["SkyPilot orchestration"] --> tools["Containerized tools<br/>simulate · train · generate · evaluate"]
         tools <--> s3["S3 artifacts<br/>inputs · checkpoints · media · reports"]
         tools -->|"when selected"| tf["Token Factory<br/>hosted inference"]
     end
 
-    s3 --> agent
+    npa <-->|"plan · submit · status"| sky
+    s3 -->|"artifacts"| npa
 ```
 
 `npa` gives the agent one bounded interface for readiness checks, infrastructure,

--- a/README.md
+++ b/README.md
@@ -44,17 +44,19 @@ flowchart TB
         direction LR
         sky["SkyPilot orchestration"] --> tools["Containerized tools<br/>simulate · train · generate · evaluate"]
         tools <--> s3["S3 artifacts<br/>inputs · checkpoints · media · reports"]
-        tools -->|"when selected"| tf["Token Factory<br/>hosted inference"]
+        tf["Token Factory<br/>hosted inference · no cluster"]
     end
 
     npa <-->|"plan · submit · status"| sky
+    npa -->|"direct inference"| tf
     s3 -->|"artifacts"| npa
 ```
 
 `npa` gives the agent one bounded interface for readiness checks, infrastructure,
 workflow lifecycle, and artifacts. SkyPilot schedules the selected tools on
-Nebius; S3 carries durable inputs and outputs between stages. You remain in the
-loop for choices and human-bound approvals such as accepting model terms.
+Nebius; Token Factory handles supported hosted inference without a cluster; S3
+carries durable inputs and outputs between stages. You remain in the loop for
+choices and human-bound approvals such as accepting model terms.
 
 Start with a [workload guide](#pick-your-first-win). The guide tells you which
 data, model access, GPU, and output to expect.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Nebius Physical AI
 
-**Run robotics, simulation, and physical-AI workloads on Nebius.**
+**The control plane your coding agent uses to run physical-AI workloads on Nebius.**
 
 <img src="docs/assets/workbench-architecture.png" alt="Nebius Physical AI Workbench architecture" width="820" />
 
@@ -23,18 +23,52 @@
 </div>
 
 
-## What is `npa`?
+## What is Workbench?
 
-`npa` runs robotics and physical-AI workloads on Nebius: simulate a robot,
-train or evaluate a policy, generate video, and curate datasets. Workbench tools
-run in containers; multi-stage workflows exchange inputs and results through S3.
-Use the CLI, Python, or a coding agent with access to this checkout.
+Workbench is the agent-facing control plane for physical AI on Nebius. You
+describe the outcome; Codex, Claude Code, or another coding agent with terminal
+access to this checkout uses `npa` to configure the project, check access, plan
+resources, run containerized tools and workflows, and inspect the result with
+you. You can drive the same operations directly through the CLI, and supported
+tools also expose Python interfaces.
+
+### How Workbench runs a task
+
+```mermaid
+flowchart LR
+    you["You"] <--> agent["Your coding agent<br/>Codex · Claude Code · other"]
+    agent --> npa["npa Workbench<br/>configure · preflight · plan · submit · inspect"]
+    spec["npa.workflow YAML"] --> npa
+
+    subgraph nebius["Nebius AI Cloud"]
+        npa --> sky["SkyPilot orchestration"]
+        sky --> tools["Containerized tools<br/>simulate · train · generate · evaluate"]
+        tools <--> s3["S3 artifacts<br/>inputs · checkpoints · media · reports"]
+        tools -->|"when selected"| tf["Token Factory<br/>hosted inference"]
+    end
+
+    s3 --> agent
+```
+
+`npa` gives the agent one bounded interface for readiness checks, infrastructure,
+workflow lifecycle, and artifacts. SkyPilot schedules the selected tools on
+Nebius; S3 carries durable inputs and outputs between stages. You remain in the
+loop for choices and human-bound approvals such as accepting model terms.
 
 Start with a [workload guide](#pick-your-first-win). The guide tells you which
-data, model access, GPU, and output to expect. For agent-assisted setup, use the
-[first-run prompts](docs/workbench/agent-first-run.md).
+data, model access, GPU, and output to expect.
 
 ## Quickstart
+
+Using a coding agent? Open this checkout in your agent and paste one of the
+maintained prompts:
+
+- [Set up Workbench for a task](docs/workbench/agent-first-run.md#set-up-workbench).
+- [Run the Cosmos 3 generation workflow](docs/workbench/agent-first-run.md#run-cosmos-3-generation).
+
+The prompts keep credentials private, stop at human approval gates, validate
+the plan before provisioning, and stay with the run through artifact inspection.
+The manual path below exposes the same control-plane steps.
 
 ### 1. Install
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,11 @@
 
 Install `npa`, connect a Nebius project, and choose a GPU workload. Each linked
 workload guide takes you through setup, execution, and inspecting its outputs.
-For guided terminal work, use the [coding-agent prompts](workbench/agent-first-run.md).
+Workbench is designed to be the control plane for a coding agent with terminal
+access to this checkout. For guided terminal work, paste the
+[setup prompt](workbench/agent-first-run.md#set-up-workbench) or go directly to
+the [Cosmos 3 workflow prompt](workbench/agent-first-run.md#run-cosmos-3-generation).
+The commands below are the corresponding manual path.
 
 ## 1. Platform overview
 

--- a/docs/workbench/agent-first-run.md
+++ b/docs/workbench/agent-first-run.md
@@ -66,36 +66,28 @@ Describe the task you want to run, then give your agent this prompt:
 
 ```text
 Set up Nebius Physical AI Workbench for the task I described. If the intended
-result or input is unclear, ask me one concise question before choosing tools.
-Read AGENTS.md and skills/index.yaml, then follow the relevant repository skills,
-workload guide, and current command help. Select a supported tool or workflow
-that directly produces my intended result. State its inputs, output artifacts,
-model access, infrastructure, and any unsupported part of my request.
+result or input is unclear, ask one concise question. Read AGENTS.md,
+skills/index.yaml, the relevant skills and workload guide, and current command
+help. Choose a supported tool or workflow and state its inputs, artifacts, model
+access, infrastructure, and any unsupported part.
 
-Use project values and the credentials required by the selected tools from
-the private process environment. Never print secret values, put them in command
-arguments, or write them into the repository.
-Never run `env`, `printenv`, `set`, `export -p`, or another command that dumps
-the process environment; inspect only allowlisted names and report present or
-missing. Do not read credential files except through npa's credential APIs.
-Use NPA_PROJECT_ALIAS if it is set; otherwise use "workbench" as the local alias.
+Use project values and credentials only through the private environment and
+npa's configuration APIs. Never print secret values, dump the environment, read
+credential files directly, pass secret values in arguments, or commit live
+infrastructure identifiers. Inspect only required variable names as present or
+missing. Use NPA_PROJECT_ALIAS when set; otherwise use "workbench".
 
-Install or verify npa, the Nebius CLI, and the host prerequisites for the
-selected runtime. Configure known project values non-interactively; ask only for
-required non-secret values you cannot resolve. Persist supported environment
-credentials with npa configure --save-env-credentials. If the task needs S3,
-explain the required storage before using explicit --provision to create or
-reuse it, and first confirm that the active identity has the required project
+Install or verify npa, the Nebius CLI, and required host tools. Configure known
+values non-interactively with npa configure --save-env-credentials. Before
+explicit S3 provisioning, explain the storage and confirm the required project
 permissions.
 
-Inspect npa configure --show. Run credential preflight checks for the selected
-services, including --checks nebius before cloud provisioning. Use npa workbench
-health access for the selected capabilities and their required model assets.
-
-Do not bypass a failed gate or provision GPU resources during setup. If model
-access needs human approval, show me the exact official pages and wait; never
-accept terms for me. Finish with a concise readiness report: what passed, what
-is still blocked, the planned workload and resources, and the next command.
+Inspect npa configure --show. Run npa workbench health preflight for the selected
+services, including --checks nebius before cloud provisioning, then run health
+access for required model assets. Stop on any failed gate and do not provision
+GPUs. If access needs human approval, show the official pages and wait; never
+accept terms for me. Finish with what passed, blockers, the planned workload
+and resources, and the next command.
 ```
 
 For project creation, federation or SSO profiles, non-interactive setup, and
@@ -123,43 +115,33 @@ public. Paste this prompt after making project values and `HF_TOKEN` available
 to the agent through its private environment:
 
 ```text
-Run my first Nebius Physical AI Workbench workflow:
-workflows/testing/cosmos3-generate.yaml. Follow AGENTS.md, skills/index.yaml,
-the relevant Cosmos 3 and workflow-operation skills, and
-docs/workbench/cosmos3-generate.md. Use the current local checkout and its npa
-installation. Use the configured project, writable bucket, and credentials.
-First install or verify npa, the Nebius CLI, and the host tools required by the
-maintained Workbench setup guide.
+Run workflows/testing/cosmos3-generate.yaml to a verified result. Follow
+AGENTS.md, skills/index.yaml, the relevant first-run, Cosmos 3, and workflow
+operation skills, and docs/workbench/cosmos3-generate.md.
 
-Never print secret values, put them in command arguments or YAML, or dump the
-process environment. Inspect only the allowlisted names needed for this run and
-report each as present or missing. Resolve credentials through npa's supported
-configuration APIs. Keep project, cluster, bucket, registry, and artifact
-identifiers out of chat and committed files.
+Use the configured project, writable bucket, and credentials through npa. Inspect
+resource and artifact identifiers locally when required, but redact them from
+chat, reports, and commits. Never print secrets, dump the environment, or pass
+secret values in arguments or YAML. Inspect only required variable names as
+present or missing.
 
-Inspect npa configure --show. Run the Nebius, selected-project S3, and Cosmos 3
-model-access gates before provisioning. If access is pending, show me the exact
-official model pages and wait for me to accept the terms; never accept them for
-me. Rerun the gate after I finish. Do not disable guardrails or bypass a failed
-check.
+Before provisioning, inspect npa configure --show and run the Nebius,
+selected-project S3, and Cosmos 3 access gates. Keep guardrails enabled. If
+access needs human approval, show the official pages, wait for me, and rerun the
+gate; never accept terms for me or bypass a failure.
 
-Validate and plan the checked-in spec using my actual bucket. Explain the
-expected vision.jpg and generate.json output plus the requested CPU, memory,
-and GPU before provisioning. Preview provision-if-absent, then create only
-missing resources through npa. Bootstrap and verify the isolated SkyPilot
-runtime, discover the accelerator name exposed by the selected cluster, and
-reconcile the workflow resource request if necessary. Revalidate the plan and
-preflight the exact workflow images.
+Validate and plan the checked-in spec with my actual bucket. State the expected
+vision.jpg and generate.json artifacts and requested resources. Preview
+provision-if-absent, create only missing resources through npa, bootstrap and
+verify SkyPilot, discover the cluster's accelerator name, reconcile it if
+needed, then revalidate and preflight the exact images.
 
-Submit the workflow with --runtime and forward secrets only by name with
---secret-env. Stay with the run until it reaches a terminal state. On failure,
-use npa workbench workflow status, logs, and artifacts to diagnose the recorded
-stage; keep log output bounded and resume safely when supported instead of
-launching an unrelated run. On success, verify that the generated media is
-non-empty, inspect generate.json, and show me the media in an available agent
-viewer. Finish with the run outcome, artifact types, and any still-running
-resources. Do not destroy shared infrastructure; offer the documented
-cancel-before-destroy cleanup path.
+Submit with --runtime and forward secrets only by name with --secret-env. Stay
+until the run is terminal. On failure, use bounded status, logs, and artifact
+inspection and resume when supported. On success, verify non-empty media,
+inspect generate.json, and show the result in an available viewer. Report the
+outcome, artifacts, and still-running resources, then offer the documented
+cancel-before-destroy cleanup path without destroying shared infrastructure.
 ```
 
 Do not treat a valid plan or accepted submission as completion: the prompt ends
@@ -176,41 +158,35 @@ Physical AI Data Factory with real source-video-conditioned Cosmos 3, attach a
 local H.264 MP4 or set `PAIDF_INPUT_URI` to one private `s3://` MP4, then paste:
 
 ```text
-Run my first Workbench workflow with me: the PAIDF Cosmos 3 video-conditioning
-workflow at workflows/main/paidf-cosmos3.yaml. Follow
-docs/workbench/guides/paidf-cosmos3.md and the repository skills. Use the
-configured Nebius project, region, writable bucket, and credentials. Use the
-attached local H.264 MP4, or PAIDF_INPUT_URI if it is set; if neither is
-available, ask me only for the input video before continuing. Keep all input and
-artifact locations private.
+Run workflows/main/paidf-cosmos3.yaml to a terminal result. Follow AGENTS.md,
+skills/index.yaml, the relevant repository skills, and
+docs/workbench/guides/paidf-cosmos3.md. Use the configured project, region,
+writable bucket, and credentials. Use the attached H.264 MP4 or
+PAIDF_INPUT_URI; if neither exists, ask only for the input video.
 
-Never run `env`, `printenv`, `set`, `export -p`, or another command that dumps
-the process environment. Inspect only allowlisted variable names and report
-present or missing; do not print secret values or read credential files directly.
+Keep input, artifact, and infrastructure locations private. Never print secrets,
+dump the environment, read credential files directly, or pass secret values in
+YAML or arguments. Inspect required variable names only as present or missing.
 
-Re-run the credential and model-access gates for paidf,cosmos3. Validate and
-plan the spec with the real bucket and input, starting with one variant and one
-supported GPU. Honor configured TF_VAR_* topology and reserved-capacity settings.
-Show me the validated plan and explain the required CPU/GPU resources before
-provisioning. Bootstrap and verify SkyPilot, provision any required resources
-that are absent, and discover the accelerator name the target cluster advertises.
-Use that name in the resource overrides and revalidate the plan. Then stage the
-input and preflight the selected images. If a selected image fails the
-SkyPilot bootstrap contract, build the repository's current compliant image,
-push it to an authorized private project registry at an immutable digest, and
-repeat preflight. Then submit with --runtime.
-Forward only secret names through --secret-env: HF_TOKEN,
-NEBIUS_TOKEN_FACTORY_KEY, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY; never put
-secret values in YAML or command arguments.
+Before provisioning, run npa workbench health preflight for the selected project
+with --checks s3,token_factory,nebius, then run npa workbench health access
+--capability cosmos3. Validate and plan with the real bucket and input, one
+variant, and one supported GPU; honor configured TF_VAR_* topology and reserved
+capacity. Show the plan and resources. Through npa, preview and create only
+missing resources, bootstrap and verify SkyPilot, discover the advertised
+accelerator, apply any required override, and revalidate. Stage the input and
+preflight the selected images. If an image fails the bootstrap contract, follow
+the guide's compliant immutable build-and-push path and repeat preflight; do not
+bypass it.
 
-Stay with the run until it reaches a terminal state. If it fails, diagnose the
-recorded stage and resume safely rather than starting an unrelated run. If it
-succeeds, show me the generated and curated artifacts and load the final Rerun
-recording when an agent viewer is available. A terminal quality rejection after
-the workflow's bounded refinement loop is a valid fail-closed result: do not
-lower the threshold or force promotion. Show me the generated video, evaluator
-report, quality disposition, and Rerun evidence, and explain that labeling and
-curation were intentionally skipped.
+Submit with --runtime and forward only these secret names with --secret-env:
+HF_TOKEN, NEBIUS_TOKEN_FACTORY_KEY, AWS_ACCESS_KEY_ID, and
+AWS_SECRET_ACCESS_KEY. Stay until terminal. On failure, diagnose the recorded
+stage and resume when safe. On success, show the generated and curated artifacts
+and load the final Rerun recording when available. Treat a terminal quality
+rejection as valid fail-closed behavior: do not lower thresholds or force
+promotion; show the generated video, evaluator report, disposition, and Rerun
+evidence, and explain why labeling and curation were skipped.
 ```
 
 The workflow uses the independent

--- a/docs/workbench/agent-first-run.md
+++ b/docs/workbench/agent-first-run.md
@@ -1,12 +1,22 @@
-# Use Workbench with a coding agent
+# Use Workbench with your coding agent
 
 [Workbench docs](README.md)
 
-Use your existing coding agent with terminal access to this checkout. Install
-`npa` and the Nebius CLI using the [quickstart](../quickstart.md). Describe the
-task you want to complete, then select individual tools or compose a workflow.
-The [self-hosted browser agent](../agent.md)
-is optional and requires a separate deployment.
+Workbench is the control plane between your coding agent and physical-AI
+workloads on Nebius. Use Codex, Claude Code, or another agent with terminal
+access to this checkout; NPA does not require or select a particular reasoning
+system. Your agent operates the same checked, auditable `npa` surfaces available
+to a human: configure, preflight, plan, provision, submit, monitor, and inspect.
+
+Install `npa` and the Nebius CLI using the [quickstart](../quickstart.md), then
+paste one of the prompts below. The [self-hosted browser agent](../agent.md) is
+optional and requires a separate deployment.
+
+| Goal | Prompt |
+| --- | --- |
+| Prepare a project for any supported task | [Set up Workbench](#set-up-workbench) |
+| Generate an image with the supported Cosmos 3 workflow | [Run Cosmos 3 generation](#run-cosmos-3-generation) |
+| Augment and curate a source video | [Run PAIDF with Cosmos 3](#run-paidf-with-cosmos-3) |
 
 ## Choose tools for your task
 
@@ -17,10 +27,13 @@ Existing examples are starting points; available tools and their contracts
 determine what you can run or combine. If the task needs an unsupported
 capability, have the agent explain the gap.
 
-The setup prompt below applies to the task you choose. The PAIDF + Cosmos 3
-prompt later in this guide is a worked video-augmentation example.
+The setup prompt below applies to the task you choose. The two Cosmos prompts
+are complete runs: standalone generation is the shorter first workflow, while
+PAIDF is a longer source-video augmentation and curation pipeline.
 
-## Configure the project and model access
+<a id="set-up-workbench"></a>
+
+## Set up Workbench
 
 Supply the project values and any credentials needed by your selected tools
 through the agent's **private environment**. Keep token values out of chat.
@@ -49,14 +62,15 @@ First-time storage setup needs **admin permission on the target project**.
 IAM group with a bucket-scoped `storage.object-editor` permit. Tenant-wide admin
 permission and tenant-wide project listing are not required.
 
-Then give your agent this prompt:
+Describe the task you want to run, then give your agent this prompt:
 
 ```text
-Set up Nebius Physical AI Workbench for the task I described. If I have not
-given you a task, ask what I want to accomplish before choosing tools. Read
-AGENTS.md and skills/index.yaml, then inspect the relevant guides and command
-help. Select tools or a workflow that fit my inputs and intended output. Explain
-their requirements and any unsupported parts of the task.
+Set up Nebius Physical AI Workbench for the task I described. If the intended
+result or input is unclear, ask me one concise question before choosing tools.
+Read AGENTS.md and skills/index.yaml, then follow the relevant repository skills,
+workload guide, and current command help. Select a supported tool or workflow
+that directly produces my intended result. State its inputs, output artifacts,
+model access, infrastructure, and any unsupported part of my request.
 
 Use project values and the credentials required by the selected tools from
 the private process environment. Never print secret values, put them in command
@@ -66,23 +80,22 @@ the process environment; inspect only allowlisted names and report present or
 missing. Do not read credential files except through npa's credential APIs.
 Use NPA_PROJECT_ALIAS if it is set; otherwise use "workbench" as the local alias.
 
-Install or verify npa and the host prerequisites for the selected runtime.
-Managed deployments need Terraform; SkyPilot Kubernetes on Debian/Ubuntu also
-needs socat. Configure the known tenant, project, and region non-interactively
-when the task uses a Nebius project. Persist supported environment credentials
-with npa configure --save-env-credentials. Use --no-provision for provider-free
-setup. If the task needs S3, explain the storage it needs before using explicit
---provision to create or reuse writable project storage. First confirm that the
-active identity can manage the project-scoped IAM objects that secure it.
+Install or verify npa, the Nebius CLI, and the host prerequisites for the
+selected runtime. Configure known project values non-interactively; ask only for
+required non-secret values you cannot resolve. Persist supported environment
+credentials with npa configure --save-env-credentials. If the task needs S3,
+explain the required storage before using explicit --provision to create or
+reuse it, and first confirm that the active identity has the required project
+permissions.
 
 Inspect npa configure --show. Run credential preflight checks for the selected
 services, including --checks nebius before cloud provisioning. Use npa workbench
 health access for the selected capabilities and their required model assets.
 
-Do not bypass a failed gate or provision GPU resources yet. If Hugging Face
-access is missing, give me the exact model-page links, wait for me to accept the
-terms, and rerun the check. Finish setup when the selected task's prerequisites
-pass, then guide me into running it.
+Do not bypass a failed gate or provision GPU resources during setup. If model
+access needs human approval, show me the exact official pages and wait; never
+accept terms for me. Finish with a concise readiness report: what passed, what
+is still blocked, the planned workload and resources, and the next command.
 ```
 
 For project creation, federation or SSO profiles, non-interactive setup, and
@@ -97,9 +110,66 @@ use its documented command and runtime requirements. Check the resulting
 artifacts against your intended output and follow the applicable recovery and
 cleanup instructions.
 
+<a id="run-cosmos-3-generation"></a>
+
+## First workflow: Cosmos 3 generation
+
+This prompt runs the checked-in
+[`workflows/testing/cosmos3-generate.yaml`](../../workflows/testing/cosmos3-generate.yaml)
+workflow on a compatible Nebius GPU. Its default is Cosmos3-Nano text-to-image
+on one H100, producing `vision.jpg` and `generate.json` in S3. The default
+guardrails require gated Hugging Face access even though the main checkpoint is
+public. Paste this prompt after making project values and `HF_TOKEN` available
+to the agent through its private environment:
+
+```text
+Run my first Nebius Physical AI Workbench workflow:
+workflows/testing/cosmos3-generate.yaml. Follow AGENTS.md, skills/index.yaml,
+the relevant Cosmos 3 and workflow-operation skills, and
+docs/workbench/cosmos3-generate.md. Use the current local checkout and its npa
+installation. Use the configured project, writable bucket, and credentials.
+First install or verify npa, the Nebius CLI, and the host tools required by the
+maintained Workbench setup guide.
+
+Never print secret values, put them in command arguments or YAML, or dump the
+process environment. Inspect only the allowlisted names needed for this run and
+report each as present or missing. Resolve credentials through npa's supported
+configuration APIs. Keep project, cluster, bucket, registry, and artifact
+identifiers out of chat and committed files.
+
+Inspect npa configure --show. Run the Nebius, selected-project S3, and Cosmos 3
+model-access gates before provisioning. If access is pending, show me the exact
+official model pages and wait for me to accept the terms; never accept them for
+me. Rerun the gate after I finish. Do not disable guardrails or bypass a failed
+check.
+
+Validate and plan the checked-in spec using my actual bucket. Explain the
+expected vision.jpg and generate.json output plus the requested CPU, memory,
+and GPU before provisioning. Preview provision-if-absent, then create only
+missing resources through npa. Bootstrap and verify the isolated SkyPilot
+runtime, discover the accelerator name exposed by the selected cluster, and
+reconcile the workflow resource request if necessary. Revalidate the plan and
+preflight the exact workflow images.
+
+Submit the workflow with --runtime and forward secrets only by name with
+--secret-env. Stay with the run until it reaches a terminal state. On failure,
+use npa workbench workflow status, logs, and artifacts to diagnose the recorded
+stage; keep log output bounded and resume safely when supported instead of
+launching an unrelated run. On success, verify that the generated media is
+non-empty, inspect generate.json, and show me the media in an available agent
+viewer. Finish with the run outcome, artifact types, and any still-running
+resources. Do not destroy shared infrastructure; offer the documented
+cancel-before-destroy cleanup path.
+```
+
+Do not treat a valid plan or accepted submission as completion: the prompt ends
+with inspected artifacts or a concrete external blocker. The
+[Cosmos 3 generation guide](cosmos3-generate.md) is the command-level source of
+truth for the workflow, outputs, access checks, and current limitations.
+
 <a id="run-paidf-with-cosmos-3"></a>
 
-## Worked example: PAIDF with Cosmos 3
+## Advanced workflow: PAIDF with Cosmos 3
 
 Use the same agent from input selection through output inspection. For the
 Physical AI Data Factory with real source-video-conditioned Cosmos 3, attach a


### PR DESCRIPTION
## Summary

- restore the root README's workflow diagram and sharpen it around the human, coding agent, Workbench control plane, and Nebius execution path
- restore direct quickstart links to maintained setup and Cosmos 3 agent prompts
- add a standalone Cosmos 3 prompt that carries a first run through access gates, resource planning, provisioning, submission, recovery, and artifact inspection

## Validation

- `npa/.venv/bin/python -m pytest npa/tests/guardrails/test_documentation_examples.py -q` — 579 passed
- `npa/.venv/bin/python -m pytest npa/tests/guardrails -q -n auto` — 3,417 passed
- `npa/.venv/bin/python -m pytest npa/tests/ -x --collect-only -q` — 21,339 collected, 3 skipped
- `npa/.venv/bin/python -m ruff check npa` — passed
- confidentiality and gitleaks scans of `origin/main..HEAD` — no findings
